### PR TITLE
Add spacing between server list and import zone

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -597,6 +597,7 @@ body {
   font-size: 0.75rem;
   cursor: pointer;
   padding: 0.5rem 0.8rem;
+  margin-top: 0.6rem;
   border: 1px dashed var(--border-strong);
   border-radius: 4px;
   transition:


### PR DESCRIPTION
## Summary
- Add `margin-top: 0.6rem` to `.add-zone` in `ui/style.css`. The class is uniquely used by the import-zone element, so the fix is fully scoped — no risk of collateral on other sections.

Fixes #112.

## Test plan
- [ ] Open the GUI; confirm clear vertical separation between the bottom server card and the dashed import-zone.