### PR TITLE
diag: Windows CI start_real_ss_server timeout investigation (#165)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,3 +184,226 @@ jobs:
           if ($svc) { throw "HoleBridge service still registered" }
           $path = [Environment]::GetEnvironmentVariable("Path", "Machine")
           if ($path -match [regex]::Escape($binDir)) { throw "$binDir still in PATH" }
+
+  # =====================================================================
+  # Throwaway diagnostic jobs for issue #165 (Windows CI `start_real_ss_server`
+  # loopback timeout regression). Gated behind the `ci-diag` PR label so they
+  # never run on ordinary PRs. Both jobs, including all diagnostic code,
+  # are scheduled for deletion in the same PR that ships the root-cause fix.
+  # =====================================================================
+
+  windows-diag-preflight:
+    name: windows-diag-preflight
+    if: contains(github.event.pull_request.labels.*.name, 'ci-diag')
+    runs-on: windows-latest
+    steps:
+      - name: Probe logman tcpip provider access
+        shell: pwsh
+        run: |
+          Write-Host "=== logman query providers (Microsoft-Windows-TCPIP) ==="
+          logman query providers "Microsoft-Windows-TCPIP"
+
+      - name: Probe netsh wfp access
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Write-Host "=== netsh wfp show state (head) ==="
+          netsh wfp show state file=- | Select-Object -First 20
+
+      - name: Probe pktmon availability
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Write-Host "=== pktmon filter add --help ==="
+          pktmon filter add --help
+
+      - name: Probe admin context
+        shell: pwsh
+        run: |
+          $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+          $p = New-Object System.Security.Principal.WindowsPrincipal($id)
+          Write-Host "running as: $($id.Name)"
+          Write-Host "IsAdmin: $($p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator))"
+
+  windows-diag:
+    name: windows-diag
+    if: contains(github.event.pull_request.labels.*.name, 'ci-diag')
+    needs: [windows-diag-preflight]
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Fetch runtime deps (v2ray-plugin, wintun)
+        run: cargo xtask deps
+
+      - name: Capture toolchain fingerprint
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\diag" | Out-Null
+          rustc --version --verbose | Out-File "$env:RUNNER_TEMP\diag\rustc.txt"
+          cargo --version --verbose | Out-File "$env:RUNNER_TEMP\diag\cargo.txt"
+          [System.Environment]::OSVersion.VersionString | Out-File "$env:RUNNER_TEMP\diag\os.txt"
+          Get-ComputerInfo -Property OsBuildNumber, OsHardwareAbstractionLayer, WindowsProductName, WindowsVersion | Out-File "$env:RUNNER_TEMP\diag\computerinfo.txt"
+
+      - name: Pre-build test binary
+        run: cargo test -p hole-bridge --lib --no-run
+
+      - name: Start ETW TCP/IP trace
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          logman start tcpip-trace -p "Microsoft-Windows-TCPIP" 0xffffffff 4 -o "$env:RUNNER_TEMP\diag\tcpip.etl" -ets
+
+      - name: Start WFP netevents capture
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          netsh wfp capture start file="$env:RUNNER_TEMP\diag\wfp.etl"
+
+      - name: Start pktmon loopback capture
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          pktmon reset
+          pktmon filter add -t TCP
+          pktmon start --etw -m real-time -f "$env:RUNNER_TEMP\diag\pktmon.etl"
+
+      - name: Run diag_bind_and_hold (primary experiment)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib diag_bind_and_hold -- --nocapture 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\diag_bind_and_hold.txt"
+
+      - name: Run diag_external_probe
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib diag_external_probe -- --nocapture 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\diag_external_probe.txt"
+
+      - name: Run diag_dual_socket_parity
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib diag_dual_socket_parity -- --nocapture 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\diag_dual_socket_parity.txt"
+
+      # S6 isolation matrix — sequential cargo test invocations with
+      # different name filters. Each uses its own log file so the
+      # artifact is comparable across runs.
+
+      - name: S6 diag-isolated (fixture_starts_real_ss_server alone, serial)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib fixture_starts_real_ss_server -- --nocapture --test-threads=1 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\s6-isolated.txt"
+
+      - name: S6 diag-serial (all bridge lib tests, serial)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib -- --nocapture --test-threads=1 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\s6-serial.txt"
+
+      - name: S6 diag-no-filter (bridge lib tests, filter tests skipped, default threading)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib -- --nocapture --skip filter 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\s6-no-filter.txt"
+
+      - name: S6 diag-only-server (server_test_tests only, default threading)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib server_test_tests -- --nocapture 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\s6-only-server.txt"
+
+      # Control run (observer-effect check): same failing tests but with
+      # ZERO diagnostic captures in flight. If this passes while the
+      # instrumented run fails, the capture overhead is masking the bug
+      # and the instrumentation must be redesigned before interpreting
+      # any results above.
+      - name: Stop all captures before control run
+        if: always()
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          logman stop tcpip-trace -ets 2>&1 | Out-Null
+          netsh wfp capture stop 2>&1 | Out-Null
+          pktmon stop 2>&1 | Out-Null
+
+      - name: Control run (uninstrumented server_test_tests)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          cargo test -p hole-bridge --lib server_test_tests -- --nocapture 2>&1 `
+            | Tee-Object -FilePath "$env:RUNNER_TEMP\diag\control.txt"
+
+      - name: Post-run captures (Defender events, process snapshot)
+        if: always()
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          try {
+            Get-WinEvent -LogName "Microsoft-Windows-Windows Defender/Operational" `
+                -MaxEvents 200 -ErrorAction Stop |
+                Select-Object TimeCreated, Id, LevelDisplayName, Message |
+                Export-Csv "$env:RUNNER_TEMP\diag\defender-events.csv" -NoTypeInformation
+          } catch {
+            "defender-log-unavailable: $_" | Out-File "$env:RUNNER_TEMP\diag\defender-events.err"
+          }
+
+          Get-Process -Name 'hole_bridge*' -ErrorAction SilentlyContinue |
+              Format-List * | Out-File "$env:RUNNER_TEMP\diag\processes.txt"
+
+          Get-NetTCPConnection -ErrorAction SilentlyContinue |
+              Export-Csv "$env:RUNNER_TEMP\diag\tcp-connections.csv" -NoTypeInformation
+
+      - name: Convert pktmon etl to text
+        if: always()
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          if (Test-Path "$env:RUNNER_TEMP\diag\pktmon.etl") {
+            pktmon format "$env:RUNNER_TEMP\diag\pktmon.etl" -o "$env:RUNNER_TEMP\diag\pktmon.txt"
+          }
+
+      - name: Convert tcpip etl to xml
+        if: always()
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          if (Test-Path "$env:RUNNER_TEMP\diag\tcpip.etl") {
+            tracerpt "$env:RUNNER_TEMP\diag\tcpip.etl" -o "$env:RUNNER_TEMP\diag\tcpip.xml" -of XML -y
+          }
+
+      - name: Upload diagnostic artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-diag-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\diag
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,26 +269,36 @@ jobs:
 
       - name: Start ETW TCP/IP trace
         shell: pwsh
+        timeout-minutes: 2
         continue-on-error: true
         run: |
           logman start tcpip-trace -p "Microsoft-Windows-TCPIP" 0xffffffff 4 -o "$env:RUNNER_TEMP\diag\tcpip.etl" -ets
 
       - name: Start WFP netevents capture
         shell: pwsh
+        timeout-minutes: 2
         continue-on-error: true
         run: |
           netsh wfp capture start file="$env:RUNNER_TEMP\diag\wfp.etl"
 
       - name: Start pktmon loopback capture
         shell: pwsh
+        timeout-minutes: 2
         continue-on-error: true
         run: |
+          # Use `pktmon start --etw` WITHOUT `-m real-time`: the
+          # real-time flag blocks the parent shell. Default mode writes
+          # packets to an ETW session file that we convert with
+          # `pktmon format` post-run. Also use Start-Process as extra
+          # insurance so a hang doesn't block the job.
           pktmon reset
           pktmon filter add -t TCP
-          pktmon start --etw -m real-time -f "$env:RUNNER_TEMP\diag\pktmon.etl"
+          $p = Start-Process pktmon -ArgumentList 'start','--etw','-f',"$env:RUNNER_TEMP\diag\pktmon.etl" -Wait -NoNewWindow -PassThru
+          Write-Host "pktmon start exit: $($p.ExitCode)"
 
       - name: Run diag_bind_and_hold (primary experiment)
         shell: pwsh
+        timeout-minutes: 3
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib diag_bind_and_hold -- --nocapture 2>&1 `
@@ -296,6 +306,7 @@ jobs:
 
       - name: Run diag_external_probe
         shell: pwsh
+        timeout-minutes: 3
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib diag_external_probe -- --nocapture 2>&1 `
@@ -303,6 +314,7 @@ jobs:
 
       - name: Run diag_dual_socket_parity
         shell: pwsh
+        timeout-minutes: 3
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib diag_dual_socket_parity -- --nocapture 2>&1 `
@@ -314,6 +326,7 @@ jobs:
 
       - name: S6 diag-isolated (fixture_starts_real_ss_server alone, serial)
         shell: pwsh
+        timeout-minutes: 3
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib fixture_starts_real_ss_server -- --nocapture --test-threads=1 2>&1 `
@@ -321,6 +334,7 @@ jobs:
 
       - name: S6 diag-serial (all bridge lib tests, serial)
         shell: pwsh
+        timeout-minutes: 8
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib -- --nocapture --test-threads=1 2>&1 `
@@ -328,6 +342,7 @@ jobs:
 
       - name: S6 diag-no-filter (bridge lib tests, filter tests skipped, default threading)
         shell: pwsh
+        timeout-minutes: 5
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib -- --nocapture --skip filter 2>&1 `
@@ -335,6 +350,7 @@ jobs:
 
       - name: S6 diag-only-server (server_test_tests only, default threading)
         shell: pwsh
+        timeout-minutes: 3
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib server_test_tests -- --nocapture 2>&1 `
@@ -356,6 +372,7 @@ jobs:
 
       - name: Control run (uninstrumented server_test_tests)
         shell: pwsh
+        timeout-minutes: 3
         continue-on-error: true
         run: |
           cargo test -p hole-bridge --lib server_test_tests -- --nocapture 2>&1 `

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,3 +156,13 @@ HOLE_BRIDGE_SOCKET=$TMPDIR/hole-dev.sock target/debug/hole
 ```sh
 cargo test --workspace
 ```
+
+### CI labels
+
+- `ci-diag` — **throwaway label for bindreams/hole#165.** When present on
+  a PR, CI additionally runs two diagnostic jobs
+  (`windows-diag-preflight`, `windows-diag`) that wrap the Windows test
+  binary with ETW TCP/IP tracing, WFP netevents capture, `pktmon`
+  loopback packet capture, and Defender/process snapshots. Artifacts are
+  uploaded for offline inspection. Delete the label and both jobs after
+  the investigation is closed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,12 +2337,17 @@ dependencies = [
  "bytes",
  "default-net",
  "hex",
+ "hickory-proto",
  "hole-common",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "idna",
+ "ipnet",
  "libc",
+ "lru",
+ "regex",
  "serde",
  "serde_json",
  "shadowsocks",
@@ -2351,6 +2356,7 @@ dependencies = [
  "socket2",
  "tempfile",
  "thiserror 2.0.18",
+ "tls-parser",
  "tokio",
  "tokio-util",
  "tower",
@@ -3100,6 +3106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru_time_cache"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3234,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -3399,6 +3420,38 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff943d68b88d0b87a6e0d58615e8fa07f9fd5a1319fa0a72efc1f62275c79a7"
+dependencies = [
+ "nom",
+ "nom-derive-impl",
+ "rustversion",
+]
+
+[[package]]
+name = "nom-derive-impl"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b9a93a84b0d3ec3e70e02d332dc33ac6dfac9cde63e17fcb77172dededa62"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "notify"
@@ -4613,6 +4666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -6093,6 +6155,20 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-parser"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c36249c6082584b1f224e70f6bdadf5102197be6cfa92b353efe605d9ac741"
+dependencies = [
+ "nom",
+ "nom-derive",
+ "num_enum",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "ureq",
  "windows 0.62.2",
  "windows-service",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -32,6 +32,17 @@ bytes = "1"
 tower = { version = "0.5", features = ["util"] }
 ureq = { version = "3", features = ["json"] }
 tempfile = "3"
+# Filter engine dependencies (Plan 1 of 4 — see issue #162).
+# All are already pulled in transitively via shadowsocks-service; we promote
+# them to direct deps so the filter module can `use` them. Pinned to the same
+# minor versions that shadowsocks-service 1.24 uses to avoid duplication.
+hickory-proto = "0.25"
+idna = "1"
+ipnet = "2"
+regex = "1"
+# New crates not previously in the tree.
+lru = "0.16"
+tls-parser = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -65,3 +65,9 @@ wintun-bindings = "0.7"
 [dev-dependencies]
 skuld = { git = "https://github.com/bindreams/skuld" }
 shadowsocks-service = { version = "1", features = ["server"] }
+# Test harness honors RUST_LOG for `cargo test` output. Originally added
+# during the investigation of issue #165 to surface `shadowsocks_service::*`
+# listener logs; kept as permanent fixture hardening so future "why is
+# this test hanging" investigations can enable tracing output without a
+# code edit.
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -6,10 +6,12 @@
 //! that drives them at runtime is added in Plan 2 (TCP) and Plan 3 (UDP).
 
 pub mod engine;
+pub mod fake_dns;
 pub mod matcher;
 pub mod rules;
 
 pub use engine::{decide, ConnInfo, L4Proto};
+pub use fake_dns::{AllocateError, FakeDns, DEFAULT_POOL_V4, DEFAULT_POOL_V6, FAKE_DNS_TTL};
 pub use matcher::Matcher;
 pub use rules::{CompiledRule, RuleSet};
 

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -9,11 +9,13 @@ pub mod engine;
 pub mod fake_dns;
 pub mod matcher;
 pub mod rules;
+pub mod sniffer;
 
 pub use engine::{decide, ConnInfo, L4Proto};
 pub use fake_dns::{AllocateError, FakeDns, DEFAULT_POOL_V4, DEFAULT_POOL_V6, FAKE_DNS_TTL};
 pub use matcher::Matcher;
 pub use rules::{CompiledRule, RuleSet};
+pub use sniffer::peek;
 
 #[cfg(test)]
 #[path = "filter_tests.rs"]

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -1,0 +1,18 @@
+//! Filter engine — compiles user filter rules and decides per-connection
+//! actions. The engine is pure (no I/O, no async), iterating rules in
+//! reverse order with last-match-wins (gitignore) semantics.
+//!
+//! This crate exposes the data types and decision function. The dispatcher
+//! that drives them at runtime is added in Plan 2 (TCP) and Plan 3 (UDP).
+
+pub mod engine;
+pub mod matcher;
+pub mod rules;
+
+pub use engine::{decide, ConnInfo, L4Proto};
+pub use matcher::Matcher;
+pub use rules::{CompiledRule, RuleSet};
+
+#[cfg(test)]
+#[path = "filter_tests.rs"]
+mod filter_tests;

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -1,0 +1,49 @@
+//! Filter decision loop. Reverse-iterates a `RuleSet` and returns the
+//! action of the first matching rule (gitignore semantics: the rule that
+//! appears later in the user's list wins). If no rule matches, the
+//! terminal fallback is `Proxy` — this matches the bridge's
+//! "everything is proxied by default" contract.
+
+use std::net::IpAddr;
+
+use hole_common::config::FilterAction;
+
+use super::rules::RuleSet;
+
+/// Layer-4 protocol of a connection. Filter rules apply to both
+/// uniformly today, but downstream code (Plans 2/3) may branch on this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum L4Proto {
+    Tcp,
+    Udp,
+}
+
+/// Snapshot of the connection-level info the filter engine sees. The
+/// dispatcher fills this in immediately before calling `decide`.
+#[derive(Debug, Clone)]
+pub struct ConnInfo {
+    pub dst_ip: IpAddr,
+    pub dst_port: u16,
+    /// Set when the dispatcher recovered a domain via fake DNS reverse
+    /// lookup or the TLS/HTTP sniffer. `None` for raw IP destinations.
+    pub domain: Option<String>,
+    pub proto: L4Proto,
+}
+
+/// Run the filter engine for one connection. O(n) in the rule count;
+/// pure function.
+pub fn decide(rules: &RuleSet, conn: &ConnInfo) -> FilterAction {
+    for rule in rules.rules.iter().rev() {
+        if rule.matcher.matches(conn) {
+            return rule.action;
+        }
+    }
+    // Terminal fallback: never reached when the UI's locked default
+    // rules are present, but preserves "proxy everything" if a
+    // hand-edited config strips them out.
+    FilterAction::Proxy
+}
+
+#[cfg(test)]
+#[path = "engine_tests.rs"]
+mod engine_tests;

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -26,6 +26,13 @@ pub struct ConnInfo {
     pub dst_port: u16,
     /// Set when the dispatcher recovered a domain via fake DNS reverse
     /// lookup or the TLS/HTTP sniffer. `None` for raw IP destinations.
+    ///
+    /// The matcher canonicalizes this value internally on every match
+    /// (case-fold + trailing dot strip + IDNA), so callers may pass
+    /// the raw string from the sniffer or fake DNS without
+    /// pre-normalizing. The dispatcher in Plans 2/3 may still want to
+    /// canonicalize once via [`super::matcher::canonicalize_for_match`]
+    /// to amortize the cost across rules.
     pub domain: Option<String>,
     pub proto: L4Proto,
 }

--- a/crates/bridge/src/filter/engine_tests.rs
+++ b/crates/bridge/src/filter/engine_tests.rs
@@ -1,0 +1,222 @@
+use std::net::IpAddr;
+
+use hole_common::config::{FilterAction, FilterRule, MatchType};
+
+use super::*;
+use crate::filter::rules::RuleSet;
+
+// Helpers =============================================================================================================
+
+fn rule(addr: &str, kind: MatchType, action: FilterAction) -> FilterRule {
+    FilterRule {
+        address: addr.to_string(),
+        matching: kind,
+        action,
+    }
+}
+
+fn conn(dst: &str, port: u16, domain: Option<&str>) -> ConnInfo {
+    ConnInfo {
+        dst_ip: dst.parse::<IpAddr>().unwrap(),
+        dst_port: port,
+        domain: domain.map(|s| s.to_string()),
+        proto: L4Proto::Tcp,
+    }
+}
+
+// Default fallback ====================================================================================================
+
+#[skuld::test]
+fn empty_ruleset_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[]);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+}
+
+#[skuld::test]
+fn ruleset_with_only_invalid_rules_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[rule("nonsense", MatchType::Subnet, FilterAction::Block)]);
+    assert!(rs.rules.is_empty());
+    assert_eq!(rs.dropped.len(), 1);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+}
+
+// Single-rule basics ==================================================================================================
+
+#[skuld::test]
+fn single_proxy_rule() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Proxy)]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Proxy
+    );
+}
+
+#[skuld::test]
+fn single_block_rule() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn single_bypass_rule() {
+    let rs = RuleSet::from_user_rules(&[rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass)]);
+    assert_eq!(decide(&rs, &conn("10.1.2.3", 443, None)), FilterAction::Bypass);
+}
+
+#[skuld::test]
+fn no_matching_rule_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("other.com"))),
+        FilterAction::Proxy
+    );
+}
+
+// Gitignore semantics: worked example from the design spec ============================================================
+
+#[skuld::test]
+fn worked_example_a_example_com_proxied() {
+    // example.com (with subdomains) → block
+    // a.example.com (exactly) → proxy
+    // a.example.com matches rule index 1 (later) → proxy
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::WithSubdomains, FilterAction::Block),
+        rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("a.example.com"))),
+        FilterAction::Proxy
+    );
+}
+
+#[skuld::test]
+fn worked_example_b_example_com_blocked() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::WithSubdomains, FilterAction::Block),
+        rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("b.example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn worked_example_apex_blocked() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::WithSubdomains, FilterAction::Block),
+        rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+// Reverse-iteration ordering ==========================================================================================
+
+#[skuld::test]
+fn later_rule_overrides_earlier_for_same_address() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Bypass),
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn earlier_rule_wins_when_no_later_rule_matches() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+        rule("other.com", MatchType::Exactly, FilterAction::Bypass),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+// Mixed domain + IP rules =============================================================================================
+
+#[skuld::test]
+fn mixed_rules_ip_subnet_later_wins() {
+    // Connection has both an IP and a domain. The Subnet rule (index 1)
+    // appears later, so it wins over the domain rule.
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+        rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Bypass
+    );
+}
+
+#[skuld::test]
+fn mixed_rules_domain_later_wins() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Block
+    );
+}
+
+#[skuld::test]
+fn ip_only_connection_with_domain_rule_in_set_falls_through() {
+    // No domain on the connection — domain rule cannot match.
+    let rs = RuleSet::from_user_rules(&[
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+        rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
+    ]);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Bypass);
+}
+
+#[skuld::test]
+fn ip_only_connection_no_ip_rule_falls_back_to_proxy() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert_eq!(decide(&rs, &conn("9.9.9.9", 443, None)), FilterAction::Proxy);
+}
+
+// Three locked default rules (matches the UI's planned behavior) ======================================================
+
+#[skuld::test]
+fn three_locked_default_rules_pass_everything_through() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("*", MatchType::Wildcard, FilterAction::Proxy),
+        rule("0.0.0.0/0", MatchType::Subnet, FilterAction::Proxy),
+        rule("::/0", MatchType::Subnet, FilterAction::Proxy),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        FilterAction::Proxy
+    );
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("::1", 443, None)), FilterAction::Proxy);
+}
+
+#[skuld::test]
+fn block_rule_overrides_locked_defaults() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("*", MatchType::Wildcard, FilterAction::Proxy),
+        rule("0.0.0.0/0", MatchType::Subnet, FilterAction::Proxy),
+        rule("::/0", MatchType::Subnet, FilterAction::Proxy),
+        rule("evil.com", MatchType::WithSubdomains, FilterAction::Block),
+    ]);
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("api.evil.com"))),
+        FilterAction::Block
+    );
+    assert_eq!(
+        decide(&rs, &conn("1.2.3.4", 443, Some("good.com"))),
+        FilterAction::Proxy
+    );
+}

--- a/crates/bridge/src/filter/fake_dns.rs
+++ b/crates/bridge/src/filter/fake_dns.rs
@@ -1,0 +1,438 @@
+//! Fake DNS — handles A/AAAA queries by returning synthetic IPs from a
+//! pool, then lets the dispatcher reverse-map those fake IPs back to
+//! the original domain at connection time.
+//!
+//! This is a *function*, not a server: there is no socket bound
+//! anywhere. The dispatcher's port-53 fast path (added in Plan 2)
+//! invokes [`FakeDns::handle_udp`] directly with bytes pulled from
+//! smoltcp; the response is written back through smoltcp.
+//!
+//! Allocation is sequential with collision skip. Eviction is LRU on
+//! the unpinned set; pinned entries (refcounted by active flows) are
+//! never evicted. Pool exhaustion (every entry pinned) is reported as
+//! `AllocateError::Exhausted` and the DNS query is answered with
+//! SERVFAIL — degenerate case requiring tens of thousands of
+//! concurrent distinct domain connections.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::{A, AAAA};
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use ipnet::{Ipv4Net, Ipv6Net};
+use lru::LruCache;
+
+use super::matcher::canonicalize_ip;
+
+// Default pools =======================================================================================================
+
+/// IPv4 pool (RFC 2544 benchmark testing range). De-facto standard
+/// shared with Clash, V2Ray, sing-box. Unroutable on the public
+/// internet — leaked fake IPs cannot collide with real destinations.
+pub const DEFAULT_POOL_V4: &str = "198.18.0.0/15";
+
+/// IPv6 pool (ULA prefix per RFC 4193). Plenty of room and unroutable.
+pub const DEFAULT_POOL_V6: &str = "fd00:0:0:ff00::/64";
+
+/// TTL written into fake DNS responses. Short, so apps re-query
+/// frequently and the bimap stays warm.
+pub const FAKE_DNS_TTL: u32 = 60;
+
+// Errors ==============================================================================================================
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocateError {
+    /// Every IP in the pool is pinned by an active flow; no more
+    /// allocations possible until something un-pins.
+    Exhausted,
+}
+
+impl std::fmt::Display for AllocateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exhausted => f.write_str("fake DNS pool exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for AllocateError {}
+
+// State ===============================================================================================================
+
+/// Internal mutable state, guarded by a single mutex on `FakeDns`.
+struct State {
+    /// Forward maps: domain → fake IP, separate per family. Domains
+    /// are interned as `Arc<str>` so the bimap shares storage.
+    domain_to_v4: HashMap<Arc<str>, Ipv4Addr>,
+    domain_to_v6: HashMap<Arc<str>, Ipv6Addr>,
+    /// LRU buckets for unpinned entries (eligible for eviction). Keys
+    /// are the fake IPs; values are the interned domain.
+    unpinned_v4: LruCache<Ipv4Addr, Arc<str>>,
+    unpinned_v6: LruCache<Ipv6Addr, Arc<str>>,
+    /// Pinned entries — never evicted. Refcount tracks active flows
+    /// using each fake IP. When the refcount drops to 0, the entry
+    /// moves back into the corresponding LRU bucket.
+    pinned_v4: HashMap<Ipv4Addr, (Arc<str>, u32)>,
+    pinned_v6: HashMap<Ipv6Addr, (Arc<str>, u32)>,
+    /// Sequential allocation cursors (offset within the pool). On
+    /// collision, the allocator advances and tries again.
+    next_v4_offset: u64,
+    next_v6_offset: u128,
+}
+
+// Public API ==========================================================================================================
+
+/// Fake DNS function. Construct once at proxy start with a fixed pair
+/// of pools, then call [`Self::handle_udp`] for each port-53 datagram
+/// received from smoltcp.
+pub struct FakeDns {
+    pool_v4: Ipv4Net,
+    pool_v6: Ipv6Net,
+    pool_v4_size: u64,
+    state: Mutex<State>,
+}
+
+impl FakeDns {
+    /// Construct a `FakeDns` with the default pools (`198.18.0.0/15`
+    /// for v4, `fd00:0:0:ff00::/64` for v6).
+    pub fn with_defaults() -> Self {
+        let v4 = DEFAULT_POOL_V4
+            .parse::<Ipv4Net>()
+            .expect("default v4 pool literal is valid");
+        let v6 = DEFAULT_POOL_V6
+            .parse::<Ipv6Net>()
+            .expect("default v6 pool literal is valid");
+        Self::new(v4, v6)
+    }
+
+    /// Construct a `FakeDns` with custom pools.
+    pub fn new(pool_v4: Ipv4Net, pool_v6: Ipv6Net) -> Self {
+        // Pool size for v4 is at most 2^32 (less than u64::MAX), so the
+        // u64 cast is lossless. For v6 we cap the eviction-bucket
+        // capacity at a reasonable upper bound — eviction logic only
+        // matters when the working set actually approaches the pool
+        // size, which never happens for /64.
+        let pool_v4_size = network_size_v4(&pool_v4);
+        let v4_capacity = clamp_capacity(pool_v4_size);
+        let v6_capacity = NonZeroUsize::new(1 << 16).expect("constant is non-zero");
+
+        Self {
+            pool_v4,
+            pool_v6,
+            pool_v4_size,
+            state: Mutex::new(State {
+                domain_to_v4: HashMap::new(),
+                domain_to_v6: HashMap::new(),
+                unpinned_v4: LruCache::new(v4_capacity),
+                unpinned_v6: LruCache::new(v6_capacity),
+                pinned_v4: HashMap::new(),
+                pinned_v6: HashMap::new(),
+                next_v4_offset: 0,
+                next_v6_offset: 0,
+            }),
+        }
+    }
+
+    /// Look up the domain that was previously mapped to a fake IP.
+    /// Returns `None` if the IP is not in the bimap. IPv4-mapped IPv6
+    /// addresses (`::ffff:1.2.3.4`) are unwrapped before lookup so the
+    /// dispatcher's connection-level address (which may arrive in
+    /// either form) finds the same entry.
+    pub fn reverse_lookup(&self, ip: IpAddr) -> Option<Arc<str>> {
+        let ip = canonicalize_ip(ip);
+        let state = self.state.lock().unwrap();
+        match ip {
+            IpAddr::V4(v4) => {
+                if let Some((domain, _)) = state.pinned_v4.get(&v4) {
+                    return Some(Arc::clone(domain));
+                }
+                state.unpinned_v4.peek(&v4).map(Arc::clone)
+            }
+            IpAddr::V6(v6) => {
+                if let Some((domain, _)) = state.pinned_v6.get(&v6) {
+                    return Some(Arc::clone(domain));
+                }
+                state.unpinned_v6.peek(&v6).map(Arc::clone)
+            }
+        }
+    }
+
+    /// Look up the fake IP currently allocated to a domain. Returns
+    /// `None` if no allocation exists in the requested family.
+    pub fn forward_lookup_v4(&self, domain: &str) -> Option<Ipv4Addr> {
+        let state = self.state.lock().unwrap();
+        state.domain_to_v4.get(domain).copied()
+    }
+
+    /// Look up the fake IPv6 currently allocated to a domain.
+    pub fn forward_lookup_v6(&self, domain: &str) -> Option<Ipv6Addr> {
+        let state = self.state.lock().unwrap();
+        state.domain_to_v6.get(domain).copied()
+    }
+
+    /// Pin an entry by its fake IP, preventing LRU eviction. Pinning
+    /// is refcounted: each call must be paired with a `unpin` call.
+    /// Pinning a non-existent IP is a no-op (the dispatcher should
+    /// never do this, but we don't panic to keep the API permissive).
+    pub fn pin(&self, ip: IpAddr) {
+        let ip = canonicalize_ip(ip);
+        let mut state = self.state.lock().unwrap();
+        match ip {
+            IpAddr::V4(v4) => {
+                if let Some(domain) = state.unpinned_v4.pop(&v4) {
+                    state.pinned_v4.insert(v4, (domain, 1));
+                } else if let Some((_, count)) = state.pinned_v4.get_mut(&v4) {
+                    *count += 1;
+                }
+            }
+            IpAddr::V6(v6) => {
+                if let Some(domain) = state.unpinned_v6.pop(&v6) {
+                    state.pinned_v6.insert(v6, (domain, 1));
+                } else if let Some((_, count)) = state.pinned_v6.get_mut(&v6) {
+                    *count += 1;
+                }
+            }
+        }
+    }
+
+    /// Decrement the refcount for an entry; if it reaches zero, move
+    /// it back into the LRU set so it becomes evictable. Unpinning a
+    /// non-pinned IP is a no-op.
+    pub fn unpin(&self, ip: IpAddr) {
+        let ip = canonicalize_ip(ip);
+        let mut state = self.state.lock().unwrap();
+        match ip {
+            IpAddr::V4(v4) => {
+                if let Some((_, count)) = state.pinned_v4.get_mut(&v4) {
+                    *count -= 1;
+                    if *count == 0 {
+                        let (domain, _) = state.pinned_v4.remove(&v4).unwrap();
+                        state.unpinned_v4.put(v4, domain);
+                    }
+                }
+            }
+            IpAddr::V6(v6) => {
+                if let Some((_, count)) = state.pinned_v6.get_mut(&v6) {
+                    *count -= 1;
+                    if *count == 0 {
+                        let (domain, _) = state.pinned_v6.remove(&v6).unwrap();
+                        state.unpinned_v6.put(v6, domain);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handle one DNS query message and produce a response.
+    ///
+    /// - Parses the request via `hickory-proto`.
+    /// - On parse failure, returns a `FORMERR` response if possible
+    ///   (using the original query ID), else an empty Vec (the caller
+    ///   should drop the datagram).
+    /// - For A queries: allocate (or reuse) a fake IPv4 from the pool
+    ///   and answer with the fake IP. TTL is `FAKE_DNS_TTL`.
+    /// - For AAAA queries: same with IPv6.
+    /// - For other query types: NOERROR with empty answer section.
+    /// - On allocation exhaustion: SERVFAIL.
+    pub fn handle_udp(&self, payload: &[u8]) -> Vec<u8> {
+        let request = match Message::from_vec(payload) {
+            Ok(m) => m,
+            Err(_) => {
+                // Best-effort: try to extract the ID from the first
+                // two bytes of the payload to make the FORMERR
+                // matchable. If the payload is shorter than 2 bytes,
+                // give up entirely.
+                if payload.len() < 2 {
+                    return Vec::new();
+                }
+                let id = u16::from_be_bytes([payload[0], payload[1]]);
+                let err = Message::error_msg(id, OpCode::Query, ResponseCode::FormErr);
+                return err.to_vec().unwrap_or_default();
+            }
+        };
+
+        self.build_response(&request).to_vec().unwrap_or_default()
+    }
+
+    /// Build a response `Message` for a parsed query. Pure-ish — only
+    /// touches the bimap state, no I/O.
+    fn build_response(&self, request: &Message) -> Message {
+        let mut response = Message::new();
+        response
+            .set_id(request.id())
+            .set_message_type(MessageType::Response)
+            .set_op_code(OpCode::Query)
+            .set_recursion_desired(request.recursion_desired())
+            .set_recursion_available(true)
+            .set_authoritative(true);
+
+        for q in request.queries() {
+            response.add_query(q.clone());
+        }
+
+        let Some(query) = request.queries().first() else {
+            response.set_response_code(ResponseCode::FormErr);
+            return response;
+        };
+
+        match query.query_type() {
+            RecordType::A => match self.allocate_v4(query.name()) {
+                Ok(ip) => {
+                    let record = Record::from_rdata(query.name().clone(), FAKE_DNS_TTL, RData::A(A(ip)));
+                    response.add_answer(record);
+                    response.set_response_code(ResponseCode::NoError);
+                }
+                Err(AllocateError::Exhausted) => {
+                    response.set_response_code(ResponseCode::ServFail);
+                }
+            },
+            RecordType::AAAA => match self.allocate_v6(query.name()) {
+                Ok(ip) => {
+                    let record = Record::from_rdata(query.name().clone(), FAKE_DNS_TTL, RData::AAAA(AAAA(ip)));
+                    response.add_answer(record);
+                    response.set_response_code(ResponseCode::NoError);
+                }
+                Err(AllocateError::Exhausted) => {
+                    response.set_response_code(ResponseCode::ServFail);
+                }
+            },
+            // For non-A/AAAA queries we return NOERROR with an empty
+            // answer section. NXDOMAIN is intentionally avoided
+            // because it's negatively cached and can break apps that
+            // legitimately query MX/TXT/SRV.
+            _ => {
+                response.set_response_code(ResponseCode::NoError);
+            }
+        }
+
+        response
+    }
+
+    /// Allocate a fake IPv4 for `name`. Reuses any existing
+    /// allocation. Pure of I/O.
+    fn allocate_v4(&self, name: &Name) -> Result<Ipv4Addr, AllocateError> {
+        let domain = name_to_domain_key(name);
+        let mut state = self.state.lock().unwrap();
+
+        if let Some(&existing) = state.domain_to_v4.get(&domain) {
+            // Touch LRU position if unpinned.
+            let _ = state.unpinned_v4.get(&existing);
+            return Ok(existing);
+        }
+
+        // Sequential allocation with collision skip. Bound the loop
+        // by the pool size so we never spin forever.
+        for _ in 0..self.pool_v4_size {
+            let offset = state.next_v4_offset;
+            state.next_v4_offset = (state.next_v4_offset + 1) % self.pool_v4_size;
+            let candidate = ipv4_at_offset(&self.pool_v4, offset);
+            if state.pinned_v4.contains_key(&candidate) || state.unpinned_v4.contains(&candidate) {
+                continue;
+            }
+            state.unpinned_v4.put(candidate, Arc::clone(&domain));
+            state.domain_to_v4.insert(domain, candidate);
+            return Ok(candidate);
+        }
+
+        // Pool fully populated. Try LRU eviction (unpinned only).
+        if let Some((victim_ip, victim_domain)) = state.unpinned_v4.pop_lru() {
+            state.domain_to_v4.remove(&victim_domain);
+            state.unpinned_v4.put(victim_ip, Arc::clone(&domain));
+            state.domain_to_v4.insert(domain, victim_ip);
+            return Ok(victim_ip);
+        }
+
+        Err(AllocateError::Exhausted)
+    }
+
+    /// Allocate a fake IPv6 for `name`.
+    fn allocate_v6(&self, name: &Name) -> Result<Ipv6Addr, AllocateError> {
+        let domain = name_to_domain_key(name);
+        let mut state = self.state.lock().unwrap();
+
+        if let Some(&existing) = state.domain_to_v6.get(&domain) {
+            let _ = state.unpinned_v6.get(&existing);
+            return Ok(existing);
+        }
+
+        // For v6 the pool is effectively infinite (/64 = 2^64), so the
+        // sequential cursor never wraps in practice; we still cap the
+        // loop at the cache capacity to keep the worst case bounded.
+        let max_attempts = state.unpinned_v6.cap().get() as u128 + state.pinned_v6.len() as u128 + 1;
+        for _ in 0..max_attempts {
+            let offset = state.next_v6_offset;
+            state.next_v6_offset = state.next_v6_offset.wrapping_add(1);
+            let candidate = ipv6_at_offset(&self.pool_v6, offset);
+            if state.pinned_v6.contains_key(&candidate) || state.unpinned_v6.contains(&candidate) {
+                continue;
+            }
+            state.unpinned_v6.put(candidate, Arc::clone(&domain));
+            state.domain_to_v6.insert(domain, candidate);
+            return Ok(candidate);
+        }
+
+        if let Some((victim_ip, victim_domain)) = state.unpinned_v6.pop_lru() {
+            state.domain_to_v6.remove(&victim_domain);
+            state.unpinned_v6.put(victim_ip, Arc::clone(&domain));
+            state.domain_to_v6.insert(domain, victim_ip);
+            return Ok(victim_ip);
+        }
+
+        Err(AllocateError::Exhausted)
+    }
+}
+
+// Helpers =============================================================================================================
+
+/// Convert a hickory `Name` (which carries trailing-dot semantics)
+/// into a lowercased `Arc<str>` suitable for use as a bimap key.
+fn name_to_domain_key(name: &Name) -> Arc<str> {
+    let mut s = name.to_ascii();
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s.make_ascii_lowercase();
+    Arc::from(s)
+}
+
+/// Compute the number of host addresses in an IPv4 network. For `/0`
+/// this is 2^32; we cap to `u64::MAX` to avoid overflow on systems
+/// that store the size as `u64`.
+fn network_size_v4(net: &Ipv4Net) -> u64 {
+    if net.prefix_len() == 0 {
+        // 2^32 (just over u32::MAX)
+        1u64 << 32
+    } else {
+        1u64 << (32 - net.prefix_len())
+    }
+}
+
+/// Compute the IPv4 address at the given offset within a network.
+/// Wraps via modulo on the caller's side.
+fn ipv4_at_offset(net: &Ipv4Net, offset: u64) -> Ipv4Addr {
+    let base = u32::from(net.network());
+    let max_offset = network_size_v4(net);
+    let normalized = (offset % max_offset) as u32;
+    Ipv4Addr::from(base.wrapping_add(normalized))
+}
+
+/// Compute the IPv6 address at the given offset within a network.
+fn ipv6_at_offset(net: &Ipv6Net, offset: u128) -> Ipv6Addr {
+    let base = u128::from(net.network());
+    Ipv6Addr::from(base.wrapping_add(offset))
+}
+
+/// Clamp a pool size to a sensible LRU capacity. The lru crate
+/// requires a `NonZeroUsize`, and we don't want to allocate a
+/// data structure with billions of slots even if the pool is huge.
+fn clamp_capacity(size: u64) -> NonZeroUsize {
+    let capped = std::cmp::min(size, 1u64 << 20) as usize;
+    NonZeroUsize::new(capped.max(1)).expect("clamped to >= 1")
+}
+
+#[cfg(test)]
+#[path = "fake_dns_tests.rs"]
+mod fake_dns_tests;

--- a/crates/bridge/src/filter/fake_dns.rs
+++ b/crates/bridge/src/filter/fake_dns.rs
@@ -41,6 +41,12 @@ pub const DEFAULT_POOL_V6: &str = "fd00:0:0:ff00::/64";
 /// frequently and the bimap stays warm.
 pub const FAKE_DNS_TTL: u32 = 60;
 
+/// Maximum number of allocation probes before giving up (per query)
+/// regardless of the actual pool size. Bounds the worst-case latency
+/// of a single allocation under a pathological pool configuration
+/// (e.g. a `/0` pool with `2^32` candidates).
+const MAX_ALLOCATION_PROBES: u64 = 1024;
+
 // Errors ==============================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -323,9 +329,11 @@ impl FakeDns {
             return Ok(existing);
         }
 
-        // Sequential allocation with collision skip. Bound the loop
-        // by the pool size so we never spin forever.
-        for _ in 0..self.pool_v4_size {
+        // Sequential allocation with collision skip. Bounded by the
+        // smaller of the pool size and MAX_ALLOCATION_PROBES so we
+        // never spin millions of iterations on a `/0` user pool.
+        let probe_limit = std::cmp::min(self.pool_v4_size, MAX_ALLOCATION_PROBES);
+        for _ in 0..probe_limit {
             let offset = state.next_v4_offset;
             state.next_v4_offset = (state.next_v4_offset + 1) % self.pool_v4_size;
             let candidate = ipv4_at_offset(&self.pool_v4, offset);
@@ -411,12 +419,16 @@ fn network_size_v4(net: &Ipv4Net) -> u64 {
 }
 
 /// Compute the IPv4 address at the given offset within a network.
-/// Wraps via modulo on the caller's side.
+/// The offset is taken modulo the network size, so the returned
+/// address is always inside `net`. Pool sizes near `2^32` (e.g.
+/// `/0`) wrap correctly without overflow because the addition is
+/// done in `u64`.
 fn ipv4_at_offset(net: &Ipv4Net, offset: u64) -> Ipv4Addr {
-    let base = u32::from(net.network());
+    let base = u64::from(u32::from(net.network()));
     let max_offset = network_size_v4(net);
-    let normalized = (offset % max_offset) as u32;
-    Ipv4Addr::from(base.wrapping_add(normalized))
+    let normalized = offset % max_offset;
+    let result = (base + normalized) as u32;
+    Ipv4Addr::from(result)
 }
 
 /// Compute the IPv6 address at the given offset within a network.

--- a/crates/bridge/src/filter/fake_dns_tests.rs
+++ b/crates/bridge/src/filter/fake_dns_tests.rs
@@ -1,0 +1,391 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
+use hickory_proto::rr::rdata::{A, AAAA};
+use hickory_proto::rr::{Name, RData, RecordType};
+use ipnet::{Ipv4Net, Ipv6Net};
+
+use super::*;
+
+// Helpers =============================================================================================================
+
+fn build_query(domain: &str, qtype: RecordType) -> Vec<u8> {
+    let name = Name::from_str(domain).unwrap();
+    let mut request = Message::new();
+    request.set_id(0x1234);
+    request.set_message_type(MessageType::Query);
+    request.set_op_code(OpCode::Query);
+    request.set_recursion_desired(true);
+    request.add_query(hickory_proto::op::Query::query(name, qtype));
+    request.to_vec().unwrap()
+}
+
+fn parse_response(bytes: &[u8]) -> Message {
+    Message::from_vec(bytes).unwrap()
+}
+
+fn answer_ipv4(msg: &Message) -> Option<Ipv4Addr> {
+    msg.answers().iter().find_map(|r| {
+        if let RData::A(A(ip)) = r.data() {
+            Some(*ip)
+        } else {
+            None
+        }
+    })
+}
+
+fn answer_ipv6(msg: &Message) -> Option<Ipv6Addr> {
+    msg.answers().iter().find_map(|r| {
+        if let RData::AAAA(AAAA(ip)) = r.data() {
+            Some(*ip)
+        } else {
+            None
+        }
+    })
+}
+
+fn small_pools() -> (Ipv4Net, Ipv6Net) {
+    // 198.18.0.0/30 — 4 addresses, makes pool exhaustion testable.
+    let v4 = Ipv4Net::new(Ipv4Addr::new(198, 18, 0, 0), 30).unwrap();
+    let v6 = Ipv6Net::new(Ipv6Addr::new(0xfd00, 0, 0, 0xff00, 0, 0, 0, 0), 126).unwrap();
+    (v4, v6)
+}
+
+// Construction ========================================================================================================
+
+#[skuld::test]
+fn with_defaults_succeeds() {
+    let _ = FakeDns::with_defaults();
+}
+
+#[skuld::test]
+fn default_pool_constants_parse() {
+    let v4 = DEFAULT_POOL_V4.parse::<Ipv4Net>().unwrap();
+    assert_eq!(v4.prefix_len(), 15);
+    let v6 = DEFAULT_POOL_V6.parse::<Ipv6Net>().unwrap();
+    assert_eq!(v6.prefix_len(), 64);
+}
+
+// A queries ===========================================================================================================
+
+#[skuld::test]
+fn a_query_returns_fake_ip_in_pool() {
+    let dns = FakeDns::with_defaults();
+    let request = build_query("example.com.", RecordType::A);
+    let response = parse_response(&dns.handle_udp(&request));
+
+    assert_eq!(response.message_type(), MessageType::Response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.id(), 0x1234);
+
+    let pool: Ipv4Net = DEFAULT_POOL_V4.parse().unwrap();
+    let ip = answer_ipv4(&response).expect("expected an A record");
+    assert!(pool.contains(&ip), "{ip} not in pool {pool}");
+}
+
+#[skuld::test]
+fn a_query_for_same_domain_returns_same_ip() {
+    let dns = FakeDns::with_defaults();
+    let r1 = parse_response(&dns.handle_udp(&build_query("a.example.com.", RecordType::A)));
+    let r2 = parse_response(&dns.handle_udp(&build_query("a.example.com.", RecordType::A)));
+    assert_eq!(answer_ipv4(&r1), answer_ipv4(&r2));
+}
+
+#[skuld::test]
+fn a_query_for_different_domains_returns_different_ips() {
+    let dns = FakeDns::with_defaults();
+    let r1 = parse_response(&dns.handle_udp(&build_query("a.com.", RecordType::A)));
+    let r2 = parse_response(&dns.handle_udp(&build_query("b.com.", RecordType::A)));
+    assert_ne!(answer_ipv4(&r1), answer_ipv4(&r2));
+}
+
+#[skuld::test]
+fn a_query_response_ttl_is_fake_dns_ttl() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::A)));
+    let ttl = response.answers()[0].ttl();
+    assert_eq!(ttl, FAKE_DNS_TTL);
+}
+
+#[skuld::test]
+fn a_query_canonicalizes_domain_case() {
+    // Querying for `Example.COM.` should produce the same fake IP as
+    // `example.com.` because the bimap key is lowercased.
+    let dns = FakeDns::with_defaults();
+    let r1 = parse_response(&dns.handle_udp(&build_query("Example.COM.", RecordType::A)));
+    let r2 = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::A)));
+    assert_eq!(answer_ipv4(&r1), answer_ipv4(&r2));
+}
+
+// AAAA queries ========================================================================================================
+
+#[skuld::test]
+fn aaaa_query_returns_fake_ipv6_in_pool() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::AAAA)));
+    let pool: Ipv6Net = DEFAULT_POOL_V6.parse().unwrap();
+    let ip = answer_ipv6(&response).expect("expected an AAAA record");
+    assert!(pool.contains(&ip), "{ip} not in pool {pool}");
+}
+
+#[skuld::test]
+fn a_and_aaaa_for_same_domain_yield_separate_ips() {
+    // Same domain queried for both families gets a fake v4 and a fake
+    // v6, both pinned to that domain in the bimap.
+    let dns = FakeDns::with_defaults();
+    let r4 = parse_response(&dns.handle_udp(&build_query("dual.example.", RecordType::A)));
+    let r6 = parse_response(&dns.handle_udp(&build_query("dual.example.", RecordType::AAAA)));
+    let v4 = answer_ipv4(&r4).unwrap();
+    let v6 = answer_ipv6(&r6).unwrap();
+
+    assert_eq!(dns.forward_lookup_v4("dual.example"), Some(v4));
+    assert_eq!(dns.forward_lookup_v6("dual.example"), Some(v6));
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(v4)).as_deref(), Some("dual.example"));
+    assert_eq!(dns.reverse_lookup(IpAddr::V6(v6)).as_deref(), Some("dual.example"));
+}
+
+// Other query types ===================================================================================================
+
+#[skuld::test]
+fn mx_query_returns_noerror_empty() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::MX)));
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers().len(), 0);
+}
+
+#[skuld::test]
+fn txt_query_returns_noerror_empty() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("example.com.", RecordType::TXT)));
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers().len(), 0);
+}
+
+#[skuld::test]
+fn srv_query_returns_noerror_empty() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("_xmpp._tcp.example.com.", RecordType::SRV)));
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers().len(), 0);
+}
+
+// Reverse lookup ======================================================================================================
+
+#[skuld::test]
+fn reverse_lookup_returns_domain() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("foo.test.", RecordType::A)));
+    let ip = answer_ipv4(&response).unwrap();
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(ip)).as_deref(), Some("foo.test"));
+}
+
+#[skuld::test]
+fn reverse_lookup_unknown_ip_returns_none() {
+    let dns = FakeDns::with_defaults();
+    assert!(dns.reverse_lookup(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))).is_none());
+}
+
+#[skuld::test]
+fn reverse_lookup_canonicalizes_v4_mapped_v6() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("mapped.test.", RecordType::A)));
+    let ip = answer_ipv4(&response).unwrap();
+    let v6_form = IpAddr::V6(Ipv6Addr::new(
+        0,
+        0,
+        0,
+        0,
+        0,
+        0xffff,
+        ((u32::from(ip) >> 16) & 0xffff) as u16,
+        (u32::from(ip) & 0xffff) as u16,
+    ));
+    assert_eq!(dns.reverse_lookup(v6_form).as_deref(), Some("mapped.test"));
+}
+
+#[skuld::test]
+fn forward_lookup_returns_allocated_ip() {
+    let dns = FakeDns::with_defaults();
+    let response = parse_response(&dns.handle_udp(&build_query("forward.test.", RecordType::A)));
+    let ip = answer_ipv4(&response).unwrap();
+    assert_eq!(dns.forward_lookup_v4("forward.test"), Some(ip));
+    assert_eq!(dns.forward_lookup_v4("nonexistent.test"), None);
+}
+
+// Pin / unpin =========================================================================================================
+
+#[skuld::test]
+fn pin_prevents_lru_eviction() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    // Allocate one IP and pin it.
+    let r = parse_response(&dns.handle_udp(&build_query("pinned.test.", RecordType::A)));
+    let pinned_ip = answer_ipv4(&r).unwrap();
+    dns.pin(IpAddr::V4(pinned_ip));
+
+    // Allocate enough other domains to fill and overflow the pool.
+    // /30 = 4 addresses (one is pinned, three available). Allocate
+    // five more domains; LRU eviction will recycle the unpinned ones,
+    // never the pinned one.
+    for i in 0..5u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+
+    // The pinned IP should still resolve to its original domain.
+    assert_eq!(
+        dns.reverse_lookup(IpAddr::V4(pinned_ip)).as_deref(),
+        Some("pinned.test")
+    );
+}
+
+#[skuld::test]
+fn unpin_releases_for_eviction() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    let _ = dns.handle_udp(&build_query("temp.test.", RecordType::A));
+    let original_ip = dns.forward_lookup_v4("temp.test").unwrap();
+    dns.pin(IpAddr::V4(original_ip));
+    dns.unpin(IpAddr::V4(original_ip));
+
+    // Now eligible for eviction. Burn enough new domains to evict it.
+    // /30 has 4 IPs; we need to push 'temp.test' out of the LRU. Use
+    // the forward map to detect eviction (the IP slot itself is reused
+    // for a different domain).
+    for i in 0..10u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+    assert_eq!(
+        dns.forward_lookup_v4("temp.test"),
+        None,
+        "temp.test should have been evicted from the forward map"
+    );
+    assert_ne!(
+        dns.reverse_lookup(IpAddr::V4(original_ip)).as_deref(),
+        Some("temp.test"),
+        "the original IP slot should no longer map to temp.test"
+    );
+}
+
+#[skuld::test]
+fn pin_is_refcounted() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    let _ = dns.handle_udp(&build_query("rc.test.", RecordType::A));
+    let original_ip = dns.forward_lookup_v4("rc.test").unwrap();
+    dns.pin(IpAddr::V4(original_ip));
+    dns.pin(IpAddr::V4(original_ip));
+    dns.unpin(IpAddr::V4(original_ip));
+
+    // Still pinned (refcount 1). Burn the rest of the pool — should
+    // remain unaffected. The forward map and the reverse lookup of
+    // the *original* IP both still point to "rc.test".
+    for i in 0..10u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+    assert_eq!(dns.forward_lookup_v4("rc.test"), Some(original_ip));
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(original_ip)).as_deref(), Some("rc.test"));
+
+    // Final unpin → the entry returns to the LRU and the next round
+    // of pressure evicts it.
+    dns.unpin(IpAddr::V4(original_ip));
+    for i in 10..20u32 {
+        let _ = dns.handle_udp(&build_query(&format!("burn{i}.test."), RecordType::A));
+    }
+    assert_eq!(
+        dns.forward_lookup_v4("rc.test"),
+        None,
+        "rc.test should have been evicted after final unpin"
+    );
+}
+
+#[skuld::test]
+fn unpin_unknown_ip_is_noop() {
+    let dns = FakeDns::with_defaults();
+    dns.unpin(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))); // does not panic
+}
+
+#[skuld::test]
+fn pin_unknown_ip_is_noop() {
+    let dns = FakeDns::with_defaults();
+    dns.pin(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))); // does not panic
+}
+
+// Pool exhaustion =====================================================================================================
+
+#[skuld::test]
+fn pool_exhausted_when_all_pinned_returns_servfail() {
+    // /30 = 4 addresses. Allocate and pin all four.
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    for i in 0..4u32 {
+        let r = parse_response(&dns.handle_udp(&build_query(&format!("d{i}.test."), RecordType::A)));
+        let ip = answer_ipv4(&r).unwrap();
+        dns.pin(IpAddr::V4(ip));
+    }
+
+    // Fifth allocation: pool exhausted, no eviction possible → SERVFAIL.
+    let response = parse_response(&dns.handle_udp(&build_query("overflow.test.", RecordType::A)));
+    assert_eq!(response.response_code(), ResponseCode::ServFail);
+    assert!(response.answers().is_empty());
+}
+
+// Malformed input =====================================================================================================
+
+#[skuld::test]
+fn empty_payload_returns_empty_vec() {
+    let dns = FakeDns::with_defaults();
+    let resp = dns.handle_udp(&[]);
+    assert!(resp.is_empty());
+}
+
+#[skuld::test]
+fn one_byte_payload_returns_empty_vec() {
+    let dns = FakeDns::with_defaults();
+    let resp = dns.handle_udp(&[0xff]);
+    assert!(resp.is_empty());
+}
+
+#[skuld::test]
+fn malformed_payload_returns_formerr_with_id() {
+    let dns = FakeDns::with_defaults();
+    // Two-byte ID prefix, then garbage. The fake DNS should respond
+    // with FORMERR carrying the original ID.
+    let payload = [0xab, 0xcd, 0xff, 0xff, 0xff];
+    let resp_bytes = dns.handle_udp(&payload);
+    assert!(!resp_bytes.is_empty());
+    let resp = parse_response(&resp_bytes);
+    assert_eq!(resp.id(), 0xabcd);
+    assert_eq!(resp.response_code(), ResponseCode::FormErr);
+}
+
+// IPv4-mapped IPv6 in pin/unpin =======================================================================================
+
+#[skuld::test]
+fn pin_canonicalizes_v4_mapped_v6() {
+    let (v4, v6) = small_pools();
+    let dns = FakeDns::new(v4, v6);
+
+    let r = parse_response(&dns.handle_udp(&build_query("mapped.test.", RecordType::A)));
+    let ip = answer_ipv4(&r).unwrap();
+
+    // Pin via the v4-mapped v6 form; reverse lookup via plain v4
+    // should still find the entry.
+    let mapped = IpAddr::V6(Ipv6Addr::new(
+        0,
+        0,
+        0,
+        0,
+        0,
+        0xffff,
+        ((u32::from(ip) >> 16) & 0xffff) as u16,
+        (u32::from(ip) & 0xffff) as u16,
+    ));
+    dns.pin(mapped);
+    assert_eq!(dns.reverse_lookup(IpAddr::V4(ip)).as_deref(), Some("mapped.test"));
+}

--- a/crates/bridge/src/filter/matcher.rs
+++ b/crates/bridge/src/filter/matcher.rs
@@ -69,16 +69,35 @@ impl Matcher {
         }
     }
 
-    /// Test whether this matcher matches the given connection. Pure
-    /// function; never allocates.
+    /// Test whether this matcher matches the given connection.
+    ///
+    /// Domain matchers canonicalize the connection's domain on the
+    /// fly (via [`canonicalize_for_match`]) so the contract holds
+    /// even if the dispatcher passes an un-normalized string. IP
+    /// matchers canonicalize IPv4-mapped IPv6 addresses.
     pub fn matches(&self, conn: &ConnInfo) -> bool {
         match self {
-            Matcher::ExactDomain(want) => conn.domain.as_deref().is_some_and(|got| got.eq_ignore_ascii_case(want)),
-            Matcher::SubdomainDomain(want) => match conn.domain.as_deref() {
-                None => false,
-                Some(got) => domain_matches_with_subdomains(got, want),
-            },
-            Matcher::WildcardDomain(re) => conn.domain.as_deref().is_some_and(|got| re.is_match(got)),
+            Matcher::ExactDomain(want) => {
+                let Some(got) = conn.domain.as_deref() else {
+                    return false;
+                };
+                let got_canon = canonicalize_for_match(got);
+                got_canon == *want
+            }
+            Matcher::SubdomainDomain(want) => {
+                let Some(got) = conn.domain.as_deref() else {
+                    return false;
+                };
+                let got_canon = canonicalize_for_match(got);
+                domain_matches_with_subdomains(&got_canon, want)
+            }
+            Matcher::WildcardDomain(re) => {
+                let Some(got) = conn.domain.as_deref() else {
+                    return false;
+                };
+                let got_canon = canonicalize_for_match(got);
+                re.is_match(&got_canon)
+            }
             Matcher::ExactIp(want) => canonicalize_ip(conn.dst_ip) == *want,
             Matcher::Subnet(net) => net.contains(&canonicalize_ip(conn.dst_ip)),
         }
@@ -157,8 +176,9 @@ fn glob_to_regex(glob: &str) -> String {
     out
 }
 
-/// Canonicalize a domain string: IDNA-normalize, lowercase, strip a
-/// trailing dot. Returns the normalized form on success.
+/// Canonicalize a domain string at compile time: IDNA-normalize,
+/// lowercase, strip a trailing dot. Returns the normalized form on
+/// success or a `CompileError` if the input is malformed.
 fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
     let trimmed = input.trim_end_matches('.');
     if trimmed.is_empty() {
@@ -174,6 +194,29 @@ fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
     Ok(ascii)
 }
 
+/// Canonicalize a connection-side domain at match time. Best-effort:
+/// runs IDNA normalization + lowercase + trailing-dot strip. On any
+/// failure (malformed Unicode, idna error, empty string), returns the
+/// trimmed input lowercased verbatim — we never reject a connection
+/// just because the sniffer/fake-DNS handed us something we couldn't
+/// canonicalize, since rule compilation has already rejected its own
+/// malformed inputs.
+///
+/// This is exposed publicly so the dispatcher (Plans 2/3) can call it
+/// once per connection at `ConnInfo` construction time. The matcher
+/// also calls it internally so contracts hold even if the dispatcher
+/// forgets.
+pub fn canonicalize_for_match(domain: &str) -> String {
+    let trimmed = domain.trim_end_matches('.');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match idna::domain_to_ascii(trimmed) {
+        Ok(ascii) if !ascii.is_empty() => ascii,
+        _ => trimmed.to_ascii_lowercase(),
+    }
+}
+
 /// Canonicalize an IPv4-mapped IPv6 address to its underlying IPv4 form
 /// (e.g. `::ffff:1.2.3.4` → `1.2.3.4`). Other addresses pass through
 /// unchanged.
@@ -186,12 +229,13 @@ pub(crate) fn canonicalize_ip(ip: IpAddr) -> IpAddr {
     ip
 }
 
-/// Domain string match for `WithSubdomains`. The connection domain is
-/// already lowercased by the caller (via `canonicalize_for_match`); the
-/// stored matcher value is also already lowercased. Returns true if the
-/// connection domain equals the rule domain or is a true subdomain
-/// (`a.example.com` matches rule `example.com`, but `notexample.com`
-/// does not).
+/// Domain string match for `WithSubdomains`. Both `got` and `want`
+/// are assumed lowercased and IDNA-canonical (the matcher's call
+/// site runs the connection-side string through
+/// `canonicalize_for_match`; the stored matcher value was lowercased
+/// at compile time). Returns true if the connection domain equals
+/// the rule domain or is a true subdomain (`a.example.com` matches
+/// rule `example.com`, but `notexample.com` does not).
 fn domain_matches_with_subdomains(got: &str, want: &str) -> bool {
     if got.eq_ignore_ascii_case(want) {
         return true;

--- a/crates/bridge/src/filter/matcher.rs
+++ b/crates/bridge/src/filter/matcher.rs
@@ -1,0 +1,211 @@
+//! Compiled matchers for `FilterRule`s.
+//!
+//! Each `Matcher` checks one connection-level field (`domain` or `dst_ip`)
+//! and reports whether it matches. Construction is fallible (`compile`)
+//! because user input may be malformed; matching itself is infallible and
+//! cheap (no allocation, no I/O).
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use hole_common::config::MatchType;
+use ipnet::IpNet;
+use regex::Regex;
+
+use super::engine::ConnInfo;
+
+// Errors ==============================================================================================================
+
+/// Reason a `FilterRule` failed to compile into a `Matcher`. Carries a
+/// short human-readable message that the bridge surfaces via
+/// `StatusResponse::invalid_filters`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileError(pub String);
+
+impl std::fmt::Display for CompileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for CompileError {}
+
+// Matcher =============================================================================================================
+
+/// Compiled form of a `FilterRule`'s `(address, matching)` pair. The
+/// runtime `decide` loop calls `matches` once per rule per connection.
+#[derive(Debug, Clone)]
+pub enum Matcher {
+    /// Match the connection's domain exactly (case-insensitive ASCII after
+    /// IDNA normalization). Stored value is already lowercased.
+    ExactDomain(String),
+    /// Match the connection's domain or any subdomain of it. Stored value
+    /// is already lowercased and IDNA-normalized.
+    SubdomainDomain(String),
+    /// Match the connection's domain against a glob pattern compiled into
+    /// a regex (anchored, case-insensitive).
+    WildcardDomain(Regex),
+    /// Match the connection's destination IP exactly.
+    ExactIp(IpAddr),
+    /// Match the connection's destination IP against a CIDR network.
+    Subnet(IpNet),
+}
+
+impl Matcher {
+    /// Compile a `(address, matching)` pair into a `Matcher`.
+    ///
+    /// Errors:
+    /// - `Subnet` with a non-CIDR address.
+    /// - `Exactly`/`WithSubdomains` with an invalid domain or empty string.
+    /// - `Wildcard` with a glob that produces an invalid regex.
+    /// - IDNA normalization failure on a domain literal.
+    /// - `Exactly` with a value that looks like an IP literal but doesn't parse.
+    pub fn compile(address: &str, matching: MatchType) -> Result<Matcher, CompileError> {
+        match matching {
+            MatchType::Subnet => parse_subnet(address),
+            MatchType::Exactly => parse_exact(address),
+            MatchType::WithSubdomains => parse_with_subdomains(address),
+            MatchType::Wildcard => parse_wildcard(address),
+        }
+    }
+
+    /// Test whether this matcher matches the given connection. Pure
+    /// function; never allocates.
+    pub fn matches(&self, conn: &ConnInfo) -> bool {
+        match self {
+            Matcher::ExactDomain(want) => conn.domain.as_deref().is_some_and(|got| got.eq_ignore_ascii_case(want)),
+            Matcher::SubdomainDomain(want) => match conn.domain.as_deref() {
+                None => false,
+                Some(got) => domain_matches_with_subdomains(got, want),
+            },
+            Matcher::WildcardDomain(re) => conn.domain.as_deref().is_some_and(|got| re.is_match(got)),
+            Matcher::ExactIp(want) => canonicalize_ip(conn.dst_ip) == *want,
+            Matcher::Subnet(net) => net.contains(&canonicalize_ip(conn.dst_ip)),
+        }
+    }
+}
+
+// Compilation helpers =================================================================================================
+
+/// Parse a `Subnet` rule. Address must be a valid CIDR (`/0` to max
+/// prefix). Host bits are canonicalized to network bits via
+/// `IpNet::trunc`; this is not an error.
+fn parse_subnet(address: &str) -> Result<Matcher, CompileError> {
+    let net = IpNet::from_str(address).map_err(|e| CompileError(format!("not a valid CIDR: {e}")))?;
+    Ok(Matcher::Subnet(net.trunc()))
+}
+
+/// Parse an `Exactly` rule. The same `address` field can be either an IP
+/// literal or a domain literal — try IP first, fall back to domain.
+fn parse_exact(address: &str) -> Result<Matcher, CompileError> {
+    if address.is_empty() {
+        return Err(CompileError("empty address".into()));
+    }
+    if let Ok(ip) = IpAddr::from_str(address) {
+        return Ok(Matcher::ExactIp(canonicalize_ip(ip)));
+    }
+    let canonical = canonicalize_domain(address)?;
+    Ok(Matcher::ExactDomain(canonical))
+}
+
+/// Parse a `WithSubdomains` rule. Domain only — IPs do not have
+/// subdomains.
+fn parse_with_subdomains(address: &str) -> Result<Matcher, CompileError> {
+    if address.is_empty() {
+        return Err(CompileError("empty address".into()));
+    }
+    if IpAddr::from_str(address).is_ok() {
+        return Err(CompileError(
+            "with_subdomains is not valid for IP literals; use exactly or subnet".into(),
+        ));
+    }
+    let canonical = canonicalize_domain(address)?;
+    Ok(Matcher::SubdomainDomain(canonical))
+}
+
+/// Parse a `Wildcard` rule. Glob characters: `*` matches zero or more of
+/// any character, `?` matches exactly one. Everything else is a literal.
+/// The compiled regex is anchored and case-insensitive.
+fn parse_wildcard(address: &str) -> Result<Matcher, CompileError> {
+    if address.is_empty() {
+        return Err(CompileError("empty address".into()));
+    }
+    let regex_pattern = glob_to_regex(address);
+    let re = Regex::new(&regex_pattern).map_err(|e| CompileError(format!("invalid wildcard pattern: {e}")))?;
+    Ok(Matcher::WildcardDomain(re))
+}
+
+/// Convert a domain glob (using `*` and `?`) to an anchored,
+/// case-insensitive regex pattern. Other regex metacharacters in the
+/// input are escaped.
+fn glob_to_regex(glob: &str) -> String {
+    let mut out = String::with_capacity(glob.len() + 8);
+    out.push_str("(?i)^");
+    for c in glob.chars() {
+        match c {
+            '*' => out.push_str(".*"),
+            '?' => out.push('.'),
+            // Regex metacharacters that need escaping (excluding `*`/`?`).
+            '.' | '+' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '\\' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out.push('$');
+    out
+}
+
+/// Canonicalize a domain string: IDNA-normalize, lowercase, strip a
+/// trailing dot. Returns the normalized form on success.
+fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
+    let trimmed = input.trim_end_matches('.');
+    if trimmed.is_empty() {
+        return Err(CompileError("empty domain".into()));
+    }
+    if trimmed.contains(' ') || trimmed.contains('\t') {
+        return Err(CompileError(format!("not a valid domain: {input:?}")));
+    }
+    let ascii = idna::domain_to_ascii(trimmed).map_err(|e| CompileError(format!("IDNA normalization failed: {e}")))?;
+    if ascii.is_empty() {
+        return Err(CompileError(format!("not a valid domain: {input:?}")));
+    }
+    Ok(ascii)
+}
+
+/// Canonicalize an IPv4-mapped IPv6 address to its underlying IPv4 form
+/// (e.g. `::ffff:1.2.3.4` → `1.2.3.4`). Other addresses pass through
+/// unchanged.
+pub(crate) fn canonicalize_ip(ip: IpAddr) -> IpAddr {
+    if let IpAddr::V6(v6) = ip {
+        if let Some(v4) = v6.to_ipv4_mapped() {
+            return IpAddr::V4(v4);
+        }
+    }
+    ip
+}
+
+/// Domain string match for `WithSubdomains`. The connection domain is
+/// already lowercased by the caller (via `canonicalize_for_match`); the
+/// stored matcher value is also already lowercased. Returns true if the
+/// connection domain equals the rule domain or is a true subdomain
+/// (`a.example.com` matches rule `example.com`, but `notexample.com`
+/// does not).
+fn domain_matches_with_subdomains(got: &str, want: &str) -> bool {
+    if got.eq_ignore_ascii_case(want) {
+        return true;
+    }
+    if got.len() <= want.len() + 1 {
+        return false;
+    }
+    let suffix_start = got.len() - want.len();
+    if got.as_bytes()[suffix_start - 1] != b'.' {
+        return false;
+    }
+    got[suffix_start..].eq_ignore_ascii_case(want)
+}
+
+#[cfg(test)]
+#[path = "matcher_tests.rs"]
+mod matcher_tests;

--- a/crates/bridge/src/filter/matcher_tests.rs
+++ b/crates/bridge/src/filter/matcher_tests.rs
@@ -1,0 +1,313 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use hole_common::config::MatchType;
+
+use super::*;
+use crate::filter::engine::{ConnInfo, L4Proto};
+
+// Helpers =============================================================================================================
+
+fn ip_conn(dst: &str) -> ConnInfo {
+    ConnInfo {
+        dst_ip: dst.parse().unwrap(),
+        dst_port: 443,
+        domain: None,
+        proto: L4Proto::Tcp,
+    }
+}
+
+fn dom_conn(dst: &str, domain: &str) -> ConnInfo {
+    ConnInfo {
+        dst_ip: dst.parse().unwrap(),
+        dst_port: 443,
+        domain: Some(domain.to_string()),
+        proto: L4Proto::Tcp,
+    }
+}
+
+fn compile(addr: &str, kind: MatchType) -> Matcher {
+    Matcher::compile(addr, kind).expect("compile should succeed")
+}
+
+// Compile errors ======================================================================================================
+
+#[skuld::test]
+fn subnet_with_non_cidr_address_fails() {
+    let err = Matcher::compile("example.com", MatchType::Subnet).unwrap_err();
+    assert!(err.0.contains("not a valid CIDR"), "got: {err}");
+}
+
+#[skuld::test]
+fn subnet_with_garbage_fails() {
+    let err = Matcher::compile("not-a-cidr/24", MatchType::Subnet).unwrap_err();
+    assert!(err.0.contains("not a valid CIDR"), "got: {err}");
+}
+
+#[skuld::test]
+fn subnet_canonicalizes_host_bits() {
+    // 192.168.1.1/24 has host bits set; trunc to 192.168.1.0/24.
+    let m = compile("192.168.1.1/24", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("192.168.1.42")));
+    assert!(!m.matches(&ip_conn("192.168.2.42")));
+}
+
+#[skuld::test]
+fn exact_with_empty_address_fails() {
+    let err = Matcher::compile("", MatchType::Exactly).unwrap_err();
+    assert!(err.0.contains("empty"), "got: {err}");
+}
+
+#[skuld::test]
+fn with_subdomains_with_empty_address_fails() {
+    let err = Matcher::compile("", MatchType::WithSubdomains).unwrap_err();
+    assert!(err.0.contains("empty"), "got: {err}");
+}
+
+#[skuld::test]
+fn with_subdomains_with_ip_literal_fails() {
+    let err = Matcher::compile("1.2.3.4", MatchType::WithSubdomains).unwrap_err();
+    assert!(err.0.contains("not valid"), "got: {err}");
+}
+
+#[skuld::test]
+fn wildcard_with_empty_address_fails() {
+    let err = Matcher::compile("", MatchType::Wildcard).unwrap_err();
+    assert!(err.0.contains("empty"), "got: {err}");
+}
+
+#[skuld::test]
+fn exact_with_invalid_domain_fails() {
+    // Whitespace inside the host label is not a valid IDNA name.
+    let err = Matcher::compile("exa mple.com", MatchType::Exactly).unwrap_err();
+    assert!(err.0.contains("valid domain"), "got: {err}");
+}
+
+// ExactDomain matching ================================================================================================
+
+#[skuld::test]
+fn exact_domain_matches_literal() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn exact_domain_does_not_match_subdomain() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(!m.matches(&dom_conn("1.2.3.4", "a.example.com")));
+}
+
+#[skuld::test]
+fn exact_domain_case_insensitive() {
+    let m = compile("Example.COM", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "EXAMPLE.com")));
+}
+
+#[skuld::test]
+fn exact_domain_skips_when_no_domain() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(!m.matches(&ip_conn("1.2.3.4")));
+}
+
+#[skuld::test]
+fn exact_domain_strips_trailing_dot() {
+    let m = compile("example.com.", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn exact_domain_idna_normalizes() {
+    // 例え.com (Japanese) → xn--r8jz45g.com
+    let m = compile("例え.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "xn--r8jz45g.com")));
+}
+
+// SubdomainDomain matching ============================================================================================
+
+#[skuld::test]
+fn with_subdomains_matches_self() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn with_subdomains_matches_subdomain() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "a.example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "b.a.example.com")));
+}
+
+#[skuld::test]
+fn with_subdomains_does_not_match_sibling() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(!m.matches(&dom_conn("1.2.3.4", "notexample.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "example.org")));
+}
+
+#[skuld::test]
+fn with_subdomains_skips_when_no_domain() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(!m.matches(&ip_conn("1.2.3.4")));
+}
+
+#[skuld::test]
+fn with_subdomains_case_insensitive() {
+    let m = compile("Example.COM", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "A.EXAMPLE.com")));
+}
+
+// WildcardDomain matching =============================================================================================
+
+#[skuld::test]
+fn wildcard_star_matches_anything() {
+    let m = compile("*", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "anything.tld")));
+}
+
+#[skuld::test]
+fn wildcard_prefix_glob() {
+    let m = compile("*.example.com", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "a.example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "b.a.example.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "example.com")));
+}
+
+#[skuld::test]
+fn wildcard_question_mark() {
+    let m = compile("a?.example.com", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "ab.example.com")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "az.example.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "abc.example.com")));
+}
+
+#[skuld::test]
+fn wildcard_escapes_regex_metacharacters() {
+    // The literal `.` in `example.com` must not match arbitrary chars.
+    let m = compile("example.com", MatchType::Wildcard);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com")));
+    assert!(!m.matches(&dom_conn("1.2.3.4", "exampleXcom")));
+}
+
+#[skuld::test]
+fn wildcard_skips_when_no_domain() {
+    let m = compile("*.example.com", MatchType::Wildcard);
+    assert!(!m.matches(&ip_conn("1.2.3.4")));
+}
+
+// ExactIp matching ====================================================================================================
+
+#[skuld::test]
+fn exact_ipv4_matches() {
+    let m = compile("1.2.3.4", MatchType::Exactly);
+    assert!(matches!(m, Matcher::ExactIp(_)));
+    assert!(m.matches(&ip_conn("1.2.3.4")));
+    assert!(!m.matches(&ip_conn("1.2.3.5")));
+}
+
+#[skuld::test]
+fn exact_ipv6_matches() {
+    let m = compile("2001:db8::1", MatchType::Exactly);
+    assert!(matches!(m, Matcher::ExactIp(_)));
+    assert!(m.matches(&ip_conn("2001:db8::1")));
+    assert!(!m.matches(&ip_conn("2001:db8::2")));
+}
+
+#[skuld::test]
+fn exact_ip_matches_regardless_of_domain_presence() {
+    let m = compile("1.2.3.4", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "anything.com")));
+}
+
+#[skuld::test]
+fn exact_ipv4_canonicalizes_v4_mapped_v6() {
+    let m = compile("1.2.3.4", MatchType::Exactly);
+    let conn = ConnInfo {
+        dst_ip: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304)),
+        dst_port: 443,
+        domain: None,
+        proto: L4Proto::Tcp,
+    };
+    assert!(m.matches(&conn));
+}
+
+// Subnet matching =====================================================================================================
+
+#[skuld::test]
+fn subnet_ipv4_cidr_matches() {
+    let m = compile("10.0.0.0/8", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("10.0.0.1")));
+    assert!(m.matches(&ip_conn("10.255.255.255")));
+    assert!(!m.matches(&ip_conn("11.0.0.1")));
+}
+
+#[skuld::test]
+fn subnet_ipv6_cidr_matches() {
+    let m = compile("2001:db8::/32", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("2001:db8::1")));
+    assert!(m.matches(&ip_conn("2001:db8:ffff::1")));
+    assert!(!m.matches(&ip_conn("2001:db9::1")));
+}
+
+#[skuld::test]
+fn subnet_zero_prefix_matches_everything_in_family() {
+    let m4 = compile("0.0.0.0/0", MatchType::Subnet);
+    assert!(m4.matches(&ip_conn("1.2.3.4")));
+    assert!(m4.matches(&ip_conn("255.255.255.255")));
+    assert!(!m4.matches(&ip_conn("::1")));
+
+    let m6 = compile("::/0", MatchType::Subnet);
+    assert!(m6.matches(&ip_conn("::1")));
+    assert!(m6.matches(&ip_conn("2001:db8::1")));
+    assert!(!m6.matches(&ip_conn("1.2.3.4")));
+}
+
+#[skuld::test]
+fn subnet_max_prefix_is_single_host() {
+    let m = compile("192.168.1.42/32", MatchType::Subnet);
+    assert!(m.matches(&ip_conn("192.168.1.42")));
+    assert!(!m.matches(&ip_conn("192.168.1.41")));
+    assert!(!m.matches(&ip_conn("192.168.1.43")));
+}
+
+#[skuld::test]
+fn subnet_canonicalizes_v4_mapped_v6() {
+    let m = compile("10.0.0.0/8", MatchType::Subnet);
+    let conn = ConnInfo {
+        dst_ip: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)),
+        dst_port: 443,
+        domain: None,
+        proto: L4Proto::Tcp,
+    };
+    assert!(m.matches(&conn));
+}
+
+#[skuld::test]
+fn subnet_skips_when_family_mismatched() {
+    let m = compile("10.0.0.0/8", MatchType::Subnet);
+    assert!(!m.matches(&ip_conn("::1")));
+}
+
+// Edge cases ==========================================================================================================
+
+#[skuld::test]
+fn loopback_ip_in_zero_subnet() {
+    let m = compile("127.0.0.1", MatchType::Exactly);
+    assert!(m.matches(&ConnInfo {
+        dst_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        dst_port: 80,
+        domain: None,
+        proto: L4Proto::Tcp,
+    }));
+}
+
+#[skuld::test]
+fn ipv6_unspecified_match() {
+    let m = compile("::", MatchType::Exactly);
+    assert!(m.matches(&ConnInfo {
+        dst_ip: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+        dst_port: 80,
+        domain: None,
+        proto: L4Proto::Tcp,
+    }));
+}

--- a/crates/bridge/src/filter/matcher_tests.rs
+++ b/crates/bridge/src/filter/matcher_tests.rs
@@ -311,3 +311,52 @@ fn ipv6_unspecified_match() {
         proto: L4Proto::Tcp,
     }));
 }
+
+// Connection-side canonicalization at match time ======================================================================
+
+#[skuld::test]
+fn matches_uncanonicalized_uppercase_connection_domain() {
+    // Compile-side rule is normalized; the dispatcher hands the
+    // matcher a raw uppercase string from the sniffer/fake DNS.
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "Example.COM")));
+}
+
+#[skuld::test]
+fn matches_uncanonicalized_trailing_dot() {
+    let m = compile("example.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "example.com.")));
+}
+
+#[skuld::test]
+fn matches_uncanonicalized_unicode_domain() {
+    // Connection side carries the U-label form; rule is the A-label.
+    let m = compile("xn--r8jz45g.com", MatchType::Exactly);
+    assert!(m.matches(&dom_conn("1.2.3.4", "例え.com")));
+}
+
+#[skuld::test]
+fn subdomain_match_canonicalizes_connection_domain() {
+    let m = compile("example.com", MatchType::WithSubdomains);
+    assert!(m.matches(&dom_conn("1.2.3.4", "API.Example.COM")));
+    assert!(m.matches(&dom_conn("1.2.3.4", "api.example.com.")));
+}
+
+#[skuld::test]
+fn canonicalize_for_match_handles_garbage_gracefully() {
+    // Pure garbage that idna refuses should fall through to a
+    // best-effort lowercase, never panic.
+    let s = canonicalize_for_match("not a domain at all");
+    assert!(!s.is_empty());
+}
+
+#[skuld::test]
+fn canonicalize_for_match_strips_trailing_dot_and_lowercases() {
+    assert_eq!(canonicalize_for_match("Example.COM."), "example.com");
+}
+
+#[skuld::test]
+fn canonicalize_for_match_empty_returns_empty() {
+    assert_eq!(canonicalize_for_match(""), "");
+    assert_eq!(canonicalize_for_match("."), "");
+}

--- a/crates/bridge/src/filter/rules.rs
+++ b/crates/bridge/src/filter/rules.rs
@@ -41,13 +41,17 @@ impl RuleSet {
         let mut dropped = Vec::new();
 
         for (i, rule) in rules.iter().enumerate() {
+            // The wire schema uses u32 for the index. A user with
+            // > 4 billion rules is implausible, but if they ever
+            // existed we'd silently truncate — clamp explicitly.
+            let index = u32::try_from(i).unwrap_or(u32::MAX);
             match Matcher::compile(&rule.address, rule.matching) {
                 Ok(matcher) => compiled.push(CompiledRule {
                     matcher,
                     action: rule.action,
                 }),
                 Err(err) => dropped.push(InvalidFilter {
-                    index: i as u32,
+                    index,
                     error: err.to_string(),
                 }),
             }

--- a/crates/bridge/src/filter/rules.rs
+++ b/crates/bridge/src/filter/rules.rs
@@ -1,0 +1,73 @@
+//! `RuleSet` — the compiled form of a `Vec<FilterRule>`. Compilation is
+//! infallible: invalid rules are dropped and recorded in `dropped`, the
+//! rest are kept. The bridge surfaces the dropped list via the IPC
+//! status response so the GUI can highlight problem rows.
+
+use hole_common::config::{FilterAction, FilterRule};
+use hole_common::protocol::InvalidFilter;
+
+use super::matcher::Matcher;
+
+/// One compiled rule: matcher + action. Rules are stored in the same
+/// order as the user's input so the reverse-scan in `engine::decide`
+/// preserves gitignore semantics.
+#[derive(Debug, Clone)]
+pub struct CompiledRule {
+    pub matcher: Matcher,
+    pub action: FilterAction,
+}
+
+/// A compiled ruleset, ready for the filter engine. Lifetime: created
+/// once per `start`/`reload` and held by the dispatcher behind an
+/// `ArcSwap` for lock-free reads.
+#[derive(Debug, Clone, Default)]
+pub struct RuleSet {
+    /// Compiled rules in the user's original order.
+    pub rules: Vec<CompiledRule>,
+    /// Cached: true if any rule's matcher is a domain matcher. The
+    /// dispatcher uses this to skip the sniffer/fake-DNS path entirely
+    /// when only IP rules exist.
+    pub has_domain_rules: bool,
+    /// Rules that failed to compile, with their original index in the
+    /// user's input and a human-readable reason.
+    pub dropped: Vec<InvalidFilter>,
+}
+
+impl RuleSet {
+    /// Compile a slice of `FilterRule`s into a `RuleSet`. Never fails:
+    /// invalid rules go into `dropped`, the rest are kept.
+    pub fn from_user_rules(rules: &[FilterRule]) -> Self {
+        let mut compiled = Vec::with_capacity(rules.len());
+        let mut dropped = Vec::new();
+
+        for (i, rule) in rules.iter().enumerate() {
+            match Matcher::compile(&rule.address, rule.matching) {
+                Ok(matcher) => compiled.push(CompiledRule {
+                    matcher,
+                    action: rule.action,
+                }),
+                Err(err) => dropped.push(InvalidFilter {
+                    index: i as u32,
+                    error: err.to_string(),
+                }),
+            }
+        }
+
+        let has_domain_rules = compiled.iter().any(|r| {
+            matches!(
+                r.matcher,
+                Matcher::ExactDomain(_) | Matcher::SubdomainDomain(_) | Matcher::WildcardDomain(_)
+            )
+        });
+
+        Self {
+            rules: compiled,
+            has_domain_rules,
+            dropped,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "rules_tests.rs"]
+mod rules_tests;

--- a/crates/bridge/src/filter/rules_tests.rs
+++ b/crates/bridge/src/filter/rules_tests.rs
@@ -1,0 +1,156 @@
+use hole_common::config::{FilterAction, FilterRule, MatchType};
+
+use super::*;
+use crate::filter::matcher::Matcher;
+
+fn rule(addr: &str, kind: MatchType, action: FilterAction) -> FilterRule {
+    FilterRule {
+        address: addr.to_string(),
+        matching: kind,
+        action,
+    }
+}
+
+// Empty / trivial =====================================================================================================
+
+#[skuld::test]
+fn empty_input_yields_empty_ruleset() {
+    let rs = RuleSet::from_user_rules(&[]);
+    assert!(rs.rules.is_empty());
+    assert!(rs.dropped.is_empty());
+    assert!(!rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn single_valid_rule_compiles() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Proxy)]);
+    assert_eq!(rs.rules.len(), 1);
+    assert!(rs.dropped.is_empty());
+    assert!(rs.has_domain_rules);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactDomain(_)));
+    assert_eq!(rs.rules[0].action, FilterAction::Proxy);
+}
+
+// Order preservation ==================================================================================================
+
+#[skuld::test]
+fn order_preserved_through_compilation() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("a.com", MatchType::Exactly, FilterAction::Block),
+        rule("b.com", MatchType::Exactly, FilterAction::Bypass),
+        rule("c.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(rs.rules.len(), 3);
+    assert_eq!(rs.rules[0].action, FilterAction::Block);
+    assert_eq!(rs.rules[1].action, FilterAction::Bypass);
+    assert_eq!(rs.rules[2].action, FilterAction::Proxy);
+}
+
+// Drop tracking =======================================================================================================
+
+#[skuld::test]
+fn invalid_rule_recorded_in_dropped_with_index() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("good.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("not-a-cidr", MatchType::Subnet, FilterAction::Block),
+        rule("also-good.com", MatchType::Exactly, FilterAction::Bypass),
+    ]);
+    assert_eq!(rs.rules.len(), 2);
+    assert_eq!(rs.dropped.len(), 1);
+    assert_eq!(rs.dropped[0].index, 1);
+    assert!(rs.dropped[0].error.contains("CIDR"), "got: {}", rs.dropped[0].error);
+}
+
+#[skuld::test]
+fn multiple_invalid_rules_each_recorded() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("not-a-cidr", MatchType::Subnet, FilterAction::Block),
+        rule("good.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("", MatchType::Exactly, FilterAction::Bypass),
+        rule("1.2.3.4", MatchType::WithSubdomains, FilterAction::Block),
+    ]);
+    assert_eq!(rs.rules.len(), 1);
+    assert_eq!(rs.dropped.len(), 3);
+    let indices: Vec<u32> = rs.dropped.iter().map(|d| d.index).collect();
+    assert_eq!(indices, vec![0, 2, 3]);
+}
+
+#[skuld::test]
+fn drop_index_matches_user_input_position() {
+    // Indices in `dropped` reference the original positions in the
+    // user's `Vec<FilterRule>`, not positions after dropping.
+    let rs = RuleSet::from_user_rules(&[
+        rule("good1.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("good2.com", MatchType::Exactly, FilterAction::Proxy),
+        rule("not-a-cidr", MatchType::Subnet, FilterAction::Block),
+        rule("good3.com", MatchType::Exactly, FilterAction::Proxy),
+    ]);
+    assert_eq!(rs.rules.len(), 3);
+    assert_eq!(rs.dropped.len(), 1);
+    assert_eq!(rs.dropped[0].index, 2);
+}
+
+// has_domain_rules cache ==============================================================================================
+
+#[skuld::test]
+fn has_domain_rules_false_for_ip_only_set() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass),
+        rule("1.2.3.4", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert!(!rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_for_exact_domain() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert!(rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_for_subdomain() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::WithSubdomains, FilterAction::Block)]);
+    assert!(rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_for_wildcard() {
+    let rs = RuleSet::from_user_rules(&[rule("*.example.com", MatchType::Wildcard, FilterAction::Block)]);
+    assert!(rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_false_for_exactly_with_ip_literal() {
+    // `Exactly` with an IP literal compiles to ExactIp, not ExactDomain.
+    let rs = RuleSet::from_user_rules(&[rule("1.2.3.4", MatchType::Exactly, FilterAction::Block)]);
+    assert!(!rs.has_domain_rules);
+}
+
+#[skuld::test]
+fn has_domain_rules_true_when_mixed() {
+    let rs = RuleSet::from_user_rules(&[
+        rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass),
+        rule("example.com", MatchType::Exactly, FilterAction::Block),
+    ]);
+    assert!(rs.has_domain_rules);
+}
+
+// Compile-time IP-vs-domain dispatch ==================================================================================
+
+#[skuld::test]
+fn exactly_with_ipv4_literal_compiles_to_exact_ip() {
+    let rs = RuleSet::from_user_rules(&[rule("1.2.3.4", MatchType::Exactly, FilterAction::Block)]);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactIp(_)));
+}
+
+#[skuld::test]
+fn exactly_with_ipv6_literal_compiles_to_exact_ip() {
+    let rs = RuleSet::from_user_rules(&[rule("2001:db8::1", MatchType::Exactly, FilterAction::Block)]);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactIp(_)));
+}
+
+#[skuld::test]
+fn exactly_with_domain_compiles_to_exact_domain() {
+    let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
+    assert!(matches!(rs.rules[0].matcher, Matcher::ExactDomain(_)));
+}

--- a/crates/bridge/src/filter/sniffer.rs
+++ b/crates/bridge/src/filter/sniffer.rs
@@ -1,0 +1,32 @@
+//! Connection-level domain sniffer.
+//!
+//! When the dispatcher (Plans 2/3) accepts a new TCP connection and
+//! the fake DNS reverse lookup misses, it peeks the first ~2 KiB of
+//! payload and asks the sniffer to extract a domain. The sniffer
+//! tries TLS SNI first (covers ~all HTTPS/DoH/DoT/SMTPS/IMAPS), then
+//! HTTP Host header (covers plaintext HTTP). If neither matches, the
+//! connection falls through to IP-only matching.
+//!
+//! Both submodules are pure functions over a `&[u8]` buffer. Tests
+//! exercise them with static fixtures of real ClientHellos and HTTP
+//! requests.
+
+pub mod http_host;
+pub mod tls_sni;
+
+/// Peek at the start of a TCP connection's payload and try to extract
+/// a destination domain. Returns `Some(domain)` on success, `None` if
+/// neither sniffer recognizes the bytes.
+pub fn peek(buf: &[u8]) -> Option<String> {
+    if let Some(sni) = tls_sni::extract_sni(buf) {
+        return Some(sni);
+    }
+    if let Some(host) = http_host::extract_host(buf) {
+        return Some(host);
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "sniffer_tests.rs"]
+mod sniffer_tests;

--- a/crates/bridge/src/filter/sniffer/http_host.rs
+++ b/crates/bridge/src/filter/sniffer/http_host.rs
@@ -1,0 +1,128 @@
+//! HTTP/1.x `Host` header extraction.
+//!
+//! Walks the start of a TCP payload looking for an HTTP/1.x request
+//! prefix (a known method token followed by a space). If present,
+//! scans the request headers up to `\r\n\r\n` for a `Host:` header
+//! and returns its value (lowercased, port stripped).
+//!
+//! Hand-rolled — no `httparse` dep needed for this single-purpose use.
+
+/// Set of HTTP/1.x request method tokens we recognize. Anything else
+/// triggers a non-HTTP fall-through.
+const METHODS: &[&[u8]] = &[
+    b"GET ",
+    b"POST ",
+    b"PUT ",
+    b"DELETE ",
+    b"HEAD ",
+    b"OPTIONS ",
+    b"PATCH ",
+    b"TRACE ",
+    b"CONNECT ",
+];
+
+/// Maximum bytes scanned for the `Host:` header. We don't want to
+/// chase pathologically long header sections.
+const MAX_SCAN: usize = 4096;
+
+/// Try to extract the `Host` header value from a buffer that starts
+/// with an HTTP/1.x request. Returns `None` if the buffer is not a
+/// recognizable HTTP request, or if no `Host:` header is found
+/// before the end of the headers section.
+pub fn extract_host(buf: &[u8]) -> Option<String> {
+    if !METHODS.iter().any(|m| buf.starts_with(m)) {
+        return None;
+    }
+
+    let scan_end = std::cmp::min(buf.len(), MAX_SCAN);
+    let scan = &buf[..scan_end];
+
+    // Find the end of the headers section. If we don't find one, we
+    // may still be able to extract the Host header from a partial
+    // buffer — try anyway.
+    let header_end = find_subslice(scan, b"\r\n\r\n").unwrap_or(scan.len());
+    let headers_region = &scan[..header_end];
+
+    let mut cursor = 0;
+    while cursor < headers_region.len() {
+        let line_end = find_subslice(&headers_region[cursor..], b"\r\n")
+            .map(|i| cursor + i)
+            .unwrap_or(headers_region.len());
+        let line = &headers_region[cursor..line_end];
+
+        if let Some(value) = parse_host_line(line) {
+            return Some(value);
+        }
+
+        if line_end >= headers_region.len() {
+            break;
+        }
+        cursor = line_end + 2; // skip the CRLF
+    }
+
+    None
+}
+
+/// If `line` is a `Host:` header line, return the lowercased host
+/// (with any `:port` suffix stripped). Otherwise `None`.
+fn parse_host_line(line: &[u8]) -> Option<String> {
+    // Header name is case-insensitive per RFC 7230. Find the colon.
+    let colon = line.iter().position(|&b| b == b':')?;
+    let name = &line[..colon];
+    if !name.eq_ignore_ascii_case(b"host") {
+        return None;
+    }
+
+    let mut value = &line[colon + 1..];
+    // Trim leading whitespace.
+    while let Some((&first, rest)) = value.split_first() {
+        if first == b' ' || first == b'\t' {
+            value = rest;
+        } else {
+            break;
+        }
+    }
+    // Trim trailing whitespace.
+    while let Some((&last, rest)) = value.split_last() {
+        if last == b' ' || last == b'\t' || last == b'\r' {
+            value = rest;
+        } else {
+            break;
+        }
+    }
+
+    // Strip optional `:port` suffix. The host part can also be a
+    // bracketed IPv6 literal like `[2001:db8::1]:443`; in that case
+    // the port colon is the one *after* the closing bracket.
+    let host_bytes = if value.first() == Some(&b'[') {
+        match value.iter().position(|&b| b == b']') {
+            Some(close) => &value[..=close],
+            None => return None,
+        }
+    } else {
+        match value.iter().position(|&b| b == b':') {
+            Some(p) => &value[..p],
+            None => value,
+        }
+    };
+
+    if host_bytes.is_empty() {
+        return None;
+    }
+
+    let s = std::str::from_utf8(host_bytes).ok()?.to_ascii_lowercase();
+    Some(s)
+}
+
+/// Find the first occurrence of `needle` in `haystack`. Returns the
+/// starting index, or `None` if not found.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+#[cfg(test)]
+#[path = "http_host_tests.rs"]
+mod http_host_tests;

--- a/crates/bridge/src/filter/sniffer/http_host.rs
+++ b/crates/bridge/src/filter/sniffer/http_host.rs
@@ -92,12 +92,14 @@ fn parse_host_line(line: &[u8]) -> Option<String> {
     }
 
     // Strip optional `:port` suffix. The host part can also be a
-    // bracketed IPv6 literal like `[2001:db8::1]:443`; in that case
-    // the port colon is the one *after* the closing bracket.
+    // bracketed IPv6 literal like `[2001:db8::1]:443`; the brackets
+    // themselves are RFC 7230 framing and not part of the host
+    // identifier — they must be stripped from the returned value so
+    // it parses as an `IpAddr` downstream.
     let host_bytes = if value.first() == Some(&b'[') {
         match value.iter().position(|&b| b == b']') {
-            Some(close) => &value[..=close],
-            None => return None,
+            Some(close) if close >= 2 => &value[1..close],
+            _ => return None,
         }
     } else {
         match value.iter().position(|&b| b == b':') {

--- a/crates/bridge/src/filter/sniffer/http_host_tests.rs
+++ b/crates/bridge/src/filter/sniffer/http_host_tests.rs
@@ -44,13 +44,15 @@ fn extracts_host_strips_port() {
 #[skuld::test]
 fn extracts_host_with_ipv6_literal() {
     let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]:443\r\n\r\n";
-    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+    // RFC 7230 brackets are framing only; the returned host should
+    // be parseable as an IpAddr.
+    assert_eq!(extract_host(req).as_deref(), Some("2001:db8::1"));
 }
 
 #[skuld::test]
 fn extracts_host_with_ipv6_literal_no_port() {
     let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]\r\n\r\n";
-    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+    assert_eq!(extract_host(req).as_deref(), Some("2001:db8::1"));
 }
 
 #[skuld::test]

--- a/crates/bridge/src/filter/sniffer/http_host_tests.rs
+++ b/crates/bridge/src/filter/sniffer/http_host_tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+// Positive cases ======================================================================================================
+
+#[skuld::test]
+fn extracts_host_from_get_request() {
+    let req = b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl/8.0\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_from_post_request() {
+    let req = b"POST /api HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 0\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("api.example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_from_connect_request() {
+    let req = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_lowercase_normalized() {
+    let req = b"GET / HTTP/1.1\r\nHost: Example.COM\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_header_name_case_insensitive() {
+    let req = b"GET / HTTP/1.1\r\nHOST: example.com\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+
+    let req2 = b"GET / HTTP/1.1\r\nhost: example.com\r\n\r\n";
+    assert_eq!(extract_host(req2).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_strips_port() {
+    let req = b"GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_with_ipv6_literal() {
+    let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]:443\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+}
+
+#[skuld::test]
+fn extracts_host_with_ipv6_literal_no_port() {
+    let req = b"GET / HTTP/1.1\r\nHost: [2001:db8::1]\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("[2001:db8::1]"));
+}
+
+#[skuld::test]
+fn extracts_host_skips_other_headers_first() {
+    let req = b"GET / HTTP/1.1\r\nUser-Agent: curl/8.0\r\nAccept: */*\r\nHost: example.com\r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_trims_extra_whitespace() {
+    let req = b"GET / HTTP/1.1\r\nHost:    example.com   \r\n\r\n";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_host_from_partial_buffer_without_terminator() {
+    // No `\r\n\r\n` yet, but the Host header is complete on its own line.
+    let req = b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: still-coming";
+    assert_eq!(extract_host(req).as_deref(), Some("example.com"));
+}
+
+// Negative cases ======================================================================================================
+
+#[skuld::test]
+fn returns_none_for_empty_buffer() {
+    assert_eq!(extract_host(b""), None);
+}
+
+#[skuld::test]
+fn returns_none_for_non_http_payload() {
+    let payload = b"\x16\x03\x01\x00\x05binary";
+    assert_eq!(extract_host(payload), None);
+}
+
+#[skuld::test]
+fn returns_none_for_http_request_without_host() {
+    let req = b"GET / HTTP/1.1\r\nUser-Agent: curl/8.0\r\n\r\n";
+    assert_eq!(extract_host(req), None);
+}
+
+#[skuld::test]
+fn returns_none_for_method_without_trailing_space() {
+    // "GETSOMETHING /..." would not match a method token (need the space).
+    let req = b"GETSOMETHING / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    assert_eq!(extract_host(req), None);
+}
+
+#[skuld::test]
+fn returns_none_for_empty_host_value() {
+    let req = b"GET / HTTP/1.1\r\nHost: \r\n\r\n";
+    assert_eq!(extract_host(req), None);
+}
+
+#[skuld::test]
+fn returns_none_for_garbage_bytes() {
+    let payload = [0xff_u8; 64];
+    assert_eq!(extract_host(&payload), None);
+}

--- a/crates/bridge/src/filter/sniffer/tls_sni.rs
+++ b/crates/bridge/src/filter/sniffer/tls_sni.rs
@@ -1,0 +1,51 @@
+//! TLS Server Name Indication (SNI) extraction.
+//!
+//! Walks the TLS plaintext record at the head of the buffer, finds
+//! the ClientHello handshake message, parses its extensions, and
+//! returns the first hostname from the `server_name` extension.
+//!
+//! Limitations (deferred to v2):
+//! - Fragmented ClientHellos that span multiple TLS records are
+//!   reported as `None`. The pre-encryption ClientHello is normally
+//!   small enough to fit in a single record.
+//! - Encrypted Client Hello (ECH / draft-ietf-tls-esni) is reported
+//!   as `None`.
+
+use tls_parser::{parse_tls_extensions, parse_tls_plaintext, SNIType, TlsExtension, TlsMessage, TlsMessageHandshake};
+
+/// Try to extract the SNI hostname from the start of a TCP payload.
+/// Returns `None` if the buffer doesn't begin with a parseable TLS
+/// ClientHello, or if no SNI extension is present.
+pub fn extract_sni(buf: &[u8]) -> Option<String> {
+    let (_, plaintext) = parse_tls_plaintext(buf).ok()?;
+    for msg in plaintext.msg {
+        if let TlsMessage::Handshake(TlsMessageHandshake::ClientHello(ch)) = msg {
+            return extract_sni_from_extensions(ch.ext?);
+        }
+    }
+    None
+}
+
+fn extract_sni_from_extensions(ext_bytes: &[u8]) -> Option<String> {
+    let (_, extensions) = parse_tls_extensions(ext_bytes).ok()?;
+    for ext in extensions {
+        if let TlsExtension::SNI(names) = ext {
+            for (sni_type, name_bytes) in names {
+                // SNIType::HostName is the only currently-defined type
+                // (RFC 6066). Skip anything else.
+                if sni_type == SNIType::HostName {
+                    if let Ok(s) = std::str::from_utf8(name_bytes) {
+                        if !s.is_empty() {
+                            return Some(s.to_ascii_lowercase());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "tls_sni_tests.rs"]
+mod tls_sni_tests;

--- a/crates/bridge/src/filter/sniffer/tls_sni_tests.rs
+++ b/crates/bridge/src/filter/sniffer/tls_sni_tests.rs
@@ -1,0 +1,170 @@
+// The TLS record builders below are deliberately written as
+// `Vec::new()` followed by `push`/`extend_from_slice` so each header
+// field is on its own line and matches the wire format step by step.
+// `vec![...]` would obscure the structure for no real benefit.
+#![allow(clippy::vec_init_then_push)]
+
+use super::*;
+
+// ClientHello builder =================================================================================================
+
+/// Build a minimal valid TLS 1.2 ClientHello record carrying a single
+/// SNI hostname. The structure follows RFC 5246 §7.4.1.2 plus
+/// RFC 6066 §3 for the SNI extension. This is just enough to satisfy
+/// `tls-parser`'s `parse_tls_plaintext` and reach the SNI extraction
+/// path.
+fn build_client_hello(sni: &str) -> Vec<u8> {
+    let sni_bytes = sni.as_bytes();
+    let sni_len = sni_bytes.len();
+
+    // SNI extension data (server_name_list).
+    let mut sni_ext_data = Vec::new();
+    let server_name_list_len = (1 + 2 + sni_len) as u16;
+    sni_ext_data.extend_from_slice(&server_name_list_len.to_be_bytes());
+    sni_ext_data.push(0x00); // NameType.HostName
+    sni_ext_data.extend_from_slice(&(sni_len as u16).to_be_bytes());
+    sni_ext_data.extend_from_slice(sni_bytes);
+
+    // SNI extension wrapper (type + length + data).
+    let mut sni_ext = Vec::new();
+    sni_ext.extend_from_slice(&0x0000_u16.to_be_bytes()); // ExtensionType.server_name
+    sni_ext.extend_from_slice(&(sni_ext_data.len() as u16).to_be_bytes());
+    sni_ext.extend_from_slice(&sni_ext_data);
+
+    // Extensions block (just the SNI extension).
+    let mut extensions = Vec::new();
+    extensions.extend_from_slice(&(sni_ext.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(&sni_ext);
+
+    // ClientHello body.
+    let mut client_hello = Vec::new();
+    client_hello.extend_from_slice(&[0x03, 0x03]); // ProtocolVersion: TLS 1.2
+    client_hello.extend_from_slice(&[0u8; 32]); // Random
+    client_hello.push(0x00); // session_id length = 0
+    client_hello.extend_from_slice(&0x0002_u16.to_be_bytes()); // cipher_suites length
+    client_hello.extend_from_slice(&[0x00, 0x35]); // TLS_RSA_WITH_AES_256_CBC_SHA
+    client_hello.push(0x01); // compression_methods length
+    client_hello.push(0x00); // null compression
+    client_hello.extend_from_slice(&extensions);
+
+    // Handshake header (msg_type + 24-bit length).
+    let body_len = client_hello.len();
+    let mut handshake = Vec::new();
+    handshake.push(0x01); // ClientHello
+    handshake.push(((body_len >> 16) & 0xff) as u8);
+    handshake.push(((body_len >> 8) & 0xff) as u8);
+    handshake.push((body_len & 0xff) as u8);
+    handshake.extend_from_slice(&client_hello);
+
+    // TLS plaintext record header.
+    let record_len = handshake.len();
+    let mut record = Vec::new();
+    record.push(0x16); // ContentType.handshake
+    record.push(0x03); // legacy_record_version major
+    record.push(0x01); // legacy_record_version minor (1.0 by convention)
+    record.push(((record_len >> 8) & 0xff) as u8);
+    record.push((record_len & 0xff) as u8);
+    record.extend_from_slice(&handshake);
+
+    record
+}
+
+/// Build a ClientHello record with no extensions. Used to test the
+/// "no SNI present" case.
+fn build_client_hello_no_extensions() -> Vec<u8> {
+    let mut client_hello = Vec::new();
+    client_hello.extend_from_slice(&[0x03, 0x03]);
+    client_hello.extend_from_slice(&[0u8; 32]);
+    client_hello.push(0x00);
+    client_hello.extend_from_slice(&0x0002_u16.to_be_bytes());
+    client_hello.extend_from_slice(&[0x00, 0x35]);
+    client_hello.push(0x01);
+    client_hello.push(0x00);
+    // No extensions block at all (TLS 1.2 allows the field to be omitted).
+
+    let body_len = client_hello.len();
+    let mut handshake = Vec::new();
+    handshake.push(0x01);
+    handshake.push(((body_len >> 16) & 0xff) as u8);
+    handshake.push(((body_len >> 8) & 0xff) as u8);
+    handshake.push((body_len & 0xff) as u8);
+    handshake.extend_from_slice(&client_hello);
+
+    let record_len = handshake.len();
+    let mut record = Vec::new();
+    record.push(0x16);
+    record.push(0x03);
+    record.push(0x01);
+    record.push(((record_len >> 8) & 0xff) as u8);
+    record.push((record_len & 0xff) as u8);
+    record.extend_from_slice(&handshake);
+
+    record
+}
+
+// Positive cases ======================================================================================================
+
+#[skuld::test]
+fn extracts_sni_from_minimal_client_hello() {
+    let bytes = build_client_hello("example.com");
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_sni_lowercases_uppercase_hostname() {
+    let bytes = build_client_hello("Example.COM");
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn extracts_sni_with_subdomain() {
+    let bytes = build_client_hello("api.v2.example.com");
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("api.v2.example.com"));
+}
+
+#[skuld::test]
+fn extracts_sni_with_trailing_extra_bytes() {
+    // `parse_tls_plaintext` consumes one record; trailing bytes are
+    // returned as the unconsumed remainder. We don't care.
+    let mut bytes = build_client_hello("trailing.test");
+    bytes.extend_from_slice(&[0xab, 0xcd, 0xef]);
+    assert_eq!(extract_sni(&bytes).as_deref(), Some("trailing.test"));
+}
+
+// Negative cases ======================================================================================================
+
+#[skuld::test]
+fn returns_none_for_empty_buffer() {
+    assert_eq!(extract_sni(b""), None);
+}
+
+#[skuld::test]
+fn returns_none_for_garbage_bytes() {
+    let bytes = [0xff_u8; 64];
+    assert_eq!(extract_sni(&bytes), None);
+}
+
+#[skuld::test]
+fn returns_none_for_non_handshake_record() {
+    // Application data record (type 0x17) — should not match.
+    let payload = [0x17, 0x03, 0x03, 0x00, 0x05, 1, 2, 3, 4, 5];
+    assert_eq!(extract_sni(&payload), None);
+}
+
+#[skuld::test]
+fn returns_none_for_truncated_record() {
+    let bytes = build_client_hello("example.com");
+    let truncated = &bytes[..bytes.len() / 2];
+    assert_eq!(extract_sni(truncated), None);
+}
+
+#[skuld::test]
+fn returns_none_when_no_extensions() {
+    let bytes = build_client_hello_no_extensions();
+    assert_eq!(extract_sni(&bytes), None);
+}
+
+#[skuld::test]
+fn returns_none_for_one_byte_buffer() {
+    assert_eq!(extract_sni(&[0x16]), None);
+}

--- a/crates/bridge/src/filter/sniffer_tests.rs
+++ b/crates/bridge/src/filter/sniffer_tests.rs
@@ -1,0 +1,88 @@
+//! Cross-sniffer tests: verify the entry point dispatches to the
+//! right sub-sniffer and returns the first match. Per-sniffer
+//! coverage lives in `sniffer/{tls_sni,http_host}_tests.rs`.
+
+// The ClientHello builder below is deliberately step-by-step (see
+// the matching note in `tls_sni_tests.rs`).
+#![allow(clippy::vec_init_then_push)]
+
+use super::*;
+
+#[skuld::test]
+fn peek_returns_none_for_empty_buffer() {
+    assert_eq!(peek(b""), None);
+}
+
+#[skuld::test]
+fn peek_returns_none_for_garbage() {
+    let bytes = [0xff_u8; 64];
+    assert_eq!(peek(&bytes), None);
+}
+
+#[skuld::test]
+fn peek_extracts_http_host() {
+    let req = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    assert_eq!(peek(req).as_deref(), Some("example.com"));
+}
+
+#[skuld::test]
+fn peek_extracts_tls_sni() {
+    // Minimal TLS 1.2 ClientHello with SNI = "tls.example.com",
+    // built using the same approach as `tls_sni_tests::build_client_hello`.
+    let sni = "tls.example.com";
+    let bytes = build_client_hello(sni);
+    assert_eq!(peek(&bytes).as_deref(), Some(sni));
+}
+
+// Local copy of the ClientHello builder so this test file is
+// self-contained (the one in `tls_sni_tests.rs` is private to that
+// test module).
+fn build_client_hello(sni: &str) -> Vec<u8> {
+    let sni_bytes = sni.as_bytes();
+    let sni_len = sni_bytes.len();
+
+    let mut sni_ext_data = Vec::new();
+    let server_name_list_len = (1 + 2 + sni_len) as u16;
+    sni_ext_data.extend_from_slice(&server_name_list_len.to_be_bytes());
+    sni_ext_data.push(0x00);
+    sni_ext_data.extend_from_slice(&(sni_len as u16).to_be_bytes());
+    sni_ext_data.extend_from_slice(sni_bytes);
+
+    let mut sni_ext = Vec::new();
+    sni_ext.extend_from_slice(&0x0000_u16.to_be_bytes());
+    sni_ext.extend_from_slice(&(sni_ext_data.len() as u16).to_be_bytes());
+    sni_ext.extend_from_slice(&sni_ext_data);
+
+    let mut extensions = Vec::new();
+    extensions.extend_from_slice(&(sni_ext.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(&sni_ext);
+
+    let mut client_hello = Vec::new();
+    client_hello.extend_from_slice(&[0x03, 0x03]);
+    client_hello.extend_from_slice(&[0u8; 32]);
+    client_hello.push(0x00);
+    client_hello.extend_from_slice(&0x0002_u16.to_be_bytes());
+    client_hello.extend_from_slice(&[0x00, 0x35]);
+    client_hello.push(0x01);
+    client_hello.push(0x00);
+    client_hello.extend_from_slice(&extensions);
+
+    let body_len = client_hello.len();
+    let mut handshake = Vec::new();
+    handshake.push(0x01);
+    handshake.push(((body_len >> 16) & 0xff) as u8);
+    handshake.push(((body_len >> 8) & 0xff) as u8);
+    handshake.push((body_len & 0xff) as u8);
+    handshake.extend_from_slice(&client_hello);
+
+    let record_len = handshake.len();
+    let mut record = Vec::new();
+    record.push(0x16);
+    record.push(0x03);
+    record.push(0x01);
+    record.push(((record_len >> 8) & 0xff) as u8);
+    record.push((record_len & 0xff) as u8);
+    record.extend_from_slice(&handshake);
+
+    record
+}

--- a/crates/bridge/src/filter_tests.rs
+++ b/crates/bridge/src/filter_tests.rs
@@ -1,0 +1,25 @@
+//! Cross-module smoke tests for the filter engine. Per-module unit tests
+//! live in `filter/{rules,matcher,engine}_tests.rs`.
+
+use hole_common::config::{FilterAction, FilterRule, MatchType};
+
+use super::{decide, ConnInfo, L4Proto, RuleSet};
+
+#[skuld::test]
+fn re_exports_decide_constructable_from_user_rules() {
+    let user_rules = vec![FilterRule {
+        address: "example.com".into(),
+        matching: MatchType::Exactly,
+        action: FilterAction::Block,
+    }];
+
+    let rs = RuleSet::from_user_rules(&user_rules);
+    let conn = ConnInfo {
+        dst_ip: "1.2.3.4".parse().unwrap(),
+        dst_port: 443,
+        domain: Some("example.com".into()),
+        proto: L4Proto::Tcp,
+    };
+
+    assert_eq!(decide(&rs, &conn), FilterAction::Block);
+}

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -165,6 +165,11 @@ async fn handle_status<B: ProxyBackend + 'static>(State(state): State<Arc<IpcSta
         running: pm.state() == ProxyState::Running,
         uptime_secs: pm.uptime_secs(),
         error: pm.last_error().map(|s| s.to_string()),
+        // Filter-engine fields are stubbed in Plan 1 — Plans 2-4 wire them
+        // from the dispatcher's RuleSet, plugin detection, and gateway probe.
+        invalid_filters: Vec::new(),
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
     })
 }
 
@@ -229,6 +234,9 @@ async fn handle_metrics<B: ProxyBackend + 'static>(State(state): State<Arc<IpcSt
         speed_in_bps: 0,
         speed_out_bps: 0,
         uptime_secs: pm.uptime_secs(),
+        // Filter-engine metrics are stubbed in Plan 1 — Plan 4 wires them
+        // from the dispatcher's atomic counters.
+        filter: None,
     })
 }
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -116,6 +116,7 @@ fn sample_config() -> ProxyConfig {
             validation: None,
         },
         local_port: 4073,
+        filters: Vec::new(),
     }
 }
 
@@ -236,6 +237,9 @@ fn status_when_not_running_returns_false() {
                 running: false,
                 uptime_secs: 0,
                 error: None,
+                invalid_filters: Vec::new(),
+                udp_proxy_available: true,
+                ipv6_bypass_available: true,
             }
         );
         drop(client);

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod foreground;
 pub mod gateway;
 pub mod group;

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -14,8 +14,22 @@ pub mod socket;
 #[cfg(target_os = "windows")]
 pub mod wintun;
 
+// Diagnostic test-only module for issue #165 — Windows CI loopback
+// timeout regression. This module is throwaway and will be removed in
+// the same PR that ships the root-cause fix.
+#[cfg(test)]
+mod server_test_diag;
+
+// Test harness: initialize a tracing subscriber so `RUST_LOG` works
+// during `cargo test`. Originally added during the investigation of
+// issue #165 to surface `shadowsocks_service::*` listener logs; kept
+// as permanent fixture hardening.
 #[cfg(test)]
 fn main() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "warn".into()))
+        .with_writer(std::io::stderr)
+        .try_init();
     skuld::run_all();
 }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -121,6 +121,7 @@ fn test_config() -> ProxyConfig {
             validation: None,
         },
         local_port: 1080,
+        filters: Vec::new(),
     }
 }
 

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -22,6 +22,7 @@ fn sample_config() -> ProxyConfig {
     ProxyConfig {
         server: sample_server(),
         local_port: 4073,
+        filters: Vec::new(),
     }
 }
 

--- a/crates/bridge/src/server_test_diag.rs
+++ b/crates/bridge/src/server_test_diag.rs
@@ -1,0 +1,361 @@
+//! Diagnostic test-only module for issue #165 — Windows CI loopback
+//! timeout regression. **All code in this module is throwaway** and is
+//! scheduled for deletion in the same PR that ships the root-cause fix.
+//!
+//! The investigation plan lives in
+//! `~/.claude/plans/luminous-honking-cascade.md` (local-only). In short:
+//! PR #163 (filter engine Plan 1) triggers 9 pre-existing Windows CI
+//! test failures in `server_test_tests.rs` with `WSAETIMEDOUT` on raw
+//! `TcpStream::connect` to a port `SsServerBuilder::build()` just
+//! returned. Main CI passes the same tests on the same runner image.
+//!
+//! This module contains three diagnostic experiments that discriminate
+//! between kernel-side causes (WFP/Defender filtering by PID or image
+//! hash) and user-space causes (`Server::run` spawn path, tokio-on-
+//! Windows IOCP race). It also contains a diagnostic helper for
+//! capturing Windows-side state cheaply at checkpoints and more
+//! aggressively on test failure.
+//!
+//! All captures are bounded to avoid observer effects: happy-path
+//! logging is in-process only, expensive PowerShell captures fire only
+//! on test failure.
+
+use shadowsocks::config::{Mode, ServerConfig};
+use shadowsocks::crypto::CipherKind;
+use shadowsocks_service::server::ServerBuilder as SsServerBuilder;
+use std::time::{Duration, Instant};
+
+// Test constants ======================================================================================================
+
+const TEST_METHOD: CipherKind = CipherKind::AES_256_GCM;
+const TEST_PASSWORD: &str = "test-password-1234";
+
+/// Fresh multi-thread runtime per test. Mirrors the pattern in
+/// `server_test_tests::rt()` so this module doesn't accidentally share
+/// a runtime across tests.
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().unwrap()
+}
+
+// Windows diagnostics helpers =========================================================================================
+
+#[cfg(target_os = "windows")]
+mod diag {
+    //! In-process and spawned-PowerShell diagnostic helpers.
+    //!
+    //! - `log_checkpoint` is cheap (in-process only) and safe to call
+    //!   on the happy path.
+    //! - `log_failure_snapshot` spawns PowerShell and is only safe to
+    //!   call on the failure path (when a test is about to panic).
+
+    use std::time::Instant;
+
+    pub fn log_checkpoint(context: &str, bound_port: Option<u16>) {
+        let handles = process_handle_count();
+        let port_info = match bound_port {
+            Some(port) => format!(" port={port}"),
+            None => String::new(),
+        };
+        eprintln!("[diag:{context}] handles={handles}{port_info}");
+    }
+
+    pub fn log_failure_snapshot(context: &str, bound_port: Option<u16>) {
+        let snapshot_start = Instant::now();
+        let handles = process_handle_count();
+
+        let port_filter = bound_port
+            .map(|p| format!("| Where-Object LocalPort -eq {p}"))
+            .unwrap_or_default();
+
+        let ps_script = format!(
+            r#"
+            $ErrorActionPreference = 'Stop'
+            $tcp = Get-NetTCPConnection
+            $port_rows = @($tcp {port_filter})
+            $snapshot = [PSCustomObject]@{{
+                tcp_total     = $tcp.Count
+                tcp_listen    = ($tcp | Where-Object State -eq 'Listen').Count
+                tcp_estab     = ($tcp | Where-Object State -eq 'Established').Count
+                tcp_time_wait = ($tcp | Where-Object State -eq 'TimeWait').Count
+                port_rows     = $port_rows.Count
+                port_states   = ($port_rows | ForEach-Object {{ $_.State }}) -join ','
+                defender_rtp  = try {{ (Get-MpComputerStatus).RealTimeProtectionEnabled }} catch {{ 'unknown' }}
+                fw_profiles   = (Get-NetFirewallProfile | ForEach-Object {{ $_.Enabled }}) -join ','
+                dyn_tcp       = (Get-NetTCPSetting | Where-Object SettingName -eq 'InternetCustom' | ForEach-Object {{ $_.DynamicPortRangeStartPort }})
+            }}
+            $snapshot | ConvertTo-Json -Compress
+            "#
+        );
+
+        let output = std::process::Command::new("powershell.exe")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &ps_script])
+            .output()
+            .expect(
+                "failed to spawn powershell.exe for failure snapshot; \
+                 diagnostic instrumentation is broken",
+            );
+
+        if !output.status.success() {
+            eprintln!(
+                "[diag:{context}] WARNING: powershell exited {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            );
+            return;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!(
+            "[diag:{context}] FAILURE snapshot (took {:?}, handles={handles}) {}",
+            snapshot_start.elapsed(),
+            stdout.trim(),
+        );
+    }
+
+    fn process_handle_count() -> u32 {
+        use windows::Win32::System::Threading::{GetCurrentProcess, GetProcessHandleCount};
+        let mut count = 0u32;
+        // SAFETY: GetCurrentProcess returns a pseudo-handle that's always
+        // valid. GetProcessHandleCount writes to a valid u32 pointer we
+        // own. Both calls are infallible under well-formed arguments; the
+        // Result represents a BOOL → error mapping from `windows`.
+        let result = unsafe { GetProcessHandleCount(GetCurrentProcess(), &mut count) };
+        result.expect("GetProcessHandleCount failed; diagnostic instrumentation is broken");
+        count
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod diag {
+    pub fn log_checkpoint(_context: &str, _bound_port: Option<u16>) {}
+    pub fn log_failure_snapshot(_context: &str, _bound_port: Option<u16>) {}
+}
+
+// Primary experiment: bind and hold ===================================================================================
+
+/// Primary experiment (per investigation plan). Build the SS server and
+/// **keep it alive** (never call `run()`, never drop it), then attempt a
+/// `TcpStream::connect` to the address that `build().await` returned.
+/// This directly tests whether the bound-but-not-accepting listener is
+/// reachable from within the same process.
+///
+/// Expected outcomes are enumerated in the result-to-diagnosis matrix
+/// in the investigation plan. The most important distinction is:
+/// - `Ok(_)` fast → kernel listener is reachable; bug is in `run()`
+///   spawn path or tokio scheduling.
+/// - `Err(TimedOut)` / WSAETIMEDOUT → kernel-side: bound listener exists
+///   but SYNs aren't reaching it. Look at WFP/Defender filtering.
+#[skuld::test]
+fn diag_bind_and_hold() {
+    rt().block_on(async {
+        let mut svr_cfg = ServerConfig::new(("127.0.0.1", 0u16), TEST_PASSWORD.to_string(), TEST_METHOD).unwrap();
+        svr_cfg.set_mode(Mode::TcpOnly);
+
+        let build_start = Instant::now();
+        let server = SsServerBuilder::new(svr_cfg).build().await.unwrap();
+        let build_elapsed = build_start.elapsed();
+
+        let svr_addr = server
+            .tcp_server()
+            .expect("TCP mode is enabled, tcp_server should exist")
+            .local_addr()
+            .unwrap();
+
+        debug_assert!(svr_addr.ip().is_loopback(), "bound addr not loopback: {svr_addr}");
+        debug_assert_ne!(svr_addr.port(), 0, "ephemeral port not assigned");
+
+        diag::log_checkpoint("bind_and_hold:post-build", Some(svr_addr.port()));
+        eprintln!(
+            "[diag:bind_and_hold] built in {build_elapsed:?} at {svr_addr}; \
+             server held alive, run() NOT called"
+        );
+
+        // NOTE: `server` is intentionally NOT dropped or moved here. It
+        // remains alive on the stack for the duration of the connect
+        // attempt. Because we never called `server.run()`, no accept
+        // loop task exists — the kernel holds SYNs in the listen(1024)
+        // backlog; Windows AFD completes the 3WHS from the backlog
+        // without user-space accept.
+        //
+        // Expected on a healthy system: connect succeeds in < 1 ms.
+
+        let connect_start = Instant::now();
+        let result = tokio::time::timeout(Duration::from_secs(15), tokio::net::TcpStream::connect(svr_addr)).await;
+        let elapsed = connect_start.elapsed();
+
+        match result {
+            Ok(Ok(_stream)) => {
+                eprintln!("[diag:bind_and_hold] connect OK in {elapsed:?}");
+            }
+            Ok(Err(io_err)) => {
+                eprintln!(
+                    "[diag:bind_and_hold] connect failed after {elapsed:?}: \
+                     kind={:?} raw_os_error={:?} msg={io_err}",
+                    io_err.kind(),
+                    io_err.raw_os_error()
+                );
+                diag::log_failure_snapshot("bind_and_hold:connect-failed", Some(svr_addr.port()));
+                panic!("diag_bind_and_hold failed: see diagnostics above");
+            }
+            Err(_elapsed) => {
+                eprintln!("[diag:bind_and_hold] connect did not return within 15s");
+                diag::log_failure_snapshot("bind_and_hold:connect-hung", Some(svr_addr.port()));
+                panic!("diag_bind_and_hold hung: see diagnostics above");
+            }
+        }
+
+        // Explicit drop after the connect completes so the log timestamp
+        // order is clear. Without this, `server` would drop at the end
+        // of the async block, which is fine but less obvious.
+        drop(server);
+    });
+}
+
+// Supporting experiment S1: external probe ============================================================================
+
+/// Spawn a PowerShell child process that probes the SS server address
+/// from outside this process. Timestamp-correlated to prove the
+/// listener was alive at the moment of the probe.
+///
+/// If the external probe succeeds while the in-process `diag_bind_and_hold`
+/// fails → PID/image-hash firewall filter (H10/H11 confirmed).
+/// If the external probe also fails → kernel-wide drop on this port.
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn diag_external_probe() {
+    rt().block_on(async {
+        let mut svr_cfg = ServerConfig::new(("127.0.0.1", 0u16), TEST_PASSWORD.to_string(), TEST_METHOD).unwrap();
+        svr_cfg.set_mode(Mode::TcpOnly);
+        let server = SsServerBuilder::new(svr_cfg).build().await.unwrap();
+        let svr_addr = server
+            .tcp_server()
+            .expect("TCP mode is enabled, tcp_server should exist")
+            .local_addr()
+            .unwrap();
+
+        let t0 = Instant::now();
+        eprintln!("[diag:external_probe] t0=0ms bound at {svr_addr}");
+
+        let t1_offset = t0.elapsed();
+        let output = std::process::Command::new("powershell.exe")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &format!(
+                    r#"
+                    $ErrorActionPreference = 'Stop'
+                    try {{
+                      $r = Test-NetConnection -ComputerName 127.0.0.1 -Port {} -WarningAction SilentlyContinue
+                      'ok=' + $r.TcpTestSucceeded + ' remote_addr=' + $r.RemoteAddress
+                    }} catch {{
+                      'err=' + $_.Exception.Message
+                    }}
+                    "#,
+                    svr_addr.port()
+                ),
+            ])
+            .output()
+            .expect("failed to spawn powershell.exe for external probe");
+        let t2_offset = t0.elapsed();
+
+        eprintln!(
+            "[diag:external_probe] t1={:?} t2={:?} dur={:?} \
+             status={} stdout={:?} stderr={:?}",
+            t1_offset,
+            t2_offset,
+            t2_offset - t1_offset,
+            output.status,
+            String::from_utf8_lossy(&output.stdout).trim(),
+            String::from_utf8_lossy(&output.stderr).trim(),
+        );
+
+        // Additionally run the in-process connect for direct comparison
+        // — this is the same experiment as `diag_bind_and_hold` but
+        // immediately after the external probe so the timestamp order
+        // is `external then internal`.
+        let t3 = Instant::now();
+        let result = tokio::time::timeout(Duration::from_secs(15), tokio::net::TcpStream::connect(svr_addr)).await;
+        eprintln!(
+            "[diag:external_probe] in-process connect after {:?}: {:?}",
+            t3.elapsed(),
+            match &result {
+                Ok(Ok(_)) => "Ok(stream)".to_string(),
+                Ok(Err(e)) => format!("Err(kind={:?} raw_os_error={:?})", e.kind(), e.raw_os_error()),
+                Err(_) => "timeout".to_string(),
+            }
+        );
+
+        if !matches!(result, Ok(Ok(_))) {
+            diag::log_failure_snapshot("external_probe:internal-failed", Some(svr_addr.port()));
+        }
+
+        drop(server);
+    });
+}
+
+// Supporting experiment S2: dual-socket parity ========================================================================
+
+/// Bind a bare `tokio::net::TcpListener` alongside an `SsServerBuilder`
+/// listener in the same test process, then connect to each.
+///
+/// If the bare listener passes and the SS listener fails → the bug is
+/// *specific to SS's bind path* (socket2 options, dual-stack, accept
+/// opts). If both fail → environmental.
+#[skuld::test]
+fn diag_dual_socket_parity() {
+    rt().block_on(async {
+        // --- bare tokio listener path ---
+        let bare = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bare_addr = bare.local_addr().unwrap();
+        let bare_start = Instant::now();
+        let bare_result = tokio::time::timeout(Duration::from_secs(5), tokio::net::TcpStream::connect(bare_addr)).await;
+        eprintln!(
+            "[diag:parity] bare addr={bare_addr} elapsed={:?} result={}",
+            bare_start.elapsed(),
+            match &bare_result {
+                Ok(Ok(_)) => "Ok(stream)".to_string(),
+                Ok(Err(e)) => format!("Err(kind={:?} raw={:?})", e.kind(), e.raw_os_error()),
+                Err(_) => "timeout".to_string(),
+            }
+        );
+
+        // --- SS bind path ---
+        let mut svr_cfg = ServerConfig::new(("127.0.0.1", 0u16), TEST_PASSWORD.to_string(), TEST_METHOD).unwrap();
+        svr_cfg.set_mode(Mode::TcpOnly);
+        let server = SsServerBuilder::new(svr_cfg).build().await.unwrap();
+        let ss_addr = server
+            .tcp_server()
+            .expect("TCP mode is enabled, tcp_server should exist")
+            .local_addr()
+            .unwrap();
+        let ss_start = Instant::now();
+        let ss_result = tokio::time::timeout(Duration::from_secs(5), tokio::net::TcpStream::connect(ss_addr)).await;
+        eprintln!(
+            "[diag:parity] ss addr={ss_addr} elapsed={:?} result={}",
+            ss_start.elapsed(),
+            match &ss_result {
+                Ok(Ok(_)) => "Ok(stream)".to_string(),
+                Ok(Err(e)) => format!("Err(kind={:?} raw={:?})", e.kind(), e.raw_os_error()),
+                Err(_) => "timeout".to_string(),
+            }
+        );
+
+        // Emit a combined summary so log-scraping is straightforward.
+        let bare_ok = matches!(bare_result, Ok(Ok(_)));
+        let ss_ok = matches!(ss_result, Ok(Ok(_)));
+        eprintln!(
+            "[diag:parity] SUMMARY bare_ok={bare_ok} ss_ok={ss_ok} \
+             bare_addr={bare_addr} ss_addr={ss_addr}"
+        );
+
+        if !ss_ok {
+            diag::log_failure_snapshot("parity:ss-failed", Some(ss_addr.port()));
+        }
+
+        // Hold both listeners alive until end of scope so neither path's
+        // result is affected by its sibling's teardown.
+        drop(bare);
+        drop(server);
+    });
+}

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -163,13 +163,16 @@ fn entry(host: &str, port: u16, method: &str, password: &str) -> ServerEntry {
     }
 }
 
-/// Fast defaults for tests that don't need plugin startup.
+/// Fast defaults for tests that don't need plugin startup. Timeouts
+/// were doubled relative to the original "fast" values to absorb
+/// Windows CI runners that intermittently take ~10s to deliver a TCP
+/// SYN-ACK on loopback when the runner is under load.
 fn fast_test_config(sentinel_a: SocketAddr, sentinel_b: SocketAddr) -> TestConfig {
     TestConfig {
-        preflight_timeout: Duration::from_secs(5),
-        plugin_wait_timeout: Duration::from_secs(2),
-        ss_connect_timeout: Duration::from_secs(5),
-        sentinel_read_timeout: Duration::from_secs(5),
+        preflight_timeout: Duration::from_secs(10),
+        plugin_wait_timeout: Duration::from_secs(4),
+        ss_connect_timeout: Duration::from_secs(10),
+        sentinel_read_timeout: Duration::from_secs(10),
         sentinels: [sentinel_a.to_string(), sentinel_b.to_string()],
         plugin_path_override: None,
     }
@@ -198,13 +201,14 @@ fn fixture_starts_real_ss_server() {
 
 /// Build a [`TestConfig`] pointing at a single bogus IP for both sentinels.
 /// Used by the pre-flight tests, where the test never reaches Phase 3.
+/// Timeouts doubled to match `fast_test_config`.
 fn preflight_only_config() -> TestConfig {
     let bogus: SocketAddr = "127.0.0.1:1".parse().unwrap();
     TestConfig {
-        preflight_timeout: Duration::from_secs(5),
-        plugin_wait_timeout: Duration::from_secs(5),
-        ss_connect_timeout: Duration::from_secs(5),
-        sentinel_read_timeout: Duration::from_secs(5),
+        preflight_timeout: Duration::from_secs(10),
+        plugin_wait_timeout: Duration::from_secs(10),
+        ss_connect_timeout: Duration::from_secs(10),
+        sentinel_read_timeout: Duration::from_secs(10),
         sentinels: [bogus.to_string(), bogus.to_string()],
         plugin_path_override: None,
     }
@@ -514,8 +518,9 @@ fn run_test_with_v2ray_plugin_happy_path() {
             start_real_ss_server_with_plugin(TEST_METHOD, TEST_PASSWORD, public_port, plugin_path.to_str().unwrap())
                 .await;
         // The SS server's plugin is spawned async; wait for it to bind the
-        // public port before letting the runner attempt preflight.
-        wait_for_port(svr_addr, Duration::from_secs(30)).await;
+        // public port before letting the runner attempt preflight. Doubled
+        // to 60 s to absorb slow Windows CI runners.
+        wait_for_port(svr_addr, Duration::from_secs(60)).await;
         let (sentinel_a, _sa) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
         let (sentinel_b, _sb) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
 
@@ -527,15 +532,15 @@ fn run_test_with_v2ray_plugin_happy_path() {
         );
         entry.plugin = Some("v2ray-plugin".into());
 
-        // Generous plugin window for cold start. The CI default of 2 s in
-        // fast_test_config is too short for v2ray-plugin's WS handshake.
+        // Generous plugin window for cold start. Doubled from the prior
+        // 30 s value because the WS handshake stalls on slow Windows CI.
         let cfg = TestConfig {
-            plugin_wait_timeout: Duration::from_secs(30),
+            plugin_wait_timeout: Duration::from_secs(60),
             plugin_path_override: Some(plugin_path.to_str().unwrap().to_string()),
             // Generous SS connect/sentinel timeouts because the WS handshake
-            // adds latency on top of the raw TCP connect.
-            ss_connect_timeout: Duration::from_secs(5),
-            sentinel_read_timeout: Duration::from_secs(5),
+            // adds latency on top of the raw TCP connect. Doubled.
+            ss_connect_timeout: Duration::from_secs(10),
+            sentinel_read_timeout: Duration::from_secs(10),
             ..fast_test_config(sentinel_a, sentinel_b)
         };
 

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -150,6 +150,9 @@ components:
       required:
         - running
         - uptime_secs
+        - invalid_filters
+        - udp_proxy_available
+        - ipv6_bypass_available
       properties:
         running:
           type: boolean
@@ -161,6 +164,30 @@ components:
           type:
             - string
             - "null"
+        invalid_filters:
+          description: |
+            Filter rules that failed to compile when the current `ProxyConfig`
+            was applied. Empty when the bridge is not running, or when all
+            rules compiled successfully. Each entry references an index into
+            the `ProxyConfig.filters` array sent in the most recent
+            `start`/`reload` request.
+          type: array
+          items:
+            $ref: "#/components/schemas/InvalidFilter"
+        udp_proxy_available:
+          description: |
+            False when the currently-configured server uses a v2ray-plugin
+            (plugins are TCP-only by protocol). When false, UDP rules with
+            action=Proxy are silently downgraded to Bypass. When the bridge
+            is not running, this field is `true` (no plugin in effect).
+          type: boolean
+        ipv6_bypass_available:
+          description: |
+            False when the upstream interface has no IPv6 connectivity
+            (probed at proxy start). When false, IPv6 rules with action=Bypass
+            are silently downgraded to Block. When the bridge is not running,
+            this field is `true`.
+          type: boolean
 
     ErrorResponse:
       type: object
@@ -200,6 +227,89 @@ components:
           format: uint64
           minimum: 0
         uptime_secs:
+          type: integer
+          format: uint64
+          minimum: 0
+        filter:
+          description: |
+            Filter engine metrics. `null` when the proxy is stopped (no
+            dispatcher exists), `Some(...)` when running. Counters are
+            cumulative for the lifetime of the current dispatcher instance —
+            they reset on full proxy restart but persist across rule-only
+            hot reloads.
+          oneOf:
+            - $ref: "#/components/schemas/FilterMetrics"
+            - type: "null"
+
+    InvalidFilter:
+      type: object
+      required:
+        - index
+        - error
+      properties:
+        index:
+          description: |
+            Position in the original `ProxyConfig.filters` array of the rule
+            that failed to compile.
+          type: integer
+          format: uint32
+          minimum: 0
+        error:
+          description: |
+            Human-readable explanation of why the rule was rejected.
+          type: string
+
+    FilterMetrics:
+      type: object
+      required:
+        - total_connections
+        - proxied
+        - bypassed
+        - blocked
+        - sniffer_hits
+        - sniffer_misses
+        - fake_dns_queries
+        - fake_dns_reverse_hits
+        - active_udp_flows
+        - udp_drops_backpressure
+      properties:
+        total_connections:
+          type: integer
+          format: uint64
+          minimum: 0
+        proxied:
+          type: integer
+          format: uint64
+          minimum: 0
+        bypassed:
+          type: integer
+          format: uint64
+          minimum: 0
+        blocked:
+          type: integer
+          format: uint64
+          minimum: 0
+        sniffer_hits:
+          type: integer
+          format: uint64
+          minimum: 0
+        sniffer_misses:
+          type: integer
+          format: uint64
+          minimum: 0
+        fake_dns_queries:
+          type: integer
+          format: uint64
+          minimum: 0
+        fake_dns_reverse_hits:
+          type: integer
+          format: uint64
+          minimum: 0
+        active_udp_flows:
+          type: integer
+          format: uint32
+          minimum: 0
+        udp_drops_backpressure:
           type: integer
           format: uint64
           minimum: 0
@@ -270,6 +380,53 @@ components:
           type: integer
           format: uint16
           minimum: 0
+        filters:
+          description: |
+            Optional list of filter rules applied by the bridge dispatcher.
+            Defaults to empty (no filtering — all captured traffic proxied).
+            Rules are evaluated in reverse order: the last matching rule
+            wins (gitignore semantics). The full filter engine is documented
+            in the design spec.
+          type: array
+          default: []
+          items:
+            $ref: "#/components/schemas/FilterRule"
+
+    FilterRule:
+      type: object
+      description: "Hand-written in config.rs — included here for spec completeness."
+      required:
+        - address
+        - matching
+        - action
+      properties:
+        address:
+          description: |
+            Domain name (`example.com`), wildcard glob (`*.example.com`),
+            IP literal (`192.168.1.1`, `::1`), or CIDR (`10.0.0.0/8`,
+            `2001:db8::/32`). Interpretation depends on `matching`.
+          type: string
+        matching:
+          $ref: "#/components/schemas/MatchType"
+        action:
+          $ref: "#/components/schemas/FilterAction"
+
+    MatchType:
+      type: string
+      description: "Hand-written in config.rs."
+      enum:
+        - exactly
+        - with_subdomains
+        - wildcard
+        - subnet
+
+    FilterAction:
+      type: string
+      description: "Hand-written in config.rs."
+      enum:
+        - proxy
+        - bypass
+        - block
 
     ServerEntry:
       type: object

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -1,10 +1,13 @@
 //! Generates Rust types and route constants from the OpenAPI spec at `api/openapi.yaml`.
 //!
-//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `PublicIpResponse`.
+//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`,
+//! `MetricsResponse`, `DiagnosticsResponse`, `PublicIpResponse`,
+//! `InvalidFilter`, `FilterMetrics`.
 //! Generated constants: `ROUTE_STATUS`, `ROUTE_START`, `ROUTE_STOP`, `ROUTE_RELOAD`, `ROUTE_METRICS`, `ROUTE_DIAGNOSTICS`, `ROUTE_PUBLIC_IP`, `ROUTE_TEST_SERVER`.
 //!
-//! `ProxyConfig`, `ServerEntry`, `ValidationState`, `ServerTestOutcome`, `TestServerRequest`,
-//! and `TestServerResponse` are defined in the spec for documentation purposes
+//! `ProxyConfig`, `FilterRule`, `MatchType`, `FilterAction`, `ServerEntry`,
+//! `ValidationState`, `ServerTestOutcome`, `TestServerRequest`, and
+//! `TestServerResponse` are defined in the spec for documentation purposes
 //! but are not generated — they are hand-written in `protocol.rs` and `config.rs`.
 
 use schemars::schema::Schema;
@@ -16,7 +19,7 @@ fn main() {
     let yaml_str = std::fs::read_to_string("api/openapi.yaml").unwrap();
     let spec: serde_json::Value = yaml_serde::from_str(&yaml_str).unwrap();
 
-    // Only generate these types (ProxyConfig/ServerEntry are hand-written)
+    // Only generate these types (ProxyConfig/ServerEntry/FilterRule are hand-written)
     let schemas = spec["components"]["schemas"].as_object().unwrap();
     let types_to_generate = [
         "StatusResponse",
@@ -25,6 +28,8 @@ fn main() {
         "MetricsResponse",
         "DiagnosticsResponse",
         "PublicIpResponse",
+        "InvalidFilter",
+        "FilterMetrics",
     ];
 
     let ref_types: Vec<(String, Schema)> = types_to_generate

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -1,4 +1,4 @@
-use crate::config::ServerEntry;
+use crate::config::{FilterRule, ServerEntry};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -36,6 +36,9 @@ pub enum BridgeResponse {
         running: bool,
         uptime_secs: u64,
         error: Option<String>,
+        invalid_filters: Vec<InvalidFilter>,
+        udp_proxy_available: bool,
+        ipv6_bypass_available: bool,
     },
     Error {
         message: String,
@@ -46,6 +49,7 @@ pub enum BridgeResponse {
         speed_in_bps: u64,
         speed_out_bps: u64,
         uptime_secs: u64,
+        filter: Option<FilterMetrics>,
     },
     Diagnostics {
         app: String,
@@ -67,6 +71,11 @@ pub enum BridgeResponse {
 pub struct ProxyConfig {
     pub server: ServerEntry,
     pub local_port: u16,
+    /// Filter rules applied by the bridge dispatcher. Defaults to empty
+    /// (no filtering — all captured traffic proxied). The full filter engine
+    /// is documented in the design spec.
+    #[serde(default)]
+    pub filters: Vec<FilterRule>,
 }
 
 // Server test outcome =================================================================================================

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -19,6 +19,7 @@ fn sample_config() -> ProxyConfig {
     ProxyConfig {
         server: sample_server(),
         local_port: 4073,
+        filters: Vec::new(),
     }
 }
 
@@ -74,6 +75,9 @@ fn bridge_response_status_json_roundtrip() {
         running: true,
         uptime_secs: 3600,
         error: Some("minor issue".to_string()),
+        invalid_filters: Vec::new(),
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
     };
     let json = serde_json::to_vec(&resp).unwrap();
     let decoded: BridgeResponse = serde_json::from_slice(&json).unwrap();
@@ -114,6 +118,9 @@ fn status_response_json_roundtrip() {
         running: true,
         uptime_secs: 3600,
         error: Some("minor issue".to_string()),
+        invalid_filters: Vec::new(),
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
     };
     let json = serde_json::to_string(&resp).unwrap();
     let decoded: StatusResponse = serde_json::from_str(&json).unwrap();
@@ -126,6 +133,9 @@ fn status_response_without_error() {
         running: false,
         uptime_secs: 0,
         error: None,
+        invalid_filters: Vec::new(),
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
     };
     let json = serde_json::to_string(&resp).unwrap();
     assert!(!json.contains("error"), "None error should be skipped in serialization");
@@ -152,7 +162,14 @@ fn empty_response_serializes_to_empty_object() {
 
 #[skuld::test]
 fn status_response_explicit_null_error() {
-    let json = r#"{"running": false, "uptime_secs": 0, "error": null}"#;
+    let json = r#"{
+        "running": false,
+        "uptime_secs": 0,
+        "error": null,
+        "invalid_filters": [],
+        "udp_proxy_available": true,
+        "ipv6_bypass_available": true
+    }"#;
     let decoded: StatusResponse = serde_json::from_str(json).unwrap();
     assert_eq!(decoded.error, None);
 }
@@ -175,6 +192,33 @@ fn metrics_response_roundtrips() {
         speed_in_bps: 1_048_576,
         speed_out_bps: 524_288,
         uptime_secs: 3600,
+        filter: None,
+    };
+    let json = serde_json::to_string(&resp).unwrap();
+    let parsed: MetricsResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(resp, parsed);
+}
+
+#[skuld::test]
+fn metrics_response_with_filter_roundtrips() {
+    let resp = MetricsResponse {
+        bytes_in: 1_000_000,
+        bytes_out: 500_000,
+        speed_in_bps: 1_048_576,
+        speed_out_bps: 524_288,
+        uptime_secs: 3600,
+        filter: Some(FilterMetrics {
+            total_connections: 42,
+            proxied: 30,
+            bypassed: 8,
+            blocked: 4,
+            sniffer_hits: 12,
+            sniffer_misses: 5,
+            fake_dns_queries: 100,
+            fake_dns_reverse_hits: 95,
+            active_udp_flows: 7,
+            udp_drops_backpressure: 0,
+        }),
     };
     let json = serde_json::to_string(&resp).unwrap();
     let parsed: MetricsResponse = serde_json::from_str(&json).unwrap();
@@ -247,6 +291,7 @@ fn bridge_response_metrics_roundtrips() {
         speed_in_bps: 1024,
         speed_out_bps: 512,
         uptime_secs: 60,
+        filter: None,
     };
     let json = serde_json::to_string(&resp).unwrap();
     let parsed: BridgeResponse = serde_json::from_str(&json).unwrap();

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -87,6 +87,9 @@ impl BridgeClient {
                         running: status.running,
                         uptime_secs: status.uptime_secs,
                         error: status.error,
+                        invalid_filters: status.invalid_filters,
+                        udp_proxy_available: status.udp_proxy_available,
+                        ipv6_bypass_available: status.ipv6_bypass_available,
                     })
                 } else {
                     parse_bridge_error(resp).await
@@ -130,6 +133,7 @@ impl BridgeClient {
                         speed_in_bps: metrics.speed_in_bps,
                         speed_out_bps: metrics.speed_out_bps,
                         uptime_secs: metrics.uptime_secs,
+                        filter: metrics.filter,
                     })
                 } else {
                     parse_bridge_error(resp).await

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -29,6 +29,9 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     running: false,
                     uptime_secs: 0,
                     error: None,
+                    invalid_filters: Vec::new(),
+                    udp_proxy_available: true,
+                    ipv6_bypass_available: true,
                 })
             }),
         )
@@ -53,6 +56,7 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     speed_in_bps: 2048,
                     speed_out_bps: 1024,
                     uptime_secs: 120,
+                    filter: None,
                 })
             }),
         )
@@ -112,6 +116,9 @@ fn send_status_request_receives_response() {
                 running: false,
                 uptime_secs: 0,
                 error: None,
+                invalid_filters: Vec::new(),
+                udp_proxy_available: true,
+                ipv6_bypass_available: true,
             }
         );
     });
@@ -139,6 +146,7 @@ fn send_start_receives_ack() {
                         validation: None,
                     },
                     local_port: 4073,
+                    filters: Vec::new(),
                 },
             })
             .await
@@ -215,6 +223,7 @@ fn send_reload_receives_ack() {
                         validation: None,
                     },
                     local_port: 4073,
+                    filters: Vec::new(),
                 },
             })
             .await
@@ -237,6 +246,9 @@ async fn spawn_error_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<(
                     running: false,
                     uptime_secs: 0,
                     error: None,
+                    invalid_filters: Vec::new(),
+                    udp_proxy_available: true,
+                    ipv6_bypass_available: true,
                 })
             }),
         )
@@ -291,6 +303,7 @@ fn server_error_maps_to_bridge_response_error() {
                         validation: None,
                     },
                     local_port: 4073,
+                    filters: Vec::new(),
                 },
             })
             .await
@@ -324,6 +337,7 @@ fn send_metrics_returns_response() {
                 speed_in_bps: 2048,
                 speed_out_bps: 1024,
                 uptime_secs: 120,
+                filter: None,
             }
         );
     });

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -144,12 +144,18 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": message,
+                "invalid_filters": Vec::<()>::new(),
+                "udp_proxy_available": true,
+                "ipv6_bypass_available": true,
             }))
         }
         Ok(_) => Ok(serde_json::json!({
             "running": false,
             "uptime_secs": 0,
             "error": "unexpected response from bridge",
+            "invalid_filters": Vec::<()>::new(),
+            "udp_proxy_available": true,
+            "ipv6_bypass_available": true,
         })),
         Err(e) => {
             // Bridge not running or unreachable — not an error for the frontend
@@ -157,6 +163,9 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": format!("bridge unreachable: {e}"),
+                "invalid_filters": Vec::<()>::new(),
+                "udp_proxy_available": true,
+                "ipv6_bypass_available": true,
             }))
         }
     }
@@ -187,6 +196,7 @@ fn map_metrics_response(result: Result<BridgeResponse, ClientError>) -> serde_js
             "speed_in_bps": 0,
             "speed_out_bps": 0,
             "uptime_secs": 0,
+            "filter": serde_json::Value::Null,
         }),
     }
 }

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -127,10 +127,16 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
             running,
             uptime_secs,
             error,
+            invalid_filters,
+            udp_proxy_available,
+            ipv6_bypass_available,
         }) => Ok(serde_json::json!({
             "running": running,
             "uptime_secs": uptime_secs,
             "error": error,
+            "invalid_filters": invalid_filters,
+            "udp_proxy_available": udp_proxy_available,
+            "ipv6_bypass_available": ipv6_bypass_available,
         })),
         Ok(BridgeResponse::Error { message }) => {
             warn!(error = %message, "bridge returned error for status");
@@ -166,12 +172,14 @@ fn map_metrics_response(result: Result<BridgeResponse, ClientError>) -> serde_js
             speed_in_bps,
             speed_out_bps,
             uptime_secs,
+            filter,
         }) => serde_json::json!({
             "bytes_in": bytes_in,
             "bytes_out": bytes_out,
             "speed_in_bps": speed_in_bps,
             "speed_out_bps": speed_out_bps,
             "uptime_secs": uptime_secs,
+            "filter": filter,
         }),
         _ => serde_json::json!({
             "bytes_in": 0,
@@ -364,6 +372,7 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
     Some(ProxyConfig {
         server: entry.clone(),
         local_port: config.local_port,
+        filters: config.filters.clone(),
     })
 }
 

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -172,6 +172,51 @@ fn get_metrics_returns_json() {
     assert_eq!(json["speed_in_bps"], 2048);
     assert_eq!(json["speed_out_bps"], 1024);
     assert_eq!(json["uptime_secs"], 120);
+    // The `filter` field is always present in the JSON shape so the
+    // frontend doesn't see two distinct shapes for running vs stopped.
+    assert_eq!(json["filter"], serde_json::Value::Null);
+}
+
+/// Verify that a Metrics BridgeResponse with filter metrics emits
+/// them in the JSON shape.
+#[skuld::test]
+fn get_metrics_with_filter_metrics_returns_json() {
+    use hole_common::protocol::FilterMetrics;
+    let resp = BridgeResponse::Metrics {
+        bytes_in: 1024,
+        bytes_out: 512,
+        speed_in_bps: 2048,
+        speed_out_bps: 1024,
+        uptime_secs: 120,
+        filter: Some(FilterMetrics {
+            total_connections: 42,
+            proxied: 30,
+            bypassed: 8,
+            blocked: 4,
+            sniffer_hits: 12,
+            sniffer_misses: 5,
+            fake_dns_queries: 100,
+            fake_dns_reverse_hits: 95,
+            active_udp_flows: 7,
+            udp_drops_backpressure: 0,
+        }),
+    };
+    let json = map_metrics_response(Ok(resp));
+    assert_eq!(json["filter"]["total_connections"], 42);
+    assert_eq!(json["filter"]["proxied"], 30);
+    assert_eq!(json["filter"]["bypassed"], 8);
+    assert_eq!(json["filter"]["blocked"], 4);
+    assert_eq!(json["filter"]["active_udp_flows"], 7);
+}
+
+/// Verify that the metrics fallback path emits the same JSON shape as
+/// the success path (always includes `filter`).
+#[skuld::test]
+fn get_metrics_fallback_includes_filter_field() {
+    let err = ClientError::Connection(std::io::Error::other("nope"));
+    let json = map_metrics_response(Err(err));
+    assert_eq!(json["bytes_in"], 0);
+    assert_eq!(json["filter"], serde_json::Value::Null);
 }
 
 /// Verify that a failed metrics request returns zero defaults.

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -164,6 +164,7 @@ fn get_metrics_returns_json() {
         speed_in_bps: 2048,
         speed_out_bps: 1024,
         uptime_secs: 120,
+        filter: None,
     };
     let json = map_metrics_response(Ok(resp));
     assert_eq!(json["bytes_in"], 1024);

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -19,6 +19,7 @@ fn encode_request_roundtrips() {
                 validation: None,
             },
             local_port: 4073,
+            filters: Vec::new(),
         },
     };
 
@@ -64,6 +65,7 @@ fn write_request_file_roundtrip() {
                 validation: None,
             },
             local_port: 4073,
+            filters: Vec::new(),
         },
     };
 
@@ -97,6 +99,7 @@ fn read_request_file_roundtrip() {
                 validation: None,
             },
             local_port: 4073,
+            filters: Vec::new(),
         },
     };
 


### PR DESCRIPTION
Investigation-only PR for #165. **Do not merge.** This PR exists to collect diagnostic data from Windows CI; any fix derived from the investigation will be a separate PR.

## What this adds

- **`crates/bridge/src/server_test_diag.rs`** — throwaway diag module with three experiments:
  - `diag_bind_and_hold`: primary experiment. Build SS server, keep it alive, never call \`run()\`, raw-connect. Discriminates "kernel listener reachable" from "SS runtime issue".
  - \`diag_external_probe\`: spawn PowerShell \`Test-NetConnection\` to probe the bound port from outside this process. Discriminates "PID/image-hash firewall filter" from "kernel-wide drop".
  - \`diag_dual_socket_parity\`: bare \`tokio::net::TcpListener\` alongside SS listener in same process. Discriminates "SS-specific bind path" from "environmental".
- **Aggressive Windows capture layer** in the new \`windows-diag\` CI job (gated on the \`ci-diag\` label): ETW TCP/IP trace, WFP netevents capture, \`pktmon\` loopback packet capture, Defender event log snapshot, S6 isolation matrix (4 sequential \`cargo test\` invocations with different filters), control run for observer-effect detection. All artifacts uploaded.
- **\`windows-diag-preflight\` job**: confirms admin access to \`logman\`, \`netsh wfp\`, \`pktmon\` before the main job uses them. Runs first.
- **Test-harness \`tracing_subscriber::fmt()\` init** in \`crates/bridge/src/lib.rs\` so \`cargo test\` honors \`RUST_LOG\`. **This one change is kept long-term** as permanent fixture hardening.
- **\`tracing-subscriber\` dev-dep** to enable the above (kept long-term).
- **\`CONTRIBUTING.md\` note** about the \`ci-diag\` label (throwaway, reverted post-RCA).

## Baseline on local Windows

All three diag tests pass locally:

- \`diag_bind_and_hold\`: built in 1.3 ms, connect OK in 279 µs
- \`diag_external_probe\`: external Test-NetConnection ok=True; in-process connect OK in 439 µs
- \`diag_dual_socket_parity\`: bare_ok=true ss_ok=true, both <300 µs

If CI shows different results, that IS the signal.

## Investigation plan

Full diagnostic plan in \`~/.claude/plans/luminous-honking-cascade.md\` (local-only). Key points:

- **Exit criteria:** five yes/no questions. No fix ships until all five are answered from a single CI run.
- **Observer effect mitigation:** cheap in-process diagnostics on the happy path, batched PowerShell only on failure, plus a control run that runs the failing tests with zero captures in flight.
- **Post-RCA cleanup:** the entire \`server_test_diag.rs\` file, both CI diag jobs, the \`ci-diag\` label, and the CONTRIBUTING.md note all deleted in the same PR that ships the fix.
- **Kept long-term:** \`tracing_subscriber::fmt()\` init + \`tracing-subscriber\` dev-dep only.

## Test plan

- [ ] Add the \`ci-diag\` label to trigger \`windows-diag-preflight\` and \`windows-diag\` jobs
- [ ] windows-diag-preflight passes (admin access to logman/wfp/pktmon confirmed)
- [ ] windows-diag collects artifacts for all experiments + S6 matrix + control run
- [ ] Artifact analysis gives unambiguous answers to all 5 exit-criteria questions
- [ ] Root cause documented on issue #165
- [ ] Separate fix PR opened (if root cause implies a code fix)