### PR TITLE
Secure daemon IPC channel with OS-level access controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ hole daemon status                → print install/running status
 hole daemon log                   → print daemon log to stdout
 hole daemon log path              → print log file path
 hole daemon log watch [--tail N]  → stream log output
+hole daemon grant-access [--then-send B64] → add current user to hole group (needs elevation)
+hole daemon ipc-send --base64 B64          → proxy a single IPC command (needs elevation)
 hole upgrade                      → check for updates and install latest version (unattended)
 hole path add                     → add hole to system PATH
 hole path remove                  → remove hole from system PATH

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "default-net",
  "hole-common",
  "interprocess",
+ "libc",
  "serde",
  "serde_json",
  "shadowsocks",
@@ -2093,6 +2094,8 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "widestring",
+ "windows 0.61.3",
  "windows-service",
 ]
 
@@ -2100,6 +2103,7 @@ dependencies = [
 name = "hole-gui"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "clap",
  "dirs 6.0.0",
  "hole-common",

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Shadowsocks GUI with transparent proxy (TUN), system tray, and v2ray-plugin supp
 
 Single-binary design — `hole` serves as both the Tauri GUI and the privileged daemon depending on CLI arguments:
 
-| Mode | Privilege | Role |
-|---|---|---|
-| `hole` (no args) | User | Tauri GUI — system tray, settings window, config management |
-| `hole daemon run` | Root / SYSTEM | Privileged helper — TUN, routing, shadowsocks-service |
+| Mode              | Privilege     | Role                                                        |
+| ----------------- | ------------- | ----------------------------------------------------------- |
+| `hole` (no args)  | User          | Tauri GUI — system tray, settings window, config management |
+| `hole daemon run` | Root / SYSTEM | Privileged helper — TUN, routing, shadowsocks-service       |
 
 Communication happens over IPC (Unix socket on macOS, named pipe on Windows) using length-prefixed JSON.
 

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -17,7 +17,7 @@ pub enum ProtocolError {
 
 // Types =====
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum DaemonRequest {
     Start { config: ProxyConfig },
     Stop,
@@ -47,8 +47,31 @@ pub struct ProxyConfig {
 
 // Constants =====
 
-/// Default socket name for the daemon IPC channel.
+/// macOS: filesystem socket path (like Docker's /var/run/docker.sock).
+#[cfg(target_os = "macos")]
+pub const DAEMON_SOCKET_PATH: &str = "/var/run/hole-daemon.sock";
+
+/// Windows: namespaced pipe name for the daemon IPC channel.
+#[cfg(target_os = "windows")]
 pub const DAEMON_SOCKET_NAME: &str = "hole-daemon";
+
+/// Actionable instructions shown when a client is denied access to the daemon.
+/// Both platform instructions are always printed regardless of the current OS.
+pub const PERMISSION_DENIED_HELP: &str = "\
+error: permission denied — you are not authorized to control the Hole daemon.
+
+How to fix:
+
+  macOS:
+    sudo dseditgroup -o edit -a $(whoami) -t user hole
+    Then log out and back in for the change to take effect.
+    Or prefix your command with: sudo
+
+  Windows:
+    net localgroup hole %USERNAME% /add
+    Then log out and back in for the change to take effect.
+    Or run your terminal as Administrator.
+";
 
 // Wire format =====
 

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -22,8 +22,18 @@ thiserror = "2"
 default-net = "0.22"
 tokio-util = "0.7"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-service = "0.7"
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_RemoteDesktop",
+] }
+widestring = "1"
 
 [dev-dependencies]
 skuld = { git = "https://github.com/bindreams/skuld" }

--- a/crates/daemon/src/group.rs
+++ b/crates/daemon/src/group.rs
@@ -1,0 +1,323 @@
+// OS group management for IPC access control.
+//
+// Creates and manages a local "hole" group that gates access to the daemon's
+// IPC socket/pipe. Members of this group (plus root/Administrators) can
+// communicate with the daemon.
+
+use std::io;
+
+pub const GROUP_NAME: &str = "hole";
+
+/// Create the `hole` group. Idempotent — succeeds if the group already exists.
+pub fn create_group() -> io::Result<()> {
+    os::create_group()
+}
+
+/// Delete the `hole` group. Idempotent — succeeds if the group doesn't exist.
+pub fn delete_group() -> io::Result<()> {
+    os::delete_group()
+}
+
+/// Add a user to the `hole` group.
+pub fn add_user_to_group(username: &str) -> io::Result<()> {
+    os::add_user_to_group(username)
+}
+
+/// Detect the real interactive user behind an elevated session.
+///
+/// On macOS: reads `SUDO_USER`, then `stat -f %Su /dev/console`, then `logname`.
+/// On Windows: queries the physical console session via WTS APIs.
+///
+/// Returns `Err` if the user cannot be determined (e.g. headless install).
+pub fn installing_username() -> io::Result<String> {
+    os::installing_username()
+}
+
+/// Look up the SID of the `hole` group as a string (e.g. `S-1-5-21-...`).
+#[cfg(target_os = "windows")]
+pub fn group_sid() -> io::Result<String> {
+    os::group_sid()
+}
+
+// macOS implementation =====
+
+#[cfg(target_os = "macos")]
+mod os {
+    use std::io;
+    use std::process::Command;
+
+    use super::GROUP_NAME;
+
+    pub fn create_group() -> io::Result<()> {
+        let output = Command::new("dseditgroup")
+            .args(["-o", "create", GROUP_NAME])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // "already exists" is not an error for our purposes
+        if stderr.contains("already exists") {
+            return Ok(());
+        }
+
+        Err(io::Error::other(format!(
+            "dseditgroup create failed: {}",
+            stderr.trim()
+        )))
+    }
+
+    pub fn delete_group() -> io::Result<()> {
+        let output = Command::new("dseditgroup")
+            .args(["-o", "delete", GROUP_NAME])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Group not found is not an error for deletion
+        if stderr.contains("not found") {
+            return Ok(());
+        }
+
+        Err(io::Error::other(format!(
+            "dseditgroup delete failed: {}",
+            stderr.trim()
+        )))
+    }
+
+    pub fn add_user_to_group(username: &str) -> io::Result<()> {
+        let output = Command::new("dseditgroup")
+            .args(["-o", "edit", "-a", username, "-t", "user", GROUP_NAME])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(io::Error::other(format!(
+            "dseditgroup add user failed: {}",
+            stderr.trim()
+        )))
+    }
+
+    pub fn installing_username() -> io::Result<String> {
+        // 1. Check SUDO_USER (set by sudo and osascript elevation)
+        if let Ok(user) = std::env::var("SUDO_USER") {
+            if !user.is_empty() && user != "root" {
+                return Ok(user);
+            }
+        }
+
+        // 2. stat /dev/console to find the GUI login user
+        let output = Command::new("stat").args(["-f", "%Su", "/dev/console"]).output()?;
+        if output.status.success() {
+            let user = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !user.is_empty() && user != "root" {
+                return Ok(user);
+            }
+        }
+
+        // 3. logname as last resort
+        let output = Command::new("logname").output()?;
+        if output.status.success() {
+            let user = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !user.is_empty() && user != "root" {
+                return Ok(user);
+            }
+        }
+
+        Err(io::Error::other("could not determine the installing user"))
+    }
+}
+
+// Windows implementation =====
+
+#[cfg(target_os = "windows")]
+mod os {
+    use std::io;
+    use std::process::Command;
+
+    use super::GROUP_NAME;
+
+    pub fn create_group() -> io::Result<()> {
+        let output = Command::new("net")
+            .args(["localgroup", GROUP_NAME, "/add", "/comment:Hole daemon access"])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Error code 1379 = "The specified local group already exists."
+        if stderr.contains("1379") || stderr.contains("already exists") {
+            return Ok(());
+        }
+
+        Err(io::Error::other(format!(
+            "net localgroup add failed: {}",
+            stderr.trim()
+        )))
+    }
+
+    pub fn delete_group() -> io::Result<()> {
+        let output = Command::new("net")
+            .args(["localgroup", GROUP_NAME, "/delete"])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Error code 1376 = "The specified local group does not exist."
+        if stderr.contains("1376") || stderr.contains("does not exist") {
+            return Ok(());
+        }
+
+        Err(io::Error::other(format!(
+            "net localgroup delete failed: {}",
+            stderr.trim()
+        )))
+    }
+
+    pub fn add_user_to_group(username: &str) -> io::Result<()> {
+        let output = Command::new("net")
+            .args(["localgroup", GROUP_NAME, username, "/add"])
+            .output()?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Error code 1378 = "The specified account name is already a member of the group."
+        if stderr.contains("1378") || stderr.contains("already a member") {
+            return Ok(());
+        }
+
+        Err(io::Error::other(format!(
+            "net localgroup add user failed: {}",
+            stderr.trim()
+        )))
+    }
+
+    pub fn installing_username() -> io::Result<String> {
+        use windows::core::PWSTR;
+        use windows::Win32::System::RemoteDesktop::{
+            WTSFreeMemory, WTSGetActiveConsoleSessionId, WTSQuerySessionInformationW, WTSUserName,
+        };
+
+        let session_id = unsafe { WTSGetActiveConsoleSessionId() };
+        if session_id == 0xFFFFFFFF {
+            return Err(io::Error::other(
+                "no physical console session found (headless/RDP install)",
+            ));
+        }
+
+        let mut buffer = PWSTR::null();
+        let mut bytes_returned: u32 = 0;
+
+        unsafe {
+            WTSQuerySessionInformationW(
+                None, // local server
+                session_id,
+                WTSUserName,
+                &mut buffer as *mut PWSTR as *mut _,
+                &mut bytes_returned,
+            )
+        }
+        .map_err(|e| io::Error::other(format!("WTSQuerySessionInformationW failed: {e}")))?;
+
+        let username = unsafe {
+            let len = (bytes_returned as usize) / 2;
+            let slice = std::slice::from_raw_parts(buffer.0, len);
+            // Trim trailing null
+            let end = slice.iter().position(|&c| c == 0).unwrap_or(len);
+            String::from_utf16_lossy(&slice[..end])
+        };
+
+        unsafe {
+            WTSFreeMemory(buffer.0 as *mut _);
+        }
+
+        if username.is_empty() {
+            return Err(io::Error::other("console session has no user"));
+        }
+
+        Ok(username)
+    }
+
+    pub fn group_sid() -> io::Result<String> {
+        use windows::core::PWSTR;
+        use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
+        use windows::Win32::Security::{LookupAccountNameW, SID_NAME_USE};
+
+        let group_name: Vec<u16> = GROUP_NAME.encode_utf16().chain(std::iter::once(0)).collect();
+
+        // First call: get required buffer sizes
+        let mut sid_size: u32 = 0;
+        let mut domain_size: u32 = 0;
+        let mut sid_type = SID_NAME_USE::default();
+
+        let _ = unsafe {
+            LookupAccountNameW(
+                None,
+                windows::core::PCWSTR(group_name.as_ptr()),
+                None,
+                &mut sid_size,
+                None,
+                &mut domain_size,
+                &mut sid_type,
+            )
+        };
+
+        if sid_size == 0 {
+            return Err(io::Error::other(format!("group '{}' not found", GROUP_NAME)));
+        }
+
+        // Second call: fill buffers
+        let mut sid_buf = vec![0u8; sid_size as usize];
+        let mut domain_buf = vec![0u16; domain_size as usize];
+        let sid_ptr = windows::Win32::Security::PSID(sid_buf.as_mut_ptr() as *mut _);
+
+        unsafe {
+            LookupAccountNameW(
+                None,
+                windows::core::PCWSTR(group_name.as_ptr()),
+                Some(sid_ptr),
+                &mut sid_size,
+                Some(PWSTR(domain_buf.as_mut_ptr())),
+                &mut domain_size,
+                &mut sid_type,
+            )
+        }
+        .map_err(|e| io::Error::other(format!("LookupAccountNameW failed: {e}")))?;
+
+        // Convert SID to string
+        let mut string_sid = PWSTR::null();
+        unsafe { ConvertSidToStringSidW(sid_ptr, &mut string_sid) }
+            .map_err(|e| io::Error::other(format!("ConvertSidToStringSidW failed: {e}")))?;
+
+        let sid_string = unsafe {
+            let len = (0..).take_while(|&i| *string_sid.0.add(i) != 0).count();
+            String::from_utf16_lossy(std::slice::from_raw_parts(string_sid.0, len))
+        };
+
+        unsafe {
+            windows::Win32::Foundation::LocalFree(Some(windows::Win32::Foundation::HLOCAL(string_sid.0 as *mut _)));
+        }
+
+        Ok(sid_string)
+    }
+}
+
+#[cfg(test)]
+#[path = "group_tests.rs"]
+mod group_tests;

--- a/crates/daemon/src/group_tests.rs
+++ b/crates/daemon/src/group_tests.rs
@@ -1,0 +1,24 @@
+// Windows-specific tests =====
+
+#[cfg(target_os = "windows")]
+mod windows {
+    #[skuld::test]
+    fn group_sid_format() {
+        // group_sid() should return a SID string starting with S-1-
+        // This test will only pass if the group actually exists,
+        // so we test the error path instead.
+        let result = crate::group::group_sid();
+        // On CI / dev machines, the group likely doesn't exist.
+        // Just verify the function doesn't panic and returns a reasonable error.
+        if let Ok(sid) = result {
+            assert!(sid.starts_with("S-1-"), "SID should start with S-1-, got: {sid}");
+        }
+    }
+}
+
+// Cross-platform tests =====
+
+#[skuld::test]
+fn group_name_is_hole() {
+    assert_eq!(crate::group::GROUP_NAME, "hole");
+}

--- a/crates/daemon/src/ipc.rs
+++ b/crates/daemon/src/ipc.rs
@@ -5,7 +5,7 @@ use hole_common::protocol::{DaemonRequest, DaemonResponse};
 use interprocess::local_socket::{
     tokio::{Listener, Stream},
     traits::tokio::Listener as ListenerTrait,
-    GenericNamespaced, ListenerOptions, ToNsName,
+    ListenerOptions,
 };
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -16,8 +16,11 @@ use tracing::{debug, error, info, warn};
 
 const MAX_MESSAGE_SIZE: u32 = 1024 * 1024; // 1 MiB
 
-/// Re-export for convenience.
+/// Re-export: socket name (Windows) or path (macOS).
+#[cfg(target_os = "windows")]
 pub use hole_common::protocol::DAEMON_SOCKET_NAME as SOCKET_NAME;
+#[cfg(target_os = "macos")]
+pub use hole_common::protocol::DAEMON_SOCKET_PATH as SOCKET_PATH;
 
 // Server =====
 
@@ -27,12 +30,44 @@ pub struct IpcServer<B: ProxyBackend> {
 }
 
 impl<B: ProxyBackend + 'static> IpcServer<B> {
-    /// Bind to the given socket name (namespaced).
+    /// Bind to the IPC socket/pipe.
+    ///
+    /// On macOS: filesystem Unix domain socket at `path`.
+    /// On Windows: namespaced named pipe with `name`.
+    #[cfg(target_os = "windows")]
     pub fn bind(name: &str, proxy: Arc<Mutex<ProxyManager<B>>>) -> std::io::Result<Self> {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+
         let ns_name = name
             .to_ns_name::<GenericNamespaced>()
             .map_err(|e| std::io::Error::other(e.to_string()))?;
-        let listener = ListenerOptions::new().name(ns_name).create_tokio()?;
+
+        let opts = ListenerOptions::new().name(ns_name);
+        #[cfg(not(test))]
+        let opts = apply_security_descriptor(opts);
+        let listener = opts.create_tokio()?;
+
+        Ok(Self { listener, proxy })
+    }
+
+    /// Bind to the IPC socket.
+    ///
+    /// Uses a filesystem Unix domain socket. Removes stale socket file before binding.
+    #[cfg(target_os = "macos")]
+    pub fn bind(path: &str, proxy: Arc<Mutex<ProxyManager<B>>>) -> std::io::Result<Self> {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+
+        // Remove stale socket (standard practice, same as Docker)
+        let _ = std::fs::remove_file(path);
+
+        let fs_name = path
+            .to_fs_name::<GenericFilePath>()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        let listener = ListenerOptions::new().name(fs_name).create_tokio()?;
+
+        // Set socket ownership and permissions post-bind
+        #[cfg(not(test))]
+        apply_socket_permissions(path);
 
         Ok(Self { listener, proxy })
     }
@@ -185,6 +220,95 @@ async fn send_error(stream: &mut Stream, message: &str) -> std::io::Result<()> {
         },
     )
     .await
+}
+
+// Security =====
+
+/// Apply a Windows DACL to the named pipe, restricting access to SYSTEM,
+/// Administrators, and the `hole` group.
+#[cfg(all(target_os = "windows", not(test)))]
+fn apply_security_descriptor(opts: ListenerOptions<'_>) -> ListenerOptions<'_> {
+    use interprocess::os::windows::local_socket::ListenerOptionsExt;
+
+    let sddl = build_sddl();
+    match security_descriptor_from_sddl(&sddl) {
+        Ok(sd) => opts.security_descriptor(sd),
+        Err(e) => {
+            warn!("failed to set pipe security descriptor: {e}");
+            opts
+        }
+    }
+}
+
+/// Build the SDDL string for the named pipe DACL.
+#[cfg(all(target_os = "windows", not(test)))]
+fn build_sddl() -> String {
+    // Base: SYSTEM + Administrators
+    let base = "D:(A;;GA;;;SY)(A;;GA;;;BA)";
+
+    match crate::group::group_sid() {
+        Ok(sid) => {
+            info!(sid = %sid, "restricting IPC to SYSTEM + Administrators + hole group");
+            format!("{base}(A;;GA;;;{sid})")
+        }
+        Err(e) => {
+            warn!("'hole' group not found ({e}), IPC restricted to admin-only");
+            base.to_string()
+        }
+    }
+}
+
+/// Parse an SDDL string into a SecurityDescriptor.
+#[cfg(all(target_os = "windows", not(test)))]
+fn security_descriptor_from_sddl(
+    sddl: &str,
+) -> std::io::Result<interprocess::os::windows::security_descriptor::SecurityDescriptor> {
+    use interprocess::os::windows::security_descriptor::SecurityDescriptor;
+    use widestring::U16CString;
+
+    let wide = U16CString::from_str(sddl).map_err(|e| std::io::Error::other(format!("invalid SDDL string: {e}")))?;
+    SecurityDescriptor::deserialize(&wide)
+        .map_err(|e| std::io::Error::other(format!("failed to deserialize SDDL: {e}")))
+}
+
+/// Set socket file ownership to root:hole and mode 0660 on macOS.
+#[cfg(all(target_os = "macos", not(test)))]
+fn apply_socket_permissions(path: &str) {
+    use std::ffi::CString;
+
+    let c_path = match CString::new(path) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("invalid socket path for permissions: {e}");
+            return;
+        }
+    };
+
+    // Look up the 'hole' group GID
+    let group_name = CString::new(crate::group::GROUP_NAME).unwrap();
+    let grp = unsafe { libc::getgrnam(group_name.as_ptr()) };
+
+    if grp.is_null() {
+        warn!("'hole' group not found, restricting socket to root-only");
+        unsafe {
+            libc::chmod(c_path.as_ptr(), 0o600);
+        }
+        return;
+    }
+
+    let gid = unsafe { (*grp).gr_gid };
+    info!(gid = gid, "setting socket ownership to root:hole, mode 0660");
+
+    unsafe {
+        if libc::chown(c_path.as_ptr(), 0, gid) != 0 {
+            warn!("chown failed, falling back to root-only socket");
+            libc::chmod(c_path.as_ptr(), 0o600);
+            return;
+        }
+        if libc::chmod(c_path.as_ptr(), 0o660) != 0 {
+            warn!("chmod failed, socket may have incorrect permissions");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/ipc_tests.rs
+++ b/crates/daemon/src/ipc_tests.rs
@@ -3,7 +3,7 @@ use crate::proxy::ProxyError;
 use crate::proxy_manager::{ProxyBackend, ProxyManager};
 use hole_common::config::ServerEntry;
 use hole_common::protocol::{encode, DaemonRequest, DaemonResponse, ProxyConfig};
-use interprocess::local_socket::{traits::tokio::Stream as StreamTrait, GenericNamespaced, ToNsName};
+use interprocess::local_socket::traits::tokio::Stream as StreamTrait;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -87,9 +87,35 @@ fn sample_config() -> ProxyConfig {
     }
 }
 
+/// Connect to a test IPC server. On Windows uses namespaced pipes, on macOS uses filesystem sockets.
 async fn connect_to(name: &str) -> interprocess::local_socket::tokio::Stream {
-    let name = name.to_ns_name::<GenericNamespaced>().unwrap();
-    interprocess::local_socket::tokio::Stream::connect(name).await.unwrap()
+    #[cfg(target_os = "windows")]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        let ns_name = name.to_ns_name::<GenericNamespaced>().unwrap();
+        interprocess::local_socket::tokio::Stream::connect(ns_name)
+            .await
+            .unwrap()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        let fs_name = name.to_fs_name::<GenericFilePath>().unwrap();
+        interprocess::local_socket::tokio::Stream::connect(fs_name)
+            .await
+            .unwrap()
+    }
+}
+
+/// Generate a test socket name. On macOS, returns a temp file path.
+#[cfg(target_os = "windows")]
+fn test_socket_name(suffix: &str) -> String {
+    format!("hole-test-{suffix}")
+}
+
+#[cfg(target_os = "macos")]
+fn test_socket_name(suffix: &str) -> String {
+    format!("/tmp/hole-test-{suffix}.sock")
 }
 
 async fn send_request(stream: &mut interprocess::local_socket::tokio::Stream, req: &DaemonRequest) -> DaemonResponse {
@@ -110,7 +136,7 @@ async fn send_request(stream: &mut interprocess::local_socket::tokio::Stream, re
 #[skuld::test]
 fn server_accepts_connection() {
     rt().block_on(async {
-        let name = "hole-test-accept";
+        let name = &test_socket_name("accept");
         let server = IpcServer::bind(name, mock_proxy()).unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
@@ -124,7 +150,7 @@ fn server_accepts_connection() {
 #[skuld::test]
 fn status_when_not_running_returns_false() {
     rt().block_on(async {
-        let name = "hole-test-status";
+        let name = &test_socket_name("status");
         let server = IpcServer::bind(name, mock_proxy()).unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
@@ -149,7 +175,7 @@ fn status_when_not_running_returns_false() {
 #[skuld::test]
 fn multiple_requests_on_same_connection() {
     rt().block_on(async {
-        let name = "hole-test-multi";
+        let name = &test_socket_name("multi");
         let server = IpcServer::bind(name, mock_proxy()).unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
@@ -170,7 +196,7 @@ fn multiple_requests_on_same_connection() {
 #[skuld::test]
 fn invalid_request_returns_error_response() {
     rt().block_on(async {
-        let name = "hole-test-invalid";
+        let name = &test_socket_name("invalid");
         let server = IpcServer::bind(name, mock_proxy()).unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
@@ -202,7 +228,7 @@ fn invalid_request_returns_error_response() {
 #[skuld::test]
 fn server_handles_client_disconnect() {
     rt().block_on(async {
-        let name = "hole-test-disconnect";
+        let name = &test_socket_name("disconnect");
         let server = IpcServer::bind(name, mock_proxy()).unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
@@ -220,7 +246,7 @@ fn server_handles_client_disconnect() {
 #[skuld::test]
 fn start_request_starts_proxy() {
     rt().block_on(async {
-        let name = "hole-test-start";
+        let name = &test_socket_name("start");
         let pm = mock_proxy();
         let server = IpcServer::bind(name, pm).unwrap();
         let handle = tokio::spawn(async move {
@@ -258,7 +284,7 @@ fn start_request_starts_proxy() {
 #[skuld::test]
 fn stop_request_stops_proxy() {
     rt().block_on(async {
-        let name = "hole-test-stop";
+        let name = &test_socket_name("stop");
         let pm = mock_proxy();
         let server = IpcServer::bind(name, pm).unwrap();
         let handle = tokio::spawn(async move {
@@ -295,7 +321,7 @@ fn stop_request_stops_proxy() {
 #[skuld::test]
 fn start_failure_returns_error() {
     rt().block_on(async {
-        let name = "hole-test-start-fail";
+        let name = &test_socket_name("start-fail");
         let pm = failing_proxy();
         let server = IpcServer::bind(name, pm).unwrap();
         let handle = tokio::spawn(async move {
@@ -329,7 +355,7 @@ fn start_failure_returns_error() {
 #[skuld::test]
 fn run_cancellation_aborts_connection_handlers() {
     rt().block_on(async {
-        let name = "hole-test-run-cancel";
+        let name = &test_socket_name("run-cancel");
         let server = IpcServer::bind(name, mock_proxy()).unwrap();
         let handle = tokio::spawn(async move {
             server.run().await.unwrap();

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod gateway;
+pub mod group;
 pub mod ipc;
 pub mod logging;
 pub mod platform;

--- a/crates/daemon/src/platform/macos.rs
+++ b/crates/daemon/src/platform/macos.rs
@@ -151,7 +151,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         )));
         let proxy_shutdown = std::sync::Arc::clone(&proxy);
 
-        let server = crate::ipc::IpcServer::bind(crate::ipc::SOCKET_NAME, proxy)?;
+        let server = crate::ipc::IpcServer::bind(crate::ipc::SOCKET_PATH, proxy)?;
 
         tokio::select! {
             result = server.run() => {

--- a/crates/gui/Cargo.toml
+++ b/crates/gui/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 thiserror = "2"
+base64 = "0.22"
 dirs = "6"
 ureq = { version = "3", features = ["json"] }
 

--- a/crates/gui/src/cli.rs
+++ b/crates/gui/src/cli.rs
@@ -44,6 +44,18 @@ enum DaemonAction {
         #[command(subcommand)]
         action: Option<LogAction>,
     },
+    /// Add the current user to the hole group (requires elevation)
+    GrantAccess {
+        /// Also send this IPC command after granting access (base64-encoded JSON)
+        #[arg(long)]
+        then_send: Option<String>,
+    },
+    /// Send a single IPC command to the daemon (requires elevation)
+    IpcSend {
+        /// Base64-encoded JSON of the DaemonRequest
+        #[arg(long)]
+        base64: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -178,6 +190,8 @@ fn handle_daemon(action: DaemonAction) -> i32 {
             }
         }
         DaemonAction::Log { action } => handle_daemon_log(action),
+        DaemonAction::GrantAccess { then_send } => handle_grant_access(then_send),
+        DaemonAction::IpcSend { base64 } => handle_ipc_send(&base64),
     }
 }
 
@@ -256,6 +270,92 @@ fn daemon_log_watch(path: &std::path::Path, tail_lines: usize) -> i32 {
             }
         }
     }
+}
+
+fn handle_grant_access(then_send: Option<String>) -> i32 {
+    use hole_common::protocol::PERMISSION_DENIED_HELP;
+
+    // Ensure the group exists (may not if daemon was installed by an older version)
+    if let Err(e) = hole_daemon::group::create_group() {
+        eprintln!("failed to create group: {e}");
+        return 1;
+    }
+
+    // Add current user to the hole group
+    match hole_daemon::group::installing_username() {
+        Ok(user) => {
+            if let Err(e) = hole_daemon::group::add_user_to_group(&user) {
+                eprintln!("failed to add '{user}' to group: {e}");
+                return 1;
+            }
+            eprintln!("added '{user}' to '{}' group", hole_daemon::group::GROUP_NAME);
+        }
+        Err(e) => {
+            eprintln!("could not determine current user: {e}");
+            eprintln!("{PERMISSION_DENIED_HELP}");
+            return 1;
+        }
+    }
+
+    // Optionally proxy a command to the daemon
+    if let Some(b64) = then_send {
+        return handle_ipc_send(&b64);
+    }
+
+    0
+}
+
+fn handle_ipc_send(base64_request: &str) -> i32 {
+    use base64::Engine;
+    use hole_common::protocol::{DaemonRequest, DaemonResponse};
+
+    // Decode base64
+    let json_bytes = match base64::engine::general_purpose::STANDARD.decode(base64_request) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("invalid base64: {e}");
+            return 1;
+        }
+    };
+
+    // Deserialize request
+    let request: DaemonRequest = match serde_json::from_slice(&json_bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("invalid request JSON: {e}");
+            return 1;
+        }
+    };
+
+    // Connect and send
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        #[cfg(target_os = "windows")]
+        let socket_id = hole_common::protocol::DAEMON_SOCKET_NAME;
+        #[cfg(target_os = "macos")]
+        let socket_id = hole_common::protocol::DAEMON_SOCKET_PATH;
+
+        let mut client = match crate::daemon_client::DaemonClient::connect(socket_id).await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("failed to connect to daemon: {e}");
+                return 1;
+            }
+        };
+
+        match client.send(request).await {
+            Ok(DaemonResponse::Ack) => 0,
+            Ok(DaemonResponse::Status { .. }) => 0,
+            Ok(DaemonResponse::Error { message }) => {
+                eprintln!("daemon error: {message}");
+                1
+            }
+            Err(e) => {
+                eprintln!("communication error: {e}");
+                1
+            }
+        }
+    })
 }
 
 fn handle_path(action: PathAction) -> i32 {

--- a/crates/gui/src/daemon_client.rs
+++ b/crates/gui/src/daemon_client.rs
@@ -1,7 +1,7 @@
 // IPC client to hole-daemon.
 
 use hole_common::protocol::{encode, DaemonRequest, DaemonResponse};
-use interprocess::local_socket::{tokio::Stream, traits::tokio::Stream as StreamTrait, GenericNamespaced, ToNsName};
+use interprocess::local_socket::{tokio::Stream, traits::tokio::Stream as StreamTrait};
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -11,6 +11,8 @@ const MAX_MESSAGE_SIZE: u32 = 1024 * 1024; // 1 MiB
 
 #[derive(Debug, Error)]
 pub enum ClientError {
+    #[error("permission denied: insufficient privileges to connect to the Hole daemon")]
+    PermissionDenied,
     #[error("connection error: {0}")]
     Connection(#[source] std::io::Error),
     #[error("i/o error: {0}")]
@@ -27,12 +29,27 @@ pub struct DaemonClient {
 }
 
 impl DaemonClient {
-    /// Connect to the daemon at the given socket name.
+    /// Connect to the daemon at the given socket name (Windows) or path (macOS).
+    #[cfg(target_os = "windows")]
     pub async fn connect(name: &str) -> Result<Self, ClientError> {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+
         let ns_name = name
             .to_ns_name::<GenericNamespaced>()
             .map_err(|e| ClientError::Connection(std::io::Error::other(e.to_string())))?;
-        let stream = Stream::connect(ns_name).await.map_err(ClientError::Connection)?;
+        let stream = Stream::connect(ns_name).await.map_err(map_connect_error)?;
+        Ok(Self { stream })
+    }
+
+    /// Connect to the daemon at the given socket path.
+    #[cfg(target_os = "macos")]
+    pub async fn connect(path: &str) -> Result<Self, ClientError> {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+
+        let fs_name = path
+            .to_fs_name::<GenericFilePath>()
+            .map_err(|e| ClientError::Connection(std::io::Error::other(e.to_string())))?;
+        let stream = Stream::connect(fs_name).await.map_err(map_connect_error)?;
         Ok(Self { stream })
     }
 
@@ -57,6 +74,16 @@ impl DaemonClient {
 
         let resp: DaemonResponse = serde_json::from_slice(&body).map_err(|e| ClientError::Protocol(e.to_string()))?;
         Ok(resp)
+    }
+}
+
+// Helpers =====
+
+fn map_connect_error(e: std::io::Error) -> ClientError {
+    if e.kind() == std::io::ErrorKind::PermissionDenied {
+        ClientError::PermissionDenied
+    } else {
+        ClientError::Connection(e)
     }
 }
 

--- a/crates/gui/src/daemon_client_tests.rs
+++ b/crates/gui/src/daemon_client_tests.rs
@@ -7,15 +7,37 @@ fn rt() -> tokio::runtime::Runtime {
     tokio::runtime::Runtime::new().unwrap()
 }
 
+/// Generate a test socket name. On macOS, returns a temp file path.
+#[cfg(target_os = "windows")]
+fn test_socket_name(suffix: &str) -> String {
+    format!("hole-gui-test-{suffix}")
+}
+
+#[cfg(target_os = "macos")]
+fn test_socket_name(suffix: &str) -> String {
+    format!("/tmp/hole-gui-test-{suffix}.sock")
+}
+
 /// Spawn a mock daemon that responds to one connection with canned responses.
 async fn spawn_mock_daemon(name: &str) -> tokio::task::JoinHandle<()> {
-    use interprocess::local_socket::{
-        traits::tokio::Listener as ListenerTrait, GenericNamespaced, ListenerOptions, ToNsName,
-    };
+    use interprocess::local_socket::{traits::tokio::Listener as ListenerTrait, ListenerOptions};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let ns_name = name.to_ns_name::<GenericNamespaced>().unwrap();
-    let listener = ListenerOptions::new().name(ns_name).create_tokio().unwrap();
+    let listener = {
+        #[cfg(target_os = "windows")]
+        {
+            use interprocess::local_socket::{GenericNamespaced, ToNsName};
+            let ns_name = name.to_ns_name::<GenericNamespaced>().unwrap();
+            ListenerOptions::new().name(ns_name).create_tokio().unwrap()
+        }
+        #[cfg(target_os = "macos")]
+        {
+            use interprocess::local_socket::{GenericFilePath, ToFsName};
+            let _ = std::fs::remove_file(name);
+            let fs_name = name.to_fs_name::<GenericFilePath>().unwrap();
+            ListenerOptions::new().name(fs_name).create_tokio().unwrap()
+        }
+    };
 
     tokio::spawn(async move {
         let mut stream = listener.accept().await.unwrap();
@@ -55,7 +77,7 @@ async fn spawn_mock_daemon(name: &str) -> tokio::task::JoinHandle<()> {
 #[skuld::test]
 fn send_status_request_receives_response() {
     rt().block_on(async {
-        let name = "hole-gui-test-status";
+        let name = &test_socket_name("status");
         let _mock = spawn_mock_daemon(name).await;
 
         let mut client = DaemonClient::connect(name).await.unwrap();
@@ -75,7 +97,7 @@ fn send_status_request_receives_response() {
 #[skuld::test]
 fn send_start_receives_ack() {
     rt().block_on(async {
-        let name = "hole-gui-test-start";
+        let name = &test_socket_name("start");
         let _mock = spawn_mock_daemon(name).await;
 
         let mut client = DaemonClient::connect(name).await.unwrap();
@@ -105,7 +127,7 @@ fn send_start_receives_ack() {
 #[skuld::test]
 fn multiple_requests_on_same_client() {
     rt().block_on(async {
-        let name = "hole-gui-test-multi";
+        let name = &test_socket_name("multi");
         let _mock = spawn_mock_daemon(name).await;
 
         let mut client = DaemonClient::connect(name).await.unwrap();
@@ -121,7 +143,28 @@ fn multiple_requests_on_same_client() {
 #[skuld::test]
 fn connect_to_nonexistent_returns_error() {
     rt().block_on(async {
-        let result = DaemonClient::connect("hole-gui-test-nonexistent").await;
+        let result = DaemonClient::connect(&test_socket_name("nonexistent")).await;
         assert!(result.is_err());
     });
+}
+
+#[skuld::test]
+fn permission_denied_maps_to_variant() {
+    // Verify that map_connect_error correctly maps PermissionDenied
+    let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
+    let client_err = super::map_connect_error(io_err);
+    assert!(
+        matches!(client_err, ClientError::PermissionDenied),
+        "expected PermissionDenied, got: {client_err:?}"
+    );
+}
+
+#[skuld::test]
+fn other_io_error_maps_to_connection() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+    let client_err = super::map_connect_error(io_err);
+    assert!(
+        matches!(client_err, ClientError::Connection(_)),
+        "expected Connection, got: {client_err:?}"
+    );
 }

--- a/crates/gui/src/elevation.rs
+++ b/crates/gui/src/elevation.rs
@@ -1,0 +1,153 @@
+// GUI elevation flow for permission-denied errors.
+//
+// When the daemon rejects a connection due to insufficient permissions,
+// this module shows a dialog and spawns a privileged helper to either
+// grant permanent access (add user to hole group) or proxy a single command.
+
+use crate::setup;
+use base64::Engine;
+use hole_common::protocol::DaemonRequest;
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+use tracing::{error, info};
+
+/// Show the elevation dialog flow and handle the user's choice.
+///
+/// Called when a user-initiated tray action fails with PermissionDenied.
+/// Returns `true` if the action was successfully proxied via elevation.
+pub async fn prompt_elevation(app: &AppHandle, request: DaemonRequest) -> bool {
+    let b64_request = encode_request(&request);
+
+    // Dialog 1: Offer permanent access
+    let grant = app
+        .dialog()
+        .message(
+            "You don't have permission to control the Hole daemon.\n\n\
+             Grant yourself permanent access?\n\
+             (Requires administrator privileges)",
+        )
+        .title("Hole — Permission Denied")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Grant Access".into(),
+            "Not Now".into(),
+        ))
+        .blocking_show();
+
+    if grant {
+        // Grant access + proxy command in one elevated invocation
+        return run_grant_access_elevated(app, &b64_request).await;
+    }
+
+    // Dialog 2: Offer one-time elevation
+    let elevate = app
+        .dialog()
+        .message("Run this action with one-time elevation?")
+        .title("Hole — One-Time Elevation")
+        .buttons(MessageDialogButtons::OkCancelCustom("Elevate".into(), "Cancel".into()))
+        .blocking_show();
+
+    if elevate {
+        return run_ipc_send_elevated(app, &b64_request).await;
+    }
+
+    false
+}
+
+/// Base64-encode a DaemonRequest for passing through CLI args.
+pub fn encode_request(request: &DaemonRequest) -> String {
+    let json = serde_json::to_vec(request).expect("DaemonRequest serialization cannot fail");
+    base64::engine::general_purpose::STANDARD.encode(&json)
+}
+
+/// Spawn `hole daemon grant-access --then-send <b64>` elevated.
+async fn run_grant_access_elevated(app: &AppHandle, b64_request: &str) -> bool {
+    let exe = match setup::daemon_binary_path() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("cannot resolve binary path: {e}");
+            return false;
+        }
+    };
+
+    let b64_owned = b64_request.to_string();
+    let result = tokio::task::spawn_blocking(move || {
+        setup::run_elevated(&exe, &["daemon", "grant-access", "--then-send", &b64_owned])
+    })
+    .await;
+
+    match result {
+        Ok(Ok(status)) if status.success() => {
+            info!("grant-access succeeded");
+            true
+        }
+        Ok(Err(setup::SetupError::Cancelled)) => {
+            info!("user cancelled elevation prompt");
+            false
+        }
+        Ok(Ok(status)) => {
+            let code = status.code().unwrap_or(-1);
+            error!("grant-access exited with code {code}");
+            app.dialog()
+                .message(format!("Failed to grant access (exit code {code})."))
+                .title("Elevation Error")
+                .blocking_show();
+            false
+        }
+        Ok(Err(e)) => {
+            error!("elevation failed: {e}");
+            app.dialog()
+                .message(format!("Elevation failed: {e}"))
+                .title("Elevation Error")
+                .blocking_show();
+            false
+        }
+        Err(e) => {
+            error!("spawn_blocking panicked: {e}");
+            false
+        }
+    }
+}
+
+/// Spawn `hole daemon ipc-send --base64 <b64>` elevated.
+async fn run_ipc_send_elevated(_app: &AppHandle, b64_request: &str) -> bool {
+    let exe = match setup::daemon_binary_path() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("cannot resolve binary path: {e}");
+            return false;
+        }
+    };
+
+    let b64_owned = b64_request.to_string();
+    let result =
+        tokio::task::spawn_blocking(move || setup::run_elevated(&exe, &["daemon", "ipc-send", "--base64", &b64_owned]))
+            .await;
+
+    match result {
+        Ok(Ok(status)) if status.success() => {
+            info!("ipc-send succeeded");
+            true
+        }
+        Ok(Err(setup::SetupError::Cancelled)) => {
+            info!("user cancelled elevation prompt");
+            false
+        }
+        Ok(Ok(status)) => {
+            let code = status.code().unwrap_or(-1);
+            error!("ipc-send exited with code {code}");
+            false
+        }
+        Ok(Err(e)) => {
+            error!("elevation failed: {e}");
+            false
+        }
+        Err(e) => {
+            error!("spawn_blocking panicked: {e}");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "elevation_tests.rs"]
+mod elevation_tests;

--- a/crates/gui/src/elevation_tests.rs
+++ b/crates/gui/src/elevation_tests.rs
@@ -1,0 +1,49 @@
+use hole_common::config::ServerEntry;
+use hole_common::protocol::{DaemonRequest, ProxyConfig};
+
+#[skuld::test]
+fn encode_request_roundtrips() {
+    use base64::Engine;
+
+    let request = DaemonRequest::Start {
+        config: ProxyConfig {
+            server: ServerEntry {
+                id: "test".into(),
+                name: "Test".into(),
+                server: "1.2.3.4".into(),
+                server_port: 8388,
+                method: "aes-256-gcm".into(),
+                password: "pw".into(),
+                plugin: None,
+                plugin_opts: None,
+            },
+            local_port: 4073,
+            plugin_path: None,
+        },
+    };
+
+    let b64 = super::encode_request(&request);
+    let decoded_bytes = base64::engine::general_purpose::STANDARD.decode(&b64).unwrap();
+    let decoded: DaemonRequest = serde_json::from_slice(&decoded_bytes).unwrap();
+    assert_eq!(decoded, request);
+}
+
+#[skuld::test]
+fn encode_stop_request() {
+    use base64::Engine;
+
+    let b64 = super::encode_request(&DaemonRequest::Stop);
+    let decoded_bytes = base64::engine::general_purpose::STANDARD.decode(&b64).unwrap();
+    let decoded: DaemonRequest = serde_json::from_slice(&decoded_bytes).unwrap();
+    assert_eq!(decoded, DaemonRequest::Stop);
+}
+
+#[skuld::test]
+fn encode_status_request() {
+    use base64::Engine;
+
+    let b64 = super::encode_request(&DaemonRequest::Status);
+    let decoded_bytes = base64::engine::general_purpose::STANDARD.decode(&b64).unwrap();
+    let decoded: DaemonRequest = serde_json::from_slice(&decoded_bytes).unwrap();
+    assert_eq!(decoded, DaemonRequest::Status);
+}

--- a/crates/gui/src/lib.rs
+++ b/crates/gui/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod daemon_client;
+pub mod elevation;
 pub mod logging;
 pub mod path_management;
 pub mod setup;

--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -4,6 +4,7 @@
 mod cli;
 mod commands;
 mod daemon_client;
+mod elevation;
 mod logging;
 mod path_management;
 mod platform;

--- a/crates/gui/src/setup.rs
+++ b/crates/gui/src/setup.rs
@@ -158,6 +158,17 @@ pub fn install_daemon() -> Result<(), Box<dyn std::error::Error>> {
     let log_dir = hole_daemon::logging::log_dir();
     std::fs::create_dir_all(&log_dir)?;
 
+    // Create access group and add installing user (before daemon starts,
+    // so the daemon can set socket/pipe permissions using the group)
+    hole_daemon::group::create_group()?;
+    match hole_daemon::group::installing_username() {
+        Ok(user) => {
+            hole_daemon::group::add_user_to_group(&user)?;
+            eprintln!("added user '{user}' to '{}' group", hole_daemon::group::GROUP_NAME);
+        }
+        Err(e) => eprintln!("warning: could not detect installing user: {e}"),
+    }
+
     // Idempotent: if already installed, stop and uninstall first
     if hole_daemon::platform::os::is_installed() {
         eprintln!("daemon already installed, reinstalling...");
@@ -184,6 +195,16 @@ pub fn uninstall_daemon() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     hole_daemon::platform::os::uninstall()?;
+
+    // Remove macOS socket file
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::fs::remove_file(hole_common::protocol::DAEMON_SOCKET_PATH);
+    }
+
+    // Best-effort: remove the access group
+    let _ = hole_daemon::group::delete_group();
+
     eprintln!("daemon uninstalled");
     Ok(())
 }
@@ -284,7 +305,12 @@ async fn poll_daemon_ipc() -> bool {
 
     for _ in 0..10 {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        if let Ok(mut client) = DaemonClient::connect(hole_daemon::ipc::SOCKET_NAME).await {
+        #[cfg(target_os = "windows")]
+        let socket_id = hole_daemon::ipc::SOCKET_NAME;
+        #[cfg(target_os = "macos")]
+        let socket_id = hole_daemon::ipc::SOCKET_PATH;
+
+        if let Ok(mut client) = DaemonClient::connect(socket_id).await {
             if client.send(DaemonRequest::Status).await.is_ok() {
                 return true;
             }

--- a/crates/gui/src/state.rs
+++ b/crates/gui/src/state.rs
@@ -2,7 +2,11 @@
 
 use crate::daemon_client::{ClientError, DaemonClient};
 use hole_common::config::AppConfig;
-use hole_common::protocol::{DaemonRequest, DaemonResponse, DAEMON_SOCKET_NAME};
+#[cfg(target_os = "windows")]
+use hole_common::protocol::DAEMON_SOCKET_NAME;
+#[cfg(target_os = "macos")]
+use hole_common::protocol::DAEMON_SOCKET_PATH;
+use hole_common::protocol::{DaemonRequest, DaemonResponse};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tracing::warn;
@@ -31,7 +35,12 @@ impl AppState {
 
         // Lazy connect
         if guard.is_none() {
-            match DaemonClient::connect(DAEMON_SOCKET_NAME).await {
+            #[cfg(target_os = "windows")]
+            let connect_result = DaemonClient::connect(DAEMON_SOCKET_NAME).await;
+            #[cfg(target_os = "macos")]
+            let connect_result = DaemonClient::connect(DAEMON_SOCKET_PATH).await;
+
+            match connect_result {
                 Ok(client) => *guard = Some(client),
                 Err(e) => {
                     warn!(error = %e, "failed to connect to daemon");

--- a/crates/gui/src/tray.rs
+++ b/crates/gui/src/tray.rs
@@ -109,7 +109,8 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 let app_handle = app.clone();
                 tauri::async_runtime::spawn(async move {
                     let state = app_handle.state::<AppState>();
-                    let ok = match state.daemon_send(DaemonRequest::Start { config: proxy_config }).await {
+                    let request = DaemonRequest::Start { config: proxy_config };
+                    let ok = match state.daemon_send(request.clone()).await {
                         Ok(DaemonResponse::Ack) => {
                             info!("proxy started");
                             true
@@ -125,6 +126,9 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                         Ok(_) => {
                             warn!("unexpected response from daemon");
                             false
+                        }
+                        Err(crate::daemon_client::ClientError::PermissionDenied) => {
+                            crate::elevation::prompt_elevation(&app_handle, request).await
                         }
                         Err(e) => {
                             error!("failed to send start: {e}");
@@ -142,7 +146,8 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 let app_handle = app.clone();
                 tauri::async_runtime::spawn(async move {
                     let state = app_handle.state::<AppState>();
-                    let ok = match state.daemon_send(DaemonRequest::Stop).await {
+                    let request = DaemonRequest::Stop;
+                    let ok = match state.daemon_send(request.clone()).await {
                         Ok(DaemonResponse::Ack) => {
                             info!("proxy stopped");
                             true
@@ -154,6 +159,9 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                         Ok(_) => {
                             warn!("unexpected response from daemon");
                             false
+                        }
+                        Err(crate::daemon_client::ClientError::PermissionDenied) => {
+                            crate::elevation::prompt_elevation(&app_handle, request).await
                         }
                         Err(e) => {
                             error!("failed to send stop: {e}");


### PR DESCRIPTION
## Summary

- Add Docker-style access control to the daemon IPC channel (local socket/named pipe)
- Create `hole` OS group during `daemon install`; installing user is auto-added
- **macOS**: filesystem socket at `/var/run/hole-daemon.sock`, owned by `root:hole`, mode `0660`
- **Windows**: named pipe DACL allowing only SYSTEM, Administrators, and the `hole` group
- GUI shows elevation dialog on permission denied (grant permanent access or one-time elevation)
- New CLI subcommands: `grant-access`, `ipc-send` for privileged helper operations

Closes #15

## Test plan

- [ ] `cargo test --workspace` passes (Windows)
- [ ] CI passes on macOS (validates macOS-specific code compiles)
- [ ] Manual: fresh MSI install creates `hole` group and adds installing user
- [ ] Manual: non-member user sees permission denied + elevation dialog in GUI
- [ ] Manual: `grant-access` adds user to group; `ipc-send` proxies commands