### PR TITLE
fix: block UDP traffic when proxy is unavailable instead of bypassing

### DIFF
--- a/crates/bridge/src/dispatcher/udp_handler.rs
+++ b/crates/bridge/src/dispatcher/udp_handler.rs
@@ -95,14 +95,14 @@ async fn create_udp_flow_inner(
     let decision = decide(rules, &conn_info);
     let mut action = decision.action;
 
-    // 3. Plugin incompatibility: downgrade Proxy -> Bypass when UDP relay
-    //    is unavailable (v2ray-plugin does not support UDP).
+    // 3. Plugin incompatibility: block when UDP relay is unavailable
+    //    (v2ray-plugin does not support UDP).
     if action == FilterAction::Proxy && !ctx.udp_proxy_available {
         let mut block_log = ctx.block_log.lock().unwrap();
         if block_log.should_log(decision.rule_index.unwrap_or(0) as u32, dst_ip, dst_port) {
-            warn!(dst_ip = %dst_ip, dst_port, "UDP proxy unavailable (v2ray-plugin), bypassing");
+            warn!(dst_ip = %dst_ip, dst_port, "UDP proxy unavailable (v2ray-plugin), blocking");
         }
-        action = FilterAction::Bypass;
+        action = FilterAction::Block;
     }
 
     // 4. Resolve bypass IP if needed.

--- a/crates/bridge/src/dispatcher/udp_handler_tests.rs
+++ b/crates/bridge/src/dispatcher/udp_handler_tests.rs
@@ -1,4 +1,14 @@
+use std::sync::atomic::AtomicBool;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
 use super::UdpReply;
+use crate::dispatcher::block_log::BlockLog;
+use crate::dispatcher::tcp_handler::HandlerContext;
+use crate::dispatcher::udp_flow::FlowHandle;
+use crate::dispatcher::upstream_dns::UpstreamResolver;
+use crate::filter::rules::RuleSet;
 
 #[skuld::test]
 fn udp_reply_fields() {
@@ -12,4 +22,45 @@ fn udp_reply_fields() {
     assert_eq!(reply.payload.len(), 3);
     assert_eq!(reply.dst_port, 12345);
     assert_eq!(reply.src_port, 443);
+}
+
+/// When `udp_proxy_available` is false (v2ray-plugin configured) and the
+/// filter engine returns Proxy, the flow must be blocked, not bypassed.
+#[skuld::test]
+fn udp_proxy_unavailable_blocks() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let ctx = HandlerContext {
+            local_port: 1080,
+            iface_index: 0,
+            ipv6_available: false,
+            upstream_resolver: UpstreamResolver::new(&["127.0.0.1".parse().unwrap()]),
+            block_log: std::sync::Mutex::new(BlockLog::new()),
+            ipv6_bypass_warned: AtomicBool::new(false),
+            udp_proxy_available: false,
+        };
+
+        // Empty ruleset: terminal fallback returns FilterAction::Proxy.
+        let rules = RuleSet::default();
+        let (reply_tx, _reply_rx) = mpsc::channel::<UdpReply>(1);
+        let cancel = CancellationToken::new();
+
+        let entry = super::create_udp_flow_inner(
+            "10.0.0.1".parse().unwrap(), // src_ip
+            12345,                       // src_port
+            "8.8.8.8".parse().unwrap(),  // dst_ip
+            443,                         // dst_port
+            &None,                       // domain
+            None,                        // pinned_ip
+            &ctx,
+            &rules,
+            &None, // fake_dns
+            reply_tx,
+            cancel,
+        )
+        .await
+        .expect("create_udp_flow_inner should not fail for a blocked flow");
+
+        assert!(matches!(entry.handle, FlowHandle::Blocked));
+    });
 }

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -123,7 +123,7 @@ fn resolve_plugin_path(name: &str) -> String {
 ///
 /// Returns `false` when a v2ray-plugin is configured — plugins are
 /// TCP-only by protocol definition, so UDP traffic cannot be carried.
-/// The dispatcher uses this to downgrade UDP Proxy actions to Bypass.
+/// The dispatcher uses this to block UDP traffic that cannot be proxied.
 pub fn udp_proxy_available(config: &ProxyConfig) -> bool {
     config.server.plugin.is_none()
 }


### PR DESCRIPTION
## Summary
- When v2ray-plugin is configured (SIP003, TCP-only), UDP traffic that would be proxied was silently **bypassed** (sent in the clear). This is a security issue.
- Changed the fallback from `FilterAction::Bypass` to `FilterAction::Block` so unproxiable UDP is dropped instead of leaked.
- Added a test verifying the block behavior.

Closes #187

## Test plan
- [x] New unit test `udp_proxy_unavailable_blocks` confirms `FlowHandle::Blocked` when `udp_proxy_available` is false
- [x] `cargo test -p hole-bridge` passes (338/339, 1 pre-existing skip for v2ray-plugin)
- [x] `cargo clippy -p hole-bridge -p hole-common` clean
- [ ] CI passes