### PR TITLE
Fix CI: remove ~/.cargo/bin from cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
@@ -71,7 +70,6 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
@@ -100,7 +98,6 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}


### PR DESCRIPTION
## Summary
- Remove `~/.cargo/bin` from `actions/cache` paths — restoring a cached (empty) directory overwrites the toolchain binaries (`cargo`, `rustc`, etc.) installed by `dtolnay/rust-toolchain`, causing `cargo: command not found`

Closes #44

## Test plan
- [ ] Verify all CI jobs pass (especially the `cargo clippy` / `cargo test` steps that were failing)