### PR TITLE
fix: allow cargo clippy without `cargo xtask deps`

### DIFF
--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -17,7 +17,24 @@ fn main() {
     // Runtime asset acquisition (v2ray-plugin Go build, wintun.dll download)
     // moved to `cargo xtask deps` in Commit 4 of this PR. See issue #143.
 
+    ensure_external_bin_stub(&repo_root);
     tauri_build::build();
+}
+
+/// Ensure the `externalBin` stub exists so `tauri_build::build()` passes
+/// validation even when `cargo xtask deps` has not been run yet.
+/// The real binary is built by `cargo xtask deps`.
+fn ensure_external_bin_stub(repo_root: &Path) {
+    let target = std::env::var("TARGET").unwrap();
+    let suffix = if target.contains("windows") { ".exe" } else { "" };
+    let path = repo_root
+        .join(".cache/v2ray-plugin")
+        .join(format!("v2ray-plugin-{target}{suffix}"));
+    if !path.exists() {
+        std::fs::create_dir_all(path.parent().unwrap()).expect("failed to create .cache/v2ray-plugin/");
+        std::fs::File::create(&path).expect("failed to create v2ray-plugin stub");
+        eprintln!("cargo:warning=created empty v2ray-plugin stub — run `cargo xtask deps` for a real build");
+    }
 }
 
 // Repo root ===========================================================================================================

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -33,7 +33,7 @@ fn ensure_external_bin_stub(repo_root: &Path) {
     if !path.exists() {
         std::fs::create_dir_all(path.parent().unwrap()).expect("failed to create .cache/v2ray-plugin/");
         std::fs::File::create(&path).expect("failed to create v2ray-plugin stub");
-        eprintln!("cargo:warning=created empty v2ray-plugin stub — run `cargo xtask deps` for a real build");
+        println!("cargo:warning=created empty v2ray-plugin stub — run `cargo xtask deps` for a real build");
     }
 }
 
@@ -156,7 +156,7 @@ fn generate_tray_icons(icons_dir: &Path) {
         match target_os.as_str() {
             "macos" => generate_tray_icons_macos(&tree, &out_dir, name),
             "windows" => generate_tray_icons_windows(&tree, &out_dir, name),
-            other => eprintln!("cargo:warning=tray icon generation not implemented for {other}"),
+            other => println!("cargo:warning=tray icon generation not implemented for {other}"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #193
- `build.rs` now touches an empty stub at `.cache/v2ray-plugin/v2ray-plugin-<triple>{.exe}` if the real binary doesn't exist, so `tauri_build::build()` validation passes without `cargo xtask deps`
- `cargo xtask deps` overwrites the stub with the real binary when run

## Test plan
- [x] Delete `.cache/v2ray-plugin/` and run `cargo clippy -p hole --all-targets -- -D warnings` — passes with a cargo warning about the stub
- [x] All prek hooks pass on commit
- [ ] CI passes