### PR TITLE
filter: UDP dispatcher + SOCKS5 UDP associate (Plan 3)

### DIFF
--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -8,6 +8,7 @@ pub mod device;
 pub mod driver;
 pub mod smoltcp_stream;
 pub mod socks5_client;
+pub mod socks5_udp;
 pub mod tcp_handler;
 pub mod udp_flow;
 pub mod upstream_dns;

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -22,7 +22,7 @@ use tracing::{debug, warn};
 
 use self::block_log::BlockLog;
 use self::driver::{TunDriver, MTU};
-use self::tcp_handler::TcpHandlerContext;
+use self::tcp_handler::HandlerContext;
 use self::upstream_dns::UpstreamResolver;
 use crate::filter::rules::RuleSet;
 use crate::filter::FakeDns;
@@ -50,6 +50,7 @@ impl Dispatcher {
         local_port: u16,
         iface_index: u32,
         ipv6_available: bool,
+        udp_proxy_available: bool,
         rules: RuleSet,
         dns_servers: &[IpAddr],
     ) -> std::io::Result<Self> {
@@ -79,13 +80,14 @@ impl Dispatcher {
         let upstream_resolver = UpstreamResolver::new(dns_servers);
 
         // Handler context (shared by all TCP handlers).
-        let handler_ctx = Arc::new(TcpHandlerContext {
+        let handler_ctx = Arc::new(HandlerContext {
             local_port,
             iface_index,
             ipv6_available,
             upstream_resolver,
             block_log: std::sync::Mutex::new(BlockLog::new()),
             ipv6_bypass_warned: AtomicBool::new(false),
+            udp_proxy_available,
         });
 
         // Cancellation token.

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -11,6 +11,7 @@ pub mod socks5_client;
 pub mod socks5_udp;
 pub mod tcp_handler;
 pub mod udp_flow;
+pub mod udp_handler;
 pub mod upstream_dns;
 
 use std::net::IpAddr;

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -9,6 +9,7 @@ pub mod driver;
 pub mod smoltcp_stream;
 pub mod socks5_client;
 pub mod tcp_handler;
+pub mod udp_flow;
 pub mod upstream_dns;
 
 use std::net::IpAddr;

--- a/crates/bridge/src/dispatcher/bypass.rs
+++ b/crates/bridge/src/dispatcher/bypass.rs
@@ -113,6 +113,32 @@ pub async fn create_bypass_tcp(dst_ip: IpAddr, dst_port: u16, iface_index: u32) 
     tcp_socket.connect(dst).await
 }
 
+// Bypass UDP socket ===================================================================================================
+
+/// Create an unconnected UDP socket bound to the upstream interface.
+pub async fn create_bypass_udp(iface_index: u32, v6: bool) -> std::io::Result<tokio::net::UdpSocket> {
+    let socket = if v6 {
+        let s = socket2::Socket::new(
+            socket2::Domain::IPV6,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )?;
+        bind_to_interface_v6(&s, iface_index)?;
+        s
+    } else {
+        let s = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )?;
+        bind_to_interface_v4(&s, iface_index)?;
+        s
+    };
+    socket.set_nonblocking(true)?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    tokio::net::UdpSocket::from_std(std_socket)
+}
+
 #[cfg(test)]
 #[path = "bypass_tests.rs"]
 mod bypass_tests;

--- a/crates/bridge/src/dispatcher/driver.rs
+++ b/crates/bridge/src/dispatcher/driver.rs
@@ -19,7 +19,7 @@ use tracing::{debug, trace, warn};
 
 use super::device::VirtualTunDevice;
 use super::smoltcp_stream::SmoltcpStream;
-use super::tcp_handler::{self, TcpHandlerContext};
+use super::tcp_handler::{self, HandlerContext};
 use crate::filter::rules::RuleSet;
 use crate::filter::FakeDns;
 
@@ -84,7 +84,7 @@ pub struct TunDriver {
     conn_semaphore: Arc<Semaphore>,
     sniffer_semaphore: Arc<Semaphore>,
     rules: Arc<ArcSwap<RuleSet>>,
-    handler_ctx: Arc<TcpHandlerContext>,
+    handler_ctx: Arc<HandlerContext>,
     /// Reference time for converting std::time::Instant to smoltcp::time::Instant.
     epoch: StdInstant,
 }
@@ -97,7 +97,7 @@ impl TunDriver {
         tun: tun::AsyncDevice,
         fake_dns: Option<Arc<FakeDns>>,
         rules: Arc<ArcSwap<RuleSet>>,
-        handler_ctx: Arc<TcpHandlerContext>,
+        handler_ctx: Arc<HandlerContext>,
         cancel: CancellationToken,
     ) -> Self {
         let mut device = VirtualTunDevice::new(MTU);

--- a/crates/bridge/src/dispatcher/driver.rs
+++ b/crates/bridge/src/dispatcher/driver.rs
@@ -5,13 +5,17 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::Instant as StdInstant;
+use std::time::{Duration, Instant as StdInstant};
 
 use arc_swap::ArcSwap;
 use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet};
+use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::socket::{tcp, udp};
 use smoltcp::time::Instant as SmoltcpInstant;
-use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, IpEndpoint};
+use smoltcp::wire::{
+    HardwareAddress, IpAddress, IpCidr, IpEndpoint, IpProtocol, Ipv4Packet, Ipv4Repr, Ipv6Packet, Ipv6Repr, UdpPacket,
+    UdpRepr,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
@@ -20,6 +24,8 @@ use tracing::{debug, trace, warn};
 use super::device::VirtualTunDevice;
 use super::smoltcp_stream::SmoltcpStream;
 use super::tcp_handler::{self, HandlerContext};
+use super::udp_flow::{FlowEntry, FlowHandle, FlowKey, FlowTable};
+use super::udp_handler::{self, UdpReply};
 use crate::filter::rules::RuleSet;
 use crate::filter::FakeDns;
 
@@ -87,6 +93,19 @@ pub struct TunDriver {
     handler_ctx: Arc<HandlerContext>,
     /// Reference time for converting std::time::Instant to smoltcp::time::Instant.
     epoch: StdInstant,
+
+    // UDP flow dispatching --------------------------------------------------------------------------------------------
+    flow_table: FlowTable,
+    /// Channel for async flow-creation tasks to send completed entries back.
+    new_flow_tx: mpsc::Sender<(FlowKey, FlowEntry)>,
+    new_flow_rx: mpsc::Receiver<(FlowKey, FlowEntry)>,
+    /// Channel for per-flow reader tasks to send reply datagrams.
+    reply_tx: mpsc::Sender<UdpReply>,
+    reply_rx: mpsc::Receiver<UdpReply>,
+    /// Pending reply packets to write to TUN (built from `UdpReply`).
+    pending_tun_writes: Vec<Vec<u8>>,
+    /// Last time idle UDP flows were swept.
+    last_sweep: StdInstant,
 }
 
 impl TunDriver {
@@ -134,6 +153,9 @@ impl TunDriver {
             None
         };
 
+        let (new_flow_tx, new_flow_rx) = mpsc::channel(256);
+        let (reply_tx, reply_rx) = mpsc::channel(1024);
+
         Self {
             tun,
             device,
@@ -150,6 +172,13 @@ impl TunDriver {
             rules,
             handler_ctx,
             epoch,
+            flow_table: FlowTable::new(),
+            new_flow_tx,
+            new_flow_rx,
+            reply_tx,
+            reply_rx,
+            pending_tun_writes: Vec::new(),
+            last_sweep: StdInstant::now(),
         }
     }
 
@@ -184,15 +213,19 @@ impl TunDriver {
                     Ok(n) => {
                         let packet = &tun_buf[..n];
 
-                        // Before feeding to smoltcp, parse the packet to set
-                        // up TCP listeners dynamically.
-                        if let Some((dst_port, proto)) = parse_ip_dst(packet) {
-                            if proto == IpProto::Tcp {
-                                self.ensure_listener(dst_port);
-                            }
-                        }
+                        // General UDP: dispatch before smoltcp sees the packet.
+                        // Returns true if the packet was consumed (non-DNS UDP).
+                        let consumed = self.handle_general_udp(packet);
 
-                        self.device.enqueue_rx(packet.to_vec());
+                        if !consumed {
+                            // TCP or DNS-UDP: set up listeners and feed to smoltcp.
+                            if let Some((dst_port, proto)) = parse_ip_dst(packet) {
+                                if proto == IpProto::Tcp {
+                                    self.ensure_listener(dst_port);
+                                }
+                            }
+                            self.device.enqueue_rx(packet.to_vec());
+                        }
                     }
                     Err(e) => {
                         warn!("TUN read error: {e}");
@@ -209,6 +242,9 @@ impl TunDriver {
             // Phase 3: Handle UDP DNS (port 53).
             self.handle_dns_udp();
 
+            // Phase 3.5: Drain completed UDP flow creations.
+            self.drain_new_flows();
+
             // Phase 4: Accept new TCP connections from listeners that
             // transitioned out of LISTEN state.
             self.accept_tcp_connections();
@@ -219,18 +255,29 @@ impl TunDriver {
             // Phase 6: Clean up finished connections.
             self.cleanup_finished_connections();
 
+            // Phase 6.5: Process UDP reply datagrams into pending TUN writes.
+            self.process_udp_replies();
+
             // Phase 7: Poll smoltcp again (handler data may have produced new output).
             self.poll_smoltcp();
 
-            // Phase 8: Flush smoltcp output to the TUN device.
+            // Phase 8: Flush smoltcp output AND pending UDP replies to TUN.
             self.flush_to_tun().await;
+
+            // Phase 9: Sweep idle UDP flows periodically.
+            if self.last_sweep.elapsed() >= Duration::from_secs(5) {
+                self.sweep_udp_flows();
+                self.last_sweep = StdInstant::now();
+            }
         }
 
         // Drain phase: abort remaining handler tasks by dropping channels.
         debug!(
-            "TUN driver shutting down, {} active connections",
-            self.connections.len()
+            "TUN driver shutting down, {} active TCP connections, {} active UDP flows",
+            self.connections.len(),
+            self.flow_table.len(),
         );
+        self.flow_table.clear();
     }
 
     // Internal methods ================================================================================================
@@ -449,10 +496,18 @@ impl TunDriver {
     }
 
     async fn flush_to_tun(&mut self) {
+        // Flush smoltcp output (TCP + DNS UDP).
         let packets = self.device.dequeue_tx();
         for pkt in packets {
             if let Err(e) = self.tun.write_all(&pkt).await {
                 trace!("TUN write error: {e}");
+                break;
+            }
+        }
+        // Flush general UDP reply packets.
+        for pkt in self.pending_tun_writes.drain(..) {
+            if let Err(e) = self.tun.write_all(&pkt).await {
+                trace!("TUN write error (UDP reply): {e}");
                 break;
             }
         }
@@ -473,6 +528,118 @@ impl TunDriver {
         let handle = self.sockets.add(socket);
         self.listeners.push(TcpListener { handle, port });
         self.listened_ports.insert(port);
+    }
+
+    // UDP flow dispatching ============================================================================================
+
+    /// Handle a general (non-DNS) UDP packet. Returns `true` if the packet
+    /// was consumed and should NOT be fed to smoltcp.
+    fn handle_general_udp(&mut self, packet: &[u8]) -> bool {
+        let parsed = match parse_ip_packet_full(packet) {
+            Some(p) if p.proto == IpProto::Udp => p,
+            _ => return false,
+        };
+
+        // DNS (port 53) when fake DNS is active goes through smoltcp.
+        if parsed.dst_port == 53 && self.fake_dns.is_some() {
+            return false;
+        }
+
+        let key = FlowKey {
+            src_ip: parsed.src_ip,
+            src_port: parsed.src_port,
+            dst_ip: parsed.dst_ip,
+            dst_port: parsed.dst_port,
+        };
+
+        let payload_start = parsed.payload_offset.min(packet.len());
+        let payload_end = (parsed.payload_offset + parsed.payload_len).min(packet.len());
+        let payload = &packet[payload_start..payload_end];
+
+        // Existing flow: forward the datagram.
+        if let Some(entry) = self.flow_table.get_mut(&key) {
+            entry.last_activity = std::time::Instant::now();
+            match &entry.handle {
+                FlowHandle::Proxy { tx } | FlowHandle::Bypass { tx } => {
+                    let _ = tx.try_send(payload.to_vec());
+                }
+                FlowHandle::Blocked => {} // silently drop
+            }
+            return true;
+        }
+
+        // New flow: spawn async creation. The first datagram(s) during
+        // setup are dropped (UDP is lossy). If a second packet races while
+        // creation is in-flight, a duplicate task spawns — the later insert
+        // overwrites the earlier one harmlessly.
+        let ctx = Arc::clone(&self.handler_ctx);
+        let rules = self.rules.load_full();
+        let fake_dns = self.fake_dns.clone();
+        let reply_tx = self.reply_tx.clone();
+        let cancel = self.cancel.clone();
+        let new_flow_tx = self.new_flow_tx.clone();
+
+        tokio::spawn(async move {
+            match udp_handler::create_udp_flow(
+                key.src_ip,
+                key.src_port,
+                key.dst_ip,
+                key.dst_port,
+                &ctx,
+                &rules,
+                &fake_dns,
+                reply_tx,
+                cancel,
+            )
+            .await
+            {
+                Ok(entry) => {
+                    let _ = new_flow_tx.send((key, entry)).await;
+                }
+                Err(e) => {
+                    debug!(error = %e, dst_ip = %key.dst_ip, dst_port = key.dst_port, "failed to create UDP flow");
+                }
+            }
+        });
+
+        true
+    }
+
+    /// Drain completed async flow creations into the flow table.
+    fn drain_new_flows(&mut self) {
+        while let Ok((key, entry)) = self.new_flow_rx.try_recv() {
+            self.flow_table.insert(key, entry);
+        }
+    }
+
+    /// Drain upstream UDP replies and build raw IP packets for TUN injection.
+    fn process_udp_replies(&mut self) {
+        while let Ok(reply) = self.reply_rx.try_recv() {
+            let packet = build_udp_packet(
+                reply.src_ip,
+                reply.src_port,
+                reply.dst_ip,
+                reply.dst_port,
+                &reply.payload,
+            );
+            if !packet.is_empty() {
+                self.pending_tun_writes.push(packet);
+            }
+        }
+    }
+
+    /// Evict idle UDP flows and unpin their fake DNS entries.
+    fn sweep_udp_flows(&mut self) {
+        let evicted = self.flow_table.sweep(Duration::from_secs(30));
+        let count = evicted.len();
+        for entry in evicted {
+            if let (Some(ref fdns), Some(ip)) = (&self.fake_dns, entry.pinned_ip) {
+                fdns.unpin(ip);
+            }
+        }
+        if count > 0 {
+            debug!(count, "swept idle UDP flows");
+        }
     }
 }
 
@@ -528,6 +695,203 @@ fn parse_ipv6_dst(packet: &[u8]) -> Option<(u16, IpProto)> {
         6 => Some((dst_port, IpProto::Tcp)),
         17 => Some((dst_port, IpProto::Udp)),
         _ => None,
+    }
+}
+
+// Full packet parsing (for UDP flow dispatching) ----------------------------------------------------------------------
+
+/// Parsed fields from an IP+TCP/UDP packet header.
+struct ParsedPacket {
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    proto: IpProto,
+    /// Byte offset where the L4 payload starts (after IP + TCP/UDP headers).
+    payload_offset: usize,
+    /// Length of the L4 payload in bytes.
+    payload_len: usize,
+}
+
+/// Parse an IP packet into its full 5-tuple + payload location.
+fn parse_ip_packet_full(packet: &[u8]) -> Option<ParsedPacket> {
+    if packet.is_empty() {
+        return None;
+    }
+    let version = packet[0] >> 4;
+    match version {
+        4 => parse_ipv4_full(packet),
+        6 => parse_ipv6_full(packet),
+        _ => None,
+    }
+}
+
+fn parse_ipv4_full(packet: &[u8]) -> Option<ParsedPacket> {
+    if packet.len() < 20 {
+        return None;
+    }
+    let ihl = ((packet[0] & 0x0f) as usize) * 4;
+    let protocol = packet[9];
+    let total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
+
+    // Need at least IP header + 8 bytes for TCP/UDP ports + lengths.
+    if packet.len() < ihl + 8 || total_len < ihl + 8 {
+        return None;
+    }
+
+    let proto = match protocol {
+        6 => IpProto::Tcp,
+        17 => IpProto::Udp,
+        _ => return None,
+    };
+
+    let src_ip = IpAddr::V4(std::net::Ipv4Addr::new(packet[12], packet[13], packet[14], packet[15]));
+    let dst_ip = IpAddr::V4(std::net::Ipv4Addr::new(packet[16], packet[17], packet[18], packet[19]));
+    let src_port = u16::from_be_bytes([packet[ihl], packet[ihl + 1]]);
+    let dst_port = u16::from_be_bytes([packet[ihl + 2], packet[ihl + 3]]);
+
+    // For UDP the payload starts right after the 8-byte UDP header.
+    // For TCP the data offset is in the TCP header itself, but we only
+    // need full parsing for UDP here.
+    let (payload_offset, payload_len) = if proto == IpProto::Udp {
+        let udp_len = u16::from_be_bytes([packet[ihl + 4], packet[ihl + 5]]) as usize;
+        let hdr = 8; // UDP header size
+        (ihl + hdr, udp_len.saturating_sub(hdr))
+    } else {
+        // TCP: we don't use payload_offset for TCP flow dispatching,
+        // but compute it for completeness.
+        let data_offset = ((packet[ihl + 12] >> 4) as usize) * 4;
+        let tcp_payload = total_len.saturating_sub(ihl + data_offset);
+        (ihl + data_offset, tcp_payload)
+    };
+
+    Some(ParsedPacket {
+        src_ip,
+        src_port,
+        dst_ip,
+        dst_port,
+        proto,
+        payload_offset,
+        payload_len,
+    })
+}
+
+fn parse_ipv6_full(packet: &[u8]) -> Option<ParsedPacket> {
+    // IPv6 fixed header is 40 bytes; need at least 8 more for L4 ports.
+    if packet.len() < 48 {
+        return None;
+    }
+    let next_header = packet[6];
+    let payload_length = u16::from_be_bytes([packet[4], packet[5]]) as usize;
+
+    let proto = match next_header {
+        6 => IpProto::Tcp,
+        17 => IpProto::Udp,
+        _ => return None,
+    };
+
+    let mut src_octets = [0u8; 16];
+    src_octets.copy_from_slice(&packet[8..24]);
+    let mut dst_octets = [0u8; 16];
+    dst_octets.copy_from_slice(&packet[24..40]);
+
+    let src_ip = IpAddr::V6(std::net::Ipv6Addr::from(src_octets));
+    let dst_ip = IpAddr::V6(std::net::Ipv6Addr::from(dst_octets));
+
+    let l4_start = 40; // fixed IPv6 header
+    let src_port = u16::from_be_bytes([packet[l4_start], packet[l4_start + 1]]);
+    let dst_port = u16::from_be_bytes([packet[l4_start + 2], packet[l4_start + 3]]);
+
+    let (payload_offset, payload_len) = if proto == IpProto::Udp {
+        let udp_len = u16::from_be_bytes([packet[l4_start + 4], packet[l4_start + 5]]) as usize;
+        let hdr = 8;
+        (l4_start + hdr, udp_len.saturating_sub(hdr))
+    } else {
+        let data_offset = ((packet[l4_start + 12] >> 4) as usize) * 4;
+        let tcp_payload = payload_length.saturating_sub(data_offset);
+        (l4_start + data_offset, tcp_payload)
+    };
+
+    Some(ParsedPacket {
+        src_ip,
+        src_port,
+        dst_ip,
+        dst_port,
+        proto,
+        payload_offset,
+        payload_len,
+    })
+}
+
+// Reply packet construction -------------------------------------------------------------------------------------------
+
+/// Build a raw IP+UDP packet from the given fields, with correct checksums.
+fn build_udp_packet(src_ip: IpAddr, src_port: u16, dst_ip: IpAddr, dst_port: u16, payload: &[u8]) -> Vec<u8> {
+    let udp_len = 8 + payload.len();
+    let checksums = ChecksumCapabilities::default(); // compute all checksums
+
+    match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => {
+            let ip_repr = Ipv4Repr {
+                src_addr: src,
+                dst_addr: dst,
+                next_header: IpProtocol::Udp,
+                payload_len: udp_len,
+                hop_limit: 64,
+            };
+            let total = ip_repr.buffer_len() + udp_len;
+            let mut buf = vec![0u8; total];
+
+            let mut ip_pkt = Ipv4Packet::new_unchecked(&mut buf);
+            ip_repr.emit(&mut ip_pkt, &checksums);
+
+            let ip_hdr_len = ip_repr.buffer_len();
+            let mut udp_pkt = UdpPacket::new_unchecked(&mut buf[ip_hdr_len..]);
+            let udp_repr = UdpRepr { src_port, dst_port };
+            udp_repr.emit(
+                &mut udp_pkt,
+                &IpAddress::Ipv4(src),
+                &IpAddress::Ipv4(dst),
+                payload.len(),
+                |buf| buf.copy_from_slice(payload),
+                &checksums,
+            );
+
+            buf
+        }
+        (IpAddr::V6(src), IpAddr::V6(dst)) => {
+            let ip_repr = Ipv6Repr {
+                src_addr: src,
+                dst_addr: dst,
+                next_header: IpProtocol::Udp,
+                payload_len: udp_len,
+                hop_limit: 64,
+            };
+            let total = ip_repr.buffer_len() + udp_len;
+            let mut buf = vec![0u8; total];
+
+            let mut ip_pkt = Ipv6Packet::new_unchecked(&mut buf);
+            ip_repr.emit(&mut ip_pkt);
+
+            let ip_hdr_len = ip_repr.buffer_len();
+            let mut udp_pkt = UdpPacket::new_unchecked(&mut buf[ip_hdr_len..]);
+            let udp_repr = UdpRepr { src_port, dst_port };
+            udp_repr.emit(
+                &mut udp_pkt,
+                &IpAddress::Ipv6(src),
+                &IpAddress::Ipv6(dst),
+                payload.len(),
+                |buf| buf.copy_from_slice(payload),
+                &checksums,
+            );
+
+            buf
+        }
+        _ => {
+            // Mismatched IP versions — should never happen.
+            debug!("mismatched IP versions in UDP reply");
+            Vec::new()
+        }
     }
 }
 

--- a/crates/bridge/src/dispatcher/driver_tests.rs
+++ b/crates/bridge/src/dispatcher/driver_tests.rs
@@ -1,7 +1,8 @@
 // Driver tests require a real TUN device (elevated privileges).
 // Unit tests for parse_ip_dst are feasible and placed here.
 
-use super::{parse_ip_dst, IpProto};
+use super::{build_udp_packet, parse_ip_dst, parse_ip_packet_full, IpProto};
+use smoltcp::wire::{IpAddress, Ipv4Packet, Ipv6Packet, UdpPacket};
 
 #[skuld::test]
 fn parse_ipv4_tcp_syn() {
@@ -58,4 +59,125 @@ fn parse_unknown_protocol_returns_none() {
     packet[0] = 0x45;
     packet[9] = 1; // ICMP
     assert_eq!(parse_ip_dst(&packet), None);
+}
+
+// parse_ip_packet_full tests ==========================================================================================
+
+#[skuld::test]
+fn parse_full_ipv4_udp() {
+    // Build a minimal IPv4+UDP packet via build_udp_packet, then parse it back.
+    let src: std::net::Ipv4Addr = "10.0.0.1".parse().unwrap();
+    let dst: std::net::Ipv4Addr = "8.8.8.8".parse().unwrap();
+    let payload = b"hello";
+    let packet = build_udp_packet(src.into(), 12345, dst.into(), 53, payload);
+
+    let parsed = parse_ip_packet_full(&packet).unwrap();
+    assert_eq!(parsed.proto, IpProto::Udp);
+    assert_eq!(parsed.src_ip, std::net::IpAddr::V4(src));
+    assert_eq!(parsed.dst_ip, std::net::IpAddr::V4(dst));
+    assert_eq!(parsed.src_port, 12345);
+    assert_eq!(parsed.dst_port, 53);
+    assert_eq!(parsed.payload_len, payload.len());
+    assert_eq!(
+        &packet[parsed.payload_offset..parsed.payload_offset + parsed.payload_len],
+        payload
+    );
+}
+
+#[skuld::test]
+fn parse_full_ipv6_udp() {
+    let src: std::net::Ipv6Addr = "fd00::1".parse().unwrap();
+    let dst: std::net::Ipv6Addr = "2001:4860:4860::8888".parse().unwrap();
+    let payload = b"world";
+    let packet = build_udp_packet(src.into(), 54321, dst.into(), 443, payload);
+
+    let parsed = parse_ip_packet_full(&packet).unwrap();
+    assert_eq!(parsed.proto, IpProto::Udp);
+    assert_eq!(parsed.src_ip, std::net::IpAddr::V6(src));
+    assert_eq!(parsed.dst_ip, std::net::IpAddr::V6(dst));
+    assert_eq!(parsed.src_port, 54321);
+    assert_eq!(parsed.dst_port, 443);
+    assert_eq!(parsed.payload_len, payload.len());
+    assert_eq!(
+        &packet[parsed.payload_offset..parsed.payload_offset + parsed.payload_len],
+        payload
+    );
+}
+
+// build_udp_packet tests ==============================================================================================
+
+#[skuld::test]
+fn build_ipv4_udp_roundtrip() {
+    let src: std::net::Ipv4Addr = "192.168.1.1".parse().unwrap();
+    let dst: std::net::Ipv4Addr = "10.0.0.2".parse().unwrap();
+    let payload = b"test payload data";
+
+    let packet = build_udp_packet(src.into(), 1234, dst.into(), 5678, payload);
+
+    // Parse with smoltcp to verify correctness.
+    let ip_pkt = Ipv4Packet::new_checked(&packet).unwrap();
+    assert_eq!(ip_pkt.src_addr(), src);
+    assert_eq!(ip_pkt.dst_addr(), dst);
+    assert_eq!(ip_pkt.next_header(), smoltcp::wire::IpProtocol::Udp);
+    assert!(ip_pkt.verify_checksum(), "IPv4 header checksum mismatch");
+
+    let ip_hdr_len = ip_pkt.header_len() as usize;
+    let udp_pkt = UdpPacket::new_checked(&packet[ip_hdr_len..]).unwrap();
+    assert_eq!(udp_pkt.src_port(), 1234);
+    assert_eq!(udp_pkt.dst_port(), 5678);
+    assert_eq!(udp_pkt.payload(), payload);
+
+    // Verify UDP checksum.
+    udp_pkt
+        .verify_checksum(&IpAddress::Ipv4(src), &IpAddress::Ipv4(dst))
+        .then_some(())
+        .expect("UDP checksum mismatch");
+}
+
+#[skuld::test]
+fn build_ipv6_udp_roundtrip() {
+    let src: std::net::Ipv6Addr = "fd00::1".parse().unwrap();
+    let dst: std::net::Ipv6Addr = "fd00::2".parse().unwrap();
+    let payload = b"ipv6 test data";
+
+    let packet = build_udp_packet(src.into(), 9999, dst.into(), 8080, payload);
+
+    // Parse with smoltcp.
+    let ip_pkt = Ipv6Packet::new_checked(&packet).unwrap();
+    assert_eq!(ip_pkt.src_addr(), src);
+    assert_eq!(ip_pkt.dst_addr(), dst);
+    assert_eq!(ip_pkt.next_header(), smoltcp::wire::IpProtocol::Udp);
+
+    let ip_hdr_len = 40; // fixed IPv6 header
+    let udp_pkt = UdpPacket::new_checked(&packet[ip_hdr_len..]).unwrap();
+    assert_eq!(udp_pkt.src_port(), 9999);
+    assert_eq!(udp_pkt.dst_port(), 8080);
+    assert_eq!(udp_pkt.payload(), payload);
+
+    udp_pkt
+        .verify_checksum(&IpAddress::Ipv6(src), &IpAddress::Ipv6(dst))
+        .then_some(())
+        .expect("UDP checksum mismatch");
+}
+
+#[skuld::test]
+fn build_udp_mismatched_ip_versions_returns_empty() {
+    let src: std::net::Ipv4Addr = "10.0.0.1".parse().unwrap();
+    let dst: std::net::Ipv6Addr = "fd00::1".parse().unwrap();
+    let packet = build_udp_packet(src.into(), 1234, dst.into(), 5678, b"data");
+    assert!(packet.is_empty());
+}
+
+#[skuld::test]
+fn build_udp_empty_payload() {
+    let src: std::net::Ipv4Addr = "10.0.0.1".parse().unwrap();
+    let dst: std::net::Ipv4Addr = "10.0.0.2".parse().unwrap();
+    let packet = build_udp_packet(src.into(), 100, dst.into(), 200, b"");
+
+    let ip_pkt = Ipv4Packet::new_checked(&packet).unwrap();
+    let ip_hdr_len = ip_pkt.header_len() as usize;
+    let udp_pkt = UdpPacket::new_checked(&packet[ip_hdr_len..]).unwrap();
+    assert_eq!(udp_pkt.payload().len(), 0);
+    assert_eq!(udp_pkt.src_port(), 100);
+    assert_eq!(udp_pkt.dst_port(), 200);
 }

--- a/crates/bridge/src/dispatcher/socks5_udp.rs
+++ b/crates/bridge/src/dispatcher/socks5_udp.rs
@@ -1,0 +1,235 @@
+//! SOCKS5 UDP Associate client for the proxy dispatch path.
+//!
+//! Implements the UDP ASSOCIATE command (RFC 1928 §4, §7) to relay UDP
+//! datagrams through the shadowsocks SOCKS5 local.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+
+// SOCKS5 UDP datagram encoding/decoding ===============================================================================
+
+/// Encode a SOCKS5 UDP datagram (RFC 1928 §7).
+///
+/// When `domain` is `Some`, the ATYP=Domain form is used (preferred —
+/// it lets the proxy resolve the name and avoids DNS leaks). Otherwise
+/// ATYP=IPv4/IPv6 is used with `dst_ip`.
+pub fn encode_socks5_udp(dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    // RSV (2 bytes) + FRAG (1 byte)
+    buf.extend_from_slice(&[0x00, 0x00, 0x00]);
+
+    if let Some(d) = domain {
+        // ATYP = Domain (0x03)
+        buf.push(0x03);
+        let domain_bytes = d.as_bytes();
+        // Length prefix (1 byte) — domain names > 255 bytes are invalid per
+        // RFC 1928 but we truncate defensively.
+        buf.push(domain_bytes.len().min(255) as u8);
+        buf.extend_from_slice(&domain_bytes[..domain_bytes.len().min(255)]);
+    } else {
+        match dst_ip {
+            IpAddr::V4(v4) => {
+                buf.push(0x01); // ATYP = IPv4
+                buf.extend_from_slice(&v4.octets());
+            }
+            IpAddr::V6(v6) => {
+                buf.push(0x04); // ATYP = IPv6
+                buf.extend_from_slice(&v6.octets());
+            }
+        }
+    }
+
+    // DST.PORT (2 bytes, big-endian)
+    buf.extend_from_slice(&dst_port.to_be_bytes());
+    // DATA
+    buf.extend_from_slice(payload);
+    buf
+}
+
+/// Decode a SOCKS5 UDP datagram header (RFC 1928 §7).
+///
+/// Returns `(src_ip, src_port, header_len)` so the payload starts at
+/// `data[header_len..]`. Returns `None` if the datagram is malformed or
+/// fragmented (FRAG != 0).
+pub fn decode_socks5_udp(data: &[u8]) -> Option<(IpAddr, u16, usize)> {
+    // Minimum: RSV(2) + FRAG(1) + ATYP(1) + addr(4 for IPv4) + port(2) = 10
+    if data.len() < 10 {
+        return None;
+    }
+
+    // FRAG != 0 means a fragmented datagram — we don't support reassembly.
+    if data[2] != 0x00 {
+        return None;
+    }
+
+    let atyp = data[3];
+    match atyp {
+        0x01 => {
+            // IPv4: 4 bytes address
+            if data.len() < 10 {
+                return None;
+            }
+            let ip = IpAddr::V4(Ipv4Addr::new(data[4], data[5], data[6], data[7]));
+            let port = u16::from_be_bytes([data[8], data[9]]);
+            Some((ip, port, 10))
+        }
+        0x03 => {
+            // Domain: 1-byte length + domain string (we return 0.0.0.0 as IP
+            // since the caller typically doesn't need it for incoming replies).
+            let dlen = data[4] as usize;
+            let header_len = 4 + 1 + dlen + 2;
+            if data.len() < header_len {
+                return None;
+            }
+            let port = u16::from_be_bytes([data[4 + 1 + dlen], data[4 + 1 + dlen + 1]]);
+            Some((IpAddr::V4(Ipv4Addr::UNSPECIFIED), port, header_len))
+        }
+        0x04 => {
+            // IPv6: 16 bytes address
+            let header_len = 4 + 16 + 2; // 22
+            if data.len() < header_len {
+                return None;
+            }
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(&data[4..20]);
+            let ip = IpAddr::V6(octets.into());
+            let port = u16::from_be_bytes([data[20], data[21]]);
+            Some((ip, port, header_len))
+        }
+        _ => None,
+    }
+}
+
+// SOCKS5 UDP relay session ============================================================================================
+
+/// A live SOCKS5 UDP Associate session.
+///
+/// The TCP `control` connection MUST stay open for the lifetime of the
+/// relay — closing it signals the SOCKS5 server to tear down the UDP
+/// association (RFC 1928 §6).
+pub struct Socks5UdpRelay {
+    #[allow(dead_code)]
+    control: TcpStream,
+    socket: UdpSocket,
+    relay_addr: SocketAddr,
+}
+
+impl Socks5UdpRelay {
+    /// Perform a SOCKS5 UDP ASSOCIATE handshake against the SS local on
+    /// `127.0.0.1:{local_port}` and return the ready-to-use relay.
+    pub async fn associate(local_port: u16) -> io::Result<Self> {
+        let proxy_addr: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), local_port);
+
+        // Step 1: TCP connect to SOCKS5 server.
+        let mut control = TcpStream::connect(proxy_addr).await?;
+
+        // Step 2: Auth negotiation — NO AUTH (method 0x00).
+        control.write_all(&[0x05, 0x01, 0x00]).await?;
+        let mut auth_reply = [0u8; 2];
+        control.read_exact(&mut auth_reply).await?;
+        if auth_reply != [0x05, 0x00] {
+            return Err(io::Error::other(format!(
+                "SOCKS5 auth failed: {:02x} {:02x}",
+                auth_reply[0], auth_reply[1]
+            )));
+        }
+
+        // Step 3: UDP ASSOCIATE request.
+        // CMD=0x03 (UDP ASSOCIATE), ATYP=0x01, ADDR=0.0.0.0, PORT=0
+        control
+            .write_all(&[0x05, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+            .await?;
+
+        // Step 4: Read reply.
+        let mut reply_head = [0u8; 4];
+        control.read_exact(&mut reply_head).await?;
+        if reply_head[1] != 0x00 {
+            return Err(io::Error::other(format!(
+                "SOCKS5 UDP ASSOCIATE failed: REP={:#04x}",
+                reply_head[1]
+            )));
+        }
+
+        let relay_addr = match reply_head[3] {
+            0x01 => {
+                // IPv4
+                let mut addr_buf = [0u8; 4];
+                control.read_exact(&mut addr_buf).await?;
+                let mut port_buf = [0u8; 2];
+                control.read_exact(&mut port_buf).await?;
+                let ip = Ipv4Addr::from(addr_buf);
+                let port = u16::from_be_bytes(port_buf);
+                SocketAddr::new(IpAddr::V4(ip), port)
+            }
+            0x04 => {
+                // IPv6
+                let mut addr_buf = [0u8; 16];
+                control.read_exact(&mut addr_buf).await?;
+                let mut port_buf = [0u8; 2];
+                control.read_exact(&mut port_buf).await?;
+                let ip = std::net::Ipv6Addr::from(addr_buf);
+                let port = u16::from_be_bytes(port_buf);
+                SocketAddr::new(IpAddr::V6(ip), port)
+            }
+            atyp => {
+                return Err(io::Error::other(format!(
+                    "SOCKS5 UDP ASSOCIATE: unsupported BND.ATYP={atyp:#04x}"
+                )));
+            }
+        };
+
+        // Replace 0.0.0.0 with localhost (shadowsocks-rust returns 0.0.0.0
+        // when it means "same host as the control connection").
+        let relay_addr = if relay_addr.ip().is_unspecified() {
+            SocketAddr::new(proxy_addr.ip(), relay_addr.port())
+        } else {
+            relay_addr
+        };
+
+        // Step 5: Bind a local UDP socket and "connect" to the relay address.
+        let socket = UdpSocket::bind("0.0.0.0:0").await?;
+        socket.connect(relay_addr).await?;
+
+        Ok(Self {
+            control,
+            socket,
+            relay_addr,
+        })
+    }
+
+    /// Send a datagram through the relay.
+    pub async fn send_to(&self, dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, payload: &[u8]) -> io::Result<()> {
+        let pkt = encode_socks5_udp(dst_ip, dst_port, domain, payload);
+        self.socket.send(&pkt).await?;
+        Ok(())
+    }
+
+    /// Receive a datagram from the relay. Returns `(payload_len, src_ip, src_port)`.
+    ///
+    /// The caller's `buf` receives the full SOCKS5 UDP datagram; the payload
+    /// starts at `buf[header_len..]` where `header_len` is derived from
+    /// [`decode_socks5_udp`].
+    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, IpAddr, u16)> {
+        let n = self.socket.recv(buf).await?;
+        let (src_ip, src_port, header_len) =
+            decode_socks5_udp(&buf[..n]).ok_or_else(|| io::Error::other("malformed SOCKS5 UDP reply"))?;
+
+        // Shift payload to the front of buf for convenience.
+        let payload_len = n - header_len;
+        buf.copy_within(header_len..n, 0);
+
+        Ok((payload_len, src_ip, src_port))
+    }
+
+    /// The relay address returned by the SOCKS5 server.
+    pub fn relay_addr(&self) -> SocketAddr {
+        self.relay_addr
+    }
+}
+
+#[cfg(test)]
+#[path = "socks5_udp_tests.rs"]
+mod socks5_udp_tests;

--- a/crates/bridge/src/dispatcher/socks5_udp_tests.rs
+++ b/crates/bridge/src/dispatcher/socks5_udp_tests.rs
@@ -1,0 +1,72 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use super::*;
+
+#[skuld::test]
+fn encode_decode_roundtrip_ipv4() {
+    let dst_ip = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
+    let dst_port = 443;
+    let payload = b"hello world";
+
+    let encoded = encode_socks5_udp(dst_ip, dst_port, None, payload);
+    let (ip, port, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
+
+    assert_eq!(ip, dst_ip);
+    assert_eq!(port, dst_port);
+    assert_eq!(&encoded[header_len..], payload);
+}
+
+#[skuld::test]
+fn encode_decode_roundtrip_ipv6() {
+    let dst_ip = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+    let dst_port = 8080;
+    let payload = b"ipv6 test";
+
+    let encoded = encode_socks5_udp(dst_ip, dst_port, None, payload);
+    let (ip, port, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
+
+    assert_eq!(ip, dst_ip);
+    assert_eq!(port, dst_port);
+    assert_eq!(&encoded[header_len..], payload);
+}
+
+#[skuld::test]
+fn encode_domain_decodes_as_unspecified_ip() {
+    let dst_ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+    let dst_port = 53;
+    let payload = b"dns query";
+    let domain = "example.com";
+
+    let encoded = encode_socks5_udp(dst_ip, dst_port, Some(domain), payload);
+
+    // ATYP should be 0x03 (domain).
+    assert_eq!(encoded[3], 0x03);
+
+    let (ip, port, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
+    // Domain-type decode returns 0.0.0.0 as the IP.
+    assert_eq!(ip, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    assert_eq!(port, dst_port);
+    assert_eq!(&encoded[header_len..], payload);
+}
+
+#[skuld::test]
+fn frag_nonzero_returns_none() {
+    let mut encoded = encode_socks5_udp(IpAddr::V4(Ipv4Addr::LOCALHOST), 80, None, b"data");
+    // Set FRAG byte to non-zero.
+    encoded[2] = 0x01;
+    assert!(decode_socks5_udp(&encoded).is_none());
+}
+
+#[skuld::test]
+fn truncated_packet_returns_none() {
+    // Too short to contain even a minimal header.
+    assert!(decode_socks5_udp(&[0x00, 0x00, 0x00, 0x01, 0x01]).is_none());
+}
+
+#[skuld::test]
+fn unknown_atyp_returns_none() {
+    let mut encoded = encode_socks5_udp(IpAddr::V4(Ipv4Addr::LOCALHOST), 80, None, b"data");
+    // Replace ATYP with an invalid value.
+    encoded[3] = 0x05;
+    assert!(decode_socks5_udp(&encoded).is_none());
+}

--- a/crates/bridge/src/dispatcher/tcp_handler.rs
+++ b/crates/bridge/src/dispatcher/tcp_handler.rs
@@ -38,7 +38,7 @@ const PEEK_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Shared state for all TCP handler tasks. Created once by the Dispatcher
 /// and passed (via Arc) to each spawned handler.
-pub struct TcpHandlerContext {
+pub struct HandlerContext {
     /// SS SOCKS5 local port on 127.0.0.1.
     pub local_port: u16,
     /// Upstream interface index for bypass sockets.
@@ -52,13 +52,15 @@ pub struct TcpHandlerContext {
     pub block_log: std::sync::Mutex<BlockLog>,
     /// One-time flag: emitted when IPv6 bypass falls back to block.
     pub ipv6_bypass_warned: AtomicBool,
+    /// Whether the current proxy config supports UDP relay (no v2ray-plugin).
+    pub udp_proxy_available: bool,
 }
 
 // Handler entry point =================================================================================================
 
 /// Per-connection environment, bundled to avoid clippy::too_many_arguments.
 pub struct ConnEnv {
-    pub ctx: Arc<TcpHandlerContext>,
+    pub ctx: Arc<HandlerContext>,
     pub rules: Arc<ArcSwap<RuleSet>>,
     pub fake_dns: Option<Arc<FakeDns>>,
     pub sniffer_semaphore: Arc<Semaphore>,
@@ -87,7 +89,7 @@ async fn handle_inner(
     stream: &mut SmoltcpStream,
     dst_ip: IpAddr,
     dst_port: u16,
-    ctx: &TcpHandlerContext,
+    ctx: &HandlerContext,
     rules: &ArcSwap<RuleSet>,
     fake_dns: Option<&FakeDns>,
     sniffer_semaphore: &Semaphore,
@@ -131,7 +133,7 @@ async fn handle_inner(
 
 /// Bundled dispatch environment (avoids too_many_arguments).
 struct DispatchEnv<'a> {
-    ctx: &'a TcpHandlerContext,
+    ctx: &'a HandlerContext,
     rules: &'a ArcSwap<RuleSet>,
     fake_dns: Option<&'a FakeDns>,
     sniffer_semaphore: &'a Semaphore,
@@ -196,7 +198,7 @@ async fn dispatch_proxy(
     dst_ip: IpAddr,
     dst_port: u16,
     domain: &Option<String>,
-    ctx: &TcpHandlerContext,
+    ctx: &HandlerContext,
     peek_buf: &[u8],
 ) -> std::io::Result<()> {
     let mut upstream = socks5_connect(ctx.local_port, dst_ip, dst_port, domain.as_deref()).await?;
@@ -215,7 +217,7 @@ async fn dispatch_bypass(
     dst_ip: IpAddr,
     dst_port: u16,
     domain: &Option<String>,
-    ctx: &TcpHandlerContext,
+    ctx: &HandlerContext,
     fake_dns: Option<&FakeDns>,
     peek_buf: &[u8],
 ) -> std::io::Result<()> {
@@ -245,7 +247,7 @@ fn dispatch_block(
     dst_ip: IpAddr,
     dst_port: u16,
     domain: Option<&str>,
-    ctx: &TcpHandlerContext,
+    ctx: &HandlerContext,
     decision: &filter::Decision,
 ) {
     let rule_index = decision.rule_index.unwrap_or(0) as u32;
@@ -270,7 +272,7 @@ fn dispatch_block(
 async fn resolve_bypass_ip(
     dst_ip: IpAddr,
     domain: Option<&str>,
-    ctx: &TcpHandlerContext,
+    ctx: &HandlerContext,
     fake_dns: Option<&FakeDns>,
 ) -> std::io::Result<IpAddr> {
     // Only resolve if the IP is a fake DNS synthetic IP.

--- a/crates/bridge/src/dispatcher/udp_flow.rs
+++ b/crates/bridge/src/dispatcher/udp_flow.rs
@@ -1,0 +1,95 @@
+//! UDP flow table — tracks active UDP flows by 4-tuple.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+
+/// 4-tuple identifying a UDP flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FlowKey {
+    pub src_ip: IpAddr,
+    pub src_port: u16,
+    pub dst_ip: IpAddr,
+    pub dst_port: u16,
+}
+
+/// What to do with datagrams in this flow.
+pub enum FlowHandle {
+    /// Forward via SOCKS5 UDP relay.
+    Proxy { tx: mpsc::Sender<Vec<u8>> },
+    /// Forward via interface-bound direct socket.
+    Bypass { tx: mpsc::Sender<Vec<u8>> },
+    /// Silently drop.
+    Blocked,
+}
+
+/// A flow table entry: handle + last-activity timestamp.
+pub struct FlowEntry {
+    pub handle: FlowHandle,
+    pub last_activity: Instant,
+    /// Domain associated with this flow (for fake DNS unpin on eviction).
+    pub domain: Option<String>,
+    /// The fake IP that was pinned (for unpin on eviction).
+    pub pinned_ip: Option<IpAddr>,
+}
+
+/// UDP flow table owned by the driver task.
+pub struct FlowTable {
+    flows: HashMap<FlowKey, FlowEntry>,
+}
+
+impl Default for FlowTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FlowTable {
+    pub fn new() -> Self {
+        Self { flows: HashMap::new() }
+    }
+
+    pub fn get_mut(&mut self, key: &FlowKey) -> Option<&mut FlowEntry> {
+        self.flows.get_mut(key)
+    }
+
+    pub fn insert(&mut self, key: FlowKey, entry: FlowEntry) {
+        self.flows.insert(key, entry);
+    }
+
+    /// Evict flows idle longer than `max_idle`. Returns evicted entries
+    /// so the caller can clean up resources (e.g., unpin fake DNS).
+    pub fn sweep(&mut self, max_idle: Duration) -> Vec<FlowEntry> {
+        let mut evicted = Vec::new();
+        let mut to_remove = Vec::new();
+        for (key, entry) in &self.flows {
+            if entry.last_activity.elapsed() >= max_idle {
+                to_remove.push(*key);
+            }
+        }
+        for key in to_remove {
+            if let Some(entry) = self.flows.remove(&key) {
+                evicted.push(entry);
+            }
+        }
+        evicted
+    }
+
+    pub fn len(&self) -> usize {
+        self.flows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.flows.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.flows.clear();
+    }
+}
+
+#[cfg(test)]
+#[path = "udp_flow_tests.rs"]
+mod udp_flow_tests;

--- a/crates/bridge/src/dispatcher/udp_flow_tests.rs
+++ b/crates/bridge/src/dispatcher/udp_flow_tests.rs
@@ -1,0 +1,68 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{Duration, Instant};
+
+use super::*;
+
+fn sample_key() -> FlowKey {
+    FlowKey {
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        src_port: 12345,
+        dst_ip: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+        dst_port: 443,
+    }
+}
+
+fn blocked_entry() -> FlowEntry {
+    FlowEntry {
+        handle: FlowHandle::Blocked,
+        last_activity: Instant::now(),
+        domain: None,
+        pinned_ip: None,
+    }
+}
+
+#[skuld::test]
+fn insert_and_lookup() {
+    let mut table = FlowTable::new();
+    let key = sample_key();
+    table.insert(key, blocked_entry());
+    assert!(table.get_mut(&key).is_some());
+}
+
+#[skuld::test]
+fn sweep_evicts_idle() {
+    let mut table = FlowTable::new();
+    let key = sample_key();
+    table.insert(
+        key,
+        FlowEntry {
+            handle: FlowHandle::Blocked,
+            last_activity: Instant::now() - Duration::from_secs(120),
+            domain: Some("example.com".into()),
+            pinned_ip: None,
+        },
+    );
+    let evicted = table.sweep(Duration::from_secs(60));
+    assert_eq!(evicted.len(), 1);
+    assert_eq!(evicted[0].domain.as_deref(), Some("example.com"));
+    assert_eq!(table.len(), 0);
+}
+
+#[skuld::test]
+fn sweep_keeps_active() {
+    let mut table = FlowTable::new();
+    let key = sample_key();
+    table.insert(key, blocked_entry());
+    let evicted = table.sweep(Duration::from_secs(60));
+    assert!(evicted.is_empty());
+    assert_eq!(table.len(), 1);
+}
+
+#[skuld::test]
+fn clear_empties_table() {
+    let mut table = FlowTable::new();
+    table.insert(sample_key(), blocked_entry());
+    assert_eq!(table.len(), 1);
+    table.clear();
+    assert_eq!(table.len(), 0);
+}

--- a/crates/bridge/src/dispatcher/udp_handler.rs
+++ b/crates/bridge/src/dispatcher/udp_handler.rs
@@ -1,0 +1,325 @@
+//! Per-datagram UDP handler: filter decision + flow creation.
+
+use std::net::IpAddr;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::filter::engine::{decide, ConnInfo, L4Proto};
+use crate::filter::rules::RuleSet;
+use crate::filter::FakeDns;
+use hole_common::config::FilterAction;
+
+use super::bypass::create_bypass_udp;
+use super::socks5_udp::Socks5UdpRelay;
+use super::tcp_handler::HandlerContext;
+use super::udp_flow::{FlowEntry, FlowHandle};
+
+/// Channel capacity for per-flow datagram forwarding. Full -> drop (UDP is lossy).
+const FLOW_CHANNEL_CAPACITY: usize = 128;
+
+/// A reply datagram from an upstream socket, to be written back to the TUN.
+pub struct UdpReply {
+    pub dst_ip: IpAddr,
+    pub dst_port: u16,
+    pub src_ip: IpAddr,
+    pub src_port: u16,
+    pub payload: Vec<u8>,
+}
+
+/// Create a new UDP flow: run filter engine, create upstream socket, spawn reader task.
+///
+/// Returns the `FlowEntry` to be inserted into the flow table by the driver.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_udp_flow(
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    ctx: &HandlerContext,
+    rules: &RuleSet,
+    fake_dns: &Option<Arc<FakeDns>>,
+    reply_tx: mpsc::Sender<UdpReply>,
+    cancel: CancellationToken,
+) -> std::io::Result<FlowEntry> {
+    // 1. Fake DNS reverse lookup.
+    let mut domain: Option<String> = None;
+    let mut pinned_ip: Option<IpAddr> = None;
+    if let Some(ref fdns) = fake_dns {
+        if let Some(d) = fdns.reverse_lookup(dst_ip) {
+            domain = Some(d.to_string());
+            fdns.pin(dst_ip);
+            pinned_ip = Some(dst_ip);
+        }
+    }
+
+    // 2. Build ConnInfo and decide.
+    let result = create_udp_flow_inner(
+        src_ip, src_port, dst_ip, dst_port, &domain, pinned_ip, ctx, rules, fake_dns, reply_tx, cancel,
+    )
+    .await;
+
+    // Unpin on failure so the fake DNS slot is not leaked.
+    if result.is_err() {
+        if let (Some(ref fdns), Some(ip)) = (fake_dns, pinned_ip) {
+            fdns.unpin(ip);
+        }
+    }
+
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_udp_flow_inner(
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    domain: &Option<String>,
+    pinned_ip: Option<IpAddr>,
+    ctx: &HandlerContext,
+    rules: &RuleSet,
+    fake_dns: &Option<Arc<FakeDns>>,
+    reply_tx: mpsc::Sender<UdpReply>,
+    cancel: CancellationToken,
+) -> std::io::Result<FlowEntry> {
+    let conn_info = ConnInfo {
+        dst_ip,
+        dst_port,
+        domain: domain.clone(),
+        proto: L4Proto::Udp,
+    };
+    let decision = decide(rules, &conn_info);
+    let mut action = decision.action;
+
+    // 3. Plugin incompatibility: downgrade Proxy -> Bypass when UDP relay
+    //    is unavailable (v2ray-plugin does not support UDP).
+    if action == FilterAction::Proxy && !ctx.udp_proxy_available {
+        let mut block_log = ctx.block_log.lock().unwrap();
+        if block_log.should_log(decision.rule_index.unwrap_or(0) as u32, dst_ip, dst_port) {
+            warn!(dst_ip = %dst_ip, dst_port, "UDP proxy unavailable (v2ray-plugin), bypassing");
+        }
+        action = FilterAction::Bypass;
+    }
+
+    // 4. Resolve bypass IP if needed.
+    let real_ip = if action == FilterAction::Bypass {
+        resolve_bypass_ip(dst_ip, domain.as_deref(), fake_dns, ctx).await?
+    } else {
+        dst_ip
+    };
+
+    // 5. Check IPv6 bypass availability.
+    if action == FilterAction::Bypass && real_ip.is_ipv6() && !ctx.ipv6_available {
+        if !ctx.ipv6_bypass_warned.swap(true, Ordering::Relaxed) {
+            warn!("IPv6 bypass unavailable for UDP, blocking");
+        }
+        action = FilterAction::Block;
+    }
+
+    // 6. Create the flow.
+    let domain = domain.clone();
+    let now = std::time::Instant::now();
+    match action {
+        FilterAction::Proxy => {
+            create_proxy_flow(
+                src_ip, src_port, dst_ip, dst_port, real_ip, domain, pinned_ip, ctx, reply_tx, cancel, now,
+            )
+            .await
+        }
+        FilterAction::Bypass => {
+            create_bypass_flow(
+                src_ip, src_port, dst_ip, dst_port, real_ip, domain, pinned_ip, ctx, reply_tx, cancel, now,
+            )
+            .await
+        }
+        FilterAction::Block => {
+            let rule_index = decision.rule_index.unwrap_or(0) as u32;
+            let mut block_log = ctx.block_log.lock().unwrap();
+            if block_log.should_log(rule_index, dst_ip, dst_port) {
+                info!(dst_ip = %dst_ip, dst_port, domain = ?domain, "blocked UDP flow");
+            }
+            Ok(FlowEntry {
+                handle: FlowHandle::Blocked,
+                last_activity: now,
+                domain,
+                pinned_ip,
+            })
+        }
+    }
+}
+
+// Flow creation helpers ===============================================================================================
+
+#[allow(clippy::too_many_arguments)]
+async fn create_proxy_flow(
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    real_ip: IpAddr,
+    domain: Option<String>,
+    pinned_ip: Option<IpAddr>,
+    ctx: &HandlerContext,
+    reply_tx: mpsc::Sender<UdpReply>,
+    cancel: CancellationToken,
+    now: std::time::Instant,
+) -> std::io::Result<FlowEntry> {
+    let relay = Arc::new(Socks5UdpRelay::associate(ctx.local_port).await?);
+    let (tx, mut rx) = mpsc::channel::<Vec<u8>>(FLOW_CHANNEL_CAPACITY);
+
+    // Reader task: recv from SOCKS5 relay, send reply back to TUN.
+    let relay2 = Arc::clone(&relay);
+    let cancel2 = cancel.clone();
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 65536];
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel2.cancelled() => break,
+                result = relay2.recv_from(&mut buf) => {
+                    match result {
+                        Ok((n, _src_ip, _src_port)) => {
+                            let _ = reply_tx.try_send(UdpReply {
+                                dst_ip: src_ip,
+                                dst_port: src_port,
+                                src_ip: dst_ip,
+                                src_port: dst_port,
+                                payload: buf[..n].to_vec(),
+                            });
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+    });
+
+    // Forwarder task: read from channel, send via relay.
+    let domain2 = domain.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => break,
+                msg = rx.recv() => {
+                    match msg {
+                        Some(payload) => {
+                            let _ = relay.send_to(real_ip, dst_port, domain2.as_deref(), &payload).await;
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(FlowEntry {
+        handle: FlowHandle::Proxy { tx },
+        last_activity: now,
+        domain,
+        pinned_ip,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_bypass_flow(
+    src_ip: IpAddr,
+    src_port: u16,
+    dst_ip: IpAddr,
+    dst_port: u16,
+    real_ip: IpAddr,
+    domain: Option<String>,
+    pinned_ip: Option<IpAddr>,
+    ctx: &HandlerContext,
+    reply_tx: mpsc::Sender<UdpReply>,
+    cancel: CancellationToken,
+    now: std::time::Instant,
+) -> std::io::Result<FlowEntry> {
+    let socket = create_bypass_udp(ctx.iface_index, real_ip.is_ipv6()).await?;
+    socket.connect(std::net::SocketAddr::new(real_ip, dst_port)).await?;
+    let socket = Arc::new(socket);
+
+    let (tx, mut rx) = mpsc::channel::<Vec<u8>>(FLOW_CHANNEL_CAPACITY);
+
+    // Reader task: recv from bypass socket, send reply.
+    let socket2 = Arc::clone(&socket);
+    let cancel2 = cancel.clone();
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 65536];
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel2.cancelled() => break,
+                result = socket2.recv(&mut buf) => {
+                    match result {
+                        Ok(n) => {
+                            let _ = reply_tx.try_send(UdpReply {
+                                dst_ip: src_ip,
+                                dst_port: src_port,
+                                src_ip: dst_ip,
+                                src_port: dst_port,
+                                payload: buf[..n].to_vec(),
+                            });
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+    });
+
+    // Forwarder task: read from channel, send via socket.
+    let socket3 = Arc::clone(&socket);
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => break,
+                msg = rx.recv() => {
+                    match msg {
+                        Some(payload) => { let _ = socket3.send(&payload).await; }
+                        None => break,
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(FlowEntry {
+        handle: FlowHandle::Bypass { tx },
+        last_activity: now,
+        domain,
+        pinned_ip,
+    })
+}
+
+// Helpers =============================================================================================================
+
+/// Resolve the real IP for a bypass-path connection.
+async fn resolve_bypass_ip(
+    dst_ip: IpAddr,
+    domain: Option<&str>,
+    fake_dns: &Option<Arc<FakeDns>>,
+    ctx: &HandlerContext,
+) -> std::io::Result<IpAddr> {
+    let is_fake = fake_dns.as_ref().is_some_and(|fdns| fdns.is_fake_ip(dst_ip));
+    if !is_fake {
+        return Ok(dst_ip);
+    }
+
+    let domain =
+        domain.ok_or_else(|| std::io::Error::other("bypass: dst_ip is in fake DNS pool but no domain available"))?;
+    let addrs = ctx.upstream_resolver.resolve(domain).await?;
+    addrs
+        .into_iter()
+        .next()
+        .ok_or_else(|| std::io::Error::other(format!("bypass: no addresses resolved for {domain}")))
+}
+
+#[cfg(test)]
+#[path = "udp_handler_tests.rs"]
+mod udp_handler_tests;

--- a/crates/bridge/src/dispatcher/udp_handler_tests.rs
+++ b/crates/bridge/src/dispatcher/udp_handler_tests.rs
@@ -1,0 +1,15 @@
+use super::UdpReply;
+
+#[skuld::test]
+fn udp_reply_fields() {
+    let reply = UdpReply {
+        dst_ip: "10.0.0.1".parse().unwrap(),
+        dst_port: 12345,
+        src_ip: "8.8.8.8".parse().unwrap(),
+        src_port: 443,
+        payload: vec![1, 2, 3],
+    };
+    assert_eq!(reply.payload.len(), 3);
+    assert_eq!(reply.dst_port, 12345);
+    assert_eq!(reply.src_port, 443);
+}

--- a/crates/bridge/src/proxy.rs
+++ b/crates/bridge/src/proxy.rs
@@ -29,7 +29,7 @@ use shadowsocks_service::config::Config;
 pub mod config;
 pub mod shadowsocks;
 
-pub use config::{build_ss_config, ProxyError, TUN_DEVICE_NAME, TUN_SUBNET};
+pub use config::{build_ss_config, udp_proxy_available, ProxyError, TUN_DEVICE_NAME, TUN_SUBNET};
 pub use shadowsocks::{ShadowsocksProxy, ShadowsocksRunning};
 
 // Used by `server_test.rs` + `proxy_tests.rs`. Kept crate-private so

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -119,6 +119,15 @@ fn resolve_plugin_path(name: &str) -> String {
     resolve_plugin_path_inner(name, std::env::current_exe().ok())
 }
 
+/// Whether UDP can be proxied through the shadowsocks server.
+///
+/// Returns `false` when a v2ray-plugin is configured — plugins are
+/// TCP-only by protocol definition, so UDP traffic cannot be carried.
+/// The dispatcher uses this to downgrade UDP Proxy actions to Bypass.
+pub fn udp_proxy_available(config: &ProxyConfig) -> bool {
+    config.server.plugin.is_none()
+}
+
 /// Inner implementation that accepts an explicit exe path for testability.
 ///
 /// Looks for the plugin binary in the same directory as the bridge executable.
@@ -146,3 +155,7 @@ pub(crate) fn resolve_plugin_path_inner(name: &str, bridge_exe: Option<PathBuf>)
     }
     name.to_string()
 }
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+use hole_common::config::ServerEntry;
+use hole_common::protocol::ProxyConfig;
+
+fn sample_server() -> ServerEntry {
+    ServerEntry {
+        id: "test".into(),
+        name: "Test".into(),
+        server: "1.2.3.4".into(),
+        server_port: 8388,
+        method: "aes-256-gcm".into(),
+        password: "secret".into(),
+        plugin: None,
+        plugin_opts: None,
+        validation: None,
+    }
+}
+
+fn sample_config() -> ProxyConfig {
+    ProxyConfig {
+        server: sample_server(),
+        local_port: 4073,
+        tunnel_mode: hole_common::protocol::TunnelMode::Full,
+        filters: vec![],
+    }
+}
+
+#[skuld::test]
+fn udp_available_without_plugin() {
+    assert!(udp_proxy_available(&sample_config()));
+}
+
+#[skuld::test]
+fn udp_unavailable_with_plugin() {
+    let mut cfg = sample_config();
+    cfg.server.plugin = Some("v2ray-plugin".into());
+    assert!(!udp_proxy_available(&cfg));
+}

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -257,6 +257,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 config.local_port,
                 gw_info.interface_index,
                 gw_info.ipv6_available,
+                crate::proxy::udp_proxy_available(config),
                 ruleset,
                 &dns_servers,
             )?;


### PR DESCRIPTION
## Summary

- UDP flow table (HashMap-based, 30s idle sweep)
- Per-datagram dispatch: fake DNS reverse lookup -> filter decide -> proxy/bypass/block
- SOCKS5 UDP Associate client (TCP control + relay, RFC 1928 header encode/decode)
- UDP bypass sockets with `IP_UNICAST_IF` / `IP_BOUND_IF`
- Plugin incompatibility: v2ray-plugin forces UDP Proxy -> Bypass with rate-limited warning
- `udp_proxy_available()` computed from plugin presence
- Renamed `TcpHandlerContext` -> `HandlerContext` (shared by TCP and UDP)
- Raw IP+UDP reply packet construction using smoltcp `Repr` API (correct checksums)
- General UDP bypasses smoltcp entirely (DNS port 53 still uses smoltcp UDP socket)
- Fake DNS pin/unpin lifecycle for UDP flows (pin on creation, unpin on sweep eviction)

Part of the filter engine v1 work. Plan 2 (#174) delivered TCP dispatcher; this is Plan 3.

Closes #175

## Test plan

- [x] 334 unit tests pass (`cargo test -p hole-bridge --lib`)
- [x] Full workspace clippy clean
- [ ] CI passes on Windows + macOS
- [ ] Manual test: UDP traffic (QUIC, game protocols) dispatched correctly