### PR TITLE
Connect button: spinner + cancellable start (closes #158)

### DIFF
--- a/crates/bridge/src/guards.rs
+++ b/crates/bridge/src/guards.rs
@@ -1,0 +1,91 @@
+// Drop-safe RAII guards for partially-started proxy state.
+//
+// These guards exist so that `ProxyManager::start_inner` can be written as a
+// cancel-safe future: if the future is dropped mid-flight (for example because
+// a `tokio::select!` arm fired the cancellation branch), every active guard
+// runs its `Drop` and cleans up the partial state that would otherwise leak.
+//
+// Guards use the `Option::take` idiom: `commit(self)` consumes the guard and
+// extracts the inner value, disarming the `Drop` cleanup. Because `commit`
+// takes `self` by value, double-commit is a compile error (not a runtime
+// check) — the first call moves ownership out of the caller.
+
+use std::path::PathBuf;
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+// StateFileGuard ======================================================================================================
+
+/// Deletes `bridge-routes.json` in `state_dir` on drop unless committed.
+///
+/// Used in `ProxyManager::start_inner` for the brief window between
+/// `route_state::save` and `RouteGuard` construction: during this window the
+/// state file exists on disk but there is no other RAII owner that would
+/// clean it up if the future is dropped.
+///
+/// Once `RouteGuard` is constructed (after `setup_routes` succeeds), call
+/// `commit()` on this guard — `RouteGuard::drop` takes over state-file
+/// cleanup as part of its normal teardown.
+pub struct StateFileGuard {
+    state_dir: Option<PathBuf>,
+}
+
+impl StateFileGuard {
+    pub fn new(state_dir: PathBuf) -> Self {
+        Self {
+            state_dir: Some(state_dir),
+        }
+    }
+
+    /// Disarm the guard. The state file will NOT be cleared on drop.
+    pub fn commit(mut self) {
+        self.state_dir.take();
+    }
+}
+
+impl Drop for StateFileGuard {
+    fn drop(&mut self) {
+        if let Some(dir) = self.state_dir.take() {
+            if let Err(e) = crate::route_state::clear(&dir) {
+                warn!(error = %e, "failed to clear route-state file in StateFileGuard drop");
+            }
+        }
+    }
+}
+
+// TaskHandleGuard =====================================================================================================
+
+/// Aborts a `JoinHandle` on drop unless committed.
+///
+/// Used in `ProxyManager::start_inner` to own the shadowsocks-service task
+/// between `backend.start_ss` and commit-to-self. If start is cancelled or
+/// a later step fails, dropping the guard aborts the spawned task.
+pub struct TaskHandleGuard<T> {
+    handle: Option<JoinHandle<T>>,
+}
+
+impl<T> TaskHandleGuard<T> {
+    pub fn new(handle: JoinHandle<T>) -> Self {
+        Self { handle: Some(handle) }
+    }
+
+    /// Disarm the guard and return the inner handle. The task will NOT be
+    /// aborted on drop.
+    pub fn commit(mut self) -> JoinHandle<T> {
+        self.handle
+            .take()
+            .expect("TaskHandleGuard has no handle — internal invariant violated")
+    }
+}
+
+impl<T> Drop for TaskHandleGuard<T> {
+    fn drop(&mut self) {
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "guards_tests.rs"]
+mod guards_tests;

--- a/crates/bridge/src/guards_tests.rs
+++ b/crates/bridge/src/guards_tests.rs
@@ -1,0 +1,107 @@
+// Unit tests for `StateFileGuard` and `TaskHandleGuard`.
+
+use super::*;
+use crate::route_state::{RouteState, SCHEMA_VERSION};
+use std::net::IpAddr;
+use std::time::Duration;
+use tempfile::TempDir;
+
+// Helpers =============================================================================================================
+
+fn write_sample_state(dir: &std::path::Path) {
+    let state = RouteState {
+        version: SCHEMA_VERSION,
+        tun_name: "wintun-hole".to_string(),
+        server_ip: IpAddr::from([10, 0, 0, 1]),
+        interface_name: "Ethernet".to_string(),
+    };
+    crate::route_state::save(dir, &state).expect("save state");
+}
+
+fn state_file_exists(dir: &std::path::Path) -> bool {
+    crate::route_state::load(dir).is_some()
+}
+
+// StateFileGuard ======================================================================================================
+
+#[skuld::test]
+fn state_file_guard_clears_on_drop() {
+    let tmp = TempDir::new().unwrap();
+    write_sample_state(tmp.path());
+    assert!(state_file_exists(tmp.path()), "precondition: state file exists");
+
+    {
+        let _guard = StateFileGuard::new(tmp.path().to_owned());
+        // guard drops at end of scope
+    }
+
+    assert!(
+        !state_file_exists(tmp.path()),
+        "state file must be cleared by StateFileGuard::drop"
+    );
+}
+
+#[skuld::test]
+fn state_file_guard_commit_prevents_clear() {
+    let tmp = TempDir::new().unwrap();
+    write_sample_state(tmp.path());
+
+    let guard = StateFileGuard::new(tmp.path().to_owned());
+    guard.commit();
+
+    assert!(
+        state_file_exists(tmp.path()),
+        "committed StateFileGuard must not clear the state file"
+    );
+}
+
+#[skuld::test]
+fn state_file_guard_clear_on_missing_file_is_silent() {
+    // No file present. Drop must not panic.
+    let tmp = TempDir::new().unwrap();
+    assert!(!state_file_exists(tmp.path()));
+    {
+        let _guard = StateFileGuard::new(tmp.path().to_owned());
+    }
+    // If we got here, drop didn't panic. Good.
+}
+
+// TaskHandleGuard =====================================================================================================
+
+#[skuld::test]
+fn task_handle_guard_aborts_on_drop() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // A task that would otherwise run for a long time.
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+
+        {
+            let _guard = TaskHandleGuard::new(handle);
+            // drop
+        }
+        // After the guard is dropped, the task should terminate promptly.
+        // We can't re-reference the handle here (it was moved), so instead
+        // we prove the runtime shuts down quickly after dropping the guard.
+        // Give the aborted task a tiny window to settle.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    });
+    // Dropping the runtime without hanging is the assertion.
+}
+
+#[skuld::test]
+fn task_handle_guard_commit_returns_handle_and_suppresses_abort() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let handle = tokio::spawn(async { 42u32 });
+        let guard = TaskHandleGuard::new(handle);
+        let handle = guard.commit();
+        let value = handle.await.expect("joined");
+        assert_eq!(value, 42);
+    });
+}
+
+// Note: the `commit(self) -> JoinHandle<T>` API consumes `self`, so
+// double-commit is prevented at compile time (the first call moves the
+// guard). There is no runtime double-commit path to test.

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -105,6 +105,27 @@ impl IpcServer {
         Ok(())
     }
 
+    /// Accept exactly `n` client connections (in parallel), then return when
+    /// all have finished. Test-only helper used by the cancellation tests
+    /// that need multiple concurrent connections — using `run()` indefinitely
+    /// adds noticeable accept-poll churn on Windows (50 ms `spawn_blocking`
+    /// loop) which can starve other parallel tests on slow CI runners.
+    /// Bounding the accept loop to exactly `n` iterations keeps the test
+    /// runtime cheap and predictable.
+    #[cfg(test)]
+    pub async fn run_n(self, n: usize) -> std::io::Result<()> {
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..n {
+            let stream = self.listener.accept().await?;
+            let router = self.router.clone();
+            tasks.spawn(async move {
+                let _ = serve_connection(TokioIo::new(stream), router).await;
+            });
+        }
+        while tasks.join_next().await.is_some() {}
+        Ok(())
+    }
+
     /// Run the server loop, accepting connections indefinitely.
     /// Each connection is handled in a separate task.
     pub async fn run(self) -> std::io::Result<()> {

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -198,7 +198,9 @@ async fn handle_start<B: ProxyBackend + 'static>(
 ) -> Result<Json<EmptyResponse>, (StatusCode, Json<ErrorResponse>)> {
     // Register the cancellation token BEFORE taking the proxy mutex. If a
     // pre-armed cancel is already queued, consume it and return immediately
-    // without even attempting the start.
+    // without even attempting the start. If a concurrent start is already
+    // in flight, reject this one — the slot is single-occupancy because a
+    // Cancel targets exactly one in-flight start.
     let token = CancellationToken::new();
     {
         let mut cs = state.start_cancel.lock().expect("start_cancel poisoned");
@@ -212,6 +214,22 @@ async fn handle_start<B: ProxyBackend + 'static>(
                 }),
             ));
         }
+        if cs.token.is_some() {
+            // A previous handle_start has already registered its token but
+            // not yet cleared it (still running or blocked on proxy.lock()).
+            // Overwriting the slot would orphan the earlier start from any
+            // future Cancel — the Cancel would signal this new token
+            // instead — so we reject the duplicate with 409 Conflict rather
+            // than silently corrupting the slot.
+            warn!("concurrent start request rejected — another start is already in flight");
+            return Err((
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    message: "start already in progress".to_string(),
+                }),
+            ));
+        }
+        debug_assert!(cs.token.is_none(), "start_cancel token slot invariant");
         cs.token = Some(token.clone());
     }
 

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -1,5 +1,6 @@
 // IPC server — HTTP/1.1 REST API over local Unix domain socket.
 
+use crate::proxy::ProxyError;
 use crate::proxy_manager::{ProxyBackend, ProxyManager, ProxyState};
 use crate::server_test::{run_server_test, TestConfig};
 use crate::socket::LocalListener;
@@ -8,8 +9,8 @@ use axum::http::StatusCode;
 use axum::Json;
 use hole_common::protocol::{
     DiagnosticsResponse, EmptyResponse, ErrorResponse, MetricsResponse, ProxyConfig, PublicIpResponse, StatusResponse,
-    TestServerRequest, TestServerResponse, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_PUBLIC_IP, ROUTE_RELOAD,
-    ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    TestServerRequest, TestServerResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
+    ROUTE_PUBLIC_IP, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
@@ -18,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
 #[allow(unused_imports)]
 use tracing::warn;
@@ -25,10 +27,30 @@ use tracing::{debug, error, info};
 
 // IPC state ===========================================================================================================
 
-/// Shared state for IPC handlers, holding the proxy manager and an IP cache.
+/// State for tracking the in-flight start's cancellation token, plus a
+/// "pre-armed" flag that consumes a Cancel arriving before any Start has
+/// registered its token. Held in a `std::sync::Mutex` because all access is
+/// a trivial read/write of a small struct, never held across `.await`, and
+/// the sync lock avoids any coupling with the async proxy mutex.
+#[derive(Default)]
+pub struct StartCancelState {
+    /// Token of the currently-in-flight start, if any. Set by `handle_start`
+    /// before calling `pm.start_cancellable`; cleared on exit.
+    pub token: Option<CancellationToken>,
+    /// Cancel request arrived while no start was in flight. Consumed by the
+    /// very next `handle_start` invocation, which returns `Cancelled`
+    /// without even attempting to start. Handles the race where a cancel
+    /// reaches the bridge before `handle_start` has stored its token.
+    pub pending: bool,
+}
+
+/// Shared state for IPC handlers, holding the proxy manager, IP cache, and
+/// the start-cancellation handoff struct.
 pub struct IpcState<B: ProxyBackend> {
     pub proxy: Arc<Mutex<ProxyManager<B>>>,
     pub ip_cache: Arc<tokio::sync::Mutex<Option<(PublicIpResponse, Instant)>>>,
+    // std::sync::Mutex — never held across .await. See StartCancelState docs.
+    pub start_cancel: Arc<std::sync::Mutex<StartCancelState>>,
 }
 
 /// IP cache time-to-live.
@@ -64,6 +86,7 @@ impl IpcServer {
         let state = Arc::new(IpcState {
             proxy,
             ip_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            start_cancel: Arc::new(std::sync::Mutex::new(StartCancelState::default())),
         });
         let router = build_router(state);
         Ok(Self {
@@ -147,6 +170,7 @@ fn build_router<B: ProxyBackend + 'static>(state: Arc<IpcState<B>>) -> axum::Rou
         .route(ROUTE_STATUS, axum::routing::get(handle_status::<B>))
         .route(ROUTE_START, axum::routing::post(handle_start::<B>))
         .route(ROUTE_STOP, axum::routing::post(handle_stop::<B>))
+        .route(ROUTE_CANCEL, axum::routing::post(handle_cancel::<B>))
         .route(ROUTE_RELOAD, axum::routing::post(handle_reload::<B>))
         .route(ROUTE_METRICS, axum::routing::get(handle_metrics::<B>))
         .route(ROUTE_DIAGNOSTICS, axum::routing::get(handle_diagnostics::<B>))
@@ -172,9 +196,47 @@ async fn handle_start<B: ProxyBackend + 'static>(
     State(state): State<Arc<IpcState<B>>>,
     Json(config): Json<ProxyConfig>,
 ) -> Result<Json<EmptyResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let mut pm = state.proxy.lock().await;
-    match pm.start(&config).await {
+    // Register the cancellation token BEFORE taking the proxy mutex. If a
+    // pre-armed cancel is already queued, consume it and return immediately
+    // without even attempting the start.
+    let token = CancellationToken::new();
+    {
+        let mut cs = state.start_cancel.lock().expect("start_cancel poisoned");
+        if cs.pending {
+            cs.pending = false;
+            info!("start request consumed pre-armed cancel");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    message: CANCELLED_MESSAGE.to_string(),
+                }),
+            ));
+        }
+        cs.token = Some(token.clone());
+    }
+
+    let result = {
+        let mut pm = state.proxy.lock().await;
+        pm.start_cancellable(&config, token).await
+    };
+
+    // Clear the token slot regardless of outcome so the next start starts
+    // with a clean slate. A Cancel arriving during this tiny window between
+    // start_cancellable returning and us clearing the slot would cancel a
+    // token that is already done — harmless.
+    {
+        let mut cs = state.start_cancel.lock().expect("start_cancel poisoned");
+        cs.token = None;
+    }
+
+    match result {
         Ok(()) => Ok(Json(EmptyResponse {})),
+        Err(ProxyError::Cancelled) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                message: CANCELLED_MESSAGE.to_string(),
+            }),
+        )),
         Err(e) => {
             error!(error = %e, "proxy start failed");
             Err((
@@ -183,6 +245,21 @@ async fn handle_start<B: ProxyBackend + 'static>(
             ))
         }
     }
+}
+
+/// Signal the in-flight start's `CancellationToken` if one is registered,
+/// or pre-arm a cancel for the next start otherwise. Always 200 Ack — the
+/// client's intent is recorded regardless.
+async fn handle_cancel<B: ProxyBackend + 'static>(State(state): State<Arc<IpcState<B>>>) -> Json<EmptyResponse> {
+    let mut cs = state.start_cancel.lock().expect("start_cancel poisoned");
+    if let Some(t) = &cs.token {
+        info!("cancelling in-flight proxy start");
+        t.cancel();
+    } else {
+        info!("no start in flight — pre-arming cancel for next start");
+        cs.pending = true;
+    }
+    Json(EmptyResponse {})
 }
 
 async fn handle_stop<B: ProxyBackend + 'static>(

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -792,7 +792,9 @@ fn cancel_while_start_in_flight_returns_cancelled() {
         let path = test_socket_path("cancel-in-flight");
         let gate = Arc::new(tokio::sync::Notify::new());
         let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
-        let handle = tokio::spawn(async move { server.run().await });
+        // Bound the accept loop to exactly the two connections this test
+        // uses, instead of running indefinitely. See `run_n` docstring.
+        let handle = tokio::spawn(async move { server.run_n(2).await });
 
         // Connection A: owns its client end. Spawn a task that drives the
         // start request so this test task can issue a cancel concurrently.
@@ -826,13 +828,12 @@ fn cancel_while_start_in_flight_returns_cancelled() {
             .expect("start task panicked");
         assert_eq!(error_message(resp_a).await, CANCELLED_MESSAGE);
 
-        // The gate is still held — release it before the server task is
-        // aborted so the waker inside the mock's `start_ss` is properly
-        // drained (the future was dropped by select!; notify_one on a
-        // dropped waker is a no-op, but this is harmless and leaves the
-        // mock in a well-defined state for any subsequent polling).
+        // Release the gate so the mock's start_ss future can settle if it
+        // is still parked anywhere; harmless no-op if already dropped.
         gate.notify_one();
-        handle.abort();
+        // run_n(2) returns naturally once both connections are handled, so
+        // no abort is needed — but use a bounded await to surface any leak.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
     });
 }
 
@@ -845,9 +846,9 @@ fn cancel_before_start_is_pre_armed_and_consumed() {
     rt().block_on(async {
         let path = test_socket_path("cancel-prearm");
         let server = IpcServer::bind(&path, mock_proxy()).unwrap();
-        let handle = tokio::spawn(async move {
-            server.run().await.unwrap();
-        });
+        // Single client connection — use run_once to avoid long-lived
+        // accept polling on Windows.
+        let handle = tokio::spawn(async move { server.run_once().await });
 
         let mut client = TestClient::connect(&path).await;
 
@@ -866,7 +867,7 @@ fn cancel_before_start_is_pre_armed_and_consumed() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
-        handle.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
     });
 }
 
@@ -877,9 +878,7 @@ fn cancel_with_no_start_is_ack_idempotent() {
     rt().block_on(async {
         let path = test_socket_path("cancel-noop");
         let server = IpcServer::bind(&path, mock_proxy()).unwrap();
-        let handle = tokio::spawn(async move {
-            server.run().await.unwrap();
-        });
+        let handle = tokio::spawn(async move { server.run_once().await });
 
         let mut client = TestClient::connect(&path).await;
 
@@ -887,7 +886,7 @@ fn cancel_with_no_start_is_ack_idempotent() {
         assert_eq!(consume(post_cancel(&mut client).await).await, 200);
 
         drop(client);
-        handle.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
     });
 }
 
@@ -902,7 +901,8 @@ fn concurrent_start_is_rejected_with_conflict() {
         let path = test_socket_path("concurrent-start");
         let gate = Arc::new(tokio::sync::Notify::new());
         let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
-        let handle = tokio::spawn(async move { server.run().await });
+        // 3 connections: A start, B start, C cancel.
+        let handle = tokio::spawn(async move { server.run_n(3).await });
 
         // Client A parks in start_ss.
         let path_a = path.clone();
@@ -944,7 +944,7 @@ fn concurrent_start_is_rejected_with_conflict() {
         assert_eq!(error_message(a_resp).await, CANCELLED_MESSAGE);
 
         gate.notify_one();
-        handle.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
     });
 }
 
@@ -957,7 +957,8 @@ fn sequential_start_cancel_start_consumes_pre_arm_once() {
     rt().block_on(async {
         let path = test_socket_path("seq-start-cancel-start");
         let server = IpcServer::bind(&path, mock_proxy()).unwrap();
-        let handle = tokio::spawn(async move { server.run().await.unwrap() });
+        // Single client connection — use run_once.
+        let handle = tokio::spawn(async move { server.run_once().await });
 
         let mut client = TestClient::connect(&path).await;
 
@@ -980,7 +981,7 @@ fn sequential_start_cancel_start_consumes_pre_arm_once() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
-        handle.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
     });
 }
 
@@ -995,7 +996,8 @@ fn concurrent_double_cancel_during_start_both_succeed() {
         let path = test_socket_path("double-cancel");
         let gate = Arc::new(tokio::sync::Notify::new());
         let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
-        let handle = tokio::spawn(async move { server.run().await });
+        // 3 connections: A start, B cancel, C cancel.
+        let handle = tokio::spawn(async move { server.run_n(3).await });
 
         // Client A parks in start_ss.
         let path_a = path.clone();
@@ -1031,7 +1033,7 @@ fn concurrent_double_cancel_during_start_both_succeed() {
         assert_eq!(error_message(a_resp).await, CANCELLED_MESSAGE);
 
         gate.notify_one();
-        handle.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
     });
 }
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -19,6 +19,10 @@ use tokio::task::JoinHandle;
 struct MockBackend {
     fail_start: AtomicBool,
     fail_gateway: AtomicBool,
+    /// If Some, `start_ss` awaits this gate before returning. Used to
+    /// simulate a slow start so tests can race `POST /v1/cancel` against
+    /// an in-flight `POST /v1/start`.
+    start_ss_gate: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl MockBackend {
@@ -26,6 +30,7 @@ impl MockBackend {
         Self {
             fail_start: AtomicBool::new(false),
             fail_gateway: AtomicBool::new(false),
+            start_ss_gate: None,
         }
     }
 
@@ -33,6 +38,7 @@ impl MockBackend {
         Self {
             fail_start: AtomicBool::new(true),
             fail_gateway: AtomicBool::new(false),
+            start_ss_gate: None,
         }
     }
 
@@ -40,6 +46,15 @@ impl MockBackend {
         Self {
             fail_start: AtomicBool::new(false),
             fail_gateway: AtomicBool::new(true),
+            start_ss_gate: None,
+        }
+    }
+
+    fn gated(gate: Arc<tokio::sync::Notify>) -> Self {
+        Self {
+            fail_start: AtomicBool::new(false),
+            fail_gateway: AtomicBool::new(false),
+            start_ss_gate: Some(gate),
         }
     }
 }
@@ -49,6 +64,9 @@ impl ProxyBackend for MockBackend {
         &self,
         _config: shadowsocks_service::config::Config,
     ) -> Result<JoinHandle<std::io::Result<()>>, ProxyError> {
+        if let Some(gate) = self.start_ss_gate.as_ref() {
+            gate.notified().await;
+        }
         if self.fail_start.load(Ordering::SeqCst) {
             return Err(ProxyError::Runtime(std::io::Error::other("mock failure")));
         }
@@ -100,6 +118,11 @@ fn failing_proxy() -> Arc<Mutex<ProxyManager<MockBackend>>> {
 fn gateway_failing_proxy() -> Arc<Mutex<ProxyManager<MockBackend>>> {
     let state_dir = tempfile::tempdir().unwrap().keep();
     Arc::new(Mutex::new(ProxyManager::new(MockBackend::gateway_failing(), state_dir)))
+}
+
+fn gated_proxy(gate: Arc<tokio::sync::Notify>) -> Arc<Mutex<ProxyManager<MockBackend>>> {
+    let state_dir = tempfile::tempdir().unwrap().keep();
+    Arc::new(Mutex::new(ProxyManager::new(MockBackend::gated(gate), state_dir)))
 }
 
 fn sample_config() -> ProxyConfig {
@@ -184,6 +207,16 @@ async fn post_stop(client: &mut TestClient) -> http::Response<hyper::body::Incom
     let req = http::Request::builder()
         .method("POST")
         .uri(ROUTE_STOP)
+        .header("host", "localhost")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    client.send(req).await
+}
+
+async fn post_cancel(client: &mut TestClient) -> http::Response<hyper::body::Incoming> {
+    let req = http::Request::builder()
+        .method("POST")
+        .uri(ROUTE_CANCEL)
         .header("host", "localhost")
         .body(Full::new(Bytes::new()))
         .unwrap();
@@ -738,6 +771,122 @@ fn diagnostics_bridge_error_after_failed_start() {
 // public_ip handler test is intentionally omitted — it makes an external HTTP call
 // to ipinfo.io which is not available in CI and cannot be easily mocked without
 // adding an HTTP client abstraction layer (a follow-up concern).
+
+// Cancel tests ========================================================================================================
+
+/// Extract the `message` field from a 500 `ErrorResponse`.
+async fn error_message(resp: http::Response<hyper::body::Incoming>) -> String {
+    assert_eq!(resp.status(), 500, "expected 500 for cancelled start");
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let err: ErrorResponse = serde_json::from_slice(&body).unwrap();
+    err.message
+}
+
+#[skuld::test]
+fn cancel_while_start_in_flight_returns_cancelled() {
+    // Two concurrent connections. A posts Start against a gated mock so
+    // start_ss hangs. B posts Cancel. A's Start response must come back
+    // with 500 + "cancelled" promptly (not after the full gate duration,
+    // which never elapses in this test).
+    rt().block_on(async {
+        let path = test_socket_path("cancel-in-flight");
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
+        let handle = tokio::spawn(async move { server.run().await });
+
+        // Connection A: owns its client end. Spawn a task that drives the
+        // start request so this test task can issue a cancel concurrently.
+        let path_a = path.clone();
+        let start_future = tokio::spawn(async move {
+            let mut client_a = TestClient::connect(&path_a).await;
+            let resp = post_start(&mut client_a, &sample_config()).await;
+            (client_a, resp)
+        });
+
+        // Give A a moment to acquire the proxy mutex and park in start_ss.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        // Connection B: cancel the in-flight start. Must succeed without
+        // waiting for the in-flight Start (which never completes since the
+        // gate is not released).
+        let mut client_b = TestClient::connect(&path).await;
+        let cancel_resp = post_cancel(&mut client_b).await;
+        assert_eq!(
+            cancel_resp.status(),
+            200,
+            "cancel must succeed even while start is in flight"
+        );
+
+        // Wait for A's Start to return, bounded. With cancellation working
+        // correctly the select! branch fires, drop-safety unwinds the
+        // partial state, and Cancelled is returned promptly.
+        let (_client_a, resp_a) = tokio::time::timeout(std::time::Duration::from_secs(5), start_future)
+            .await
+            .expect("start did not return within 5s of cancel")
+            .expect("start task panicked");
+        assert_eq!(error_message(resp_a).await, CANCELLED_MESSAGE);
+
+        // Release the gate so the spawned ss future (from MockBackend) can
+        // settle cleanly as part of the TaskHandleGuard drop path.
+        gate.notify_one();
+        handle.abort();
+    });
+}
+
+#[skuld::test]
+fn cancel_before_start_is_pre_armed_and_consumed() {
+    // A cancel arriving before any start is in flight pre-arms a flag
+    // that the next start consumes. The next Start returns 500 +
+    // "cancelled" immediately without even attempting to acquire the
+    // proxy mutex or call backend.start_ss.
+    rt().block_on(async {
+        let path = test_socket_path("cancel-prearm");
+        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let handle = tokio::spawn(async move {
+            server.run().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+
+        // Pre-arm: cancel with no start in flight — still 200 Ack.
+        let resp = post_cancel(&mut client).await;
+        assert_eq!(consume(resp).await, 200);
+
+        // Now start — should be rejected as cancelled, consuming the pre-arm.
+        let start_resp = post_start(&mut client, &sample_config()).await;
+        assert_eq!(error_message(start_resp).await, CANCELLED_MESSAGE);
+
+        // A second start with no pre-arm should succeed normally.
+        assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
+
+        // Cleanup
+        consume(post_stop(&mut client).await).await;
+
+        drop(client);
+        handle.abort();
+    });
+}
+
+#[skuld::test]
+fn cancel_with_no_start_is_ack_idempotent() {
+    // Double-cancel with no start in flight — both 200. The pre-arm flag
+    // is idempotent: arming it twice is equivalent to arming it once.
+    rt().block_on(async {
+        let path = test_socket_path("cancel-noop");
+        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let handle = tokio::spawn(async move {
+            server.run().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+
+        assert_eq!(consume(post_cancel(&mut client).await).await, 200);
+        assert_eq!(consume(post_cancel(&mut client).await).await, 200);
+
+        drop(client);
+        handle.abort();
+    });
+}
 
 // SDDL tests (Windows only) ===========================================================================================
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -826,8 +826,11 @@ fn cancel_while_start_in_flight_returns_cancelled() {
             .expect("start task panicked");
         assert_eq!(error_message(resp_a).await, CANCELLED_MESSAGE);
 
-        // Release the gate so the spawned ss future (from MockBackend) can
-        // settle cleanly as part of the TaskHandleGuard drop path.
+        // The gate is still held — release it before the server task is
+        // aborted so the waker inside the mock's `start_ss` is properly
+        // drained (the future was dropped by select!; notify_one on a
+        // dropped waker is a no-op, but this is harmless and leaves the
+        // mock in a well-defined state for any subsequent polling).
         gate.notify_one();
         handle.abort();
     });
@@ -884,6 +887,150 @@ fn cancel_with_no_start_is_ack_idempotent() {
         assert_eq!(consume(post_cancel(&mut client).await).await, 200);
 
         drop(client);
+        handle.abort();
+    });
+}
+
+#[skuld::test]
+fn concurrent_start_is_rejected_with_conflict() {
+    // Client A holds a start parked in start_ss on the gate. Client B
+    // sends a second Start concurrently. B must be rejected with 409
+    // Conflict rather than silently overwriting A's token slot — the
+    // slot is single-occupancy because a Cancel targets exactly one
+    // in-flight start. This covers the pre-fix bug in review #4.
+    rt().block_on(async {
+        let path = test_socket_path("concurrent-start");
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
+        let handle = tokio::spawn(async move { server.run().await });
+
+        // Client A parks in start_ss.
+        let path_a = path.clone();
+        let a_future = tokio::spawn(async move {
+            let mut client_a = TestClient::connect(&path_a).await;
+            let resp = post_start(&mut client_a, &sample_config()).await;
+            (client_a, resp)
+        });
+
+        // Give A a moment to register its token.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        // Client B sends a concurrent Start and must be rejected.
+        let mut client_b = TestClient::connect(&path).await;
+        let b_resp = post_start(&mut client_b, &sample_config()).await;
+        assert_eq!(
+            b_resp.status(),
+            409,
+            "concurrent start must be rejected with 409 Conflict"
+        );
+        let b_body = b_resp.into_body().collect().await.unwrap().to_bytes();
+        let b_err: ErrorResponse = serde_json::from_slice(&b_body).unwrap();
+        assert!(
+            b_err.message.contains("already in progress"),
+            "unexpected message: {}",
+            b_err.message
+        );
+
+        // B's rejection must not have perturbed A's token slot — a
+        // subsequent cancel must still reach A. Send it.
+        let mut client_c = TestClient::connect(&path).await;
+        assert_eq!(consume(post_cancel(&mut client_c).await).await, 200);
+
+        // A's start must eventually return Cancelled.
+        let (_client_a, a_resp) = tokio::time::timeout(std::time::Duration::from_secs(5), a_future)
+            .await
+            .expect("A's start did not return")
+            .expect("A task panicked");
+        assert_eq!(error_message(a_resp).await, CANCELLED_MESSAGE);
+
+        gate.notify_one();
+        handle.abort();
+    });
+}
+
+#[skuld::test]
+fn sequential_start_cancel_start_consumes_pre_arm_once() {
+    // Plan scenario: Start completes, then Cancel arrives (sets pending),
+    // then another Start arrives (consumes pending → Cancelled). A third
+    // Start after that must succeed normally — the pre-arm must be
+    // consumed exactly once, not forever.
+    rt().block_on(async {
+        let path = test_socket_path("seq-start-cancel-start");
+        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let handle = tokio::spawn(async move { server.run().await.unwrap() });
+
+        let mut client = TestClient::connect(&path).await;
+
+        // Start #1 succeeds.
+        assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
+        // Stop so the next start has somewhere to go.
+        assert_eq!(consume(post_stop(&mut client).await).await, 200);
+
+        // Cancel with nothing in flight — pre-arms the flag.
+        assert_eq!(consume(post_cancel(&mut client).await).await, 200);
+
+        // Start #2 consumes the pre-arm and must fail with Cancelled.
+        let resp2 = post_start(&mut client, &sample_config()).await;
+        assert_eq!(error_message(resp2).await, CANCELLED_MESSAGE);
+
+        // Start #3 must succeed (pre-arm was a one-shot).
+        assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
+
+        // Cleanup.
+        consume(post_stop(&mut client).await).await;
+
+        drop(client);
+        handle.abort();
+    });
+}
+
+#[skuld::test]
+fn concurrent_double_cancel_during_start_both_succeed() {
+    // Two Cancel requests arrive on separate connections while a single
+    // Start is in flight. Both must succeed with 200 — the cancel path
+    // is idempotent, and the second cancel sees the token already
+    // signaled and is a no-op that still returns 200. The in-flight
+    // Start must return Cancelled promptly.
+    rt().block_on(async {
+        let path = test_socket_path("double-cancel");
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
+        let handle = tokio::spawn(async move { server.run().await });
+
+        // Client A parks in start_ss.
+        let path_a = path.clone();
+        let a_future = tokio::spawn(async move {
+            let mut client_a = TestClient::connect(&path_a).await;
+            let resp = post_start(&mut client_a, &sample_config()).await;
+            (client_a, resp)
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        // Two concurrent cancels on separate connections.
+        let path_b = path.clone();
+        let b_task = tokio::spawn(async move {
+            let mut client = TestClient::connect(&path_b).await;
+            post_cancel(&mut client).await
+        });
+        let path_c = path.clone();
+        let c_task = tokio::spawn(async move {
+            let mut client = TestClient::connect(&path_c).await;
+            post_cancel(&mut client).await
+        });
+
+        let b_resp = b_task.await.unwrap();
+        let c_resp = c_task.await.unwrap();
+        assert_eq!(b_resp.status(), 200);
+        assert_eq!(c_resp.status(), 200);
+
+        // A's start returns Cancelled.
+        let (_client_a, a_resp) = tokio::time::timeout(std::time::Duration::from_secs(5), a_future)
+            .await
+            .expect("A's start did not return")
+            .expect("A task panicked");
+        assert_eq!(error_message(a_resp).await, CANCELLED_MESSAGE);
+
+        gate.notify_one();
         handle.abort();
     });
 }

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod foreground;
 pub mod gateway;
 pub mod group;
+pub mod guards;
 pub mod ipc;
 pub mod logging;
 pub mod platform;

--- a/crates/bridge/src/proxy.rs
+++ b/crates/bridge/src/proxy.rs
@@ -27,6 +27,13 @@ pub enum ProxyError {
     RouteSetup(String),
     #[error("proxy already running")]
     AlreadyRunning,
+    /// The start was cancelled via `CancellationToken` before it could
+    /// complete. The error message is the stable `CANCELLED_MESSAGE`
+    /// constant from `hole_common::protocol` so bridge and client can
+    /// round-trip it exactly. Not set as `last_error` — the user asked
+    /// for the cancel, so it is not a diagnostic failure.
+    #[error("cancelled")]
+    Cancelled,
     #[error("wintun.dll not found (tried: {})", .tried.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", "))]
     WintunMissing { tried: Vec<PathBuf> },
     #[error("wintun.dll load failed at {}: {message}", .path.display())]

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -10,6 +10,7 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 // StartedState ========================================================================================================
@@ -131,21 +132,59 @@ impl<B: ProxyBackend> ProxyManager<B> {
         self.last_error.as_deref()
     }
 
+    /// Non-cancellable convenience wrapper around `start_cancellable`.
+    /// Equivalent to passing a fresh, never-signaled `CancellationToken`.
+    /// Used by existing callers (tests, `reload`) that don't need cancel
+    /// semantics.
     pub async fn start(&mut self, config: &ProxyConfig) -> Result<(), ProxyError> {
+        self.start_cancellable(config, CancellationToken::new()).await
+    }
+
+    /// Start the proxy with a caller-supplied `CancellationToken`. Signaling
+    /// the token at any point during `start_inner` returns
+    /// `Err(ProxyError::Cancelled)` and rolls back partial state (via the
+    /// RAII guards inside `start_inner`) without mutating `self`.
+    ///
+    /// Three race scenarios are handled correctly:
+    ///
+    /// 1. **Cancel before any `start_inner` await.** `tokio::select!` with
+    ///    `biased;` polls the cancel branch first, so an already-cancelled
+    ///    token returns `Cancelled` without invoking `start_inner` at all.
+    /// 2. **Cancel mid-flight.** `select!` drops the `start_inner` future,
+    ///    which runs every live RAII guard's `Drop` in reverse-declaration
+    ///    order — the ss task is aborted, the route-state file is cleared,
+    ///    and (if `setup_routes` had already committed) routes are torn
+    ///    down by `RouteGuard::drop`.
+    /// 3. **Cancel right after `start_inner` returns `Ok(started)`.** Commit
+    ///    to `self` happens in this outer function AFTER `select!` has
+    ///    already yielded `Ok(started)`, so the late cancel cannot race the
+    ///    commit. The started proxy is left running; the client sees
+    ///    `Ok(())`. A caller that wanted to cancel that late can follow up
+    ///    with an explicit stop.
+    pub async fn start_cancellable(
+        &mut self,
+        config: &ProxyConfig,
+        cancel: CancellationToken,
+    ) -> Result<(), ProxyError> {
         if self.state == ProxyState::Running {
             return Err(ProxyError::AlreadyRunning);
         }
 
-        // `start_inner` is an associated function — it does NOT touch
-        // `self`. All partial state lives in local variables wrapped in
-        // RAII guards, and only on `Ok` is the resulting `StartedState`
-        // committed into `self` here in the outer function. This makes
-        // the whole call drop-safe: if the future returned by
-        // `start_inner` is dropped at any `.await` point, every live
-        // guard runs its `Drop` and `self` is left in its pre-start
-        // state. See Phase 4 for where this property is exploited by
-        // `tokio::select!`-based cancellation.
-        match Self::start_inner(&self.backend, config, &self.state_dir).await {
+        // Run start_inner in a select! against the cancel token. Note that
+        // start_inner is a free associated function — it does NOT touch
+        // `self`, so dropping the future leaves `self` untouched. All
+        // partial state is owned by RAII guards inside start_inner and
+        // cleans up on drop.
+        let result: Result<StartedState, ProxyError> = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => Err(ProxyError::Cancelled),
+            r = Self::start_inner(&self.backend, config, &self.state_dir) => r,
+        };
+
+        // Commit (or record the error) in the outer function, so the only
+        // path that mutates `self.state = Running` is strictly after the
+        // select! has completed successfully.
+        match result {
             Ok(started) => {
                 let server_ip = started.server_ip;
                 self.task_handle = Some(started.task_handle);
@@ -156,6 +195,11 @@ impl<B: ProxyBackend> ProxyManager<B> {
                 self.state = ProxyState::Running;
                 info!(server_ip = %server_ip, "proxy started");
                 Ok(())
+            }
+            Err(ProxyError::Cancelled) => {
+                // Do NOT set last_error on cancel — the user asked for it.
+                info!("proxy start cancelled");
+                Err(ProxyError::Cancelled)
             }
             Err(e) => {
                 self.last_error = Some(e.to_string());

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1,15 +1,29 @@
 // Proxy lifecycle manager — start/stop/reload orchestration.
 
 use crate::gateway::GatewayInfo;
+use crate::guards::{StateFileGuard, TaskHandleGuard};
 use crate::proxy::{build_ss_config, ProxyError, TUN_DEVICE_NAME};
 use crate::routing::RouteGuard;
 use hole_common::protocol::ProxyConfig;
 use shadowsocks_service::config::Config;
 use std::net::IpAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
+
+// StartedState ========================================================================================================
+
+/// Everything `start_inner` produces on success. Held by value until the
+/// outer `start` commits it into `self`, so that cancelling `start_inner`
+/// mid-flight (dropping the future) runs every guard's `Drop` without ever
+/// touching the `ProxyManager` fields.
+struct StartedState {
+    task_handle: JoinHandle<std::io::Result<()>>,
+    route_guard: RouteGuard,
+    server_ip: IpAddr,
+    started_at: Instant,
+}
 
 // State ===============================================================================================================
 
@@ -122,96 +136,126 @@ impl<B: ProxyBackend> ProxyManager<B> {
             return Err(ProxyError::AlreadyRunning);
         }
 
-        // Build shadowsocks config
-        let ss_config = build_ss_config(config).inspect_err(|e| {
-            self.last_error = Some(e.to_string());
-        })?;
-
-        // Pre-load wintun.dll explicitly so we can give a descriptive error
-        // if it's missing. shadowsocks-service uses the bare "wintun.dll" name
-        // via tun-0.8.6, which becomes LoadLibraryExW with default search
-        // order. By loading the DLL here first (with an absolute path), the
-        // OS loader-table services the later bare-name lookup from the same
-        // process via base-name dedup. See crates/bridge/src/wintun.rs.
-        //
-        // No routes have been touched yet at this point, so we don't need
-        // to roll anything back — just record last_error and return like
-        // the build_ss_config path above.
-        #[cfg(target_os = "windows")]
-        crate::wintun::ensure_loaded().inspect_err(|e| {
-            self.last_error = Some(e.to_string());
-        })?;
-
-        // Resolve server hostname to IP
-        let server_ip = resolve_server_ip(&config.server.server, config.server.server_port)
-            .await
-            .inspect_err(|e| {
+        // `start_inner` is an associated function — it does NOT touch
+        // `self`. All partial state lives in local variables wrapped in
+        // RAII guards, and only on `Ok` is the resulting `StartedState`
+        // committed into `self` here in the outer function. This makes
+        // the whole call drop-safe: if the future returned by
+        // `start_inner` is dropped at any `.await` point, every live
+        // guard runs its `Drop` and `self` is left in its pre-start
+        // state. See Phase 4 for where this property is exploited by
+        // `tokio::select!`-based cancellation.
+        match Self::start_inner(&self.backend, config, &self.state_dir).await {
+            Ok(started) => {
+                let server_ip = started.server_ip;
+                self.task_handle = Some(started.task_handle);
+                self.route_guard = Some(started.route_guard);
+                self.server_ip = Some(started.server_ip);
+                self.started_at = Some(started.started_at);
+                self.last_error = None;
+                self.state = ProxyState::Running;
+                info!(server_ip = %server_ip, "proxy started");
+                Ok(())
+            }
+            Err(e) => {
                 self.last_error = Some(e.to_string());
-            })?;
+                Err(e)
+            }
+        }
+    }
 
-        // Detect default gateway and interface
-        let gw_info = self.backend.default_gateway().inspect_err(|e| {
-            self.last_error = Some(e.to_string());
-        })?;
+    /// Produce a `StartedState` without touching `self`. All partial
+    /// state is owned by local RAII guards so that dropping this future
+    /// at any `.await` point unwinds cleanly:
+    ///
+    /// 1. `StateFileGuard` — clears `bridge-routes.json` if dropped
+    ///    before `RouteGuard` takes over state-file cleanup.
+    /// 2. `TaskHandleGuard` — aborts the shadowsocks-service task if
+    ///    dropped before commit.
+    /// 3. `RouteGuard` — on drop tears down routes AND clears the state
+    ///    file (`RouteGuard::drop` handles both), so once it is
+    ///    constructed, `StateFileGuard` is committed to avoid a
+    ///    double-clear race.
+    ///
+    /// CRITICAL ORDERING: the route-state file is persisted BEFORE any
+    /// routing mutation. A panic or SIGKILL between `setup_routes` and
+    /// `RouteGuard` construction would otherwise leak routes with no
+    /// on-disk record, defeating crash recovery on next startup. The
+    /// guard discipline above maintains this invariant under drop as
+    /// well as under explicit error returns.
+    async fn start_inner(backend: &B, config: &ProxyConfig, state_dir: &Path) -> Result<StartedState, ProxyError> {
+        // Build shadowsocks config (sync, no partial state).
+        let ss_config: Config = build_ss_config(config)?;
 
-        // CRITICAL ORDERING: persist the route-recovery state BEFORE any
-        // routing mutation. A panic/SIGKILL between setup_routes and
-        // construction of the RouteGuard would otherwise leak routes with
-        // no on-disk record, defeating crash recovery on next startup.
+        // Pre-load wintun.dll explicitly so we can give a descriptive
+        // error if it's missing. shadowsocks-service uses the bare
+        // "wintun.dll" name via tun-0.8.6, which becomes LoadLibraryExW
+        // with default search order. By loading the DLL here first
+        // (with an absolute path), the OS loader-table services the
+        // later bare-name lookup from the same process via base-name
+        // dedup. See crates/bridge/src/wintun.rs.
+        //
+        // No routes have been touched yet at this point, so we don't
+        // need to roll anything back on failure.
+        #[cfg(target_os = "windows")]
+        crate::wintun::ensure_loaded()?;
+
+        // Resolve server hostname to IP.
+        let server_ip = resolve_server_ip(&config.server.server, config.server.server_port).await?;
+
+        // Detect default gateway and interface.
+        let gw_info = backend.default_gateway()?;
+
+        // Persist the route-recovery state. From here on, if the future
+        // is dropped or an error is returned, `StateFileGuard::drop`
+        // clears the file.
         let persisted_state = crate::route_state::RouteState {
             version: crate::route_state::SCHEMA_VERSION,
             tun_name: TUN_DEVICE_NAME.to_owned(),
             server_ip,
             interface_name: gw_info.interface_name.clone(),
         };
-        if let Err(e) = crate::route_state::save(&self.state_dir, &persisted_state) {
-            let msg = format!("failed to persist route-state: {e}");
-            self.last_error = Some(msg.clone());
-            return Err(ProxyError::RouteSetup(msg));
-        }
+        crate::route_state::save(state_dir, &persisted_state)
+            .map_err(|e| ProxyError::RouteSetup(format!("failed to persist route-state: {e}")))?;
+        let state_file_guard = StateFileGuard::new(state_dir.to_owned());
 
-        // Start shadowsocks-service (no route mutation yet). On failure,
-        // clear the state file we just wrote — no routes were installed
-        // and a stale file would only mislead the next recover_routes.
-        let handle = match self.backend.start_ss(ss_config).await {
-            Ok(h) => h,
-            Err(e) => {
-                self.last_error = Some(e.to_string());
-                let _ = crate::route_state::clear(&self.state_dir);
-                return Err(e);
-            }
-        };
+        // Start shadowsocks-service (no route mutation yet). Wrap in a
+        // TaskHandleGuard so the spawned task is aborted if we drop or
+        // return an error before commit.
+        let task_guard = TaskHandleGuard::new(backend.start_ss(ss_config).await?);
 
-        // Set up routes — if this fails, roll back: abort ss, defensively
-        // tear down any partial route state, and clear the state file so we
-        // return to a clean Stopped with no stale on-disk artifacts.
-        if let Err(e) =
-            self.backend
-                .setup_routes(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)
-        {
-            handle.abort();
-            let _ = self
-                .backend
-                .teardown_routes(TUN_DEVICE_NAME, server_ip, &gw_info.interface_name);
-            let _ = crate::route_state::clear(&self.state_dir);
-            self.last_error = Some(e.to_string());
-            return Err(e);
-        }
+        // Set up routes. On failure both `task_guard` and
+        // `state_file_guard` are dropped in reverse-declaration order,
+        // cleaning up the ss task and the state file. `teardown_routes`
+        // is NOT called explicitly: if `setup_routes` itself fails,
+        // nothing has been installed; if it partially installed and
+        // then errored, the backend is expected to clean up its own
+        // partial state (the existing contract — see `RealBackend`).
+        backend.setup_routes(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
-        self.task_handle = Some(handle);
-        self.route_guard = Some(RouteGuard::new(
+        // Routes are installed. RouteGuard takes over both route
+        // teardown and state-file clearing (see RouteGuard::drop), so
+        // disarm StateFileGuard to avoid double-clearing the file on
+        // success paths.
+        let route_guard = RouteGuard::new(
             TUN_DEVICE_NAME.to_owned(),
             server_ip,
             gw_info.interface_name,
-            self.state_dir.clone(),
-        ));
-        self.server_ip = Some(server_ip);
-        self.started_at = Some(Instant::now());
-        self.last_error = None;
-        self.state = ProxyState::Running;
+            state_dir.to_owned(),
+        );
+        state_file_guard.commit();
 
-        info!(server_ip = %server_ip, "proxy started");
-        Ok(())
+        // Extract the task handle from the guard now that routes are
+        // committed. The handle moves into StartedState and will be
+        // owned by the ProxyManager after the outer `start` commits.
+        let task_handle = task_guard.commit();
+
+        Ok(StartedState {
+            task_handle,
+            route_guard,
+            server_ip,
+            started_at: Instant::now(),
+        })
     }
 
     pub async fn stop(&mut self) -> Result<(), ProxyError> {

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -7,14 +7,18 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 // Mock backend ========================================================================================================
 
 struct MockBackend {
     start_called: Arc<AtomicU32>,
+    teardown_called: Arc<AtomicU32>,
     fail_start: AtomicBool,
     fail_routes: AtomicBool,
     fail_gateway: AtomicBool,
+    /// If Some, start_ss awaits this gate before returning.
+    start_ss_gate: Option<Arc<tokio::sync::Notify>>,
     gateway: IpAddr,
 }
 
@@ -22,9 +26,11 @@ impl MockBackend {
     fn new() -> Self {
         Self {
             start_called: Arc::new(AtomicU32::new(0)),
+            teardown_called: Arc::new(AtomicU32::new(0)),
             fail_start: AtomicBool::new(false),
             fail_routes: AtomicBool::new(false),
             fail_gateway: AtomicBool::new(false),
+            start_ss_gate: None,
             gateway: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
         }
     }
@@ -46,6 +52,12 @@ impl MockBackend {
         m.fail_gateway = AtomicBool::new(true);
         m
     }
+
+    fn with_start_ss_gate(gate: Arc<tokio::sync::Notify>) -> Self {
+        let mut m = Self::new();
+        m.start_ss_gate = Some(gate);
+        m
+    }
 }
 
 impl ProxyBackend for MockBackend {
@@ -54,6 +66,9 @@ impl ProxyBackend for MockBackend {
         _config: shadowsocks_service::config::Config,
     ) -> Result<JoinHandle<std::io::Result<()>>, ProxyError> {
         self.start_called.fetch_add(1, Ordering::SeqCst);
+        if let Some(gate) = self.start_ss_gate.as_ref() {
+            gate.notified().await;
+        }
         if self.fail_start.load(Ordering::SeqCst) {
             return Err(ProxyError::Runtime(std::io::Error::other("mock start failure")));
         }
@@ -78,6 +93,7 @@ impl ProxyBackend for MockBackend {
     }
 
     fn teardown_routes(&self, _tun_name: &str, _server_ip: IpAddr, _interface_name: &str) -> Result<(), ProxyError> {
+        self.teardown_called.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 
@@ -389,5 +405,164 @@ fn route_failure_clears_stale_state_file() {
             !state_path.exists(),
             "state file must be cleared on setup_routes failure"
         );
+    });
+}
+
+// Cancellation ========================================================================================================
+
+#[skuld::test]
+fn start_cancellable_succeeds_when_not_cancelled() {
+    rt().block_on(async {
+        let (mut pm, _dir) = new_manager(MockBackend::new());
+        let token = CancellationToken::new();
+        pm.start_cancellable(&test_config(), token).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
+fn start_cancellable_cancelled_during_ss_start_rolls_back() {
+    rt().block_on(async {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let backend = MockBackend::with_start_ss_gate(gate.clone());
+        let teardown_count = Arc::clone(&backend.teardown_called);
+
+        let (mut pm, dir) = new_manager(backend);
+        let state_path = dir.path().join(crate::route_state::STATE_FILE_NAME);
+        let token = CancellationToken::new();
+
+        // Fire off the cancel after a short delay so the start is already
+        // parked in `start_ss`.
+        let cancel_clone = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        let err = pm.start_cancellable(&test_config(), token).await.unwrap_err();
+        assert!(matches!(err, ProxyError::Cancelled), "expected Cancelled, got {err:?}");
+        assert_eq!(pm.state(), ProxyState::Stopped);
+        assert!(
+            pm.last_error().is_none(),
+            "ProxyError::Cancelled must NOT be recorded as last_error"
+        );
+        assert!(
+            !state_path.exists(),
+            "state file must be cleared on cancel during start_ss"
+        );
+        // setup_routes was never called, so no teardown should have run.
+        assert_eq!(teardown_count.load(Ordering::SeqCst), 0);
+
+        // The gate is still held — release it so the spawned ss task can drop cleanly.
+        gate.notify_one();
+    });
+}
+
+#[skuld::test]
+fn start_cancellable_cancel_before_start_returns_immediately() {
+    rt().block_on(async {
+        let (mut pm, dir) = new_manager(MockBackend::new());
+        let state_path = dir.path().join(crate::route_state::STATE_FILE_NAME);
+        let token = CancellationToken::new();
+        token.cancel(); // already cancelled before start is even called
+
+        let err = pm.start_cancellable(&test_config(), token).await.unwrap_err();
+        assert!(matches!(err, ProxyError::Cancelled));
+        assert_eq!(pm.state(), ProxyState::Stopped);
+        assert!(pm.last_error().is_none());
+        assert!(!state_path.exists());
+    });
+}
+
+#[skuld::test]
+fn start_cancellable_cancel_after_success_does_not_corrupt_state() {
+    // Race scenario: start_inner has committed successfully and returned
+    // Ok(StartedState) before the cancel token is signaled. The commit
+    // happens in the outer `start_cancellable` AFTER `select!` resolves,
+    // so a late cancel that lost the race must not leave the manager in
+    // an inconsistent (Running + last_error=cancelled) state.
+    rt().block_on(async {
+        let (mut pm, _dir) = new_manager(MockBackend::new());
+        let token = CancellationToken::new();
+        let result = pm.start_cancellable(&test_config(), token.clone()).await;
+        // Fire the cancel after start has returned. This is a no-op for
+        // the just-started proxy but must not panic or corrupt state.
+        token.cancel();
+
+        // Outcome must be Ok + Running (start completed before cancel landed)
+        // OR Err(Cancelled) + Stopped (cancel raced and won). Never a mix.
+        match result {
+            Ok(()) => {
+                assert_eq!(pm.state(), ProxyState::Running);
+                assert!(pm.last_error().is_none());
+                pm.stop().await.unwrap();
+            }
+            Err(ProxyError::Cancelled) => {
+                assert_eq!(pm.state(), ProxyState::Stopped);
+                assert!(pm.last_error().is_none());
+            }
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
+    });
+}
+
+#[skuld::test]
+fn start_cancellable_dropped_future_runs_guards() {
+    // Drop-safety: even without CancellationToken, dropping the start
+    // future at an await point must clean up. Uses `tokio::time::timeout`
+    // with a very short deadline to force the drop while `start_ss` is
+    // parked on the gate.
+    rt().block_on(async {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let backend = MockBackend::with_start_ss_gate(gate.clone());
+        let teardown_count = Arc::clone(&backend.teardown_called);
+
+        let (mut pm, dir) = new_manager(backend);
+        let state_path = dir.path().join(crate::route_state::STATE_FILE_NAME);
+        let token = CancellationToken::new();
+
+        // Short deadline — the future will be dropped before start_ss
+        // ever returns (the gate is never released).
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            pm.start_cancellable(&test_config(), token),
+        )
+        .await;
+        assert!(result.is_err(), "expected elapsed timeout");
+
+        assert_eq!(pm.state(), ProxyState::Stopped);
+        assert!(
+            !state_path.exists(),
+            "StateFileGuard::drop must clear the file on dropped future"
+        );
+        assert_eq!(
+            teardown_count.load(Ordering::SeqCst),
+            0,
+            "setup_routes never ran, so teardown should not have either"
+        );
+
+        gate.notify_one();
+    });
+}
+
+#[skuld::test]
+fn reload_creates_fresh_uncancellable_token() {
+    // reload() internally calls start_cancellable with a fresh token that
+    // is never signaled. Verifies the reload path still works after the
+    // cancellation refactor.
+    rt().block_on(async {
+        let backend = MockBackend::new();
+        let start_count = Arc::clone(&backend.start_called);
+
+        let (mut pm, _dir) = new_manager(backend);
+        pm.start(&test_config()).await.unwrap();
+        assert_eq!(start_count.load(Ordering::SeqCst), 1);
+
+        pm.reload(&test_config()).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        assert_eq!(start_count.load(Ordering::SeqCst), 2);
+
+        pm.stop().await.unwrap();
     });
 }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -476,34 +476,29 @@ fn start_cancellable_cancel_before_start_returns_immediately() {
 }
 
 #[skuld::test]
-fn start_cancellable_cancel_after_success_does_not_corrupt_state() {
-    // Race scenario: start_inner has committed successfully and returned
-    // Ok(StartedState) before the cancel token is signaled. The commit
-    // happens in the outer `start_cancellable` AFTER `select!` resolves,
-    // so a late cancel that lost the race must not leave the manager in
-    // an inconsistent (Running + last_error=cancelled) state.
+fn start_cancellable_late_cancel_on_finished_token_is_noop() {
+    // Sanity check that cancelling a CancellationToken AFTER its owning
+    // start has already completed is a harmless no-op. The "post-commit
+    // race" (cancel fires between select!'s ok branch resolving and the
+    // outer match arm committing to self) is not reachable here — the
+    // match arms are synchronous, so once select! has chosen the Ok
+    // branch there is no await between that and the commit. This test
+    // verifies only that a late cancel does not panic or mutate state
+    // after the start has returned. The real post-commit race is
+    // prevented by the synchronous-commit design in start_cancellable,
+    // not by this test.
     rt().block_on(async {
         let (mut pm, _dir) = new_manager(MockBackend::new());
         let token = CancellationToken::new();
-        let result = pm.start_cancellable(&test_config(), token.clone()).await;
-        // Fire the cancel after start has returned. This is a no-op for
-        // the just-started proxy but must not panic or corrupt state.
-        token.cancel();
+        pm.start_cancellable(&test_config(), token.clone()).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
 
-        // Outcome must be Ok + Running (start completed before cancel landed)
-        // OR Err(Cancelled) + Stopped (cancel raced and won). Never a mix.
-        match result {
-            Ok(()) => {
-                assert_eq!(pm.state(), ProxyState::Running);
-                assert!(pm.last_error().is_none());
-                pm.stop().await.unwrap();
-            }
-            Err(ProxyError::Cancelled) => {
-                assert_eq!(pm.state(), ProxyState::Stopped);
-                assert!(pm.last_error().is_none());
-            }
-            Err(e) => panic!("unexpected error: {e:?}"),
-        }
+        // Late cancel — must not panic, must not mutate proxy state.
+        token.cancel();
+        assert_eq!(pm.state(), ProxyState::Running);
+        assert!(pm.last_error().is_none());
+
+        pm.stop().await.unwrap();
     });
 }
 

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -59,6 +59,24 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /v1/cancel:
+    post:
+      summary: Cancel an in-flight proxy start
+      description: |
+        Idempotent signal that interrupts an in-flight `POST /v1/start`. If no
+        start is currently in flight, the cancel is "pre-armed" and consumed by
+        the very next start. Always returns 200 — the bridge records the intent
+        regardless of whether there is anything to cancel right now. The
+        cancelled start itself returns 500 with `ErrorResponse { message: "cancelled" }`.
+      operationId: cancelProxy
+      responses:
+        "200":
+          description: Cancel recorded (idempotent)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+
   /v1/reload:
     post:
       summary: Reload the proxy with new configuration

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -16,15 +16,30 @@ pub use api_generated::*;
 /// maps variants to HTTP endpoints internally.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum BridgeRequest {
-    Start { config: ProxyConfig },
+    Start {
+        config: ProxyConfig,
+    },
     Stop,
+    /// Cancel an in-flight `Start`. Idempotent — if no start is in flight, the
+    /// cancel is pre-armed and consumed by the next start. See the
+    /// `/v1/cancel` route in `openapi.yaml`.
+    Cancel,
     Status,
-    Reload { config: ProxyConfig },
+    Reload {
+        config: ProxyConfig,
+    },
     Metrics,
     Diagnostics,
     PublicIp,
-    TestServer { entry: ServerEntry },
+    TestServer {
+        entry: ServerEntry,
+    },
 }
+
+/// Error-payload message string that identifies a cancelled start. Both bridge
+/// and client compare against this constant rather than re-parsing the error
+/// text.
+pub const CANCELLED_MESSAGE: &str = "cancelled";
 
 /// Client-side response enum. Used by the GUI client API and elevation flow.
 /// Not part of the wire protocol — the client maps HTTP responses back to

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -61,6 +61,22 @@ fn bridge_request_reload_json_roundtrip() {
 }
 
 #[skuld::test]
+fn bridge_request_cancel_json_roundtrip() {
+    let req = BridgeRequest::Cancel;
+    let json = serde_json::to_vec(&req).unwrap();
+    let decoded: BridgeRequest = serde_json::from_slice(&json).unwrap();
+    assert_eq!(decoded, req);
+}
+
+#[skuld::test]
+fn cancelled_message_constant_is_stable() {
+    // The bridge writes this exact string into ErrorResponse when a Start is
+    // cancelled; the client matches against it. Changing it is a breaking
+    // change to the client/bridge contract.
+    assert_eq!(CANCELLED_MESSAGE, "cancelled");
+}
+
+#[skuld::test]
 fn bridge_response_ack_json_roundtrip() {
     let resp = BridgeResponse::Ack;
     let json = serde_json::to_vec(&resp).unwrap();
@@ -162,6 +178,7 @@ fn route_constants_are_correct() {
     assert_eq!(ROUTE_STATUS, "/v1/status");
     assert_eq!(ROUTE_START, "/v1/start");
     assert_eq!(ROUTE_STOP, "/v1/stop");
+    assert_eq!(ROUTE_CANCEL, "/v1/cancel");
     assert_eq!(ROUTE_RELOAD, "/v1/reload");
 }
 

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -3,8 +3,8 @@
 use bytes::Bytes;
 use hole_common::protocol::{
     BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, PublicIpResponse,
-    StatusResponse, TestServerRequest, TestServerResponse, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_PUBLIC_IP,
-    ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    StatusResponse, TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
+    ROUTE_PUBLIC_IP, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -103,6 +103,14 @@ impl BridgeClient {
             }
             BridgeRequest::Stop => {
                 let resp = self.http_post(ROUTE_STOP, Vec::new()).await?;
+                if resp.status().is_success() {
+                    Ok(BridgeResponse::Ack)
+                } else {
+                    parse_bridge_error(resp).await
+                }
+            }
+            BridgeRequest::Cancel => {
+                let resp = self.http_post(ROUTE_CANCEL, Vec::new()).await?;
                 if resp.status().is_success() {
                     Ok(BridgeResponse::Ack)
                 } else {

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -41,6 +41,10 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
             axum::routing::post(|| async { Json(EmptyResponse {}) }),
         )
         .route(
+            hole_common::protocol::ROUTE_CANCEL,
+            axum::routing::post(|| async { Json(EmptyResponse {}) }),
+        )
+        .route(
             hole_common::protocol::ROUTE_RELOAD,
             axum::routing::post(|| async { Json(EmptyResponse {}) }),
         )
@@ -191,6 +195,18 @@ fn other_io_error_maps_to_connection() {
         matches!(client_err, ClientError::Connection(_)),
         "expected Connection, got: {client_err:?}"
     );
+}
+
+#[skuld::test]
+fn send_cancel_receives_ack() {
+    rt().block_on(async {
+        let path = test_socket_path("cancel");
+        let _mock = spawn_mock_bridge(&path).await;
+
+        let mut client = BridgeClient::connect(&path).await.unwrap();
+        let resp = client.send(BridgeRequest::Cancel).await.unwrap();
+        assert_eq!(resp, BridgeResponse::Ack);
+    });
 }
 
 #[skuld::test]

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -84,6 +84,7 @@ fn launch_gui(show_dashboard: bool) {
             commands::test_server,
             commands::mark_validated_by_proxy_start,
             tray::toggle_proxy,
+            tray::cancel_proxy,
         ])
         .setup(move |app| {
             // Manage shared state here (instead of pre-`.setup()`) so that

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -53,11 +53,7 @@ impl AppState {
 
         // Lazy connect
         if guard.is_none() {
-            let socket_path = std::env::var("HOLE_BRIDGE_SOCKET")
-                .ok()
-                .map(PathBuf::from)
-                .unwrap_or_else(hole_common::protocol::default_bridge_socket_path);
-            let connect_result = BridgeClient::connect(&socket_path).await;
+            let connect_result = BridgeClient::connect(&resolve_bridge_socket_path()).await;
 
             match connect_result {
                 Ok(client) => *guard = Some(client),
@@ -84,4 +80,29 @@ impl AppState {
             }
         }
     }
+
+    /// Send a request over a fresh, single-use bridge connection that
+    /// bypasses the pooled `BridgeClient`. This exists specifically so
+    /// `BridgeRequest::Cancel` can race an in-flight request on the main
+    /// connection: `bridge_send` holds `self.bridge.lock().await` for the
+    /// entire duration of each request, which would otherwise block a
+    /// concurrent cancel until the request it is trying to cancel finishes.
+    ///
+    /// Unix-domain-socket connect latency is sub-millisecond, so the
+    /// per-call overhead is negligible. Use sparingly — the pooled client
+    /// is still the right choice for normal request traffic.
+    pub async fn bridge_send_oneshot(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
+        let mut client = BridgeClient::connect(&resolve_bridge_socket_path()).await?;
+        client.send(req).await
+    }
+}
+
+/// Resolve the bridge socket path from `HOLE_BRIDGE_SOCKET` or the
+/// platform default. Extracted so `bridge_send` and `bridge_send_oneshot`
+/// stay in sync.
+fn resolve_bridge_socket_path() -> PathBuf {
+    std::env::var("HOLE_BRIDGE_SOCKET")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(hole_common::protocol::default_bridge_socket_path)
 }

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -3,11 +3,31 @@
 use crate::commands::build_proxy_config;
 use crate::state::AppState;
 use hole::tray_icons;
-use hole_common::protocol::{BridgeRequest, BridgeResponse};
+use hole_common::protocol::{BridgeRequest, BridgeResponse, CANCELLED_MESSAGE};
+use serde::Serialize;
 use tauri::menu::{CheckMenuItem, MenuEvent, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 use tracing::{error, info, warn};
+
+// ToggleOutcome =======================================================================================================
+
+/// Result of a `set_proxy_enabled` call, distinguishing an ordinary
+/// state transition from a user-initiated cancellation of a Start.
+/// The frontend maps these variants to its own state machine (see
+/// `ui/connection-state.ts`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToggleOutcome {
+    /// Proxy is now running.
+    Running,
+    /// Proxy is now stopped.
+    Stopped,
+    /// The Start was cancelled via `cancel_proxy` before it could finish;
+    /// proxy is back in the Stopped state. Never returned by
+    /// `set_proxy_enabled(false)` — stop is not cancellable.
+    Cancelled,
+}
 
 // Menu IDs ============================================================================================================
 
@@ -181,17 +201,27 @@ fn revert_proxy_state(app: &AppHandle, enabled: bool) {
     rebuild_tray_menu(app);
 }
 
-/// Set the proxy to the given enabled state. Returns the new state on success.
+/// Set the proxy to the given enabled state. Returns a `ToggleOutcome`
+/// describing whether the proxy ended up Running, Stopped, or the Start
+/// was Cancelled before it could complete (only when `enabled == true`).
 ///
-/// On failure, reverts config + tray state and returns an error message.
+/// On bridge errors that are NOT a cancellation, reverts config + tray
+/// state and returns an error message. On `Cancelled`, reverts config
+/// back to `false` — the optimistic `config.enabled = true` flip is
+/// rolled back so the persisted state matches reality.
 /// Used by both the tray Enable checkbox and the frontend toggle button.
-pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, String> {
+pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<ToggleOutcome, String> {
     let state = app.state::<AppState>();
 
     let proxy_config = {
         let mut config = state.config.lock().unwrap();
         if config.enabled == enabled {
-            return Ok(enabled); // Already in the desired state (concurrent toggle)
+            // Already in the desired state (concurrent toggle).
+            return Ok(if enabled {
+                ToggleOutcome::Running
+            } else {
+                ToggleOutcome::Stopped
+            });
         }
         config.enabled = enabled;
         config.save(&state.config_path).ok();
@@ -200,7 +230,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, S
 
     set_tray_icon(app, enabled);
 
-    let result = if enabled {
+    let result: Result<ToggleOutcome, String> = if enabled {
         let Some(proxy_config) = proxy_config else {
             revert_proxy_state(app, false);
             return Err("No server is selected. Open the Dashboard and select a server before connecting.".into());
@@ -210,11 +240,15 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, S
         match state.bridge_send(request.clone()).await {
             Ok(BridgeResponse::Ack) => {
                 info!("proxy started");
-                Ok(true)
+                Ok(ToggleOutcome::Running)
+            }
+            Ok(BridgeResponse::Error { message }) if message == CANCELLED_MESSAGE => {
+                info!("proxy start cancelled");
+                Ok(ToggleOutcome::Cancelled)
             }
             Ok(BridgeResponse::Error { message }) if message.contains("already running") => {
                 info!("proxy already running");
-                Ok(true)
+                Ok(ToggleOutcome::Running)
             }
             Ok(BridgeResponse::Error { message }) => {
                 error!("bridge error: {message}");
@@ -226,7 +260,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, S
             }
             Err(crate::bridge_client::ClientError::PermissionDenied) => {
                 if crate::elevation::prompt_elevation(app, request).await {
-                    Ok(true)
+                    Ok(ToggleOutcome::Running)
                 } else {
                     Err("Elevation was denied or failed".into())
                 }
@@ -241,7 +275,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, S
         match state.bridge_send(request.clone()).await {
             Ok(BridgeResponse::Ack) => {
                 info!("proxy stopped");
-                Ok(false)
+                Ok(ToggleOutcome::Stopped)
             }
             Ok(BridgeResponse::Error { message }) => {
                 error!("bridge error: {message}");
@@ -253,7 +287,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, S
             }
             Err(crate::bridge_client::ClientError::PermissionDenied) => {
                 if crate::elevation::prompt_elevation(app, request).await {
-                    Ok(false)
+                    Ok(ToggleOutcome::Stopped)
                 } else {
                     Err("Elevation was denied or failed".into())
                 }
@@ -266,7 +300,14 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<bool, S
     };
 
     match &result {
-        Ok(_) => rebuild_tray_menu(app),
+        Ok(ToggleOutcome::Running | ToggleOutcome::Stopped) => rebuild_tray_menu(app),
+        Ok(ToggleOutcome::Cancelled) => {
+            // The user cancelled the Start. Roll back the optimistic
+            // `config.enabled = true` flip so persisted state matches
+            // reality, and rebuild the menu with enabled=false.
+            debug_assert!(enabled, "Cancelled outcome only possible on Start");
+            revert_proxy_state(app, false);
+        }
         Err(_) => revert_proxy_state(app, !enabled),
     }
 
@@ -304,9 +345,20 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
                 let enabled = !state.config.lock().unwrap().enabled;
-                if let Err(msg) = set_proxy_enabled(&app_handle, enabled).await {
-                    use tauri_plugin_dialog::DialogExt;
-                    app_handle.dialog().message(msg).title("Error").blocking_show();
+                match set_proxy_enabled(&app_handle, enabled).await {
+                    Ok(ToggleOutcome::Running) | Ok(ToggleOutcome::Stopped) => { /* menu already rebuilt */ }
+                    Ok(ToggleOutcome::Cancelled) => {
+                        // Tray never initiates Cancel itself, so this is an
+                        // observer effect: the frontend cancelled while the
+                        // tray-triggered Start was still in flight. The
+                        // config has already been reverted by
+                        // set_proxy_enabled. Nothing to do here.
+                        info!("tray: start was cancelled externally");
+                    }
+                    Err(msg) => {
+                        use tauri_plugin_dialog::DialogExt;
+                        app_handle.dialog().message(msg).title("Error").blocking_show();
+                    }
                 }
             });
         }
@@ -712,11 +764,32 @@ pub(crate) fn open_settings_window(app: &AppHandle) {
 
 // Tauri commands ======================================================================================================
 
-/// Toggle the proxy on/off. Returns `true` if proxy is now enabled, `false` if disabled.
+/// Toggle the proxy on/off. Returns a `ToggleOutcome` describing the
+/// resulting state (Running / Stopped / Cancelled). The frontend
+/// distinguishes the three cases in its connection state machine.
 #[tauri::command]
-pub async fn toggle_proxy(app: AppHandle, state: tauri::State<'_, AppState>) -> Result<bool, String> {
+pub async fn toggle_proxy(app: AppHandle, state: tauri::State<'_, AppState>) -> Result<ToggleOutcome, String> {
     let enabled = !state.config.lock().unwrap().enabled;
     set_proxy_enabled(&app, enabled).await
+}
+
+/// Cancel an in-flight proxy start. Uses `bridge_send_oneshot` so the
+/// cancel can race an in-flight `toggle_proxy` on the main pooled
+/// bridge connection. Always returns `Ok(())` on a successful bridge
+/// round-trip — the bridge's `/v1/cancel` route is idempotent.
+#[tauri::command]
+pub async fn cancel_proxy(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    match state.bridge_send_oneshot(BridgeRequest::Cancel).await {
+        Ok(BridgeResponse::Ack) => Ok(()),
+        Ok(other) => {
+            warn!("unexpected response to Cancel: {other:?}");
+            Err("Unexpected response from bridge".into())
+        }
+        Err(e) => {
+            error!("failed to send cancel: {e}");
+            Err(format!("Failed to cancel: {e}"))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ui/connection-state.ts
+++ b/ui/connection-state.ts
@@ -1,0 +1,122 @@
+// Connection state machine for the sidebar power button.
+//
+// The power button has seven states — four idle (Disconnected, Connected,
+// ConnectionFailed, DisconnectionFailed) and three transition states
+// (Connecting, Disconnecting, Cancelling). This module owns the state
+// type, the text/CSS mapping, and the small set of predicates that the
+// DOM-wiring layer (`sidebar.ts`) uses to decide what to render.
+//
+// See `docs/superpowers/specs/` design notes for the full transition
+// graph and rationale (backend cancellation, 15 s client timeout, etc.).
+
+export type ConnectionState =
+  | "disconnected" //       red,       "Disconnected",       click → start
+  | "connecting" //         spinner,   "Connecting...",      click → cancel
+  | "cancelling" //         spinner,   "Cancelling...",      click → no-op
+  | "connected" //          green,     "Connected",          click → stop
+  | "disconnecting" //      spinner,   "Disconnecting...",   click → no-op
+  | "connection-failed" //  red,       "Connection failed",  click → start (retry)
+  | "disconnection-failed"; // green,  "Disconnect failed",  click → stop  (retry)
+
+/// Idle states never have a pending IPC request. Polling may overwrite
+/// state only when the current state is in this set — transition states
+/// must not be clobbered mid-flight.
+export const IDLE_STATES = new Set<ConnectionState>([
+  "disconnected",
+  "connected",
+  "connection-failed",
+  "disconnection-failed",
+]);
+
+/// Transition states show a spinner. The button is not interactive in
+/// `cancelling` or `disconnecting`; `connecting` is the only transition
+/// state where a click fires `cancel_proxy`.
+export const TRANSITION_STATES = new Set<ConnectionState>(["connecting", "disconnecting", "cancelling"]);
+
+/// True if the UI represents the proxy as "running" for the user — i.e.
+/// clicking the button should initiate a disconnect. Includes the
+/// optimistic Running state and the DisconnectionFailed state (where the
+/// proxy is still up because a stop failed).
+export function isEffectivelyOn(state: ConnectionState): boolean {
+  return state === "connected" || state === "disconnection-failed";
+}
+
+/// Human-readable status text shown next to the power button.
+export function statusTextFor(state: ConnectionState): string {
+  switch (state) {
+    case "disconnected":
+      return "Disconnected";
+    case "connecting":
+      return "Connecting...";
+    case "cancelling":
+      return "Cancelling...";
+    case "connected":
+      return "Connected";
+    case "disconnecting":
+      return "Disconnecting...";
+    case "connection-failed":
+      return "Connection failed";
+    case "disconnection-failed":
+      return "Disconnect failed";
+  }
+}
+
+/// CSS class for the `#status-word` element. Drives the text color: on
+/// = green, off = red, transitioning = neutral/muted.
+export function statusWordClassFor(state: ConnectionState): string {
+  switch (state) {
+    case "connected":
+    case "disconnection-failed":
+      return "on";
+    case "disconnected":
+    case "connection-failed":
+      return "off";
+    case "connecting":
+    case "cancelling":
+    case "disconnecting":
+      return "transitioning";
+  }
+}
+
+/// CSS class for the `#power-btn` element. The button has three base
+/// modes (on / off / transitioning) plus a short-lived "failed" flash on
+/// top of on/off.
+export function powerBtnClassFor(state: ConnectionState): string {
+  switch (state) {
+    case "connected":
+      return "power-btn on";
+    case "disconnection-failed":
+      return "power-btn on failed-on";
+    case "disconnected":
+      return "power-btn off";
+    case "connection-failed":
+      return "power-btn off failed-off";
+    case "connecting":
+    case "cancelling":
+    case "disconnecting":
+      return "power-btn transitioning";
+  }
+}
+
+/// Map the backend-side `ToggleOutcome` variants (serialized lowercase)
+/// to the frontend state that should result when a toggle succeeds.
+export function stateForToggleOutcome(outcome: "running" | "stopped" | "cancelled"): ConnectionState {
+  switch (outcome) {
+    case "running":
+      return "connected";
+    case "stopped":
+      return "disconnected";
+    case "cancelled":
+      // Cancel during connect — we end up Disconnected. The UI may have
+      // already shown "Cancelling..." briefly; the transition settles
+      // into the idle Disconnected state.
+      return "disconnected";
+  }
+}
+
+/// Derive the state the sidebar should be in given a `running` flag from
+/// the periodic status poll. Used by `updateProxyStatus` when the current
+/// UI state is idle (the poll never overwrites a transition state).
+export function stateForPolledRunning(running: boolean): ConnectionState {
+  return running ? "connected" : "disconnected";
+}

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -74,18 +74,20 @@ async function pollProxyStatus() {
   try {
     const status = await invoke<ProxyStatus>("get_proxy_status");
     const result = updateProxyStatus(status);
-    if (!result.changed) return;
+    if (result.state === result.previousState) return;
 
     // Connection state changed — refresh IP.
     updatePublicIp();
 
-    // Stopped → Running transition: mark the selected server as
-    // "validated by a successful proxy start" so the user gets a green
-    // dot without needing to run an explicit test. Sequence the persist
-    // BEFORE the reload so loadConfig() sees the new validation state
-    // and a subsequent disconnect cannot sneak in between persist and
-    // reload.
-    if (result.connected && config?.selected_server) {
+    // Fire `mark_validated_by_proxy_start` only on the specific
+    // transition into `connected`. This avoids re-firing on every poll
+    // that happens to observe `running: true`, and sidesteps the
+    // polling-vs-click race: the user-initiated connect goes through
+    // `handlePowerClick` which uses the same transition so the event
+    // is emitted consistently regardless of which path landed the
+    // state change. Sequence the persist BEFORE the reload so
+    // loadConfig() sees the new validation state.
+    if (result.state === "connected" && config?.selected_server) {
       try {
         await invoke("mark_validated_by_proxy_start", { entryId: config.selected_server });
         await loadConfig();

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -74,26 +74,14 @@ async function pollProxyStatus() {
   try {
     const status = await invoke<ProxyStatus>("get_proxy_status");
     const result = updateProxyStatus(status);
-    if (result.state === result.previousState) return;
-
-    // Connection state changed — refresh IP.
-    updatePublicIp();
-
-    // Fire `mark_validated_by_proxy_start` only on the specific
-    // transition into `connected`. This avoids re-firing on every poll
-    // that happens to observe `running: true`, and sidesteps the
-    // polling-vs-click race: the user-initiated connect goes through
-    // `handlePowerClick` which uses the same transition so the event
-    // is emitted consistently regardless of which path landed the
-    // state change. Sequence the persist BEFORE the reload so
-    // loadConfig() sees the new validation state.
-    if (result.state === "connected" && config?.selected_server) {
-      try {
-        await invoke("mark_validated_by_proxy_start", { entryId: config.selected_server });
-        await loadConfig();
-      } catch (err) {
-        console.error("mark_validated_by_proxy_start failed:", err);
-      }
+    // The poll only reconciles state when the bridge disagrees with the
+    // UI (e.g. an external disconnect). Click-driven transitions fire
+    // `mark_validated_by_proxy_start` themselves from the click handler
+    // — the poll never observes the `connecting` intermediate state, so
+    // it cannot distinguish "user just connected" from "bridge was
+    // already connected when the GUI started".
+    if (result.changed) {
+      updatePublicIp();
     }
   } catch (err) {
     console.error("get_proxy_status failed:", err);

--- a/ui/sidebar.ts
+++ b/ui/sidebar.ts
@@ -13,7 +13,7 @@ import {
   statusTextFor,
   statusWordClassFor,
 } from "./connection-state";
-import { config } from "./main";
+import { config, loadConfig } from "./main";
 import { statusTooltipFor } from "./servers";
 import {
   type DiagnosticsData,
@@ -86,7 +86,6 @@ const versionFooter = document.getElementById("version-footer")!;
 // State ===============================================================================================================
 
 let currentState: ConnectionState = "disconnected";
-let previousState: ConnectionState = "disconnected";
 let currentIp = "";
 
 // Throughput graph data — circular buffer of 60 data points.
@@ -130,12 +129,8 @@ graphSvg.appendChild(txLine);
 
 // Power button ========================================================================================================
 
-/// Transition the UI to a new state and repaint the DOM. Tracks the
-/// previous state for polling-side event emission
-/// (`mark_validated_by_proxy_start` fires on connecting → connected
-/// specifically, not on any "became connected").
+/// Transition the UI to a new state and repaint the DOM.
 function setState(next: ConnectionState) {
-  previousState = currentState;
   currentState = next;
   updateConnectionUI();
 }
@@ -202,16 +197,52 @@ async function toggleFromIdle(goingToConnect: boolean) {
     return;
   }
 
-  if (raced.kind === "ok") {
-    setState(stateForToggleOutcome(raced.outcome));
-    // Refresh IP on any successful transition.
+  if (raced.kind === "err") {
+    console.error("toggle_proxy failed:", raced.error);
+    setState(goingToConnect ? "connection-failed" : "disconnection-failed");
+    return;
+  }
+
+  // raced.kind === "ok"
+  const outcome = raced.outcome;
+
+  // Race: the user clicked Cancel during connecting, but the Start had
+  // already succeeded at the bridge before the cancel reached it. The
+  // outcome is Running despite the user's intent to cancel. Honor the
+  // user's intent by firing a follow-up Stop. This preserves the plan's
+  // "cancelling --raced-- disconnecting" transition.
+  if (currentState === "cancelling" && outcome === "running") {
+    console.info("cancel raced with successful start — firing follow-up stop");
+    setState("disconnecting");
+    try {
+      const stopOutcome = await invoke<ToggleOutcome>("toggle_proxy");
+      setState(stateForToggleOutcome(stopOutcome));
+    } catch (err) {
+      console.error("follow-up stop failed:", err);
+      setState("disconnection-failed");
+    }
     updatePublicIp();
     return;
   }
 
-  // raced.kind === "err"
-  console.error("toggle_proxy failed:", raced.error);
-  setState(goingToConnect ? "connection-failed" : "disconnection-failed");
+  setState(stateForToggleOutcome(outcome));
+  // Refresh IP on any successful transition.
+  updatePublicIp();
+
+  // User-initiated connect succeeded — mark the selected server as
+  // validated so the UI gets a green dot without a separate test run.
+  // Fired from the click handler (not polling) because `connecting →
+  // connected` is a click-local transition that polling never observes.
+  // Sequence the persist BEFORE the reload so loadConfig() sees the
+  // new validation state.
+  if (goingToConnect && outcome === "running" && config?.selected_server) {
+    try {
+      await invoke("mark_validated_by_proxy_start", { entryId: config.selected_server });
+      await loadConfig();
+    } catch (err) {
+      console.error("mark_validated_by_proxy_start failed:", err);
+    }
+  }
 }
 
 // IP display ==========================================================================================================
@@ -424,19 +455,23 @@ export function updateMetrics(metrics: Metrics) {
  * and must not be clobbered by a poll landing mid-transition. A poll
  * that arrives during a transition is a no-op for state purposes.
  *
- * Returns `{ state, previousState }` so `main.ts` can emit
- * `mark_validated_by_proxy_start` on the specific `connecting → connected`
- * transition (not on every poll that observes `running: true`).
+ * Returns `{ state, changed }` where `changed` is true iff this poll
+ * itself caused a state change (not including click-driven transitions
+ * that were applied between polls). `main.ts` uses this to know when to
+ * refresh the public IP. The click handler owns the `connecting →
+ * connected` emission of `mark_validated_by_proxy_start`, so the poll
+ * does not need to track previous state.
  */
 export function updateProxyStatus(status: ProxyStatus) {
   if (!IDLE_STATES.has(currentState)) {
-    return { state: currentState, previousState };
+    return { state: currentState, changed: false };
   }
   const polled = stateForPolledRunning(!!status.running);
-  if (polled !== currentState) {
-    setState(polled);
+  if (polled === currentState) {
+    return { state: currentState, changed: false };
   }
-  return { state: currentState, previousState };
+  setState(polled);
+  return { state: currentState, changed: true };
 }
 
 /** Returns the current connection state. */

--- a/ui/sidebar.ts
+++ b/ui/sidebar.ts
@@ -3,6 +3,16 @@
 
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
+import {
+  type ConnectionState,
+  IDLE_STATES,
+  isEffectivelyOn,
+  powerBtnClassFor,
+  stateForPolledRunning,
+  stateForToggleOutcome,
+  statusTextFor,
+  statusWordClassFor,
+} from "./connection-state";
 import { config } from "./main";
 import { statusTooltipFor } from "./servers";
 import {
@@ -13,6 +23,17 @@ import {
   type PublicIpData,
   type ValidationState,
 } from "./types";
+
+/// Backend returns `ToggleOutcome` serialized as lowercase strings. Must
+/// match `crates/hole/src/tray.rs::ToggleOutcome`.
+type ToggleOutcome = "running" | "stopped" | "cancelled";
+
+/// Client-side timeout for `toggle_proxy`. If the IPC call doesn't
+/// resolve within this window we fire `cancel_proxy` and move the UI to
+/// a "failed" state. Chosen to comfortably exceed a real connect (DNS +
+/// handshake + route setup usually <5 s) while still surfacing a hung
+/// bridge promptly.
+const TOGGLE_TIMEOUT_MS = 15_000;
 
 // Formatting helpers ==================================================================================================
 
@@ -64,8 +85,8 @@ const versionFooter = document.getElementById("version-footer")!;
 
 // State ===============================================================================================================
 
-let connected = false;
-let toggling = false;
+let currentState: ConnectionState = "disconnected";
+let previousState: ConnectionState = "disconnected";
 let currentIp = "";
 
 // Throughput graph data — circular buffer of 60 data points.
@@ -109,29 +130,88 @@ graphSvg.appendChild(txLine);
 
 // Power button ========================================================================================================
 
-async function handlePowerClick() {
-  if (toggling) return;
-  toggling = true;
-  powerBtn.style.opacity = "0.6";
-
-  try {
-    const newState = await invoke<boolean>("toggle_proxy");
-    connected = newState;
-    updateConnectionUI();
-    // Refresh IP on connection state change.
-    updatePublicIp();
-  } catch (err) {
-    console.error("toggle_proxy failed:", err);
-  } finally {
-    toggling = false;
-    powerBtn.style.opacity = "";
-  }
+/// Transition the UI to a new state and repaint the DOM. Tracks the
+/// previous state for polling-side event emission
+/// (`mark_validated_by_proxy_start` fires on connecting → connected
+/// specifically, not on any "became connected").
+function setState(next: ConnectionState) {
+  previousState = currentState;
+  currentState = next;
+  updateConnectionUI();
 }
 
 function updateConnectionUI() {
-  powerBtn.className = connected ? "power-btn on" : "power-btn off";
-  statusWord.className = connected ? "on" : "off";
-  statusWord.textContent = connected ? "Connected" : "Disconnected";
+  powerBtn.className = powerBtnClassFor(currentState);
+  statusWord.className = statusWordClassFor(currentState);
+  statusWord.textContent = statusTextFor(currentState);
+}
+
+async function handlePowerClick() {
+  // Non-interactive transition states — click is ignored.
+  if (currentState === "cancelling" || currentState === "disconnecting") {
+    return;
+  }
+
+  // Click during connecting → fire cancel. The original toggle_proxy
+  // promise is still pending in toggleFromIdle(); `cancel_proxy`
+  // races it on a fresh bridge connection so it does not block behind
+  // the in-flight start.
+  if (currentState === "connecting") {
+    setState("cancelling");
+    invoke("cancel_proxy").catch((err) => {
+      console.error("cancel_proxy failed:", err);
+    });
+    return;
+  }
+
+  // Idle state — start or stop based on whether the proxy is
+  // effectively on. Retry paths (connection-failed, disconnection-failed)
+  // are treated as their base idle states for the purpose of this dispatch.
+  const goingToConnect = !isEffectivelyOn(currentState);
+  await toggleFromIdle(goingToConnect);
+}
+
+/// Issue `toggle_proxy` with a 15 s client-side timeout. On success,
+/// the state transitions per `ToggleOutcome`; on explicit failure, to
+/// the matching `-failed` idle state; on timeout, to the matching
+/// `-failed` state AND a best-effort `cancel_proxy` is fired to stop
+/// the bridge from completing the operation in the background.
+async function toggleFromIdle(goingToConnect: boolean) {
+  setState(goingToConnect ? "connecting" : "disconnecting");
+
+  const togglePromise = invoke<ToggleOutcome>("toggle_proxy");
+  // Prevent unhandled-rejection warnings if the promise settles after
+  // we've already moved on due to timeout.
+  togglePromise.catch(() => {});
+
+  const raced = await Promise.race<
+    { kind: "ok"; outcome: ToggleOutcome } | { kind: "err"; error: unknown } | { kind: "timeout" }
+  >([
+    togglePromise
+      .then((outcome) => ({ kind: "ok" as const, outcome }))
+      .catch((error) => ({ kind: "err" as const, error })),
+    new Promise((resolve) => setTimeout(() => resolve({ kind: "timeout" as const }), TOGGLE_TIMEOUT_MS)),
+  ]);
+
+  if (raced.kind === "timeout") {
+    console.error(`toggle_proxy timed out after ${TOGGLE_TIMEOUT_MS}ms — firing cancel`);
+    // Best-effort cancel so the bridge doesn't finish the connect in
+    // the background behind our back. Ignore the result.
+    invoke("cancel_proxy").catch(() => {});
+    setState(goingToConnect ? "connection-failed" : "disconnection-failed");
+    return;
+  }
+
+  if (raced.kind === "ok") {
+    setState(stateForToggleOutcome(raced.outcome));
+    // Refresh IP on any successful transition.
+    updatePublicIp();
+    return;
+  }
+
+  // raced.kind === "err"
+  console.error("toggle_proxy failed:", raced.error);
+  setState(goingToConnect ? "connection-failed" : "disconnection-failed");
 }
 
 // IP display ==========================================================================================================
@@ -336,19 +416,32 @@ export function updateMetrics(metrics: Metrics) {
 }
 
 /**
- * Update the connection state from a proxy status poll.
- * Returns the `running` boolean so main.ts can track state changes.
+ * Update the connection state from a periodic proxy status poll.
+ *
+ * Only overwrites `currentState` when the current state is IDLE.
+ * Transition states (`connecting`/`cancelling`/`disconnecting`) are
+ * short-lived, carry their own owning IPC promise in `handlePowerClick`,
+ * and must not be clobbered by a poll landing mid-transition. A poll
+ * that arrives during a transition is a no-op for state purposes.
+ *
+ * Returns `{ state, previousState }` so `main.ts` can emit
+ * `mark_validated_by_proxy_start` on the specific `connecting → connected`
+ * transition (not on every poll that observes `running: true`).
  */
 export function updateProxyStatus(status: ProxyStatus) {
-  const wasConnected = connected;
-  connected = !!status.running;
-  updateConnectionUI();
-  return { connected, changed: wasConnected !== connected };
+  if (!IDLE_STATES.has(currentState)) {
+    return { state: currentState, previousState };
+  }
+  const polled = stateForPolledRunning(!!status.running);
+  if (polled !== currentState) {
+    setState(polled);
+  }
+  return { state: currentState, previousState };
 }
 
 /** Returns the current connection state. */
-export function isConnected() {
-  return connected;
+export function getConnectionState(): ConnectionState {
+  return currentState;
 }
 
 // Initialization ======================================================================================================

--- a/ui/style.css
+++ b/ui/style.css
@@ -231,6 +231,7 @@ order. (0,2,0) > (0,1,0). */
   justify-content: center;
   cursor: pointer;
   flex-shrink: 0;
+  position: relative;
   transition:
     background 0.2s,
     box-shadow 0.2s;
@@ -247,9 +248,60 @@ order. (0,2,0) > (0,1,0). */
   box-shadow: 0 0 12px var(--red-glow);
 }
 
+/* Transition state: neutral background, spinning arc instead of the
+  power icon. Click is still enabled (so "cancel connect" works) but
+  the button visually reads as busy/indeterminate. */
+.power-btn.transitioning {
+  background: var(--text-ghost);
+  box-shadow: 0 0 12px rgba(128, 128, 128, 0.25);
+}
+
+/* Failure flash — briefly draws attention to a just-failed button so
+  the state change is visually distinct from the idle red/green. The
+  persistent "Connection failed" / "Disconnect failed" text next to
+  the button is the actual persistent error signal. */
+.power-btn.failed-off {
+  animation: power-btn-failed-flash 0.8s ease-out;
+}
+
+.power-btn.failed-on {
+  animation: power-btn-failed-flash 0.8s ease-out;
+}
+
+@keyframes power-btn-failed-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.8);
+  }
+  100% {
+    box-shadow: 0 0 12px rgba(239, 68, 68, 0.35);
+  }
+}
+
 .power-btn svg {
   width: 18px;
   height: 18px;
+}
+
+/* Hide the power icon while transitioning; the rotating arc
+  (rendered via ::before) stands in for it. */
+.power-btn.transitioning svg {
+  display: none;
+}
+
+.power-btn.transitioning::before {
+  content: "";
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2.5px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #ffffff;
+  animation: power-btn-spin 1s linear infinite;
+}
+
+@keyframes power-btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .sb-status-block {
@@ -275,6 +327,10 @@ order. (0,2,0) > (0,1,0). */
 
 .sb-status strong.off {
   color: var(--red);
+}
+
+.sb-status strong.transitioning {
+  color: var(--text-secondary);
 }
 
 .sb-ip {


### PR DESCRIPTION
## Summary

Transforms the sidebar power button from a two-state boolean (connected/disconnected) into a seven-state machine that gives the user explicit feedback during the slow connect/disconnect transitions, plus the ability to cancel a hung connect.

**Frontend state machine** (`ui/connection-state.ts`):
- Idle: `disconnected`, `connected`, `connection-failed`, `disconnection-failed`
- Transition (spinner): `connecting`, `disconnecting`, `cancelling`
- 15 s client-side timeout on `toggle_proxy`; timeout fires a best-effort `cancel_proxy` and moves the UI to `connection-failed`
- Click during `connecting` fires `cancel_proxy` on a dedicated fresh bridge connection that bypasses the pooled `BridgeClient` mutex (so it can race an in-flight start)

**Backend cancellation** — Rust/Tokio idiomatic via `tokio_util::sync::CancellationToken` + `tokio::select!` + drop-safe RAII:
- New `BridgeRequest::Cancel` + `POST /v1/cancel` + shared `CANCELLED_MESSAGE` constant
- `ProxyManager::start_cancellable` wraps `start_inner` in `tokio::select!` with `biased;` cancel-first polling
- `start_inner` takes `&B + &Path` (not `&mut self`) and returns `StartedState` by value — commit to `self` happens in the outer function after `select!` resolves, so the post-commit race cannot corrupt state
- New `StateFileGuard` and `TaskHandleGuard<T>` drop-safe RAII guards (`crates/bridge/src/guards.rs`) clean up partial state if the future is dropped mid-flight
- `IpcState::start_cancel: Arc<std::sync::Mutex<StartCancelState>>` holds the in-flight token plus a "pre-armed" flag for the pre-registration race. Sync mutex is deliberate: access is microseconds, never across `.await`
- Concurrent `handle_start` rejected with 409 Conflict to preserve token-slot single-occupancy (plan review finding — otherwise a second Start would silently orphan the first from any future Cancel)

**Tauri command layer**:
- `ToggleOutcome { Running, Stopped, Cancelled }` replaces `Result<bool, String>` from `set_proxy_enabled`
- New `cancel_proxy` command uses `AppState::bridge_send_oneshot` — a fresh single-use `BridgeClient` connection that bypasses the pooled mutex held by `bridge_send`
- Tray `ID_CONNECT` handler handles the new `Cancelled` variant

**Non-goals (deliberately out of scope)**:
- Cancelling `Stop` / "Disconnecting..." — `stop()` is already fast
- Push-based status events from the bridge (polling stays)
- Toast/notification system
- `reload()` cancellation

## Test plan

- [x] `cargo test --workspace` — 159 bridge tests pass (up from 142), including 10 new cancellation tests
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `npm run check` (tsc) clean
- [x] `npm run build` (vite) clean
- [ ] Manual smoke test via `uv run scripts/dev.py`:
  - Known-good server → spinner → green Connected
  - Bad config → spinner → red "Connection failed"
  - Slow server, click to cancel → "Cancelling..." → "Disconnected"
  - Kill bridge mid-transition → after 15 s, "Connection failed"
  - Click disconnect → "Disconnecting..." → "Disconnected"
- [ ] CI passes on all platforms

## Commits (7 phased + 1 review fix)

1. `Add BridgeRequest::Cancel + /v1/cancel route`
2. `Add StateFileGuard + TaskHandleGuard drop-safe RAII guards`
3. `Refactor ProxyManager::start to drop-safe start_inner + StartedState`
4. `Add cancellable ProxyManager::start_cancellable with CancellationToken`
5. `Wire /v1/cancel IPC route with StartCancelState`
6. `Add cancel_proxy Tauri command + ToggleOutcome enum`
7. `Add ConnectionState machine + spinner + 15s cancel timeout`
8. `Address review: reject concurrent starts, fix polling staleness + cancel/running race`