### PR TITLE
fix: disable smoltcp RX checksum verification for TUN device

### DIFF
--- a/crates/bridge/src/dispatcher/device.rs
+++ b/crates/bridge/src/dispatcher/device.rs
@@ -1,6 +1,6 @@
 //! smoltcp `Device` implementation backed by in-memory queues.
 
-use smoltcp::phy::{self, Device, DeviceCapabilities, Medium};
+use smoltcp::phy::{self, Checksum, Device, DeviceCapabilities, Medium};
 use smoltcp::time::Instant;
 use std::collections::VecDeque;
 
@@ -59,6 +59,16 @@ impl Device for VirtualTunDevice {
         let mut caps = DeviceCapabilities::default();
         caps.medium = Medium::Ip;
         caps.max_transmission_unit = self.mtu;
+        // Don't verify checksums on received packets. TUN adapters (wintun
+        // on Windows, utun on macOS) deliver packets without computing
+        // transport-layer checksums — the OS relies on NIC hardware
+        // offloading, which a virtual adapter lacks. Still compute checksums
+        // on transmitted packets so the OS accepts them.
+        caps.checksum.ipv4 = Checksum::Tx;
+        caps.checksum.tcp = Checksum::Tx;
+        caps.checksum.udp = Checksum::Tx;
+        caps.checksum.icmpv4 = Checksum::Tx;
+        caps.checksum.icmpv6 = Checksum::Tx;
         caps
     }
 }

--- a/crates/bridge/src/dispatcher/device_tests.rs
+++ b/crates/bridge/src/dispatcher/device_tests.rs
@@ -1,5 +1,5 @@
 use super::VirtualTunDevice;
-use smoltcp::phy::{Device, RxToken, TxToken};
+use smoltcp::phy::{Checksum, Device, RxToken, TxToken};
 use smoltcp::time::Instant;
 
 #[skuld::test]
@@ -51,4 +51,15 @@ fn dequeue_tx_drains_all() {
     let sent = dev.dequeue_tx();
     assert_eq!(sent.len(), 2);
     assert!(!dev.has_tx());
+}
+
+#[skuld::test]
+fn capabilities_skip_rx_checksum_verification() {
+    let dev = VirtualTunDevice::new(1400);
+    let caps = dev.capabilities();
+    assert!(matches!(caps.checksum.ipv4, Checksum::Tx));
+    assert!(matches!(caps.checksum.tcp, Checksum::Tx));
+    assert!(matches!(caps.checksum.udp, Checksum::Tx));
+    assert!(matches!(caps.checksum.icmpv4, Checksum::Tx));
+    assert!(matches!(caps.checksum.icmpv6, Checksum::Tx));
 }

--- a/crates/bridge/src/dispatcher/driver.rs
+++ b/crates/bridge/src/dispatcher/driver.rs
@@ -398,7 +398,7 @@ impl TunDriver {
             tokio::spawn(async move {
                 let result = tcp_handler::handle_tcp_connection(stream, dst_ip, dst_port, env).await;
                 if let Err(e) = result {
-                    trace!("TCP handler error for {dst_ip}:{dst_port}: {e}");
+                    debug!("TCP handler error for {dst_ip}:{dst_port}: {e}");
                 }
                 drop(permit);
             });


### PR DESCRIPTION
## Summary

Closes #181.

- Set `VirtualTunDevice` checksum capabilities to `Checksum::Tx` (compute on send, skip verification on receive), matching shadowsocks-service. TUN adapters (wintun, utun) deliver packets without computed transport-layer checksums because the OS relies on NIC hardware offloading. smoltcp's default `Checksum::Both` silently drops every such packet.
- Upgrade TCP handler error logging from `trace!` to `debug!` so future dispatcher issues are diagnosable.
- Add regression test asserting all checksum capabilities are `Checksum::Tx`.

## Test plan

- [x] `cargo test -p hole-bridge` passes (337/337, excluding pre-existing v2ray-plugin skip)
- [x] `cargo clippy --workspace` clean
- [x] New `capabilities_skip_rx_checksum_verification` test passes
- [ ] Manual: `uv run scripts/dev.py` with remote config, verify internet works