### PR TITLE
Add window constraints, Apply button, drop zone empty state

### DIFF
--- a/crates/gui/src/tray.rs
+++ b/crates/gui/src/tray.rs
@@ -541,6 +541,7 @@ fn open_settings_window(app: &AppHandle) {
     let mut builder = WebviewWindowBuilder::new(app, "settings", WebviewUrl::default())
         .title("Hole Settings")
         .inner_size(600.0, 400.0)
+        .min_inner_size(450.0, 300.0)
         .resizable(true);
 
     // Menu bar (all platforms) ----------------------------------------------------------------------------------------

--- a/ui/index.html
+++ b/ui/index.html
@@ -32,9 +32,9 @@
         <!-- rows rendered by JS -->
       </tbody>
     </table>
-    <p id="empty-message" class="muted">No servers configured. Import a config to get started.</p>
-    <div class="button-row">
-      <button id="btn-import" type="button">Import...</button>
+    <div id="empty-state" class="drop-zone" style="display: none;">
+      <p>No servers configured</p>
+      <p class="muted">Drag and drop a JSON config file here, or use File &gt; Import</p>
     </div>
   </section>
 
@@ -47,7 +47,7 @@
   </section>
 
   <footer>
-    <button id="btn-save" type="button">Save</button>
+    <button id="btn-apply" type="button" disabled>Apply</button>
     <span id="save-status"></span>
   </footer>
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -4,17 +4,24 @@ const { listen } = window.__TAURI__.event;
 // State =====
 
 let config = null;
+let dirty = false;
 
 // DOM refs =====
 
 const serverList = document.getElementById("server-list");
-const emptyMessage = document.getElementById("empty-message");
+const emptyState = document.getElementById("empty-state");
 const localPortInput = document.getElementById("local-port");
-const btnImport = document.getElementById("btn-import");
-const btnSave = document.getElementById("btn-save");
+const btnApply = document.getElementById("btn-apply");
 const btnToggle = document.getElementById("btn-toggle");
 const saveStatus = document.getElementById("save-status");
 const statusBadge = document.getElementById("status");
+
+// Dirty tracking =====
+
+function setDirty(value) {
+  dirty = value;
+  btnApply.disabled = !dirty;
+}
 
 // Rendering =====
 
@@ -22,10 +29,10 @@ function renderServers() {
   serverList.innerHTML = "";
 
   if (!config || config.servers.length === 0) {
-    emptyMessage.style.display = "";
+    emptyState.style.display = "";
     return;
   }
-  emptyMessage.style.display = "none";
+  emptyState.style.display = "none";
 
   for (const server of config.servers) {
     const tr = document.createElement("tr");
@@ -111,15 +118,17 @@ function updateToggleButton(enabled) {
 async function loadConfig() {
   config = await invoke("get_config");
   localPortInput.value = config.local_port;
+  setDirty(false);
   updateToggleButton(config.enabled);
   renderServers();
 }
 
-async function saveConfig() {
+async function applyConfig() {
   config.local_port = parseInt(localPortInput.value, 10) || 4073;
   try {
     await invoke("save_config", { config });
-    saveStatus.textContent = "Saved.";
+    setDirty(false);
+    saveStatus.textContent = "Applied.";
     setTimeout(() => { saveStatus.textContent = ""; }, 2000);
   } catch (e) {
     saveStatus.textContent = `Error: ${e}`;
@@ -143,6 +152,17 @@ async function importServers() {
   }
 }
 
+async function importFromPath(path) {
+  try {
+    await invoke("import_servers_from_file", { path });
+    await loadConfig();
+    saveStatus.textContent = "Servers imported.";
+    setTimeout(() => { saveStatus.textContent = ""; }, 2000);
+  } catch (e) {
+    saveStatus.textContent = `Import error: ${e}`;
+  }
+}
+
 async function toggleProxy() {
   btnToggle.disabled = true;
   try {
@@ -152,7 +172,6 @@ async function toggleProxy() {
   } catch (e) {
     saveStatus.textContent = `Error: ${e}`;
     setTimeout(() => { saveStatus.textContent = ""; }, 4000);
-    // Reload config to get the reverted state
     try { await loadConfig(); } catch { /* best-effort */ }
   } finally {
     btnToggle.disabled = false;
@@ -168,7 +187,6 @@ async function checkDaemonStatus() {
     statusBadge.textContent = "Daemon: disconnected";
     statusBadge.className = "status disconnected";
   }
-  // Sync toggle button with current config state
   try {
     const cfg = await invoke("get_config");
     updateToggleButton(cfg.enabled);
@@ -177,12 +195,24 @@ async function checkDaemonStatus() {
 
 // Events =====
 
-btnSave.addEventListener("click", saveConfig);
-btnImport.addEventListener("click", importServers);
+btnApply.addEventListener("click", applyConfig);
 btnToggle.addEventListener("click", toggleProxy);
+localPortInput.addEventListener("input", () => setDirty(true));
+
+// Empty state click-to-import
+emptyState.addEventListener("click", importServers);
 
 // Listen for import requests from the File > Import menu
 listen("import-requested", importServers);
+
+// Drag-and-drop via Tauri's built-in file drop event
+listen("tauri://drag-drop", (event) => {
+  const paths = event.payload.paths || [];
+  const jsonFile = paths.find((p) => p.toLowerCase().endsWith(".json"));
+  if (jsonFile) {
+    importFromPath(jsonFile);
+  }
+});
 
 // Poll daemon status periodically
 setInterval(checkDaemonStatus, 5000);

--- a/ui/style.css
+++ b/ui/style.css
@@ -156,15 +156,21 @@ button:hover {
   background: #f0f0f0;
 }
 
-#btn-save {
+#btn-apply {
   background: #0066cc;
   color: #fff;
   border-color: #0055aa;
   font-weight: 600;
 }
 
-#btn-save:hover {
+#btn-apply:hover:not(:disabled) {
   background: #0055aa;
+}
+
+#btn-apply:disabled {
+  background: #99bbdd;
+  cursor: default;
+  opacity: 0.6;
 }
 
 /* Fields */
@@ -199,6 +205,25 @@ footer {
 #save-status {
   font-size: 0.8rem;
   color: #555;
+}
+
+/* Drop zone (empty state) */
+.drop-zone {
+  border: 2px dashed #ccc;
+  border-radius: 8px;
+  padding: 2rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.drop-zone:hover {
+  border-color: #999;
+  background: #f5f5f5;
+}
+
+.drop-zone p {
+  margin: 0.3rem 0;
 }
 
 .plugin-badge {


### PR DESCRIPTION
## Summary
Closes #72. Depends on #75.

- **Window min size** — Set `min_inner_size(450, 300)` to prevent resizing to zero or unreasonably small.
- **Save -> Apply** — Renamed "Save" to "Apply". Button is disabled (greyed out) when no changes are pending. Port input changes set a dirty flag; applying clears it. Server selection and deletion auto-save immediately (not tracked by dirty flag).
- **Empty state drop zone** — When no servers are configured, shows a styled dashed-border area with "Drag and drop a JSON config file here, or use File > Import". Clicking the zone opens the import dialog. Drag-and-drop uses Tauri's `tauri://drag-drop` event to receive file paths and import the first `.json` file.
- **Removed standalone Import button** — Import is now available via File > Import menu and the empty state drop zone.

## Test plan
- [x] `cargo test --workspace` passes
- [ ] Manual: window cannot be resized below 450x300
- [ ] Manual: Apply button greyed out initially, enables on port change, greys after applying
- [ ] Manual: empty state shows drop zone when no servers
- [ ] Manual: drag-and-drop a .json file imports servers
- [ ] Manual: clicking drop zone opens file dialog