### PR TITLE
chore: allowlist cargo nextest and xtask deps/stage

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,10 @@
   "permissions": {
     "allow": [
       "Bash(uv run --group dev pytest *)",
-      "Bash(uv run --directory msi-installer upgrade-wix *)"
+      "Bash(uv run --directory msi-installer upgrade-wix *)",
+      "Bash(cargo nextest run *)",
+      "Bash(cargo xtask deps *)",
+      "Bash(cargo xtask stage *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `cargo nextest run`, `cargo xtask deps`, and `cargo xtask stage` to the Claude Code allowlist in `.claude/settings.json`.

Closes #201

## Test plan
- [x] Pre-commit hooks pass locally.
- [ ] CI green.