### PR TITLE
Fix elevation UX: user SID in DACL, single dialog, prompt-shown persistence

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -21,6 +21,13 @@ pub struct AppConfig {
     pub selected_server: Option<String>,
     pub local_port: u16,
     pub enabled: bool,
+
+    /// Whether the elevation explanation dialog has been shown to the user.
+    ///
+    /// This is a GUI-only field stored in the shared config to avoid a second
+    /// config file. Once set to `true`, subsequent PermissionDenied errors
+    /// skip the explanation dialog and go directly to a UAC prompt.
+    pub elevation_prompt_shown: bool,
 }
 
 impl Default for AppConfig {
@@ -30,6 +37,7 @@ impl Default for AppConfig {
             selected_server: None,
             local_port: 4073,
             enabled: false,
+            elevation_prompt_shown: false,
         }
     }
 }

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -28,6 +28,7 @@ fn load_valid_json_roundtrips(#[fixture(temp_dir)] dir: &Path) {
         selected_server: Some("abc-123".to_string()),
         local_port: 5555,
         enabled: true,
+        ..Default::default()
     };
     original.save(&path).unwrap();
     let loaded = AppConfig::load(&path).unwrap();
@@ -129,6 +130,28 @@ fn deserialize_with_extra_unknown_fields_succeeds() {
     let json = r#"{"servers": [], "future_field": 42, "another": "hi"}"#;
     let config: AppConfig = serde_json::from_str(json).unwrap();
     assert_eq!(config.local_port, 4073);
+}
+
+// elevation_prompt_shown tests ----------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn deserialize_without_elevation_prompt_shown_defaults_to_false() {
+    let json = r#"{"servers": [], "local_port": 4073}"#;
+    let config: AppConfig = serde_json::from_str(json).unwrap();
+    assert!(!config.elevation_prompt_shown);
+}
+
+#[skuld::test]
+fn elevation_prompt_shown_roundtrips(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    let config = AppConfig {
+        elevation_prompt_shown: true,
+        ..Default::default()
+    };
+    config.save(&path).unwrap();
+
+    let loaded = AppConfig::load(&path).unwrap();
+    assert!(loaded.elevation_prompt_shown);
 }
 
 // macOS permission tests ----------------------------------------------------------------------------------------------

--- a/crates/daemon/src/group.rs
+++ b/crates/daemon/src/group.rs
@@ -33,10 +33,16 @@ pub fn installing_username() -> io::Result<String> {
     os::installing_username()
 }
 
+/// Look up the SID of any account (user or group) as a string (e.g. `S-1-5-21-...`).
+#[cfg(target_os = "windows")]
+pub fn lookup_sid(name: &str) -> io::Result<String> {
+    os::lookup_sid(name)
+}
+
 /// Look up the SID of the `hole` group as a string (e.g. `S-1-5-21-...`).
 #[cfg(target_os = "windows")]
 pub fn group_sid() -> io::Result<String> {
-    os::group_sid()
+    lookup_sid(GROUP_NAME)
 }
 
 // macOS implementation ================================================================================================
@@ -266,19 +272,20 @@ mod os {
         Ok(username)
     }
 
-    pub fn group_sid() -> io::Result<String> {
+    /// Look up any account name (user or group) and return its SID as a string.
+    pub fn lookup_sid(name: &str) -> io::Result<String> {
         use windows::core::PWSTR;
         use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
         use windows::Win32::Security::{LookupAccountNameW, SID_NAME_USE};
 
-        let group_name: Vec<u16> = GROUP_NAME.encode_utf16().chain(std::iter::once(0)).collect();
+        let account_name: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
 
         // First call: get required buffer sizes
         let mut sid_size: u32 = 0;
         let mut domain_size: u32 = 0;
         let mut sid_type = SID_NAME_USE::default();
 
-        // SAFETY: First call to get required buffer sizes. `group_name` is a valid
+        // SAFETY: First call to get required buffer sizes. `account_name` is a valid
         // null-terminated UTF-16 string kept alive for the call. Output buffer
         // pointers are None (size query only). `sid_size` and `domain_size` are
         // out-parameters filled with required sizes. Expected to fail with
@@ -286,7 +293,7 @@ mod os {
         let _ = unsafe {
             LookupAccountNameW(
                 None,
-                windows::core::PCWSTR(group_name.as_ptr()),
+                windows::core::PCWSTR(account_name.as_ptr()),
                 None,
                 &mut sid_size,
                 None,
@@ -296,7 +303,7 @@ mod os {
         };
 
         if sid_size == 0 {
-            return Err(io::Error::other(format!("group '{}' not found", GROUP_NAME)));
+            return Err(io::Error::other(format!("account '{name}' not found")));
         }
 
         // Second call: fill buffers
@@ -313,12 +320,12 @@ mod os {
 
         // SAFETY: Second call with correctly sized buffers. `sid_buf` is at least
         // `sid_size` bytes (allocated above). `domain_buf` is at least `domain_size`
-        // u16 elements. `group_name` remains alive. `sid_ptr` wraps `sid_buf`'s
+        // u16 elements. `account_name` remains alive. `sid_ptr` wraps `sid_buf`'s
         // pointer. The result is checked with `?`.
         unsafe {
             LookupAccountNameW(
                 None,
-                windows::core::PCWSTR(group_name.as_ptr()),
+                windows::core::PCWSTR(account_name.as_ptr()),
                 Some(sid_ptr),
                 &mut sid_size,
                 Some(PWSTR(domain_buf.as_mut_ptr())),

--- a/crates/daemon/src/group_tests.rs
+++ b/crates/daemon/src/group_tests.rs
@@ -5,14 +5,26 @@ mod windows {
     #[skuld::test]
     fn group_sid_format() {
         // group_sid() should return a SID string starting with S-1-
-        // This test will only pass if the group actually exists,
-        // so we test the error path instead.
-        let result = crate::group::group_sid();
         // On CI / dev machines, the group likely doesn't exist.
         // Just verify the function doesn't panic and returns a reasonable error.
+        let result = crate::group::group_sid();
         if let Ok(sid) = result {
             assert!(sid.starts_with("S-1-"), "SID should start with S-1-, got: {sid}");
         }
+    }
+
+    #[skuld::test]
+    fn lookup_sid_resolves_current_user() {
+        // The current user always has a SID — this must succeed.
+        let username = crate::group::installing_username().expect("should detect current user");
+        let sid = crate::group::lookup_sid(&username).expect("lookup_sid should resolve current user");
+        assert!(sid.starts_with("S-1-"), "SID should start with S-1-, got: {sid}");
+    }
+
+    #[skuld::test]
+    fn lookup_sid_nonexistent_returns_error() {
+        let result = crate::group::lookup_sid("nonexistent_user_that_does_not_exist_12345");
+        assert!(result.is_err());
     }
 }
 

--- a/crates/daemon/src/ipc.rs
+++ b/crates/daemon/src/ipc.rs
@@ -205,7 +205,7 @@ pub(crate) const SDDL_BASE: &str = "D:(A;;GA;;;SY)(A;;GA;;;BA)";
 /// When `protect` is false, inherited ACEs are preserved. This is used for
 /// the final DACL in `apply_socket_permissions` (adding the `hole` group).
 #[cfg(target_os = "windows")]
-pub(crate) fn set_dacl_from_sddl(path: &Path, sddl: &str, protect: bool) -> std::io::Result<()> {
+pub fn set_dacl_from_sddl(path: &Path, sddl: &str, protect: bool) -> std::io::Result<()> {
     use windows::core::HSTRING;
     use windows::Win32::Foundation::LocalFree;
     use windows::Win32::Security::Authorization::{
@@ -309,21 +309,70 @@ pub(crate) fn set_dacl_from_sddl(path: &Path, sddl: &str, protect: bool) -> std:
 /// adding the `hole` group on both platforms.
 ///
 /// On Windows: sets a DACL restricting access to SYSTEM, Administrators, and the `hole` group.
+/// If an `installer-user-sid` file exists (written by `install_daemon` in `setup.rs`),
+/// the SID it contains is also added to the DACL, then the file is deleted. This is a
+/// workaround for the Windows token snapshot limitation: process tokens are immutable
+/// snapshots of group memberships captured at logon time, so a newly-added group
+/// membership is not reflected in any running process's token until the user logs out
+/// and back in. Adding the user's own SID directly to the DACL provides immediate
+/// access without requiring re-login. The per-user SID is cleaned up on the next
+/// daemon restart (when the group membership will have taken effect after re-login).
+///
 /// On macOS: sets ownership to root:hole with mode 0660.
 #[cfg(all(target_os = "windows", not(test)))]
 fn apply_socket_permissions(path: &Path) {
-    let sddl = build_sddl();
+    let mut extra_sids = Vec::new();
+    let sid_file = installer_user_sid_path();
+    if let Ok(sid) = std::fs::read_to_string(&sid_file) {
+        let sid = sid.trim().to_string();
+        if !sid.is_empty() {
+            info!(sid = %sid, "including installer user SID in socket DACL");
+            extra_sids.push(sid);
+        }
+        // Delete the file after reading — the per-user SID is a temporary bridge
+        // that is no longer needed after the daemon restarts (group membership
+        // will be in the token after re-login).
+        let _ = std::fs::remove_file(&sid_file);
+    }
+    let extra_refs: Vec<&str> = extra_sids.iter().map(|s| s.as_str()).collect();
+    let sddl = build_sddl(&extra_refs);
     if let Err(e) = set_dacl_from_sddl(path, &sddl, false) {
         warn!("failed to set socket permissions: {e}");
     }
 }
 
+/// Path to the file where the installing user's SID is stored temporarily.
+///
+/// Written by `install_daemon()` in `setup.rs`, read and deleted by
+/// `apply_socket_permissions()` on daemon startup.
+#[cfg(target_os = "windows")]
+pub fn installer_user_sid_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(std::env::var("ProgramData").unwrap_or_else(|_| r"C:\ProgramData".into()))
+        .join("hole")
+        .join("installer-user-sid")
+}
+
+/// Check that a string looks like a valid Windows SID (e.g. `S-1-5-21-...`).
+///
+/// Only allows the pattern `S-` followed by dash-separated decimal numbers. This prevents
+/// SDDL injection via crafted strings containing `)` or other SDDL metacharacters.
+#[cfg(target_os = "windows")]
+pub(crate) fn is_valid_sid_string(s: &str) -> bool {
+    s.starts_with("S-") && s.len() > 3 && s[2..].bytes().all(|b| b.is_ascii_digit() || b == b'-')
+}
+
 /// Build the SDDL string for the socket file DACL.
-#[cfg(all(target_os = "windows", not(test)))]
-fn build_sddl() -> String {
+///
+/// Always includes SYSTEM + Administrators + the `hole` group (if it exists).
+/// Additional per-user SIDs can be appended via `extra_sids` — this is used
+/// as a temporary workaround for the Windows token snapshot limitation (see
+/// [`apply_socket_permissions`] and the doc comment on `handle_grant_access`
+/// in `cli.rs`).
+#[cfg(target_os = "windows")]
+pub fn build_sddl(extra_sids: &[&str]) -> String {
     let base = SDDL_BASE;
 
-    match crate::group::group_sid() {
+    let mut sddl = match crate::group::group_sid() {
         Ok(sid) => {
             info!(sid = %sid, "restricting IPC to SYSTEM + Administrators + hole group");
             format!("{base}(A;;GA;;;{sid})")
@@ -332,7 +381,17 @@ fn build_sddl() -> String {
             warn!("'hole' group not found ({e}), IPC restricted to admin-only");
             base.to_string()
         }
+    };
+
+    for sid in extra_sids {
+        if is_valid_sid_string(sid) {
+            sddl.push_str(&format!("(A;;GA;;;{sid})"));
+        } else {
+            warn!(sid = %sid, "ignoring malformed SID string in DACL");
+        }
     }
+
+    sddl
 }
 
 /// Set socket file ownership to root:hole and mode 0660 on macOS.

--- a/crates/daemon/src/ipc_tests.rs
+++ b/crates/daemon/src/ipc_tests.rs
@@ -485,6 +485,80 @@ fn wrong_method_returns_405() {
     });
 }
 
+// SDDL tests (Windows only) ===========================================================================================
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn build_sddl_without_extra_sids() {
+    let sddl = crate::ipc::build_sddl(&[]);
+    // Must start with the base SDDL (SYSTEM + Administrators)
+    assert!(
+        sddl.starts_with(crate::ipc::SDDL_BASE),
+        "SDDL should start with base: {sddl}"
+    );
+    // The hole group SID ACE may or may not be present depending on whether
+    // the group exists on this machine. Either way, no extra user SIDs.
+    // Count ACE entries: each starts with "(A;;"
+    let ace_count = sddl.matches("(A;;").count();
+    // Base has 2 (SYSTEM + BA), group adds 0 or 1
+    assert!(
+        ace_count == 2 || ace_count == 3,
+        "expected 2 or 3 ACEs (base + optional group), got {ace_count} in: {sddl}"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn build_sddl_with_extra_sids() {
+    let fake_sid = "S-1-5-21-1234567890-1234567890-1234567890-1001";
+    let sddl = crate::ipc::build_sddl(&[fake_sid]);
+    assert!(
+        sddl.contains(&format!("(A;;GA;;;{fake_sid})")),
+        "SDDL should contain extra SID ACE: {sddl}"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn build_sddl_with_multiple_extra_sids() {
+    let sid1 = "S-1-5-21-1111111111-1111111111-1111111111-1001";
+    let sid2 = "S-1-5-21-2222222222-2222222222-2222222222-1002";
+    let sddl = crate::ipc::build_sddl(&[sid1, sid2]);
+    assert!(
+        sddl.contains(&format!("(A;;GA;;;{sid1})")),
+        "SDDL should contain first extra SID: {sddl}"
+    );
+    assert!(
+        sddl.contains(&format!("(A;;GA;;;{sid2})")),
+        "SDDL should contain second extra SID: {sddl}"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn build_sddl_rejects_malformed_sid() {
+    // A malformed SID with SDDL metacharacters should be ignored
+    let malformed = "S-1-1-0)(A;;GA;;;S-1-1-0";
+    let sddl = crate::ipc::build_sddl(&[malformed]);
+    assert!(!sddl.contains(malformed), "malformed SID should be rejected: {sddl}");
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn is_valid_sid_string_accepts_valid() {
+    assert!(crate::ipc::is_valid_sid_string("S-1-5-21-1234567890-1001"));
+    assert!(crate::ipc::is_valid_sid_string("S-1-1-0"));
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn is_valid_sid_string_rejects_invalid() {
+    assert!(!crate::ipc::is_valid_sid_string(""));
+    assert!(!crate::ipc::is_valid_sid_string("not-a-sid"));
+    assert!(!crate::ipc::is_valid_sid_string("S-1-1-0)(A;;GA;;;S-1-1-0"));
+    assert!(!crate::ipc::is_valid_sid_string("S-1-1-0 "));
+}
+
 // Socket lifecycle tests ==============================================================================================
 
 #[skuld::test]

--- a/crates/gui/src/cli.rs
+++ b/crates/gui/src/cli.rs
@@ -311,6 +311,23 @@ fn daemon_log_watch(path: &std::path::Path, tail_lines: usize) -> i32 {
     }
 }
 
+/// Handle the `daemon grant-access` command.
+///
+/// Adds the current user to the `hole` group and, on Windows, immediately
+/// updates the daemon socket DACL to include the user's SID. This is a
+/// workaround for the Windows token snapshot limitation:
+///
+/// 1. Windows process tokens are immutable snapshots of group memberships
+///    captured at logon time. There is no Win32 API to refresh a process's
+///    token to pick up new group memberships.
+/// 2. `klist purge` / `nltest` only affect Kerberos/AD tickets, not local
+///    group tokens.
+/// 3. Adding the user's own SID directly to the socket DACL provides
+///    immediate access — a user's own SID is always present in their token.
+/// 4. The per-user SID is cleaned up on daemon restart (when the group
+///    membership will have taken effect after re-login), because
+///    `apply_socket_permissions` rebuilds the DACL from scratch with only
+///    SYSTEM + Administrators + the `hole` group.
 fn handle_grant_access(then_send: Option<String>, then_send_file: Option<std::path::PathBuf>) -> i32 {
     use hole_common::protocol::PERMISSION_DENIED_HELP;
 
@@ -321,20 +338,45 @@ fn handle_grant_access(then_send: Option<String>, then_send_file: Option<std::pa
     }
 
     // Add current user to the hole group
-    match hole_daemon::group::installing_username() {
+    let username = match hole_daemon::group::installing_username() {
         Ok(user) => {
             if let Err(e) = hole_daemon::group::add_user_to_group(&user) {
                 eprintln!("failed to add '{user}' to group: {e}");
                 return 1;
             }
             eprintln!("added '{user}' to '{}' group", hole_daemon::group::GROUP_NAME);
+            user
         }
         Err(e) => {
             eprintln!("could not determine current user: {e}");
             eprintln!("{PERMISSION_DENIED_HELP}");
             return 1;
         }
+    };
+
+    // On Windows, immediately update the daemon socket DACL with the user's SID
+    // so the unprivileged GUI can connect without re-login.
+    #[cfg(target_os = "windows")]
+    {
+        let socket_path = hole_common::protocol::default_daemon_socket_path();
+        if socket_path.exists() {
+            match hole_daemon::group::lookup_sid(&username) {
+                Ok(user_sid) => {
+                    let sddl = hole_daemon::ipc::build_sddl(&[&user_sid]);
+                    if let Err(e) = hole_daemon::ipc::set_dacl_from_sddl(&socket_path, &sddl, false) {
+                        eprintln!("warning: failed to update socket DACL: {e}");
+                    } else {
+                        eprintln!("updated socket DACL with user SID for immediate access");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("warning: could not look up user SID: {e}");
+                }
+            }
+        }
     }
+
+    drop(username); // used on Windows for DACL update, suppress unused warning on macOS
 
     // Optionally proxy a command to the daemon
     match (then_send, then_send_file) {

--- a/crates/gui/src/commands.rs
+++ b/crates/gui/src/commands.rs
@@ -17,9 +17,13 @@ pub fn get_config(state: State<AppState>) -> AppConfig {
 }
 
 #[tauri::command]
-pub fn save_config(state: State<AppState>, config: AppConfig) -> Result<(), String> {
+pub fn save_config(state: State<AppState>, mut config: AppConfig) -> Result<(), String> {
+    let mut current = state.config.lock().unwrap();
+    // The frontend doesn't know about elevation_prompt_shown — preserve the
+    // in-memory value so a save from the Settings UI doesn't reset it.
+    config.elevation_prompt_shown = current.elevation_prompt_shown;
     config.save(&state.config_path).map_err(|e| e.to_string())?;
-    *state.config.lock().unwrap() = config;
+    *current = config;
     Ok(())
 }
 

--- a/crates/gui/src/commands_tests.rs
+++ b/crates/gui/src/commands_tests.rs
@@ -23,6 +23,7 @@ fn build_proxy_config_with_selected_server() {
         selected_server: Some("b".to_string()),
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     let pc = build_proxy_config(&config).expect("should return Some");
@@ -37,6 +38,7 @@ fn build_proxy_config_no_selection() {
         selected_server: None,
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     assert!(build_proxy_config(&config).is_none());
@@ -49,9 +51,46 @@ fn build_proxy_config_invalid_selection() {
         selected_server: Some("nonexistent".to_string()),
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     assert!(build_proxy_config(&config).is_none());
+}
+
+// save_config preservation tests ======================================================================================
+
+/// Verify that merging a frontend config (elevation_prompt_shown=false) with
+/// an in-memory config (elevation_prompt_shown=true) preserves the flag.
+///
+/// This mirrors the logic in `save_config`: re-inject the in-memory
+/// `elevation_prompt_shown` before saving, because the frontend doesn't
+/// know about the field and always sends `false`.
+#[skuld::test]
+fn save_config_preserves_elevation_prompt_shown() {
+    // Simulate in-memory state where the dialog has been shown
+    let in_memory = AppConfig {
+        elevation_prompt_shown: true,
+        ..Default::default()
+    };
+
+    // Simulate what the frontend sends (doesn't know about the field)
+    let mut from_frontend = AppConfig {
+        local_port: 5555, // user changed the port
+        elevation_prompt_shown: false,
+        ..Default::default()
+    };
+
+    // Apply the same logic as save_config
+    from_frontend.elevation_prompt_shown = in_memory.elevation_prompt_shown;
+
+    assert!(
+        from_frontend.elevation_prompt_shown,
+        "elevation_prompt_shown should be preserved from in-memory state"
+    );
+    assert_eq!(
+        from_frontend.local_port, 5555,
+        "other fields should keep frontend values"
+    );
 }
 
 // auto_select_first_server tests ======================================================================================
@@ -63,6 +102,7 @@ fn auto_select_first_server_when_none_selected() {
         selected_server: None,
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     auto_select_first_server(&mut config);
@@ -76,6 +116,7 @@ fn auto_select_preserves_existing_selection() {
         selected_server: Some("b".to_string()),
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     auto_select_first_server(&mut config);
@@ -89,6 +130,7 @@ fn auto_select_fixes_stale_selection() {
         selected_server: Some("deleted-id".to_string()),
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     auto_select_first_server(&mut config);
@@ -102,6 +144,7 @@ fn auto_select_noop_on_empty_servers() {
         selected_server: None,
         local_port: 4073,
         enabled: false,
+        ..Default::default()
     };
 
     auto_select_first_server(&mut config);

--- a/crates/gui/src/elevation.rs
+++ b/crates/gui/src/elevation.rs
@@ -3,51 +3,77 @@
 // When the daemon rejects a connection due to insufficient permissions,
 // this module shows a dialog and spawns a privileged helper to either
 // grant permanent access (add user to hole group) or proxy a single command.
+//
+// Windows token limitation background:
+//
+// Windows process tokens are immutable snapshots of group memberships captured
+// at logon time. There is no Win32 API to refresh a process's token to pick up
+// new group memberships — `klist purge` and `nltest` only affect Kerberos/AD
+// tickets, not local group tokens.
+//
+// When the user is first added to the `hole` group (either at install time or
+// via `grant-access`), no running process will reflect that membership until
+// the user logs out and back in. To provide immediate access, the elevated
+// `grant-access` command adds the user's own SID directly to the daemon
+// socket's DACL (a user's own SID is always present in their token). The
+// per-user SID is cleaned up on daemon restart, when the group membership
+// will have taken effect after re-login.
 
 use crate::setup;
+use crate::state::AppState;
 use hole_common::protocol::DaemonRequest;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Show the elevation dialog flow and handle the user's choice.
 ///
 /// Called when a user-initiated tray action fails with PermissionDenied.
 /// Returns `true` if the action was successfully proxied via elevation.
+///
+/// If this is the first time PermissionDenied is encountered, shows a single
+/// dialog explaining the situation and offering permanent access. On subsequent
+/// encounters (`elevation_prompt_shown` is `true` in config), skips the dialog
+/// and goes directly to a UAC prompt via `ipc-send`.
 pub async fn prompt_elevation(app: &AppHandle, request: DaemonRequest) -> bool {
-    // Dialog 1: Offer permanent access
-    let grant = app
-        .dialog()
-        .message(
-            "You don't have permission to control the Hole daemon.\n\n\
-             Grant yourself permanent access?\n\
-             (Requires administrator privileges)",
-        )
-        .title("Hole — Permission Denied")
-        .buttons(MessageDialogButtons::OkCancelCustom(
-            "Grant Access".into(),
-            "Not Now".into(),
-        ))
-        .blocking_show();
+    let state = app.state::<AppState>();
 
-    if grant {
-        // Grant access + proxy command in one elevated invocation
-        return run_grant_access_elevated(app, &request).await;
-    }
+    let already_shown = state.config.lock().unwrap().elevation_prompt_shown;
 
-    // Dialog 2: Offer one-time elevation
-    let elevate = app
-        .dialog()
-        .message("Run this action with one-time elevation?")
-        .title("Hole — One-Time Elevation")
-        .buttons(MessageDialogButtons::OkCancelCustom("Elevate".into(), "Cancel".into()))
-        .blocking_show();
-
-    if elevate {
+    if already_shown {
+        // User has already seen the explanation — just UAC-elevate the command.
         return run_ipc_send_elevated(app, &request).await;
     }
 
-    false
+    // First encounter: show the explanation dialog.
+    let grant = app
+        .dialog()
+        .message(
+            "Hole requires administrator permissions to enable the VPN.\n\n\
+             Grant yourself permanent access?",
+        )
+        .title("Hole — Permission Required")
+        .buttons(MessageDialogButtons::OkCancelCustom("Yes".into(), "No".into()))
+        .blocking_show();
+
+    // Mark dialog as shown BEFORE calling elevated processes — once the user
+    // has seen the explanation, we don't show it again regardless of outcome.
+    {
+        let mut config = state.config.lock().unwrap();
+        config.elevation_prompt_shown = true;
+        if let Err(e) = config.save(&state.config_path) {
+            warn!(error = %e, "failed to persist elevation_prompt_shown");
+        }
+    }
+
+    if grant {
+        // Grant permanent access + send the command in one elevated invocation
+        // (single UAC prompt). Uses --then-send-file to combine both operations.
+        return run_grant_access_elevated(app, &request).await;
+    }
+
+    // User declined permanent access — one-time elevated send
+    run_ipc_send_elevated(app, &request).await
 }
 
 /// Base64-encode a DaemonRequest (test helper for the legacy `--base64` CLI flag).
@@ -82,6 +108,9 @@ pub fn read_request_file(path: &std::path::Path) -> Result<DaemonRequest, String
 }
 
 /// Spawn `hole daemon grant-access --then-send-file <path>` elevated.
+///
+/// Combines group membership grant, DACL update, and IPC command proxy in a single
+/// elevated invocation (one UAC prompt).
 async fn run_grant_access_elevated(app: &AppHandle, request: &DaemonRequest) -> bool {
     let exe = match setup::daemon_binary_path() {
         Ok(p) => p,

--- a/crates/gui/src/setup.rs
+++ b/crates/gui/src/setup.rs
@@ -251,6 +251,27 @@ pub fn install_daemon() -> Result<(), Box<dyn std::error::Error>> {
         Ok(user) => {
             hole_daemon::group::add_user_to_group(&user)?;
             eprintln!("added user '{user}' to '{}' group", hole_daemon::group::GROUP_NAME);
+
+            // Write the installing user's SID so the daemon can add it to the
+            // socket DACL on first startup. This works around the Windows token
+            // snapshot limitation: group membership changes are not reflected in
+            // running processes until re-login, but a user's own SID is always
+            // present in their token.
+            #[cfg(target_os = "windows")]
+            match hole_daemon::group::lookup_sid(&user) {
+                Ok(sid) => {
+                    let sid_path = hole_daemon::ipc::installer_user_sid_path();
+                    if let Some(parent) = sid_path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    if let Err(e) = std::fs::write(&sid_path, &sid) {
+                        eprintln!("warning: could not write installer user SID: {e}");
+                    } else {
+                        eprintln!("wrote installer user SID ({sid}) for immediate access");
+                    }
+                }
+                Err(e) => eprintln!("warning: could not look up installer user SID: {e}"),
+            }
         }
         Err(e) => eprintln!("warning: could not detect installing user: {e}"),
     }


### PR DESCRIPTION
## Summary
Closes #80.

### Windows token snapshot workaround
On Windows, process tokens are immutable snapshots of group memberships from logon time. When `daemon install` adds the user to the `hole` group, the running GUI still has a stale token and gets PermissionDenied on the IPC socket. No Win32 API exists to refresh the token.

**Fix:** Add the installing user's SID directly to the socket DACL (in addition to the group SID). A user's own SID is always in their token, so access works immediately. Per-user SIDs are cleaned up on daemon restart (after re-login, group membership is in the token).

Two paths:
- **`daemon install`** — writes user SID to `ProgramData/hole/installer-user-sid` file; daemon reads it on startup and includes in initial DACL
- **`grant-access`** — directly updates the running socket's DACL with the user's SID (immediate access)

### Elevation dialog simplification
- Combined two stacked dialogs into one: "Grant yourself permanent access?" [Yes / No]
- **Yes** → `grant-access --then-send-file` (single UAC, grants + proxies command)
- **No** → `ipc-send` (single UAC, one-time elevated send)
- Persisted `elevation_prompt_shown` in config — after first encounter, all subsequent PermissionDenied errors go straight to `ipc-send` (UAC only, no Hole dialog)
- `save_config` preserves `elevation_prompt_shown` from in-memory state (frontend can't clobber it)

### Other changes
- Extracted `lookup_sid(name)` from `group_sid()` for reuse
- SID format validation in `build_sddl` prevents SDDL injection
- Parameterized `build_sddl(extra_sids)` for testability

## Test plan
- [x] 11 new tests (258 total, all pass)
- [x] SID validation: `is_valid_sid_string_accepts_valid`, `rejects_invalid`, `build_sddl_rejects_malformed_sid`
- [x] SDDL construction: `build_sddl_without_extra_sids`, `with_extra_sids`, `with_multiple_extra_sids`
- [x] Config: `deserialize_without_elevation_prompt_shown_defaults_to_false`, `elevation_prompt_shown_roundtrips`
- [x] Preservation: `save_config_preserves_elevation_prompt_shown`
- [x] SID lookup: `lookup_sid_resolves_current_user`, `lookup_sid_nonexistent_returns_error`
- [ ] Manual: fresh install → connect → no elevation dialog → connected immediately
- [ ] Manual: reboot → connect → still works (group membership in token, SID file cleaned up)