### PR TITLE
Restrict log directory permissions and redact password in Debug output

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -34,7 +34,7 @@ impl Default for AppConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct ServerEntry {
     pub id: String,
     pub name: String,
@@ -46,6 +46,21 @@ pub struct ServerEntry {
     pub plugin: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plugin_opts: Option<String>,
+}
+
+impl std::fmt::Debug for ServerEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerEntry")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("server", &self.server)
+            .field("server_port", &self.server_port)
+            .field("method", &self.method)
+            .field("password", &"<redacted>")
+            .field("plugin", &self.plugin)
+            .field("plugin_opts", &self.plugin_opts)
+            .finish()
+    }
 }
 
 // Methods =============================================================================================================

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -209,3 +209,50 @@ fn save_preserves_permissions_on_repeated_saves(#[fixture(temp_dir)] dir: &Path)
     );
     assert_eq!(dir_mode, 0o700, "dir permissions should stay 0700 after repeated saves");
 }
+
+// Debug redaction tests -----------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn server_entry_debug_redacts_password() {
+    let entry = ServerEntry {
+        id: "test-id".to_string(),
+        name: "Test".to_string(),
+        server: "1.2.3.4".to_string(),
+        server_port: 8388,
+        method: "aes-256-gcm".to_string(),
+        password: "super-secret-do-not-leak".to_string(),
+        plugin: None,
+        plugin_opts: None,
+    };
+    let debug_output = format!("{:?}", entry);
+    assert!(
+        !debug_output.contains("super-secret-do-not-leak"),
+        "Debug output must not contain the actual password: {debug_output}"
+    );
+    assert!(
+        debug_output.contains("<redacted>"),
+        "Debug output must contain redacted placeholder: {debug_output}"
+    );
+}
+
+#[skuld::test]
+fn server_entry_debug_shows_non_sensitive_fields() {
+    let entry = ServerEntry {
+        id: "unique-id-123".to_string(),
+        name: "MyServer".to_string(),
+        server: "10.20.30.40".to_string(),
+        server_port: 9999,
+        method: "chacha20-ietf-poly1305".to_string(),
+        password: "do-not-show-this".to_string(),
+        plugin: Some("v2ray-plugin".to_string()),
+        plugin_opts: Some("server;tls".to_string()),
+    };
+    let debug_output = format!("{:?}", entry);
+    assert!(debug_output.contains("unique-id-123"), "should contain id");
+    assert!(debug_output.contains("MyServer"), "should contain name");
+    assert!(debug_output.contains("10.20.30.40"), "should contain server");
+    assert!(debug_output.contains("9999"), "should contain server_port");
+    assert!(debug_output.contains("chacha20-ietf-poly1305"), "should contain method");
+    assert!(debug_output.contains("v2ray-plugin"), "should contain plugin");
+    assert!(debug_output.contains("server;tls"), "should contain plugin_opts");
+}

--- a/crates/daemon/src/logging.rs
+++ b/crates/daemon/src/logging.rs
@@ -1,26 +1,46 @@
 // Daemon logging initialization.
 
+use std::io;
+use std::path::PathBuf;
+
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 
 /// Returns the daemon log directory path.
-pub fn log_dir() -> std::path::PathBuf {
+pub fn log_dir() -> PathBuf {
     if cfg!(target_os = "windows") {
-        std::path::PathBuf::from(std::env::var("ProgramData").unwrap_or_else(|_| "C:\\ProgramData".into()))
+        PathBuf::from(std::env::var("ProgramData").unwrap_or_else(|_| "C:\\ProgramData".into()))
             .join("hole")
             .join("logs")
     } else {
-        std::path::PathBuf::from("/var/log/hole")
+        PathBuf::from("/var/log/hole")
     }
+}
+
+/// Create the log directory and restrict its permissions.
+///
+/// On macOS the directory is set to `root:hole 0750` (or `root:root 0700` if
+/// the `hole` group does not exist yet).  On Windows the default ACLs on
+/// `ProgramData` are sufficient.
+///
+/// Requires elevated privileges (root on macOS, Administrator on Windows).
+pub fn ensure_log_dir() -> io::Result<PathBuf> {
+    let dir = log_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    #[cfg(all(target_os = "macos", not(test)))]
+    restrict_log_dir_permissions(&dir)?;
+
+    Ok(dir)
 }
 
 /// Initialize daemon logging (rolling daily file appender).
 ///
-/// Returns a guard that must be held for the lifetime of the daemon process;
-/// dropping it flushes and closes the log file.
-pub fn init() -> WorkerGuard {
-    let dir = log_dir();
-    let _ = std::fs::create_dir_all(&dir);
+/// Creates the log directory with restricted permissions, then sets up a
+/// rolling daily file appender.  Returns a guard that must be held for the
+/// lifetime of the daemon process; dropping it flushes and closes the log file.
+pub fn init() -> io::Result<WorkerGuard> {
+    let dir = ensure_log_dir()?;
 
     let file_appender = tracing_appender::rolling::daily(&dir, "hole-daemon.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
@@ -32,5 +52,51 @@ pub fn init() -> WorkerGuard {
         .with_writer(non_blocking)
         .init();
 
-    guard
+    Ok(guard)
+}
+
+// Restrict log directory permissions on macOS -------------------------------------------------------------------------
+
+/// Restrict the log directory to `root:hole 0750`, falling back to `root 0700`.
+///
+/// Locks down to 0700 first (closing any window where the directory is
+/// world-readable), then attempts to chown to `root:hole` and widen to 0750.
+#[cfg(all(target_os = "macos", not(test)))]
+fn restrict_log_dir_permissions(dir: &std::path::Path) -> io::Result<()> {
+    use std::ffi::CString;
+
+    let path_str = dir
+        .to_str()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "log dir path is not valid UTF-8"))?;
+    let c_path = CString::new(path_str).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+    // Immediately restrict to root-only so the directory is never exposed with
+    // its umask-derived permissions while we attempt chown below.
+    if unsafe { libc::chmod(c_path.as_ptr(), 0o700) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let group_name = CString::new(crate::group::GROUP_NAME).unwrap();
+    let grp = unsafe { libc::getgrnam(group_name.as_ptr()) };
+
+    if grp.is_null() {
+        return Ok(()); // Already 0700 — group doesn't exist yet.
+    }
+
+    let gid = unsafe { (*grp).gr_gid };
+
+    if unsafe { libc::chown(c_path.as_ptr(), 0, gid) } != 0 {
+        eprintln!(
+            "warning: chown {dir:?} to root:{} failed, log directory will be root-only",
+            crate::group::GROUP_NAME
+        );
+        return Ok(()); // Already 0700 — safe fallback.
+    }
+
+    // Widen to group-readable now that ownership is correct.
+    if unsafe { libc::chmod(c_path.as_ptr(), 0o750) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
 }

--- a/crates/gui/src/cli.rs
+++ b/crates/gui/src/cli.rs
@@ -149,7 +149,13 @@ fn handle_upgrade() -> i32 {
 fn handle_daemon(action: DaemonAction) -> i32 {
     match action {
         DaemonAction::Run { socket_path } => {
-            let _guard = hole_daemon::logging::init();
+            let _guard = match hole_daemon::logging::init() {
+                Ok(guard) => guard,
+                Err(e) => {
+                    eprintln!("failed to initialize logging: {e}");
+                    return 1;
+                }
+            };
             tracing::info!("hole daemon starting");
             hole_daemon::routing::teardown_split_routes().ok();
 

--- a/crates/gui/src/setup.rs
+++ b/crates/gui/src/setup.rs
@@ -163,8 +163,7 @@ pub fn install_daemon() -> Result<(), Box<dyn std::error::Error>> {
     let binary_path = daemon_binary_path()?;
 
     // Create data directories
-    let log_dir = hole_daemon::logging::log_dir();
-    std::fs::create_dir_all(&log_dir)?;
+    hole_daemon::logging::ensure_log_dir()?;
 
     // Create access group and add installing user (before daemon starts,
     // so the daemon can set socket/pipe permissions using the group)


### PR DESCRIPTION
## Summary
- Restrict daemon log directory (`/var/log/hole/`) to `root:hole 0750` on macOS (fallback `root 0700` if `hole` group doesn't exist), eliminating world-readable log files
- Replace `#[derive(Debug)]` on `ServerEntry` with a manual impl that redacts the `password` field
- Change `logging::init()` to return `io::Result` so the daemon refuses to start if it cannot secure its log directory

Closes #59

## Test plan
- [x] `cargo test -p hole-common` — new Debug redaction tests pass alongside existing tests (56 total)
- [x] `cargo test -p hole-daemon` — all 57 tests pass
- [x] `cargo check --workspace` — full workspace compiles
- [ ] CI passes