### PR TITLE
filter: TCP dispatcher + TUN ownership (Plan 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,47 +1116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
-dependencies = [
- "defmt 1.0.1",
-]
-
-[[package]]
-name = "defmt"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
-dependencies = [
- "defmt-parser",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,15 +1459,6 @@ name = "escape8259"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
-
-[[package]]
-name = "etherparse"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b119b9796ff800751a220394b8b3613f26dd30c48f254f6837e64c464872d1c7"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "euclid"
@@ -2333,12 +2289,14 @@ dependencies = [
 name = "hole-bridge"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "axum",
  "base64 0.22.1",
  "bytes",
  "default-net",
  "hex",
  "hickory-proto",
+ "hickory-resolver",
  "hole-common",
  "http",
  "http-body-util",
@@ -2356,14 +2314,17 @@ dependencies = [
  "shadowsocks",
  "shadowsocks-service",
  "skuld 0.1.0 (git+https://github.com/bindreams/skuld?rev=ce215370354a2624b5f1662c96190424df8329aa)",
+ "smoltcp",
  "socket2",
  "tempfile",
  "thiserror 2.0.18",
  "tls-parser",
  "tokio",
+ "tokio-socks",
  "tokio-util",
  "tower",
  "tracing",
+ "tun",
  "ureq",
  "windows 0.62.2",
  "windows-service",
@@ -4185,28 +4146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5241,7 +5180,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "cfg-if",
- "etherparse",
  "futures",
  "hickory-resolver",
  "http",
@@ -5262,13 +5200,11 @@ dependencies = [
  "serde",
  "serde_json",
  "shadowsocks",
- "smoltcp",
  "socket2",
  "spin",
  "thiserror 2.0.18",
  "tokio",
  "trait-variant",
- "tun",
  "windows-sys 0.61.2",
 ]
 
@@ -5416,9 +5352,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "defmt 0.3.100",
  "heapless",
- "log",
  "managed",
 ]
 
@@ -6255,6 +6189,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,6 +4187,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5352,6 +5415,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
+ "defmt 0.3.100",
  "heapless",
  "managed",
 ]

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 
 [dependencies]
 hole-common = { path = "../common" }
-shadowsocks-service = { version = "1", features = ["local", "local-tun", "local-http", "aead-cipher-2022"] }
+shadowsocks-service = { version = "1", features = ["local", "local-http", "aead-cipher-2022"] }
 shadowsocks = "=1.24.0"
 hex = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "io-util", "net"] }
@@ -43,6 +43,17 @@ regex = "1"
 # New crates not previously in the tree.
 lru = "0.16"
 tls-parser = "0.12"
+# Filter engine Plan 2 — dispatcher dependencies.
+# tun and smoltcp are pinned to the same versions shadowsocks-service 1.24
+# uses transitively so cargo deduplicates them.
+tun = { version = "0.8", features = ["async"] }
+smoltcp = { version = "0.12", default-features = false, features = [
+    "medium-ip", "proto-ipv4", "proto-ipv6",
+    "socket-tcp", "socket-udp",
+] }
+arc-swap = "1"
+tokio-socks = "0.5"
+hickory-resolver = "0.25"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
@@ -54,6 +65,9 @@ windows = { version = "0.62", features = [
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_System_RemoteDesktop",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
 ] }
 # Pinned to the same minor version that shadowsocks-service 1.24 uses
 # transitively (via tun-0.8.6) so cargo deduplicates the crate. We load

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -48,6 +48,7 @@ tls-parser = "0.12"
 # uses transitively so cargo deduplicates them.
 tun = { version = "0.8", features = ["async"] }
 smoltcp = { version = "0.12", default-features = false, features = [
+    "alloc",
     "medium-ip", "proto-ipv4", "proto-ipv6",
     "socket-tcp", "socket-udp",
 ] }

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -1,0 +1,1 @@
+pub mod block_log;

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -3,4 +3,7 @@
 //! paths. Constructed by `ProxyManager::start`, destroyed on `stop`.
 
 pub mod block_log;
+pub mod bypass;
+pub mod device;
 pub mod socks5_client;
+pub mod upstream_dns;

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use tokio::task::JoinHandle;
+use tokio::task::{AbortHandle, JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -32,7 +32,10 @@ use crate::filter::FakeDns;
 pub struct Dispatcher {
     rules: Arc<ArcSwap<RuleSet>>,
     cancel: CancellationToken,
-    driver_handle: JoinHandle<()>,
+    /// `Option` so `shutdown()` can take it for graceful await.
+    /// `Drop` aborts via `driver_abort` as a safety net.
+    driver_handle: Option<JoinHandle<()>>,
+    driver_abort: AbortHandle,
 }
 
 impl Dispatcher {
@@ -98,13 +101,15 @@ impl Dispatcher {
         );
 
         let driver_handle = tokio::spawn(driver.run());
+        let driver_abort = driver_handle.abort_handle();
 
         debug!("Dispatcher started (local_port={local_port}, iface_index={iface_index})");
 
         Ok(Self {
             rules: rules_arc,
             cancel,
-            driver_handle,
+            driver_handle: Some(driver_handle),
+            driver_abort,
         })
     }
 
@@ -113,33 +118,36 @@ impl Dispatcher {
         self.rules.store(Arc::new(new_rules));
     }
 
-    /// Graceful shutdown.
-    ///
-    /// 1. Cancel token (signals driver + handlers to stop; driver's
-    ///    TUN read is racing against cancelled(), so cancel unblocks it)
-    /// 2. Wait up to 2 s for the driver to finish
-    /// 3. Abort the driver handle if it doesn't finish in time
-    pub async fn shutdown(self) {
+    /// Graceful shutdown. Cancels the driver, waits up to 2s, then
+    /// aborts if needed. Idempotent — safe to call multiple times or
+    /// after Drop has already aborted.
+    pub async fn shutdown(&mut self) {
         debug!("Dispatcher shutting down");
-
-        // Signal cancellation. The driver's main loop uses `tokio::select!`
-        // between TUN read and cancel, so this unblocks the driver promptly.
         self.cancel.cancel();
 
-        // Abort handle before awaiting so we can force-stop on timeout.
-        let abort_handle = self.driver_handle.abort_handle();
-
-        // Wait for the driver with a timeout.
-        match tokio::time::timeout(std::time::Duration::from_secs(2), self.driver_handle).await {
-            Ok(Ok(())) => debug!("Dispatcher driver exited cleanly"),
-            Ok(Err(e)) if e.is_cancelled() => debug!("Dispatcher driver was aborted"),
-            Ok(Err(e)) => warn!("Dispatcher driver panicked: {e}"),
-            Err(_) => {
-                warn!("Dispatcher driver did not exit in 2s, aborting");
-                abort_handle.abort();
+        if let Some(handle) = self.driver_handle.take() {
+            match tokio::time::timeout(std::time::Duration::from_secs(2), handle).await {
+                Ok(Ok(())) => debug!("Dispatcher driver exited cleanly"),
+                Ok(Err(e)) if e.is_cancelled() => debug!("Dispatcher driver was aborted"),
+                Ok(Err(e)) => warn!("Dispatcher driver panicked: {e}"),
+                Err(_) => {
+                    warn!("Dispatcher driver did not exit in 2s, aborting");
+                    self.driver_abort.abort();
+                }
             }
         }
 
         debug!("Dispatcher shutdown complete");
+    }
+}
+
+/// Cancel the driver and abort it on drop. This ensures that implicit
+/// drops (e.g., from `check_health` or a cancelled `start_cancellable`)
+/// do not leak the driver task. `shutdown()` is preferred for graceful
+/// teardown, but the `Drop` provides a safety net.
+impl Drop for Dispatcher {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        self.driver_abort.abort();
     }
 }

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -5,5 +5,141 @@
 pub mod block_log;
 pub mod bypass;
 pub mod device;
+pub mod driver;
+pub mod smoltcp_stream;
 pub mod socks5_client;
+pub mod tcp_handler;
 pub mod upstream_dns;
+
+use std::net::IpAddr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use self::block_log::BlockLog;
+use self::driver::{TunDriver, MTU};
+use self::tcp_handler::TcpHandlerContext;
+use self::upstream_dns::UpstreamResolver;
+use crate::filter::rules::RuleSet;
+use crate::filter::FakeDns;
+
+/// The main dispatcher — owns the TUN device (via the driver) and
+/// coordinates per-connection filter decisions.
+pub struct Dispatcher {
+    rules: Arc<ArcSwap<RuleSet>>,
+    cancel: CancellationToken,
+    driver_handle: JoinHandle<()>,
+}
+
+impl Dispatcher {
+    /// Create and start the dispatcher.
+    ///
+    /// - `local_port`: SS SOCKS5 listen port on 127.0.0.1.
+    /// - `iface_index`: upstream interface index for bypass sockets.
+    /// - `ipv6_available`: whether the upstream has IPv6.
+    /// - `rules`: compiled filter rules.
+    /// - `dns_servers`: upstream DNS server IPs (discovered before TUN up).
+    pub fn new(
+        local_port: u16,
+        iface_index: u32,
+        ipv6_available: bool,
+        rules: RuleSet,
+        dns_servers: &[IpAddr],
+    ) -> std::io::Result<Self> {
+        // Create TUN device.
+        let mut tun_config = tun::Configuration::default();
+        tun_config
+            .tun_name("hole-tun")
+            .address("10.255.0.1")
+            .netmask("255.255.255.0")
+            .mtu(MTU as u16)
+            .up();
+
+        let tun_device = tun::create_as_async(&tun_config)
+            .map_err(|e| std::io::Error::other(format!("failed to create TUN device: {e}")))?;
+
+        // Set up shared state.
+        let rules_arc = Arc::new(ArcSwap::from_pointee(rules.clone()));
+
+        // FakeDns — only when domain rules exist.
+        let fake_dns = if rules.has_domain_rules {
+            Some(Arc::new(FakeDns::with_defaults()))
+        } else {
+            None
+        };
+
+        // Upstream resolver.
+        let upstream_resolver = UpstreamResolver::new(dns_servers);
+
+        // Handler context (shared by all TCP handlers).
+        let handler_ctx = Arc::new(TcpHandlerContext {
+            local_port,
+            iface_index,
+            ipv6_available,
+            upstream_resolver,
+            block_log: std::sync::Mutex::new(BlockLog::new()),
+            ipv6_bypass_warned: AtomicBool::new(false),
+        });
+
+        // Cancellation token.
+        let cancel = CancellationToken::new();
+
+        // Create and spawn the driver.
+        let driver = TunDriver::new(
+            tun_device,
+            fake_dns,
+            Arc::clone(&rules_arc),
+            handler_ctx,
+            cancel.clone(),
+        );
+
+        let driver_handle = tokio::spawn(driver.run());
+
+        debug!("Dispatcher started (local_port={local_port}, iface_index={iface_index})");
+
+        Ok(Self {
+            rules: rules_arc,
+            cancel,
+            driver_handle,
+        })
+    }
+
+    /// Hot-swap the filter rules without restarting the dispatcher.
+    pub fn swap_rules(&self, new_rules: RuleSet) {
+        self.rules.store(Arc::new(new_rules));
+    }
+
+    /// Graceful shutdown.
+    ///
+    /// 1. Cancel token (signals driver + handlers to stop; driver's
+    ///    TUN read is racing against cancelled(), so cancel unblocks it)
+    /// 2. Wait up to 2 s for the driver to finish
+    /// 3. Abort the driver handle if it doesn't finish in time
+    pub async fn shutdown(self) {
+        debug!("Dispatcher shutting down");
+
+        // Signal cancellation. The driver's main loop uses `tokio::select!`
+        // between TUN read and cancel, so this unblocks the driver promptly.
+        self.cancel.cancel();
+
+        // Abort handle before awaiting so we can force-stop on timeout.
+        let abort_handle = self.driver_handle.abort_handle();
+
+        // Wait for the driver with a timeout.
+        match tokio::time::timeout(std::time::Duration::from_secs(2), self.driver_handle).await {
+            Ok(Ok(())) => debug!("Dispatcher driver exited cleanly"),
+            Ok(Err(e)) if e.is_cancelled() => debug!("Dispatcher driver was aborted"),
+            Ok(Err(e)) => warn!("Dispatcher driver panicked: {e}"),
+            Err(_) => {
+                warn!("Dispatcher driver did not exit in 2s, aborting");
+                abort_handle.abort();
+            }
+        }
+
+        debug!("Dispatcher shutdown complete");
+    }
+}

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -1,1 +1,6 @@
+//! TCP dispatcher — owns the TUN device and smoltcp interface, runs
+//! per-connection filter decisions, and dispatches to proxy/bypass/block
+//! paths. Constructed by `ProxyManager::start`, destroyed on `stop`.
+
 pub mod block_log;
+pub mod socks5_client;

--- a/crates/bridge/src/dispatcher/block_log.rs
+++ b/crates/bridge/src/dispatcher/block_log.rs
@@ -1,0 +1,48 @@
+use lru::LruCache;
+use std::net::IpAddr;
+use std::num::NonZeroUsize;
+use std::time::Instant;
+
+const BLOCK_LOG_LRU_CAPACITY: usize = 1024;
+const SUPPRESS_DURATION: std::time::Duration = std::time::Duration::from_secs(1);
+
+type BlockKey = (u32, IpAddr, u16);
+
+pub struct BlockLog {
+    cache: LruCache<BlockKey, Instant>,
+}
+
+impl Default for BlockLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BlockLog {
+    pub fn new() -> Self {
+        Self::with_capacity(BLOCK_LOG_LRU_CAPACITY)
+    }
+
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            cache: LruCache::new(NonZeroUsize::new(cap.max(1)).unwrap()),
+        }
+    }
+
+    /// Returns true if this block should be logged (not suppressed).
+    pub fn should_log(&mut self, rule_index: u32, dst_ip: IpAddr, dst_port: u16) -> bool {
+        let key = (rule_index, dst_ip, dst_port);
+        let now = Instant::now();
+        if let Some(last) = self.cache.get(&key) {
+            if now.duration_since(*last) < SUPPRESS_DURATION {
+                return false;
+            }
+        }
+        self.cache.put(key, now);
+        true
+    }
+}
+
+#[cfg(test)]
+#[path = "block_log_tests.rs"]
+mod block_log_tests;

--- a/crates/bridge/src/dispatcher/block_log_tests.rs
+++ b/crates/bridge/src/dispatcher/block_log_tests.rs
@@ -1,0 +1,61 @@
+use std::net::IpAddr;
+
+use super::BlockLog;
+
+#[skuld::test]
+fn first_block_is_always_logged() {
+    let mut log = BlockLog::new();
+    let ip: IpAddr = "10.0.0.1".parse().unwrap();
+    assert!(log.should_log(0, ip, 443));
+}
+
+#[skuld::test]
+fn same_tuple_suppressed_within_one_second() {
+    let mut log = BlockLog::new();
+    let ip: IpAddr = "10.0.0.1".parse().unwrap();
+
+    assert!(log.should_log(0, ip, 443));
+    assert!(!log.should_log(0, ip, 443));
+    assert!(!log.should_log(0, ip, 443));
+}
+
+#[skuld::test]
+fn different_tuple_is_not_suppressed() {
+    let mut log = BlockLog::new();
+    let ip1: IpAddr = "10.0.0.1".parse().unwrap();
+    let ip2: IpAddr = "10.0.0.2".parse().unwrap();
+
+    assert!(log.should_log(0, ip1, 443));
+    assert!(log.should_log(0, ip2, 443));
+    assert!(log.should_log(0, ip1, 80));
+}
+
+#[skuld::test]
+fn different_rule_index_not_suppressed() {
+    let mut log = BlockLog::new();
+    let ip: IpAddr = "10.0.0.1".parse().unwrap();
+
+    assert!(log.should_log(0, ip, 443));
+    assert!(log.should_log(1, ip, 443));
+}
+
+#[skuld::test]
+fn lru_eviction_allows_re_logging() {
+    let mut log = BlockLog::with_capacity(2);
+    let ip1: IpAddr = "10.0.0.1".parse().unwrap();
+    let ip2: IpAddr = "10.0.0.2".parse().unwrap();
+    let ip3: IpAddr = "10.0.0.3".parse().unwrap();
+
+    // Fill the cache with two entries.
+    assert!(log.should_log(0, ip1, 443));
+    assert!(log.should_log(0, ip2, 443));
+
+    // Third entry evicts ip1.
+    assert!(log.should_log(0, ip3, 443));
+
+    // ip1 was evicted, so it should be logged again.
+    assert!(log.should_log(0, ip1, 443));
+
+    // ip2 and ip3 are still suppressed.
+    assert!(!log.should_log(0, ip3, 443));
+}

--- a/crates/bridge/src/dispatcher/bypass.rs
+++ b/crates/bridge/src/dispatcher/bypass.rs
@@ -1,0 +1,118 @@
+//! Bypass-path socket helpers — interface binding + TCP connect.
+
+use std::net::{IpAddr, SocketAddr};
+use tokio::net::TcpStream;
+
+// Interface binding helpers (shared) ==================================================================================
+
+/// Bind an IPv4 socket to the upstream interface by index.
+#[cfg(target_os = "windows")]
+pub(crate) fn bind_to_interface_v4(socket: &socket2::Socket, index: u32) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    // IP_UNICAST_IF expects network byte order.
+    let val = index.to_be();
+    let ret = unsafe {
+        windows::Win32::Networking::WinSock::setsockopt(
+            windows::Win32::Networking::WinSock::SOCKET(socket.as_raw_socket() as usize),
+            windows::Win32::Networking::WinSock::IPPROTO_IP.0,
+            windows::Win32::Networking::WinSock::IP_UNICAST_IF,
+            Some(std::slice::from_raw_parts(
+                &val as *const u32 as *const u8,
+                std::mem::size_of::<u32>(),
+            )),
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Bind an IPv6 socket to the upstream interface by index.
+#[cfg(target_os = "windows")]
+pub(crate) fn bind_to_interface_v6(socket: &socket2::Socket, index: u32) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    // IPV6_UNICAST_IF expects host byte order (different from v4!).
+    let ret = unsafe {
+        windows::Win32::Networking::WinSock::setsockopt(
+            windows::Win32::Networking::WinSock::SOCKET(socket.as_raw_socket() as usize),
+            windows::Win32::Networking::WinSock::IPPROTO_IPV6.0,
+            windows::Win32::Networking::WinSock::IPV6_UNICAST_IF,
+            Some(std::slice::from_raw_parts(
+                &index as *const u32 as *const u8,
+                std::mem::size_of::<u32>(),
+            )),
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+const IP_BOUND_IF: libc::c_int = 25;
+
+/// Bind an IPv4 socket to the upstream interface by index.
+#[cfg(target_os = "macos")]
+pub(crate) fn bind_to_interface_v4(socket: &socket2::Socket, index: u32) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            IP_BOUND_IF,
+            &index as *const u32 as *const libc::c_void,
+            std::mem::size_of::<u32>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Bind an IPv6 socket to the upstream interface by index.
+#[cfg(target_os = "macos")]
+pub(crate) fn bind_to_interface_v6(socket: &socket2::Socket, index: u32) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_BOUND_IF,
+            &index as *const u32 as *const libc::c_void,
+            std::mem::size_of::<u32>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+// Bypass TCP connect ==================================================================================================
+
+/// Open a TCP connection via the upstream interface, bypassing the TUN device.
+pub async fn create_bypass_tcp(dst_ip: IpAddr, dst_port: u16, iface_index: u32) -> std::io::Result<TcpStream> {
+    let dst = SocketAddr::new(dst_ip, dst_port);
+    let tcp_socket = match dst_ip {
+        IpAddr::V4(_) => {
+            let sock = tokio::net::TcpSocket::new_v4()?;
+            let raw = socket2::SockRef::from(&sock);
+            bind_to_interface_v4(&raw, iface_index)?;
+            sock
+        }
+        IpAddr::V6(_) => {
+            let sock = tokio::net::TcpSocket::new_v6()?;
+            let raw = socket2::SockRef::from(&sock);
+            bind_to_interface_v6(&raw, iface_index)?;
+            sock
+        }
+    };
+    tcp_socket.connect(dst).await
+}
+
+#[cfg(test)]
+#[path = "bypass_tests.rs"]
+mod bypass_tests;

--- a/crates/bridge/src/dispatcher/bypass_tests.rs
+++ b/crates/bridge/src/dispatcher/bypass_tests.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[skuld::test]
+#[ignore] // Requires network — run manually with `cargo test -- --ignored`
+fn bypass_socket_connects_to_loopback() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // interface_index=1 is typically the loopback on both Windows and macOS.
+        let (connect_result, _accept) = tokio::join!(create_bypass_tcp(addr.ip(), addr.port(), 1), listener.accept());
+        assert!(
+            connect_result.is_ok(),
+            "bypass connect failed: {:?}",
+            connect_result.err()
+        );
+    });
+}

--- a/crates/bridge/src/dispatcher/device.rs
+++ b/crates/bridge/src/dispatcher/device.rs
@@ -1,0 +1,97 @@
+//! smoltcp `Device` implementation backed by in-memory queues.
+
+use smoltcp::phy::{self, Device, DeviceCapabilities, Medium};
+use smoltcp::time::Instant;
+use std::collections::VecDeque;
+
+pub struct VirtualTunDevice {
+    rx_queue: VecDeque<Vec<u8>>,
+    tx_queue: VecDeque<Vec<u8>>,
+    mtu: usize,
+}
+
+impl VirtualTunDevice {
+    pub fn new(mtu: usize) -> Self {
+        Self {
+            rx_queue: VecDeque::new(),
+            tx_queue: VecDeque::new(),
+            mtu,
+        }
+    }
+
+    /// Enqueue a packet received from the real TUN device.
+    pub fn enqueue_rx(&mut self, packet: Vec<u8>) {
+        self.rx_queue.push_back(packet);
+    }
+
+    /// Dequeue all packets smoltcp wants to send to the TUN.
+    pub fn dequeue_tx(&mut self) -> Vec<Vec<u8>> {
+        self.tx_queue.drain(..).collect()
+    }
+
+    /// Check if there are packets waiting to be sent to the TUN.
+    pub fn has_tx(&self) -> bool {
+        !self.tx_queue.is_empty()
+    }
+}
+
+impl Device for VirtualTunDevice {
+    type RxToken<'a> = RxToken;
+    type TxToken<'a> = TxToken<'a>;
+
+    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let packet = self.rx_queue.pop_front()?;
+        Some((
+            RxToken { buffer: packet },
+            TxToken {
+                queue: &mut self.tx_queue,
+            },
+        ))
+    }
+
+    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        Some(TxToken {
+            queue: &mut self.tx_queue,
+        })
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut caps = DeviceCapabilities::default();
+        caps.medium = Medium::Ip;
+        caps.max_transmission_unit = self.mtu;
+        caps
+    }
+}
+
+pub struct RxToken {
+    buffer: Vec<u8>,
+}
+
+impl phy::RxToken for RxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        f(&self.buffer)
+    }
+}
+
+pub struct TxToken<'a> {
+    queue: &'a mut VecDeque<Vec<u8>>,
+}
+
+impl<'a> phy::TxToken for TxToken<'a> {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut buffer = vec![0u8; len];
+        let result = f(&mut buffer);
+        self.queue.push_back(buffer);
+        result
+    }
+}
+
+#[cfg(test)]
+#[path = "device_tests.rs"]
+mod device_tests;

--- a/crates/bridge/src/dispatcher/device_tests.rs
+++ b/crates/bridge/src/dispatcher/device_tests.rs
@@ -1,0 +1,54 @@
+use super::VirtualTunDevice;
+use smoltcp::phy::{Device, RxToken, TxToken};
+use smoltcp::time::Instant;
+
+#[skuld::test]
+fn receive_returns_none_when_empty() {
+    let mut dev = VirtualTunDevice::new(1400);
+    assert!(dev.receive(Instant::ZERO).is_none());
+}
+
+#[skuld::test]
+fn receive_returns_queued_packet() {
+    let mut dev = VirtualTunDevice::new(1400);
+    dev.enqueue_rx(vec![0x45, 0x00, 0x00, 0x14]);
+    let (rx, _tx) = dev.receive(Instant::ZERO).unwrap();
+    let data: Vec<u8> = rx.consume(|buf: &[u8]| buf.to_vec());
+    assert_eq!(data, vec![0x45, 0x00, 0x00, 0x14]);
+}
+
+#[skuld::test]
+fn transmit_enqueues_packet() {
+    let mut dev = VirtualTunDevice::new(1400);
+    {
+        let token = dev.transmit(Instant::ZERO).unwrap();
+        token.consume(4, |buf: &mut [u8]| {
+            buf.copy_from_slice(&[0x45, 0x00, 0x00, 0x14]);
+        });
+    }
+    let sent = dev.dequeue_tx();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(&sent[0], &[0x45, 0x00, 0x00, 0x14]);
+}
+
+#[skuld::test]
+fn capabilities_uses_ip_medium() {
+    let dev = VirtualTunDevice::new(1400);
+    let caps = dev.capabilities();
+    assert_eq!(caps.medium, smoltcp::phy::Medium::Ip);
+    assert_eq!(caps.max_transmission_unit, 1400);
+}
+
+#[skuld::test]
+fn dequeue_tx_drains_all() {
+    let mut dev = VirtualTunDevice::new(1400);
+    dev.transmit(Instant::ZERO).unwrap().consume(2, |buf: &mut [u8]| {
+        buf.copy_from_slice(&[1, 2]);
+    });
+    dev.transmit(Instant::ZERO).unwrap().consume(3, |buf: &mut [u8]| {
+        buf.copy_from_slice(&[3, 4, 5]);
+    });
+    let sent = dev.dequeue_tx();
+    assert_eq!(sent.len(), 2);
+    assert!(!dev.has_tx());
+}

--- a/crates/bridge/src/dispatcher/driver.rs
+++ b/crates/bridge/src/dispatcher/driver.rs
@@ -57,6 +57,9 @@ struct TcpConn {
     to_handler: mpsc::Sender<Vec<u8>>,
     /// Receive data FROM the handler task (handler writes to SmoltcpStream).
     from_handler: mpsc::Receiver<Vec<u8>>,
+    /// Buffered remainder from a partial `smoltcp::send_slice` call.
+    /// Drained on the next relay pass before reading new data from the channel.
+    pending_send: Vec<u8>,
 }
 
 /// Tracks a TCP listener socket in smoltcp waiting for incoming SYN packets.
@@ -154,43 +157,51 @@ impl TunDriver {
     /// or the TUN device is closed.
     pub async fn run(mut self) {
         let mut tun_buf = vec![0u8; TUN_BUF_SIZE];
+        // Poll interval ensures handler→smoltcp data is relayed even
+        // when no TUN packets are arriving (e.g. response data for
+        // established connections).
+        let mut poll_interval = tokio::time::interval(std::time::Duration::from_millis(1));
+        poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
-            // Phase 1: Read from TUN (non-blocking) or wait for events.
+            // Phase 1: Read from TUN OR poll interval tick OR cancel.
             let read_result = tokio::select! {
                 biased;
                 _ = self.cancel.cancelled() => {
                     debug!("TUN driver cancelled");
                     break;
                 }
-                result = self.tun.read(&mut tun_buf) => result,
+                result = self.tun.read(&mut tun_buf) => Some(result),
+                _ = poll_interval.tick() => None,
             };
 
-            match read_result {
-                Ok(0) => {
-                    debug!("TUN device closed (read 0 bytes)");
-                    break;
-                }
-                Ok(n) => {
-                    let packet = &tun_buf[..n];
-
-                    // Before feeding to smoltcp, parse the packet to set up
-                    // TCP listeners dynamically. This ensures smoltcp has a
-                    // socket ready to accept the SYN.
-                    if let Some((dst_port, proto)) = parse_ip_dst(packet) {
-                        if proto == IpProto::Tcp {
-                            self.ensure_listener(dst_port);
-                        }
-                        // Port 53 UDP is handled by the smoltcp UDP socket.
+            if let Some(read_result) = read_result {
+                match read_result {
+                    Ok(0) => {
+                        debug!("TUN device closed (read 0 bytes)");
+                        break;
                     }
+                    Ok(n) => {
+                        let packet = &tun_buf[..n];
 
-                    self.device.enqueue_rx(packet.to_vec());
-                }
-                Err(e) => {
-                    warn!("TUN read error: {e}");
-                    break;
+                        // Before feeding to smoltcp, parse the packet to set
+                        // up TCP listeners dynamically.
+                        if let Some((dst_port, proto)) = parse_ip_dst(packet) {
+                            if proto == IpProto::Tcp {
+                                self.ensure_listener(dst_port);
+                            }
+                        }
+
+                        self.device.enqueue_rx(packet.to_vec());
+                    }
+                    Err(e) => {
+                        warn!("TUN read error: {e}");
+                        break;
+                    }
                 }
             }
+            // If read_result is None, it was a poll-interval tick — we
+            // still need to run phases 2-8 to relay handler data.
 
             // Phase 2: Poll smoltcp.
             self.poll_smoltcp();
@@ -324,6 +335,7 @@ impl TunDriver {
                 TcpConn {
                     to_handler,
                     from_handler,
+                    pending_send: Vec::new(),
                 },
             );
 
@@ -383,14 +395,27 @@ impl TunDriver {
 
             // Direction: handler → smoltcp (recv from handler, send to socket).
             if socket.may_send() {
-                while socket.can_send() {
+                // First, drain any pending partial send from the previous pass.
+                if !conn.pending_send.is_empty() && socket.can_send() {
+                    if let Ok(sent) = socket.send_slice(&conn.pending_send) {
+                        if sent >= conn.pending_send.len() {
+                            conn.pending_send.clear();
+                        } else {
+                            conn.pending_send.drain(..sent);
+                        }
+                    }
+                }
+
+                // Then read new data from the handler channel.
+                while conn.pending_send.is_empty() && socket.can_send() {
                     match conn.from_handler.try_recv() {
                         Ok(data) => match socket.send_slice(&data) {
-                            Ok(sent) => {
-                                if sent < data.len() {
-                                    trace!("partial smoltcp send: {sent}/{} bytes", data.len());
-                                }
+                            Ok(sent) if sent < data.len() => {
+                                // Partial send: buffer the remainder for next pass.
+                                conn.pending_send = data[sent..].to_vec();
+                                break;
                             }
+                            Ok(_) => {} // fully sent
                             Err(_) => break,
                         },
                         Err(mpsc::error::TryRecvError::Empty) => break,

--- a/crates/bridge/src/dispatcher/driver.rs
+++ b/crates/bridge/src/dispatcher/driver.rs
@@ -1,0 +1,522 @@
+//! TUN driver main loop — bridges the OS TUN device with the smoltcp
+//! userspace TCP/IP stack, dispatches new TCP connections to handler tasks,
+//! and serves port-53 DNS via a smoltcp UDP socket when fake DNS is active.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Instant as StdInstant;
+
+use arc_swap::ArcSwap;
+use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet};
+use smoltcp::socket::{tcp, udp};
+use smoltcp::time::Instant as SmoltcpInstant;
+use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, IpEndpoint};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{mpsc, Semaphore};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, trace, warn};
+
+use super::device::VirtualTunDevice;
+use super::smoltcp_stream::SmoltcpStream;
+use super::tcp_handler::{self, TcpHandlerContext};
+use crate::filter::rules::RuleSet;
+use crate::filter::FakeDns;
+
+// Constants ===========================================================================================================
+
+/// MTU for the virtual smoltcp device (and the TUN). Slightly below
+/// typical Ethernet MTU to leave room for encapsulation.
+pub(crate) const MTU: usize = 1400;
+
+/// Maximum concurrent TCP connections.
+const MAX_CONNECTIONS: usize = 4096;
+
+/// Maximum concurrent sniffer peek operations.
+const MAX_SNIFFERS: usize = 1024;
+
+/// smoltcp TCP socket buffer sizes (per direction).
+const TCP_RX_BUF_SIZE: usize = 65536;
+const TCP_TX_BUF_SIZE: usize = 65536;
+
+/// smoltcp UDP socket buffer sizes (per direction, for DNS).
+const UDP_RX_META_SLOTS: usize = 32;
+const UDP_RX_PAYLOAD_SIZE: usize = 8192;
+const UDP_TX_META_SLOTS: usize = 32;
+const UDP_TX_PAYLOAD_SIZE: usize = 8192;
+
+/// TUN read buffer size — one IP packet.
+const TUN_BUF_SIZE: usize = MTU + 64;
+
+// Types ===============================================================================================================
+
+/// Tracks a TCP connection that the driver is relaying data for between
+/// the smoltcp socket and a handler task.
+struct TcpConn {
+    /// Send data TO the handler task (handler reads from SmoltcpStream).
+    to_handler: mpsc::Sender<Vec<u8>>,
+    /// Receive data FROM the handler task (handler writes to SmoltcpStream).
+    from_handler: mpsc::Receiver<Vec<u8>>,
+}
+
+/// Tracks a TCP listener socket in smoltcp waiting for incoming SYN packets.
+struct TcpListener {
+    handle: SocketHandle,
+    port: u16,
+}
+
+/// The main TUN driver, owning the smoltcp Interface, socket set, and TUN device.
+pub struct TunDriver {
+    tun: tun::AsyncDevice,
+    device: VirtualTunDevice,
+    iface: Interface,
+    sockets: SocketSet<'static>,
+    fake_dns: Option<Arc<FakeDns>>,
+    udp_dns_handle: Option<SocketHandle>,
+    listeners: Vec<TcpListener>,
+    connections: HashMap<SocketHandle, TcpConn>,
+    /// Ports that already have a listener.
+    listened_ports: std::collections::HashSet<u16>,
+    cancel: CancellationToken,
+    conn_semaphore: Arc<Semaphore>,
+    sniffer_semaphore: Arc<Semaphore>,
+    rules: Arc<ArcSwap<RuleSet>>,
+    handler_ctx: Arc<TcpHandlerContext>,
+    /// Reference time for converting std::time::Instant to smoltcp::time::Instant.
+    epoch: StdInstant,
+}
+
+impl TunDriver {
+    /// Create a new TUN driver.
+    ///
+    /// The TUN device must already be created and configured by the caller.
+    pub fn new(
+        tun: tun::AsyncDevice,
+        fake_dns: Option<Arc<FakeDns>>,
+        rules: Arc<ArcSwap<RuleSet>>,
+        handler_ctx: Arc<TcpHandlerContext>,
+        cancel: CancellationToken,
+    ) -> Self {
+        let mut device = VirtualTunDevice::new(MTU);
+
+        let config = Config::new(HardwareAddress::Ip);
+        let epoch = StdInstant::now();
+        let now = SmoltcpInstant::from_millis(0);
+        let mut iface = Interface::new(config, &mut device, now);
+        iface.set_any_ip(true);
+        iface.update_ip_addrs(|addrs| {
+            addrs.push(IpCidr::new(IpAddress::v4(10, 255, 0, 1), 24)).unwrap();
+            addrs
+                .push(IpCidr::new(IpAddress::v6(0xfd00, 0, 0, 0xff00, 0, 0, 0, 1), 64))
+                .unwrap();
+        });
+
+        let mut sockets = SocketSet::new(vec![]);
+
+        // If fake DNS is active, create a UDP socket bound to port 53.
+        let udp_dns_handle = if fake_dns.is_some() {
+            let rx_buf = udp::PacketBuffer::new(
+                vec![udp::PacketMetadata::EMPTY; UDP_RX_META_SLOTS],
+                vec![0u8; UDP_RX_PAYLOAD_SIZE],
+            );
+            let tx_buf = udp::PacketBuffer::new(
+                vec![udp::PacketMetadata::EMPTY; UDP_TX_META_SLOTS],
+                vec![0u8; UDP_TX_PAYLOAD_SIZE],
+            );
+            let mut udp_socket = udp::Socket::new(rx_buf, tx_buf);
+            udp_socket.bind(53).expect("binding smoltcp UDP :53");
+            let handle = sockets.add(udp_socket);
+            Some(handle)
+        } else {
+            None
+        };
+
+        Self {
+            tun,
+            device,
+            iface,
+            sockets,
+            fake_dns,
+            udp_dns_handle,
+            listeners: Vec::new(),
+            connections: HashMap::new(),
+            listened_ports: std::collections::HashSet::new(),
+            cancel,
+            conn_semaphore: Arc::new(Semaphore::new(MAX_CONNECTIONS)),
+            sniffer_semaphore: Arc::new(Semaphore::new(MAX_SNIFFERS)),
+            rules,
+            handler_ctx,
+            epoch,
+        }
+    }
+
+    /// Run the main driver loop. Returns when the cancellation token fires
+    /// or the TUN device is closed.
+    pub async fn run(mut self) {
+        let mut tun_buf = vec![0u8; TUN_BUF_SIZE];
+
+        loop {
+            // Phase 1: Read from TUN (non-blocking) or wait for events.
+            let read_result = tokio::select! {
+                biased;
+                _ = self.cancel.cancelled() => {
+                    debug!("TUN driver cancelled");
+                    break;
+                }
+                result = self.tun.read(&mut tun_buf) => result,
+            };
+
+            match read_result {
+                Ok(0) => {
+                    debug!("TUN device closed (read 0 bytes)");
+                    break;
+                }
+                Ok(n) => {
+                    let packet = &tun_buf[..n];
+
+                    // Before feeding to smoltcp, parse the packet to set up
+                    // TCP listeners dynamically. This ensures smoltcp has a
+                    // socket ready to accept the SYN.
+                    if let Some((dst_port, proto)) = parse_ip_dst(packet) {
+                        if proto == IpProto::Tcp {
+                            self.ensure_listener(dst_port);
+                        }
+                        // Port 53 UDP is handled by the smoltcp UDP socket.
+                    }
+
+                    self.device.enqueue_rx(packet.to_vec());
+                }
+                Err(e) => {
+                    warn!("TUN read error: {e}");
+                    break;
+                }
+            }
+
+            // Phase 2: Poll smoltcp.
+            self.poll_smoltcp();
+
+            // Phase 3: Handle UDP DNS (port 53).
+            self.handle_dns_udp();
+
+            // Phase 4: Accept new TCP connections from listeners that
+            // transitioned out of LISTEN state.
+            self.accept_tcp_connections();
+
+            // Phase 5: Relay data between smoltcp TCP sockets and handler channels.
+            self.relay_tcp_data();
+
+            // Phase 6: Clean up finished connections.
+            self.cleanup_finished_connections();
+
+            // Phase 7: Poll smoltcp again (handler data may have produced new output).
+            self.poll_smoltcp();
+
+            // Phase 8: Flush smoltcp output to the TUN device.
+            self.flush_to_tun().await;
+        }
+
+        // Drain phase: abort remaining handler tasks by dropping channels.
+        debug!(
+            "TUN driver shutting down, {} active connections",
+            self.connections.len()
+        );
+    }
+
+    // Internal methods ================================================================================================
+
+    fn smoltcp_now(&self) -> SmoltcpInstant {
+        let elapsed = self.epoch.elapsed();
+        SmoltcpInstant::from_millis(elapsed.as_millis() as i64)
+    }
+
+    fn poll_smoltcp(&mut self) {
+        let now = self.smoltcp_now();
+        self.iface.poll(now, &mut self.device, &mut self.sockets);
+    }
+
+    fn handle_dns_udp(&mut self) {
+        let Some(handle) = self.udp_dns_handle else {
+            return;
+        };
+        let Some(fake_dns) = &self.fake_dns else {
+            return;
+        };
+
+        let udp_socket = self.sockets.get_mut::<udp::Socket>(handle);
+
+        // Process all queued datagrams.
+        while udp_socket.can_recv() {
+            let (payload, meta) = match udp_socket.recv() {
+                Ok(v) => v,
+                Err(udp::RecvError::Truncated) => continue,
+                Err(udp::RecvError::Exhausted) => break,
+            };
+
+            let response = fake_dns.handle_udp(payload);
+            if response.is_empty() {
+                continue;
+            }
+
+            // Reply to the sender.
+            let reply_endpoint = IpEndpoint {
+                addr: meta.endpoint.addr,
+                port: meta.endpoint.port,
+            };
+            if let Err(e) = udp_socket.send_slice(&response, reply_endpoint) {
+                trace!("DNS UDP reply send error: {e:?}");
+            }
+        }
+    }
+
+    fn accept_tcp_connections(&mut self) {
+        // Check each listener to see if it has accepted a connection
+        // (transitioned from LISTEN to ESTABLISHED or SYN-RECEIVED).
+        let mut accepted = Vec::new();
+
+        for listener in &self.listeners {
+            let socket = self.sockets.get::<tcp::Socket>(listener.handle);
+            if socket.state() != tcp::State::Listen {
+                accepted.push((listener.handle, listener.port));
+            }
+        }
+
+        for (handle, port) in accepted {
+            // Remove this listener.
+            self.listeners.retain(|l| l.handle != handle);
+            self.listened_ports.remove(&port);
+
+            let socket = self.sockets.get::<tcp::Socket>(handle);
+
+            // The local endpoint is the destination the client intended
+            // to connect to (since any_ip is enabled, smoltcp accepted
+            // the packet to an arbitrary IP).
+            let (dst_ip, dst_port) = match socket.local_endpoint() {
+                Some(ep) => (smoltcp_to_std_ip(ep.addr), ep.port),
+                None => {
+                    warn!("accepted TCP connection with no local endpoint on port {port}");
+                    let socket = self.sockets.get_mut::<tcp::Socket>(handle);
+                    socket.abort();
+                    self.sockets.remove(handle);
+                    self.ensure_listener(port);
+                    continue;
+                }
+            };
+
+            // Try to acquire a connection semaphore permit.
+            let permit = match self.conn_semaphore.clone().try_acquire_owned() {
+                Ok(p) => p,
+                Err(_) => {
+                    warn!("connection limit reached, rejecting {dst_ip}:{dst_port}");
+                    let socket = self.sockets.get_mut::<tcp::Socket>(handle);
+                    socket.abort();
+                    self.sockets.remove(handle);
+                    self.ensure_listener(port);
+                    continue;
+                }
+            };
+
+            // Create SmoltcpStream channels.
+            let (stream, to_handler, from_handler) = SmoltcpStream::new();
+
+            // Register the connection for relay.
+            self.connections.insert(
+                handle,
+                TcpConn {
+                    to_handler,
+                    from_handler,
+                },
+            );
+
+            // Spawn handler task.
+            let env = tcp_handler::ConnEnv {
+                ctx: Arc::clone(&self.handler_ctx),
+                rules: Arc::clone(&self.rules),
+                fake_dns: self.fake_dns.clone(),
+                sniffer_semaphore: Arc::clone(&self.sniffer_semaphore),
+                cancel: self.cancel.clone(),
+            };
+
+            tokio::spawn(async move {
+                let result = tcp_handler::handle_tcp_connection(stream, dst_ip, dst_port, env).await;
+                if let Err(e) = result {
+                    trace!("TCP handler error for {dst_ip}:{dst_port}: {e}");
+                }
+                drop(permit);
+            });
+
+            // Re-create listener for this port for subsequent connections.
+            // Known limitation: 1-poll-interval SYN race window.
+            self.ensure_listener(port);
+        }
+    }
+
+    fn relay_tcp_data(&mut self) {
+        let handles: Vec<SocketHandle> = self.connections.keys().copied().collect();
+
+        for handle in handles {
+            let conn = match self.connections.get_mut(&handle) {
+                Some(c) => c,
+                None => continue,
+            };
+
+            let socket = self.sockets.get_mut::<tcp::Socket>(handle);
+
+            // Direction: smoltcp → handler (recv from socket, send to handler).
+            if socket.may_recv() {
+                let _ = socket.recv(|buf| {
+                    if buf.is_empty() {
+                        return (0, ());
+                    }
+                    // Try to send to handler via channel. If the channel is
+                    // full, don't dequeue from the socket — this naturally
+                    // constrains the recv window.
+                    match conn.to_handler.try_send(buf.to_vec()) {
+                        Ok(()) => (buf.len(), ()),
+                        Err(mpsc::error::TrySendError::Full(_)) => (0, ()),
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            // Handler dropped. The cleanup pass will handle this.
+                            (0, ())
+                        }
+                    }
+                });
+            }
+
+            // Direction: handler → smoltcp (recv from handler, send to socket).
+            if socket.may_send() {
+                while socket.can_send() {
+                    match conn.from_handler.try_recv() {
+                        Ok(data) => match socket.send_slice(&data) {
+                            Ok(sent) => {
+                                if sent < data.len() {
+                                    trace!("partial smoltcp send: {sent}/{} bytes", data.len());
+                                }
+                            }
+                            Err(_) => break,
+                        },
+                        Err(mpsc::error::TryRecvError::Empty) => break,
+                        Err(mpsc::error::TryRecvError::Disconnected) => {
+                            // Handler finished writing. Close the smoltcp socket's
+                            // send half so FIN gets sent.
+                            socket.close();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn cleanup_finished_connections(&mut self) {
+        let finished: Vec<SocketHandle> = self
+            .connections
+            .keys()
+            .copied()
+            .filter(|&handle| {
+                let socket = self.sockets.get::<tcp::Socket>(handle);
+                matches!(socket.state(), tcp::State::Closed | tcp::State::TimeWait)
+            })
+            .collect();
+
+        for handle in finished {
+            self.connections.remove(&handle);
+            self.sockets.remove(handle);
+        }
+    }
+
+    async fn flush_to_tun(&mut self) {
+        let packets = self.device.dequeue_tx();
+        for pkt in packets {
+            if let Err(e) = self.tun.write_all(&pkt).await {
+                trace!("TUN write error: {e}");
+                break;
+            }
+        }
+    }
+
+    /// Ensure a TCP listener socket exists for the given port.
+    fn ensure_listener(&mut self, port: u16) {
+        if self.listened_ports.contains(&port) {
+            return;
+        }
+        let rx_buf = tcp::SocketBuffer::new(vec![0u8; TCP_RX_BUF_SIZE]);
+        let tx_buf = tcp::SocketBuffer::new(vec![0u8; TCP_TX_BUF_SIZE]);
+        let mut socket = tcp::Socket::new(rx_buf, tx_buf);
+        if let Err(e) = socket.listen(port) {
+            warn!("failed to listen on port {port}: {e:?}");
+            return;
+        }
+        let handle = self.sockets.add(socket);
+        self.listeners.push(TcpListener { handle, port });
+        self.listened_ports.insert(port);
+    }
+}
+
+// Helpers =============================================================================================================
+
+/// Parse an incoming IP packet and return the destination port and protocol
+/// for TCP/UDP. Used to dynamically create smoltcp listeners.
+fn parse_ip_dst(packet: &[u8]) -> Option<(u16, IpProto)> {
+    if packet.is_empty() {
+        return None;
+    }
+    let version = packet[0] >> 4;
+    match version {
+        4 => parse_ipv4_dst(packet),
+        6 => parse_ipv6_dst(packet),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IpProto {
+    Tcp,
+    Udp,
+}
+
+fn parse_ipv4_dst(packet: &[u8]) -> Option<(u16, IpProto)> {
+    // Minimum IPv4 header is 20 bytes.
+    if packet.len() < 20 {
+        return None;
+    }
+    let ihl = ((packet[0] & 0x0f) as usize) * 4;
+    let protocol = packet[9];
+    if packet.len() < ihl + 4 {
+        return None;
+    }
+    let dst_port = u16::from_be_bytes([packet[ihl + 2], packet[ihl + 3]]);
+    match protocol {
+        6 => Some((dst_port, IpProto::Tcp)),
+        17 => Some((dst_port, IpProto::Udp)),
+        _ => None,
+    }
+}
+
+fn parse_ipv6_dst(packet: &[u8]) -> Option<(u16, IpProto)> {
+    // IPv6 header is 40 bytes fixed.
+    if packet.len() < 40 + 4 {
+        return None;
+    }
+    let next_header = packet[6];
+    // We only handle TCP/UDP in the base header (no extension header chasing).
+    let dst_port = u16::from_be_bytes([packet[42], packet[43]]);
+    match next_header {
+        6 => Some((dst_port, IpProto::Tcp)),
+        17 => Some((dst_port, IpProto::Udp)),
+        _ => None,
+    }
+}
+
+/// Convert a smoltcp `IpAddress` to a `std::net::IpAddr`.
+///
+/// smoltcp 0.12 re-exports `core::net::Ipv4Addr`/`Ipv6Addr` as its
+/// address types, so this is a trivial wrapping.
+fn smoltcp_to_std_ip(addr: IpAddress) -> IpAddr {
+    match addr {
+        IpAddress::Ipv4(v4) => IpAddr::V4(v4),
+        IpAddress::Ipv6(v6) => IpAddr::V6(v6),
+    }
+}
+
+#[cfg(test)]
+#[path = "driver_tests.rs"]
+mod driver_tests;

--- a/crates/bridge/src/dispatcher/driver_tests.rs
+++ b/crates/bridge/src/dispatcher/driver_tests.rs
@@ -1,0 +1,61 @@
+// Driver tests require a real TUN device (elevated privileges).
+// Unit tests for parse_ip_dst are feasible and placed here.
+
+use super::{parse_ip_dst, IpProto};
+
+#[skuld::test]
+fn parse_ipv4_tcp_syn() {
+    // Minimal IPv4 header (20 bytes) + TCP header start (4 bytes for ports).
+    let mut packet = [0u8; 24];
+    packet[0] = 0x45; // version=4, IHL=5 (20 bytes)
+    packet[9] = 6; // protocol = TCP
+                   // Destination port at offset IHL+2..IHL+4 = 22..24
+    packet[22] = 0x01;
+    packet[23] = 0xBB; // port 443
+    let result = parse_ip_dst(&packet);
+    assert_eq!(result, Some((443, IpProto::Tcp)));
+}
+
+#[skuld::test]
+fn parse_ipv4_udp() {
+    let mut packet = [0u8; 24];
+    packet[0] = 0x45;
+    packet[9] = 17; // protocol = UDP
+    packet[22] = 0x00;
+    packet[23] = 0x35; // port 53
+    let result = parse_ip_dst(&packet);
+    assert_eq!(result, Some((53, IpProto::Udp)));
+}
+
+#[skuld::test]
+fn parse_ipv6_tcp() {
+    // IPv6 header (40 bytes) + TCP header start (4 bytes for ports).
+    let mut packet = [0u8; 44];
+    packet[0] = 0x60; // version=6
+    packet[6] = 6; // next header = TCP
+                   // Destination port at offset 42..44
+    packet[42] = 0x00;
+    packet[43] = 0x50; // port 80
+    let result = parse_ip_dst(&packet);
+    assert_eq!(result, Some((80, IpProto::Tcp)));
+}
+
+#[skuld::test]
+fn parse_empty_packet_returns_none() {
+    assert_eq!(parse_ip_dst(&[]), None);
+}
+
+#[skuld::test]
+fn parse_truncated_ipv4_returns_none() {
+    // Only 10 bytes — not enough for an IPv4 header.
+    let packet = [0x45u8; 10];
+    assert_eq!(parse_ip_dst(&packet), None);
+}
+
+#[skuld::test]
+fn parse_unknown_protocol_returns_none() {
+    let mut packet = [0u8; 24];
+    packet[0] = 0x45;
+    packet[9] = 1; // ICMP
+    assert_eq!(parse_ip_dst(&packet), None);
+}

--- a/crates/bridge/src/dispatcher/smoltcp_stream.rs
+++ b/crates/bridge/src/dispatcher/smoltcp_stream.rs
@@ -1,0 +1,114 @@
+//! `SmoltcpStream` — `AsyncRead + AsyncWrite` adapter over mpsc channels.
+//!
+//! The TUN driver relays data between smoltcp TCP sockets and per-connection
+//! handler tasks through a pair of channels. This adapter lets the handler
+//! code use standard tokio I/O traits (`copy_bidirectional`, etc.) without
+//! knowing about the underlying channel mechanics.
+//!
+//! Write side uses [`tokio_util::sync::PollSender`] to implement
+//! `AsyncWrite::poll_write` without requiring an async context.
+
+use bytes::BytesMut;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::mpsc;
+use tokio_util::sync::PollSender;
+
+/// Channel capacity for the driver ↔ handler data path. Sized to
+/// roughly match a TCP window (~64 KiB at 1400 MTU ≈ 46 segments).
+const CHANNEL_CAPACITY: usize = 64;
+
+/// Async read/write adapter backed by mpsc channels. The TUN driver
+/// holds the other ends of the channels and relays data between this
+/// stream and the smoltcp TCP socket.
+pub struct SmoltcpStream {
+    rx: mpsc::Receiver<Vec<u8>>,
+    tx: PollSender<Vec<u8>>,
+    read_buf: BytesMut,
+}
+
+impl SmoltcpStream {
+    /// Create a new stream and return the channel ends for the driver.
+    ///
+    /// Returns `(stream, driver_tx, driver_rx)` where:
+    /// - `driver_tx` sends data TO the handler (the handler reads it)
+    /// - `driver_rx` receives data FROM the handler (the handler wrote it)
+    pub fn new() -> (Self, mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
+        let (to_handler_tx, to_handler_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let (from_handler_tx, from_handler_rx) = mpsc::channel(CHANNEL_CAPACITY);
+
+        let stream = Self {
+            rx: to_handler_rx,
+            tx: PollSender::new(from_handler_tx),
+            read_buf: BytesMut::new(),
+        };
+
+        (stream, to_handler_tx, from_handler_rx)
+    }
+}
+
+impl AsyncRead for SmoltcpStream {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        // Drain the internal buffer first.
+        if !self.read_buf.is_empty() {
+            let n = std::cmp::min(self.read_buf.len(), buf.remaining());
+            buf.put_slice(&self.read_buf.split_to(n));
+            return Poll::Ready(Ok(()));
+        }
+
+        // Try to receive new data from the driver.
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(data)) => {
+                let n = std::cmp::min(data.len(), buf.remaining());
+                buf.put_slice(&data[..n]);
+                if n < data.len() {
+                    self.read_buf.extend_from_slice(&data[n..]);
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(None) => {
+                // Channel closed = EOF.
+                Poll::Ready(Ok(()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl AsyncWrite for SmoltcpStream {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        // Reserve capacity in the PollSender.
+        match self.tx.poll_reserve(cx) {
+            Poll::Ready(Ok(())) => {
+                let data = buf.to_vec();
+                let len = data.len();
+                self.tx
+                    .send_item(data)
+                    .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "channel closed"))?;
+                Poll::Ready(Ok(len))
+            }
+            Poll::Ready(Err(_)) => Poll::Ready(Err(io::Error::new(io::ErrorKind::BrokenPipe, "channel closed"))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Channels don't need flushing.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.tx.close();
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+#[path = "smoltcp_stream_tests.rs"]
+mod smoltcp_stream_tests;

--- a/crates/bridge/src/dispatcher/smoltcp_stream_tests.rs
+++ b/crates/bridge/src/dispatcher/smoltcp_stream_tests.rs
@@ -1,0 +1,72 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::SmoltcpStream;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().unwrap()
+}
+
+#[skuld::test]
+fn read_receives_data_from_driver() {
+    rt().block_on(async {
+        let (mut stream, driver_tx, _driver_rx) = SmoltcpStream::new();
+        driver_tx.send(b"hello".to_vec()).await.unwrap();
+
+        let mut buf = [0u8; 16];
+        let n = stream.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"hello");
+    });
+}
+
+#[skuld::test]
+fn write_sends_data_to_driver() {
+    rt().block_on(async {
+        let (mut stream, _driver_tx, mut driver_rx) = SmoltcpStream::new();
+        stream.write_all(b"world").await.unwrap();
+
+        let data = driver_rx.recv().await.unwrap();
+        assert_eq!(data, b"world");
+    });
+}
+
+#[skuld::test]
+fn partial_read_buffers_remainder() {
+    rt().block_on(async {
+        let (mut stream, driver_tx, _driver_rx) = SmoltcpStream::new();
+        driver_tx.send(b"abcdef".to_vec()).await.unwrap();
+
+        // Read only 3 bytes — the remaining 3 should be buffered internally.
+        let mut buf = [0u8; 3];
+        let n = stream.read(&mut buf).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&buf[..n], b"abc");
+
+        // Second read should return the buffered remainder.
+        let n = stream.read(&mut buf).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&buf[..n], b"def");
+    });
+}
+
+#[skuld::test]
+fn read_returns_eof_when_channel_closed() {
+    rt().block_on(async {
+        let (mut stream, driver_tx, _driver_rx) = SmoltcpStream::new();
+        drop(driver_tx);
+
+        let mut buf = [0u8; 16];
+        let n = stream.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0);
+    });
+}
+
+#[skuld::test]
+fn shutdown_closes_write_channel() {
+    rt().block_on(async {
+        let (mut stream, _driver_tx, mut driver_rx) = SmoltcpStream::new();
+        stream.shutdown().await.unwrap();
+
+        // The driver_rx should see channel closure.
+        assert!(driver_rx.recv().await.is_none());
+    });
+}

--- a/crates/bridge/src/dispatcher/socks5_client.rs
+++ b/crates/bridge/src/dispatcher/socks5_client.rs
@@ -1,0 +1,40 @@
+//! SOCKS5 CONNECT client for the proxy dispatch path.
+
+use std::net::IpAddr;
+use tokio::net::TcpStream;
+use tokio_socks::tcp::Socks5Stream;
+
+/// Connect to the target through the SS SOCKS5 local.
+///
+/// - `local_port`: SS's SOCKS5 listen port on 127.0.0.1.
+/// - `dst_ip`: the connection's destination IP (may be a fake-DNS IP).
+/// - `dst_port`: the connection's destination port.
+/// - `domain`: if available, used as the SOCKS5 target (preferred to
+///   prevent DNS leaks).
+pub async fn socks5_connect(
+    local_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    domain: Option<&str>,
+) -> std::io::Result<TcpStream> {
+    let proxy_addr = format!("127.0.0.1:{local_port}");
+    let stream = match domain {
+        Some(d) => {
+            let target = format!("{d}:{dst_port}");
+            Socks5Stream::connect(proxy_addr.as_str(), target.as_str())
+                .await
+                .map_err(|e| std::io::Error::other(format!("SOCKS5 connect (domain) failed: {e}")))?
+        }
+        None => {
+            let target = std::net::SocketAddr::new(dst_ip, dst_port);
+            Socks5Stream::connect(proxy_addr.as_str(), target)
+                .await
+                .map_err(|e| std::io::Error::other(format!("SOCKS5 connect (IP) failed: {e}")))?
+        }
+    };
+    Ok(stream.into_inner())
+}
+
+#[cfg(test)]
+#[path = "socks5_client_tests.rs"]
+mod socks5_client_tests;

--- a/crates/bridge/src/dispatcher/socks5_client_tests.rs
+++ b/crates/bridge/src/dispatcher/socks5_client_tests.rs
@@ -1,0 +1,14 @@
+use super::*;
+use std::net::Ipv4Addr;
+
+#[skuld::test]
+fn socks5_connect_refuses_when_no_server() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let result = rt.block_on(socks5_connect(1, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 80, None));
+
+    assert!(result.is_err(), "expected error when no SOCKS5 server is listening");
+}

--- a/crates/bridge/src/dispatcher/tcp_handler.rs
+++ b/crates/bridge/src/dispatcher/tcp_handler.rs
@@ -1,0 +1,295 @@
+//! Per-TCP-connection handler task. Each connection runs through:
+//! 1. Port 53 fast path (DNS over TCP)
+//! 2. Fake DNS reverse lookup (pin on success)
+//! 3. Optional sniffer peek (2 KiB, 100 ms budget)
+//! 4. Filter engine decision
+//! 5. Dispatch: proxy / bypass / block
+
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use super::block_log::BlockLog;
+use super::bypass::create_bypass_tcp;
+use super::smoltcp_stream::SmoltcpStream;
+use super::socks5_client::socks5_connect;
+use super::upstream_dns::UpstreamResolver;
+use crate::filter::engine::{ConnInfo, L4Proto};
+use crate::filter::rules::RuleSet;
+use crate::filter::{self, FakeDns};
+use hole_common::config::FilterAction;
+
+// Constants ===========================================================================================================
+
+/// Maximum bytes to peek for the sniffer (TLS ClientHello + HTTP request line).
+const PEEK_BUF_SIZE: usize = 2048;
+
+/// Maximum time to wait for the first payload bytes (for sniffer).
+const PEEK_TIMEOUT: Duration = Duration::from_millis(100);
+
+// Context shared across all handler tasks =============================================================================
+
+/// Shared state for all TCP handler tasks. Created once by the Dispatcher
+/// and passed (via Arc) to each spawned handler.
+pub struct TcpHandlerContext {
+    /// SS SOCKS5 local port on 127.0.0.1.
+    pub local_port: u16,
+    /// Upstream interface index for bypass sockets.
+    pub iface_index: u32,
+    /// Whether the upstream interface has IPv6 connectivity.
+    pub ipv6_available: bool,
+    /// Upstream DNS resolver for the bypass path.
+    pub upstream_resolver: UpstreamResolver,
+    /// Rate-limited block log. Uses `std::sync::Mutex` because the
+    /// critical section is sub-microsecond and never held across .await.
+    pub block_log: std::sync::Mutex<BlockLog>,
+    /// One-time flag: emitted when IPv6 bypass falls back to block.
+    pub ipv6_bypass_warned: AtomicBool,
+}
+
+// Handler entry point =================================================================================================
+
+/// Per-connection environment, bundled to avoid clippy::too_many_arguments.
+pub struct ConnEnv {
+    pub ctx: Arc<TcpHandlerContext>,
+    pub rules: Arc<ArcSwap<RuleSet>>,
+    pub fake_dns: Option<Arc<FakeDns>>,
+    pub sniffer_semaphore: Arc<Semaphore>,
+    pub cancel: CancellationToken,
+}
+
+/// Handle a single TCP connection from smoltcp.
+pub async fn handle_tcp_connection(
+    mut stream: SmoltcpStream,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    env: ConnEnv,
+) -> std::io::Result<()> {
+    // Run the handler with cancellation support.
+    tokio::select! {
+        biased;
+        _ = env.cancel.cancelled() => Ok(()),
+        result = handle_inner(
+            &mut stream, dst_ip, dst_port, &env.ctx, &env.rules,
+            env.fake_dns.as_deref(), &env.sniffer_semaphore
+        ) => result,
+    }
+}
+
+async fn handle_inner(
+    stream: &mut SmoltcpStream,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    ctx: &TcpHandlerContext,
+    rules: &ArcSwap<RuleSet>,
+    fake_dns: Option<&FakeDns>,
+    sniffer_semaphore: &Semaphore,
+) -> std::io::Result<()> {
+    // Step 1: Port 53 fast path — DNS over TCP.
+    if dst_port == 53 {
+        if let Some(dns) = fake_dns {
+            return dns.handle_tcp(stream).await;
+        }
+    }
+
+    // Step 2: Fake DNS reverse lookup.
+    let mut domain: Option<String> = None;
+    let mut pinned = false;
+
+    if let Some(dns) = fake_dns {
+        if let Some(d) = dns.reverse_lookup(dst_ip) {
+            domain = Some(d.to_string());
+            dns.pin(dst_ip);
+            pinned = true;
+        }
+    }
+
+    // Ensure we unpin on all exit paths if we pinned.
+    let denv = DispatchEnv {
+        ctx,
+        rules,
+        fake_dns,
+        sniffer_semaphore,
+    };
+    let result = dispatch(stream, dst_ip, dst_port, &mut domain, &denv).await;
+
+    if pinned {
+        if let Some(dns) = fake_dns {
+            dns.unpin(dst_ip);
+        }
+    }
+
+    result
+}
+
+/// Bundled dispatch environment (avoids too_many_arguments).
+struct DispatchEnv<'a> {
+    ctx: &'a TcpHandlerContext,
+    rules: &'a ArcSwap<RuleSet>,
+    fake_dns: Option<&'a FakeDns>,
+    sniffer_semaphore: &'a Semaphore,
+}
+
+async fn dispatch(
+    stream: &mut SmoltcpStream,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    domain: &mut Option<String>,
+    env: &DispatchEnv<'_>,
+) -> std::io::Result<()> {
+    // Step 3: Sniffer peek — only when domain is unknown AND domain rules exist.
+    let mut peek_buf = Vec::new();
+    let current_rules = env.rules.load();
+
+    if domain.is_none() && current_rules.has_domain_rules {
+        // Acquire sniffer semaphore (bounded concurrency for peeks).
+        if let Ok(_permit) = env.sniffer_semaphore.try_acquire() {
+            let mut buf = [0u8; PEEK_BUF_SIZE];
+            match tokio::time::timeout(PEEK_TIMEOUT, stream.read(&mut buf)).await {
+                Ok(Ok(n)) if n > 0 => {
+                    peek_buf = buf[..n].to_vec();
+                    if let Some(sni) = filter::peek(&peek_buf) {
+                        *domain = Some(sni);
+                    }
+                }
+                Ok(Ok(_)) => {} // EOF or 0 bytes
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {} // timeout — proceed without domain
+            }
+        }
+    }
+
+    // Step 4: Filter engine decision.
+    let conn_info = ConnInfo {
+        dst_ip,
+        dst_port,
+        domain: domain.clone(),
+        proto: L4Proto::Tcp,
+    };
+    let decision = filter::decide(&current_rules, &conn_info);
+    drop(current_rules);
+
+    // Step 5: Dispatch.
+    match decision.action {
+        FilterAction::Proxy => dispatch_proxy(stream, dst_ip, dst_port, domain, env.ctx, &peek_buf).await,
+        FilterAction::Bypass => {
+            dispatch_bypass(stream, dst_ip, dst_port, domain, env.ctx, env.fake_dns, &peek_buf).await
+        }
+        FilterAction::Block => {
+            dispatch_block(dst_ip, dst_port, domain.as_deref(), env.ctx, &decision);
+            Ok(())
+        }
+    }
+}
+
+// Dispatch paths ======================================================================================================
+
+async fn dispatch_proxy(
+    stream: &mut SmoltcpStream,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    domain: &Option<String>,
+    ctx: &TcpHandlerContext,
+    peek_buf: &[u8],
+) -> std::io::Result<()> {
+    let mut upstream = socks5_connect(ctx.local_port, dst_ip, dst_port, domain.as_deref()).await?;
+
+    // Write peek buffer if non-empty.
+    if !peek_buf.is_empty() {
+        upstream.write_all(peek_buf).await?;
+    }
+
+    tokio::io::copy_bidirectional(stream, &mut upstream).await?;
+    Ok(())
+}
+
+async fn dispatch_bypass(
+    stream: &mut SmoltcpStream,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    domain: &Option<String>,
+    ctx: &TcpHandlerContext,
+    fake_dns: Option<&FakeDns>,
+    peek_buf: &[u8],
+) -> std::io::Result<()> {
+    // Resolve the real IP if dst_ip is a fake DNS address.
+    let real_ip = resolve_bypass_ip(dst_ip, domain.as_deref(), ctx, fake_dns).await?;
+
+    // Check IPv6 availability for bypass.
+    if real_ip.is_ipv6() && !ctx.ipv6_available {
+        if !ctx.ipv6_bypass_warned.swap(true, Ordering::Relaxed) {
+            warn!("IPv6 bypass requested but upstream has no IPv6; falling back to block");
+        }
+        return Ok(());
+    }
+
+    let mut upstream = create_bypass_tcp(real_ip, dst_port, ctx.iface_index).await?;
+
+    // Write peek buffer if non-empty.
+    if !peek_buf.is_empty() {
+        upstream.write_all(peek_buf).await?;
+    }
+
+    tokio::io::copy_bidirectional(stream, &mut upstream).await?;
+    Ok(())
+}
+
+fn dispatch_block(
+    dst_ip: IpAddr,
+    dst_port: u16,
+    domain: Option<&str>,
+    ctx: &TcpHandlerContext,
+    decision: &filter::Decision,
+) {
+    let rule_index = decision.rule_index.unwrap_or(0) as u32;
+    let should_log = ctx.block_log.lock().unwrap().should_log(rule_index, dst_ip, dst_port);
+
+    if should_log {
+        match domain {
+            Some(d) => debug!("blocked {d} ({dst_ip}:{dst_port}) by rule #{rule_index}"),
+            None => debug!("blocked {dst_ip}:{dst_port} by rule #{rule_index}"),
+        }
+    }
+    // Connection is dropped → smoltcp sends RST.
+}
+
+// Helpers =============================================================================================================
+
+/// Determine the real IP address for a bypass connection.
+///
+/// If `dst_ip` is in the fake DNS pool, resolve the domain via the
+/// upstream resolver. Otherwise use `dst_ip` directly (the sniffer
+/// recovered the domain but the IP is already real).
+async fn resolve_bypass_ip(
+    dst_ip: IpAddr,
+    domain: Option<&str>,
+    ctx: &TcpHandlerContext,
+    fake_dns: Option<&FakeDns>,
+) -> std::io::Result<IpAddr> {
+    // Only resolve if the IP is a fake DNS synthetic IP.
+    let is_fake = fake_dns.is_some_and(|dns| dns.is_fake_ip(dst_ip));
+
+    if !is_fake {
+        return Ok(dst_ip);
+    }
+
+    let domain =
+        domain.ok_or_else(|| std::io::Error::other("bypass: dst_ip is in fake DNS pool but no domain available"))?;
+
+    let addrs = ctx.upstream_resolver.resolve(domain).await?;
+    addrs
+        .into_iter()
+        .next()
+        .ok_or_else(|| std::io::Error::other(format!("bypass: no addresses resolved for {domain}")))
+}
+
+#[cfg(test)]
+#[path = "tcp_handler_tests.rs"]
+mod tcp_handler_tests;

--- a/crates/bridge/src/dispatcher/tcp_handler_tests.rs
+++ b/crates/bridge/src/dispatcher/tcp_handler_tests.rs
@@ -1,0 +1,3 @@
+// TCP handler tests require a real TUN device and proxy infrastructure.
+// Integration tests with elevated privileges are the right place for
+// end-to-end handler verification. Helper unit tests go here.

--- a/crates/bridge/src/dispatcher/upstream_dns.rs
+++ b/crates/bridge/src/dispatcher/upstream_dns.rs
@@ -1,0 +1,66 @@
+//! Upstream DNS resolver for the bypass dispatch path.
+//!
+//! Resolves real domain names for bypass-path connections whose dst_ip
+//! is a fake-DNS synthetic IP. Uses the host's real DNS servers,
+//! discovered before TUN routes are installed.
+
+use hickory_proto::xfer::Protocol;
+use hickory_resolver::config::{NameServerConfig, ResolverConfig};
+use hickory_resolver::{Resolver, TokioResolver};
+use std::net::{IpAddr, SocketAddr};
+
+/// Discover the OS's configured DNS server IPs.
+///
+/// Called once at proxy start, before TUN routes are installed, so the
+/// returned IPs are reachable via the real upstream interface.
+pub fn discover_dns_servers() -> std::io::Result<Vec<IpAddr>> {
+    let (config, _opts) = hickory_resolver::system_conf::read_system_conf()
+        .map_err(|e| std::io::Error::other(format!("failed to read system DNS config: {e}")))?;
+    let servers: Vec<IpAddr> = config.name_servers().iter().map(|ns| ns.socket_addr.ip()).collect();
+    if servers.is_empty() {
+        return Err(std::io::Error::other("no DNS servers found in system config"));
+    }
+    Ok(servers)
+}
+
+/// Async DNS resolver that uses the discovered upstream DNS servers.
+pub struct UpstreamResolver {
+    resolver: TokioResolver,
+}
+
+impl UpstreamResolver {
+    /// Construct a resolver from the given DNS server IPs.
+    ///
+    /// Note: the resolver's transport sockets are NOT interface-bound
+    /// (hickory-resolver doesn't expose socket customization). The DNS
+    /// server IPs need host-route exceptions added alongside the SS
+    /// server IP exception to prevent routing loops through the TUN.
+    pub fn new(servers: &[IpAddr]) -> Self {
+        let mut config = ResolverConfig::new();
+        for &ip in servers {
+            config.add_name_server(NameServerConfig::new(SocketAddr::new(ip, 53), Protocol::Udp));
+        }
+        let resolver = Resolver::builder_with_config(config, Default::default()).build();
+        Self { resolver }
+    }
+
+    /// Resolve a domain name to IP addresses. Prefers IPv4.
+    pub async fn resolve(&self, domain: &str) -> std::io::Result<Vec<IpAddr>> {
+        let response = self
+            .resolver
+            .lookup_ip(domain)
+            .await
+            .map_err(|e| std::io::Error::other(format!("DNS resolution failed for {domain}: {e}")))?;
+        let mut v4: Vec<IpAddr> = response.iter().filter(|ip| ip.is_ipv4()).collect();
+        let v6: Vec<IpAddr> = response.iter().filter(|ip| ip.is_ipv6()).collect();
+        v4.extend(v6);
+        if v4.is_empty() {
+            return Err(std::io::Error::other(format!("no addresses returned for {domain}")));
+        }
+        Ok(v4)
+    }
+}
+
+#[cfg(test)]
+#[path = "upstream_dns_tests.rs"]
+mod upstream_dns_tests;

--- a/crates/bridge/src/dispatcher/upstream_dns_tests.rs
+++ b/crates/bridge/src/dispatcher/upstream_dns_tests.rs
@@ -1,0 +1,21 @@
+use super::{discover_dns_servers, UpstreamResolver};
+
+#[skuld::test]
+fn discover_dns_servers_returns_at_least_one() {
+    let servers = discover_dns_servers().unwrap();
+    assert!(!servers.is_empty(), "should find at least one DNS server");
+}
+
+#[skuld::test]
+fn upstream_resolver_resolves_known_domain() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let servers = discover_dns_servers().unwrap();
+        let resolver = UpstreamResolver::new(&servers);
+        let ips = resolver.resolve("example.com").await.unwrap();
+        assert!(!ips.is_empty(), "example.com should resolve");
+    });
+}

--- a/crates/bridge/src/filter.rs
+++ b/crates/bridge/src/filter.rs
@@ -11,7 +11,7 @@ pub mod matcher;
 pub mod rules;
 pub mod sniffer;
 
-pub use engine::{decide, ConnInfo, L4Proto};
+pub use engine::{decide, ConnInfo, Decision, L4Proto};
 pub use fake_dns::{AllocateError, FakeDns, DEFAULT_POOL_V4, DEFAULT_POOL_V6, FAKE_DNS_TTL};
 pub use matcher::Matcher;
 pub use rules::{CompiledRule, RuleSet};

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -37,18 +37,34 @@ pub struct ConnInfo {
     pub proto: L4Proto,
 }
 
+/// Result of a filter engine decision: the action to take and the index
+/// of the rule that matched (if any). The rule index is the position in
+/// the original user-supplied rule list. `None` means the terminal
+/// fallback fired (no rule matched).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Decision {
+    pub action: FilterAction,
+    pub rule_index: Option<usize>,
+}
+
 /// Run the filter engine for one connection. O(n) in the rule count;
 /// pure function.
-pub fn decide(rules: &RuleSet, conn: &ConnInfo) -> FilterAction {
-    for rule in rules.rules.iter().rev() {
+pub fn decide(rules: &RuleSet, conn: &ConnInfo) -> Decision {
+    for (i, rule) in rules.rules.iter().enumerate().rev() {
         if rule.matcher.matches(conn) {
-            return rule.action;
+            return Decision {
+                action: rule.action,
+                rule_index: Some(i),
+            };
         }
     }
     // Terminal fallback: never reached when the UI's locked default
     // rules are present, but preserves "proxy everything" if a
     // hand-edited config strips them out.
-    FilterAction::Proxy
+    Decision {
+        action: FilterAction::Proxy,
+        rule_index: None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/filter/engine_tests.rs
+++ b/crates/bridge/src/filter/engine_tests.rs
@@ -29,7 +29,7 @@ fn conn(dst: &str, port: u16, domain: Option<&str>) -> ConnInfo {
 #[skuld::test]
 fn empty_ruleset_falls_back_to_proxy() {
     let rs = RuleSet::from_user_rules(&[]);
-    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)).action, FilterAction::Proxy);
 }
 
 #[skuld::test]
@@ -37,7 +37,7 @@ fn ruleset_with_only_invalid_rules_falls_back_to_proxy() {
     let rs = RuleSet::from_user_rules(&[rule("nonsense", MatchType::Subnet, FilterAction::Block)]);
     assert!(rs.rules.is_empty());
     assert_eq!(rs.dropped.len(), 1);
-    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)).action, FilterAction::Proxy);
 }
 
 // Single-rule basics ==================================================================================================
@@ -46,7 +46,7 @@ fn ruleset_with_only_invalid_rules_falls_back_to_proxy() {
 fn single_proxy_rule() {
     let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Proxy)]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Proxy
     );
 }
@@ -55,7 +55,7 @@ fn single_proxy_rule() {
 fn single_block_rule() {
     let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Block
     );
 }
@@ -63,14 +63,14 @@ fn single_block_rule() {
 #[skuld::test]
 fn single_bypass_rule() {
     let rs = RuleSet::from_user_rules(&[rule("10.0.0.0/8", MatchType::Subnet, FilterAction::Bypass)]);
-    assert_eq!(decide(&rs, &conn("10.1.2.3", 443, None)), FilterAction::Bypass);
+    assert_eq!(decide(&rs, &conn("10.1.2.3", 443, None)).action, FilterAction::Bypass);
 }
 
 #[skuld::test]
 fn no_matching_rule_falls_back_to_proxy() {
     let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("other.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("other.com"))).action,
         FilterAction::Proxy
     );
 }
@@ -87,7 +87,7 @@ fn worked_example_a_example_com_proxied() {
         rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("a.example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("a.example.com"))).action,
         FilterAction::Proxy
     );
 }
@@ -99,7 +99,7 @@ fn worked_example_b_example_com_blocked() {
         rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("b.example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("b.example.com"))).action,
         FilterAction::Block
     );
 }
@@ -111,7 +111,7 @@ fn worked_example_apex_blocked() {
         rule("a.example.com", MatchType::Exactly, FilterAction::Proxy),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Block
     );
 }
@@ -125,7 +125,7 @@ fn later_rule_overrides_earlier_for_same_address() {
         rule("example.com", MatchType::Exactly, FilterAction::Block),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Block
     );
 }
@@ -137,7 +137,7 @@ fn earlier_rule_wins_when_no_later_rule_matches() {
         rule("other.com", MatchType::Exactly, FilterAction::Bypass),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Block
     );
 }
@@ -153,7 +153,7 @@ fn mixed_rules_ip_subnet_later_wins() {
         rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Bypass
     );
 }
@@ -165,7 +165,7 @@ fn mixed_rules_domain_later_wins() {
         rule("example.com", MatchType::Exactly, FilterAction::Block),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Block
     );
 }
@@ -177,13 +177,13 @@ fn ip_only_connection_with_domain_rule_in_set_falls_through() {
         rule("example.com", MatchType::Exactly, FilterAction::Block),
         rule("1.2.3.0/24", MatchType::Subnet, FilterAction::Bypass),
     ]);
-    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Bypass);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)).action, FilterAction::Bypass);
 }
 
 #[skuld::test]
 fn ip_only_connection_no_ip_rule_falls_back_to_proxy() {
     let rs = RuleSet::from_user_rules(&[rule("example.com", MatchType::Exactly, FilterAction::Block)]);
-    assert_eq!(decide(&rs, &conn("9.9.9.9", 443, None)), FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("9.9.9.9", 443, None)).action, FilterAction::Proxy);
 }
 
 // Three locked default rules (matches the UI's planned behavior) ======================================================
@@ -196,11 +196,11 @@ fn three_locked_default_rules_pass_everything_through() {
         rule("::/0", MatchType::Subnet, FilterAction::Proxy),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("example.com"))).action,
         FilterAction::Proxy
     );
-    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)), FilterAction::Proxy);
-    assert_eq!(decide(&rs, &conn("::1", 443, None)), FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("1.2.3.4", 443, None)).action, FilterAction::Proxy);
+    assert_eq!(decide(&rs, &conn("::1", 443, None)).action, FilterAction::Proxy);
 }
 
 #[skuld::test]
@@ -212,11 +212,11 @@ fn block_rule_overrides_locked_defaults() {
         rule("evil.com", MatchType::WithSubdomains, FilterAction::Block),
     ]);
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("api.evil.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("api.evil.com"))).action,
         FilterAction::Block
     );
     assert_eq!(
-        decide(&rs, &conn("1.2.3.4", 443, Some("good.com"))),
+        decide(&rs, &conn("1.2.3.4", 443, Some("good.com"))).action,
         FilterAction::Proxy
     );
 }

--- a/crates/bridge/src/filter/fake_dns.rs
+++ b/crates/bridge/src/filter/fake_dns.rs
@@ -24,6 +24,7 @@ use hickory_proto::rr::rdata::{A, AAAA};
 use hickory_proto::rr::{Name, RData, Record, RecordType};
 use ipnet::{Ipv4Net, Ipv6Net};
 use lru::LruCache;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::matcher::canonicalize_ip;
 
@@ -261,6 +262,39 @@ impl FakeDns {
         };
 
         self.build_response(&request).to_vec().unwrap_or_default()
+    }
+
+    /// Handle DNS queries over TCP (RFC 1035 section 4.2.2 framing).
+    ///
+    /// Each message on the stream is prefixed with a 2-byte big-endian
+    /// length. The method loops until the client closes the connection
+    /// (EOF on the length read).
+    pub async fn handle_tcp<S>(&self, mut stream: S) -> std::io::Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        loop {
+            // Read the 2-byte length prefix. EOF here means the client
+            // closed the connection gracefully.
+            let len = match stream.read_u16().await {
+                Ok(n) => n as usize,
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+                Err(e) => return Err(e),
+            };
+
+            // Read the DNS message.
+            let mut buf = vec![0u8; len];
+            stream.read_exact(&mut buf).await?;
+
+            // Process via the same logic as UDP.
+            let response = self.handle_udp(&buf);
+
+            // Write 2-byte length prefix + response.
+            let resp_len = response.len() as u16;
+            stream.write_u16(resp_len).await?;
+            stream.write_all(&response).await?;
+            stream.flush().await?;
+        }
     }
 
     /// Build a response `Message` for a parsed query. Pure-ish — only

--- a/crates/bridge/src/filter/fake_dns.rs
+++ b/crates/bridge/src/filter/fake_dns.rs
@@ -205,6 +205,18 @@ impl FakeDns {
         }
     }
 
+    /// Check whether an IP address falls within one of the fake DNS pools
+    /// (without requiring it to be currently allocated). Used by the
+    /// dispatcher's bypass path to decide whether upstream DNS resolution
+    /// is needed.
+    pub fn is_fake_ip(&self, ip: IpAddr) -> bool {
+        let ip = canonicalize_ip(ip);
+        match ip {
+            IpAddr::V4(v4) => self.pool_v4.contains(&v4),
+            IpAddr::V6(v6) => self.pool_v6.contains(&v6),
+        }
+    }
+
     /// Decrement the refcount for an entry; if it reaches zero, move
     /// it back into the LRU set so it becomes evictable. Unpinning a
     /// non-pinned IP is a no-op.

--- a/crates/bridge/src/filter/fake_dns_tests.rs
+++ b/crates/bridge/src/filter/fake_dns_tests.rs
@@ -5,6 +5,7 @@ use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
 use hickory_proto::rr::rdata::{A, AAAA};
 use hickory_proto::rr::{Name, RData, RecordType};
 use ipnet::{Ipv4Net, Ipv6Net};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::*;
 
@@ -388,4 +389,93 @@ fn pin_canonicalizes_v4_mapped_v6() {
     ));
     dns.pin(mapped);
     assert_eq!(dns.reverse_lookup(IpAddr::V4(ip)).as_deref(), Some("mapped.test"));
+}
+
+// TCP framing (RFC 1035 §4.2.2) =======================================================================================
+
+/// Write a DNS message with TCP framing (2-byte big-endian length prefix).
+async fn tcp_write_query<W: AsyncWriteExt + Unpin>(w: &mut W, payload: &[u8]) {
+    w.write_u16(payload.len() as u16).await.unwrap();
+    w.write_all(payload).await.unwrap();
+    w.flush().await.unwrap();
+}
+
+/// Read a TCP-framed DNS response: 2-byte length prefix, then that many bytes.
+async fn tcp_read_response<R: AsyncReadExt + Unpin>(r: &mut R) -> Vec<u8> {
+    let len = r.read_u16().await.unwrap() as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).await.unwrap();
+    buf
+}
+
+#[skuld::test]
+fn handle_tcp_resolves_a_record() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let dns = FakeDns::with_defaults();
+        let (mut client, server) = tokio::io::duplex(4096);
+
+        let handle = tokio::spawn(async move { dns.handle_tcp(server).await });
+
+        // Send an A query for example.com.
+        let query = build_query("example.com.", RecordType::A);
+        tcp_write_query(&mut client, &query).await;
+
+        // Read and verify the response.
+        let resp_bytes = tcp_read_response(&mut client).await;
+        let resp = parse_response(&resp_bytes);
+        assert_eq!(resp.message_type(), MessageType::Response);
+        assert_eq!(resp.response_code(), ResponseCode::NoError);
+        assert_eq!(resp.id(), 0x1234);
+
+        let pool: Ipv4Net = DEFAULT_POOL_V4.parse().unwrap();
+        let ip = answer_ipv4(&resp).expect("expected an A record");
+        assert!(pool.contains(&ip), "{ip} not in pool {pool}");
+
+        // Close the client side so handle_tcp sees EOF and returns Ok(()).
+        drop(client);
+        handle.await.unwrap().unwrap();
+    });
+}
+
+#[skuld::test]
+fn handle_tcp_multiple_queries() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let dns = FakeDns::with_defaults();
+        let (mut client, server) = tokio::io::duplex(4096);
+
+        let handle = tokio::spawn(async move { dns.handle_tcp(server).await });
+
+        // First query: A record for alpha.test.
+        let q1 = build_query("alpha.test.", RecordType::A);
+        tcp_write_query(&mut client, &q1).await;
+        let r1_bytes = tcp_read_response(&mut client).await;
+        let r1 = parse_response(&r1_bytes);
+        assert_eq!(r1.response_code(), ResponseCode::NoError);
+        let ip1 = answer_ipv4(&r1).expect("expected an A record for alpha.test");
+
+        // Second query: A record for beta.test.
+        let q2 = build_query("beta.test.", RecordType::A);
+        tcp_write_query(&mut client, &q2).await;
+        let r2_bytes = tcp_read_response(&mut client).await;
+        let r2 = parse_response(&r2_bytes);
+        assert_eq!(r2.response_code(), ResponseCode::NoError);
+        let ip2 = answer_ipv4(&r2).expect("expected an A record for beta.test");
+
+        // The two domains should get different fake IPs.
+        assert_ne!(ip1, ip2, "different domains should get different fake IPs");
+
+        // Close the client side so handle_tcp returns.
+        drop(client);
+        handle.await.unwrap().unwrap();
+    });
 }

--- a/crates/bridge/src/filter_tests.rs
+++ b/crates/bridge/src/filter_tests.rs
@@ -21,5 +21,5 @@ fn re_exports_decide_constructable_from_user_rules() {
         proto: L4Proto::Tcp,
     };
 
-    assert_eq!(decide(&rs, &conn), FilterAction::Block);
+    assert_eq!(decide(&rs, &conn).action, FilterAction::Block);
 }

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -75,6 +75,8 @@ impl Routing for StubRouting {
         Ok(GatewayInfo {
             gateway_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             interface_name: "StubIf".into(),
+            interface_index: 1,
+            ipv6_available: false,
         })
     }
 }

--- a/crates/bridge/src/gateway.rs
+++ b/crates/bridge/src/gateway.rs
@@ -9,6 +9,10 @@ pub struct GatewayInfo {
     /// Platform-appropriate interface name for route commands.
     /// On Windows: friendly name (e.g., "Wi-Fi"). On macOS: BSD name (e.g., "en0").
     pub interface_name: String,
+    /// OS interface index (used by bypass socket helpers to bind to the upstream NIC).
+    pub interface_index: u32,
+    /// Whether the upstream interface can reach an IPv6 destination.
+    pub ipv6_available: bool,
 }
 
 /// Detect the system's default gateway IP and original interface name.
@@ -22,10 +26,14 @@ pub fn get_default_gateway_info() -> std::io::Result<GatewayInfo> {
         .ok_or_else(|| std::io::Error::other("default interface has no gateway"))?;
 
     let interface_name = platform_interface_name(&iface)?;
+    let interface_index = platform_interface_index(&iface)?;
+    let ipv6_available = probe_ipv6(interface_index);
 
     Ok(GatewayInfo {
         gateway_ip,
         interface_name,
+        interface_index,
+        ipv6_available,
     })
 }
 
@@ -40,6 +48,71 @@ fn platform_interface_name(iface: &default_net::Interface) -> std::io::Result<St
 #[cfg(target_os = "macos")]
 fn platform_interface_name(iface: &default_net::Interface) -> std::io::Result<String> {
     Ok(iface.name.clone())
+}
+
+// Interface index detection ===========================================================================================
+
+#[cfg(target_os = "windows")]
+fn platform_interface_index(iface: &default_net::Interface) -> std::io::Result<u32> {
+    use windows::core::HSTRING;
+    use windows::Win32::Foundation::NO_ERROR;
+    use windows::Win32::NetworkManagement::IpHelper::{ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToIndex};
+    use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+
+    let friendly_name = iface
+        .friendly_name
+        .as_deref()
+        .ok_or_else(|| std::io::Error::other("default interface has no friendly name"))?;
+    let alias = HSTRING::from(friendly_name);
+    let mut luid = NET_LUID_LH::default();
+    let err = unsafe { ConvertInterfaceAliasToLuid(&alias, &mut luid) };
+    if err != NO_ERROR {
+        return Err(std::io::Error::other(format!(
+            "ConvertInterfaceAliasToLuid: error {err:?}"
+        )));
+    }
+    let mut index = 0u32;
+    let err = unsafe { ConvertInterfaceLuidToIndex(&luid, &mut index) };
+    if err != NO_ERROR {
+        return Err(std::io::Error::other(format!(
+            "ConvertInterfaceLuidToIndex: error {err:?}"
+        )));
+    }
+    Ok(index)
+}
+
+#[cfg(target_os = "macos")]
+fn platform_interface_index(iface: &default_net::Interface) -> std::io::Result<u32> {
+    let c_name = std::ffi::CString::new(iface.name.as_str())
+        .map_err(|e| std::io::Error::other(format!("invalid interface name: {e}")))?;
+    let idx = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
+    if idx == 0 {
+        return Err(std::io::Error::other(format!(
+            "if_nametoindex failed for '{}'",
+            iface.name
+        )));
+    }
+    Ok(idx)
+}
+
+// IPv6 availability probe =============================================================================================
+
+fn probe_ipv6(interface_index: u32) -> bool {
+    let socket = match socket2::Socket::new(
+        socket2::Domain::IPV6,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    ) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    if crate::dispatcher::bypass::bind_to_interface_v6(&socket, interface_index).is_err() {
+        return false;
+    }
+    let target: std::net::SocketAddrV6 = "[2606:4700:4700::1111]:443".parse().unwrap();
+    socket
+        .connect(&socket2::SockAddr::from(std::net::SocketAddr::V6(target)))
+        .is_ok()
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/gateway_tests.rs
+++ b/crates/bridge/src/gateway_tests.rs
@@ -10,4 +10,7 @@ fn get_default_gateway_info_returns_valid_result() {
         info.gateway_ip
     );
     assert!(!info.interface_name.is_empty(), "interface name should not be empty");
+    assert!(info.interface_index > 0, "interface index should be non-zero");
+    // ipv6_available is informational — just ensure it doesn't panic.
+    let _ = info.ipv6_available;
 }

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -147,6 +147,8 @@ impl Routing for MockRouting {
         Ok(GatewayInfo {
             gateway_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
             interface_name: "MockEthernet".into(),
+            interface_index: 1,
+            ipv6_available: false,
         })
     }
 }

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod dispatcher;
 pub mod filter;
 pub mod foreground;
 pub mod gateway;

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -6,7 +6,7 @@
 // `crates/bridge/src/proxy/shadowsocks.rs`.
 
 use hole_common::config::is_valid_plugin_name;
-use hole_common::protocol::{ProxyConfig, TunnelMode};
+use hole_common::protocol::ProxyConfig;
 use shadowsocks::config::ServerAddr;
 use shadowsocks::ServerConfig;
 use shadowsocks_service::config::{
@@ -57,13 +57,11 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 
 /// Build a shadowsocks-service Config from our ProxyConfig.
 ///
-/// The number of local instances depends on `config.tunnel_mode`:
-/// - [`TunnelMode::Full`] (production default): TUN + SOCKS5. The TUN
-///   adapter provides transparent proxying for all traffic; the SOCKS5
-///   listener is there for advanced users.
-/// - [`TunnelMode::SocksOnly`]: SOCKS5 only. No TUN adapter is created
-///   by `shadowsocks-service::local::Server::new`, so the resulting
-///   server works without elevation.
+/// Always creates exactly one local instance: SOCKS5 on
+/// `127.0.0.1:{local_port}` with `Mode::TcpAndUdp`. The TUN device is
+/// now owned by the dispatcher (`crates/bridge/src/dispatcher/`), not
+/// by shadowsocks-service. `TunnelMode` is respected by the
+/// `ProxyManager` which skips the dispatcher in `SocksOnly` mode.
 pub fn build_ss_config(config: &ProxyConfig) -> Result<Config, ProxyError> {
     let entry = &config.server;
 
@@ -100,21 +98,13 @@ pub fn build_ss_config(config: &ProxyConfig) -> Result<Config, ProxyError> {
         .server
         .push(ServerInstanceConfig::with_server_config(server_config));
 
-    // Local 1: TUN (only in Full mode). SocksOnly deliberately skips
-    // this — `shadowsocks-service::local::Server::new` would otherwise
-    // try to open the TUN adapter, which requires elevation.
-    if matches!(config.tunnel_mode, TunnelMode::Full) {
-        let mut tun_local = LocalConfig::new(ProtocolType::Tun);
-        tun_local.tun_interface_address = Some(TUN_SUBNET.parse().expect("TUN_SUBNET is a valid CIDR literal"));
-        tun_local.tun_interface_name = Some(TUN_DEVICE_NAME.to_owned());
-        ss_config.local.push(LocalInstanceConfig::with_local_config(tun_local));
-    }
-
-    // Local 2: SOCKS5 (always present)
+    // SOCKS5 local — the only local instance. TcpAndUdp enables UDP
+    // associate for the dispatcher's proxy path (Plan 3).
     let socks_addr: SocketAddr = format!("127.0.0.1:{}", config.local_port)
         .parse()
         .expect("127.0.0.1:{u16} is always a valid SocketAddr");
-    let socks_local = LocalConfig::new_with_addr(ServerAddr::SocketAddr(socks_addr), ProtocolType::Socks);
+    let mut socks_local = LocalConfig::new_with_addr(ServerAddr::SocketAddr(socks_addr), ProtocolType::Socks);
+    socks_local.mode = shadowsocks::config::Mode::TcpAndUdp;
     ss_config
         .local
         .push(LocalInstanceConfig::with_local_config(socks_local));

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -44,28 +44,23 @@ pub enum ProxyState {
 
 // Running state =======================================================================================================
 
-/// Per-cycle state owned only while a proxy is running. Dropping this
-/// struct tears down routes and then aborts the proxy task.
+/// Per-cycle state owned only while a proxy is running.
 ///
-/// **Field declaration order is load-bearing.** Rust drops fields in
-/// declaration order. `routes` is declared BEFORE `proxy` so that on
-/// Drop (panic path, cancel path, or scope exit without explicit
-/// `stop()`), route teardown runs while the TUN adapter — owned by the
-/// proxy task — is still alive. If the proxy drops first, the TUN
-/// adapter disappears and Windows starts asynchronously flushing routes
-/// bound to it; the subsequent `netsh delete route ... hole-tun`
-/// commands then race against the OS flush and often fail silently,
-/// leaving localhost traffic broken for seconds. See bindreams/hole#160
-/// CI investigation.
+/// **Field declaration order is load-bearing.** Dispatcher drops first
+/// (closes TUN, cancels handlers), then routes (teardown commands
+/// target a live TUN since the dispatcher already closed it), then
+/// proxy (releases SS). `None` fields for SocksOnly mode where
+/// routing/dispatcher are skipped.
 struct RunningState<P: Proxy, R: Routing> {
-    /// Installed routes. Dropped FIRST so teardown commands target a
-    /// live TUN interface. `None` in `SocksOnly` mode where routing is
-    /// skipped entirely. Held only for the Drop side effect —
-    /// `#[allow(dead_code)]` because the field is "unused" syntactically
-    /// but load-bearing semantically.
+    /// TCP dispatcher — owns TUN device, smoltcp, fake DNS, handler
+    /// tasks. Drops FIRST. `None` in SocksOnly mode and under
+    /// `#[cfg(test)]`.
+    #[allow(dead_code)]
+    dispatcher: Option<crate::dispatcher::Dispatcher>,
+    /// Installed routes. Dropped SECOND. `None` in SocksOnly mode.
     #[allow(dead_code)]
     routes: Option<R::Installed>,
-    /// Handle on the running proxy. Dropped AFTER routes. Drop aborts
+    /// Handle on the running proxy. Dropped LAST. Drop aborts
     /// the task (best-effort); supported graceful shutdown is via
     /// `stop().await` from [`ProxyManager::stop`].
     proxy: P::Running,
@@ -213,7 +208,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
     /// defeating crash recovery on next startup. See
     /// [`crate::routing::SystemRouting::install`] for the invariant.
     async fn start_inner(proxy: &P, routing: &R, config: &ProxyConfig) -> Result<RunningState<P, R>, ProxyError> {
-        // Build shadowsocks config (sync, no partial state).
+        // Build shadowsocks config (SOCKS5 only, no TUN).
         let ss_config = build_ss_config(config)?;
 
         // SocksOnly mode: skip everything routing-related (wintun preload,
@@ -224,6 +219,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         if matches!(config.tunnel_mode, TunnelMode::SocksOnly) {
             let running_proxy = proxy.start(ss_config).await?;
             return Ok(RunningState {
+                dispatcher: None,
                 routes: None,
                 proxy: running_proxy,
                 server_ip: None,
@@ -242,19 +238,41 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // Query the OS default gateway via the routing provider.
         let gw_info = routing.default_gateway()?;
 
-        // Start the proxy tunnel. From here on, if the future is
-        // dropped or an error is returned, `P::Running::drop` aborts
-        // the spawned task (best-effort, no await).
+        // Discover upstream DNS servers BEFORE routes are installed, so
+        // queries use the real upstream path (not the TUN).
+        let dns_servers = crate::dispatcher::upstream_dns::discover_dns_servers()
+            .map_err(|e| ProxyError::Gateway(format!("DNS discovery failed: {e}")))?;
+
+        // Compile filter rules.
+        let ruleset = crate::filter::rules::RuleSet::from_user_rules(&config.filters);
+
+        // Start the SS SOCKS5 proxy.
         let running_proxy = proxy.start(ss_config).await?;
 
-        // Install the routes. On failure, `running_proxy` drops
-        // (aborting the proxy task) as the `?` propagates.
-        // `SystemRouting::install` writes the state file atomically
-        // BEFORE mutating routes and clears it on its own internal
-        // rollback path, so no `StateFileGuard` is needed here.
+        // Start the dispatcher (owns TUN device + smoltcp). Skipped
+        // under #[cfg(test)] because creating a TUN requires elevation.
+        #[cfg(not(test))]
+        let dispatcher = {
+            let d = crate::dispatcher::Dispatcher::new(
+                config.local_port,
+                gw_info.interface_index,
+                gw_info.ipv6_available,
+                ruleset,
+                &dns_servers,
+            )?;
+            Some(d)
+        };
+        #[cfg(test)]
+        let dispatcher: Option<crate::dispatcher::Dispatcher> = {
+            let _ = (ruleset, dns_servers); // suppress unused warnings
+            None
+        };
+
+        // Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
         Ok(RunningState {
+            dispatcher,
             routes: Some(routes),
             proxy: running_proxy,
             server_ip: Some(server_ip),
@@ -266,43 +284,26 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         let Some(state) = self.running.take() else {
             return Ok(());
         };
-        // Destructure so the proxy handle can be moved out for
-        // `stop(self).await` while the routes guard drops at the end
-        // of the scope.
         let RunningState {
+            dispatcher,
             proxy,
             routes,
             server_ip: _,
             started_at: _,
         } = state;
 
-        // ORDERING: tear down routes FIRST while the TUN adapter is
-        // still alive, THEN stop the proxy (which releases the adapter).
-        //
-        // The proxy task owns the TUN adapter via shadowsocks-service's
-        // Server → TunLocal → wintun handle. If we stop the proxy first,
-        // wintun releases the adapter, and Windows starts asynchronously
-        // flushing routes bound to `hole-tun`. The subsequent
-        // `netsh delete route ... hole-tun` commands in the routes
-        // teardown then race against the OS flush and often fail silently,
-        // leaving localhost traffic broken for several seconds.
-        //
-        // By tearing down routes first (while `hole-tun` still exists),
-        // the `netsh` commands target a live interface and succeed
-        // deterministically. The subsequent proxy stop releases the
-        // adapter cleanly — there are no routes left to flush.
-        //
-        // This matches the field declaration order in `RunningState`
-        // (routes before proxy) so the Drop path (panic/cancel) gets
-        // the same correct ordering.
-        drop(routes); // tears down routes + clears state file via RAII
+        // 1. Shut down dispatcher (closes TUN, cancels all handlers).
+        if let Some(mut d) = dispatcher {
+            d.shutdown().await;
+        }
+
+        // 2. Graceful proxy shutdown (stops SS SOCKS5).
         let res = proxy.stop().await;
 
-        // Clear any error from a previous failed start. A clean stop
-        // is the user's signal that the bridge is in a good state
-        // again — keeping the stale error would make
-        // `handle_diagnostics` report `bridge = "error"` indefinitely.
-        // See issue #142.
+        // 3. Routes tear down via RAII Drop.
+        drop(routes);
+
+        // Clear any error from a previous failed start. See issue #142.
         self.last_error = None;
         info!("proxy stopped");
         res

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -217,6 +217,8 @@ impl Routing for MockRouting {
         Ok(GatewayInfo {
             gateway_ip: self.gateway,
             interface_name: "MockEthernet".into(),
+            interface_index: 1,
+            ipv6_available: false,
         })
     }
 }

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -67,34 +67,29 @@ fn invalid_method_returns_error() {
 // Local instances tests ===============================================================================================
 
 #[skuld::test]
-fn creates_two_local_instances() {
+fn creates_one_local_instance() {
     let ss = build_ss_config(&sample_config()).unwrap();
-    assert_eq!(ss.local.len(), 2);
+    assert_eq!(ss.local.len(), 1, "only SOCKS5 local, no TUN");
 }
 
 #[skuld::test]
-fn first_local_is_tun() {
+fn local_is_socks5() {
     let ss = build_ss_config(&sample_config()).unwrap();
-    assert_eq!(ss.local[0].config.protocol.as_str(), "tun");
+    assert_eq!(ss.local[0].config.protocol.as_str(), "socks");
 }
 
 #[skuld::test]
-fn tun_has_correct_subnet() {
+fn socks5_mode_is_tcp_and_udp() {
     let ss = build_ss_config(&sample_config()).unwrap();
-    let addr = ss.local[0].config.tun_interface_address.unwrap();
-    assert_eq!(addr.to_string(), "10.255.0.1/24");
-}
-
-#[skuld::test]
-fn second_local_is_socks5() {
-    let ss = build_ss_config(&sample_config()).unwrap();
-    assert_eq!(ss.local[1].config.protocol.as_str(), "socks");
+    let mode = ss.local[0].config.mode;
+    // Mode doesn't impl PartialEq; use Debug string comparison.
+    assert_eq!(format!("{mode:?}"), "TcpAndUdp");
 }
 
 #[skuld::test]
 fn socks5_binds_to_localhost_on_configured_port() {
     let ss = build_ss_config(&sample_config()).unwrap();
-    let addr = ss.local[1].config.addr.as_ref().unwrap();
+    let addr = ss.local[0].config.addr.as_ref().unwrap();
     assert_eq!(addr.host(), "127.0.0.1");
     assert_eq!(addr.port(), 4073);
 }
@@ -104,7 +99,7 @@ fn socks5_uses_custom_port() {
     let mut cfg = sample_config();
     cfg.local_port = 9999;
     let ss = build_ss_config(&cfg).unwrap();
-    let addr = ss.local[1].config.addr.as_ref().unwrap();
+    let addr = ss.local[0].config.addr.as_ref().unwrap();
     assert_eq!(addr.port(), 9999);
 }
 


### PR DESCRIPTION
## Summary

- Removes shadowsocks-service's built-in TUN local; SS now runs SOCKS5 only (`Mode::TcpAndUdp`)
- Adds hole-owned TUN device + smoltcp userspace TCP/IP stack
- Per-connection TCP dispatch: fake DNS reverse lookup -> sniffer peek -> filter decide -> proxy/bypass/block
- Port 53 UDP hijack for fake DNS domain recovery (via smoltcp UDP socket)
- Bypass sockets with `IP_UNICAST_IF` (Windows) / `IP_BOUND_IF` (macOS)
- Rate-limited block logging (LRU, 1s suppress)
- Upstream DNS resolver for bypass-path real IP resolution
- `FakeDns::handle_tcp` for TCP DNS queries (RFC 7766)
- `decide()` now returns `Decision { action, rule_index }` (avoids double evaluation in block path)
- Wired into `ProxyManager` start/stop lifecycle (dispatcher field drops first)
- `Dispatcher::Drop` cancels + aborts driver as safety net
- Driver poll-interval tick ensures handler->smoltcp data flows even without incoming TUN packets
- Partial `send_slice` buffered to prevent TCP data loss

Part of the filter engine v1 work. Plan 1 (#163) delivered foundations; this is Plan 2.

Closes #173

## Test plan

- [x] 311 unit tests pass (`cargo test -p hole-bridge --lib`)
- [x] Full workspace builds clean (`cargo build --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [ ] CI passes on Windows + macOS
- [ ] Manual test: configure filter rules, verify proxy/bypass/block paths work