### PR TITLE
Fix MSI same-version reinstall creating duplicate uninstall entries

### DIFF
--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -18,6 +18,7 @@
     UpgradeCode="6F2A8C1D-3E4B-4F5A-9D7E-1C2B3A4F5E6D">
 
     <MajorUpgrade
+      AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of Hole is already installed." />
 
     <!-- Installation directory structure -->

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -243,6 +243,16 @@ def test_major_upgrade_exists(package: ET.Element) -> None:
     assert mu is not None, "MajorUpgrade element is required for upgrade support"
 
 
+def test_major_upgrade_allows_same_version(package: ET.Element) -> None:
+    """Reinstalling the same version must not create duplicate uninstall entries."""
+    mu = package.find("wix:MajorUpgrade", NS)
+    assert mu is not None
+    assert mu.get("AllowSameVersionUpgrades") == "yes", (
+        "MajorUpgrade must have AllowSameVersionUpgrades='yes' to handle "
+        "reinstalls of the same version without creating duplicate entries"
+    )
+
+
 # Custom action attribute tests ========================================================================================
 
 


### PR DESCRIPTION
## Summary
Closes #82.

Add `AllowSameVersionUpgrades="yes"` to `<MajorUpgrade>` in `hole.wxs`. Without this, reinstalling the same version creates duplicate entries in Windows "Apps & features" because WiX only handles upgrades to a *different* version by default.

## Test plan
- [x] New test `test_major_upgrade_allows_same_version` (TDD — written first, verified failure, then fixed)
- [x] All 29 MSI tests pass
- [ ] Manual: install MSI, reinstall same version, verify single uninstall entry