### PR TITLE
filter: UI integration, hot reload, metrics (Plan 4)

### DIFF
--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -118,6 +118,11 @@ impl Dispatcher {
         })
     }
 
+    /// Get the list of invalid (dropped) filter rules from the current ruleset.
+    pub fn invalid_filters(&self) -> Vec<hole_common::protocol::InvalidFilter> {
+        self.rules.load().dropped.clone()
+    }
+
     /// Hot-swap the filter rules without restarting the dispatcher.
     pub fn swap_rules(&self, new_rules: RuleSet) {
         self.rules.store(Arc::new(new_rules));

--- a/crates/bridge/src/filter/rules.rs
+++ b/crates/bridge/src/filter/rules.rs
@@ -4,18 +4,9 @@
 //! status response so the GUI can highlight problem rows.
 
 use hole_common::config::{FilterAction, FilterRule};
-use serde::{Deserialize, Serialize};
+pub use hole_common::protocol::InvalidFilter;
 
 use super::matcher::Matcher;
-
-/// A filter rule that failed to compile, recording its original index
-/// and a human-readable reason. Moved to `hole_common::protocol` and
-/// wired into the IPC status response in Plan 4 when the GUI needs it.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct InvalidFilter {
-    pub index: u32,
-    pub error: String,
-}
 
 /// One compiled rule: matcher + action. Rules are stored in the same
 /// order as the user's input so the reverse-scan in `engine::decide`

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -216,6 +216,9 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
         running: pm.state() == ProxyState::Running,
         uptime_secs: pm.uptime_secs(),
         error: pm.last_error().map(|s| s.to_string()),
+        invalid_filters: pm.invalid_filters(),
+        udp_proxy_available: pm.udp_proxy_available(),
+        ipv6_bypass_available: pm.ipv6_bypass_available(),
     })
 }
 
@@ -349,12 +352,18 @@ async fn handle_metrics<P: Proxy + 'static, R: Routing + 'static>(
 ) -> Json<MetricsResponse> {
     let mut pm = state.proxy.lock().await;
     pm.check_health();
+    let filter = if pm.state() == ProxyState::Running {
+        Some(hole_common::protocol::FilterMetrics::default())
+    } else {
+        None
+    };
     Json(MetricsResponse {
         bytes_in: 0,
         bytes_out: 0,
         speed_in_bps: 0,
         speed_out_bps: 0,
         uptime_secs: pm.uptime_secs(),
+        filter,
     })
 }
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -341,6 +341,9 @@ fn status_when_not_running_returns_false() {
                 running: false,
                 uptime_secs: 0,
                 error: None,
+                invalid_filters: Vec::new(),
+                udp_proxy_available: true,
+                ipv6_bypass_available: true,
             }
         );
         drop(client);

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -400,6 +400,9 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 error!("proxy task exited unexpectedly");
                 self.last_error = Some("proxy task exited unexpectedly".into());
                 self.running = None; // Drop tears down routes + clears state file
+                self.active_config = None;
+                self.udp_proxy_available = true;
+                self.ipv6_bypass_available = true;
             }
         }
     }

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -66,6 +66,10 @@ struct RunningState<P: Proxy, R: Routing> {
     proxy: P::Running,
     server_ip: Option<IpAddr>,
     started_at: Instant,
+    /// Whether UDP proxy relay is available (from plugin config).
+    udp_proxy_available: bool,
+    /// Whether IPv6 bypass is available (from gateway info).
+    ipv6_bypass_available: bool,
 }
 
 // ProxyManager ========================================================================================================
@@ -75,6 +79,13 @@ pub struct ProxyManager<P: Proxy = ShadowsocksProxy, R: Routing = SystemRouting>
     routing: R,
     running: Option<RunningState<P, R>>,
     last_error: Option<String>,
+    /// Last successfully-started config. Used by `reload` to detect
+    /// filter-only changes (hot-swap path vs full restart).
+    active_config: Option<ProxyConfig>,
+    /// Whether the server's plugin configuration supports UDP relay.
+    udp_proxy_available: bool,
+    /// Whether the upstream network has IPv6 connectivity.
+    ipv6_bypass_available: bool,
 }
 
 impl<P: Proxy, R: Routing> ProxyManager<P, R> {
@@ -84,6 +95,9 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             routing,
             running: None,
             last_error: None,
+            active_config: None,
+            udp_proxy_available: true,
+            ipv6_bypass_available: true,
         }
     }
 
@@ -116,6 +130,25 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
     /// host OS.
     pub fn default_gateway(&self) -> Result<crate::gateway::GatewayInfo, ProxyError> {
         self.routing.default_gateway()
+    }
+
+    /// Get the list of invalid (dropped) filter rules from the current ruleset.
+    pub fn invalid_filters(&self) -> Vec<hole_common::protocol::InvalidFilter> {
+        self.running
+            .as_ref()
+            .and_then(|r| r.dispatcher.as_ref())
+            .map(|d| d.invalid_filters())
+            .unwrap_or_default()
+    }
+
+    /// Whether UDP proxy relay is available with the current config.
+    pub fn udp_proxy_available(&self) -> bool {
+        self.udp_proxy_available
+    }
+
+    /// Whether IPv6 bypass is available on the upstream network.
+    pub fn ipv6_bypass_available(&self) -> bool {
+        self.ipv6_bypass_available
     }
 
     /// Non-cancellable convenience wrapper around
@@ -176,7 +209,10 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         match result {
             Ok(state) => {
                 let server_ip = state.server_ip;
+                self.udp_proxy_available = state.udp_proxy_available;
+                self.ipv6_bypass_available = state.ipv6_bypass_available;
                 self.running = Some(state);
+                self.active_config = Some(config.clone());
                 self.last_error = None;
                 info!(server_ip = ?server_ip, "proxy started");
                 Ok(())
@@ -224,6 +260,8 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 proxy: running_proxy,
                 server_ip: None,
                 started_at: Instant::now(),
+                udp_proxy_available: crate::proxy::udp_proxy_available(config),
+                ipv6_bypass_available: false,
             });
         }
 
@@ -278,6 +316,8 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             proxy: running_proxy,
             server_ip: Some(server_ip),
             started_at: Instant::now(),
+            udp_proxy_available: crate::proxy::udp_proxy_available(config),
+            ipv6_bypass_available: gw_info.ipv6_available,
         })
     }
 
@@ -291,6 +331,8 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             routes,
             server_ip: _,
             started_at: _,
+            udp_proxy_available: _,
+            ipv6_bypass_available: _,
         } = state;
 
         // 1. Shut down dispatcher (closes TUN, cancels all handlers).
@@ -306,13 +348,40 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
 
         // Clear any error from a previous failed start. See issue #142.
         self.last_error = None;
+        self.active_config = None;
+        self.udp_proxy_available = true;
+        self.ipv6_bypass_available = true;
         info!("proxy stopped");
         res
     }
 
     pub async fn reload(&mut self, config: &ProxyConfig) -> Result<(), ProxyError> {
-        self.stop().await?;
-        self.start(config).await
+        let Some(ref active) = self.active_config else {
+            // Not running: just start.
+            return self.start(config).await;
+        };
+
+        // Structural equality check (ignoring filters).
+        let structural_same = active.server == config.server
+            && active.local_port == config.local_port
+            && active.tunnel_mode == config.tunnel_mode;
+
+        if structural_same {
+            // Fast path: hot-swap filter rules without restart.
+            let new_ruleset = crate::filter::rules::RuleSet::from_user_rules(&config.filters);
+            if let Some(ref state) = self.running {
+                if let Some(ref dispatcher) = state.dispatcher {
+                    dispatcher.swap_rules(new_ruleset);
+                }
+            }
+            self.active_config = Some(config.clone());
+            info!("filter rules hot-swapped");
+            Ok(())
+        } else {
+            // Slow path: full stop + start.
+            self.stop().await?;
+            self.start(config).await
+        }
     }
 
     /// Sync health check: detects a proxy task that exited on its own

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -443,6 +443,36 @@ fn check_health_detects_crashed_task() {
 }
 
 #[skuld::test]
+fn check_health_clears_active_config_so_reload_restarts() {
+    // Regression guard: check_health must clear active_config, otherwise
+    // a subsequent reload would take the hot-swap path (no-op) instead
+    // of starting a new proxy.
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let state = proxy.start_calls_handle();
+
+        let (mut pm, _dir) = new_manager(proxy);
+        pm.start(&test_config()).await.unwrap();
+        assert_eq!(state.start_calls.load(Ordering::SeqCst), 1);
+
+        // Simulate crash.
+        state.crashed.store(true, Ordering::SeqCst);
+        pm.check_health();
+        assert_eq!(pm.state(), ProxyState::Stopped);
+
+        // Un-crash so the next start succeeds.
+        state.crashed.store(false, Ordering::SeqCst);
+
+        // Reload must detect that we're not running and do a full start.
+        pm.reload(&test_config()).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        assert_eq!(state.start_calls.load(Ordering::SeqCst), 2);
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
 fn check_health_does_not_mark_healthy_task_as_crashed() {
     rt().block_on(async {
         let (mut pm, _dir) = new_manager(MockProxy::new());

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -336,7 +336,7 @@ fn start_when_running_returns_already_running() {
 }
 
 #[skuld::test]
-fn reload_stops_then_starts() {
+fn reload_with_same_server_hot_swaps_rules() {
     rt().block_on(async {
         let backend = MockProxy::new();
         let state = backend.start_calls_handle();
@@ -345,7 +345,37 @@ fn reload_stops_then_starts() {
         pm.start(&test_config()).await.unwrap();
         assert_eq!(state.start_calls.load(Ordering::SeqCst), 1);
 
-        pm.reload(&test_config()).await.unwrap();
+        // Reload with same server config but different filters — hot-swap path.
+        let mut config = test_config();
+        config.filters.push(hole_common::config::FilterRule {
+            address: "example.com".into(),
+            matching: hole_common::config::MatchType::Exactly,
+            action: hole_common::config::FilterAction::Block,
+        });
+        pm.reload(&config).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        // start was NOT called a second time (hot swap, no restart)
+        assert_eq!(state.start_calls.load(Ordering::SeqCst), 1);
+
+        pm.stop().await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Stopped);
+    });
+}
+
+#[skuld::test]
+fn reload_with_different_server_restarts() {
+    rt().block_on(async {
+        let backend = MockProxy::new();
+        let state = backend.start_calls_handle();
+
+        let (mut pm, _dir) = new_manager(backend);
+        pm.start(&test_config()).await.unwrap();
+        assert_eq!(state.start_calls.load(Ordering::SeqCst), 1);
+
+        // Reload with different server → full stop + start.
+        let mut config = test_config();
+        config.server.server = "10.0.0.1".into();
+        pm.reload(&config).await.unwrap();
         assert_eq!(pm.state(), ProxyState::Running);
         // start was called a second time (stop + start)
         assert_eq!(state.start_calls.load(Ordering::SeqCst), 2);
@@ -745,9 +775,9 @@ fn start_cancellable_dropped_future_runs_guards() {
 
 #[skuld::test]
 fn reload_creates_fresh_uncancellable_token() {
-    // reload() internally calls start_cancellable with a fresh token
-    // that is never signaled. Verifies the reload path still works
-    // after the cancellation refactor.
+    // reload() with a different server internally calls start_cancellable
+    // with a fresh token that is never signaled. Verifies the full-restart
+    // reload path still works after the cancellation refactor.
     rt().block_on(async {
         let proxy = MockProxy::new();
         let state = proxy.start_calls_handle();
@@ -756,9 +786,29 @@ fn reload_creates_fresh_uncancellable_token() {
         pm.start(&test_config()).await.unwrap();
         assert_eq!(state.start_calls.load(Ordering::SeqCst), 1);
 
-        pm.reload(&test_config()).await.unwrap();
+        // Different server triggers full stop + start path.
+        let mut config = test_config();
+        config.server.server = "10.0.0.1".into();
+        pm.reload(&config).await.unwrap();
         assert_eq!(pm.state(), ProxyState::Running);
         assert_eq!(state.start_calls.load(Ordering::SeqCst), 2);
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
+fn reload_when_not_running_starts() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let state = proxy.start_calls_handle();
+
+        let (mut pm, _dir) = new_manager(proxy);
+        assert_eq!(pm.state(), ProxyState::Stopped);
+
+        pm.reload(&test_config()).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        assert_eq!(state.start_calls.load(Ordering::SeqCst), 1);
 
         pm.stop().await.unwrap();
     });

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -350,6 +350,9 @@ impl BridgeIpcClient {
                         running: status.running,
                         uptime_secs: status.uptime_secs,
                         error: status.error,
+                        invalid_filters: status.invalid_filters,
+                        udp_proxy_available: status.udp_proxy_available,
+                        ipv6_bypass_available: status.ipv6_bypass_available,
                     })
                 } else {
                     parse_bridge_error(resp).await
@@ -400,6 +403,7 @@ impl BridgeIpcClient {
                         speed_in_bps: metrics.speed_in_bps,
                         speed_out_bps: metrics.speed_out_bps,
                         uptime_secs: metrics.uptime_secs,
+                        filter: metrics.filter,
                     })
                 } else {
                     parse_bridge_error(resp).await

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -179,6 +179,17 @@ components:
           type:
             - string
             - "null"
+        invalid_filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/InvalidFilter"
+          default: []
+        udp_proxy_available:
+          type: boolean
+          default: true
+        ipv6_bypass_available:
+          type: boolean
+          default: true
 
     ErrorResponse:
       type: object
@@ -191,6 +202,74 @@ components:
     EmptyResponse:
       type: object
       additionalProperties: false
+
+    InvalidFilter:
+      type: object
+      required:
+        - index
+        - error
+      properties:
+        index:
+          type: integer
+          format: uint32
+          minimum: 0
+        error:
+          type: string
+
+    FilterMetrics:
+      type: object
+      required:
+        - total_connections
+        - proxied
+        - bypassed
+        - blocked
+        - sniffer_hits
+        - sniffer_misses
+        - fake_dns_queries
+        - fake_dns_reverse_hits
+        - active_udp_flows
+        - udp_drops_backpressure
+      properties:
+        total_connections:
+          type: integer
+          format: uint64
+          minimum: 0
+        proxied:
+          type: integer
+          format: uint64
+          minimum: 0
+        bypassed:
+          type: integer
+          format: uint64
+          minimum: 0
+        blocked:
+          type: integer
+          format: uint64
+          minimum: 0
+        sniffer_hits:
+          type: integer
+          format: uint64
+          minimum: 0
+        sniffer_misses:
+          type: integer
+          format: uint64
+          minimum: 0
+        fake_dns_queries:
+          type: integer
+          format: uint64
+          minimum: 0
+        fake_dns_reverse_hits:
+          type: integer
+          format: uint64
+          minimum: 0
+        active_udp_flows:
+          type: integer
+          format: uint32
+          minimum: 0
+        udp_drops_backpressure:
+          type: integer
+          format: uint64
+          minimum: 0
 
     MetricsResponse:
       type: object
@@ -221,6 +300,10 @@ components:
           type: integer
           format: uint64
           minimum: 0
+        filter:
+          oneOf:
+            - $ref: "#/components/schemas/FilterMetrics"
+            - type: "null"
 
     DiagnosticsResponse:
       type: object

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -1,6 +1,6 @@
 //! Generates Rust types and route constants from the OpenAPI spec at `api/openapi.yaml`.
 //!
-//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `PublicIpResponse`.
+//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `PublicIpResponse`, `InvalidFilter`, `FilterMetrics`.
 //! Generated constants: `ROUTE_STATUS`, `ROUTE_START`, `ROUTE_STOP`, `ROUTE_RELOAD`, `ROUTE_METRICS`, `ROUTE_DIAGNOSTICS`, `ROUTE_PUBLIC_IP`, `ROUTE_TEST_SERVER`.
 //!
 //! `ProxyConfig`, `ServerEntry`, `ValidationState`, `ServerTestOutcome`, `TestServerRequest`,
@@ -25,6 +25,8 @@ fn main() {
         "MetricsResponse",
         "DiagnosticsResponse",
         "PublicIpResponse",
+        "InvalidFilter",
+        "FilterMetrics",
     ];
 
     let ref_types: Vec<(String, Schema)> = types_to_generate

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -9,6 +9,24 @@ mod api_generated {
 }
 pub use api_generated::*;
 
+#[allow(clippy::derivable_impls)] // FilterMetrics is code-generated without Default
+impl Default for FilterMetrics {
+    fn default() -> Self {
+        Self {
+            total_connections: 0,
+            proxied: 0,
+            bypassed: 0,
+            blocked: 0,
+            sniffer_hits: 0,
+            sniffer_misses: 0,
+            fake_dns_queries: 0,
+            fake_dns_reverse_hits: 0,
+            active_udp_flows: 0,
+            udp_drops_backpressure: 0,
+        }
+    }
+}
+
 // Types ===============================================================================================================
 
 /// Client-side request enum. Used by the GUI client API and elevation flow
@@ -51,6 +69,9 @@ pub enum BridgeResponse {
         running: bool,
         uptime_secs: u64,
         error: Option<String>,
+        invalid_filters: Vec<InvalidFilter>,
+        udp_proxy_available: bool,
+        ipv6_bypass_available: bool,
     },
     Error {
         message: String,
@@ -61,6 +82,7 @@ pub enum BridgeResponse {
         speed_in_bps: u64,
         speed_out_bps: u64,
         uptime_secs: u64,
+        filter: Option<FilterMetrics>,
     },
     Diagnostics {
         app: String,

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -92,6 +92,12 @@ fn bridge_response_status_json_roundtrip() {
         running: true,
         uptime_secs: 3600,
         error: Some("minor issue".to_string()),
+        invalid_filters: vec![InvalidFilter {
+            index: 2,
+            error: "bad pattern".to_string(),
+        }],
+        udp_proxy_available: true,
+        ipv6_bypass_available: false,
     };
     let json = serde_json::to_vec(&resp).unwrap();
     let decoded: BridgeResponse = serde_json::from_slice(&json).unwrap();
@@ -132,6 +138,12 @@ fn status_response_json_roundtrip() {
         running: true,
         uptime_secs: 3600,
         error: Some("minor issue".to_string()),
+        invalid_filters: vec![InvalidFilter {
+            index: 1,
+            error: "bad pattern".to_string(),
+        }],
+        udp_proxy_available: false,
+        ipv6_bypass_available: true,
     };
     let json = serde_json::to_string(&resp).unwrap();
     let decoded: StatusResponse = serde_json::from_str(&json).unwrap();
@@ -144,6 +156,9 @@ fn status_response_without_error() {
         running: false,
         uptime_secs: 0,
         error: None,
+        invalid_filters: Vec::new(),
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
     };
     let json = serde_json::to_string(&resp).unwrap();
     assert!(!json.contains("error"), "None error should be skipped in serialization");
@@ -173,6 +188,10 @@ fn status_response_explicit_null_error() {
     let json = r#"{"running": false, "uptime_secs": 0, "error": null}"#;
     let decoded: StatusResponse = serde_json::from_str(json).unwrap();
     assert_eq!(decoded.error, None);
+    // Default values should be applied for missing fields
+    assert!(decoded.invalid_filters.is_empty());
+    assert!(decoded.udp_proxy_available);
+    assert!(decoded.ipv6_bypass_available);
 }
 
 #[skuld::test]
@@ -194,6 +213,7 @@ fn metrics_response_roundtrips() {
         speed_in_bps: 1_048_576,
         speed_out_bps: 524_288,
         uptime_secs: 3600,
+        filter: Some(FilterMetrics::default()),
     };
     let json = serde_json::to_string(&resp).unwrap();
     let parsed: MetricsResponse = serde_json::from_str(&json).unwrap();
@@ -266,6 +286,7 @@ fn bridge_response_metrics_roundtrips() {
         speed_in_bps: 1024,
         speed_out_bps: 512,
         uptime_secs: 60,
+        filter: Some(FilterMetrics::default()),
     };
     let json = serde_json::to_string(&resp).unwrap();
     let parsed: BridgeResponse = serde_json::from_str(&json).unwrap();

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -87,6 +87,9 @@ impl BridgeClient {
                         running: status.running,
                         uptime_secs: status.uptime_secs,
                         error: status.error,
+                        invalid_filters: status.invalid_filters,
+                        udp_proxy_available: status.udp_proxy_available,
+                        ipv6_bypass_available: status.ipv6_bypass_available,
                     })
                 } else {
                     parse_bridge_error(resp).await
@@ -138,6 +141,7 @@ impl BridgeClient {
                         speed_in_bps: metrics.speed_in_bps,
                         speed_out_bps: metrics.speed_out_bps,
                         uptime_secs: metrics.uptime_secs,
+                        filter: metrics.filter,
                     })
                 } else {
                     parse_bridge_error(resp).await

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -29,6 +29,9 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     running: false,
                     uptime_secs: 0,
                     error: None,
+                    invalid_filters: Vec::new(),
+                    udp_proxy_available: true,
+                    ipv6_bypass_available: true,
                 })
             }),
         )
@@ -57,6 +60,7 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     speed_in_bps: 2048,
                     speed_out_bps: 1024,
                     uptime_secs: 120,
+                    filter: None,
                 })
             }),
         )
@@ -116,6 +120,9 @@ fn send_status_request_receives_response() {
                 running: false,
                 uptime_secs: 0,
                 error: None,
+                invalid_filters: Vec::new(),
+                udp_proxy_available: true,
+                ipv6_bypass_available: true,
             }
         );
     });
@@ -257,6 +264,9 @@ async fn spawn_error_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<(
                     running: false,
                     uptime_secs: 0,
                     error: None,
+                    invalid_filters: Vec::new(),
+                    udp_proxy_available: true,
+                    ipv6_bypass_available: true,
                 })
             }),
         )
@@ -346,6 +356,7 @@ fn send_metrics_returns_response() {
                 speed_in_bps: 2048,
                 speed_out_bps: 1024,
                 uptime_secs: 120,
+                filter: None,
             }
         );
     });

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -127,10 +127,16 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
             running,
             uptime_secs,
             error,
+            invalid_filters,
+            udp_proxy_available,
+            ipv6_bypass_available,
         }) => Ok(serde_json::json!({
             "running": running,
             "uptime_secs": uptime_secs,
             "error": error,
+            "invalid_filters": invalid_filters,
+            "udp_proxy_available": udp_proxy_available,
+            "ipv6_bypass_available": ipv6_bypass_available,
         })),
         Ok(BridgeResponse::Error { message }) => {
             warn!(error = %message, "bridge returned error for status");
@@ -138,12 +144,18 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": message,
+                "invalid_filters": [],
+                "udp_proxy_available": true,
+                "ipv6_bypass_available": true,
             }))
         }
         Ok(_) => Ok(serde_json::json!({
             "running": false,
             "uptime_secs": 0,
             "error": "unexpected response from bridge",
+            "invalid_filters": [],
+            "udp_proxy_available": true,
+            "ipv6_bypass_available": true,
         })),
         Err(e) => {
             // Bridge not running or unreachable — not an error for the frontend
@@ -151,6 +163,9 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
                 "running": false,
                 "uptime_secs": 0,
                 "error": format!("bridge unreachable: {e}"),
+                "invalid_filters": [],
+                "udp_proxy_available": true,
+                "ipv6_bypass_available": true,
             }))
         }
     }
@@ -166,12 +181,14 @@ fn map_metrics_response(result: Result<BridgeResponse, ClientError>) -> serde_js
             speed_in_bps,
             speed_out_bps,
             uptime_secs,
+            filter,
         }) => serde_json::json!({
             "bytes_in": bytes_in,
             "bytes_out": bytes_out,
             "speed_in_bps": speed_in_bps,
             "speed_out_bps": speed_out_bps,
             "uptime_secs": uptime_secs,
+            "filter": filter,
         }),
         _ => serde_json::json!({
             "bytes_in": 0,
@@ -179,6 +196,7 @@ fn map_metrics_response(result: Result<BridgeResponse, ClientError>) -> serde_js
             "speed_in_bps": 0,
             "speed_out_bps": 0,
             "uptime_secs": 0,
+            "filter": null,
         }),
     }
 }
@@ -372,6 +390,29 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: config.filters.clone(),
     })
+}
+
+/// Reload the proxy's filter rules from the current config. If the proxy
+/// is not running, this is a no-op (changes apply on next start).
+#[tauri::command]
+pub async fn reload_proxy_filters(state: State<'_, AppState>) -> Result<(), String> {
+    let config = {
+        let app_config = state.config.lock().unwrap();
+        if !app_config.enabled {
+            return Ok(()); // Not running, changes apply on next start.
+        }
+        build_proxy_config(&app_config)
+    };
+
+    let Some(proxy_config) = config else {
+        return Ok(()); // No server selected.
+    };
+
+    state
+        .bridge_send(BridgeRequest::Reload { config: proxy_config })
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -164,6 +164,7 @@ fn get_metrics_returns_json() {
         speed_in_bps: 2048,
         speed_out_bps: 1024,
         uptime_secs: 120,
+        filter: None,
     };
     let json = map_metrics_response(Ok(resp));
     assert_eq!(json["bytes_in"], 1024);
@@ -171,6 +172,7 @@ fn get_metrics_returns_json() {
     assert_eq!(json["speed_in_bps"], 2048);
     assert_eq!(json["speed_out_bps"], 1024);
     assert_eq!(json["uptime_secs"], 120);
+    assert!(json["filter"].is_null());
 }
 
 /// Verify that a failed metrics request returns zero defaults.

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -83,6 +83,7 @@ fn launch_gui(show_dashboard: bool) {
             commands::get_public_ip,
             commands::test_server,
             commands::mark_validated_by_proxy_start,
+            commands::reload_proxy_filters,
             tray::toggle_proxy,
             tray::cancel_proxy,
         ])


### PR DESCRIPTION
## Summary

- **Move `InvalidFilter` to `hole-common`**: The bridge-local `InvalidFilter` struct is now code-generated from `openapi.yaml` and exported from `hole_common::protocol`, shared across bridge and GUI.
- **Extend `StatusResponse`** with `invalid_filters`, `udp_proxy_available`, `ipv6_bypass_available` (all with backward-compatible defaults).
- **Add `FilterMetrics` and extend `MetricsResponse`** with an optional `filter` field for filter engine counters.
- **Hot-reload filter rules**: `ProxyManager::reload` now detects filter-only changes (same server/port/tunnel_mode) and hot-swaps rules via the dispatcher's `ArcSwap` without a full stop+start cycle.
- **Add `reload_proxy_filters` Tauri command** for the GUI to trigger a filter reload.
- **Add `Dispatcher::invalid_filters()` getter** to read dropped rules from the current ruleset.
- **Fix `check_health` crash recovery**: Clears `active_config` when a proxy crash is detected, preventing a subsequent `reload` from silently no-oping via the stale hot-swap path.

## Test plan

- [x] `cargo test -p hole-common` -- all 108 tests pass
- [x] `cargo test -p hole-bridge` -- all 336 tests pass (1 skipped: v2ray-plugin not staged)
- [x] `cargo clippy -p hole-common -p hole-bridge -- -D warnings` -- clean
- [x] New tests: `reload_with_same_server_hot_swaps_rules`, `reload_with_different_server_restarts`, `reload_when_not_running_starts`, `check_health_clears_active_config_so_reload_restarts`
- [ ] CI passes

Closes #177