### PR TITLE
Extract CI build setup into a composite action

### DIFF
--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -1,0 +1,35 @@
+name: Setup Build
+description: Set up a compilable Rust workspace (toolchains, cache, runtime deps)
+
+runs:
+  using: composite
+  steps:
+    - name: Set cargo env vars
+      shell: bash
+      run: |
+        echo "CARGO_TERM_COLOR=always" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+    - uses: dtolnay/rust-toolchain@stable
+      id: rust-toolchain
+      with:
+        components: clippy, rustfmt
+
+    - uses: actions/setup-go@v6
+      with:
+        go-version: stable
+
+    - uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
+
+    - uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Fetch runtime deps (v2ray-plugin, wintun)
+      shell: bash
+      run: cargo xtask deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
-
 jobs:
   lint:
     name: Lint
@@ -19,23 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-        with:
-          components: clippy, rustfmt
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/setup-build
 
       - uses: actions/setup-python@v6
         with:
@@ -45,13 +24,6 @@ jobs:
 
       - name: Install prek
         run: uv tool install prek
-
-      # prek runs `cargo clippy` which compiles `crates/hole/build.rs`,
-      # which calls `tauri_build::build()`, which validates that the
-      # `externalBin` declared in tauri.conf.json (`v2ray-plugin-*`) actually
-      # exists on disk. So even the lint job needs the runtime deps cached.
-      - name: Fetch runtime deps (v2ray-plugin, wintun)
-        run: cargo xtask deps
 
       - name: Run linters
         run: prek run --all-files --show-diff-on-failure
@@ -71,26 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-        with:
-          components: clippy
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Fetch runtime deps (v2ray-plugin, wintun)
-        run: cargo xtask deps
+      - uses: ./.github/actions/setup-build
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -127,23 +80,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: ./.github/actions/setup-build
       - uses: astral-sh/setup-uv@v7
-
-      - name: Fetch runtime deps (v2ray-plugin, wintun)
-        run: cargo xtask deps
 
       - name: Test
         working-directory: msi-installer

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-build
-
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-
       - uses: astral-sh/setup-uv@v7
+
+      - uses: ./.github/actions/setup-build
 
       - name: Install prek
         run: uv tool install prek
@@ -80,8 +79,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-build
       - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/setup-build
 
       - name: Test
         working-directory: msi-installer

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -59,11 +59,12 @@ jobs:
       - name: Create local tag for build
         run: git tag "v${{ needs.validate.outputs.version }}"
 
+      - uses: astral-sh/setup-uv@v7
+        if: matrix.os == 'windows'
+
       - uses: ./.github/actions/setup-build
 
       # Windows build
-      - uses: astral-sh/setup-uv@v7
-        if: matrix.os == 'windows'
       - name: Build MSI
         if: matrix.os == 'windows'
         run: uv run --directory msi-installer build

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -13,11 +13,6 @@ on:
 permissions:
   contents: write
 
-env:
-  CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
-
 jobs:
   validate:
     name: Validate version
@@ -64,24 +59,7 @@ jobs:
       - name: Create local tag for build
         run: git tag "v${{ needs.validate.outputs.version }}"
 
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: stable
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Fetch runtime deps (v2ray-plugin, wintun)
-        run: cargo xtask deps
+      - uses: ./.github/actions/setup-build
 
       # Windows build
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Closes #179

## Summary
- New composite action at `.github/actions/setup-build/action.yaml` encapsulating Rust toolchain, Go, cargo cache, sccache, and `cargo xtask deps`.
- Replaced the duplicated 5-step setup block in all CI jobs (lint, test, test-installer, draft-release build) with a single `uses:` line.
- The action also sets `CARGO_TERM_COLOR`, `SCCACHE_GHA_ENABLED`, and `RUSTC_WRAPPER` via `$GITHUB_ENV`, removing the need for workflow-level env blocks.
- All jobs now install clippy + rustfmt (previously only lint/test did). This changes the cargo cache key, causing a one-time cold cache on the first run after merge. The overhead of installing unused components is negligible.

## Test plan
- [ ] CI passes on all matrix entries (windows, darwin/amd64, darwin/arm64)
- [ ] Cargo cache shows hits on subsequent runs
- [ ] `cargo xtask deps` runs correctly on all platforms