### PR TITLE
Add Help > Collect Logs and MSI post-install auto-launch

### DIFF
--- a/crates/gui/Cargo.toml
+++ b/crates/gui/Cargo.toml
@@ -40,6 +40,7 @@ bytes = "1"
 ureq = { version = "3", features = ["json"] }
 sha2 = "0.11"
 minisign-verify = "0.2"
+zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.56"

--- a/crates/gui/capabilities/default.json
+++ b/crates/gui/capabilities/default.json
@@ -7,6 +7,7 @@
     "autostart:allow-disable",
     "autostart:allow-is-enabled",
     "dialog:allow-open",
-    "dialog:allow-message"
+    "dialog:allow-message",
+    "dialog:allow-save"
   ]
 }

--- a/crates/gui/src/log_collector.rs
+++ b/crates/gui/src/log_collector.rs
@@ -1,0 +1,95 @@
+// Collect GUI and daemon logs into a zip archive.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+/// Locate all log directories (GUI and daemon).
+fn log_dirs() -> Vec<(&'static str, PathBuf)> {
+    let mut dirs = Vec::new();
+
+    if let Some(local_data) = dirs::data_local_dir() {
+        dirs.push(("gui", local_data.join("hole").join("logs")));
+    }
+
+    // Daemon logs on Windows
+    #[cfg(target_os = "windows")]
+    dirs.push(("daemon", PathBuf::from(r"C:\ProgramData\hole\logs")));
+
+    // Daemon logs on macOS / Linux
+    #[cfg(not(target_os = "windows"))]
+    dirs.push(("daemon", PathBuf::from("/var/log/hole")));
+
+    dirs
+}
+
+/// Create a zip archive containing all log files. Returns the path to the temp zip.
+pub fn collect_logs_to_zip() -> Result<PathBuf, String> {
+    let zip_dir = tempfile::tempdir().map_err(|e| format!("Failed to create temp directory: {e}"))?;
+    let zip_path = zip_dir.keep().join("hole-logs.zip");
+
+    let file = std::fs::File::create(&zip_path).map_err(|e| format!("Failed to create zip file: {e}"))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    let mut file_count = 0;
+
+    for (prefix, dir) in log_dirs() {
+        if !dir.exists() {
+            info!(dir = %dir.display(), "log directory does not exist, skipping");
+            continue;
+        }
+
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(dir = %dir.display(), error = %e, "failed to read log directory");
+                continue;
+            }
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+
+            let file_name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+
+            let archive_name = format!("{prefix}/{file_name}");
+            if let Err(e) = add_file_to_zip(&mut zip, &path, &archive_name, options) {
+                warn!(file = %path.display(), error = %e, "failed to add log file to zip");
+                continue;
+            }
+            file_count += 1;
+        }
+    }
+
+    zip.finish().map_err(|e| format!("Failed to finalize zip: {e}"))?;
+
+    if file_count == 0 {
+        return Err("No log files found".to_string());
+    }
+
+    info!(count = file_count, path = %zip_path.display(), "collected log files");
+    Ok(zip_path)
+}
+
+fn add_file_to_zip(
+    zip: &mut zip::ZipWriter<std::fs::File>,
+    path: &Path,
+    archive_name: &str,
+    options: zip::write::SimpleFileOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = std::fs::read(path)?;
+    zip.start_file(archive_name, options)?;
+    zip.write_all(&data)?;
+    Ok(())
+}

--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod commands;
 mod daemon_client;
 mod elevation;
+mod log_collector;
 mod logging;
 mod path_management;
 mod platform;

--- a/crates/gui/src/tray.rs
+++ b/crates/gui/src/tray.rs
@@ -25,6 +25,7 @@ const ID_WINDOW_EXIT: &str = "window_exit";
 const ID_UNINSTALL_HELPER: &str = "uninstall_helper";
 const ID_ABOUT: &str = "about";
 const ID_CHECK_UPDATE: &str = "check_update";
+const ID_COLLECT_LOGS: &str = "window_collect_logs";
 
 // Tray creation =======================================================================================================
 
@@ -317,6 +318,13 @@ fn handle_window_menu_event(app: &AppHandle, event: MenuEvent) {
                 handle_check_for_updates(app_handle).await;
             });
         }
+        ID_COLLECT_LOGS => {
+            info!("menu: collect logs");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                handle_collect_logs(app_handle).await;
+            });
+        }
         ID_ABOUT => {
             info!("menu: about dialog");
             use tauri_plugin_dialog::DialogExt;
@@ -485,6 +493,47 @@ async fn handle_install_update_from_tray(app: AppHandle) {
     }
 }
 
+async fn handle_collect_logs(app: AppHandle) {
+    use tauri_plugin_dialog::DialogExt;
+
+    let zip_result = tokio::task::spawn_blocking(crate::log_collector::collect_logs_to_zip).await;
+
+    let zip_path = match zip_result {
+        Ok(Ok(path)) => path,
+        Ok(Err(e)) => {
+            app.dialog().message(e).title("Collect Logs").blocking_show();
+            return;
+        }
+        Err(e) => {
+            error!("collect logs task panicked: {e}");
+            return;
+        }
+    };
+
+    // Show a save dialog so the user can choose where to save
+    let dest = app
+        .dialog()
+        .file()
+        .set_file_name("hole-logs.zip")
+        .add_filter("ZIP Archive", &["zip"])
+        .blocking_save_file();
+
+    if let Some(dest) = dest {
+        if let Err(e) = std::fs::copy(&zip_path, dest.as_path().unwrap()) {
+            app.dialog()
+                .message(format!("Failed to save: {e}"))
+                .title("Collect Logs")
+                .blocking_show();
+        }
+    }
+
+    // Clean up temp file
+    let _ = std::fs::remove_file(&zip_path);
+    if let Some(parent) = zip_path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+}
+
 async fn handle_check_for_updates(app: AppHandle) {
     use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
@@ -560,10 +609,17 @@ fn open_settings_window(app: &AppHandle) {
         // Help menu
         let check_update_item = MenuItem::with_id(app, ID_CHECK_UPDATE, "Check for Updates...", true, None::<&str>)
             .expect("failed to create menu item");
+        let collect_logs_item = MenuItem::with_id(app, ID_COLLECT_LOGS, "Collect Logs...", true, None::<&str>)
+            .expect("failed to create menu item");
         let about_item =
             MenuItem::with_id(app, ID_ABOUT, "About Hole", true, None::<&str>).expect("failed to create menu item");
-        let help_submenu = Submenu::with_items(app, "Help", true, &[&check_update_item, &about_item])
-            .expect("failed to create submenu");
+        let help_submenu = Submenu::with_items(
+            app,
+            "Help",
+            true,
+            &[&check_update_item, &collect_logs_item, &about_item],
+        )
+        .expect("failed to create submenu");
 
         #[cfg(not(target_os = "macos"))]
         let menu = Menu::with_items(app, &[&file_submenu, &help_submenu]).expect("failed to create menu");

--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -99,6 +99,18 @@
       Impersonate="no"
       Return="ignore" />
 
+    <!-- Launch the app after a fresh interactive install.
+         Runs as the installing user (Impersonate=yes), non-blocking (asyncNoWait).
+         Skipped on upgrades (WIX_UPGRADE_DETECTED), uninstalls, and silent installs
+         (pass SUPPRESS_LAUNCH=1 on the msiexec command line). -->
+    <CustomAction
+      Id="LaunchApp"
+      FileRef="hole.exe"
+      ExeCommand=""
+      Execute="immediate"
+      Impersonate="yes"
+      Return="asyncNoWait" />
+
     <InstallExecuteSequence>
       <!-- Post-install: daemon install then PATH add -->
       <Custom Action="DaemonInstall" After="InstallFiles"
@@ -113,6 +125,10 @@
         Condition="REMOVE=&quot;ALL&quot;" />
       <Custom Action="DaemonUninstall" Before="RemoveFiles"
         Condition="REMOVE=&quot;ALL&quot;" />
+
+      <!-- Launch app after fresh install (not upgrades, not silent) -->
+      <Custom Action="LaunchApp" After="InstallFinalize"
+        Condition="NOT Installed AND NOT WIX_UPGRADE_DETECTED AND NOT REMOVE AND NOT SUPPRESS_LAUNCH" />
     </InstallExecuteSequence>
 
   </Package>

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -141,8 +141,12 @@ def _is_uninstall_condition(condition: str) -> bool:
     return 'REMOVE="' in condition or "REMOVE~=" in condition
 
 
+# CAs that launch the app after install — exempt from Return=check and After=InstallFiles rules.
+_LAUNCH_CAS = {"LaunchApp"}
+
+
 def test_install_cas_sequenced_after_install_files(package: ET.Element) -> None:
-    """Every install CA must be transitively After='InstallFiles'."""
+    """Every install CA (except launch CAs) must be transitively After='InstallFiles'."""
     customs = _get_custom_entries(package)
 
     # Build a map: action -> what it's After
@@ -157,6 +161,8 @@ def test_install_cas_sequenced_after_install_files(package: ET.Element) -> None:
 
     for custom in install_cas:
         action = custom.get("Action", "")
+        if action in _LAUNCH_CAS:
+            continue
         # Walk the After chain to verify it reaches InstallFiles
         visited: set[str] = set()
         current = action
@@ -173,6 +179,22 @@ def test_install_cas_sequenced_after_install_files(package: ET.Element) -> None:
             f"Install CA '{action}' is not transitively After='InstallFiles'. "
             f"Chain: {' -> '.join(visited)}"
         )
+
+
+def test_launch_ca_after_install_finalize(package: ET.Element) -> None:
+    """Launch CAs must be After='InstallFinalize' and Return='asyncNoWait'."""
+    cas = _ca_map(package)
+    customs = _get_custom_entries(package)
+
+    for custom in customs:
+        action = custom.get("Action", "")
+        if action not in _LAUNCH_CAS:
+            continue
+        assert custom.get("After") == "InstallFinalize", (f"Launch CA '{action}' must be After='InstallFinalize'")
+        ca = cas[action]
+        assert ca.get("Return") == "asyncNoWait", (f"Launch CA '{action}' must have Return='asyncNoWait'")
+        assert ca.get("Impersonate"
+                      ) == "yes", (f"Launch CA '{action}' must have Impersonate='yes' to run as the installing user")
 
 
 def test_uninstall_cas_sequenced_before_remove_files(package: ET.Element) -> None:
@@ -243,6 +265,8 @@ def test_install_cas_return_check(package: ET.Element) -> None:
     for custom in _get_custom_entries(package):
         if _is_install_condition(custom.get("Condition", "")):
             action = custom.get("Action", "")
+            if action in _LAUNCH_CAS:
+                continue
             ca = cas.get(action)
             assert ca is not None, f"Custom references undefined CA '{action}'"
             assert ca.get("Return") == "check", (


### PR DESCRIPTION
## Summary
Closes #73. Replaces #77.

- **Help > Collect Logs** — New menu item that gathers GUI and daemon log files into a zip and opens a save dialog.
- **MSI auto-launch** — Launches the app after a fresh interactive install (skipped on upgrades and silent installs).
- **New `log_collector.rs` module** and MSI `LaunchApp` custom action with test coverage.

## Test plan
- [x] `cargo test --workspace` passes
- [x] MSI tests pass (28 tests)
- [ ] Manual: Help > Collect Logs
- [ ] Manual: MSI auto-launch