### PR TITLE
Fix Ctrl+C handling in dev.py on Windows

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -413,8 +413,22 @@ def main() -> None:
         threading.Thread(target=prefix_stream, args=(gui_proc.stdout, "client", MAGENTA), daemon=True).start()
         threading.Thread(target=wait_for_exit, args=(gui_proc, done), daemon=True).start()
 
-        # Block until any process exits or Ctrl+C
-        done.wait()
+        # Block until any process exits or Ctrl+C.
+        #
+        # Poll on a short timeout instead of an unbounded wait. On Windows, an
+        # unbounded threading.Event.wait() blocks in a native condition variable
+        # that does not return for queued Python signals, swallowing Ctrl+C and
+        # preventing the `finally: shutdown(procs)` clause from running. A timed
+        # wait wakes the interpreter periodically so the pending KeyboardInterrupt
+        # can actually be raised.
+        #
+        # This is NOT a busy-wait or a latency penalty for the normal exit path:
+        # Event.wait(timeout) on both POSIX (futex) and Windows (WaitForSingleObject)
+        # wakes immediately when the daemon `wait_for_exit` thread calls done.set(),
+        # regardless of how much of the 0.5s remains. The 0.5s only bounds the
+        # Ctrl+C delivery latency.
+        while not done.wait(timeout=0.5):
+            pass
 
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
## Summary
- Replace unbounded `done.wait()` with `while not done.wait(timeout=0.5): pass`. The polled wait wakes the interpreter periodically so a queued `KeyboardInterrupt` can actually be raised on Windows, where an unbounded `threading.Event.wait()` blocks in a native condition variable that does not return for queued Python signals.
- `Event.wait(timeout)` on both POSIX (futex) and Windows (`WaitForSingleObject`) wakes immediately when the worker thread calls `done.set()`, so this is not a busy-wait or a latency penalty for the normal exit path.

Fixes #111.

## Test plan
- [ ] `uv run scripts/dev.py` from elevated PowerShell, wait for all three processes to start, press Ctrl+C, confirm "Shutting down..." appears within ~1s and all child processes (vite, bridge, GUI) are gone.