### PR TITLE
feat(xtask): stage --with-tests for stable test-binary paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,14 @@ Runtime asset acquisition (v2ray-plugin Go build, wintun.dll download) lives
 in `cargo xtask deps`. `crates/hole/build.rs` is restricted to compile-time
 metadata (icon generation, git version via `xtask-lib::version`).
 
+`cargo xtask stage --with-tests --tests-out-dir <dir>` additionally stages
+workspace test binaries at stable paths (`<dir>/{crate}.test.exe`) so Windows
+Firewall can cache consent across rebuilds (bindreams/hole#210). Convention:
+`<dir>` is the sibling of `--out-dir` (e.g. `target/debug/dist/tests`). When
+two cargo targets share a name (e.g. the `hole` crate's lib and bin), the
+staged name is disambiguated to `{crate}-{kind}.test.exe`
+(`hole-lib.test.exe` + `hole-bin.test.exe`).
+
 ## Build
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow (hot-reload, foreground bridge mode).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,23 @@ HOLE_BRIDGE_SOCKET=$TMPDIR/hole-dev.sock target/debug/hole
 cargo test --workspace
 ```
 
+### Avoiding Windows Firewall prompts on every rebuild
+
+Bridge tests bind a TCP listener on all interfaces (for TUN routing), so Windows Firewall prompts for "allow access to local networks" when the test binary starts. Cargo names test binaries `target/debug/deps/hole_bridge-{hash}.exe` with a content-hash suffix that churns on every rebuild, so Firewall never caches consent. On a fullscreen-capable setup the prompt also closes fullscreen apps.
+
+To approve once and never again:
+
+```sh
+cargo xtask stage --with-tests \
+    --out-dir target/debug/dist/bin \
+    --tests-out-dir target/debug/dist/tests
+./target/debug/dist/tests/hole_bridge.test.exe   # approve the prompt once
+```
+
+Test execution may report failures on that first run — individual tests aren't the point here. The goal is simply for `hole_bridge.test.exe` to bind its socket so Windows Firewall shows the prompt against a path that won't churn.
+
+Subsequent `cargo xtask stage --with-tests` runs reuse the same stable path, so Firewall consent persists. Re-run the staging command after each source change — the staged binary does not update automatically. When two cargo targets share a name (e.g. the `hole` crate's lib and bin), dest names get disambiguated to `hole-lib.test.exe` / `hole-bin.test.exe`. See bindreams/hole#210.
+
 ### Investigating Windows CI flakes
 
 When Windows CI fails with a timeout in `server_test_tests` or loopback connects time out unexpectedly, work through these steps IN ORDER before proposing any timeout bump. bindreams/hole#165 was debugged for multiple hours because these steps were not documented — the bug was a unit test that shelled out to `netsh` via an RAII guard that bypassed the backend trait.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8159,6 +8159,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "clap",
  "glob",
  "sha2 0.11.0",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+cargo_metadata = "0.19"
 clap = { version = "4", features = ["derive"] }
 glob = "0.3"
 xtask-lib = { path = "../xtask-lib" }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 pub mod bindir;
 pub mod galoshes;
 pub mod stage;
+pub mod test_binaries;
 pub mod v2ray_plugin;
 pub mod wintun;
 
@@ -20,6 +21,9 @@ mod bindir_tests;
 #[cfg(test)]
 #[path = "stage_tests.rs"]
 mod stage_tests;
+#[cfg(test)]
+#[path = "test_binaries_tests.rs"]
+mod test_binaries_tests;
 
 #[derive(Parser)]
 #[command(
@@ -49,6 +53,18 @@ pub enum Command {
         /// Directory to populate with the staged files. Created if missing.
         #[arg(long)]
         out_dir: PathBuf,
+
+        /// Also compile workspace test binaries and stage them at stable paths
+        /// under `--tests-out-dir`. See bindreams/hole#210 for motivation.
+        #[arg(long)]
+        with_tests: bool,
+
+        /// Directory for staged test binaries (`{crate}.test{.exe}`). Required
+        /// when `--with-tests` is set. Convention: sibling of `--out-dir`
+        /// (e.g. `target/debug/dist/tests` when `--out-dir` is
+        /// `target/debug/dist/bin`).
+        #[arg(long, requires = "with_tests")]
+        tests_out_dir: Option<PathBuf>,
     },
     /// Build the v2ray-plugin sidecar from `external/v2ray-plugin/`.
     ///
@@ -99,7 +115,26 @@ impl Profile {
 
 pub fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
-        Command::Stage { profile, out_dir } => run_stage(profile, &out_dir),
+        Command::Stage {
+            profile,
+            out_dir,
+            with_tests,
+            tests_out_dir,
+        } => {
+            // Validate the flag combination before doing any filesystem work —
+            // otherwise `--with-tests` without `--tests-out-dir` would stage
+            // the production bindir and then error, wasting the hardlink pass.
+            let tests_dir = if with_tests {
+                Some(tests_out_dir.ok_or_else(|| anyhow::anyhow!("--with-tests requires --tests-out-dir"))?)
+            } else {
+                None
+            };
+            run_stage(profile, &out_dir)?;
+            if let Some(tests_dir) = tests_dir {
+                test_binaries::stage_test_binaries(profile, &tests_dir)?;
+            }
+            Ok(())
+        }
         Command::V2rayPlugin => run_v2ray_plugin(),
         Command::Galoshes => run_galoshes(),
         Command::Wintun => run_wintun(),

--- a/xtask/src/test_binaries.rs
+++ b/xtask/src/test_binaries.rs
@@ -1,0 +1,212 @@
+//! Stage workspace test binaries at stable paths under `<out_dir>`.
+//!
+//! Cargo names compiled test binaries `target/<profile>/deps/<crate>-<hash>.exe`.
+//! The hash churns on every rebuild, so Windows Firewall re-prompts every time
+//! a test binary binds a non-loopback socket (bindreams/hole#210).
+//!
+//! `stage_test_binaries` runs `cargo test --no-run --workspace --message-format=json`,
+//! parses the artifact stream, and copies each test executable into
+//! `<out_dir>/<target-name>.test<.exe>` — a stable path that Firewall can cache.
+//! On Windows we also stage the companion `.pdb` so staged-crash symbolication keeps working.
+
+use std::collections::{HashMap, HashSet};
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+use cargo_metadata::Message;
+
+use crate::bindir::BindirFile;
+use crate::{stage, Profile};
+
+pub(crate) fn exe_suffix() -> &'static str {
+    if cfg!(windows) {
+        ".exe"
+    } else {
+        ""
+    }
+}
+
+/// Extracted metadata for one compiled test binary. Decoupled from
+/// `cargo_metadata::Artifact` so the collision / dest-name logic can be
+/// exercised with hand-rolled fixtures.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TestArtifact {
+    pub target_name: String,
+    pub target_kind: String,
+    pub executable: PathBuf,
+}
+
+/// Filter a cargo JSON message stream down to test-binary artifacts only.
+pub(crate) fn extract_test_artifacts<R: BufRead>(stream: R) -> Result<Vec<TestArtifact>> {
+    let mut out = Vec::new();
+    for msg in Message::parse_stream(stream) {
+        let msg = msg.context("read cargo message")?;
+        let Message::CompilerArtifact(a) = msg else {
+            continue;
+        };
+        if !a.profile.test {
+            continue;
+        }
+        let Some(exe) = a.executable.as_ref() else {
+            continue;
+        };
+        debug_assert!(
+            !a.target.kind.is_empty(),
+            "cargo emitted test artifact with empty target.kind: {}",
+            a.target.name
+        );
+        let kind = a.target.kind.first().map(|k| k.to_string()).unwrap_or_default();
+        out.push(TestArtifact {
+            target_name: a.target.name.clone(),
+            target_kind: kind,
+            executable: PathBuf::from(exe.as_str()),
+        });
+    }
+    Ok(out)
+}
+
+/// Assign a stable, collision-free `dest_name` to each artifact.
+///
+/// Default is `{target_name}.test{ext}`. Artifacts that collide at the default
+/// name all fall back to `{target_name}-{kind}.test{ext}`. Any remaining
+/// collision after disambiguation is a hard error — we never silently overwrite.
+pub(crate) fn assign_dest_names(artifacts: Vec<TestArtifact>) -> Result<Vec<(String, TestArtifact)>> {
+    let ext = exe_suffix();
+    let default = |a: &TestArtifact| format!("{}.test{ext}", a.target_name);
+    let disambiguated = |a: &TestArtifact| format!("{}-{}.test{ext}", a.target_name, a.target_kind);
+
+    // HashMap is fine — final output is sorted below for determinism.
+    let mut groups: HashMap<String, Vec<TestArtifact>> = HashMap::new();
+    for a in artifacts {
+        groups.entry(default(&a)).or_default().push(a);
+    }
+
+    let mut named: Vec<(String, TestArtifact)> = Vec::new();
+    let mut used: HashMap<String, PathBuf> = HashMap::new();
+    for (name, group) in groups {
+        if group.len() == 1 {
+            let a = group.into_iter().next().unwrap();
+            if let Some(prev) = used.insert(name.clone(), a.executable.clone()) {
+                bail!(
+                    "dest_name collision at {name}: {} vs {}",
+                    prev.display(),
+                    a.executable.display()
+                );
+            }
+            named.push((name, a));
+        } else {
+            for a in group {
+                let dname = disambiguated(&a);
+                if let Some(prev) = used.insert(dname.clone(), a.executable.clone()) {
+                    bail!(
+                        "dest_name collision after disambiguation at {dname}: {} vs {}",
+                        prev.display(),
+                        a.executable.display()
+                    );
+                }
+                named.push((dname, a));
+            }
+        }
+    }
+
+    named.sort_by(|(n1, _), (n2, _)| n1.cmp(n2));
+    Ok(named)
+}
+
+/// Expand a named test artifact into the concrete files to stage: the exe, and
+/// — on Windows if present — the companion `.pdb`.
+pub(crate) fn bindir_files_for_artifact(dest_name: &str, artifact: &TestArtifact) -> Vec<BindirFile> {
+    let mut files = Vec::with_capacity(2);
+    files.push(BindirFile::new(artifact.executable.clone(), dest_name.to_string()));
+
+    if cfg!(windows) {
+        if let (Some(stem), Some(dir)) = (
+            artifact.executable.file_stem().and_then(|s| s.to_str()),
+            artifact.executable.parent(),
+        ) {
+            let pdb = dir.join(format!("{stem}.pdb"));
+            if pdb.is_file() {
+                // `dest_name` is produced by `assign_dest_names`, which always
+                // appends `exe_suffix()` (".exe" on Windows). This block runs
+                // only on Windows, so the suffix is guaranteed present.
+                let dest_stem = dest_name.strip_suffix(".exe").unwrap_or(dest_name);
+                files.push(BindirFile::new(pdb, format!("{dest_stem}.pdb")));
+            }
+        }
+    }
+
+    files
+}
+
+/// List files in `dir` that look like staged test artifacts (on Windows:
+/// `*.test.exe`, `*.test.pdb`; elsewhere: `*.test`) and are not in `keep`.
+pub(crate) fn stale_files_to_remove(dir: &Path, keep: &HashSet<String>) -> Result<Vec<PathBuf>> {
+    let mut stale = Vec::new();
+    if !dir.exists() {
+        return Ok(stale);
+    }
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("read entry in {}", dir.display()))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let looks_staged = if cfg!(windows) {
+            name.ends_with(".test.exe") || name.ends_with(".test.pdb")
+        } else {
+            name.ends_with(".test")
+        };
+        if looks_staged && !keep.contains(&name) {
+            stale.push(entry.path());
+        }
+    }
+    Ok(stale)
+}
+
+fn run_cargo_test_no_run(profile: Profile) -> Result<Vec<TestArtifact>> {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.arg("test")
+        .arg("--no-run")
+        .arg("--workspace")
+        .arg("--message-format=json");
+    if profile == Profile::Release {
+        cmd.arg("--release");
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().context("spawn `cargo test --no-run`")?;
+    let stdout = child.stdout.take().expect("stdout piped");
+    let reader = std::io::BufReader::new(stdout);
+    let artifacts = extract_test_artifacts(reader)?;
+    let status = child.wait().context("wait on cargo")?;
+    if !status.success() {
+        bail!("`cargo test --no-run` exited with {status}");
+    }
+    Ok(artifacts)
+}
+
+/// Build workspace test binaries and stage them at stable paths under `out_dir`.
+pub fn stage_test_binaries(profile: Profile, out_dir: &Path) -> Result<()> {
+    let artifacts = run_cargo_test_no_run(profile)?;
+    let named = assign_dest_names(artifacts)?;
+
+    let mut files: Vec<BindirFile> = Vec::new();
+    for (name, a) in &named {
+        files.extend(bindir_files_for_artifact(name, a));
+    }
+
+    std::fs::create_dir_all(out_dir).with_context(|| format!("create {}", out_dir.display()))?;
+    // Stage first, sweep stale second: new binaries are guaranteed present
+    // before the sweep runs, so a watcher that sees `out_dir` change never
+    // observes a moment with zero staged binaries.
+    stage::stage(out_dir, &files)?;
+
+    let keep: HashSet<String> = files.iter().map(|f| f.dest_name.clone()).collect();
+    let stale = stale_files_to_remove(out_dir, &keep)?;
+    for path in &stale {
+        std::fs::remove_file(path).with_context(|| format!("remove stale {}", path.display()))?;
+    }
+
+    println!("xtask: staged {} test binaries into {}", named.len(), out_dir.display());
+    Ok(())
+}

--- a/xtask/src/test_binaries_tests.rs
+++ b/xtask/src/test_binaries_tests.rs
@@ -1,0 +1,226 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use crate::test_binaries::{
+    assign_dest_names, bindir_files_for_artifact, exe_suffix, extract_test_artifacts, stale_files_to_remove,
+    TestArtifact,
+};
+
+fn art(name: &str, kind: &str, exe: &str) -> TestArtifact {
+    TestArtifact {
+        target_name: name.to_string(),
+        target_kind: kind.to_string(),
+        executable: PathBuf::from(exe),
+    }
+}
+
+// extract_test_artifacts ==============================================================================================
+
+/// Build a canned JSON message stream containing: a test binary artifact (keep),
+/// a non-test build-script artifact (drop), a test-profile non-binary artifact
+/// (drop — no executable), a non-artifact "build-finished" message (drop).
+fn canned_json_stream() -> Vec<u8> {
+    let test_bin = r#"{"reason":"compiler-artifact","package_id":"path+file:///a#hole-bridge@0.1.0","manifest_path":"/a/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"hole_bridge","src_path":"/a/src/lib.rs","edition":"2021","doc":true,"doctest":false,"test":true},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":true,"overflow_checks":true,"test":true},"features":[],"filenames":["/a/target/debug/deps/libhole_bridge.rlib"],"executable":"/a/target/debug/deps/hole_bridge-abc.exe","fresh":false}"#;
+    let build_script = r#"{"reason":"compiler-artifact","package_id":"path+file:///a#hole-bridge@0.1.0","manifest_path":"/a/Cargo.toml","target":{"kind":["custom-build"],"crate_types":["bin"],"name":"build-script-build","src_path":"/a/build.rs","edition":"2021","doc":false,"doctest":false,"test":false},"profile":{"opt_level":"0","debuginfo":0,"debug_assertions":true,"overflow_checks":true,"test":false},"features":[],"filenames":["/a/target/debug/build/script.exe"],"executable":null,"fresh":true}"#;
+    let rlib_only = r#"{"reason":"compiler-artifact","package_id":"path+file:///a#hole-common@0.1.0","manifest_path":"/a/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"hole_common","src_path":"/a/src/lib.rs","edition":"2021","doc":true,"doctest":false,"test":true},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":true,"overflow_checks":true,"test":true},"features":[],"filenames":["/a/target/debug/libhole_common.rlib"],"executable":null,"fresh":false}"#;
+    let build_finished = r#"{"reason":"build-finished","success":true}"#;
+
+    [test_bin, build_script, rlib_only, build_finished]
+        .join("\n")
+        .into_bytes()
+}
+
+#[skuld::test]
+fn extract_keeps_test_binary_and_drops_non_test_and_null_exe() {
+    let stream = canned_json_stream();
+    let out = extract_test_artifacts(std::io::Cursor::new(stream)).unwrap();
+    assert_eq!(out.len(), 1, "expected 1 test binary, got {out:?}");
+    assert_eq!(out[0].target_name, "hole_bridge");
+    assert_eq!(out[0].target_kind, "lib");
+    assert_eq!(
+        out[0].executable,
+        PathBuf::from("/a/target/debug/deps/hole_bridge-abc.exe")
+    );
+}
+
+// assign_dest_names ===================================================================================================
+
+#[skuld::test]
+fn assign_dest_names_empty() {
+    let out = assign_dest_names(Vec::new()).unwrap();
+    assert!(out.is_empty());
+}
+
+#[skuld::test]
+fn assign_dest_names_no_collision_uses_default_form() {
+    let ext = exe_suffix();
+    let input = vec![
+        art("hole_bridge", "lib", "/t/hole_bridge-abc"),
+        art("hole", "lib", "/t/hole-def"),
+        art("hole_common", "lib", "/t/hole_common-ghi"),
+    ];
+    let out = assign_dest_names(input).unwrap();
+    let names: Vec<_> = out.iter().map(|(n, _)| n.as_str()).collect();
+    // Sorted alphabetically by the impl.
+    assert_eq!(
+        names,
+        vec![
+            format!("hole.test{ext}").as_str(),
+            format!("hole_bridge.test{ext}").as_str(),
+            format!("hole_common.test{ext}").as_str(),
+        ]
+    );
+}
+
+#[skuld::test]
+fn assign_dest_names_collision_disambiguates_by_kind() {
+    let ext = exe_suffix();
+    // Same target_name "hole_bridge" — one lib unit test, one integration test.
+    let input = vec![
+        art("hole_bridge", "lib", "/t/hole_bridge-abc"),
+        art("hole_bridge", "test", "/t/hole_bridge-def"),
+    ];
+    let out = assign_dest_names(input).unwrap();
+    let names: Vec<_> = out.iter().map(|(n, _)| n.clone()).collect();
+    assert_eq!(
+        names,
+        vec![
+            format!("hole_bridge-lib.test{ext}"),
+            format!("hole_bridge-test.test{ext}"),
+        ]
+    );
+}
+
+#[skuld::test]
+fn assign_dest_names_unresolvable_collision_errors() {
+    // Two artifacts with the same target_name AND same kind. Even after
+    // disambiguation they'd collide. Must error, not silently overwrite.
+    let input = vec![art("hole_bridge", "lib", "/t/a"), art("hole_bridge", "lib", "/t/b")];
+    let err = assign_dest_names(input).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("collision") || msg.contains("Collision"),
+        "expected collision error, got: {msg}"
+    );
+}
+
+// bindir_files_for_artifact ===========================================================================================
+
+#[skuld::test]
+fn bindir_files_exe_only_when_no_pdb() {
+    let tmp = TempDir::new().unwrap();
+    let exe = tmp.path().join("hole_bridge-abc.exe");
+    std::fs::write(&exe, b"").unwrap();
+    // No .pdb alongside — only the exe should be emitted.
+    let a = art("hole_bridge", "lib", exe.to_str().unwrap());
+    let files = bindir_files_for_artifact("hole_bridge.test.exe", &a);
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].dest_name, "hole_bridge.test.exe");
+    assert_eq!(files[0].source, exe);
+}
+
+#[cfg(windows)]
+#[skuld::test]
+fn bindir_files_includes_pdb_when_present() {
+    let tmp = TempDir::new().unwrap();
+    let exe = tmp.path().join("hole_bridge-abc.exe");
+    let pdb = tmp.path().join("hole_bridge-abc.pdb");
+    std::fs::write(&exe, b"").unwrap();
+    std::fs::write(&pdb, b"").unwrap();
+
+    let a = art("hole_bridge", "lib", exe.to_str().unwrap());
+    let files = bindir_files_for_artifact("hole_bridge.test.exe", &a);
+    assert_eq!(files.len(), 2);
+    let names: HashSet<&str> = files.iter().map(|f| f.dest_name.as_str()).collect();
+    assert!(names.contains("hole_bridge.test.exe"));
+    assert!(names.contains("hole_bridge.test.pdb"));
+}
+
+// stale_files_to_remove ===============================================================================================
+
+#[skuld::test]
+fn stale_files_nonexistent_dir_returns_empty() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("does_not_exist");
+    let keep = HashSet::new();
+    let stale = stale_files_to_remove(&missing, &keep).unwrap();
+    assert!(stale.is_empty());
+}
+
+#[skuld::test]
+fn stale_files_identifies_staged_artifacts_not_in_keep() {
+    let ext = exe_suffix();
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    // Staged that we want to keep.
+    let keep_name = format!("hole_bridge.test{ext}");
+    std::fs::write(dir.join(&keep_name), b"").unwrap();
+
+    // Staged that is now stale.
+    let stale_name = format!("gone_crate.test{ext}");
+    std::fs::write(dir.join(&stale_name), b"").unwrap();
+
+    // Unrelated file, must be left alone.
+    std::fs::write(dir.join("README.md"), b"").unwrap();
+
+    let mut keep = HashSet::new();
+    keep.insert(keep_name.clone());
+
+    let stale = stale_files_to_remove(dir, &keep).unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0].file_name().unwrap(), stale_name.as_str());
+}
+
+#[cfg(windows)]
+#[skuld::test]
+fn stale_files_preserves_current_build_pdbs() {
+    // Regression guard: the stale sweep's `keep` set must include PDB names
+    // produced by `bindir_files_for_artifact` — otherwise the current build's
+    // PDBs would be swept on every run. This mirrors the caller's contract.
+    let tmp = TempDir::new().unwrap();
+    let stage_dir = tmp.path();
+
+    // Simulate the caller: stage hole_bridge.test.exe + .pdb alongside.
+    let exe_dest = "hole_bridge.test.exe";
+    let pdb_dest = "hole_bridge.test.pdb";
+    std::fs::write(stage_dir.join(exe_dest), b"").unwrap();
+    std::fs::write(stage_dir.join(pdb_dest), b"").unwrap();
+
+    // Build the `keep` set the way `stage_test_binaries` does.
+    let mut keep = HashSet::new();
+    keep.insert(exe_dest.to_string());
+    keep.insert(pdb_dest.to_string());
+
+    let stale = stale_files_to_remove(stage_dir, &keep).unwrap();
+    assert!(
+        stale.is_empty(),
+        "current-build exe+pdb must survive stale sweep, got {stale:?}"
+    );
+}
+
+#[cfg(windows)]
+#[skuld::test]
+fn stale_files_identifies_stale_pdbs() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    // Only the current exe's name is in keep; its companion pdb (not in keep)
+    // would still be caught — so a real caller should include both in `keep`.
+    // This test just confirms .test.pdb is considered "staged-looking".
+    std::fs::write(dir.join("gone.test.exe"), b"").unwrap();
+    std::fs::write(dir.join("gone.test.pdb"), b"").unwrap();
+    std::fs::write(dir.join("plain.txt"), b"").unwrap();
+
+    let keep = HashSet::new();
+    let stale = stale_files_to_remove(dir, &keep).unwrap();
+    let names: HashSet<_> = stale
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    assert!(names.contains("gone.test.exe"));
+    assert!(names.contains("gone.test.pdb"));
+    assert!(!names.contains("plain.txt"));
+}


### PR DESCRIPTION
Fixes #210.

## Summary

- Adds `--with-tests` + `--tests-out-dir` to `cargo xtask stage`. When set, xtask runs `cargo test --no-run --workspace --message-format=json`, parses the artifact stream via `cargo_metadata`, and stages each test binary at `{tests_out_dir}/{crate}.test{.exe}` — a stable path so Windows Firewall can cache consent across rebuilds.
- PDBs stage alongside on Windows. Collision disambiguator: `{crate}-{kind}.test{.exe}` (kicks in for `hole` lib+bin, `xtask` lib+bin). Stale artifacts from previous builds get swept. Bindir convention and existing `run_stage` signature unchanged — `DistHarness` / MSI / CI untouched.

## Test plan

- [x] `cargo test --package xtask` — 19 tests pass (new: extract filter, collision cases, PDB companion, stale sweep, PDB-sweep regression guard).
- [x] `cargo clippy --package xtask --all-targets -- -D warnings` — clean.
- [x] `cargo check --workspace --all-targets` — clean.
- [x] Plain `cargo xtask stage --out-dir ... ` does NOT create a `tests/` sibling (regression guard for MSI / `dist_fixture`).
- [x] `cargo xtask stage --with-tests --out-dir ... --tests-out-dir ...` produces all 7 workspace test binaries (+ PDBs) at stable paths with correct collision disambiguation.
- [x] Staging again after creating a `zombie.test.exe` removes it while preserving unrelated files.
- [ ] **User verification (interactive):** launch `hole_bridge.test.exe` twice, approve the firewall prompt the first time, rebuild + re-stage, launch again — no prompt the second time.
- [ ] CI green.