### PR TITLE
Add File menu, connect/disconnect button, refactor proxy toggle

### DIFF
--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -48,6 +48,7 @@ fn launch_gui() {
             commands::save_config,
             commands::import_servers_from_file,
             commands::get_proxy_status,
+            tray::toggle_proxy,
         ])
         .on_window_event(|window, event| {
             #[cfg(target_os = "macos")]

--- a/crates/gui/src/tray.rs
+++ b/crates/gui/src/tray.rs
@@ -11,14 +11,19 @@ use tracing::{error, info, warn};
 
 // Menu IDs ============================================================================================================
 
+// Tray menu -----------------------------------------------------------------------------------------------------------
 const ID_ENABLE: &str = "enable";
 const ID_AUTOSTART: &str = "autostart";
 const ID_SETTINGS: &str = "settings";
 const ID_EXIT: &str = "exit";
+const ID_INSTALL_UPDATE: &str = "install_update";
+
+// Window menu ---------------------------------------------------------------------------------------------------------
+const ID_WINDOW_IMPORT: &str = "window_import";
+const ID_WINDOW_EXIT: &str = "window_exit";
 #[cfg(target_os = "macos")]
 const ID_UNINSTALL_HELPER: &str = "uninstall_helper";
 const ID_ABOUT: &str = "about";
-const ID_INSTALL_UPDATE: &str = "install_update";
 const ID_CHECK_UPDATE: &str = "check_update";
 
 // Tray creation =======================================================================================================
@@ -99,12 +104,12 @@ pub fn set_tray_icon(app: &AppHandle, enabled: bool) {
     }
 }
 
-// Tray event handler ==================================================================================================
+// Proxy state management ==============================================================================================
 
 /// Rebuild the tray menu to sync checkbox state with the current config.
 ///
 /// Preserves the "Install Update" item if an update is available.
-fn rebuild_tray_menu(app: &AppHandle) {
+pub fn rebuild_tray_menu(app: &AppHandle) {
     if let Some(tray) = app.tray_by_id("main") {
         let update_state = app.state::<hole_gui::update::UpdateState>();
         let update_info = update_state.rx.borrow().clone();
@@ -118,6 +123,119 @@ fn rebuild_tray_menu(app: &AppHandle) {
     }
 }
 
+/// Send a best-effort Stop to the daemon and exit the application.
+async fn exit_app(app: AppHandle) {
+    let state = app.state::<AppState>();
+    let _ = state.daemon_send(DaemonRequest::Stop).await;
+    app.exit(0);
+}
+
+/// Revert config.enabled and sync the tray icon + menu.
+fn revert_proxy_state(app: &AppHandle, enabled: bool) {
+    let state = app.state::<AppState>();
+    {
+        let mut config = state.config.lock().unwrap();
+        config.enabled = enabled;
+        config.save(&state.config_path).ok();
+    }
+    set_tray_icon(app, enabled);
+    rebuild_tray_menu(app);
+}
+
+/// Set the proxy to the given enabled state. Returns the new state on success.
+///
+/// On failure, reverts config + tray state and returns an error message.
+/// Used by both the tray Enable checkbox and the frontend toggle button.
+pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, String> {
+    let state = app.state::<AppState>();
+
+    let proxy_config = {
+        let mut config = state.config.lock().unwrap();
+        if config.enabled == enabled {
+            return Ok(enabled); // Already in the desired state (concurrent toggle)
+        }
+        config.enabled = enabled;
+        config.save(&state.config_path).ok();
+        build_proxy_config(&config)
+    };
+
+    set_tray_icon(app, enabled);
+
+    let result = if enabled {
+        let Some(proxy_config) = proxy_config else {
+            revert_proxy_state(app, false);
+            return Err("No server is selected. Open Settings and select a server before enabling.".into());
+        };
+
+        let request = DaemonRequest::Start { config: proxy_config };
+        match state.daemon_send(request.clone()).await {
+            Ok(DaemonResponse::Ack) => {
+                info!("proxy started");
+                Ok(true)
+            }
+            Ok(DaemonResponse::Error { message }) if message.contains("already running") => {
+                info!("proxy already running");
+                Ok(true)
+            }
+            Ok(DaemonResponse::Error { message }) => {
+                error!("daemon error: {message}");
+                Err(format!("Daemon error: {message}"))
+            }
+            Ok(_) => {
+                warn!("unexpected response from daemon");
+                Err("Unexpected response from daemon".into())
+            }
+            Err(crate::daemon_client::ClientError::PermissionDenied) => {
+                if crate::elevation::prompt_elevation(app, request).await {
+                    Ok(true)
+                } else {
+                    Err("Elevation was denied or failed".into())
+                }
+            }
+            Err(e) => {
+                error!("failed to send start: {e}");
+                Err(format!("Failed to connect to daemon: {e}"))
+            }
+        }
+    } else {
+        let request = DaemonRequest::Stop;
+        match state.daemon_send(request.clone()).await {
+            Ok(DaemonResponse::Ack) => {
+                info!("proxy stopped");
+                Ok(false)
+            }
+            Ok(DaemonResponse::Error { message }) => {
+                error!("daemon error: {message}");
+                Err(format!("Daemon error: {message}"))
+            }
+            Ok(_) => {
+                warn!("unexpected response from daemon");
+                Err("Unexpected response from daemon".into())
+            }
+            Err(crate::daemon_client::ClientError::PermissionDenied) => {
+                if crate::elevation::prompt_elevation(app, request).await {
+                    Ok(false)
+                } else {
+                    Err("Elevation was denied or failed".into())
+                }
+            }
+            Err(e) => {
+                error!("failed to send stop: {e}");
+                Err(format!("Failed to connect to daemon: {e}"))
+            }
+        }
+    };
+
+    match &result {
+        Ok(_) => rebuild_tray_menu(app),
+        Err(_) => revert_proxy_state(app, !enabled),
+    }
+
+    result
+}
+
+// Tray event handler ==================================================================================================
+
 /// Handle events from the tray menu.
 ///
 /// Separated from `handle_window_menu_event` because Tauri v2 dispatches menu events globally
@@ -127,118 +245,15 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
     match event.id().as_ref() {
         ID_ENABLE => {
             info!("tray: enable toggled");
-            let state = app.state::<AppState>();
-
-            // Toggle enabled flag and build proxy config
-            let (enabled, proxy_config) = {
-                let mut config = state.config.lock().unwrap();
-                config.enabled = !config.enabled;
-                config.save(&state.config_path).ok();
-                let enabled = config.enabled;
-                let pc = build_proxy_config(&config);
-                (enabled, pc)
-            };
-
-            set_tray_icon(app, enabled);
-
-            if enabled {
-                let Some(proxy_config) = proxy_config else {
-                    error!("tray: no server selected, cannot enable");
-                    // Revert the toggle
-                    {
-                        let mut config = state.config.lock().unwrap();
-                        config.enabled = false;
-                        config.save(&state.config_path).ok();
-                    }
-                    set_tray_icon(app, false);
-                    rebuild_tray_menu(app);
-                    // Show error dialog so the user knows what happened
-                    let app_handle = app.clone();
-                    tauri::async_runtime::spawn(async move {
-                        use tauri_plugin_dialog::DialogExt;
-                        app_handle
-                            .dialog()
-                            .message("No server is selected. Open Settings and select a server before enabling.")
-                            .title("Cannot Enable")
-                            .blocking_show();
-                    });
-                    return;
-                };
-
-                let app_handle = app.clone();
-                tauri::async_runtime::spawn(async move {
-                    let state = app_handle.state::<AppState>();
-                    let request = DaemonRequest::Start { config: proxy_config };
-                    let ok = match state.daemon_send(request.clone()).await {
-                        Ok(DaemonResponse::Ack) => {
-                            info!("proxy started");
-                            true
-                        }
-                        Ok(DaemonResponse::Error { message }) if message.contains("already running") => {
-                            info!("proxy already running");
-                            true
-                        }
-                        Ok(DaemonResponse::Error { message }) => {
-                            error!("daemon error: {message}");
-                            false
-                        }
-                        Ok(_) => {
-                            warn!("unexpected response from daemon");
-                            false
-                        }
-                        Err(crate::daemon_client::ClientError::PermissionDenied) => {
-                            crate::elevation::prompt_elevation(&app_handle, request).await
-                        }
-                        Err(e) => {
-                            error!("failed to send start: {e}");
-                            false
-                        }
-                    };
-                    if !ok {
-                        // Revert config on failure
-                        let mut config = state.config.lock().unwrap();
-                        config.enabled = false;
-                        config.save(&state.config_path).ok();
-                        set_tray_icon(&app_handle, false);
-                        rebuild_tray_menu(&app_handle);
-                    }
-                });
-            } else {
-                let app_handle = app.clone();
-                tauri::async_runtime::spawn(async move {
-                    let state = app_handle.state::<AppState>();
-                    let request = DaemonRequest::Stop;
-                    let ok = match state.daemon_send(request.clone()).await {
-                        Ok(DaemonResponse::Ack) => {
-                            info!("proxy stopped");
-                            true
-                        }
-                        Ok(DaemonResponse::Error { message }) => {
-                            error!("daemon error: {message}");
-                            false
-                        }
-                        Ok(_) => {
-                            warn!("unexpected response from daemon");
-                            false
-                        }
-                        Err(crate::daemon_client::ClientError::PermissionDenied) => {
-                            crate::elevation::prompt_elevation(&app_handle, request).await
-                        }
-                        Err(e) => {
-                            error!("failed to send stop: {e}");
-                            false
-                        }
-                    };
-                    if !ok {
-                        // Revert config on failure
-                        let mut config = state.config.lock().unwrap();
-                        config.enabled = true;
-                        config.save(&state.config_path).ok();
-                        set_tray_icon(&app_handle, true);
-                        rebuild_tray_menu(&app_handle);
-                    }
-                });
-            }
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app_handle.state::<AppState>();
+                let enabled = !state.config.lock().unwrap().enabled;
+                if let Err(msg) = set_proxy_enabled(&app_handle, enabled).await {
+                    use tauri_plugin_dialog::DialogExt;
+                    app_handle.dialog().message(msg).title("Error").blocking_show();
+                }
+            });
         }
         ID_AUTOSTART => {
             info!("tray: autostart toggled");
@@ -265,12 +280,7 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
         ID_EXIT => {
             info!("tray: exit requested");
             let app_handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                let state = app_handle.state::<AppState>();
-                // Best-effort stop
-                let _ = state.daemon_send(DaemonRequest::Stop).await;
-                app_handle.exit(0);
-            });
+            tauri::async_runtime::spawn(async move { exit_app(app_handle).await });
         }
         ID_INSTALL_UPDATE => {
             info!("tray: install update requested");
@@ -288,6 +298,18 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
 /// Handle events from the settings window menu bar. See `handle_tray_event` for why this is separate.
 fn handle_window_menu_event(app: &AppHandle, event: MenuEvent) {
     match event.id().as_ref() {
+        ID_WINDOW_IMPORT => {
+            info!("menu: import requested");
+            use tauri::Emitter;
+            if let Some(w) = app.get_webview_window("settings") {
+                w.emit("import-requested", ()).ok();
+            }
+        }
+        ID_WINDOW_EXIT => {
+            info!("menu: exit requested");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move { exit_app(app_handle).await });
+        }
         ID_CHECK_UPDATE => {
             info!("menu: check for updates");
             let app_handle = app.clone();
@@ -525,6 +547,16 @@ fn open_settings_window(app: &AppHandle) {
     {
         use tauri::menu::{Menu, Submenu};
 
+        // File menu
+        let import_item = MenuItem::with_id(app, ID_WINDOW_IMPORT, "Import...", true, Some("CmdOrCtrl+O"))
+            .expect("failed to create menu item");
+        let file_sep = PredefinedMenuItem::separator(app).expect("failed to create separator");
+        let exit_item = MenuItem::with_id(app, ID_WINDOW_EXIT, "Exit", true, Some("CmdOrCtrl+Q"))
+            .expect("failed to create menu item");
+        let file_submenu = Submenu::with_items(app, "File", true, &[&import_item, &file_sep, &exit_item])
+            .expect("failed to create submenu");
+
+        // Help menu
         let check_update_item = MenuItem::with_id(app, ID_CHECK_UPDATE, "Check for Updates...", true, None::<&str>)
             .expect("failed to create menu item");
         let about_item =
@@ -533,7 +565,7 @@ fn open_settings_window(app: &AppHandle) {
             .expect("failed to create submenu");
 
         #[cfg(not(target_os = "macos"))]
-        let menu = Menu::with_items(app, &[&help_submenu]).expect("failed to create menu");
+        let menu = Menu::with_items(app, &[&file_submenu, &help_submenu]).expect("failed to create menu");
 
         #[cfg(target_os = "macos")]
         let menu = {
@@ -541,7 +573,7 @@ fn open_settings_window(app: &AppHandle) {
                 .expect("failed to create menu item");
             let hole_submenu =
                 Submenu::with_items(app, "Hole", true, &[&uninstall_item]).expect("failed to create submenu");
-            Menu::with_items(app, &[&hole_submenu, &help_submenu]).expect("failed to create menu")
+            Menu::with_items(app, &[&hole_submenu, &file_submenu, &help_submenu]).expect("failed to create menu")
         };
 
         builder = builder.menu(menu).on_menu_event(|window, event| {
@@ -558,6 +590,15 @@ fn open_settings_window(app: &AppHandle) {
             error!(error = %e, "failed to open settings window");
         }
     }
+}
+
+// Tauri commands ======================================================================================================
+
+/// Toggle the proxy on/off. Returns `true` if proxy is now enabled, `false` if disabled.
+#[tauri::command]
+pub async fn toggle_proxy(app: AppHandle, state: tauri::State<'_, AppState>) -> Result<bool, String> {
+    let enabled = !state.config.lock().unwrap().enabled;
+    set_proxy_enabled(&app, enabled).await
 }
 
 #[cfg(test)]

--- a/ui/index.html
+++ b/ui/index.html
@@ -9,7 +9,10 @@
 <body>
   <header>
     <h1>Hole Settings</h1>
-    <div id="status" class="status disconnected">Daemon: disconnected</div>
+    <div class="header-controls">
+      <button id="btn-toggle" type="button" class="btn-connect" disabled>Connect</button>
+      <div id="status" class="status disconnected">Daemon: disconnected</div>
+    </div>
   </header>
 
   <section id="servers-section">

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,4 +1,5 @@
 const { invoke } = window.__TAURI__.core;
+const { listen } = window.__TAURI__.event;
 
 // State =====
 
@@ -11,6 +12,7 @@ const emptyMessage = document.getElementById("empty-message");
 const localPortInput = document.getElementById("local-port");
 const btnImport = document.getElementById("btn-import");
 const btnSave = document.getElementById("btn-save");
+const btnToggle = document.getElementById("btn-toggle");
 const saveStatus = document.getElementById("save-status");
 const statusBadge = document.getElementById("status");
 
@@ -98,11 +100,18 @@ function renderServers() {
   }
 }
 
+function updateToggleButton(enabled) {
+  btnToggle.textContent = enabled ? "Disconnect" : "Connect";
+  btnToggle.className = enabled ? "btn-disconnect" : "btn-connect";
+  btnToggle.disabled = false;
+}
+
 // Actions =====
 
 async function loadConfig() {
   config = await invoke("get_config");
   localPortInput.value = config.local_port;
+  updateToggleButton(config.enabled);
   renderServers();
 }
 
@@ -134,6 +143,22 @@ async function importServers() {
   }
 }
 
+async function toggleProxy() {
+  btnToggle.disabled = true;
+  try {
+    const enabled = await invoke("toggle_proxy");
+    updateToggleButton(enabled);
+    await checkDaemonStatus();
+  } catch (e) {
+    saveStatus.textContent = `Error: ${e}`;
+    setTimeout(() => { saveStatus.textContent = ""; }, 4000);
+    // Reload config to get the reverted state
+    try { await loadConfig(); } catch { /* best-effort */ }
+  } finally {
+    btnToggle.disabled = false;
+  }
+}
+
 async function checkDaemonStatus() {
   try {
     const status = await invoke("get_proxy_status");
@@ -143,12 +168,24 @@ async function checkDaemonStatus() {
     statusBadge.textContent = "Daemon: disconnected";
     statusBadge.className = "status disconnected";
   }
+  // Sync toggle button with current config state
+  try {
+    const cfg = await invoke("get_config");
+    updateToggleButton(cfg.enabled);
+  } catch { /* best-effort */ }
 }
 
 // Events =====
 
 btnSave.addEventListener("click", saveConfig);
 btnImport.addEventListener("click", importServers);
+btnToggle.addEventListener("click", toggleProxy);
+
+// Listen for import requests from the File > Import menu
+listen("import-requested", importServers);
+
+// Poll daemon status periodically
+setInterval(checkDaemonStatus, 5000);
 
 // Init =====
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -30,6 +30,42 @@ h2 {
   padding-bottom: 0.3rem;
 }
 
+/* Header controls */
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* Connect/Disconnect button */
+.btn-connect {
+  background: #28a745;
+  color: #fff;
+  border-color: #218838;
+  font-weight: 600;
+}
+
+.btn-connect:hover:not(:disabled) {
+  background: #218838;
+}
+
+.btn-disconnect {
+  background: #dc3545;
+  color: #fff;
+  border-color: #c82333;
+  font-weight: 600;
+}
+
+.btn-disconnect:hover:not(:disabled) {
+  background: #c82333;
+}
+
+.btn-connect:disabled,
+.btn-disconnect:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 /* Status badge */
 .status {
   font-size: 0.8rem;


### PR DESCRIPTION
## Summary
Closes #71. Depends on #74.

- **File menu** — Added File > Import (Ctrl+O) and File > Exit (Ctrl+Q) to the settings window. Import emits an event to the frontend that triggers the import dialog. Exit stops the proxy and exits the app (same as tray Exit).
- **Connect/Disconnect button** — Added a toggle button in the settings window header. Calls the new `toggle_proxy` Tauri command. Button shows "Connect" (green) or "Disconnect" (red) based on current state.
- **Refactored proxy toggle** — Extracted `set_proxy_enabled()` shared async function used by both the tray Enable checkbox and the `toggle_proxy` command. Includes race-condition guard (returns early if already in desired state).
- **Daemon status polling** — Frontend polls `get_proxy_status` every 5 seconds to keep the status badge and toggle button in sync with actual daemon state.
- **Exit logic deduplicated** — Shared `exit_app()` function used by both tray and window Exit handlers.

## Test plan
- [x] `cargo test --workspace` passes (96 tests, all from prior changes)
- [ ] Manual: File > Import opens file dialog
- [ ] Manual: File > Exit stops proxy and closes app
- [ ] Manual: Connect button starts proxy, shows Disconnect
- [ ] Manual: Disconnect button stops proxy, shows Connect
- [ ] Manual: Ctrl+O / Ctrl+Q keyboard shortcuts work