### PR TITLE
bridge: bump skuld to per-test tracing capture rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "skuld",
+ "skuld 0.1.0 (git+https://github.com/bindreams/skuld)",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -2347,7 +2347,7 @@ dependencies = [
  "serde_json",
  "shadowsocks",
  "shadowsocks-service",
- "skuld",
+ "skuld 0.1.0 (git+https://github.com/bindreams/skuld?rev=ce215370354a2624b5f1662c96190424df8329aa)",
  "socket2",
  "tempfile",
  "thiserror 2.0.18",
@@ -2374,7 +2374,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "skuld",
+ "skuld 0.1.0 (git+https://github.com/bindreams/skuld)",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -5244,6 +5244,22 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 [[package]]
 name = "skuld"
 version = "0.1.0"
+source = "git+https://github.com/bindreams/skuld?rev=ce215370354a2624b5f1662c96190424df8329aa#ce215370354a2624b5f1662c96190424df8329aa"
+dependencies = [
+ "clap",
+ "inventory",
+ "libtest-mimic",
+ "serde",
+ "serde_yml",
+ "skuld-macros 0.1.0 (git+https://github.com/bindreams/skuld?rev=ce215370354a2624b5f1662c96190424df8329aa)",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "skuld"
+version = "0.1.0"
 source = "git+https://github.com/bindreams/skuld#e63157105a0a38eb5b6f22972e8ac892fcf47519"
 dependencies = [
  "clap",
@@ -5251,8 +5267,18 @@ dependencies = [
  "libtest-mimic",
  "serde",
  "serde_yml",
- "skuld-macros",
+ "skuld-macros 0.1.0 (git+https://github.com/bindreams/skuld)",
  "tempfile",
+]
+
+[[package]]
+name = "skuld-macros"
+version = "0.1.0"
+source = "git+https://github.com/bindreams/skuld?rev=ce215370354a2624b5f1662c96190424df8329aa#ce215370354a2624b5f1662c96190424df8329aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7894,7 +7920,7 @@ dependencies = [
  "clap",
  "glob",
  "sha2 0.11.0",
- "skuld",
+ "skuld 0.1.0 (git+https://github.com/bindreams/skuld)",
  "tempfile",
  "ureq",
  "xtask-lib",
@@ -7907,7 +7933,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "semver",
- "skuld",
+ "skuld 0.1.0 (git+https://github.com/bindreams/skuld)",
  "tempfile",
 ]
 

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -52,5 +52,5 @@ windows = { version = "0.62", features = [
 wintun-bindings = "0.7"
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld" }
+skuld = { git = "https://github.com/bindreams/skuld", rev = "ce215370354a2624b5f1662c96190424df8329aa" }
 shadowsocks-service = { version = "1", features = ["server"] }


### PR DESCRIPTION
## Summary

- Bumps the `skuld` dev-dependency to a rev with per-test tracing capture + runner-level start/finish/duration events. See https://github.com/bindreams/skuld/pull/1.
- Zero production code changes in this repo — the only diff is `crates/bridge/Cargo.toml` and `Cargo.lock`.
- Test output now includes `[skuld] <test_name>: pass (NN ms)` lines for every test, always visible (not hidden behind a failure). On test panic, library `tracing::info!`/`warn!`/`error!` events from the failing test are dumped to stderr with a clear header/footer.

## Motivation

Closes #167, part of the #165 mitigation plan. The #165 investigation was disproportionately hard because:
- libtest-mimic (which skuld uses) does NOT capture stdout/stderr per-test.
- The bridge test harness never initialized a `tracing` subscriber, so every `tracing::info!`/`warn!`/`error!` in library code during tests went to `/dev/null`.
- There was no per-test wall-clock duration visible in the standard test output.

This PR fixes all three in one dep bump. Addresses incident-report gaps 1.9, 2.3, 2.4, 3.1, 3.6.

## #147 regression guard

The skuld PR explicitly pins `tracing-subscriber` features to `["env-filter", "fmt"]` with `default-features = false` — the `tracing-log` feature is NOT enabled, which means no `LogTracer` is installed and `log::max_level` is not mutated. This preserves the workaround documented in `crates/bridge/src/ipc_tests.rs:720-736` that prevents the #147 Windows CI timeout regression.

## Test plan

- [x] `cargo build --workspace` succeeds with the new skuld rev pinned.
- [x] `cargo test --workspace` passes (all 639 tests across the workspace pass: 112 + 80 + 159 + 102 + 8 + 21 + doctests).
- [x] Per-test duration output visible in the normal `cargo test` log (e.g. `[skuld] start_transitions_to_running: pass (252 ms)`).
- [x] Verified no `tracing-log` in the enabled feature set via `cargo tree -e features --package tracing-subscriber`.
- [ ] Windows CI passes (this PR's CI run is the critical #147 non-regression check — wall-clock time for `server_test_tests` must be comparable to main).