### PR TITLE
Add auto-update system (CLI upgrade + GUI check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ hole daemon status                → print install/running status
 hole daemon log                   → print daemon log to stdout
 hole daemon log path              → print log file path
 hole daemon log watch [--tail N]  → stream log output
+hole upgrade                      → check for updates and install latest version (unattended)
 hole path add                     → add hole to system PATH
 hole path remove                  → remove hole from system PATH
 ```
@@ -67,6 +68,15 @@ npx tauri build                  # produces .dmg in target/release/bundle/
 
 Uses [skuld](https://github.com/bindreams/skuld) framework (`#[skuld::test]`), not `#[test]`.
 Unit test files are siblings: `foo.rs` → `foo_tests.rs`.
+
+## Releases
+
+Release assets follow GOOS/GOARCH naming, OS first:
+- `hole-{version}-windows-amd64.msi`
+- `hole-{version}-darwin-arm64.dmg`
+- `hole-{version}-darwin-amd64.dmg`
+
+The auto-updater matches assets by these suffixes.
 
 ## Icons
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,8 +670,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1129,6 +1148,15 @@ name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dom_query"
@@ -2039,6 +2067,7 @@ dependencies = [
 name = "hole-common"
 version = "0.1.0"
 dependencies = [
+ "semver",
  "serde",
  "serde_json",
  "skuld",
@@ -2079,6 +2108,7 @@ dependencies = [
  "interprocess",
  "png 0.18.1",
  "resvg",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -2776,6 +2806,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -6126,11 +6162,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "ureq-proto",
  "utf-8",
  "webpki-roots",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,6 +9,7 @@ harness = false
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod import;
 pub mod protocol;
+pub mod version;
 
 #[cfg(test)]
 fn main() {

--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -1,0 +1,90 @@
+// Shared release version type for semver parsing and comparison.
+
+use std::fmt;
+use std::ops::Deref;
+
+use thiserror::Error;
+
+// Error =====
+
+#[derive(Debug, Error)]
+pub enum VersionError {
+    #[error("invalid semver: {0}")]
+    Semver(#[from] semver::Error),
+    #[error("{0}")]
+    Custom(String),
+}
+
+// ReleaseVersion =====
+
+/// A strict `MAJOR.MINOR.PATCH` version with no pre-release or build metadata.
+///
+/// Wraps [`semver::Version`] and enforces the invariant that `pre` and `build`
+/// are both empty.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReleaseVersion(semver::Version);
+
+impl ReleaseVersion {
+    /// Parse a strict `MAJOR.MINOR.PATCH` version string.
+    ///
+    /// Accepts an optional `v` prefix (e.g. `"v1.2.3"` or `"1.2.3"`).
+    /// Rejects pre-release suffixes and build metadata.
+    pub fn parse(s: &str) -> Result<Self, VersionError> {
+        let s = s.strip_prefix('v').unwrap_or(s);
+        let v = semver::Version::parse(s)?;
+        if !v.pre.is_empty() {
+            return Err(VersionError::Custom(format!(
+                "pre-release versions are not allowed: {v}"
+            )));
+        }
+        if !v.build.is_empty() {
+            return Err(VersionError::Custom(format!("build metadata is not allowed: {v}")));
+        }
+        Ok(Self(v))
+    }
+
+    /// Extract the base release version from a build-time version string.
+    ///
+    /// The build-time format is: `MAJOR.MINOR.PATCH[-snapshot+git.HASH][.dirty]`
+    ///
+    /// Returns `(version, is_snapshot)` where `is_snapshot` is `true` when the
+    /// build is ahead of the last release tag (contains `-snapshot`).
+    pub fn from_build_version(s: &str) -> Result<(Self, bool), VersionError> {
+        // The base version is everything before the first '-' or '.dirty' suffix.
+        // Possible formats:
+        //   "0.1.0"
+        //   "0.1.0.dirty"
+        //   "0.1.0-snapshot+git.abc123"
+        //   "0.1.0-snapshot+git.abc123.dirty"
+        let is_snapshot = s.contains("-snapshot");
+
+        let base = match s.find('-') {
+            Some(idx) => &s[..idx],
+            None => s,
+        };
+
+        // Strip ".dirty" suffix if present on the base (only for on-tag dirty builds).
+        let base = base.strip_suffix(".dirty").unwrap_or(base);
+
+        let version = Self::parse(base)?;
+        Ok((version, is_snapshot))
+    }
+}
+
+impl Deref for ReleaseVersion {
+    type Target = semver::Version;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for ReleaseVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.0.major, self.0.minor, self.0.patch)
+    }
+}
+
+#[cfg(test)]
+#[path = "version_tests.rs"]
+mod version_tests;

--- a/crates/common/src/version_tests.rs
+++ b/crates/common/src/version_tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+// parse =====
+
+#[skuld::test]
+fn parse_bare_version() {
+    let v = ReleaseVersion::parse("1.2.3").unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 2);
+    assert_eq!(v.patch, 3);
+}
+
+#[skuld::test]
+fn parse_v_prefix() {
+    let v = ReleaseVersion::parse("v1.2.3").unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 2);
+    assert_eq!(v.patch, 3);
+}
+
+#[skuld::test]
+fn parse_v_prefix_equals_bare() {
+    let a = ReleaseVersion::parse("v1.2.3").unwrap();
+    let b = ReleaseVersion::parse("1.2.3").unwrap();
+    assert_eq!(a, b);
+}
+
+#[skuld::test]
+fn parse_rejects_prerelease() {
+    assert!(ReleaseVersion::parse("1.2.3-alpha").is_err());
+}
+
+#[skuld::test]
+fn parse_rejects_build_metadata() {
+    assert!(ReleaseVersion::parse("1.2.3+build").is_err());
+}
+
+#[skuld::test]
+fn parse_rejects_two_components() {
+    assert!(ReleaseVersion::parse("1.2").is_err());
+}
+
+#[skuld::test]
+fn parse_rejects_leading_zero() {
+    assert!(ReleaseVersion::parse("01.2.3").is_err());
+}
+
+#[skuld::test]
+fn parse_rejects_empty() {
+    assert!(ReleaseVersion::parse("").is_err());
+}
+
+#[skuld::test]
+fn parse_rejects_garbage() {
+    assert!(ReleaseVersion::parse("not-a-version").is_err());
+}
+
+// from_build_version =====
+
+#[skuld::test]
+fn from_build_version_release() {
+    let (v, is_snapshot) = ReleaseVersion::from_build_version("0.1.0").unwrap();
+    assert_eq!(v, ReleaseVersion::parse("0.1.0").unwrap());
+    assert!(!is_snapshot);
+}
+
+#[skuld::test]
+fn from_build_version_snapshot() {
+    let (v, is_snapshot) = ReleaseVersion::from_build_version("0.1.0-snapshot+git.abc123def456").unwrap();
+    assert_eq!(v, ReleaseVersion::parse("0.1.0").unwrap());
+    assert!(is_snapshot);
+}
+
+#[skuld::test]
+fn from_build_version_snapshot_dirty() {
+    let (v, is_snapshot) = ReleaseVersion::from_build_version("0.1.0-snapshot+git.abc123def456.dirty").unwrap();
+    assert_eq!(v, ReleaseVersion::parse("0.1.0").unwrap());
+    assert!(is_snapshot);
+}
+
+#[skuld::test]
+fn from_build_version_dirty_on_tag() {
+    let (v, is_snapshot) = ReleaseVersion::from_build_version("0.1.0.dirty").unwrap();
+    assert_eq!(v, ReleaseVersion::parse("0.1.0").unwrap());
+    assert!(!is_snapshot);
+}
+
+#[skuld::test]
+fn from_build_version_rejects_garbage() {
+    assert!(ReleaseVersion::from_build_version("not-a-version").is_err());
+}
+
+// Ordering =====
+
+#[skuld::test]
+fn ordering_patch() {
+    let a = ReleaseVersion::parse("0.1.0").unwrap();
+    let b = ReleaseVersion::parse("0.1.1").unwrap();
+    assert!(a < b);
+}
+
+#[skuld::test]
+fn ordering_minor() {
+    let a = ReleaseVersion::parse("0.1.0").unwrap();
+    let b = ReleaseVersion::parse("0.2.0").unwrap();
+    assert!(a < b);
+}
+
+#[skuld::test]
+fn ordering_major() {
+    let a = ReleaseVersion::parse("0.2.0").unwrap();
+    let b = ReleaseVersion::parse("1.0.0").unwrap();
+    assert!(a < b);
+}
+
+#[skuld::test]
+fn ordering_chain() {
+    let a = ReleaseVersion::parse("0.1.0").unwrap();
+    let b = ReleaseVersion::parse("0.2.0").unwrap();
+    let c = ReleaseVersion::parse("1.0.0").unwrap();
+    assert!(a < b);
+    assert!(b < c);
+}
+
+// Display =====
+
+#[skuld::test]
+fn display_no_v_prefix() {
+    let v = ReleaseVersion::parse("v1.2.3").unwrap();
+    assert_eq!(v.to_string(), "1.2.3");
+}
+
+#[skuld::test]
+fn display_roundtrip() {
+    let v = ReleaseVersion::parse("1.2.3").unwrap();
+    assert_eq!(v.to_string(), "1.2.3");
+}

--- a/crates/gui/Cargo.toml
+++ b/crates/gui/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 thiserror = "2"
 dirs = "6"
+ureq = { version = "3", features = ["json"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.56"
@@ -44,6 +45,7 @@ skuld = { git = "https://github.com/bindreams/skuld" }
 
 [build-dependencies]
 tauri-build = "2"
+semver = "1"
 resvg = "0.45"
 png = "0.18"
 ico = "0.5"

--- a/crates/gui/build.rs
+++ b/crates/gui/build.rs
@@ -91,9 +91,11 @@ fn compute_git_version(repo_root: &Path) -> Result<String, String> {
     let semver = tag
         .strip_prefix('v')
         .ok_or_else(|| format!("tag '{tag}' missing 'v' prefix"))?;
-    let semver_parts: Vec<&str> = semver.split('.').collect();
-    if semver_parts.len() != 3 || !semver_parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit())) {
-        return Err(format!("tag '{tag}' is not strict vMAJOR.MINOR.PATCH"));
+    let parsed = semver::Version::parse(semver).map_err(|e| format!("tag '{tag}' is not valid semver: {e}"))?;
+    if !parsed.pre.is_empty() || !parsed.build.is_empty() {
+        return Err(format!(
+            "tag '{tag}' must be strict vMAJOR.MINOR.PATCH (no pre-release/build)"
+        ));
     }
 
     let mut version = semver.to_string();

--- a/crates/gui/src/cli.rs
+++ b/crates/gui/src/cli.rs
@@ -15,6 +15,8 @@ struct Cli {
 enum Command {
     /// Print version information
     Version,
+    /// Check for updates and install the latest version
+    Upgrade,
     /// Manage the privileged daemon service
     Daemon {
         #[command(subcommand)]
@@ -79,11 +81,55 @@ pub fn dispatch() -> ! {
             println!("hole {}", hole_gui::version::VERSION);
             0
         }
+        Command::Upgrade => handle_upgrade(),
         Command::Daemon { action } => handle_daemon(action),
         Command::Path { action } => handle_path(action),
     };
 
     std::process::exit(code)
+}
+
+fn handle_upgrade() -> i32 {
+    eprintln!("checking for updates...");
+    match hole_gui::update::check_for_update() {
+        Ok(Some(info)) => {
+            eprintln!("update available: v{}", info.version);
+
+            let download_dir = std::env::temp_dir().join("hole-update");
+            if let Err(e) = std::fs::create_dir_all(&download_dir) {
+                eprintln!("failed to create temp dir: {e}");
+                return 1;
+            }
+            let dest = download_dir.join(&info.asset_name);
+
+            eprintln!("downloading {}...", info.asset_name);
+            if let Err(e) = hole_gui::update::download_asset(&info.asset_url, &dest) {
+                eprintln!("download failed: {e}");
+                return 1;
+            }
+
+            eprintln!("installing...");
+            if let Err(e) = hole_gui::update::run_installer(&dest, true) {
+                eprintln!("installation failed: {e}");
+                // Best-effort cleanup
+                let _ = std::fs::remove_file(&dest);
+                return 1;
+            }
+
+            // Best-effort cleanup
+            let _ = std::fs::remove_file(&dest);
+            eprintln!("updated to v{}", info.version);
+            0
+        }
+        Ok(None) => {
+            eprintln!("already up to date ({})", hole_gui::version::VERSION);
+            0
+        }
+        Err(e) => {
+            eprintln!("update check failed: {e}");
+            1
+        }
+    }
 }
 
 fn handle_daemon(action: DaemonAction) -> i32 {

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -4,6 +4,7 @@ pub mod logging;
 pub mod path_management;
 pub mod setup;
 pub mod state;
+pub mod update;
 pub mod version;
 
 #[cfg(test)]

--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -41,6 +41,7 @@ fn launch_gui() {
         ))
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState::new(config_path))
+        .manage(hole_gui::update::UpdateState::default())
         .invoke_handler(tauri::generate_handler![
             commands::get_config,
             commands::save_config,
@@ -61,6 +62,21 @@ fn launch_gui() {
             tray::create_tray(app)?;
             platform::on_setup(app)?;
             setup::check_daemon_on_launch(app.handle().clone());
+            hole_gui::update::start_update_checker(app.handle().clone(), |app, info| {
+                // Rebuild tray menu to include the "Install Update" item.
+                if let Some(tray_icon) = app.tray_by_id("main") {
+                    match tray::build_tray_menu(app, Some(info)) {
+                        Ok(menu) => {
+                            // Re-sync checkbox state from config before applying new menu.
+                            tray::sync_menu_state(app, &menu);
+                            tray_icon.set_menu(Some(menu)).ok();
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "failed to rebuild tray menu with update");
+                        }
+                    }
+                }
+            });
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/crates/gui/src/tray.rs
+++ b/crates/gui/src/tray.rs
@@ -17,11 +17,16 @@ const ID_EXIT: &str = "exit";
 #[cfg(target_os = "macos")]
 const ID_UNINSTALL_HELPER: &str = "uninstall_helper";
 const ID_ABOUT: &str = "about";
+const ID_INSTALL_UPDATE: &str = "install_update";
+const ID_CHECK_UPDATE: &str = "check_update";
 
 // Tray creation =====
 
-/// Create and register the system tray icon with its menu.
-pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
+/// Build the tray menu, optionally including an "Install Update" item.
+pub fn build_tray_menu(
+    app: &AppHandle,
+    update: Option<&hole_gui::update::UpdateInfo>,
+) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
     let enable = CheckMenuItem::with_id(app, ID_ENABLE, "Enable", true, false, None::<&str>)?;
     let autostart = CheckMenuItem::with_id(app, ID_AUTOSTART, "Start at Login", true, false, None::<&str>)?;
     let settings = MenuItem::with_id(app, ID_SETTINGS, "Settings...", true, None::<&str>)?;
@@ -29,18 +34,46 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
     let sep2 = PredefinedMenuItem::separator(app)?;
     let exit = MenuItem::with_id(app, ID_EXIT, "Exit", true, None::<&str>)?;
 
-    let menu = tauri::menu::Menu::with_items(app, &[&enable, &autostart, &sep1, &settings, &sep2, &exit])?;
+    if let Some(info) = update {
+        let update_item = MenuItem::with_id(
+            app,
+            ID_INSTALL_UPDATE,
+            format!("Install Update (v{})", info.version),
+            true,
+            None::<&str>,
+        )?;
+        let sep3 = PredefinedMenuItem::separator(app)?;
+        tauri::menu::Menu::with_items(
+            app,
+            &[&enable, &autostart, &sep1, &settings, &sep2, &update_item, &sep3, &exit],
+        )
+    } else {
+        tauri::menu::Menu::with_items(app, &[&enable, &autostart, &sep1, &settings, &sep2, &exit])
+    }
+}
 
-    let tray = TrayIconBuilder::new()
+/// Sync tray menu checkbox states from the current config.
+pub fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>) {
+    let state = app.state::<AppState>();
+    let config = state.config.lock().unwrap();
+    if let Some(item) = menu.get(ID_ENABLE) {
+        if let Some(check) = item.as_check_menuitem() {
+            check.set_checked(config.enabled).ok();
+        }
+    }
+}
+
+/// Create and register the system tray icon with its menu.
+pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
+    let menu = build_tray_menu(app.handle(), None)?;
+
+    let tray = TrayIconBuilder::with_id("main")
         .menu(&menu)
         .tooltip("Hole")
         .on_menu_event(handle_menu_event)
         .build(app)?;
 
-    // Sync initial state from config
-    let state = app.state::<AppState>();
-    let config = state.config.lock().unwrap();
-    enable.set_checked(config.enabled).ok();
+    sync_menu_state(app.handle(), &menu);
 
     Ok(tray)
 }
@@ -176,6 +209,20 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 handle_uninstall_helper(app_handle).await;
             });
         }
+        ID_INSTALL_UPDATE => {
+            info!("tray: install update requested");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                handle_install_update_from_tray(app_handle).await;
+            });
+        }
+        ID_CHECK_UPDATE => {
+            info!("menu: check for updates");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                handle_check_for_updates(app_handle).await;
+            });
+        }
         ID_ABOUT => {
             info!("menu: about dialog");
             use tauri_plugin_dialog::DialogExt;
@@ -243,6 +290,117 @@ async fn handle_uninstall_helper(app: AppHandle) {
     }
 }
 
+async fn handle_install_update_from_tray(app: AppHandle) {
+    use tauri_plugin_dialog::DialogExt;
+
+    // Get update info from update state.
+    let update_state = app.state::<hole_gui::update::UpdateState>();
+    let update_info = update_state.rx.borrow().clone();
+
+    let Some(info) = update_info else {
+        warn!("install update clicked but no update info available");
+        return;
+    };
+
+    let download_dir = std::env::temp_dir().join("hole-update");
+    if let Err(e) = std::fs::create_dir_all(&download_dir) {
+        error!("failed to create temp dir: {e}");
+        return;
+    }
+    let dest = download_dir.join(&info.asset_name);
+    let asset_url = info.asset_url.clone();
+    let dest_for_download = dest.clone();
+
+    // Download on blocking thread.
+    let download_result =
+        tokio::task::spawn_blocking(move || hole_gui::update::download_asset(&asset_url, &dest_for_download)).await;
+
+    match download_result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            error!("download failed: {e}");
+            app.dialog()
+                .message(format!("Download failed: {e}"))
+                .title("Update Error")
+                .blocking_show();
+            return;
+        }
+        Err(e) => {
+            error!("download task panicked: {e}");
+            return;
+        }
+    }
+
+    // Run installer (interactive mode).
+    let dest_clone = dest.clone();
+    let install_result = tokio::task::spawn_blocking(move || hole_gui::update::run_installer(&dest_clone, false)).await;
+
+    match install_result {
+        Ok(Ok(())) => {
+            // On Windows, exit app to let MSI complete.
+            // On macOS, the installer already copied the app.
+            let _ = std::fs::remove_file(&dest);
+            app.exit(0);
+        }
+        Ok(Err(e)) => {
+            error!("installation failed: {e}");
+            let _ = std::fs::remove_file(&dest);
+            app.dialog()
+                .message(format!("Installation failed: {e}"))
+                .title("Update Error")
+                .blocking_show();
+        }
+        Err(e) => {
+            error!("install task panicked: {e}");
+        }
+    }
+}
+
+async fn handle_check_for_updates(app: AppHandle) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+
+    let result = tokio::task::spawn_blocking(hole_gui::update::check_for_update).await;
+
+    match result {
+        Ok(Ok(Some(info))) => {
+            let confirmed = app
+                .dialog()
+                .message(format!(
+                    "Version {} is available.\n\nWould you like to install it now?",
+                    info.version
+                ))
+                .title("Update Available")
+                .buttons(MessageDialogButtons::OkCancelCustom("Install".into(), "Later".into()))
+                .blocking_show();
+
+            if confirmed {
+                // Store the update info and reuse the install handler.
+                let update_state = app.state::<hole_gui::update::UpdateState>();
+                update_state.tx.send_replace(Some(info));
+                handle_install_update_from_tray(app).await;
+            }
+        }
+        Ok(Ok(None)) => {
+            app.dialog()
+                .message(format!(
+                    "You're running the latest version ({}).",
+                    hole_gui::version::VERSION
+                ))
+                .title("No Updates Available")
+                .blocking_show();
+        }
+        Ok(Err(e)) => {
+            app.dialog()
+                .message(format!("Failed to check for updates: {e}"))
+                .title("Update Error")
+                .blocking_show();
+        }
+        Err(e) => {
+            error!("update check task panicked: {e}");
+        }
+    }
+}
+
 fn open_settings_window(app: &AppHandle) {
     // Reuse existing window if it's already open
     if let Some(window) = app.get_webview_window("settings") {
@@ -260,9 +418,12 @@ fn open_settings_window(app: &AppHandle) {
     {
         use tauri::menu::{Menu, Submenu};
 
+        let check_update_item = MenuItem::with_id(app, ID_CHECK_UPDATE, "Check for Updates...", true, None::<&str>)
+            .expect("failed to create menu item");
         let about_item =
             MenuItem::with_id(app, ID_ABOUT, "About Hole", true, None::<&str>).expect("failed to create menu item");
-        let help_submenu = Submenu::with_items(app, "Help", true, &[&about_item]).expect("failed to create submenu");
+        let help_submenu = Submenu::with_items(app, "Help", true, &[&check_update_item, &about_item])
+            .expect("failed to create submenu");
 
         #[cfg(not(target_os = "macos"))]
         let menu = Menu::with_items(app, &[&help_submenu]).expect("failed to create menu");

--- a/crates/gui/src/update.rs
+++ b/crates/gui/src/update.rs
@@ -1,0 +1,26 @@
+// Auto-update: check GitHub releases, download, and install.
+
+pub(crate) mod check;
+mod download;
+mod error;
+mod install;
+mod periodic;
+
+pub use check::{check_for_update, UpdateInfo};
+pub use download::download_asset;
+pub use error::UpdateError;
+pub use install::run_installer;
+pub use periodic::start_update_checker;
+
+/// Tauri-managed state for update availability.
+pub struct UpdateState {
+    pub tx: tokio::sync::watch::Sender<Option<UpdateInfo>>,
+    pub rx: tokio::sync::watch::Receiver<Option<UpdateInfo>>,
+}
+
+impl Default for UpdateState {
+    fn default() -> Self {
+        let (tx, rx) = tokio::sync::watch::channel(None);
+        Self { tx, rx }
+    }
+}

--- a/crates/gui/src/update/check.rs
+++ b/crates/gui/src/update/check.rs
@@ -1,0 +1,200 @@
+// GitHub release update checking.
+//
+// Uses a two-step tag-then-release approach:
+// 1. Fetch all tags (lightweight), filter to valid semver, sort descending.
+// 2. For each candidate tag, fetch the specific release. First qualifying one wins.
+
+use hole_common::version::ReleaseVersion;
+use serde::Deserialize;
+
+use super::error::UpdateError;
+
+// GitHub API types =====
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GitHubTag {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GitHubRelease {
+    pub tag_name: String,
+    pub draft: bool,
+    pub prerelease: bool,
+    pub body: Option<String>,
+    pub html_url: String,
+    pub assets: Vec<GitHubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GitHubAsset {
+    pub name: String,
+    pub browser_download_url: String,
+}
+
+// Platform asset suffix =====
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+const ASSET_SUFFIX: &str = "windows-amd64.msi";
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const ASSET_SUFFIX: &str = "darwin-arm64.dmg";
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const ASSET_SUFFIX: &str = "darwin-amd64.dmg";
+
+#[cfg(not(any(
+    all(target_os = "windows", target_arch = "x86_64"),
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "macos", target_arch = "x86_64"),
+)))]
+compile_error!("unsupported platform for auto-update asset matching");
+
+// Public API =====
+
+/// Information about an available update.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub version: ReleaseVersion,
+    pub asset_url: String,
+    pub asset_name: String,
+    pub release_notes: Option<String>,
+    pub html_url: String,
+}
+
+const REPO: &str = "bindreams/hole";
+
+/// Check GitHub for an available update.
+///
+/// This is a blocking function — call from `spawn_blocking`.
+pub fn check_for_update() -> Result<Option<UpdateInfo>, UpdateError> {
+    let (current, is_snapshot) = ReleaseVersion::from_build_version(crate::version::VERSION)
+        .map_err(|e| UpdateError::Io(std::io::Error::other(format!("failed to parse current version: {e}"))))?;
+
+    // Step 1: Fetch all tags, filter to candidates.
+    let all_tags = fetch_all_tags()?;
+    let candidates = candidate_tags(&all_tags, &current, is_snapshot);
+
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    // Step 2: For each candidate (highest first), try to fetch a qualifying release.
+    for (_, tag_name) in &candidates {
+        match fetch_release_for_tag(tag_name)? {
+            Some(release) => {
+                if let Some(info) = release_qualifies(&release) {
+                    return Ok(Some(info));
+                }
+            }
+            None => continue,
+        }
+    }
+
+    Ok(None)
+}
+
+// Internal helpers =====
+
+/// Fetch all tags from GitHub, transparently paginating.
+fn fetch_all_tags() -> Result<Vec<GitHubTag>, UpdateError> {
+    let mut tags = Vec::new();
+    let mut url = format!("https://api.github.com/repos/{REPO}/tags?per_page=100");
+
+    loop {
+        let mut response = ureq::get(&url).header("Accept", "application/vnd.github+json").call()?;
+
+        let next_url = response
+            .headers()
+            .get("link")
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_next_link);
+
+        let page: Vec<GitHubTag> = response.body_mut().read_json()?;
+        tags.extend(page);
+
+        match next_url {
+            Some(next) => url = next,
+            None => break,
+        }
+    }
+
+    Ok(tags)
+}
+
+/// Fetch the release associated with a specific tag. Returns `None` if no release exists (404).
+fn fetch_release_for_tag(tag_name: &str) -> Result<Option<GitHubRelease>, UpdateError> {
+    let url = format!("https://api.github.com/repos/{REPO}/releases/tags/{tag_name}");
+
+    match ureq::get(&url).header("Accept", "application/vnd.github+json").call() {
+        Ok(mut response) => {
+            let release: GitHubRelease = response.body_mut().read_json()?;
+            Ok(Some(release))
+        }
+        Err(ureq::Error::StatusCode(404)) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Filter and sort tags into candidate versions, highest first.
+///
+/// A tag is a candidate if:
+/// - It parses as a valid strict semver (`vMAJOR.MINOR.PATCH`).
+/// - Its version is greater than `current`, or equal to `current` when `is_snapshot` is true.
+pub(crate) fn candidate_tags(
+    tags: &[GitHubTag],
+    current: &ReleaseVersion,
+    is_snapshot: bool,
+) -> Vec<(ReleaseVersion, String)> {
+    let mut candidates: Vec<(ReleaseVersion, String)> = tags
+        .iter()
+        .filter_map(|t| {
+            let ver = ReleaseVersion::parse(&t.name).ok()?;
+            let dominated = if is_snapshot { ver >= *current } else { ver > *current };
+            dominated.then(|| (ver, t.name.clone()))
+        })
+        .collect();
+
+    // Sort descending by version (highest first).
+    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    candidates
+}
+
+/// Check if a release qualifies as an update: not draft, not prerelease, has a matching platform asset.
+pub(crate) fn release_qualifies(release: &GitHubRelease) -> Option<UpdateInfo> {
+    if release.draft || release.prerelease {
+        return None;
+    }
+
+    let asset = release.assets.iter().find(|a| a.name.ends_with(ASSET_SUFFIX))?;
+
+    let version = ReleaseVersion::parse(&release.tag_name).ok()?;
+
+    Some(UpdateInfo {
+        version,
+        asset_url: asset.browser_download_url.clone(),
+        asset_name: asset.name.clone(),
+        release_notes: release.body.clone(),
+        html_url: release.html_url.clone(),
+    })
+}
+
+/// Parse the `Link` response header to extract the URL for the next page.
+///
+/// GitHub uses the standard format: `<URL>; rel="next", <URL>; rel="last"`.
+pub(crate) fn parse_next_link(header: &str) -> Option<String> {
+    for part in header.split(',') {
+        let part = part.trim();
+        if part.ends_with("rel=\"next\"") {
+            // Extract URL between < and >
+            let start = part.find('<')? + 1;
+            let end = part.find('>')?;
+            return Some(part[start..end].to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "check_tests.rs"]
+mod check_tests;

--- a/crates/gui/src/update/check_tests.rs
+++ b/crates/gui/src/update/check_tests.rs
@@ -1,0 +1,149 @@
+use super::*;
+use hole_common::version::ReleaseVersion;
+
+/// Asset name that matches the current platform's ASSET_SUFFIX.
+fn platform_asset_name(version: &str) -> String {
+    format!("hole-{version}-{ASSET_SUFFIX}")
+}
+
+fn tag(name: &str) -> GitHubTag {
+    GitHubTag { name: name.to_string() }
+}
+
+fn asset(name: &str, url: &str) -> GitHubAsset {
+    GitHubAsset {
+        name: name.to_string(),
+        browser_download_url: url.to_string(),
+    }
+}
+
+fn release(tag: &str, draft: bool, prerelease: bool, assets: Vec<GitHubAsset>) -> GitHubRelease {
+    GitHubRelease {
+        tag_name: tag.to_string(),
+        draft,
+        prerelease,
+        body: Some("Release notes".to_string()),
+        html_url: format!("https://github.com/test/repo/releases/tag/{tag}"),
+        assets,
+    }
+}
+
+// candidate_tags =====
+
+#[skuld::test]
+fn candidate_tags_filters_non_semver() {
+    let tags = vec![tag("v1.0.0"), tag("nightly"), tag("v2.0.0"), tag("bad")];
+    let current = ReleaseVersion::parse("0.9.0").unwrap();
+    let result = candidate_tags(&tags, &current, false);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].0, ReleaseVersion::parse("2.0.0").unwrap());
+    assert_eq!(result[1].0, ReleaseVersion::parse("1.0.0").unwrap());
+}
+
+#[skuld::test]
+fn candidate_tags_sorts_descending() {
+    let tags = vec![tag("v1.0.0"), tag("v3.0.0"), tag("v2.0.0")];
+    let current = ReleaseVersion::parse("0.1.0").unwrap();
+    let result = candidate_tags(&tags, &current, false);
+    assert_eq!(result[0].0, ReleaseVersion::parse("3.0.0").unwrap());
+    assert_eq!(result[1].0, ReleaseVersion::parse("2.0.0").unwrap());
+    assert_eq!(result[2].0, ReleaseVersion::parse("1.0.0").unwrap());
+}
+
+#[skuld::test]
+fn candidate_tags_excludes_older_and_equal() {
+    let tags = vec![tag("v1.0.0"), tag("v2.0.0"), tag("v3.0.0")];
+    let current = ReleaseVersion::parse("2.0.0").unwrap();
+    let result = candidate_tags(&tags, &current, false);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, ReleaseVersion::parse("3.0.0").unwrap());
+}
+
+#[skuld::test]
+fn candidate_tags_includes_equal_when_snapshot() {
+    let tags = vec![tag("v1.0.0"), tag("v2.0.0")];
+    let current = ReleaseVersion::parse("2.0.0").unwrap();
+    let result = candidate_tags(&tags, &current, true);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, ReleaseVersion::parse("2.0.0").unwrap());
+}
+
+#[skuld::test]
+fn candidate_tags_empty_when_no_newer() {
+    let tags = vec![tag("v1.0.0"), tag("v0.5.0")];
+    let current = ReleaseVersion::parse("1.0.0").unwrap();
+    let result = candidate_tags(&tags, &current, false);
+    assert!(result.is_empty());
+}
+
+// release_qualifies =====
+
+#[skuld::test]
+fn release_qualifies_valid() {
+    let name = platform_asset_name("1.0.0");
+    let r = release(
+        "v1.0.0",
+        false,
+        false,
+        vec![asset(&name, "https://example.com/hole-asset")],
+    );
+    let info = release_qualifies(&r).unwrap();
+    assert_eq!(info.version, ReleaseVersion::parse("1.0.0").unwrap());
+    assert_eq!(info.asset_url, "https://example.com/hole-asset");
+    assert_eq!(info.asset_name, name);
+}
+
+#[skuld::test]
+fn release_qualifies_draft_returns_none() {
+    let name = platform_asset_name("1.0.0");
+    let r = release("v1.0.0", true, false, vec![asset(&name, "https://example.com/hole")]);
+    assert!(release_qualifies(&r).is_none());
+}
+
+#[skuld::test]
+fn release_qualifies_prerelease_returns_none() {
+    let name = platform_asset_name("1.0.0");
+    let r = release("v1.0.0", false, true, vec![asset(&name, "https://example.com/hole")]);
+    assert!(release_qualifies(&r).is_none());
+}
+
+#[skuld::test]
+fn release_qualifies_no_matching_asset_returns_none() {
+    // Use an asset name that will never match any platform's ASSET_SUFFIX.
+    let r = release(
+        "v1.0.0",
+        false,
+        false,
+        vec![asset(
+            "hole-1.0.0-linux-amd64.tar.gz",
+            "https://example.com/hole.tar.gz",
+        )],
+    );
+    assert!(release_qualifies(&r).is_none());
+}
+
+#[skuld::test]
+fn release_qualifies_no_assets_returns_none() {
+    let r = release("v1.0.0", false, false, vec![]);
+    assert!(release_qualifies(&r).is_none());
+}
+
+// parse_next_link =====
+
+#[skuld::test]
+fn parse_next_link_standard() {
+    let header = r#"<https://api.github.com/repos/test/tags?page=2>; rel="next", <https://api.github.com/repos/test/tags?page=5>; rel="last""#;
+    let next = parse_next_link(header).unwrap();
+    assert_eq!(next, "https://api.github.com/repos/test/tags?page=2");
+}
+
+#[skuld::test]
+fn parse_next_link_only_prev() {
+    let header = r#"<https://api.github.com/repos/test/tags?page=1>; rel="prev""#;
+    assert!(parse_next_link(header).is_none());
+}
+
+#[skuld::test]
+fn parse_next_link_empty() {
+    assert!(parse_next_link("").is_none());
+}

--- a/crates/gui/src/update/download.rs
+++ b/crates/gui/src/update/download.rs
@@ -1,0 +1,35 @@
+// Asset download with atomic rename.
+
+use std::path::{Path, PathBuf};
+
+use super::error::UpdateError;
+
+/// Download an asset from a URL to `dest`, using an intermediate `.part` file.
+///
+/// Any existing `.part` file from a prior failed attempt is overwritten.
+/// This is a blocking function — call from `spawn_blocking`.
+pub fn download_asset(url: &str, dest: &Path) -> Result<(), UpdateError> {
+    let part = part_file_path(dest);
+
+    // Stream to .part file.
+    let response = ureq::get(url).call()?;
+    let mut body = response.into_body().into_reader();
+    let mut file = std::fs::File::create(&part)?;
+    std::io::copy(&mut body, &mut file)?;
+    drop(file);
+
+    // Atomic-ish rename to final destination.
+    std::fs::rename(&part, dest)?;
+    Ok(())
+}
+
+/// Compute the `.part` file path for a given destination.
+pub(crate) fn part_file_path(dest: &Path) -> PathBuf {
+    let mut name = dest.as_os_str().to_owned();
+    name.push(".part");
+    PathBuf::from(name)
+}
+
+#[cfg(test)]
+#[path = "download_tests.rs"]
+mod download_tests;

--- a/crates/gui/src/update/download_tests.rs
+++ b/crates/gui/src/update/download_tests.rs
@@ -1,0 +1,10 @@
+use std::path::Path;
+
+use super::*;
+
+#[skuld::test]
+fn part_path_appends_suffix() {
+    let dest = Path::new("/tmp/hole-update/hole.msi");
+    let part = part_file_path(dest);
+    assert_eq!(part, Path::new("/tmp/hole-update/hole.msi.part"));
+}

--- a/crates/gui/src/update/error.rs
+++ b/crates/gui/src/update/error.rs
@@ -1,0 +1,21 @@
+// Update error types.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    #[error("HTTP request failed: {0}")]
+    Http(Box<ureq::Error>),
+    #[error("failed to parse response: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("installer failed with exit code {0}")]
+    InstallerFailed(i32),
+}
+
+impl From<ureq::Error> for UpdateError {
+    fn from(e: ureq::Error) -> Self {
+        Self::Http(Box::new(e))
+    }
+}

--- a/crates/gui/src/update/install.rs
+++ b/crates/gui/src/update/install.rs
@@ -1,0 +1,113 @@
+// Platform-specific installer execution.
+
+use std::path::Path;
+
+use super::error::UpdateError;
+
+// Windows =====
+
+#[cfg(target_os = "windows")]
+pub fn run_installer(path: &Path, quiet: bool) -> Result<(), UpdateError> {
+    let args = msiexec_args(path, quiet);
+    let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    if quiet {
+        // Quiet mode skips UAC, so we must elevate explicitly.
+        let status = crate::setup::run_elevated(Path::new("msiexec"), &args_ref)
+            .map_err(|e| UpdateError::Io(std::io::Error::other(e.to_string())))?;
+        if !status.success() {
+            return Err(UpdateError::InstallerFailed(status.code().unwrap_or(-1)));
+        }
+    } else {
+        // Interactive mode: msiexec shows its own UAC prompt.
+        let status = std::process::Command::new("msiexec").args(&args_ref).status()?;
+        if !status.success() {
+            return Err(UpdateError::InstallerFailed(status.code().unwrap_or(-1)));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn msiexec_args(path: &Path, quiet: bool) -> Vec<String> {
+    let path_str = path.to_string_lossy().to_string();
+    let mut args = vec!["/i".to_string(), path_str.clone()];
+
+    if quiet {
+        args.push("/quiet".to_string());
+        args.push("/norestart".to_string());
+        // Log file for diagnostics next to the MSI.
+        let log_path = format!("{path_str}.log");
+        args.push(format!("/L*v{log_path}"));
+    }
+
+    args
+}
+
+// macOS =====
+
+#[cfg(target_os = "macos")]
+pub fn run_installer(path: &Path, _quiet: bool) -> Result<(), UpdateError> {
+    let mount_dir = std::env::temp_dir().join("hole-dmg-mount");
+    std::fs::create_dir_all(&mount_dir)?;
+
+    // Mount the DMG
+    let attach_args = hdiutil_attach_args(path, &mount_dir);
+    let attach_args_ref: Vec<&str> = attach_args.iter().map(|s| s.as_str()).collect();
+    let status = std::process::Command::new("hdiutil").args(&attach_args_ref).status()?;
+    if !status.success() {
+        return Err(UpdateError::InstallerFailed(status.code().unwrap_or(-1)));
+    }
+
+    // Find the .app bundle inside the mount
+    let app_entry = std::fs::read_dir(&mount_dir)?
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().extension().is_some_and(|ext| ext == "app"));
+
+    let Some(app_entry) = app_entry else {
+        // Unmount before returning error
+        let _ = std::process::Command::new("hdiutil")
+            .args(["detach", &mount_dir.to_string_lossy()])
+            .status();
+        return Err(UpdateError::Io(std::io::Error::other("no .app bundle found in DMG")));
+    };
+
+    let app_src = app_entry.path();
+    let app_name = app_src.file_name().unwrap().to_string_lossy().to_string();
+    let app_dest = format!("/Applications/{app_name}");
+
+    // Copy to /Applications via elevated cp
+    let cp_path = Path::new("/bin/cp");
+    let src_str = app_src.to_string_lossy().to_string();
+    let cp_args = ["-R", &src_str, &app_dest];
+    let result = crate::setup::run_elevated(cp_path, &cp_args);
+
+    // Always unmount
+    let _ = std::process::Command::new("hdiutil")
+        .args(["detach", &mount_dir.to_string_lossy()])
+        .status();
+
+    let status = result.map_err(|e| UpdateError::Io(std::io::Error::other(e.to_string())))?;
+    if !status.success() {
+        return Err(UpdateError::InstallerFailed(status.code().unwrap_or(-1)));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn hdiutil_attach_args(dmg: &Path, mountpoint: &Path) -> Vec<String> {
+    vec![
+        "attach".to_string(),
+        "-nobrowse".to_string(),
+        "-quiet".to_string(),
+        "-mountpoint".to_string(),
+        mountpoint.to_string_lossy().to_string(),
+        dmg.to_string_lossy().to_string(),
+    ]
+}
+
+#[cfg(test)]
+#[path = "install_tests.rs"]
+mod install_tests;

--- a/crates/gui/src/update/install_tests.rs
+++ b/crates/gui/src/update/install_tests.rs
@@ -1,0 +1,42 @@
+use std::path::Path;
+
+use super::*;
+
+// Windows msiexec arg construction =====
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn msiexec_args_quiet() {
+    let path = Path::new(r"C:\tmp\hole.msi");
+    let args = msiexec_args(path, true);
+    assert_eq!(args[0], "/i");
+    assert_eq!(args[1], r"C:\tmp\hole.msi");
+    assert!(args.contains(&"/quiet".to_string()));
+    assert!(args.contains(&"/norestart".to_string()));
+    // Should have a log flag
+    assert!(args.iter().any(|a| a.starts_with("/L*v")));
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn msiexec_args_interactive() {
+    let path = Path::new(r"C:\tmp\hole.msi");
+    let args = msiexec_args(path, false);
+    assert_eq!(args[0], "/i");
+    assert_eq!(args[1], r"C:\tmp\hole.msi");
+    assert!(!args.contains(&"/quiet".to_string()));
+}
+
+// macOS hdiutil arg construction =====
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn hdiutil_attach_args_correct() {
+    let dmg = Path::new("/tmp/hole.dmg");
+    let mount = Path::new("/tmp/hole-mount");
+    let args = hdiutil_attach_args(dmg, mount);
+    assert!(args.contains(&"attach".to_string()));
+    assert!(args.contains(&"-nobrowse".to_string()));
+    assert!(args.contains(&"-quiet".to_string()));
+    assert!(args.contains(&"-mountpoint".to_string()));
+}

--- a/crates/gui/src/update/periodic.rs
+++ b/crates/gui/src/update/periodic.rs
@@ -1,0 +1,48 @@
+// Periodic background update checker.
+
+use tauri::{AppHandle, Manager};
+use tracing::{debug, info, warn};
+
+use super::check::check_for_update;
+use super::UpdateState;
+
+/// Start the periodic update checker.
+///
+/// Checks immediately on launch, then every 24 hours. Once an update is found,
+/// publishes it to `UpdateState` and calls `on_update_found`, then stops.
+pub fn start_update_checker(app: AppHandle, on_update_found: impl Fn(&AppHandle, &super::UpdateInfo) + Send + 'static) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let result = tokio::task::spawn_blocking(check_for_update).await;
+
+            match result {
+                Ok(Ok(Some(update_info))) => {
+                    info!(version = %update_info.version, "update available");
+
+                    // Publish to state.
+                    let state = app.state::<UpdateState>();
+                    state.tx.send_replace(Some(update_info.clone()));
+
+                    // Notify caller (e.g. to rebuild tray menu).
+                    on_update_found(&app, &update_info);
+                    return; // Stop checking — user can act on this update.
+                }
+                Ok(Ok(None)) => {
+                    debug!("no update available");
+                }
+                Ok(Err(e)) => {
+                    warn!(error = %e, "update check failed");
+                }
+                Err(e) => {
+                    warn!(error = %e, "update check task panicked");
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(24 * 60 * 60)).await;
+        }
+    });
+}
+
+#[cfg(test)]
+#[path = "periodic_tests.rs"]
+mod periodic_tests;

--- a/crates/gui/src/update/periodic_tests.rs
+++ b/crates/gui/src/update/periodic_tests.rs
@@ -1,0 +1,1 @@
+// Periodic checker is thin plumbing — core logic tested in check_tests.rs.


### PR DESCRIPTION
## Summary

Closes #13.

- **CLI**: `hole upgrade` subcommand — checks GitHub for latest release, downloads platform asset, runs installer unattended (MSI `/quiet` on Windows, DMG mount+copy on macOS)
- **GUI**: "Check for Updates..." in Help menu, auto-check on launch + every 24h, "Install Update (v{x.y.z})" tray menu item when available
- **Semver dedup**: Added `semver` crate and shared `ReleaseVersion` type in `hole-common`, refactored `build.rs` manual parsing

### Update check strategy
1. Fetch tags from GitHub (lightweight, paginating)
2. Filter to valid semver, sort descending
3. For each candidate, query the specific release
4. First qualifying release (not draft, not prerelease, has platform asset) wins

### New dependencies
- `semver = "1"` (hole-common + hole-gui build-dep)
- `ureq = "3"` with `json` feature (hole-gui runtime)

## Test plan
- [x] `cargo test --workspace` — 130 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI passes on this PR
- [ ] Manual test: `hole upgrade` against a GitHub release
- [ ] Manual test: GUI tray update notification