### PR TITLE
Fix Enable proxy not working: double-fire, auto-select, error feedback

### DIFF
--- a/crates/gui/capabilities/default.json
+++ b/crates/gui/capabilities/default.json
@@ -6,6 +6,7 @@
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled",
-    "dialog:allow-open"
+    "dialog:allow-open",
+    "dialog:allow-message"
   ]
 }

--- a/crates/gui/src/commands.rs
+++ b/crates/gui/src/commands.rs
@@ -67,6 +67,20 @@ fn sanitize_import_error(err: &import::ImportError) -> String {
     }
 }
 
+/// Select the first server if no valid server is currently selected.
+///
+/// Handles both `None` and stale selections (pointing to a server ID that no longer exists).
+fn auto_select_first_server(config: &mut AppConfig) {
+    let has_valid_selection = config
+        .selected_server
+        .as_ref()
+        .is_some_and(|id| config.servers.iter().any(|s| &s.id == id));
+
+    if !has_valid_selection {
+        config.selected_server = config.servers.first().map(|s| s.id.clone());
+    }
+}
+
 /// Import servers from a config file path. Reads the file and parses it.
 #[tauri::command]
 pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<Vec<ServerEntry>, String> {
@@ -84,6 +98,7 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
             config.servers.push(server.clone());
         }
     }
+    auto_select_first_server(&mut config);
     config.save(&state.config_path).map_err(|e| e.to_string())?;
 
     Ok(new_servers)

--- a/crates/gui/src/commands_tests.rs
+++ b/crates/gui/src/commands_tests.rs
@@ -54,6 +54,60 @@ fn build_proxy_config_invalid_selection() {
     assert!(build_proxy_config(&config).is_none());
 }
 
+// auto_select_first_server tests ======================================================================================
+
+#[skuld::test]
+fn auto_select_first_server_when_none_selected() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b")],
+        selected_server: None,
+        local_port: 4073,
+        enabled: false,
+    };
+
+    auto_select_first_server(&mut config);
+    assert_eq!(config.selected_server.as_deref(), Some("a"));
+}
+
+#[skuld::test]
+fn auto_select_preserves_existing_selection() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b")],
+        selected_server: Some("b".to_string()),
+        local_port: 4073,
+        enabled: false,
+    };
+
+    auto_select_first_server(&mut config);
+    assert_eq!(config.selected_server.as_deref(), Some("b"));
+}
+
+#[skuld::test]
+fn auto_select_fixes_stale_selection() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b")],
+        selected_server: Some("deleted-id".to_string()),
+        local_port: 4073,
+        enabled: false,
+    };
+
+    auto_select_first_server(&mut config);
+    assert_eq!(config.selected_server.as_deref(), Some("a"));
+}
+
+#[skuld::test]
+fn auto_select_noop_on_empty_servers() {
+    let mut config = AppConfig {
+        servers: vec![],
+        selected_server: None,
+        local_port: 4073,
+        enabled: false,
+    };
+
+    auto_select_first_server(&mut config);
+    assert!(config.selected_server.is_none());
+}
+
 // validate_and_read_import tests ======================================================================================
 
 const VALID_SERVER_JSON: &str = r#"{"server":"1.2.3.4","server_port":8388,"password":"pw","method":"aes-256-gcm"}"#;

--- a/crates/gui/src/tray.rs
+++ b/crates/gui/src/tray.rs
@@ -76,7 +76,7 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
         .menu(&menu)
         .tooltip("Hole")
         .icon(icon)
-        .on_menu_event(handle_menu_event);
+        .on_menu_event(handle_tray_event);
 
     #[cfg(target_os = "macos")]
     {
@@ -99,9 +99,31 @@ pub fn set_tray_icon(app: &AppHandle, enabled: bool) {
     }
 }
 
-// Event handler =======================================================================================================
+// Tray event handler ==================================================================================================
 
-fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
+/// Rebuild the tray menu to sync checkbox state with the current config.
+///
+/// Preserves the "Install Update" item if an update is available.
+fn rebuild_tray_menu(app: &AppHandle) {
+    if let Some(tray) = app.tray_by_id("main") {
+        let update_state = app.state::<hole_gui::update::UpdateState>();
+        let update_info = update_state.rx.borrow().clone();
+        match build_tray_menu(app, update_info.as_ref()) {
+            Ok(menu) => {
+                sync_menu_state(app, &menu);
+                tray.set_menu(Some(menu)).ok();
+            }
+            Err(e) => warn!(error = %e, "failed to rebuild tray menu"),
+        }
+    }
+}
+
+/// Handle events from the tray menu.
+///
+/// Separated from `handle_window_menu_event` because Tauri v2 dispatches menu events globally
+/// to all registered `on_menu_event` handlers. Without the split, clicking a tray item would
+/// also invoke the window's handler (and vice versa), causing actions to fire twice.
+fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
     match event.id().as_ref() {
         ID_ENABLE => {
             info!("tray: enable toggled");
@@ -123,10 +145,23 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 let Some(proxy_config) = proxy_config else {
                     error!("tray: no server selected, cannot enable");
                     // Revert the toggle
-                    let mut config = state.config.lock().unwrap();
-                    config.enabled = false;
-                    config.save(&state.config_path).ok();
+                    {
+                        let mut config = state.config.lock().unwrap();
+                        config.enabled = false;
+                        config.save(&state.config_path).ok();
+                    }
                     set_tray_icon(app, false);
+                    rebuild_tray_menu(app);
+                    // Show error dialog so the user knows what happened
+                    let app_handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        use tauri_plugin_dialog::DialogExt;
+                        app_handle
+                            .dialog()
+                            .message("No server is selected. Open Settings and select a server before enabling.")
+                            .title("Cannot Enable")
+                            .blocking_show();
+                    });
                     return;
                 };
 
@@ -165,6 +200,7 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                         config.enabled = false;
                         config.save(&state.config_path).ok();
                         set_tray_icon(&app_handle, false);
+                        rebuild_tray_menu(&app_handle);
                     }
                 });
             } else {
@@ -199,6 +235,7 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                         config.enabled = true;
                         config.save(&state.config_path).ok();
                         set_tray_icon(&app_handle, true);
+                        rebuild_tray_menu(&app_handle);
                     }
                 });
             }
@@ -235,14 +272,6 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 app_handle.exit(0);
             });
         }
-        #[cfg(target_os = "macos")]
-        ID_UNINSTALL_HELPER => {
-            info!("tray: uninstall helper requested");
-            let app_handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                handle_uninstall_helper(app_handle).await;
-            });
-        }
         ID_INSTALL_UPDATE => {
             info!("tray: install update requested");
             let app_handle = app.clone();
@@ -250,6 +279,15 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 handle_install_update_from_tray(app_handle).await;
             });
         }
+        _ => {}
+    }
+}
+
+// Window event handler ================================================================================================
+
+/// Handle events from the settings window menu bar. See `handle_tray_event` for why this is separate.
+fn handle_window_menu_event(app: &AppHandle, event: MenuEvent) {
+    match event.id().as_ref() {
         ID_CHECK_UPDATE => {
             info!("menu: check for updates");
             let app_handle = app.clone();
@@ -264,6 +302,14 @@ fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
                 .message(format!("Hole {}", hole_gui::version::VERSION))
                 .title("About Hole")
                 .blocking_show();
+        }
+        #[cfg(target_os = "macos")]
+        ID_UNINSTALL_HELPER => {
+            info!("menu: uninstall helper requested");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                handle_uninstall_helper(app_handle).await;
+            });
         }
         _ => {}
     }
@@ -499,7 +545,7 @@ fn open_settings_window(app: &AppHandle) {
         };
 
         builder = builder.menu(menu).on_menu_event(|window, event| {
-            handle_menu_event(window.app_handle(), event);
+            handle_window_menu_event(window.app_handle(), event);
         });
     }
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -37,9 +37,14 @@ function renderServers() {
     radio.type = "radio";
     radio.name = "selected-server";
     radio.checked = server.id === config.selected_server;
-    radio.addEventListener("change", () => {
+    radio.addEventListener("change", async () => {
       config.selected_server = server.id;
       renderServers();
+      try {
+        await invoke("save_config", { config });
+      } catch (e) {
+        saveStatus.textContent = `Error: ${e}`;
+      }
     });
     tdRadio.appendChild(radio);
     tr.appendChild(tdRadio);
@@ -74,12 +79,17 @@ function renderServers() {
     const btnDel = document.createElement("button");
     btnDel.className = "btn-delete";
     btnDel.textContent = "Delete";
-    btnDel.addEventListener("click", () => {
+    btnDel.addEventListener("click", async () => {
       config.servers = config.servers.filter((s) => s.id !== server.id);
       if (config.selected_server === server.id) {
         config.selected_server = null;
       }
       renderServers();
+      try {
+        await invoke("save_config", { config });
+      } catch (e) {
+        saveStatus.textContent = `Error: ${e}`;
+      }
     });
     tdDelete.appendChild(btnDel);
     tr.appendChild(tdDelete);


### PR DESCRIPTION
## Summary
Closes #70

- **Split menu event handlers** — `handle_menu_event` → `handle_tray_event` + `handle_window_menu_event` with disjoint match arms. Tauri v2 dispatches menu events globally to all `on_menu_event` handlers; without the split, clicking a tray item also invokes the window's handler, causing actions to fire twice.
- **Auto-select first server on import** — `auto_select_first_server` selects the first server when none is currently selected (or when the selection points to a deleted server).
- **Error dialog on Enable failure** — Instead of silently reverting, show "No server selected" dialog and rebuild the tray menu to sync the checkbox state.
- **Auto-save server selection and deletion** — Radio button changes and server deletions in the frontend now immediately persist to disk, eliminating the gap where the UI shows a selection but the tray reads `null` from config.
- **Rebuild tray menu on all failure paths** — Both the "no server" and daemon failure revert paths now sync the tray checkbox via `rebuild_tray_menu`.

## Test plan
- [x] 4 new unit tests for `auto_select_first_server` (none selected, existing preserved, stale fixed, empty servers)
- [x] `cargo test --workspace` passes (96 tests)
- [ ] Manual: import servers → first is auto-selected → Enable from tray works
- [ ] Manual: Help > About shows one dialog (not two)
- [ ] Manual: Enable with no server shows error dialog