### PR TITLE
filter: foundations (protocol types, pure engine, fake DNS, sniffer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,12 +2337,17 @@ dependencies = [
  "bytes",
  "default-net",
  "hex",
+ "hickory-proto",
  "hole-common",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "idna",
+ "ipnet",
  "libc",
+ "lru",
+ "regex",
  "serde",
  "serde_json",
  "shadowsocks",
@@ -2351,6 +2356,7 @@ dependencies = [
  "socket2",
  "tempfile",
  "thiserror 2.0.18",
+ "tls-parser",
  "tokio",
  "tokio-util",
  "tower",
@@ -3100,6 +3106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru_time_cache"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3234,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -3399,6 +3420,38 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff943d68b88d0b87a6e0d58615e8fa07f9fd5a1319fa0a72efc1f62275c79a7"
+dependencies = [
+ "nom",
+ "nom-derive-impl",
+ "rustversion",
+]
+
+[[package]]
+name = "nom-derive-impl"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b9a93a84b0d3ec3e70e02d332dc33ac6dfac9cde63e17fcb77172dededa62"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "notify"
@@ -4613,6 +4666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -6119,6 +6181,20 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-parser"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c36249c6082584b1f224e70f6bdadf5102197be6cfa92b353efe605d9ac741"
+dependencies = [
+ "nom",
+ "nom-derive",
+ "num_enum",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "tokio"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -32,6 +32,17 @@ bytes = "1"
 tower = { version = "0.5", features = ["util"] }
 ureq = { version = "3", features = ["json"] }
 tempfile = "3"
+# Filter engine dependencies (Plan 1 of 4 — see issue #162).
+# All are already pulled in transitively via shadowsocks-service; we promote
+# them to direct deps so the filter module can `use` them. Pinned to the same
+# minor versions that shadowsocks-service 1.24 uses to avoid duplication.
+hickory-proto = "0.25"
+idna = "1"
+ipnet = "2"
+regex = "1"
+# New crates not previously in the tree.
+lru = "0.16"
+tls-parser = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -6,10 +6,12 @@
 //! that drives them at runtime is added in Plan 2 (TCP) and Plan 3 (UDP).
 
 pub mod engine;
+pub mod fake_dns;
 pub mod matcher;
 pub mod rules;
 
 pub use engine::{decide, ConnInfo, L4Proto};
+pub use fake_dns::{AllocateError, FakeDns, DEFAULT_POOL_V4, DEFAULT_POOL_V6, FAKE_DNS_TTL};
 pub use matcher::Matcher;
 pub use rules::{CompiledRule, RuleSet};
 

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -9,11 +9,13 @@ pub mod engine;
 pub mod fake_dns;
 pub mod matcher;
 pub mod rules;
+pub mod sniffer;
 
 pub use engine::{decide, ConnInfo, L4Proto};
 pub use fake_dns::{AllocateError, FakeDns, DEFAULT_POOL_V4, DEFAULT_POOL_V6, FAKE_DNS_TTL};
 pub use matcher::Matcher;
 pub use rules::{CompiledRule, RuleSet};
+pub use sniffer::peek;
 
 #[cfg(test)]
 #[path = "filter_tests.rs"]

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -1,0 +1,18 @@
+//! Filter engine — compiles user filter rules and decides per-connection
+//! actions. The engine is pure (no I/O, no async), iterating rules in
+//! reverse order with last-match-wins (gitignore) semantics.
+//!
+//! This crate exposes the data types and decision function. The dispatcher
+//! that drives them at runtime is added in Plan 2 (TCP) and Plan 3 (UDP).
+
+pub mod engine;
+pub mod matcher;
+pub mod rules;
+
+pub use engine::{decide, ConnInfo, L4Proto};
+pub use matcher::Matcher;
+pub use rules::{CompiledRule, RuleSet};
+
+#[cfg(test)]
+#[path = "filter_tests.rs"]
+mod filter_tests;

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -1,0 +1,49 @@
+//! Filter decision loop. Reverse-iterates a `RuleSet` and returns the
+//! action of the first matching rule (gitignore semantics: the rule that
+//! appears later in the user's list wins). If no rule matches, the
+//! terminal fallback is `Proxy` — this matches the bridge's
+//! "everything is proxied by default" contract.
+
+use std::net::IpAddr;
+
+use hole_common::config::FilterAction;
+
+use super::rules::RuleSet;
+
+/// Layer-4 protocol of a connection. Filter rules apply to both
+/// uniformly today, but downstream code (Plans 2/3) may branch on this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum L4Proto {
+    Tcp,
+    Udp,
+}
+
+/// Snapshot of the connection-level info the filter engine sees. The
+/// dispatcher fills this in immediately before calling `decide`.
+#[derive(Debug, Clone)]
+pub struct ConnInfo {
+    pub dst_ip: IpAddr,
+    pub dst_port: u16,
+    /// Set when the dispatcher recovered a domain via fake DNS reverse
+    /// lookup or the TLS/HTTP sniffer. `None` for raw IP destinations.
+    pub domain: Option<String>,
+    pub proto: L4Proto,
+}
+
+/// Run the filter engine for one connection. O(n) in the rule count;
+/// pure function.
+pub fn decide(rules: &RuleSet, conn: &ConnInfo) -> FilterAction {
+    for rule in rules.rules.iter().rev() {
+        if rule.matcher.matches(conn) {
+            return rule.action;
+        }
+    }
+    // Terminal fallback: never reached when the UI's locked default
+    // rules are present, but preserves "proxy everything" if a
+    // hand-edited config strips them out.
+    FilterAction::Proxy
+}
+
+#[cfg(test)]
+#[path = "engine_tests.rs"]
+mod engine_tests;

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -26,6 +26,13 @@ pub struct ConnInfo {
     pub dst_port: u16,
     /// Set when the dispatcher recovered a domain via fake DNS reverse
     /// lookup or the TLS/HTTP sniffer. `None` for raw IP destinations.
+    ///
+    /// The matcher canonicalizes this value internally on every match
+    /// (case-fold + trailing dot strip + IDNA), so callers may pass
+    /// the raw string from the sniffer or fake DNS without
+    /// pre-normalizing. The dispatcher in Plans 2/3 may still want to
+    /// canonicalize once via [`super::matcher::canonicalize_for_match`]
+    /// to amortize the cost across rules.
     pub domain: Option<String>,
     pub proto: L4Proto,
 }

--- a/crates/bridge/src/filter/engine_tests.rs
+++ b/crates/bridge/src/filter/engine_tests.rs
@@ -1,0 +1,222 @@
+use std::net::IpAddr;
+
+use hole_common::config::{FilterAction, FilterRule, MatchType};
+
+use super::*;
+use crate::filter::rules::RuleSet;
+
+// Helpers =============================================================================================================
+
+fn rule(addr: &str, kind: MatchType, action: FilterAction) -> FilterRule {
+    FilterRule {
+        address: addr.to_string(),
+        matching: kind,
+        action,
+    }
+}
+
+fn conn(dst: &str, port: u16, domain: Option<&str>) -> ConnInfo {
+    ConnInfo {
+        dst_ip: dst.parse::<IpAddr>().unwrap(),
+        dst_port: port,
+        domain: domain.map(|s| s.to_string()),
+        proto: L4Proto::Tcp,
+    }
+}
+
+// Default fallback ====================================================================================================
+
+#[skuld::test]
+fn empty_ruleset_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[]);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+}
+
+#[skuld::test]
+fn ruleset_with_only_invalid_rules_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[rule("nonsense", MatchType::Subnet, FilterAction::Block)]);
+    assert!(rs.rules.is_empty());
+    assert_eq!(rs.dropped.len(), 1);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+}
+
+// Single-rule basics ==================================================================================================
+
+#[skuld::test]
+fn single_proxy_rule() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Proxy)]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Proxy
+    );
+}
+
+#[skuld::test]
+fn single_block_rule() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn single_bypass_rule() {
+    let rs = RuleSet::from_user_rules(&[rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass)]);
+    assert_eq!(decide(&rs, &conn("10.1.2.3", 443, None)), FilterAction::Bypass);
+}
+
+#[skuld::test]
+fn no_matching_rule_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("other.com"))),
+        FilterAction::Proxy
+    );
+}
+
+// Gitignore semantics: worked example from the design spec ============================================================
+
+#[skuld::test]
+fn worked_example_a_example_com_proxied() {
+    // example.com (with subdomains) → block
+    // a.example.com (exactly) → proxy
+    // a.example.com matches rule index 1 (later) → proxy
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::WithSubdomains, FilterAction::Block),
+        rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("a.example.com"))),
+        FilterAction::Proxy
+    );
+}
+
+#[skuld::test]
+fn worked_example_b_example_com_blocked() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::WithSubdomains, FilterAction::Block),
+        rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("b.example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn worked_example_apex_blocked() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::WithSubdomains, FilterAction::Block),
+        rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+// Reverse-iteration ordering ==========================================================================================
+
+#[skuld::test]
+fn later_rule_overrides_earlier_for_same_address() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Bypass),
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn earlier_rule_wins_when_no_later_rule_matches() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+        rule("other.com", MatchType::Exactly, FilterAction::Bypass),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+// Mixed domain + IP rules =============================================================================================
+
+#[skuld::test]
+fn mixed_rules_ip_subnet_later_wins() {
+    // Connection has both an IP and a domain. The Subnet rule (index 1)
+    // appears later, so it wins over the domain rule.
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+        rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Bypass
+    );
+}
+
+#[skuld::test]
+fn mixed_rules_domain_later_wins() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn ip_only_connection_with_domain_rule_in_set_falls_through() {
+    // No domain on the connection — domain rule cannot match.
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+        rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
+    ]);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Bypass);
+}
+
+#[skuld::test]
+fn ip_only_connection_no_ip_rule_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert_eq!(decide(&rs, &conn("9.9.9.9", 443, None)), FilterAction::Proxy);
+}
+
+// Three locked default rules (matches the UI's planned behavior) ======================================================
+
+#[skuld::test]
+fn three_locked_default_rules_pass_everything_through() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("*", MatchType::Wildcard, FilterAction::Proxy),
+        rule("0.0.0.0/0", MatchType::Subnet, FilterAction::Proxy),
+        rule("::/0", MatchType::Subnet, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Proxy
+    );
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("::1", 443, None)), FilterAction::Proxy);
+}
+
+#[skuld::test]
+fn block_rule_overrides_locked_defaults() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("*", MatchType::Wildcard, FilterAction::Proxy),
+        rule("0.0.0.0/0", MatchType::Subnet, FilterAction::Proxy),
+        rule("::/0", MatchType::Subnet, FilterAction::Proxy),
+        rule("evil.com", MatchType::WithSubdomains, FilterAction::Block),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("api.evil.com"))),
+        FilterAction::Block
+    );
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("good.com"))),
+        FilterAction::Proxy
+    );
+}

--- a/crates/bridge/src/filter/fake_dns.rs
+++ b/crates/bridge/src/filter/fake_dns.rs
@@ -1,0 +1,438 @@
+//! Fake DNS — handles A/AAAA queries by returning synthetic IPs from a
+//! pool, then lets the dispatcher reverse-map those fake IPs back to
+//! the original domain at connection time.
+//!
+//! This is a *function*, not a server: there is no socket bound
+//! anywhere. The dispatcher's port-53 fast path (added in Plan 2)
+//! invokes [`FakeDns::handle_udp`] directly with bytes pulled from
+//! smoltcp; the response is written back through smoltcp.
+//!
+//! Allocation is sequential with collision skip. Eviction is LRU on
+//! the unpinned set; pinned entries (refcounted by active flows) are
+//! never evicted. Pool exhaustion (every entry pinned) is reported as
+//! `AllocateError::Exhausted` and the DNS query is answered with
+//! SERVFAIL — degenerate case requiring tens of thousands of
+//! concurrent distinct domain connections.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::{A, AAAA};
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use ipnet::{Ipv4Net, Ipv6Net};
+use lru::LruCache;
+
+use super::matcher::canonicalize_ip;
+
+// Default pools =======================================================================================================
+
+/// IPv4 pool (RFC 2544 benchmark testing range). De-facto standard
+/// shared with Clash, V2Ray, sing-box. Unroutable on the public
+/// internet — leaked fake IPs cannot collide with real destinations.
+pub const DEFAULT_POOL_V4: &str = "198.18.0.0/15";
+
+/// IPv6 pool (ULA prefix per RFC 4193). Plenty of room and unroutable.
+pub const DEFAULT_POOL_V6: &str = "fd00:0:0:ff00::/64";
+
+/// TTL written into fake DNS responses. Short, so apps re-query
+/// frequently and the bimap stays warm.
+pub const FAKE_DNS_TTL: u32 = 60;
+
+// Errors ==============================================================================================================
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocateError {
+    /// Every IP in the pool is pinned by an active flow; no more
+    /// allocations possible until something un-pins.
+    Exhausted,
+}
+
+impl std::fmt::Display for AllocateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exhausted => f.write_str("fake DNS pool exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for AllocateError {}
+
+// State ===============================================================================================================
+
+/// Internal mutable state, guarded by a single mutex on `FakeDns`.
+struct State {
+    /// Forward maps: domain → fake IP, separate per family. Domains
+    /// are interned as `Arc<str>` so the bimap shares storage.
+    domain_to_v4: HashMap<Arc<str>, Ipv4Addr>,
+    domain_to_v6: HashMap<Arc<str>, Ipv6Addr>,
+    /// LRU buckets for unpinned entries (eligible for eviction). Keys
+    /// are the fake IPs; values are the interned domain.
+    unpinned_v4: LruCache<Ipv4Addr, Arc<str>>,
+    unpinned_v6: LruCache<Ipv6Addr, Arc<str>>,
+    /// Pinned entries — never evicted. Refcount tracks active flows
+    /// using each fake IP. When the refcount drops to 0, the entry
+    /// moves back into the corresponding LRU bucket.
+    pinned_v4: HashMap<Ipv4Addr, (Arc<str>, u32)>,
+    pinned_v6: HashMap<Ipv6Addr, (Arc<str>, u32)>,
+    /// Sequential allocation cursors (offset within the pool). On
+    /// collision, the allocator advances and tries again.
+    next_v4_offset: u64,
+    next_v6_offset: u128,
+}
+
+// Public API ==========================================================================================================
+
+/// Fake DNS function. Construct once at proxy start with a fixed pair
+/// of pools, then call [`Self::handle_udp`] for each port-53 datagram
+/// received from smoltcp.
+pub struct FakeDns {
+    pool_v4: Ipv4Net,
+    pool_v6: Ipv6Net,
+    pool_v4_size: u64,
+    state: Mutex<State>,
+}
+
+impl FakeDns {
+    /// Construct a `FakeDns` with the default pools (`198.18.0.0/15`
+    /// for v4, `fd00:0:0:ff00::/64` for v6).
+    pub fn with_defaults() -> Self {
+        let v4 = DEFAULT_POOL_V4
+            .parse::<Ipv4Net>()
+            .expect("default v4 pool literal is valid");
+        let v6 = DEFAULT_POOL_V6
+            .parse::<Ipv6Net>()
+            .expect("default v6 pool literal is valid");
+        Self::new(v4, v6)
+    }
+
+    /// Construct a `FakeDns` with custom pools.
+    pub fn new(pool_v4: Ipv4Net, pool_v6: Ipv6Net) -> Self {
+        // Pool size for v4 is at most 2^32 (less than u64::MAX), so the
+        // u64 cast is lossless. For v6 we cap the eviction-bucket
+        // capacity at a reasonable upper bound — eviction logic only
+        // matters when the working set actually approaches the pool
+        // size, which never happens for /64.
+        let pool_v4_size = network_size_v4(&pool_v4);
+        let v4_capacity = clamp_capacity(pool_v4_size);
+        let v6_capacity = NonZeroUsize::new(1 << 16).expect("constant is non-zero");
+
+        Self {
+            pool_v4,
+            pool_v6,
+            pool_v4_size,
+            state: Mutex::new(State {
+                domain_to_v4: HashMap::new(),
+                domain_to_v6: HashMap::new(),
+                unpinned_v4: LruCache::new(v4_capacity),
+                unpinned_v6: LruCache::new(v6_capacity),
+                pinned_v4: HashMap::new(),
+                pinned_v6: HashMap::new(),
+                next_v4_offset: 0,
+                next_v6_offset: 0,
+            }),
+        }
+    }
+
+    /// Look up the domain that was previously mapped to a fake IP.
+    /// Returns `None` if the IP is not in the bimap. IPv4-mapped IPv6
+    /// addresses (`::ffff:1.2.3.4`) are unwrapped before lookup so the
+    /// dispatcher's connection-level address (which may arrive in
+    /// either form) finds the same entry.
+    pub fn reverse_lookup(&self, ip: IpAddr) -> Option<Arc<str>> {
+        let ip = canonicalize_ip(ip);
+        let state = self.state.lock().unwrap();
+        match ip {
+            IpAddr::V4(v4) => {
+                if let Some((domain, _)) = state.pinned_v4.get(&v4) {
+                    return Some(Arc::clone(domain));
+                }
+                state.unpinned_v4.peek(&v4).map(Arc::clone)
+            }
+            IpAddr::V6(v6) => {
+                if let Some((domain, _)) = state.pinned_v6.get(&v6) {
+                    return Some(Arc::clone(domain));
+                }
+                state.unpinned_v6.peek(&v6).map(Arc::clone)
+            }
+        }
+    }
+
+    /// Look up the fake IP currently allocated to a domain. Returns
+    /// `None` if no allocation exists in the requested family.
+    pub fn forward_lookup_v4(&self, domain: &str) -> Option<Ipv4Addr> {
+        let state = self.state.lock().unwrap();
+        state.domain_to_v4.get(domain).copied()
+    }
+
+    /// Look up the fake IPv6 currently allocated to a domain.
+    pub fn forward_lookup_v6(&self, domain: &str) -> Option<Ipv6Addr> {
+        let state = self.state.lock().unwrap();
+        state.domain_to_v6.get(domain).copied()
+    }
+
+    /// Pin an entry by its fake IP, preventing LRU eviction. Pinning
+    /// is refcounted: each call must be paired with a `unpin` call.
+    /// Pinning a non-existent IP is a no-op (the dispatcher should
+    /// never do this, but we don't panic to keep the API permissive).
+    pub fn pin(&self, ip: IpAddr) {
+        let ip = canonicalize_ip(ip);
+        let mut state = self.state.lock().unwrap();
+        match ip {
+            IpAddr::V4(v4) => {
+                if let Some(domain) = state.unpinned_v4.pop(&v4) {
+                    state.pinned_v4.insert(v4, (domain, 1));
+                } else if let Some((_, count)) = state.pinned_v4.get_mut(&v4) {
+                    *count += 1;
+                }
+            }
+            IpAddr::V6(v6) => {
+                if let Some(domain) = state.unpinned_v6.pop(&v6) {
+                    state.pinned_v6.insert(v6, (domain, 1));
+                } else if let Some((_, count)) = state.pinned_v6.get_mut(&v6) {
+                    *count += 1;
+                }
+            }
+        }
+    }
+
+    /// Decrement the refcount for an entry; if it reaches zero, move
+    /// it back into the LRU set so it becomes evictable. Unpinning a
+    /// non-pinned IP is a no-op.
+    pub fn unpin(&self, ip: IpAddr) {
+        let ip = canonicalize_ip(ip);
+        let mut state = self.state.lock().unwrap();
+        match ip {
+            IpAddr::V4(v4) => {
+                if let Some((_, count)) = state.pinned_v4.get_mut(&v4) {
+                    *count -= 1;
+                    if *count == 0 {
+                        let (domain, _) = state.pinned_v4.remove(&v4).unwrap();
+                        state.unpinned_v4.put(v4, domain);
+                    }
+                }
+            }
+            IpAddr::V6(v6) => {
+                if let Some((_, count)) = state.pinned_v6.get_mut(&v6) {
+                    *count -= 1;
+                    if *count == 0 {
+                        let (domain, _) = state.pinned_v6.remove(&v6).unwrap();
+                        state.unpinned_v6.put(v6, domain);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handle one DNS query message and produce a response.
+    ///
+    /// - Parses the request via `hickory-proto`.
+    /// - On parse failure, returns a `FORMERR` response if possible
+    ///   (using the original query ID), else an empty Vec (the caller
+    ///   should drop the datagram).
+    /// - For A queries: allocate (or reuse) a fake IPv4 from the pool
+    ///   and answer with the fake IP. TTL is `FAKE_DNS_TTL`.
+    /// - For AAAA queries: same with IPv6.
+    /// - For other query types: NOERROR with empty answer section.
+    /// - On allocation exhaustion: SERVFAIL.
+    pub fn handle_udp(&self, payload: &[u8]) -> Vec<u8> {
+        let request = match Message::from_vec(payload) {
+            Ok(m) => m,
+            Err(_) => {
+                // Best-effort: try to extract the ID from the first
+                // two bytes of the payload to make the FORMERR
+                // matchable. If the payload is shorter than 2 bytes,
+                // give up entirely.
+                if payload.len() < 2 {
+                    return Vec::new();
+                }
+                let id = u16::from_be_bytes([payload[0], payload[1]]);
+                let err = Message::error_msg(id, OpCode::Query, ResponseCode::FormErr);
+                return err.to_vec().unwrap_or_default();
+            }
+        };
+
+        self.build_response(&request).to_vec().unwrap_or_default()
+    }
+
+    /// Build a response `Message` for a parsed query. Pure-ish — only
+    /// touches the bimap state, no I/O.
+    fn build_response(&self, request: &Message) -> Message {
+        let mut response = Message::new();
+        response
+            .set_id(request.id())
+            .set_message_type(MessageType::Response)
+            .set_op_code(OpCode::Query)
+            .set_recursion_desired(request.recursion_desired())
+            .set_recursion_available(true)
+            .set_authoritative(true);
+
+        for q in request.queries() {
+            response.add_query(q.clone());
+        }
+
+        let Some(query) = request.queries().first() else {
+            response.set_response_code(ResponseCode::FormErr);
+            return response;
+        };
+
+        match query.query_type() {
+            RecordType::A => match self.allocate_v4(query.name()) {
+                Ok(ip) => {
+                    let record = Record::from_rdata(query.name().clone(), FAKE_DNS_TTL, RData::A(A(ip)));
+                    response.add_answer(record);
+                    response.set_response_code(ResponseCode::NoError);
+                }
+                Err(AllocateError::Exhausted) => {
+                    response.set_response_code(ResponseCode::ServFail);
+                }
+            },
+            RecordType::AAAA => match self.allocate_v6(query.name()) {
+                Ok(ip) => {
+                    let record = Record::from_rdata(query.name().clone(), FAKE_DNS_TTL, RData::AAAA(AAAA(ip)));
+                    response.add_answer(record);
+                    response.set_response_code(ResponseCode::NoError);
+                }
+                Err(AllocateError::Exhausted) => {
+                    response.set_response_code(ResponseCode::ServFail);
+                }
+            },
+            // For non-A/AAAA queries we return NOERROR with an empty
+            // answer section. NXDOMAIN is intentionally avoided
+            // because it's negatively cached and can break apps that
+            // legitimately query MX/TXT/SRV.
+            _ => {
+                response.set_response_code(ResponseCode::NoError);
+            }
+        }
+
+        response
+    }
+
+    /// Allocate a fake IPv4 for `name`. Reuses any existing
+    /// allocation. Pure of I/O.
+    fn allocate_v4(&self, name: &Name) -> Result<Ipv4Addr, AllocateError> {
+        let domain = name_to_domain_key(name);
+        let mut state = self.state.lock().unwrap();
+
+        if let Some(&existing) = state.domain_to_v4.get(&domain) {
+            // Touch LRU position if unpinned.
+            let _ = state.unpinned_v4.get(&existing);
+            return Ok(existing);
+        }
+
+        // Sequential allocation with collision skip. Bound the loop
+        // by the pool size so we never spin forever.
+        for _ in 0..self.pool_v4_size {
+            let offset = state.next_v4_offset;
+            state.next_v4_offset = (state.next_v4_offset + 1) % self.pool_v4_size;
+            let candidate = ipv4_at_offset(&self.pool_v4, offset);
+            if state.pinned_v4.contains_key(&candidate) || state.unpinned_v4.contains(&candidate) {
+                continue;
+            }
+            state.unpinned_v4.put(candidate, Arc::clone(&domain));
+            state.domain_to_v4.insert(domain, candidate);
+            return Ok(candidate);
+        }
+
+        // Pool fully populated. Try LRU eviction (unpinned only).
+        if let Some((victim_ip, victim_domain)) = state.unpinned_v4.pop_lru() {
+            state.domain_to_v4.remove(&victim_domain);
+            state.unpinned_v4.put(victim_ip, Arc::clone(&domain));
+            state.domain_to_v4.insert(domain, victim_ip);
+            return Ok(victim_ip);
+        }
+
+        Err(AllocateError::Exhausted)
+    }
+
+    /// Allocate a fake IPv6 for `name`.
+    fn allocate_v6(&self, name: &Name) -> Result<Ipv6Addr, AllocateError> {
+        let domain = name_to_domain_key(name);
+        let mut state = self.state.lock().unwrap();
+
+        if let Some(&existing) = state.domain_to_v6.get(&domain) {
+            let _ = state.unpinned_v6.get(&existing);
+            return Ok(existing);
+        }
+
+        // For v6 the pool is effectively infinite (/64 = 2^64), so the
+        // sequential cursor never wraps in practice; we still cap the
+        // loop at the cache capacity to keep the worst case bounded.
+        let max_attempts = state.unpinned_v6.cap().get() as u128 + state.pinned_v6.len() as u128 + 1;
+        for _ in 0..max_attempts {
+            let offset = state.next_v6_offset;
+            state.next_v6_offset = state.next_v6_offset.wrapping_add(1);
+            let candidate = ipv6_at_offset(&self.pool_v6, offset);
+            if state.pinned_v6.contains_key(&candidate) || state.unpinned_v6.contains(&candidate) {
+                continue;
+            }
+            state.unpinned_v6.put(candidate, Arc::clone(&domain));
+            state.domain_to_v6.insert(domain, candidate);
+            return Ok(candidate);
+        }
+
+        if let Some((victim_ip, victim_domain)) = state.unpinned_v6.pop_lru() {
+            state.domain_to_v6.remove(&victim_domain);
+            state.unpinned_v6.put(victim_ip, Arc::clone(&domain));
+            state.domain_to_v6.insert(domain, victim_ip);
+            return Ok(victim_ip);
+        }
+
+        Err(AllocateError::Exhausted)
+    }
+}
+
+// Helpers =============================================================================================================
+
+/// Convert a hickory `Name` (which carries trailing-dot semantics)
+/// into a lowercased `Arc<str>` suitable for use as a bimap key.
+fn name_to_domain_key(name: &Name) -> Arc<str> {
+    let mut s = name.to_ascii();
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s.make_ascii_lowercase();
+    Arc::from(s)
+}
+
+/// Compute the number of host addresses in an IPv4 network. For `/0`
+/// this is 2^32; we cap to `u64::MAX` to avoid overflow on systems
+/// that store the size as `u64`.
+fn network_size_v4(net: &Ipv4Net) -> u64 {
+    if net.prefix_len() == 0 {
+        // 2^32 (just over u32::MAX)
+        1u64 << 32
+    } else {
+        1u64 << (32 - net.prefix_len())
+    }
+}
+
+/// Compute the IPv4 address at the given offset within a network.
+/// Wraps via modulo on the caller's side.
+fn ipv4_at_offset(net: &Ipv4Net, offset: u64) -> Ipv4Addr {
+    let base = u32::from(net.network());
+    let max_offset = network_size_v4(net);
+    let normalized = (offset % max_offset) as u32;
+    Ipv4Addr::from(base.wrapping_add(normalized))
+}
+
+/// Compute the IPv6 address at the given offset within a network.
+fn ipv6_at_offset(net: &Ipv6Net, offset: u128) -> Ipv6Addr {
+    let base = u128::from(net.network());
+    Ipv6Addr::from(base.wrapping_add(offset))
+}
+
+/// Clamp a pool size to a sensible LRU capacity. The lru crate
+/// requires a `NonZeroUsize`, and we don't want to allocate a
+/// data structure with billions of slots even if the pool is huge.
+fn clamp_capacity(size: u64) -> NonZeroUsize {
+    let capped = std::cmp::min(size, 1u64 << 20) as usize;
+    NonZeroUsize::new(capped.max(1)).expect("clamped to >= 1")
+}
+
+#[cfg(test)]
+#[path = "fake_dns_tests.rs"]
+mod fake_dns_tests;

--- a/crates/bridge/src/filter/fake_dns.rs
+++ b/crates/bridge/src/filter/fake_dns.rs
@@ -41,6 +41,12 @@ pub const DEFAULT_POOL_V6: &str = "fd00:0:0:ff00::/64";
 /// frequently and the bimap stays warm.
 pub const FAKE_DNS_TTL: u32 = 60;
 
+/// Maximum number of allocation probes before giving up (per query)
+/// regardless of the actual pool size. Bounds the worst-case latency
+/// of a single allocation under a pathological pool configuration
+/// (e.g. a `/0` pool with `2^32` candidates).
+const MAX_ALLOCATION_PROBES: u64 = 1024;
+
 // Errors ==============================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -323,9 +329,11 @@ impl FakeDns {
             return Ok(existing);
         }
 
-        // Sequential allocation with collision skip. Bound the loop
-        // by the pool size so we never spin forever.
-        for _ in 0..self.pool_v4_size {
+        // Sequential allocation with collision skip. Bounded by the
+        // smaller of the pool size and MAX_ALLOCATION_PROBES so we
+        // never spin millions of iterations on a `/0` user pool.
+        let probe_limit = std::cmp::min(self.pool_v4_size, MAX_ALLOCATION_PROBES);
+        for _ in 0..probe_limit {
             let offset = state.next_v4_offset;
             state.next_v4_offset = (state.next_v4_offset + 1) % self.pool_v4_size;
             let candidate = ipv4_at_offset(&self.pool_v4, offset);
@@ -411,12 +419,16 @@ fn network_size_v4(net: &Ipv4Net) -> u64 {
 }
 
 /// Compute the IPv4 address at the given offset within a network.
-/// Wraps via modulo on the caller's side.
+/// The offset is taken modulo the network size, so the returned
+/// address is always inside `net`. Pool sizes near `2^32` (e.g.
+/// `/0`) wrap correctly without overflow because the addition is
+/// done in `u64`.
 fn ipv4_at_offset(net: &Ipv4Net, offset: u64) -> Ipv4Addr {
-    let base = u32::from(net.network());
+    let base = u64::from(u32::from(net.network()));
     let max_offset = network_size_v4(net);
-    let normalized = (offset % max_offset) as u32;
-    Ipv4Addr::from(base.wrapping_add(normalized))
+    let normalized = offset % max_offset;
+    let result = (base + normalized) as u32;
+    Ipv4Addr::from(result)
 }
 
 /// Compute the IPv6 address at the given offset within a network.

--- a/crates/bridge/src/filter/fake_dns_tests.rs
+++ b/crates/bridge/src/filter/fake_dns_tests.rs
@@ -1,0 +1,391 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::{A, AAAA};
+use hickory_proto::rr::{Name, RData, RecordType};
+use ipnet::{Ipv4Net, Ipv6Net};
+
+use super::*;
+
+// Helpers =============================================================================================================
+
+fn build_query(domain: &str, qtype: RecordType) -> Vec<u8> {
+    let name = Name::from_str(domain).unwrap();
+    let mut request = Message::new();
+    request.set_id(0x1234);
+    request.set_message_type(MessageType::Query);
+    request.set_op_code(OpCode::Query);
+    request.set_recursion_desired(true);
+    request.add_query(hickory_proto::op::Query::query(name, qtype));
+    request.to_vec().unwrap()
+}
+
+fn parse_response(bytes: &[u8]) -> Message {
+    Message::from_vec(bytes).unwrap()
+}
+
+fn answer_ipv4(msg: &Message) -> Option<Ipv4Addr> {
+    msg.answers().iter().find_map(|r| {
+        if let RData::A(A(ip)) = r.data() {
+            Some(*ip)
+        } else {
+            None
+        }
+    })
+}
+
+fn answer_ipv6(msg: &Message) -> Option<Ipv6Addr> {
+    msg.answers().iter().find_map(|r| {
+        if let RData::AAAA(AAAA(ip)) = r.data() {
+            Some(*ip)
+        } else {
+            None
+        }
+    })
+}
+
+fn small_pools() -> (Ipv4Net, Ipv6Net) {
+    // 198.18.0.0/30 — 4 addresses, makes pool exhaustion testable.
+    let v4 = Ipv4Net::new(Ipv4Addr::new(198, 18, 0, 0), 30).unwrap();
+    let v6 = Ipv6Net::new(Ipv6Addr::new(0xfd00, 0, 0, 0xff00, 0, 0, 0, 0), 126).unwrap();
+    (v4, v6)
+}
+
+// Construction ========================================================================================================
+
+#[skuld::test]
+fn with_defaults_succeeds() {
+    let _ = FakeDns::with_defaults();
+}
+
+#[skuld::test]
+fn default_pool_constants_parse() {
+    let v4 = DEFAULT_POOL_V4.parse::<Ipv4Net>().unwrap();
+    assert_eq!(v4.prefix_len(), 15);
+    let v6 = DEFAULT_POOL_V6.parse::<Ipv6Net>().unwrap();
+    assert_eq!(v6.prefix_len(), 64);
+}
+
+// A queries ===========================================================================================================
+
+#[skuld::test]
+fn a_query_returns_fake_ip_in_pool() {
+    let dns = FakeDns::with_defaults();
+    let request = build_query("example.com.", RecordType::A);
+    let response = parse_response(&dns.handle_udp(&request));
+
+    assert_eq!(response.message_type(), MessageType::Response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.id(), 0x1234);
+
+    let pool: Ipv4Net = DEFAULT_POOL_V4.parse().unwrap();
+    let ip = answer_ipv4(&response).expect("expected an A record");
+    assert!(pool.contains(&ip), "{ip} not in pool {pool}");
+}
+
+#[skuld::test]
+fn a_query_for_same_domain_returns_same_ip() {
+    let dns = FakeDns::with_defaults();
+    let r1 = parse_response(&dns.handle_udp(&build_query("a.example.com.", RecordType::A)));
+    let r2 = parse_response(&dns.handle_udp(&build_query("a.example.com.", RecordType::A)));
+    assert_eq!(answer_ipv4(&r1), answer_ipv4(&r2));
+}
+
+#[skuld::test]
+fn a_query_for_different_domains_returns_different_ips() {
+    let dns = FakeDns::with_defaults();
+    let r1 = parse_response(&dns.handle_udp(&build_query("a.com.", RecordType::A)));
+    let r2 = parse_response(&dns.handle_udp(&build_query("b.com.", RecordType::A)));
+    assert_ne!(answer_ipv4(&r1), answer_ipv4(&r2));
+}
+
+#[skuld::test]
+fn a_query_response_ttl_is_fake_dns_ttl() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::A)));
+    let ttl = response.answers()[0].ttl();
+    assert_eq!(ttl, FAKE_DNS_TTL);
+}
+
+#[skuld::test]
+fn a_query_canonicalizes_domain_case() {
+    // Querying for `Example.COM.` should produce the same fake IP as
+    // `example.com.` because the bimap key is lowercased.
+    let dns = FakeDns::with_defaults();
+    let r1 = parse_response(&dns.handle_udp(&build_query("Example.COM.", RecordType::A)));
+    let r2 = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::A)));
+    assert_eq!(answer_ipv4(&r1), answer_ipv4(&r2));
+}
+
+// AAAA queries ========================================================================================================
+
+#[skuld::test]
+fn aaaa_query_returns_fake_ipv6_in_pool() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::AAAA)));
+    let pool: Ipv6Net = DEFAULT_POOL_V6.parse().unwrap();
+    let ip = answer_ipv6(&response).expect("expected an AAAA record");
+    assert!(pool.contains(&ip), "{ip} not in pool {pool}");
+}
+
+#[skuld::test]
+fn a_and_aaaa_for_same_domain_yield_separate_ips() {
+    // Same domain queried for both families gets a fake v4 and a fake
+    // v6, both pinned to that domain in the bimap.
+    let dns = FakeDns::with_defaults();
+    let r4 = parse_response(&dns.handle_udp(&build_query("dual.example.", RecordType::A)));
+    let r6 = parse_response(&dns.handle_udp(&build_query("dual.example.", RecordType::AAAA)));
+    let v4 = answer_ipv4(&r4).unwrap();
+    let v6 = answer_ipv6(&r6).unwrap();
+
+    assert_eq!(dns.forward_lookup_v4("dual.example"), Some(v4));
+    assert_eq!(dns.forward_lookup_v6("dual.example"), Some(v6));
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(v4)).as_deref(), Some("dual.example"));
+    assert_eq!(dns.reverse_lookup(IpAddr::V6(v6)).as_deref(), Some("dual.example"));
+}
+
+// Other query types ===================================================================================================
+
+#[skuld::test]
+fn mx_query_returns_noerror_empty() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::MX)));
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers().len(), 0);
+}
+
+#[skuld::test]
+fn txt_query_returns_noerror_empty() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::TXT)));
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers().len(), 0);
+}
+
+#[skuld::test]
+fn srv_query_returns_noerror_empty() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("_xmpp._tcp.example.com.", RecordType::SRV)));
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers().len(), 0);
+}
+
+// Reverse lookup ======================================================================================================
+
+#[skuld::test]
+fn reverse_lookup_returns_domain() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("foo.test.", RecordType::A)));
+    let ip = answer_ipv4(&response).unwrap();
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(ip)).as_deref(), Some("foo.test"));
+}
+
+#[skuld::test]
+fn reverse_lookup_unknown_ip_returns_none() {
+    let dns = FakeDns::with_defaults();
+    assert!(dns.reverse_lookup(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))).is_none());
+}
+
+#[skuld::test]
+fn reverse_lookup_canonicalizes_v4_mapped_v6() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("mapped.test.", RecordType::A)));
+    let ip = answer_ipv4(&response).unwrap();
+    let v6_form = IpAddr::V6(Ipv6Addr::new(
+        0,
+        0,
+        0,
+        0,
+        0,
+        0xffff,
+        ((u32::from(ip) >> 16) & 0xffff) as u16,
+        (u32::from(ip) & 0xffff) as u16,
+    ));
+    assert_eq!(dns.reverse_lookup(v6_form).as_deref(), Some("mapped.test"));
+}
+
+#[skuld::test]
+fn forward_lookup_returns_allocated_ip() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("forward.test.", RecordType::A)));
+    let ip = answer_ipv4(&response).unwrap();
+    assert_eq!(dns.forward_lookup_v4("forward.test"), Some(ip));
+    assert_eq!(dns.forward_lookup_v4("nonexistent.test"), None);
+}
+
+// Pin / unpin =========================================================================================================
+
+#[skuld::test]
+fn pin_prevents_lru_eviction() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    // Allocate one IP and pin it.
+    let r = parse_response(&dns.handle_udp(&build_query("pinned.test.", RecordType::A)));
+    let pinned_ip = answer_ipv4(&r).unwrap();
+    dns.pin(IpAddr::V4(pinned_ip));
+
+    // Allocate enough other domains to fill and overflow the pool.
+    // /30 = 4 addresses (one is pinned, three available). Allocate
+    // five more domains; LRU eviction will recycle the unpinned ones,
+    // never the pinned one.
+    for i in 0..5u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+
+    // The pinned IP should still resolve to its original domain.
+    assert_eq!(
+        dns.reverse_lookup(IpAddr::V4(pinned_ip)).as_deref(),
+        Some("pinned.test")
+    );
+}
+
+#[skuld::test]
+fn unpin_releases_for_eviction() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    let _ = dns.handle_udp(&build_query("temp.test.", RecordType::A));
+    let original_ip = dns.forward_lookup_v4("temp.test").unwrap();
+    dns.pin(IpAddr::V4(original_ip));
+    dns.unpin(IpAddr::V4(original_ip));
+
+    // Now eligible for eviction. Burn enough new domains to evict it.
+    // /30 has 4 IPs; we need to push 'temp.test' out of the LRU. Use
+    // the forward map to detect eviction (the IP slot itself is reused
+    // for a different domain).
+    for i in 0..10u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+    assert_eq!(
+        dns.forward_lookup_v4("temp.test"),
+        None,
+        "temp.test should have been evicted from the forward map"
+    );
+    assert_ne!(
+        dns.reverse_lookup(IpAddr::V4(original_ip)).as_deref(),
+        Some("temp.test"),
+        "the original IP slot should no longer map to temp.test"
+    );
+}
+
+#[skuld::test]
+fn pin_is_refcounted() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    let _ = dns.handle_udp(&build_query("rc.test.", RecordType::A));
+    let original_ip = dns.forward_lookup_v4("rc.test").unwrap();
+    dns.pin(IpAddr::V4(original_ip));
+    dns.pin(IpAddr::V4(original_ip));
+    dns.unpin(IpAddr::V4(original_ip));
+
+    // Still pinned (refcount 1). Burn the rest of the pool — should
+    // remain unaffected. The forward map and the reverse lookup of
+    // the *original* IP both still point to "rc.test".
+    for i in 0..10u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+    assert_eq!(dns.forward_lookup_v4("rc.test"), Some(original_ip));
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(original_ip)).as_deref(), Some("rc.test"));
+
+    // Final unpin → the entry returns to the LRU and the next round
+    // of pressure evicts it.
+    dns.unpin(IpAddr::V4(original_ip));
+    for i in 10..20u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+    assert_eq!(
+        dns.forward_lookup_v4("rc.test"),
+        None,
+        "rc.test should have been evicted after final unpin"
+    );
+}
+
+#[skuld::test]
+fn unpin_unknown_ip_is_noop() {
+    let dns = FakeDns::with_defaults();
+    dns.unpin(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))); // does not panic
+}
+
+#[skuld::test]
+fn pin_unknown_ip_is_noop() {
+    let dns = FakeDns::with_defaults();
+    dns.pin(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))); // does not panic
+}
+
+// Pool exhaustion =====================================================================================================
+
+#[skuld::test]
+fn pool_exhausted_when_all_pinned_returns_servfail() {
+    // /30 = 4 addresses. Allocate and pin all four.
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    for i in 0..4u32 {
+        let r = parse_response(&dns.handle_udp(&build_query(&format!("d{i}.test."), RecordType::A)));
+        let ip = answer_ipv4(&r).unwrap();
+        dns.pin(IpAddr::V4(ip));
+    }
+
+    // Fifth allocation: pool exhausted, no eviction possible → SERVFAIL.
+    let response = parse_response(&dns.handle_udp(&build_query("overflow.test.", RecordType::A)));
+    assert_eq!(response.response_code(), ResponseCode::ServFail);
+    assert!(response.answers().is_empty());
+}
+
+// Malformed input =====================================================================================================
+
+#[skuld::test]
+fn empty_payload_returns_empty_vec() {
+    let dns = FakeDns::with_defaults();
+    let resp = dns.handle_udp(&[]);
+    assert!(resp.is_empty());
+}
+
+#[skuld::test]
+fn one_byte_payload_returns_empty_vec() {
+    let dns = FakeDns::with_defaults();
+    let resp = dns.handle_udp(&[0xff]);
+    assert!(resp.is_empty());
+}
+
+#[skuld::test]
+fn malformed_payload_returns_formerr_with_id() {
+    let dns = FakeDns::with_defaults();
+    // Two-byte ID prefix, then garbage. The fake DNS should respond
+    // with FORMERR carrying the original ID.
+    let payload = [0xab, 0xcd, 0xff, 0xff, 0xff];
+    let resp_bytes = dns.handle_udp(&payload);
+    assert!(!resp_bytes.is_empty());
+    let resp = parse_response(&resp_bytes);
+    assert_eq!(resp.id(), 0xabcd);
+    assert_eq!(resp.response_code(), ResponseCode::FormErr);
+}
+
+// IPv4-mapped IPv6 in pin/unpin =======================================================================================
+
+#[skuld::test]
+fn pin_canonicalizes_v4_mapped_v6() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    let r = parse_response(&dns.handle_udp(&build_query("mapped.test.", RecordType::A)));
+    let ip = answer_ipv4(&r).unwrap();
+
+    // Pin via the v4-mapped v6 form; reverse lookup via plain v4
+    // should still find the entry.
+    let mapped = IpAddr::V6(Ipv6Addr::new(
+        0,
+        0,
+        0,
+        0,
+        0,
+        0xffff,
+        ((u32::from(ip) >> 16) & 0xffff) as u16,
+        (u32::from(ip) & 0xffff) as u16,
+    ));
+    dns.pin(mapped);
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(ip)).as_deref(), Some("mapped.test"));
+}

--- a/crates/bridge/src/filter/matcher.rs
+++ b/crates/bridge/src/filter/matcher.rs
@@ -69,16 +69,35 @@ impl Matcher {
         }
     }
 
-    /// Test whether this matcher matches the given connection. Pure
-    /// function; never allocates.
+    /// Test whether this matcher matches the given connection.
+    ///
+    /// Domain matchers canonicalize the connection's domain on the
+    /// fly (via [`canonicalize_for_match`]) so the contract holds
+    /// even if the dispatcher passes an un-normalized string. IP
+    /// matchers canonicalize IPv4-mapped IPv6 addresses.
     pub fn matches(&self, conn: &ConnInfo) -> bool {
         match self {
-            Matcher::ExactDomain(want) => conn.domain.as_deref().is_some_and(|got| got.eq_ignore_ascii_case(want)),
-            Matcher::SubdomainDomain(want) => match conn.domain.as_deref() {
-                None => false,
-                Some(got) => domain_matches_with_subdomains(got, want),
-            },
-            Matcher::WildcardDomain(re) => conn.domain.as_deref().is_some_and(|got| re.is_match(got)),
+            Matcher::ExactDomain(want) => {
+                let Some(got) = conn.domain.as_deref() else {
+                    return false;
+                };
+                let got_canon = canonicalize_for_match(got);
+                got_canon == *want
+            }
+            Matcher::SubdomainDomain(want) => {
+                let Some(got) = conn.domain.as_deref() else {
+                    return false;
+                };
+                let got_canon = canonicalize_for_match(got);
+                domain_matches_with_subdomains(&got_canon, want)
+            }
+            Matcher::WildcardDomain(re) => {
+                let Some(got) = conn.domain.as_deref() else {
+                    return false;
+                };
+                let got_canon = canonicalize_for_match(got);
+                re.is_match(&got_canon)
+            }
             Matcher::ExactIp(want) => canonicalize_ip(conn.dst_ip) == *want,
             Matcher::Subnet(net) => net.contains(&canonicalize_ip(conn.dst_ip)),
         }
@@ -157,8 +176,9 @@ fn glob_to_regex(glob: &str) -> String {
     out
 }
 
-/// Canonicalize a domain string: IDNA-normalize, lowercase, strip a
-/// trailing dot. Returns the normalized form on success.
+/// Canonicalize a domain string at compile time: IDNA-normalize,
+/// lowercase, strip a trailing dot. Returns the normalized form on
+/// success or a `CompileError` if the input is malformed.
 fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
     let trimmed = input.trim_end_matches('.');
     if trimmed.is_empty() {
@@ -174,6 +194,29 @@ fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
     Ok(ascii)
 }
 
+/// Canonicalize a connection-side domain at match time. Best-effort:
+/// runs IDNA normalization + lowercase + trailing-dot strip. On any
+/// failure (malformed Unicode, idna error, empty string), returns the
+/// trimmed input lowercased verbatim — we never reject a connection
+/// just because the sniffer/fake-DNS handed us something we couldn't
+/// canonicalize, since rule compilation has already rejected its own
+/// malformed inputs.
+///
+/// This is exposed publicly so the dispatcher (Plans 2/3) can call it
+/// once per connection at `ConnInfo` construction time. The matcher
+/// also calls it internally so contracts hold even if the dispatcher
+/// forgets.
+pub fn canonicalize_for_match(domain: &str) -> String {
+    let trimmed = domain.trim_end_matches('.');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match idna::domain_to_ascii(trimmed) {
+        Ok(ascii) if !ascii.is_empty() => ascii,
+        _ => trimmed.to_ascii_lowercase(),
+    }
+}
+
 /// Canonicalize an IPv4-mapped IPv6 address to its underlying IPv4 form
 /// (e.g. `::ffff:1.2.3.4` → `1.2.3.4`). Other addresses pass through
 /// unchanged.
@@ -186,12 +229,13 @@ pub(crate) fn canonicalize_ip(ip: IpAddr) -> IpAddr {
     ip
 }
 
-/// Domain string match for `WithSubdomains`. The connection domain is
-/// already lowercased by the caller (via `canonicalize_for_match`); the
-/// stored matcher value is also already lowercased. Returns true if the
-/// connection domain equals the rule domain or is a true subdomain
-/// (`a.example.com` matches rule `example.com`, but `notexample.com`
-/// does not).
+/// Domain string match for `WithSubdomains`. Both `got` and `want`
+/// are assumed lowercased and IDNA-canonical (the matcher's call
+/// site runs the connection-side string through
+/// `canonicalize_for_match`; the stored matcher value was lowercased
+/// at compile time). Returns true if the connection domain equals
+/// the rule domain or is a true subdomain (`a.example.com` matches
+/// rule `example.com`, but `notexample.com` does not).
 fn domain_matches_with_subdomains(got: &str, want: &str) -> bool {
     if got.eq_ignore_ascii_case(want) {
         return true;

--- a/crates/bridge/src/filter/matcher.rs
+++ b/crates/bridge/src/filter/matcher.rs
@@ -1,0 +1,211 @@
+//! Compiled matchers for `FilterRule`s.
+//!
+//! Each `Matcher` checks one connection-level field (`domain` or `dst_ip`)
+//! and reports whether it matches. Construction is fallible (`compile`)
+//! because user input may be malformed; matching itself is infallible and
+//! cheap (no allocation, no I/O).
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use hole_common::config::MatchType;
+use ipnet::IpNet;
+use regex::Regex;
+
+use super::engine::ConnInfo;
+
+// Errors ==============================================================================================================
+
+/// Reason a `FilterRule` failed to compile into a `Matcher`. Carries a
+/// short human-readable message that the bridge surfaces via
+/// `StatusResponse::invalid_filters`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileError(pub String);
+
+impl std::fmt::Display for CompileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for CompileError {}
+
+// Matcher =============================================================================================================
+
+/// Compiled form of a `FilterRule`'s `(address, matching)` pair. The
+/// runtime `decide` loop calls `matches` once per rule per connection.
+#[derive(Debug, Clone)]
+pub enum Matcher {
+    /// Match the connection's domain exactly (case-insensitive ASCII after
+    /// IDNA normalization). Stored value is already lowercased.
+    ExactDomain(String),
+    /// Match the connection's domain or any subdomain of it. Stored value
+    /// is already lowercased and IDNA-normalized.
+    SubdomainDomain(String),
+    /// Match the connection's domain against a glob pattern compiled into
+    /// a regex (anchored, case-insensitive).
+    WildcardDomain(Regex),
+    /// Match the connection's destination IP exactly.
+    ExactIp(IpAddr),
+    /// Match the connection's destination IP against a CIDR network.
+    Subnet(IpNet),
+}
+
+impl Matcher {
+    /// Compile a `(address, matching)` pair into a `Matcher`.
+    ///
+    /// Errors:
+    /// - `Subnet` with a non-CIDR address.
+    /// - `Exactly`/`WithSubdomains` with an invalid domain or empty string.
+    /// - `Wildcard` with a glob that produces an invalid regex.
+    /// - IDNA normalization failure on a domain literal.
+    /// - `Exactly` with a value that looks like an IP literal but doesn't parse.
+    pub fn compile(address: &str, matching: MatchType) -> Result<Matcher, CompileError> {
+        match matching {
+            MatchType::Subnet => parse_subnet(address),
+            MatchType::Exactly => parse_exact(address),
+            MatchType::WithSubdomains => parse_with_subdomains(address),
+            MatchType::Wildcard => parse_wildcard(address),
+        }
+    }
+
+    /// Test whether this matcher matches the given connection. Pure
+    /// function; never allocates.
+    pub fn matches(&self, conn: &ConnInfo) -> bool {
+        match self {
+            Matcher::ExactDomain(want) => conn.domain.as_deref().is_some_and(|got| got.eq_ignore_ascii_case(want)),
+            Matcher::SubdomainDomain(want) => match conn.domain.as_deref() {
+                None => false,
+                Some(got) => domain_matches_with_subdomains(got, want),
+            },
+            Matcher::WildcardDomain(re) => conn.domain.as_deref().is_some_and(|got| re.is_match(got)),
+            Matcher::ExactIp(want) => canonicalize_ip(conn.dst_ip) == *want,
+            Matcher::Subnet(net) => net.contains(&canonicalize_ip(conn.dst_ip)),
+        }
+    }
+}
+
+// Compilation helpers =================================================================================================
+
+/// Parse a `Subnet` rule. Address must be a valid CIDR (`/0` to max
+/// prefix). Host bits are canonicalized to network bits via
+/// `IpNet::trunc`; this is not an error.
+fn parse_subnet(address: &str) -> Result<Matcher, CompileError> {
+    let net = IpNet::from_str(address).map_err(|e| CompileError(format!("not a valid CIDR: {e}")))?;
+    Ok(Matcher::Subnet(net.trunc()))
+}
+
+/// Parse an `Exactly` rule. The same `address` field can be either an IP
+/// literal or a domain literal — try IP first, fall back to domain.
+fn parse_exact(address: &str) -> Result<Matcher, CompileError> {
+    if address.is_empty() {
+        return Err(CompileError("empty address".into()));
+    }
+    if let Ok(ip) = IpAddr::from_str(address) {
+        return Ok(Matcher::ExactIp(canonicalize_ip(ip)));
+    }
+    let canonical = canonicalize_domain(address)?;
+    Ok(Matcher::ExactDomain(canonical))
+}
+
+/// Parse a `WithSubdomains` rule. Domain only — IPs do not have
+/// subdomains.
+fn parse_with_subdomains(address: &str) -> Result<Matcher, CompileError> {
+    if address.is_empty() {
+        return Err(CompileError("empty address".into()));
+    }
+    if IpAddr::from_str(address).is_ok() {
+        return Err(CompileError(
+            "with_subdomains is not valid for IP literals; use exactly or subnet".into(),
+        ));
+    }
+    let canonical = canonicalize_domain(address)?;
+    Ok(Matcher::SubdomainDomain(canonical))
+}
+
+/// Parse a `Wildcard` rule. Glob characters: `*` matches zero or more of
+/// any character, `?` matches exactly one. Everything else is a literal.
+/// The compiled regex is anchored and case-insensitive.
+fn parse_wildcard(address: &str) -> Result<Matcher, CompileError> {
+    if address.is_empty() {
+        return Err(CompileError("empty address".into()));
+    }
+    let regex_pattern = glob_to_regex(address);
+    let re = Regex::new(&regex_pattern).map_err(|e| CompileError(format!("invalid wildcard pattern: {e}")))?;
+    Ok(Matcher::WildcardDomain(re))
+}
+
+/// Convert a domain glob (using `*` and `?`) to an anchored,
+/// case-insensitive regex pattern. Other regex metacharacters in the
+/// input are escaped.
+fn glob_to_regex(glob: &str) -> String {
+    let mut out = String::with_capacity(glob.len() + 8);
+    out.push_str("(?i)^");
+    for c in glob.chars() {
+        match c {
+            '*' => out.push_str(".*"),
+            '?' => out.push('.'),
+            // Regex metacharacters that need escaping (excluding `*`/`?`).
+            '.' | '+' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '\\' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out.push('$');
+    out
+}
+
+/// Canonicalize a domain string: IDNA-normalize, lowercase, strip a
+/// trailing dot. Returns the normalized form on success.
+fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
+    let trimmed = input.trim_end_matches('.');
+    if trimmed.is_empty() {
+        return Err(CompileError("empty domain".into()));
+    }
+    if trimmed.contains(' ') || trimmed.contains('\t') {
+        return Err(CompileError(format!("not a valid domain: {input:?}")));
+    }
+    let ascii = idna::domain_to_ascii(trimmed).map_err(|e| CompileError(format!("IDNA normalization failed: {e}")))?;
+    if ascii.is_empty() {
+        return Err(CompileError(format!("not a valid domain: {input:?}")));
+    }
+    Ok(ascii)
+}
+
+/// Canonicalize an IPv4-mapped IPv6 address to its underlying IPv4 form
+/// (e.g. `::ffff:1.2.3.4` → `1.2.3.4`). Other addresses pass through
+/// unchanged.
+pub(crate) fn canonicalize_ip(ip: IpAddr) -> IpAddr {
+    if let IpAddr::V6(v6) = ip {
+        if let Some(v4) = v6.to_ipv4_mapped() {
+            return IpAddr::V4(v4);
+        }
+    }
+    ip
+}
+
+/// Domain string match for `WithSubdomains`. The connection domain is
+/// already lowercased by the caller (via `canonicalize_for_match`); the
+/// stored matcher value is also already lowercased. Returns true if the
+/// connection domain equals the rule domain or is a true subdomain
+/// (`a.example.com` matches rule `example.com`, but `notexample.com`
+/// does not).
+fn domain_matches_with_subdomains(got: &str, want: &str) -> bool {
+    if got.eq_ignore_ascii_case(want) {
+        return true;
+    }
+    if got.len() <= want.len() + 1 {
+        return false;
+    }
+    let suffix_start = got.len() - want.len();
+    if got.as_bytes()[suffix_start - 1] != b'.' {
+        return false;
+    }
+    got[suffix_start..].eq_ignore_ascii_case(want)
+}
+
+#[cfg(test)]
+#[path = "matcher_tests.rs"]
+mod matcher_tests;

--- a/crates/bridge/src/filter/matcher_tests.rs
+++ b/crates/bridge/src/filter/matcher_tests.rs
@@ -1,0 +1,313 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use hole_common::config::MatchType;
+
+use super::*;
+use crate::filter::engine::{ConnInfo, L4Proto};
+
+// Helpers =============================================================================================================
+
+fn ip_conn(dst: &str) -> ConnInfo {
+    ConnInfo {
+        dst_ip: dst.parse().unwrap(),
+        dst_port: 443,
+        domain: None,
+        proto: L4Proto::Tcp,
+    }
+}
+
+fn dom_conn(dst: &str, domain: &str) -> ConnInfo {
+    ConnInfo {
+        dst_ip: dst.parse().unwrap(),
+        dst_port: 443,
+        domain: Some(domain.to_string()),
+        proto: L4Proto::Tcp,
+    }
+}
+
+fn compile(addr: &str, kind: MatchType) -> Matcher {
+    Matcher::compile(addr, kind).expect("compile should succeed")
+}
+
+// Compile errors ======================================================================================================
+
+#[skuld::test]
+fn subnet_with_non_cidr_address_fails() {
+    let err = Matcher::compile("example.com", MatchType::Subnet).unwrap_err();
+    assert!(err.0.contains("not a valid CIDR"), "got: {err}");
+}
+
+#[skuld::test]
+fn subnet_with_garbage_fails() {
+    let err = Matcher::compile("not-a-cidr/24", MatchType::Subnet).unwrap_err();
+    assert!(err.0.contains("not a valid CIDR"), "got: {err}");
+}
+
+#[skuld::test]
+fn subnet_canonicalizes_host_bits() {
+    // 192.168.1.1/24 has host bits set; trunc to 192.168.1.0/24.
+    let m = compile("192.168.1.1/24", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("192.168.1.42")));
+    assert!(!m.matches(&ip_conn("192.168.2.42")));
+}
+
+#[skuld::test]
+fn exact_with_empty_address_fails() {
+    let err = Matcher::compile("", MatchType::Exactly).unwrap_err();
+    assert!(err.0.contains("empty"), "got: {err}");
+}
+
+#[skuld::test]
+fn with_subdomains_with_empty_address_fails() {
+    let err = Matcher::compile("", MatchType::WithSubdomains).unwrap_err();
+    assert!(err.0.contains("empty"), "got: {err}");
+}
+
+#[skuld::test]
+fn with_subdomains_with_ip_literal_fails() {
+    let err = Matcher::compile("1.2.3.4", MatchType::WithSubdomains).unwrap_err();
+    assert!(err.0.contains("not valid"), "got: {err}");
+}
+
+#[skuld::test]
+fn wildcard_with_empty_address_fails() {
+    let err = Matcher::compile("", MatchType::Wildcard).unwrap_err();
+    assert!(err.0.contains("empty"), "got: {err}");
+}
+
+#[skuld::test]
+fn exact_with_invalid_domain_fails() {
+    // Whitespace inside the host label is not a valid IDNA name.
+    let err = Matcher::compile("exa mple.com", MatchType::Exactly).unwrap_err();
+    assert!(err.0.contains("valid domain"), "got: {err}");
+}
+
+// ExactDomain matching ================================================================================================
+
+#[skuld::test]
+fn exact_domain_matches_literal() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn exact_domain_does_not_match_subdomain() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(!m.matches(&dom_conn("1.2.3.4", "a.example.com")));
+}
+
+#[skuld::test]
+fn exact_domain_case_insensitive() {
+    let m = compile("Example.COM", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "EXAMPLE.com")));
+}
+
+#[skuld::test]
+fn exact_domain_skips_when_no_domain() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(!m.matches(&ip_conn("1.2.3.4")));
+}
+
+#[skuld::test]
+fn exact_domain_strips_trailing_dot() {
+    let m = compile("example.com.", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn exact_domain_idna_normalizes() {
+    // 例え.com (Japanese) → xn--r8jz45g.com
+    let m = compile("例え.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "xn--r8jz45g.com")));
+}
+
+// SubdomainDomain matching ============================================================================================
+
+#[skuld::test]
+fn with_subdomains_matches_self() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn with_subdomains_matches_subdomain() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "a.example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "b.a.example.com")));
+}
+
+#[skuld::test]
+fn with_subdomains_does_not_match_sibling() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(!m.matches(&dom_conn("1.2.3.4", "notexample.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "example.org")));
+}
+
+#[skuld::test]
+fn with_subdomains_skips_when_no_domain() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(!m.matches(&ip_conn("1.2.3.4")));
+}
+
+#[skuld::test]
+fn with_subdomains_case_insensitive() {
+    let m = compile("Example.COM", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "A.EXAMPLE.com")));
+}
+
+// WildcardDomain matching =============================================================================================
+
+#[skuld::test]
+fn wildcard_star_matches_anything() {
+    let m = compile("*", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "anything.tld")));
+}
+
+#[skuld::test]
+fn wildcard_prefix_glob() {
+    let m = compile("*.example.com", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "a.example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "b.a.example.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn wildcard_question_mark() {
+    let m = compile("a?.example.com", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "ab.example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "az.example.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "abc.example.com")));
+}
+
+#[skuld::test]
+fn wildcard_escapes_regex_metacharacters() {
+    // The literal `.` in `example.com` must not match arbitrary chars.
+    let m = compile("example.com", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "exampleXcom")));
+}
+
+#[skuld::test]
+fn wildcard_skips_when_no_domain() {
+    let m = compile("*.example.com", MatchType::Wildcard);
+    assert!(!m.matches(&ip_conn("1.2.3.4")));
+}
+
+// ExactIp matching ====================================================================================================
+
+#[skuld::test]
+fn exact_ipv4_matches() {
+    let m = compile("1.2.3.4", MatchType::Exactly);
+    assert!(matches!(m, Matcher::ExactIp(_)));
+    assert!(m.matches(&ip_conn("1.2.3.4")));
+    assert!(!m.matches(&ip_conn("1.2.3.5")));
+}
+
+#[skuld::test]
+fn exact_ipv6_matches() {
+    let m = compile("2001:db8::1", MatchType::Exactly);
+    assert!(matches!(m, Matcher::ExactIp(_)));
+    assert!(m.matches(&ip_conn("2001:db8::1")));
+    assert!(!m.matches(&ip_conn("2001:db8::2")));
+}
+
+#[skuld::test]
+fn exact_ip_matches_regardless_of_domain_presence() {
+    let m = compile("1.2.3.4", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "anything.com")));
+}
+
+#[skuld::test]
+fn exact_ipv4_canonicalizes_v4_mapped_v6() {
+    let m = compile("1.2.3.4", MatchType::Exactly);
+    let conn = ConnInfo {
+        dst_ip: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304)),
+        dst_port: 443,
+        domain: None,
+        proto: L4Proto::Tcp,
+    };
+    assert!(m.matches(&conn));
+}
+
+// Subnet matching =====================================================================================================
+
+#[skuld::test]
+fn subnet_ipv4_cidr_matches() {
+    let m = compile("10.0.0.0/8", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("10.0.0.1")));
+    assert!(m.matches(&ip_conn("10.255.255.255")));
+    assert!(!m.matches(&ip_conn("11.0.0.1")));
+}
+
+#[skuld::test]
+fn subnet_ipv6_cidr_matches() {
+    let m = compile("2001:db8::/32", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("2001:db8::1")));
+    assert!(m.matches(&ip_conn("2001:db8:ffff::1")));
+    assert!(!m.matches(&ip_conn("2001:db9::1")));
+}
+
+#[skuld::test]
+fn subnet_zero_prefix_matches_everything_in_family() {
+    let m4 = compile("0.0.0.0/0", MatchType::Subnet);
+    assert!(m4.matches(&ip_conn("1.2.3.4")));
+    assert!(m4.matches(&ip_conn("255.255.255.255")));
+    assert!(!m4.matches(&ip_conn("::1")));
+
+    let m6 = compile("::/0", MatchType::Subnet);
+    assert!(m6.matches(&ip_conn("::1")));
+    assert!(m6.matches(&ip_conn("2001:db8::1")));
+    assert!(!m6.matches(&ip_conn("1.2.3.4")));
+}
+
+#[skuld::test]
+fn subnet_max_prefix_is_single_host() {
+    let m = compile("192.168.1.42/32", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("192.168.1.42")));
+    assert!(!m.matches(&ip_conn("192.168.1.41")));
+    assert!(!m.matches(&ip_conn("192.168.1.43")));
+}
+
+#[skuld::test]
+fn subnet_canonicalizes_v4_mapped_v6() {
+    let m = compile("10.0.0.0/8", MatchType::Subnet);
+    let conn = ConnInfo {
+        dst_ip: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)),
+        dst_port: 443,
+        domain: None,
+        proto: L4Proto::Tcp,
+    };
+    assert!(m.matches(&conn));
+}
+
+#[skuld::test]
+fn subnet_skips_when_family_mismatched() {
+    let m = compile("10.0.0.0/8", MatchType::Subnet);
+    assert!(!m.matches(&ip_conn("::1")));
+}
+
+// Edge cases ==========================================================================================================
+
+#[skuld::test]
+fn loopback_ip_in_zero_subnet() {
+    let m = compile("127.0.0.1", MatchType::Exactly);
+    assert!(m.matches(&ConnInfo {
+        dst_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        dst_port: 80,
+        domain: None,
+        proto: L4Proto::Tcp,
+    }));
+}
+
+#[skuld::test]
+fn ipv6_unspecified_match() {
+    let m = compile("::", MatchType::Exactly);
+    assert!(m.matches(&ConnInfo {
+        dst_ip: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+        dst_port: 80,
+        domain: None,
+        proto: L4Proto::Tcp,
+    }));
+}

--- a/crates/bridge/src/filter/matcher_tests.rs
+++ b/crates/bridge/src/filter/matcher_tests.rs
@@ -311,3 +311,52 @@ fn ipv6_unspecified_match() {
         proto: L4Proto::Tcp,
     }));
 }
+
+// Connection-side canonicalization at match time ======================================================================
+
+#[skuld::test]
+fn matches_uncanonicalized_uppercase_connection_domain() {
+    // Compile-side rule is normalized; the dispatcher hands the
+    // matcher a raw uppercase string from the sniffer/fake DNS.
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "Example.COM")));
+}
+
+#[skuld::test]
+fn matches_uncanonicalized_trailing_dot() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com.")));
+}
+
+#[skuld::test]
+fn matches_uncanonicalized_unicode_domain() {
+    // Connection side carries the U-label form; rule is the A-label.
+    let m = compile("xn--r8jz45g.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "例え.com")));
+}
+
+#[skuld::test]
+fn subdomain_match_canonicalizes_connection_domain() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "API.Example.COM")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "api.example.com.")));
+}
+
+#[skuld::test]
+fn canonicalize_for_match_handles_garbage_gracefully() {
+    // Pure garbage that idna refuses should fall through to a
+    // best-effort lowercase, never panic.
+    let s = canonicalize_for_match("not a domain at all");
+    assert!(!s.is_empty());
+}
+
+#[skuld::test]
+fn canonicalize_for_match_strips_trailing_dot_and_lowercases() {
+    assert_eq!(canonicalize_for_match("Example.COM."), "example.com");
+}
+
+#[skuld::test]
+fn canonicalize_for_match_empty_returns_empty() {
+    assert_eq!(canonicalize_for_match(""), "");
+    assert_eq!(canonicalize_for_match("."), "");
+}

--- a/crates/bridge/src/filter/rules.rs
+++ b/crates/bridge/src/filter/rules.rs
@@ -41,13 +41,17 @@ impl RuleSet {
         let mut dropped = Vec::new();
 
         for (i, rule) in rules.iter().enumerate() {
+            // The wire schema uses u32 for the index. A user with
+            // > 4 billion rules is implausible, but if they ever
+            // existed we'd silently truncate — clamp explicitly.
+            let index = u32::try_from(i).unwrap_or(u32::MAX);
             match Matcher::compile(&rule.address, rule.matching) {
                 Ok(matcher) => compiled.push(CompiledRule {
                     matcher,
                     action: rule.action,
                 }),
                 Err(err) => dropped.push(InvalidFilter {
-                    index: i as u32,
+                    index,
                     error: err.to_string(),
                 }),
             }

--- a/crates/bridge/src/filter/rules.rs
+++ b/crates/bridge/src/filter/rules.rs
@@ -1,0 +1,73 @@
+//! `RuleSet` — the compiled form of a `Vec<FilterRule>`. Compilation is
+//! infallible: invalid rules are dropped and recorded in `dropped`, the
+//! rest are kept. The bridge surfaces the dropped list via the IPC
+//! status response so the GUI can highlight problem rows.
+
+use hole_common::config::{FilterAction, FilterRule};
+use hole_common::protocol::InvalidFilter;
+
+use super::matcher::Matcher;
+
+/// One compiled rule: matcher + action. Rules are stored in the same
+/// order as the user's input so the reverse-scan in `engine::decide`
+/// preserves gitignore semantics.
+#[derive(Debug, Clone)]
+pub struct CompiledRule {
+    pub matcher: Matcher,
+    pub action: FilterAction,
+}
+
+/// A compiled ruleset, ready for the filter engine. Lifetime: created
+/// once per `start`/`reload` and held by the dispatcher behind an
+/// `ArcSwap` for lock-free reads.
+#[derive(Debug, Clone, Default)]
+pub struct RuleSet {
+    /// Compiled rules in the user's original order.
+    pub rules: Vec<CompiledRule>,
+    /// Cached: true if any rule's matcher is a domain matcher. The
+    /// dispatcher uses this to skip the sniffer/fake-DNS path entirely
+    /// when only IP rules exist.
+    pub has_domain_rules: bool,
+    /// Rules that failed to compile, with their original index in the
+    /// user's input and a human-readable reason.
+    pub dropped: Vec<InvalidFilter>,
+}
+
+impl RuleSet {
+    /// Compile a slice of `FilterRule`s into a `RuleSet`. Never fails:
+    /// invalid rules go into `dropped`, the rest are kept.
+    pub fn from_user_rules(rules: &[FilterRule]) -> Self {
+        let mut compiled = Vec::with_capacity(rules.len());
+        let mut dropped = Vec::new();
+
+        for (i, rule) in rules.iter().enumerate() {
+            match Matcher::compile(&rule.address, rule.matching) {
+                Ok(matcher) => compiled.push(CompiledRule {
+                    matcher,
+                    action: rule.action,
+                }),
+                Err(err) => dropped.push(InvalidFilter {
+                    index: i as u32,
+                    error: err.to_string(),
+                }),
+            }
+        }
+
+        let has_domain_rules = compiled.iter().any(|r| {
+            matches!(
+                r.matcher,
+                Matcher::ExactDomain(_) | Matcher::SubdomainDomain(_) | Matcher::WildcardDomain(_)
+            )
+        });
+
+        Self {
+            rules: compiled,
+            has_domain_rules,
+            dropped,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "rules_tests.rs"]
+mod rules_tests;

--- a/crates/bridge/src/filter/rules.rs
+++ b/crates/bridge/src/filter/rules.rs
@@ -4,9 +4,18 @@
 //! status response so the GUI can highlight problem rows.
 
 use hole_common::config::{FilterAction, FilterRule};
-use hole_common::protocol::InvalidFilter;
+use serde::{Deserialize, Serialize};
 
 use super::matcher::Matcher;
+
+/// A filter rule that failed to compile, recording its original index
+/// and a human-readable reason. Moved to `hole_common::protocol` and
+/// wired into the IPC status response in Plan 4 when the GUI needs it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvalidFilter {
+    pub index: u32,
+    pub error: String,
+}
 
 /// One compiled rule: matcher + action. Rules are stored in the same
 /// order as the user's input so the reverse-scan in `engine::decide`

--- a/crates/bridge/src/filter/rules_tests.rs
+++ b/crates/bridge/src/filter/rules_tests.rs
@@ -1,0 +1,156 @@
+use hole_common::config::{FilterAction, FilterRule, MatchType};
+
+use super::*;
+use crate::filter::matcher::Matcher;
+
+fn rule(addr: &str, kind: MatchType, action: FilterAction) -> FilterRule {
+    FilterRule {
+        address: addr.to_string(),
+        matching: kind,
+        action,
+    }
+}
+
+// Empty / trivial =====================================================================================================
+
+#[skuld::test]
+fn empty_input_yields_empty_ruleset() {
+    let rs = RuleSet::from_user_rules(&[]);
+    assert!(rs.rules.is_empty());
+    assert!(rs.dropped.is_empty());
+    assert!(!rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn single_valid_rule_compiles() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Proxy)]);
+    assert_eq!(rs.rules.len(), 1);
+    assert!(rs.dropped.is_empty());
+    assert!(rs.has_domain_rules);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactDomain(_)));
+    assert_eq!(rs.rules[0].action, FilterAction::Proxy);
+}
+
+// Order preservation ==================================================================================================
+
+#[skuld::test]
+fn order_preserved_through_compilation() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("a.com", MatchType::Exactly, FilterAction::Block),
+        rule("b.com", MatchType::Exactly, FilterAction::Bypass),
+        rule("c.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(rs.rules.len(), 3);
+    assert_eq!(rs.rules[0].action, FilterAction::Block);
+    assert_eq!(rs.rules[1].action, FilterAction::Bypass);
+    assert_eq!(rs.rules[2].action, FilterAction::Proxy);
+}
+
+// Drop tracking =======================================================================================================
+
+#[skuld::test]
+fn invalid_rule_recorded_in_dropped_with_index() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("good.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("not-a-cidr", MatchType::Subnet, FilterAction::Block),
+        rule("also-good.com", MatchType::Exactly, FilterAction::Bypass),
+    ]);
+    assert_eq!(rs.rules.len(), 2);
+    assert_eq!(rs.dropped.len(), 1);
+    assert_eq!(rs.dropped[0].index, 1);
+    assert!(rs.dropped[0].error.contains("CIDR"), "got: {}", rs.dropped[0].error);
+}
+
+#[skuld::test]
+fn multiple_invalid_rules_each_recorded() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("not-a-cidr", MatchType::Subnet, FilterAction::Block),
+        rule("good.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("", MatchType::Exactly, FilterAction::Bypass),
+        rule("1.2.3.4", MatchType::WithSubdomains, FilterAction::Block),
+    ]);
+    assert_eq!(rs.rules.len(), 1);
+    assert_eq!(rs.dropped.len(), 3);
+    let indices: Vec<u32> = rs.dropped.iter().map(|d| d.index).collect();
+    assert_eq!(indices, vec![0, 2, 3]);
+}
+
+#[skuld::test]
+fn drop_index_matches_user_input_position() {
+    // Indices in `dropped` reference the original positions in the
+    // user's `Vec<FilterRule>`, not positions after dropping.
+    let rs = RuleSet::from_user_rules(&[
+        rule("good1.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("good2.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("not-a-cidr", MatchType::Subnet, FilterAction::Block),
+        rule("good3.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(rs.rules.len(), 3);
+    assert_eq!(rs.dropped.len(), 1);
+    assert_eq!(rs.dropped[0].index, 2);
+}
+
+// has_domain_rules cache ==============================================================================================
+
+#[skuld::test]
+fn has_domain_rules_false_for_ip_only_set() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass),
+        rule("1.2.3.4", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert!(!rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_for_exact_domain() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert!(rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_for_subdomain() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::WithSubdomains, FilterAction::Block)]);
+    assert!(rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_for_wildcard() {
+    let rs = RuleSet::from_user_rules(&[rule("*.example.com", MatchType::Wildcard, FilterAction::Block)]);
+    assert!(rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_false_for_exactly_with_ip_literal() {
+    // `Exactly` with an IP literal compiles to ExactIp, not ExactDomain.
+    let rs = RuleSet::from_user_rules(&[rule("1.2.3.4", MatchType::Exactly, FilterAction::Block)]);
+    assert!(!rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_when_mixed() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass),
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert!(rs.has_domain_rules);
+}
+
+// Compile-time IP-vs-domain dispatch ==================================================================================
+
+#[skuld::test]
+fn exactly_with_ipv4_literal_compiles_to_exact_ip() {
+    let rs = RuleSet::from_user_rules(&[rule("1.2.3.4", MatchType::Exactly, FilterAction::Block)]);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactIp(_)));
+}
+
+#[skuld::test]
+fn exactly_with_ipv6_literal_compiles_to_exact_ip() {
+    let rs = RuleSet::from_user_rules(&[rule("2001:db8::1", MatchType::Exactly, FilterAction::Block)]);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactIp(_)));
+}
+
+#[skuld::test]
+fn exactly_with_domain_compiles_to_exact_domain() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactDomain(_)));
+}

--- a/crates/bridge/src/filter/sniffer.rs
+++ b/crates/bridge/src/filter/sniffer.rs
@@ -1,0 +1,32 @@
+//! Connection-level domain sniffer.
+//!
+//! When the dispatcher (Plans 2/3) accepts a new TCP connection and
+//! the fake DNS reverse lookup misses, it peeks the first ~2 KiB of
+//! payload and asks the sniffer to extract a domain. The sniffer
+//! tries TLS SNI first (covers ~all HTTPS/DoH/DoT/SMTPS/IMAPS), then
+//! HTTP Host header (covers plaintext HTTP). If neither matches, the
+//! connection falls through to IP-only matching.
+//!
+//! Both submodules are pure functions over a `&[u8]` buffer. Tests
+//! exercise them with static fixtures of real ClientHellos and HTTP
+//! requests.
+
+pub mod http_host;
+pub mod tls_sni;
+
+/// Peek at the start of a TCP connection's payload and try to extract
+/// a destination domain. Returns `Some(domain)` on success, `None` if
+/// neither sniffer recognizes the bytes.
+pub fn peek(buf: &[u8]) -> Option<String> {
+    if let Some(sni) = tls_sni::extract_sni(buf) {
+        return Some(sni);
+    }
+    if let Some(host) = http_host::extract_host(buf) {
+        return Some(host);
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "sniffer_tests.rs"]
+mod sniffer_tests;

--- a/crates/bridge/src/filter/sniffer/http_host.rs
+++ b/crates/bridge/src/filter/sniffer/http_host.rs
@@ -1,0 +1,128 @@
+//! HTTP/1.x `Host` header extraction.
+//!
+//! Walks the start of a TCP payload looking for an HTTP/1.x request
+//! prefix (a known method token followed by a space). If present,
+//! scans the request headers up to `\r\n\r\n` for a `Host:` header
+//! and returns its value (lowercased, port stripped).
+//!
+//! Hand-rolled — no `httparse` dep needed for this single-purpose use.
+
+/// Set of HTTP/1.x request method tokens we recognize. Anything else
+/// triggers a non-HTTP fall-through.
+const METHODS: &[&[u8]] = &[
+    b"GET ",
+    b"POST ",
+    b"PUT ",
+    b"DELETE ",
+    b"HEAD ",
+    b"OPTIONS ",
+    b"PATCH ",
+    b"TRACE ",
+    b"CONNECT ",
+];
+
+/// Maximum bytes scanned for the `Host:` header. We don't want to
+/// chase pathologically long header sections.
+const MAX_SCAN: usize = 4096;
+
+/// Try to extract the `Host` header value from a buffer that starts
+/// with an HTTP/1.x request. Returns `None` if the buffer is not a
+/// recognizable HTTP request, or if no `Host:` header is found
+/// before the end of the headers section.
+pub fn extract_host(buf: &[u8]) -> Option<String> {
+    if !METHODS.iter().any(|m| buf.starts_with(m)) {
+        return None;
+    }
+
+    let scan_end = std::cmp::min(buf.len(), MAX_SCAN);
+    let scan = &buf[..scan_end];
+
+    // Find the end of the headers section. If we don't find one, we
+    // may still be able to extract the Host header from a partial
+    // buffer — try anyway.
+    let header_end = find_subslice(scan, b"\r\n\r\n").unwrap_or(scan.len());
+    let headers_region = &scan[..header_end];
+
+    let mut cursor = 0;
+    while cursor < headers_region.len() {
+        let line_end = find_subslice(&headers_region[cursor..], b"\r\n")
+            .map(|i| cursor + i)
+            .unwrap_or(headers_region.len());
+        let line = &headers_region[cursor..line_end];
+
+        if let Some(value) = parse_host_line(line) {
+            return Some(value);
+        }
+
+        if line_end >= headers_region.len() {
+            break;
+        }
+        cursor = line_end + 2; // skip the CRLF
+    }
+
+    None
+}
+
+/// If `line` is a `Host:` header line, return the lowercased host
+/// (with any `:port` suffix stripped). Otherwise `None`.
+fn parse_host_line(line: &[u8]) -> Option<String> {
+    // Header name is case-insensitive per RFC 7230. Find the colon.
+    let colon = line.iter().position(|&b| b == b':')?;
+    let name = &line[..colon];
+    if !name.eq_ignore_ascii_case(b"host") {
+        return None;
+    }
+
+    let mut value = &line[colon + 1..];
+    // Trim leading whitespace.
+    while let Some((&first, rest)) = value.split_first() {
+        if first == b' ' || first == b'\t' {
+            value = rest;
+        } else {
+            break;
+        }
+    }
+    // Trim trailing whitespace.
+    while let Some((&last, rest)) = value.split_last() {
+        if last == b' ' || last == b'\t' || last == b'\r' {
+            value = rest;
+        } else {
+            break;
+        }
+    }
+
+    // Strip optional `:port` suffix. The host part can also be a
+    // bracketed IPv6 literal like `[2001:db8::1]:443`; in that case
+    // the port colon is the one *after* the closing bracket.
+    let host_bytes = if value.first() == Some(&b'[') {
+        match value.iter().position(|&b| b == b']') {
+            Some(close) => &value[..=close],
+            None => return None,
+        }
+    } else {
+        match value.iter().position(|&b| b == b':') {
+            Some(p) => &value[..p],
+            None => value,
+        }
+    };
+
+    if host_bytes.is_empty() {
+        return None;
+    }
+
+    let s = std::str::from_utf8(host_bytes).ok()?.to_ascii_lowercase();
+    Some(s)
+}
+
+/// Find the first occurrence of `needle` in `haystack`. Returns the
+/// starting index, or `None` if not found.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+#[cfg(test)]
+#[path = "http_host_tests.rs"]
+mod http_host_tests;

--- a/crates/bridge/src/filter/sniffer/http_host.rs
+++ b/crates/bridge/src/filter/sniffer/http_host.rs
@@ -92,12 +92,14 @@ fn parse_host_line(line: &[u8]) -> Option<String> {
     }
 
     // Strip optional `:port` suffix. The host part can also be a
-    // bracketed IPv6 literal like `[2001:db8::1]:443`; in that case
-    // the port colon is the one *after* the closing bracket.
+    // bracketed IPv6 literal like `[2001:db8::1]:443`; the brackets
+    // themselves are RFC 7230 framing and not part of the host
+    // identifier — they must be stripped from the returned value so
+    // it parses as an `IpAddr` downstream.
     let host_bytes = if value.first() == Some(&b'[') {
         match value.iter().position(|&b| b == b']') {
-            Some(close) => &value[..=close],
-            None => return None,
+            Some(close) if close >= 2 => &value[1..close],
+            _ => return None,
         }
     } else {
         match value.iter().position(|&b| b == b':') {

--- a/crates/bridge/src/filter/sniffer/http_host_tests.rs
+++ b/crates/bridge/src/filter/sniffer/http_host_tests.rs
@@ -44,13 +44,15 @@ fn extracts_host_strips_port() {
 #[skuld::test]
 fn extracts_host_with_ipv6_literal() {
     let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]:443\r\n\r\n";
-    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+    // RFC 7230 brackets are framing only; the returned host should
+    // be parseable as an IpAddr.
+    assert_eq!(extract_host(req).as_deref(), Some("2001:db8::1"));
 }
 
 #[skuld::test]
 fn extracts_host_with_ipv6_literal_no_port() {
     let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]\r\n\r\n";
-    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+    assert_eq!(extract_host(req).as_deref(), Some("2001:db8::1"));
 }
 
 #[skuld::test]

--- a/crates/bridge/src/filter/sniffer/http_host_tests.rs
+++ b/crates/bridge/src/filter/sniffer/http_host_tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+// Positive cases ======================================================================================================
+
+#[skuld::test]
+fn extracts_host_from_get_request() {
+    let req = b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl/8.0\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_from_post_request() {
+    let req = b"POST /api HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 0\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("api.example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_from_connect_request() {
+    let req = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_lowercase_normalized() {
+    let req = b"GET / HTTP/1.1\r\nHost: Example.COM\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_header_name_case_insensitive() {
+    let req = b"GET / HTTP/1.1\r\nHOST: example.com\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+
+    let req2 = b"GET / HTTP/1.1\r\nhost: example.com\r\n\r\n";
+    assert_eq!(extract_host(req2).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_strips_port() {
+    let req = b"GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_with_ipv6_literal() {
+    let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]:443\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+}
+
+#[skuld::test]
+fn extracts_host_with_ipv6_literal_no_port() {
+    let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+}
+
+#[skuld::test]
+fn extracts_host_skips_other_headers_first() {
+    let req = b"GET / HTTP/1.1\r\nUser-Agent: curl/8.0\r\nAccept: */*\r\nHost: example.com\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_trims_extra_whitespace() {
+    let req = b"GET / HTTP/1.1\r\nHost:    example.com   \r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_from_partial_buffer_without_terminator() {
+    // No `\r\n\r\n` yet, but the Host header is complete on its own line.
+    let req = b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: still-coming";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+// Negative cases ======================================================================================================
+
+#[skuld::test]
+fn returns_none_for_empty_buffer() {
+    assert_eq!(extract_host(b""), None);
+}
+
+#[skuld::test]
+fn returns_none_for_non_http_payload() {
+    let payload = b"\x16\x03\x01\x00\x05binary";
+    assert_eq!(extract_host(payload), None);
+}
+
+#[skuld::test]
+fn returns_none_for_http_request_without_host() {
+    let req = b"GET / HTTP/1.1\r\nUser-Agent: curl/8.0\r\n\r\n";
+    assert_eq!(extract_host(req), None);
+}
+
+#[skuld::test]
+fn returns_none_for_method_without_trailing_space() {
+    // "GETSOMETHING /..." would not match a method token (need the space).
+    let req = b"GETSOMETHING / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    assert_eq!(extract_host(req), None);
+}
+
+#[skuld::test]
+fn returns_none_for_empty_host_value() {
+    let req = b"GET / HTTP/1.1\r\nHost: \r\n\r\n";
+    assert_eq!(extract_host(req), None);
+}
+
+#[skuld::test]
+fn returns_none_for_garbage_bytes() {
+    let payload = [0xff_u8; 64];
+    assert_eq!(extract_host(&payload), None);
+}

--- a/crates/bridge/src/filter/sniffer/tls_sni.rs
+++ b/crates/bridge/src/filter/sniffer/tls_sni.rs
@@ -1,0 +1,51 @@
+//! TLS Server Name Indication (SNI) extraction.
+//!
+//! Walks the TLS plaintext record at the head of the buffer, finds
+//! the ClientHello handshake message, parses its extensions, and
+//! returns the first hostname from the `server_name` extension.
+//!
+//! Limitations (deferred to v2):
+//! - Fragmented ClientHellos that span multiple TLS records are
+//!   reported as `None`. The pre-encryption ClientHello is normally
+//!   small enough to fit in a single record.
+//! - Encrypted Client Hello (ECH / draft-ietf-tls-esni) is reported
+//!   as `None`.
+
+use tls_parser::{parse_tls_extensions, parse_tls_plaintext, SNIType, TlsExtension, TlsMessage, TlsMessageHandshake};
+
+/// Try to extract the SNI hostname from the start of a TCP payload.
+/// Returns `None` if the buffer doesn't begin with a parseable TLS
+/// ClientHello, or if no SNI extension is present.
+pub fn extract_sni(buf: &[u8]) -> Option<String> {
+    let (_, plaintext) = parse_tls_plaintext(buf).ok()?;
+    for msg in plaintext.msg {
+        if let TlsMessage::Handshake(TlsMessageHandshake::ClientHello(ch)) = msg {
+            return extract_sni_from_extensions(ch.ext?);
+        }
+    }
+    None
+}
+
+fn extract_sni_from_extensions(ext_bytes: &[u8]) -> Option<String> {
+    let (_, extensions) = parse_tls_extensions(ext_bytes).ok()?;
+    for ext in extensions {
+        if let TlsExtension::SNI(names) = ext {
+            for (sni_type, name_bytes) in names {
+                // SNIType::HostName is the only currently-defined type
+                // (RFC 6066). Skip anything else.
+                if sni_type == SNIType::HostName {
+                    if let Ok(s) = std::str::from_utf8(name_bytes) {
+                        if !s.is_empty() {
+                            return Some(s.to_ascii_lowercase());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "tls_sni_tests.rs"]
+mod tls_sni_tests;

--- a/crates/bridge/src/filter/sniffer/tls_sni_tests.rs
+++ b/crates/bridge/src/filter/sniffer/tls_sni_tests.rs
@@ -1,0 +1,170 @@
+// The TLS record builders below are deliberately written as
+// `Vec::new()` followed by `push`/`extend_from_slice` so each header
+// field is on its own line and matches the wire format step by step.
+// `vec![...]` would obscure the structure for no real benefit.
+#![allow(clippy::vec_init_then_push)]
+
+use super::*;
+
+// ClientHello builder =================================================================================================
+
+/// Build a minimal valid TLS 1.2 ClientHello record carrying a single
+/// SNI hostname. The structure follows RFC 5246 §7.4.1.2 plus
+/// RFC 6066 §3 for the SNI extension. This is just enough to satisfy
+/// `tls-parser`'s `parse_tls_plaintext` and reach the SNI extraction
+/// path.
+fn build_client_hello(sni: &str) -> Vec<u8> {
+    let sni_bytes = sni.as_bytes();
+    let sni_len = sni_bytes.len();
+
+    // SNI extension data (server_name_list).
+    let mut sni_ext_data = Vec::new();
+    let server_name_list_len = (1 + 2 + sni_len) as u16;
+    sni_ext_data.extend_from_slice(&server_name_list_len.to_be_bytes());
+    sni_ext_data.push(0x00); // NameType.HostName
+    sni_ext_data.extend_from_slice(&(sni_len as u16).to_be_bytes());
+    sni_ext_data.extend_from_slice(sni_bytes);
+
+    // SNI extension wrapper (type + length + data).
+    let mut sni_ext = Vec::new();
+    sni_ext.extend_from_slice(&0x0000_u16.to_be_bytes()); // ExtensionType.server_name
+    sni_ext.extend_from_slice(&(sni_ext_data.len() as u16).to_be_bytes());
+    sni_ext.extend_from_slice(&sni_ext_data);
+
+    // Extensions block (just the SNI extension).
+    let mut extensions = Vec::new();
+    extensions.extend_from_slice(&(sni_ext.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(&sni_ext);
+
+    // ClientHello body.
+    let mut client_hello = Vec::new();
+    client_hello.extend_from_slice(&[0x03, 0x03]); // ProtocolVersion: TLS 1.2
+    client_hello.extend_from_slice(&[0u8; 32]); // Random
+    client_hello.push(0x00); // session_id length = 0
+    client_hello.extend_from_slice(&0x0002_u16.to_be_bytes()); // cipher_suites length
+    client_hello.extend_from_slice(&[0x00, 0x35]); // TLS_RSA_WITH_AES_256_CBC_SHA
+    client_hello.push(0x01); // compression_methods length
+    client_hello.push(0x00); // null compression
+    client_hello.extend_from_slice(&extensions);
+
+    // Handshake header (msg_type + 24-bit length).
+    let body_len = client_hello.len();
+    let mut handshake = Vec::new();
+    handshake.push(0x01); // ClientHello
+    handshake.push(((body_len >> 16) & 0xff) as u8);
+    handshake.push(((body_len >> 8) & 0xff) as u8);
+    handshake.push((body_len & 0xff) as u8);
+    handshake.extend_from_slice(&client_hello);
+
+    // TLS plaintext record header.
+    let record_len = handshake.len();
+    let mut record = Vec::new();
+    record.push(0x16); // ContentType.handshake
+    record.push(0x03); // legacy_record_version major
+    record.push(0x01); // legacy_record_version minor (1.0 by convention)
+    record.push(((record_len >> 8) & 0xff) as u8);
+    record.push((record_len & 0xff) as u8);
+    record.extend_from_slice(&handshake);
+
+    record
+}
+
+/// Build a ClientHello record with no extensions. Used to test the
+/// "no SNI present" case.
+fn build_client_hello_no_extensions() -> Vec<u8> {
+    let mut client_hello = Vec::new();
+    client_hello.extend_from_slice(&[0x03, 0x03]);
+    client_hello.extend_from_slice(&[0u8; 32]);
+    client_hello.push(0x00);
+    client_hello.extend_from_slice(&0x0002_u16.to_be_bytes());
+    client_hello.extend_from_slice(&[0x00, 0x35]);
+    client_hello.push(0x01);
+    client_hello.push(0x00);
+    // No extensions block at all (TLS 1.2 allows the field to be omitted).
+
+    let body_len = client_hello.len();
+    let mut handshake = Vec::new();
+    handshake.push(0x01);
+    handshake.push(((body_len >> 16) & 0xff) as u8);
+    handshake.push(((body_len >> 8) & 0xff) as u8);
+    handshake.push((body_len & 0xff) as u8);
+    handshake.extend_from_slice(&client_hello);
+
+    let record_len = handshake.len();
+    let mut record = Vec::new();
+    record.push(0x16);
+    record.push(0x03);
+    record.push(0x01);
+    record.push(((record_len >> 8) & 0xff) as u8);
+    record.push((record_len & 0xff) as u8);
+    record.extend_from_slice(&handshake);
+
+    record
+}
+
+// Positive cases ======================================================================================================
+
+#[skuld::test]
+fn extracts_sni_from_minimal_client_hello() {
+    let bytes = build_client_hello("example.com");
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_sni_lowercases_uppercase_hostname() {
+    let bytes = build_client_hello("Example.COM");
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_sni_with_subdomain() {
+    let bytes = build_client_hello("api.v2.example.com");
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("api.v2.example.com"));
+}
+
+#[skuld::test]
+fn extracts_sni_with_trailing_extra_bytes() {
+    // `parse_tls_plaintext` consumes one record; trailing bytes are
+    // returned as the unconsumed remainder. We don't care.
+    let mut bytes = build_client_hello("trailing.test");
+    bytes.extend_from_slice(&[0xab, 0xcd, 0xef]);
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("trailing.test"));
+}
+
+// Negative cases ======================================================================================================
+
+#[skuld::test]
+fn returns_none_for_empty_buffer() {
+    assert_eq!(extract_sni(b""), None);
+}
+
+#[skuld::test]
+fn returns_none_for_garbage_bytes() {
+    let bytes = [0xff_u8; 64];
+    assert_eq!(extract_sni(&bytes), None);
+}
+
+#[skuld::test]
+fn returns_none_for_non_handshake_record() {
+    // Application data record (type 0x17) — should not match.
+    let payload = [0x17, 0x03, 0x03, 0x00, 0x05, 1, 2, 3, 4, 5];
+    assert_eq!(extract_sni(&payload), None);
+}
+
+#[skuld::test]
+fn returns_none_for_truncated_record() {
+    let bytes = build_client_hello("example.com");
+    let truncated = &bytes[..bytes.len() / 2];
+    assert_eq!(extract_sni(truncated), None);
+}
+
+#[skuld::test]
+fn returns_none_when_no_extensions() {
+    let bytes = build_client_hello_no_extensions();
+    assert_eq!(extract_sni(&bytes), None);
+}
+
+#[skuld::test]
+fn returns_none_for_one_byte_buffer() {
+    assert_eq!(extract_sni(&[0x16]), None);
+}

--- a/crates/bridge/src/filter/sniffer_tests.rs
+++ b/crates/bridge/src/filter/sniffer_tests.rs
@@ -1,0 +1,88 @@
+//! Cross-sniffer tests: verify the entry point dispatches to the
+//! right sub-sniffer and returns the first match. Per-sniffer
+//! coverage lives in `sniffer/{tls_sni,http_host}_tests.rs`.
+
+// The ClientHello builder below is deliberately step-by-step (see
+// the matching note in `tls_sni_tests.rs`).
+#![allow(clippy::vec_init_then_push)]
+
+use super::*;
+
+#[skuld::test]
+fn peek_returns_none_for_empty_buffer() {
+    assert_eq!(peek(b""), None);
+}
+
+#[skuld::test]
+fn peek_returns_none_for_garbage() {
+    let bytes = [0xff_u8; 64];
+    assert_eq!(peek(&bytes), None);
+}
+
+#[skuld::test]
+fn peek_extracts_http_host() {
+    let req = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    assert_eq!(peek(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn peek_extracts_tls_sni() {
+    // Minimal TLS 1.2 ClientHello with SNI = "tls.example.com",
+    // built using the same approach as `tls_sni_tests::build_client_hello`.
+    let sni = "tls.example.com";
+    let bytes = build_client_hello(sni);
+    assert_eq!(peek(&bytes).as_deref(), Some(sni));
+}
+
+// Local copy of the ClientHello builder so this test file is
+// self-contained (the one in `tls_sni_tests.rs` is private to that
+// test module).
+fn build_client_hello(sni: &str) -> Vec<u8> {
+    let sni_bytes = sni.as_bytes();
+    let sni_len = sni_bytes.len();
+
+    let mut sni_ext_data = Vec::new();
+    let server_name_list_len = (1 + 2 + sni_len) as u16;
+    sni_ext_data.extend_from_slice(&server_name_list_len.to_be_bytes());
+    sni_ext_data.push(0x00);
+    sni_ext_data.extend_from_slice(&(sni_len as u16).to_be_bytes());
+    sni_ext_data.extend_from_slice(sni_bytes);
+
+    let mut sni_ext = Vec::new();
+    sni_ext.extend_from_slice(&0x0000_u16.to_be_bytes());
+    sni_ext.extend_from_slice(&(sni_ext_data.len() as u16).to_be_bytes());
+    sni_ext.extend_from_slice(&sni_ext_data);
+
+    let mut extensions = Vec::new();
+    extensions.extend_from_slice(&(sni_ext.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(&sni_ext);
+
+    let mut client_hello = Vec::new();
+    client_hello.extend_from_slice(&[0x03, 0x03]);
+    client_hello.extend_from_slice(&[0u8; 32]);
+    client_hello.push(0x00);
+    client_hello.extend_from_slice(&0x0002_u16.to_be_bytes());
+    client_hello.extend_from_slice(&[0x00, 0x35]);
+    client_hello.push(0x01);
+    client_hello.push(0x00);
+    client_hello.extend_from_slice(&extensions);
+
+    let body_len = client_hello.len();
+    let mut handshake = Vec::new();
+    handshake.push(0x01);
+    handshake.push(((body_len >> 16) & 0xff) as u8);
+    handshake.push(((body_len >> 8) & 0xff) as u8);
+    handshake.push((body_len & 0xff) as u8);
+    handshake.extend_from_slice(&client_hello);
+
+    let record_len = handshake.len();
+    let mut record = Vec::new();
+    record.push(0x16);
+    record.push(0x03);
+    record.push(0x01);
+    record.push(((record_len >> 8) & 0xff) as u8);
+    record.push((record_len & 0xff) as u8);
+    record.extend_from_slice(&handshake);
+
+    record
+}

--- a/crates/bridge/src/filter_tests.rs
+++ b/crates/bridge/src/filter_tests.rs
@@ -1,0 +1,25 @@
+//! Cross-module smoke tests for the filter engine. Per-module unit tests
+//! live in `filter/{rules,matcher,engine}_tests.rs`.
+
+use hole_common::config::{FilterAction, FilterRule, MatchType};
+
+use super::{decide, ConnInfo, L4Proto, RuleSet};
+
+#[skuld::test]
+fn re_exports_decide_constructable_from_user_rules() {
+    let user_rules = vec![FilterRule {
+        address: "example.com".into(),
+        matching: MatchType::Exactly,
+        action: FilterAction::Block,
+    }];
+
+    let rs = RuleSet::from_user_rules(&user_rules);
+    let conn = ConnInfo {
+        dst_ip: "1.2.3.4".parse().unwrap(),
+        dst_port: 443,
+        domain: Some("example.com".into()),
+        proto: L4Proto::Tcp,
+    };
+
+    assert_eq!(decide(&rs, &conn), FilterAction::Block);
+}

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -209,6 +209,7 @@ fn sample_config() -> ProxyConfig {
             validation: None,
         },
         local_port: 4073,
+        filters: Vec::new(),
     }
 }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod foreground;
 pub mod gateway;
 pub mod group;

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -275,6 +275,7 @@ fn test_config() -> ProxyConfig {
             validation: None,
         },
         local_port: 1080,
+        filters: Vec::new(),
     }
 }
 

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -22,6 +22,7 @@ fn sample_config() -> ProxyConfig {
     ProxyConfig {
         server: sample_server(),
         local_port: 4073,
+        filters: Vec::new(),
     }
 }
 

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -1,4 +1,4 @@
-use crate::config::ServerEntry;
+use crate::config::{FilterRule, ServerEntry};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -82,6 +82,10 @@ pub enum BridgeResponse {
 pub struct ProxyConfig {
     pub server: ServerEntry,
     pub local_port: u16,
+    /// Filter rules applied by the bridge dispatcher. Defaults to empty
+    /// (no filtering — all captured traffic proxied).
+    #[serde(default)]
+    pub filters: Vec<FilterRule>,
 }
 
 // Server test outcome =================================================================================================

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -19,6 +19,7 @@ fn sample_config() -> ProxyConfig {
     ProxyConfig {
         server: sample_server(),
         local_port: 4073,
+        filters: Vec::new(),
     }
 }
 

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -143,6 +143,7 @@ fn send_start_receives_ack() {
                         validation: None,
                     },
                     local_port: 4073,
+                    filters: Vec::new(),
                 },
             })
             .await
@@ -231,6 +232,7 @@ fn send_reload_receives_ack() {
                         validation: None,
                     },
                     local_port: 4073,
+                    filters: Vec::new(),
                 },
             })
             .await
@@ -307,6 +309,7 @@ fn server_error_maps_to_bridge_response_error() {
                         validation: None,
                     },
                     local_port: 4073,
+                    filters: Vec::new(),
                 },
             })
             .await

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -138,18 +138,12 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": message,
-                "invalid_filters": Vec::<()>::new(),
-                "udp_proxy_available": true,
-                "ipv6_bypass_available": true,
             }))
         }
         Ok(_) => Ok(serde_json::json!({
             "running": false,
             "uptime_secs": 0,
             "error": "unexpected response from bridge",
-            "invalid_filters": Vec::<()>::new(),
-            "udp_proxy_available": true,
-            "ipv6_bypass_available": true,
         })),
         Err(e) => {
             // Bridge not running or unreachable — not an error for the frontend
@@ -157,9 +151,6 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": format!("bridge unreachable: {e}"),
-                "invalid_filters": Vec::<()>::new(),
-                "udp_proxy_available": true,
-                "ipv6_bypass_available": true,
             }))
         }
     }
@@ -188,7 +179,6 @@ fn map_metrics_response(result: Result<BridgeResponse, ClientError>) -> serde_js
             "speed_in_bps": 0,
             "speed_out_bps": 0,
             "uptime_secs": 0,
-            "filter": serde_json::Value::Null,
         }),
     }
 }
@@ -374,6 +364,7 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
     Some(ProxyConfig {
         server: entry.clone(),
         local_port: config.local_port,
+        filters: config.filters.clone(),
     })
 }
 

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -138,12 +138,18 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": message,
+                "invalid_filters": Vec::<()>::new(),
+                "udp_proxy_available": true,
+                "ipv6_bypass_available": true,
             }))
         }
         Ok(_) => Ok(serde_json::json!({
             "running": false,
             "uptime_secs": 0,
             "error": "unexpected response from bridge",
+            "invalid_filters": Vec::<()>::new(),
+            "udp_proxy_available": true,
+            "ipv6_bypass_available": true,
         })),
         Err(e) => {
             // Bridge not running or unreachable — not an error for the frontend
@@ -151,6 +157,9 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": format!("bridge unreachable: {e}"),
+                "invalid_filters": Vec::<()>::new(),
+                "udp_proxy_available": true,
+                "ipv6_bypass_available": true,
             }))
         }
     }
@@ -179,6 +188,7 @@ fn map_metrics_response(result: Result<BridgeResponse, ClientError>) -> serde_js
             "speed_in_bps": 0,
             "speed_out_bps": 0,
             "uptime_secs": 0,
+            "filter": serde_json::Value::Null,
         }),
     }
 }

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -171,6 +171,51 @@ fn get_metrics_returns_json() {
     assert_eq!(json["speed_in_bps"], 2048);
     assert_eq!(json["speed_out_bps"], 1024);
     assert_eq!(json["uptime_secs"], 120);
+    // The `filter` field is always present in the JSON shape so the
+    // frontend doesn't see two distinct shapes for running vs stopped.
+    assert_eq!(json["filter"], serde_json::Value::Null);
+}
+
+/// Verify that a Metrics BridgeResponse with filter metrics emits
+/// them in the JSON shape.
+#[skuld::test]
+fn get_metrics_with_filter_metrics_returns_json() {
+    use hole_common::protocol::FilterMetrics;
+    let resp = BridgeResponse::Metrics {
+        bytes_in: 1024,
+        bytes_out: 512,
+        speed_in_bps: 2048,
+        speed_out_bps: 1024,
+        uptime_secs: 120,
+        filter: Some(FilterMetrics {
+            total_connections: 42,
+            proxied: 30,
+            bypassed: 8,
+            blocked: 4,
+            sniffer_hits: 12,
+            sniffer_misses: 5,
+            fake_dns_queries: 100,
+            fake_dns_reverse_hits: 95,
+            active_udp_flows: 7,
+            udp_drops_backpressure: 0,
+        }),
+    };
+    let json = map_metrics_response(Ok(resp));
+    assert_eq!(json["filter"]["total_connections"], 42);
+    assert_eq!(json["filter"]["proxied"], 30);
+    assert_eq!(json["filter"]["bypassed"], 8);
+    assert_eq!(json["filter"]["blocked"], 4);
+    assert_eq!(json["filter"]["active_udp_flows"], 7);
+}
+
+/// Verify that the metrics fallback path emits the same JSON shape as
+/// the success path (always includes `filter`).
+#[skuld::test]
+fn get_metrics_fallback_includes_filter_field() {
+    let err = ClientError::Connection(std::io::Error::other("nope"));
+    let json = map_metrics_response(Err(err));
+    assert_eq!(json["bytes_in"], 0);
+    assert_eq!(json["filter"], serde_json::Value::Null);
 }
 
 /// Verify that a failed metrics request returns zero defaults.

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -171,51 +171,6 @@ fn get_metrics_returns_json() {
     assert_eq!(json["speed_in_bps"], 2048);
     assert_eq!(json["speed_out_bps"], 1024);
     assert_eq!(json["uptime_secs"], 120);
-    // The `filter` field is always present in the JSON shape so the
-    // frontend doesn't see two distinct shapes for running vs stopped.
-    assert_eq!(json["filter"], serde_json::Value::Null);
-}
-
-/// Verify that a Metrics BridgeResponse with filter metrics emits
-/// them in the JSON shape.
-#[skuld::test]
-fn get_metrics_with_filter_metrics_returns_json() {
-    use hole_common::protocol::FilterMetrics;
-    let resp = BridgeResponse::Metrics {
-        bytes_in: 1024,
-        bytes_out: 512,
-        speed_in_bps: 2048,
-        speed_out_bps: 1024,
-        uptime_secs: 120,
-        filter: Some(FilterMetrics {
-            total_connections: 42,
-            proxied: 30,
-            bypassed: 8,
-            blocked: 4,
-            sniffer_hits: 12,
-            sniffer_misses: 5,
-            fake_dns_queries: 100,
-            fake_dns_reverse_hits: 95,
-            active_udp_flows: 7,
-            udp_drops_backpressure: 0,
-        }),
-    };
-    let json = map_metrics_response(Ok(resp));
-    assert_eq!(json["filter"]["total_connections"], 42);
-    assert_eq!(json["filter"]["proxied"], 30);
-    assert_eq!(json["filter"]["bypassed"], 8);
-    assert_eq!(json["filter"]["blocked"], 4);
-    assert_eq!(json["filter"]["active_udp_flows"], 7);
-}
-
-/// Verify that the metrics fallback path emits the same JSON shape as
-/// the success path (always includes `filter`).
-#[skuld::test]
-fn get_metrics_fallback_includes_filter_field() {
-    let err = ClientError::Connection(std::io::Error::other("nope"));
-    let json = map_metrics_response(Err(err));
-    assert_eq!(json["bytes_in"], 0);
-    assert_eq!(json["filter"], serde_json::Value::Null);
 }
 
 /// Verify that a failed metrics request returns zero defaults.

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -19,6 +19,7 @@ fn encode_request_roundtrips() {
                 validation: None,
             },
             local_port: 4073,
+            filters: Vec::new(),
         },
     };
 
@@ -64,6 +65,7 @@ fn write_request_file_roundtrip() {
                 validation: None,
             },
             local_port: 4073,
+            filters: Vec::new(),
         },
     };
 
@@ -97,6 +99,7 @@ fn read_request_file_roundtrip() {
                 validation: None,
             },
             local_port: 4073,
+            filters: Vec::new(),
         },
     };
 


### PR DESCRIPTION
Closes #162.

This is **Plan 1 of 4** for the filter engine, ships **foundations only — no behavior change for users**. Hole runs exactly as today; the filter table in the UI continues to do nothing at runtime. The new modules compile, are fully unit-tested, and are wired into nothing. Plans 2–4 will replace SS's TUN local with a hole-owned dispatcher and integrate these foundations.

The full design spec (with the four-plan decomposition rationale) is in \`~/.claude/plans/luminous-honking-cascade.md\`. It went through brainstorming + two rounds of plan-review before implementation began.

## Why replace SS's filter primitives at all

\`shadowsocks-service\` 1.24's built-in \`AccessControl\` cannot deliver what the spec wants:
- \`check_outbound_blocked\` is server-side only — only called from \`src/server/tcprelay.rs\` and \`src/server/udprelay.rs\`, never from any \`src/local/\` file. Local mode is proxy-or-bypass only; there's no Block primitive.
- The two ACL lists (\`white_list\`, \`black_list\`) have fixed priority — \`proxy\` always beats \`bypass\` regardless of rule order. No way to express gitignore "later overrides earlier" semantics.
- \`AccessControl\` has no public programmatic constructor; only \`load_from_file\`.

So the filter engine is hole-owned. This PR ships the pure-function pieces that the dispatcher (Plan 2) will plug into.

## Slices in this PR

- **\`7c656cf\`** — Schema additions. \`ProxyConfig.filters\`, new \`InvalidFilter\`/\`FilterMetrics\` types generated from \`openapi.yaml\`, extended \`StatusResponse\`/\`MetricsResponse\`, updated \`BridgeResponse\` variants and all their construction sites.
- **\`f8549d2\`** — Pure filter engine. \`filter/{rules,matcher,engine}.rs\` with reverse-iteration last-match-wins gitignore semantics. Five matcher variants (ExactDomain, SubdomainDomain, WildcardDomain, ExactIp, Subnet), compile-time IP-vs-domain dispatch on the rule's \`address\` field. Three locked default rules (\`*\`, \`0.0.0.0/0\`, \`::/0\` → proxy) supported by the engine.
- **\`4e6f92c\`** — Fake DNS module. Function-not-server design with v4 (\`198.18.0.0/15\`) and v6 (\`fd00:0:0:ff00::/64\`) pools, LRU eviction, refcount pinning, sequential allocation with collision skip. SERVFAIL on pool exhaustion.
- **\`b4ef180\`** — TLS SNI + HTTP Host sniffer. \`tls-parser\`-backed TLS extraction; hand-rolled HTTP Host parser. Both pure functions over \`&[u8]\`.
- **\`2df6c24\`** — Review feedback fix-up: canonicalize connection-side domains at match time (so the dispatcher doesn't have to), strip RFC 7230 brackets from IPv6 \`Host:\` values, make the \`get_proxy_status\` and \`map_metrics_response\` JSON shapes consistent across success/error/fallback branches, cap fake DNS allocation probes to bound the worst-case latency on user-supplied \`/0\` pools, fix \`u32\` truncation cast in \`RuleSet::from_user_rules\`. Also adds tests for the new behaviors.

## What this PR does not do

Explicitly out of scope (each is in a follow-up plan):
- TUN ownership transfer or any dispatcher (Plans 2–3)
- TCP per-connection dispatch (Plan 2)
- UDP flow table and SOCKS5 UDP associate (Plan 3)
- v2ray-plugin UDP compatibility handling (Plan 3)
- UI changes — \`ensureDefaultRules\`, IPv6 CIDR validator, locked rows (Plan 4)
- Hot-reload Tauri command + bridge-side reload diff (Plan 4)
- Metrics widget in GUI (Plan 4)
- QUIC SNI sniffer (v2)

## Testing

- \`cargo test --workspace\` clean: 275 hole-bridge lib tests, 113 hole tests, 81 hole-bridge tests, 101 hole-common tests, plus xtask/xtask-lib unit + doc tests = ~600 tests workspace-wide.
- \`cargo build --workspace\` clean.
- \`cargo clippy -p hole-bridge --tests --no-deps\` clean (no warnings, no \`disallowed_methods\` violations).
- New unit test count for Plan 1: ~140 (filter engine, fake DNS, sniffer, plus the JSON shape and protocol round-trip tests).
- All four LRU/refcount scenarios for fake DNS are exercised: pin-then-unpin-then-churn, double-pin-single-unpin (still pinned), fully-pinned-pool-returns-SERVFAIL, IPv4-mapped IPv6 reverse lookup canonicalization.
- TLS ClientHello fixtures are constructed in-test (RFC 5246 §7.4.1.2 + RFC 6066 §3 framing) and parse cleanly via \`tls-parser\`.

## Test plan

- [ ] CI green on Windows + macOS
- [ ] No new clippy warnings under \`disallowed_methods\` (the only deny in \`Cargo.toml\` workspace lints)
- [ ] No regression in existing pre-Plan-1 tests
- [ ] Cargo dependency tree audit: new direct deps are \`tls-parser\`, \`dashmap\`, \`lru\`. The other promotions (\`tun\`, \`smoltcp\`, \`etherparse\`, \`ipnet\`, \`regex\`, \`arc-swap\`, \`hickory-proto\`, \`hickory-resolver\`) are already pulled in transitively via \`shadowsocks-service\` so no new compile time or binary size impact.