### PR TITLE
fix: wire orphaned e2e tests into test binary

### DIFF
--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -440,3 +440,7 @@ async fn resolve_server_ip(host: &str, port: u16) -> Result<IpAddr, ProxyError> 
 #[cfg(test)]
 #[path = "proxy_manager_tests.rs"]
 mod proxy_manager_tests;
+
+#[cfg(test)]
+#[path = "proxy_manager_e2e_tests.rs"]
+mod proxy_manager_e2e_tests;

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -84,6 +84,7 @@ async fn run_socks_only_e2e(dist: &Path, ss: &SsServerHandle, http: &HttpTarget)
         server: entry_from(ss),
         local_port,
         tunnel_mode: TunnelMode::SocksOnly,
+        filters: vec![],
     };
 
     let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -185,6 +186,7 @@ mod tun {
             server: entry_from(ss),
             local_port,
             tunnel_mode: TunnelMode::Full,
+            filters: vec![],
         };
 
         let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -247,6 +249,7 @@ fn lifecycle_start_twice_returns_error(
             server: entry_from(ss),
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -297,6 +300,7 @@ fn lifecycle_reload_changes_local_port(
             server: entry_from(ss),
             local_port: port1,
             tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -336,6 +340,7 @@ fn lifecycle_state_file_absent_in_socks_only_mode(
             server: entry_from(ss),
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -381,6 +386,7 @@ fn cipher_chacha20_ietf_poly1305_roundtrip(
             },
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -417,6 +423,7 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
             },
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();


### PR DESCRIPTION
## Summary

Closes #185.

`proxy_manager_e2e_tests.rs` was never `mod`-declared — 11 e2e tests (including TUN full-tunnel round-trips that would have caught #181) were dead code.

- Add `mod proxy_manager_e2e_tests` declaration to `proxy_manager.rs`
- Fix `ProxyConfig` initializers to include the `filters` field added in #178

## Test plan

- [x] Tests compile (previously didn't, since the file was orphaned)
- [x] `cargo clippy --workspace` clean
- [ ] CI: all e2e tests pass (SocksOnly + TUN on Windows)