### PR TITLE
chore: port skuld from git to crates.io v0.1

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,8 +6,9 @@ slow-timeout = { period = "10s", terminate-after = 3 }
 # Serialize ALL bridge tests. E2E tests share process-global resources (TUN
 # device, system routes, galoshes extraction dir) and the server-side plugin
 # fixture has a TOCTOU in shadowsocks-service's port allocation that concurrent
-# tests can trigger. Skuld's in-process Mutex doesn't cross process boundaries
-# under nextest, so we enforce serialization here at the scheduler level.
+# NON-serial tests can trigger. Skuld v0.1.0's SQLite coordinator serializes
+# serial-marked tests across binaries, but non-serial tests in hole-bridge also
+# touch these resources, so we belt-and-suspenders at the scheduler level.
 #
 # Other workspace crates (hole, hole-common, xtask-lib) still run in parallel.
 [test-groups.bridge-serial]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,6 +1532,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2219,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heapless"
@@ -3069,6 +3090,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,6 +3831,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "phf"
@@ -4687,6 +4762,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5359,13 +5459,17 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 [[package]]
 name = "skuld"
 version = "0.1.0"
-source = "git+https://github.com/bindreams/skuld#f344faf815762c2abca0a96c0ab719b66cea51af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e06310cbdf3dc4c1db21297f396f41d27c2516a4f12d78cc7dcb3e3702090f9"
 dependencies = [
  "clap",
  "inventory",
  "libc",
  "libtest-mimic",
  "os_pipe",
+ "pest",
+ "pest_derive",
+ "rusqlite",
  "serde",
  "serde_yml",
  "skuld-macros",
@@ -5377,7 +5481,8 @@ dependencies = [
 [[package]]
 name = "skuld-macros"
 version = "0.1.0"
-source = "git+https://github.com/bindreams/skuld#f344faf815762c2abca0a96c0ab719b66cea51af"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81615ca2f468ee03c84b12390845c27f0e5a036231ecc3ed1f7dd952544b0d88"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5494,6 +5599,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6908,6 +7025,12 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -80,7 +80,7 @@ windows = { version = "0.62", features = [
 wintun-bindings = "0.7"
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld", features = ["tokio"] }
+skuld = { version = "0.1", features = ["tokio"] }
 shadowsocks-service = { version = "1", features = ["server"] }
 rcgen = "0.13"
 rand = "0.9"

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -19,7 +19,7 @@
 //! 6. Sends `BridgeRequest::Stop` and asserts the result.
 //!
 //! TUN tests go through the same pipeline with `tunnel_mode: Full` and are
-//! `cfg(target_os = "windows")` + `labels = [tun]` because macOS CI does
+//! `cfg(target_os = "windows")` + `labels = [TUN]` because macOS CI does
 //! not run elevated and spawning an elevated child from an unelevated
 //! test binary would fail on both OSes.
 
@@ -224,7 +224,7 @@ mod tun {
     /// Test 5: Full mode (TUN + routing), no plugin. Requires Windows
     /// admin. TUN tests are serial because they all bind the hardcoded
     /// `hole-tun` device name.
-    #[skuld::test(labels = [tun], serial)]
+    #[skuld::test(labels = [TUN], serial)]
     fn e2e_none_full_tunnel_roundtrip(
         #[fixture(dist_dir)] dist: &Path,
         #[fixture(ssserver_none)] ss: &SsServerHandle,
@@ -235,7 +235,7 @@ mod tun {
 
     /// Test 6: Full mode with galoshes (websocket). Requires Windows
     /// admin.
-    #[skuld::test(labels = [tun], serial)]
+    #[skuld::test(labels = [TUN], serial)]
     fn e2e_ws_full_tunnel_roundtrip(
         #[fixture(dist_dir)] dist: &Path,
         #[fixture(ssserver_ws)] ss: &SsServerHandle,
@@ -451,7 +451,7 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
 
 /// Test 13: ws plugin, SocksOnly mode, IPv6 HTTP target on `[::1]`.
 ///
-#[skuld::test(labels = [ipv6], serial)]
+#[skuld::test(labels = [IPV6], serial)]
 fn ipv6_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,

--- a/crates/bridge/src/test_support/skuld_fixtures.rs
+++ b/crates/bridge/src/test_support/skuld_fixtures.rs
@@ -24,6 +24,13 @@
 //! can use them interchangeably with `build_socks_harness` /
 //! `build_tun_harness`.
 
+// Labels ==============================================================================================================
+
+skuld::new_label!(pub(crate) TUN, "tun");
+skuld::new_label!(pub(crate) IPV6, "ipv6");
+
+// Fixtures ============================================================================================================
+
 use crate::test_support::certs::{path_for_plugin_opts, TestCerts};
 use crate::test_support::http_target::{start_http_target, HttpTarget, TargetBind};
 use crate::test_support::port_alloc::allocate_ephemeral_port;

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -40,6 +40,6 @@ serde_json = "1"
 yaml_serde = "0.10"
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld" }
+skuld = "0.1"
 log = "0.4"
 tempfile = "3"

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -56,7 +56,7 @@ windows = { version = "0.62", features = [
 ] }
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld" }
+skuld = "0.1"
 axum = { version = "0.8", default-features = false, features = ["json"] }
 tower = { version = "0.5", features = ["util"] }
 tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/external/galoshes/.gitrepo
+++ b/external/galoshes/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/bindreams/galoshes.git
 	branch = main
 	commit = 50577bace00519424cbd9df61eb45e7ef1080a6b
-	parent = 15817a81cdf6b6121fb2f4ba3069feab8c1777e7
+	parent = cf2ffc755b613e773f7db245983d55d109f97114
 	method = merge
 	cmdver = 0.4.9

--- a/external/galoshes/.gitrepo
+++ b/external/galoshes/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/bindreams/galoshes.git
 	branch = main
-	commit = 50577bace00519424cbd9df61eb45e7ef1080a6b
-	parent = cf2ffc755b613e773f7db245983d55d109f97114
+	commit = a2cb172daca0a38adcf62b068268cb9e14d36b2d
+	parent = a4f5365e8c0c5f02d3187e8cfbb730529a577a2e
 	method = merge
 	cmdver = 0.4.9

--- a/external/galoshes/CLAUDE.md
+++ b/external/galoshes/CLAUDE.md
@@ -34,8 +34,8 @@ cargo build -p galoshes              # build galoshes (requires prior xtask step
 
 - Unit tests live in separate files: `foo_tests.rs` for `foo.rs`
 - Integration tests use the `skuld` test harness (`harness = false`) for reliable child process cleanup
-- Since `skuld` has no async support, use `tokio::runtime::Runtime::new().block_on()` inside `#[skuld::test]`
-- Tests mutating env vars use `#[serial_test::serial]`
+- Async tests use `#[skuld::test]` directly on `async fn`; the `tokio` feature is enabled in the workspace's `skuld` dep
+- Tests mutating env vars take the `env` fixture (`#[fixture] env: &skuld::EnvGuard`), which auto-serialises and reverts
 - The `mock-plugin` crate is a minimal SIP003u TCP relay for integration tests
 
 ## Platform-specific code

--- a/external/galoshes/CONTRIBUTING.md
+++ b/external/galoshes/CONTRIBUTING.md
@@ -61,7 +61,7 @@ cargo test --workspace                                # all unit tests
 cargo test -p garter --test chain_integration         # integration test (spawns mock-plugin)
 ```
 
-Integration tests use the [skuld](https://github.com/bindreams/skuld) test harness for reliable child process cleanup. Since skuld has no async support, wrap async test bodies in `tokio::runtime::Runtime::new().block_on()`.
+Integration tests use the [skuld](https://crates.io/crates/skuld) test harness for reliable child-process cleanup and fixture injection. Async tests are written as plain `#[skuld::test] async fn ...` — the workspace enables skuld's `tokio` feature.
 
 ### Key conventions
 

--- a/external/galoshes/Cargo.lock
+++ b/external/galoshes/Cargo.lock
@@ -106,6 +106,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,10 +230,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -344,7 +378,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -385,9 +419,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -402,7 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -447,6 +499,17 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libtest-mimic"
@@ -558,6 +621,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +651,49 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -605,6 +721,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -693,6 +815,31 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
 
 [[package]]
 name = "rustix"
@@ -791,6 +938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,24 +956,30 @@ dependencies = [
 [[package]]
 name = "skuld"
 version = "0.1.0"
-source = "git+https://github.com/bindreams/skuld#5bd704c7ff8dc5ff127a9d58948c817fbcfc1afe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e06310cbdf3dc4c1db21297f396f41d27c2516a4f12d78cc7dcb3e3702090f9"
 dependencies = [
  "clap",
  "inventory",
+ "libc",
  "libtest-mimic",
+ "os_pipe",
+ "pest",
+ "pest_derive",
+ "rusqlite",
  "serde",
  "serde_yml",
  "skuld-macros",
  "tempfile",
  "tokio",
- "tracing",
- "tracing-subscriber",
+ "windows 0.62.2",
 ]
 
 [[package]]
 name = "skuld-macros"
 version = "0.1.0"
-source = "git+https://github.com/bindreams/skuld#5bd704c7ff8dc5ff127a9d58948c817fbcfc1afe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81615ca2f468ee03c84b12390845c27f0e5a036231ecc3ed1f7dd952544b0d88"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -847,6 +1006,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1024,6 +1195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1217,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1123,11 +1306,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -1136,7 +1331,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1148,8 +1352,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -1158,9 +1375,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -1203,8 +1431,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1217,12 +1455,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1241,6 +1497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/external/galoshes/Cargo.toml
+++ b/external/galoshes/Cargo.toml
@@ -16,3 +16,4 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 contracts = "0.6"
 async-trait = "0.1"
+skuld = { version = "0.1", features = ["tokio"] }

--- a/external/galoshes/galoshes/Cargo.toml
+++ b/external/galoshes/galoshes/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = "0.10"
 tempfile = "3"
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld", features = ["tokio"] }
+skuld = { workspace = true }
 
 [build-dependencies]
 sha2 = "0.10"

--- a/external/galoshes/garter-bin/Cargo.toml
+++ b/external/galoshes/garter-bin/Cargo.toml
@@ -21,4 +21,4 @@ serde = { workspace = true }
 yaml_serde = "0.10"
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld", features = ["tokio"] }
+skuld = { workspace = true }

--- a/external/galoshes/garter/Cargo.toml
+++ b/external/galoshes/garter/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = { workspace = true }
 harness = false
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld", features = ["tokio"] }
+skuld = { workspace = true }
 
 [[test]]
 name = "chain_integration"

--- a/external/galoshes/garter/tests/chain_integration.rs
+++ b/external/galoshes/garter/tests/chain_integration.rs
@@ -94,9 +94,9 @@ async fn two_plugin_chain_relays_data() {
     drop(client);
     echo_task.abort();
 
-    // Chain plugins loop on accept() indefinitely. When the runtime is
-    // dropped (end of block_on), tasks are cancelled and kill_on_drop
-    // terminates the child processes.
+    // Chain plugins loop on accept() indefinitely. When the skuld test
+    // harness drops the tokio runtime at the end of the test, tasks are
+    // cancelled and kill_on_drop terminates the child processes.
     let _ = tokio::time::timeout(Duration::from_secs(10), chain_task).await;
 }
 

--- a/xtask-lib/Cargo.toml
+++ b/xtask-lib/Cargo.toml
@@ -17,5 +17,5 @@ anyhow = "1"
 semver = "1"
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld" }
+skuld = "0.1"
 tempfile = "3"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,5 +30,5 @@ ureq = "3"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-skuld = { git = "https://github.com/bindreams/skuld" }
+skuld = "0.1"
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Bump `skuld` from unpinned git dependency to `skuld = "0.1"` from crates.io across all 5 hole workspace crates (`crates/bridge`, `crates/common`, `crates/hole`, `xtask`, `xtask-lib`).
- Declare label sentinels (`TUN`, `IPV6`) via `skuld::new_label!` in `crates/bridge/src/test_support/skuld_fixtures.rs` and update the three `labels = [...]` call sites in `proxy_manager_e2e_tests.rs` to use uppercase identifiers (required to avoid collision with `mod tun` and to satisfy `non_upper_case_globals` under `-D warnings`).
- Refresh obsolete comment in `.config/nextest.toml` — skuld v0.1.0 now coordinates serial tests across binaries via SQLite, but we keep `max-threads = 1` for hole-bridge because non-serial tests still share TUN / routes / galoshes extraction dir / shadowsocks port-allocation TOCTOU.
- Pull galoshes subrepo to upstream `a2cb172` (the galoshes-side counterpart of the same skuld port).

Closes #203.

## Behavioral notes

- **Labels.** In v0.1.0 labels became typed sentinels; string-literal form is gone. Uppercase identifiers chosen deliberately: `tun` would collide with `mod tun` at `proxy_manager_e2e_tests.rs:166` (explicit `mod` outranks glob-imported `const`), and lowercase const bindings trip `non_upper_case_globals` which `-D warnings` promotes to a hard error. `SKULD_LABELS` env-var strings are unaffected (match on the second arg to `new_label!`, which is still `"tun"` / `"ipv6"`).
- **Bare `serial` widened.** In v0.1.0 a bare `serial` desugars to `"*"` and blocks *every* other test in the workspace (SQLite-coordinated), not just other serial tests. Hole's 19 serial call sites are either already serialized at the nextest level (hole-bridge via `max-threads = 1`) or protect global logging state where stricter blocking is strictly safer. No source-level narrowing needed in this PR.
- **Out of scope.** Reworking the 19 serial sites into `serial = <label>` form to recover cross-binary parallelism is a separate change, gated on observing actual CI wall-time regressions.

## Test plan

- [x] `cargo build --workspace` — all crates compile
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no lint errors (especially `non_upper_case_globals`)
- [x] `cargo xtask deps` — galoshes builds cleanly with new crates.io skuld
- [x] `cargo nextest run --workspace` — 684/684 pass, 2 skipped (same as main; label-gated e2e module is cfg-gated to Linux-only per #197/#200 so doesn't compile on Win/macOS)
- [x] `cargo check -p hole-bridge --tests` with the Linux-only cfg gate temporarily removed — label sentinels compile (verifies the `[TUN]` / `[IPV6]` rewrites)
- [x] `Cargo.lock` — `skuld` source changed from `git+https://...` to `registry+https://github.com/rust-lang/crates.io-index` with `checksum = "..."` present; transitive `skuld-macros v0.1.0` appears as new registry dep
- [x] `uv tool run prek run --all-files` — all hooks pass
- [ ] CI passes on Windows + macOS runners