### PR TITLE
ci: prebuilt nextest + scheduled cache cleanup (#216)

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -52,6 +52,10 @@ jobs:
 
           THRESHOLD = datetime.now(timezone.utc) - timedelta(days=MAX_AGE_DAYS)
 
+          PAGE_SIZE = 100               # maximum supported by the API
+          DRY_PREVIEW_LIMIT = 20        # how many sample ids to echo in dry-run mode
+          DELETE_SPACING_S = 0.25       # ~240 deletes/min; well under GitHub's write secondary rate limit
+
           def gh_api(endpoint):
               return json.loads(subprocess.run(
                   ["gh", "api", "-X", "GET", endpoint],
@@ -62,20 +66,24 @@ jobs:
               # Py ≤3.10 doesn't accept trailing 'Z' in fromisoformat.
               return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
-          def fetch_stale_page(limit=100):
-              """Return oldest-accessed entries older than THRESHOLD, up to `limit`.
-              Deleted entries drop off the next page 1 naturally, so we always
-              re-query page 1 rather than paginating with ?page=N.
+          def fetch_stale_page(page=1):
+              """Return (stale_entries, saw_non_stale_entry) for one page of the caches API.
+
+              The API returns entries sorted oldest-access first, so encountering any
+              non-stale entry on a page means we've passed the end of the stale set.
               """
               resp = gh_api(
                   f"repos/{REPO}/actions/caches"
-                  f"?per_page={limit}&sort=last_accessed_at&direction=asc"
+                  f"?per_page={PAGE_SIZE}&page={page}&sort=last_accessed_at&direction=asc"
               )
-              return [
-                  (e["id"], e["size_in_bytes"])
-                  for e in resp.get("actions_caches", [])
-                  if parse_iso(e["last_accessed_at"]) < THRESHOLD
-              ]
+              stale = []
+              saw_non_stale = False
+              for e in resp["actions_caches"]:
+                  if parse_iso(e["last_accessed_at"]) < THRESHOLD:
+                      stale.append((e["id"], e["size_in_bytes"]))
+                  else:
+                      saw_non_stale = True
+              return stale, saw_non_stale
 
           def delete_cache(cache_id):
               try:
@@ -89,13 +97,37 @@ jobs:
 
           print(f"Pruning entries last accessed before {THRESHOLD.isoformat()}")
 
-          processed = set()     # successfully handled — never retry
+          # ---- dry-run: enumerate all stale entries across pages --------------
+          # Since nothing gets deleted, page offsets stay stable and we can
+          # paginate normally. Stop as soon as a page contains a non-stale entry.
+          if DRY_RUN:
+              all_stale = []
+              page = 1
+              while True:
+                  batch, saw_non_stale = fetch_stale_page(page=page)
+                  if not batch and not saw_non_stale:
+                      break    # empty page = past the end
+                  all_stale.extend(batch)
+                  if saw_non_stale:
+                      break    # sorted ascending, so no more stale beyond this
+                  page += 1
+
+              for cache_id, size in all_stale[:DRY_PREVIEW_LIMIT]:
+                  print(f"[dry-run] would delete id={cache_id} size={size}")
+              more = f" (first {DRY_PREVIEW_LIMIT} of {len(all_stale)} shown above)" if len(all_stale) > DRY_PREVIEW_LIMIT else ""
+              print(f"[dry-run] would delete {len(all_stale)} entries{more}.")
+              sys.exit(0)
+
+          # ---- live prune: delete stale entries, re-fetching page 1 each time --
+          # As entries are deleted, they drop off the result set, so page 1 always
+          # contains the next-oldest undeleted entries. Stop when the page is empty
+          # or when a whole batch makes no progress (all-failed deletes).
+          processed = set()
           deleted = 0
           failed = 0
-          dry_preview = []
 
           while True:
-              batch = fetch_stale_page()
+              batch, _ = fetch_stale_page(page=1)
               if not batch:
                   print("no stale entries remain")
                   break
@@ -103,16 +135,7 @@ jobs:
               made_progress = False
               for cache_id, size in batch:
                   if cache_id in processed:
-                      # Shouldn't re-appear from a fresh fetch, but guard anyway.
-                      continue
-
-                  if DRY_RUN:
-                      if len(dry_preview) < 20:
-                          dry_preview.append((cache_id, size))
-                      processed.add(cache_id)
-                      made_progress = True
-                      continue
-
+                      continue    # defensive: shouldn't happen after successful delete
                   ok, err = delete_cache(cache_id)
                   if ok:
                       deleted += 1
@@ -120,24 +143,17 @@ jobs:
                       made_progress = True
                   else:
                       failed += 1
-                      # Don't mark as processed: a transient 5xx is retryable
-                      # on the next page fetch. If every entry in the next
-                      # batch fails too, we'll bail via `made_progress`.
+                      # Don't mark as processed: a transient 5xx is retryable on
+                      # the next page fetch. If every entry in the next batch
+                      # fails too, we bail via `made_progress`.
                       print(f"::warning::failed to delete cache id={cache_id}: {err or 'no stderr'}")
-
-                  # Stay under GitHub's write secondary rate limit (~300/min).
-                  time.sleep(0.25)
+                  time.sleep(DELETE_SPACING_S)
 
               if not made_progress:
                   print(f"::warning::no progress in last batch; stopping (failed={failed}, deleted={deleted})")
                   break
 
-          if DRY_RUN:
-              for cache_id, size in dry_preview:
-                  print(f"[dry-run] would delete id={cache_id} size={size}")
-              print(f"[dry-run] would have attempted to delete {len(processed)} entries (first 20 listed above).")
-          else:
-              print(f"Deleted {deleted} entries (failed: {failed}).")
+          print(f"Deleted {deleted} entries (failed: {failed}).")
 
       - name: Report post-cleanup usage
         shell: python

--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -6,16 +6,8 @@ on:
     - cron: "15 3 * * *"
   workflow_dispatch:
     inputs:
-      high-watermark-pct:
-        description: "Only prune if cache usage is above this % of quota"
-        required: false
-        default: "70"
-      low-watermark-pct:
-        description: "Stop pruning once usage drops below this % of quota"
-        required: false
-        default: "50"
       max-age-days:
-        description: "Never delete entries accessed within this many days"
+        description: "Delete cache entries not accessed within this many days"
         required: false
         default: "3"
       dry-run:
@@ -41,12 +33,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          # GitHub's per-repo Actions cache quota. Documented as 10 GiB at
-          # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
-          # No public API exposes this number; bump manually if the plan changes.
-          QUOTA_BYTES: "10737418240"
-          HIGH_PCT: ${{ inputs['high-watermark-pct'] || '70' }}
-          LOW_PCT: ${{ inputs['low-watermark-pct'] || '50' }}
           MAX_AGE_DAYS: ${{ inputs['max-age-days'] || '3' }}
           DRY_RUN: ${{ inputs['dry-run'] || 'false' }}
         run: |
@@ -57,63 +43,41 @@ jobs:
           import time
           from datetime import datetime, timedelta, timezone
 
-          # ---- inputs --------------------------------------------------------
           REPO = os.environ["GH_REPO"]
-          QUOTA_BYTES = int(os.environ["QUOTA_BYTES"])
-          HIGH_PCT = int(os.environ["HIGH_PCT"])
-          LOW_PCT = int(os.environ["LOW_PCT"])
           MAX_AGE_DAYS = int(os.environ["MAX_AGE_DAYS"])
           DRY_RUN = os.environ["DRY_RUN"].lower() == "true"
 
-          # Validate: low must be strictly less than high, and high <= 100.
-          if not (0 <= LOW_PCT < HIGH_PCT <= 100):
-              sys.exit(f"::error::invalid watermarks: low={LOW_PCT} high={HIGH_PCT} (need 0 <= low < high <= 100)")
           if MAX_AGE_DAYS < 0:
               sys.exit(f"::error::max-age-days must be >= 0: {MAX_AGE_DAYS}")
 
-          HIGH_BYTES = QUOTA_BYTES * HIGH_PCT // 100
-          LOW_BYTES = QUOTA_BYTES * LOW_PCT // 100
           THRESHOLD = datetime.now(timezone.utc) - timedelta(days=MAX_AGE_DAYS)
 
-          # ---- helpers -------------------------------------------------------
-          def gh(*args):
-              """Run `gh` and return its stdout as bytes. Raises CalledProcessError on failure."""
-              return subprocess.run(
-                  ["gh", *args], check=True, capture_output=True
-              ).stdout
-
-          def api_get(endpoint):
-              """GET a GitHub API endpoint and parse JSON."""
-              return json.loads(gh("api", "-X", "GET", endpoint))
-
-          def cache_usage():
-              """Return (size_bytes, entry_count) from the cache/usage endpoint."""
-              r = api_get(f"repos/{REPO}/actions/cache/usage")
-              return r["active_caches_size_in_bytes"], r["active_caches_count"]
+          def gh_api(endpoint):
+              return json.loads(subprocess.run(
+                  ["gh", "api", "-X", "GET", endpoint],
+                  check=True, capture_output=True,
+              ).stdout)
 
           def parse_iso(s):
-              """Parse an ISO-8601 timestamp from the GitHub API into a tz-aware datetime."""
-              # fromisoformat in Py 3.11+ accepts trailing 'Z'; earlier versions don't.
+              # Py ≤3.10 doesn't accept trailing 'Z' in fromisoformat.
               return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
           def fetch_stale_page(limit=100):
-              """Fetch up to `limit` oldest-accessed cache entries older than THRESHOLD.
-
-              Deleted entries naturally fall off the next page fetch, so we always
-              re-query from page 1 rather than paginating with ?page=N.
+              """Return oldest-accessed entries older than THRESHOLD, up to `limit`.
+              Deleted entries drop off the next page 1 naturally, so we always
+              re-query page 1 rather than paginating with ?page=N.
               """
-              resp = api_get(
+              resp = gh_api(
                   f"repos/{REPO}/actions/caches"
                   f"?per_page={limit}&sort=last_accessed_at&direction=asc"
               )
-              out = []
-              for e in resp.get("actions_caches", []):
-                  if parse_iso(e["last_accessed_at"]) < THRESHOLD:
-                      out.append((e["id"], e["size_in_bytes"]))
-              return out
+              return [
+                  (e["id"], e["size_in_bytes"])
+                  for e in resp.get("actions_caches", [])
+                  if parse_iso(e["last_accessed_at"]) < THRESHOLD
+              ]
 
           def delete_cache(cache_id):
-              """Try to delete a cache entry. Returns (ok, error_message_or_None)."""
               try:
                   subprocess.run(
                       ["gh", "cache", "delete", str(cache_id)],
@@ -123,41 +87,29 @@ jobs:
               except subprocess.CalledProcessError as e:
                   return False, (e.stderr or e.stdout or b"").decode(errors="replace").strip()
 
-          # ---- gate ----------------------------------------------------------
-          usage, count = cache_usage()
-          print(f"[gate] usage={usage} high={HIGH_BYTES} low={LOW_BYTES} count={count}")
-          if usage < HIGH_BYTES:
-              print("below high watermark; no cleanup needed")
-              sys.exit(0)
-          print(f"above high watermark; pruning entries accessed before {THRESHOLD.isoformat()}")
+          print(f"Pruning entries last accessed before {THRESHOLD.isoformat()}")
 
-          # ---- prune ---------------------------------------------------------
-          # Track estimated usage locally instead of re-polling cache/usage every
-          # iteration: the usage endpoint is eventually consistent and can lag
-          # real state by minutes, causing the loop to overshoot the low watermark.
-          usage_est = usage
-          processed = set()    # ids we've successfully deleted (or previewed in dry-run)
+          processed = set()     # successfully handled — never retry
           deleted = 0
           failed = 0
           dry_preview = []
 
-          while usage_est >= LOW_BYTES:
+          while True:
               batch = fetch_stale_page()
               if not batch:
-                  print(f"no entries older than {THRESHOLD.isoformat()} remain")
+                  print("no stale entries remain")
                   break
 
               made_progress = False
               for cache_id, size in batch:
                   if cache_id in processed:
-                      # Shouldn't re-appear from a fresh API fetch, but guard anyway.
+                      # Shouldn't re-appear from a fresh fetch, but guard anyway.
                       continue
 
                   if DRY_RUN:
                       if len(dry_preview) < 20:
                           dry_preview.append((cache_id, size))
                       processed.add(cache_id)
-                      usage_est -= size
                       made_progress = True
                       continue
 
@@ -165,32 +117,27 @@ jobs:
                   if ok:
                       deleted += 1
                       processed.add(cache_id)
-                      usage_est -= size
                       made_progress = True
                   else:
                       failed += 1
-                      # Don't mark as processed: a transient 5xx should be retryable
-                      # via the next page fetch. If every entry in the next batch
-                      # fails too, `made_progress` stays False and we bail.
+                      # Don't mark as processed: a transient 5xx is retryable
+                      # on the next page fetch. If every entry in the next
+                      # batch fails too, we'll bail via `made_progress`.
                       print(f"::warning::failed to delete cache id={cache_id}: {err or 'no stderr'}")
 
-                  # Stay under the ~300/min write secondary rate limit.
+                  # Stay under GitHub's write secondary rate limit (~300/min).
                   time.sleep(0.25)
-
-                  if usage_est < LOW_BYTES:
-                      break    # inner loop
 
               if not made_progress:
                   print(f"::warning::no progress in last batch; stopping (failed={failed}, deleted={deleted})")
                   break
 
-          # ---- report --------------------------------------------------------
           if DRY_RUN:
               for cache_id, size in dry_preview:
                   print(f"[dry-run] would delete id={cache_id} size={size}")
               print(f"[dry-run] would have attempted to delete {len(processed)} entries (first 20 listed above).")
           else:
-              print(f"Deleted {deleted} entries (failed: {failed}). Estimated remaining usage: {usage_est} bytes.")
+              print(f"Deleted {deleted} entries (failed: {failed}).")
 
       - name: Report post-cleanup usage
         shell: python

--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -38,31 +38,48 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      # GitHub's per-repo Actions cache quota. Documented as 10 GiB at
+      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+      # No public API exposes this number, so bump manually if the repo's plan changes.
       QUOTA_BYTES: 10737418240        # 10 GiB
       HIGH_PCT: ${{ inputs.high_watermark_pct || '70' }}
       LOW_PCT: ${{ inputs.low_watermark_pct || '50' }}
       MAX_AGE_DAYS: ${{ inputs.max_age_days || '3' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$HIGH_PCT"      =~ ^[0-9]+$ ]] || { echo "::error::high_watermark_pct must be a non-negative integer: $HIGH_PCT"; exit 1; }
+          [[ "$LOW_PCT"       =~ ^[0-9]+$ ]] || { echo "::error::low_watermark_pct must be a non-negative integer: $LOW_PCT"; exit 1; }
+          [[ "$MAX_AGE_DAYS"  =~ ^[0-9]+$ ]] || { echo "::error::max_age_days must be a non-negative integer: $MAX_AGE_DAYS"; exit 1; }
+          (( LOW_PCT < HIGH_PCT )) || { echo "::error::low_watermark_pct ($LOW_PCT) must be strictly less than high_watermark_pct ($HIGH_PCT)"; exit 1; }
+          (( HIGH_PCT <= 100 ))    || { echo "::error::high_watermark_pct must be <= 100: $HIGH_PCT"; exit 1; }
+
       - name: Gate on cache size
         id: gate
         shell: bash
         run: |
           set -euo pipefail
-          usage=$(gh api "repos/${GH_REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
-          count=$(gh api "repos/${GH_REPO}/actions/cache/usage" --jq '.active_caches_count')
-          [[ "$usage" =~ ^[0-9]+$ ]] || { echo "::error::unexpected usage value: $usage"; exit 1; }
-          [[ "$count" =~ ^[0-9]+$ ]] || { echo "::error::unexpected count value: $count"; exit 1; }
+          # One API call, read both fields. Using command substitution so a `gh api`
+          # failure trips `set -e`; process substitution wouldn't.
+          resp=$(gh api "repos/${GH_REPO}/actions/cache/usage" \
+            --jq '"\(.active_caches_size_in_bytes) \(.active_caches_count)"')
+          read -r usage count <<<"$resp"
+          [[ "$usage" =~ ^[0-9]+$ ]] || { echo "::error::unexpected usage value from API: $usage"; exit 1; }
+          [[ "$count" =~ ^[0-9]+$ ]] || { echo "::error::unexpected count value from API: $count"; exit 1; }
           high=$(( QUOTA_BYTES * HIGH_PCT / 100 ))
           low=$((  QUOTA_BYTES * LOW_PCT  / 100 ))
-          echo "usage=$usage  high=$high  low=$low  count=$count"
+          echo "[gate] usage=$usage high=$high low=$low count=$count"
           echo "low_bytes=$low" >> "$GITHUB_OUTPUT"
           if [[ "$usage" -lt "$high" ]]; then
             echo "below high watermark; no cleanup needed"
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
             echo "above high watermark; cleanup will run"
-            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "run=true"  >> "$GITHUB_OUTPUT"
+            echo "initial_usage=$usage" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Delete stale GHA cache entries (oldest-first, down to low watermark)
@@ -70,57 +87,90 @@ jobs:
         shell: bash
         env:
           LOW_BYTES: ${{ steps.gate.outputs.low_bytes }}
+          INITIAL_USAGE: ${{ steps.gate.outputs.initial_usage }}
         run: |
           set -euo pipefail
-          threshold=$(date -u -d "${MAX_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
-          echo "Pruning entries last accessed before $threshold, down to $LOW_BYTES bytes total."
+          # Threshold as epoch seconds so lexicographic comparisons can't misbehave
+          # when GitHub's cache metadata ever gains sub-second precision.
+          threshold_epoch=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+          threshold_iso=$(date -u -d "@${threshold_epoch}" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Pruning entries with last_accessed_at < ${threshold_iso} (epoch ${threshold_epoch}), targeting usage < ${LOW_BYTES} bytes."
 
-          declare -A seen=()
+          # Track estimated usage locally. cache/usage is eventually consistent and
+          # can lag real state by minutes; if we trusted it exclusively, a single
+          # scheduled run could overshoot the low watermark and delete far more than
+          # intended. Subtracting each freshly-deleted entry's size_in_bytes gives
+          # a sound upper-bound estimate we can gate on.
+          usage_est=${INITIAL_USAGE}
+
+          # Dedup only *successful* processing; failed entries remain retryable
+          # on the next list page so a transient 5xx doesn't skip them permanently.
+          declare -A processed=()
           deleted=0
+          failed=0
           skipped_preview=0
 
           while : ; do
-            current=$(gh api "repos/${GH_REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
-            [[ "$current" =~ ^[0-9]+$ ]] || { echo "::error::bad usage: $current"; exit 1; }
-            if [[ "$current" -lt "$LOW_BYTES" ]]; then
-              echo "reached low watermark"
+            if [[ "$usage_est" -lt "$LOW_BYTES" ]]; then
+              echo "reached low watermark (estimated usage $usage_est < $LOW_BYTES)"
               break
             fi
 
-            mapfile -t batch < <(
-              gh api "repos/${GH_REPO}/actions/caches?per_page=100&sort=last_accessed_at&direction=asc" \
-                --jq ".actions_caches[] | select(.last_accessed_at < \"$threshold\") | .id"
-            )
-            if [[ ${#batch[@]} -eq 0 ]]; then
-              echo "no entries older than $threshold remain"
+            # Fetch next page. Capture to a temp file so `gh api` failures are
+            # detected — `mapfile < <(gh api ...)` would silently swallow errors
+            # because process-substitution failures don't trip `set -e`.
+            batch_file=$(mktemp)
+            if ! gh api "repos/${GH_REPO}/actions/caches?per_page=100&sort=last_accessed_at&direction=asc" \
+              --jq ".actions_caches[] | select((.last_accessed_at | fromdateiso8601) < ${threshold_epoch}) | \"\(.id) \(.size_in_bytes)\"" \
+              > "$batch_file"; then
+              echo "::error::gh api failed when listing caches"
+              rm -f "$batch_file"
+              exit 1
+            fi
+
+            if [[ ! -s "$batch_file" ]]; then
+              echo "no entries older than ${threshold_iso} remain"
+              rm -f "$batch_file"
               break
             fi
 
             made_progress=false
-            for id in "${batch[@]}"; do
-              if [[ -n "${seen[$id]:-}" ]]; then
-                continue
+            while read -r id size; do
+              [[ -n "$id" ]] || continue
+              [[ "$id"   =~ ^[0-9]+$ ]] || { echo "::error::unexpected id from API: $id"; exit 1; }
+              [[ "$size" =~ ^[0-9]+$ ]] || { echo "::error::unexpected size for id=$id: $size"; exit 1; }
+              if [[ -n "${processed[$id]:-}" ]]; then
+                continue    # already deleted in a prior iteration; shouldn't re-appear, defensive
               fi
-              seen[$id]=1
               if [[ "$DRY_RUN" == "true" ]]; then
                 if [[ $skipped_preview -lt 20 ]]; then
-                  echo "[dry-run] would delete $id"
+                  echo "[dry-run] would delete id=$id size=$size"
                 fi
                 skipped_preview=$((skipped_preview + 1))
+                processed[$id]=1
+                usage_est=$(( usage_est - size ))
                 made_progress=true
                 continue
               fi
-              if gh cache delete "$id" >/dev/null 2>&1; then
+              # Preserve stderr for diagnostics on failure.
+              if err=$(gh cache delete "$id" 2>&1 >/dev/null); then
                 deleted=$((deleted + 1))
+                processed[$id]=1
+                usage_est=$(( usage_est - size ))
                 made_progress=true
               else
-                echo "::warning::failed to delete cache id=$id"
+                failed=$((failed + 1))
+                # Don't add to `processed`: the entry is still a deletion candidate
+                # and will re-appear on the next page fetch. If every entry in the
+                # next batch fails too, `made_progress` stays false and we bail.
+                echo "::warning::failed to delete cache id=$id: ${err:-no stderr}"
               fi
-              sleep 0.25
-            done
+              sleep 0.25    # stay well under GitHub's write secondary rate limit
+            done < "$batch_file"
+            rm -f "$batch_file"
 
             if ! $made_progress; then
-              echo "::warning::no progress in last batch (${#batch[@]} entries all failed or already seen); stopping"
+              echo "::warning::no progress in last batch; stopping (failed=$failed, deleted=$deleted)"
               break
             fi
           done
@@ -128,7 +178,7 @@ jobs:
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "[dry-run] would have attempted to delete $skipped_preview entries (first 20 listed above)."
           else
-            echo "Deleted $deleted entries."
+            echo "Deleted $deleted entries (failed: $failed). Estimated remaining usage: $usage_est bytes."
           fi
 
       - name: Report post-cleanup usage

--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -6,19 +6,19 @@ on:
     - cron: "15 3 * * *"
   workflow_dispatch:
     inputs:
-      high_watermark_pct:
+      high-watermark-pct:
         description: "Only prune if cache usage is above this % of quota"
         required: false
         default: "70"
-      low_watermark_pct:
+      low-watermark-pct:
         description: "Stop pruning once usage drops below this % of quota"
         required: false
         default: "50"
-      max_age_days:
+      max-age-days:
         description: "Never delete entries accessed within this many days"
         required: false
         default: "3"
-      dry_run:
+      dry-run:
         description: "List what would be deleted, without deleting"
         type: boolean
         default: false
@@ -35,154 +35,176 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GH_REPO: ${{ github.repository }}
-      # GitHub's per-repo Actions cache quota. Documented as 10 GiB at
-      # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
-      # No public API exposes this number, so bump manually if the repo's plan changes.
-      QUOTA_BYTES: 10737418240        # 10 GiB
-      HIGH_PCT: ${{ inputs.high_watermark_pct || '70' }}
-      LOW_PCT: ${{ inputs.low_watermark_pct || '50' }}
-      MAX_AGE_DAYS: ${{ inputs.max_age_days || '3' }}
-      DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
-      - name: Validate inputs
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$HIGH_PCT"      =~ ^[0-9]+$ ]] || { echo "::error::high_watermark_pct must be a non-negative integer: $HIGH_PCT"; exit 1; }
-          [[ "$LOW_PCT"       =~ ^[0-9]+$ ]] || { echo "::error::low_watermark_pct must be a non-negative integer: $LOW_PCT"; exit 1; }
-          [[ "$MAX_AGE_DAYS"  =~ ^[0-9]+$ ]] || { echo "::error::max_age_days must be a non-negative integer: $MAX_AGE_DAYS"; exit 1; }
-          (( LOW_PCT < HIGH_PCT )) || { echo "::error::low_watermark_pct ($LOW_PCT) must be strictly less than high_watermark_pct ($HIGH_PCT)"; exit 1; }
-          (( HIGH_PCT <= 100 ))    || { echo "::error::high_watermark_pct must be <= 100: $HIGH_PCT"; exit 1; }
-
-      - name: Gate on cache size
-        id: gate
-        shell: bash
-        run: |
-          set -euo pipefail
-          # One API call, read both fields. Using command substitution so a `gh api`
-          # failure trips `set -e`; process substitution wouldn't.
-          resp=$(gh api "repos/${GH_REPO}/actions/cache/usage" \
-            --jq '"\(.active_caches_size_in_bytes) \(.active_caches_count)"')
-          read -r usage count <<<"$resp"
-          [[ "$usage" =~ ^[0-9]+$ ]] || { echo "::error::unexpected usage value from API: $usage"; exit 1; }
-          [[ "$count" =~ ^[0-9]+$ ]] || { echo "::error::unexpected count value from API: $count"; exit 1; }
-          high=$(( QUOTA_BYTES * HIGH_PCT / 100 ))
-          low=$((  QUOTA_BYTES * LOW_PCT  / 100 ))
-          echo "[gate] usage=$usage high=$high low=$low count=$count"
-          echo "low_bytes=$low" >> "$GITHUB_OUTPUT"
-          if [[ "$usage" -lt "$high" ]]; then
-            echo "below high watermark; no cleanup needed"
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "above high watermark; cleanup will run"
-            echo "run=true"  >> "$GITHUB_OUTPUT"
-            echo "initial_usage=$usage" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Delete stale GHA cache entries (oldest-first, down to low watermark)
-        if: steps.gate.outputs.run == 'true'
-        shell: bash
+      - name: Prune stale GHA cache entries
+        shell: python
         env:
-          LOW_BYTES: ${{ steps.gate.outputs.low_bytes }}
-          INITIAL_USAGE: ${{ steps.gate.outputs.initial_usage }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          # GitHub's per-repo Actions cache quota. Documented as 10 GiB at
+          # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+          # No public API exposes this number; bump manually if the plan changes.
+          QUOTA_BYTES: "10737418240"
+          HIGH_PCT: ${{ inputs['high-watermark-pct'] || '70' }}
+          LOW_PCT: ${{ inputs['low-watermark-pct'] || '50' }}
+          MAX_AGE_DAYS: ${{ inputs['max-age-days'] || '3' }}
+          DRY_RUN: ${{ inputs['dry-run'] || 'false' }}
         run: |
-          set -euo pipefail
-          # Threshold as epoch seconds so lexicographic comparisons can't misbehave
-          # when GitHub's cache metadata ever gains sub-second precision.
-          threshold_epoch=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
-          threshold_iso=$(date -u -d "@${threshold_epoch}" +%Y-%m-%dT%H:%M:%SZ)
-          echo "Pruning entries with last_accessed_at < ${threshold_iso} (epoch ${threshold_epoch}), targeting usage < ${LOW_BYTES} bytes."
+          import json
+          import os
+          import subprocess
+          import sys
+          import time
+          from datetime import datetime, timedelta, timezone
 
-          # Track estimated usage locally. cache/usage is eventually consistent and
-          # can lag real state by minutes; if we trusted it exclusively, a single
-          # scheduled run could overshoot the low watermark and delete far more than
-          # intended. Subtracting each freshly-deleted entry's size_in_bytes gives
-          # a sound upper-bound estimate we can gate on.
-          usage_est=${INITIAL_USAGE}
+          # ---- inputs --------------------------------------------------------
+          REPO = os.environ["GH_REPO"]
+          QUOTA_BYTES = int(os.environ["QUOTA_BYTES"])
+          HIGH_PCT = int(os.environ["HIGH_PCT"])
+          LOW_PCT = int(os.environ["LOW_PCT"])
+          MAX_AGE_DAYS = int(os.environ["MAX_AGE_DAYS"])
+          DRY_RUN = os.environ["DRY_RUN"].lower() == "true"
 
-          # Dedup only *successful* processing; failed entries remain retryable
-          # on the next list page so a transient 5xx doesn't skip them permanently.
-          declare -A processed=()
-          deleted=0
-          failed=0
-          skipped_preview=0
+          # Validate: low must be strictly less than high, and high <= 100.
+          if not (0 <= LOW_PCT < HIGH_PCT <= 100):
+              sys.exit(f"::error::invalid watermarks: low={LOW_PCT} high={HIGH_PCT} (need 0 <= low < high <= 100)")
+          if MAX_AGE_DAYS < 0:
+              sys.exit(f"::error::max-age-days must be >= 0: {MAX_AGE_DAYS}")
 
-          while : ; do
-            if [[ "$usage_est" -lt "$LOW_BYTES" ]]; then
-              echo "reached low watermark (estimated usage $usage_est < $LOW_BYTES)"
-              break
-            fi
+          HIGH_BYTES = QUOTA_BYTES * HIGH_PCT // 100
+          LOW_BYTES = QUOTA_BYTES * LOW_PCT // 100
+          THRESHOLD = datetime.now(timezone.utc) - timedelta(days=MAX_AGE_DAYS)
 
-            # Fetch next page. Capture to a temp file so `gh api` failures are
-            # detected — `mapfile < <(gh api ...)` would silently swallow errors
-            # because process-substitution failures don't trip `set -e`.
-            batch_file=$(mktemp)
-            if ! gh api "repos/${GH_REPO}/actions/caches?per_page=100&sort=last_accessed_at&direction=asc" \
-              --jq ".actions_caches[] | select((.last_accessed_at | fromdateiso8601) < ${threshold_epoch}) | \"\(.id) \(.size_in_bytes)\"" \
-              > "$batch_file"; then
-              echo "::error::gh api failed when listing caches"
-              rm -f "$batch_file"
-              exit 1
-            fi
+          # ---- helpers -------------------------------------------------------
+          def gh(*args):
+              """Run `gh` and return its stdout as bytes. Raises CalledProcessError on failure."""
+              return subprocess.run(
+                  ["gh", *args], check=True, capture_output=True
+              ).stdout
 
-            if [[ ! -s "$batch_file" ]]; then
-              echo "no entries older than ${threshold_iso} remain"
-              rm -f "$batch_file"
-              break
-            fi
+          def api_get(endpoint):
+              """GET a GitHub API endpoint and parse JSON."""
+              return json.loads(gh("api", "-X", "GET", endpoint))
 
-            made_progress=false
-            while read -r id size; do
-              [[ -n "$id" ]] || continue
-              [[ "$id"   =~ ^[0-9]+$ ]] || { echo "::error::unexpected id from API: $id"; exit 1; }
-              [[ "$size" =~ ^[0-9]+$ ]] || { echo "::error::unexpected size for id=$id: $size"; exit 1; }
-              if [[ -n "${processed[$id]:-}" ]]; then
-                continue    # already deleted in a prior iteration; shouldn't re-appear, defensive
-              fi
-              if [[ "$DRY_RUN" == "true" ]]; then
-                if [[ $skipped_preview -lt 20 ]]; then
-                  echo "[dry-run] would delete id=$id size=$size"
-                fi
-                skipped_preview=$((skipped_preview + 1))
-                processed[$id]=1
-                usage_est=$(( usage_est - size ))
-                made_progress=true
-                continue
-              fi
-              # Preserve stderr for diagnostics on failure.
-              if err=$(gh cache delete "$id" 2>&1 >/dev/null); then
-                deleted=$((deleted + 1))
-                processed[$id]=1
-                usage_est=$(( usage_est - size ))
-                made_progress=true
-              else
-                failed=$((failed + 1))
-                # Don't add to `processed`: the entry is still a deletion candidate
-                # and will re-appear on the next page fetch. If every entry in the
-                # next batch fails too, `made_progress` stays false and we bail.
-                echo "::warning::failed to delete cache id=$id: ${err:-no stderr}"
-              fi
-              sleep 0.25    # stay well under GitHub's write secondary rate limit
-            done < "$batch_file"
-            rm -f "$batch_file"
+          def cache_usage():
+              """Return (size_bytes, entry_count) from the cache/usage endpoint."""
+              r = api_get(f"repos/{REPO}/actions/cache/usage")
+              return r["active_caches_size_in_bytes"], r["active_caches_count"]
 
-            if ! $made_progress; then
-              echo "::warning::no progress in last batch; stopping (failed=$failed, deleted=$deleted)"
-              break
-            fi
-          done
+          def parse_iso(s):
+              """Parse an ISO-8601 timestamp from the GitHub API into a tz-aware datetime."""
+              # fromisoformat in Py 3.11+ accepts trailing 'Z'; earlier versions don't.
+              return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
-          if [[ "$DRY_RUN" == "true" ]]; then
-            echo "[dry-run] would have attempted to delete $skipped_preview entries (first 20 listed above)."
-          else
-            echo "Deleted $deleted entries (failed: $failed). Estimated remaining usage: $usage_est bytes."
-          fi
+          def fetch_stale_page(limit=100):
+              """Fetch up to `limit` oldest-accessed cache entries older than THRESHOLD.
+
+              Deleted entries naturally fall off the next page fetch, so we always
+              re-query from page 1 rather than paginating with ?page=N.
+              """
+              resp = api_get(
+                  f"repos/{REPO}/actions/caches"
+                  f"?per_page={limit}&sort=last_accessed_at&direction=asc"
+              )
+              out = []
+              for e in resp.get("actions_caches", []):
+                  if parse_iso(e["last_accessed_at"]) < THRESHOLD:
+                      out.append((e["id"], e["size_in_bytes"]))
+              return out
+
+          def delete_cache(cache_id):
+              """Try to delete a cache entry. Returns (ok, error_message_or_None)."""
+              try:
+                  subprocess.run(
+                      ["gh", "cache", "delete", str(cache_id)],
+                      check=True, capture_output=True,
+                  )
+                  return True, None
+              except subprocess.CalledProcessError as e:
+                  return False, (e.stderr or e.stdout or b"").decode(errors="replace").strip()
+
+          # ---- gate ----------------------------------------------------------
+          usage, count = cache_usage()
+          print(f"[gate] usage={usage} high={HIGH_BYTES} low={LOW_BYTES} count={count}")
+          if usage < HIGH_BYTES:
+              print("below high watermark; no cleanup needed")
+              sys.exit(0)
+          print(f"above high watermark; pruning entries accessed before {THRESHOLD.isoformat()}")
+
+          # ---- prune ---------------------------------------------------------
+          # Track estimated usage locally instead of re-polling cache/usage every
+          # iteration: the usage endpoint is eventually consistent and can lag
+          # real state by minutes, causing the loop to overshoot the low watermark.
+          usage_est = usage
+          processed = set()    # ids we've successfully deleted (or previewed in dry-run)
+          deleted = 0
+          failed = 0
+          dry_preview = []
+
+          while usage_est >= LOW_BYTES:
+              batch = fetch_stale_page()
+              if not batch:
+                  print(f"no entries older than {THRESHOLD.isoformat()} remain")
+                  break
+
+              made_progress = False
+              for cache_id, size in batch:
+                  if cache_id in processed:
+                      # Shouldn't re-appear from a fresh API fetch, but guard anyway.
+                      continue
+
+                  if DRY_RUN:
+                      if len(dry_preview) < 20:
+                          dry_preview.append((cache_id, size))
+                      processed.add(cache_id)
+                      usage_est -= size
+                      made_progress = True
+                      continue
+
+                  ok, err = delete_cache(cache_id)
+                  if ok:
+                      deleted += 1
+                      processed.add(cache_id)
+                      usage_est -= size
+                      made_progress = True
+                  else:
+                      failed += 1
+                      # Don't mark as processed: a transient 5xx should be retryable
+                      # via the next page fetch. If every entry in the next batch
+                      # fails too, `made_progress` stays False and we bail.
+                      print(f"::warning::failed to delete cache id={cache_id}: {err or 'no stderr'}")
+
+                  # Stay under the ~300/min write secondary rate limit.
+                  time.sleep(0.25)
+
+                  if usage_est < LOW_BYTES:
+                      break    # inner loop
+
+              if not made_progress:
+                  print(f"::warning::no progress in last batch; stopping (failed={failed}, deleted={deleted})")
+                  break
+
+          # ---- report --------------------------------------------------------
+          if DRY_RUN:
+              for cache_id, size in dry_preview:
+                  print(f"[dry-run] would delete id={cache_id} size={size}")
+              print(f"[dry-run] would have attempted to delete {len(processed)} entries (first 20 listed above).")
+          else:
+              print(f"Deleted {deleted} entries (failed: {failed}). Estimated remaining usage: {usage_est} bytes.")
 
       - name: Report post-cleanup usage
-        shell: bash
+        shell: python
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          gh api "repos/${GH_REPO}/actions/cache/usage" \
-            --jq '"Remaining: \(.active_caches_count) entries, \(.active_caches_size_in_bytes / 1024 / 1024 | round) MB"'
+          import json
+          import os
+          import subprocess
+
+          resp = json.loads(subprocess.run(
+              ["gh", "api", "-X", "GET", f"repos/{os.environ['GH_REPO']}/actions/cache/usage"],
+              check=True, capture_output=True,
+          ).stdout)
+          size_mb = round(resp["active_caches_size_in_bytes"] / 1024 / 1024)
+          print(f"Remaining: {resp['active_caches_count']} entries, {size_mb} MB")

--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,0 +1,138 @@
+name: Cache cleanup
+
+on:
+  schedule:
+    # Daily at 03:15 UTC (off-peak for US/EU contributors).
+    - cron: "15 3 * * *"
+  workflow_dispatch:
+    inputs:
+      high_watermark_pct:
+        description: "Only prune if cache usage is above this % of quota"
+        required: false
+        default: "70"
+      low_watermark_pct:
+        description: "Stop pruning once usage drops below this % of quota"
+        required: false
+        default: "50"
+      max_age_days:
+        description: "Never delete entries accessed within this many days"
+        required: false
+        default: "3"
+      dry_run:
+        description: "List what would be deleted, without deleting"
+        type: boolean
+        default: false
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cache-cleanup
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      QUOTA_BYTES: 10737418240        # 10 GiB
+      HIGH_PCT: ${{ inputs.high_watermark_pct || '70' }}
+      LOW_PCT: ${{ inputs.low_watermark_pct || '50' }}
+      MAX_AGE_DAYS: ${{ inputs.max_age_days || '3' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+    steps:
+      - name: Gate on cache size
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          usage=$(gh api "repos/${GH_REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+          count=$(gh api "repos/${GH_REPO}/actions/cache/usage" --jq '.active_caches_count')
+          [[ "$usage" =~ ^[0-9]+$ ]] || { echo "::error::unexpected usage value: $usage"; exit 1; }
+          [[ "$count" =~ ^[0-9]+$ ]] || { echo "::error::unexpected count value: $count"; exit 1; }
+          high=$(( QUOTA_BYTES * HIGH_PCT / 100 ))
+          low=$((  QUOTA_BYTES * LOW_PCT  / 100 ))
+          echo "usage=$usage  high=$high  low=$low  count=$count"
+          echo "low_bytes=$low" >> "$GITHUB_OUTPUT"
+          if [[ "$usage" -lt "$high" ]]; then
+            echo "below high watermark; no cleanup needed"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "above high watermark; cleanup will run"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete stale GHA cache entries (oldest-first, down to low watermark)
+        if: steps.gate.outputs.run == 'true'
+        shell: bash
+        env:
+          LOW_BYTES: ${{ steps.gate.outputs.low_bytes }}
+        run: |
+          set -euo pipefail
+          threshold=$(date -u -d "${MAX_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Pruning entries last accessed before $threshold, down to $LOW_BYTES bytes total."
+
+          declare -A seen=()
+          deleted=0
+          skipped_preview=0
+
+          while : ; do
+            current=$(gh api "repos/${GH_REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+            [[ "$current" =~ ^[0-9]+$ ]] || { echo "::error::bad usage: $current"; exit 1; }
+            if [[ "$current" -lt "$LOW_BYTES" ]]; then
+              echo "reached low watermark"
+              break
+            fi
+
+            mapfile -t batch < <(
+              gh api "repos/${GH_REPO}/actions/caches?per_page=100&sort=last_accessed_at&direction=asc" \
+                --jq ".actions_caches[] | select(.last_accessed_at < \"$threshold\") | .id"
+            )
+            if [[ ${#batch[@]} -eq 0 ]]; then
+              echo "no entries older than $threshold remain"
+              break
+            fi
+
+            made_progress=false
+            for id in "${batch[@]}"; do
+              if [[ -n "${seen[$id]:-}" ]]; then
+                continue
+              fi
+              seen[$id]=1
+              if [[ "$DRY_RUN" == "true" ]]; then
+                if [[ $skipped_preview -lt 20 ]]; then
+                  echo "[dry-run] would delete $id"
+                fi
+                skipped_preview=$((skipped_preview + 1))
+                made_progress=true
+                continue
+              fi
+              if gh cache delete "$id" >/dev/null 2>&1; then
+                deleted=$((deleted + 1))
+                made_progress=true
+              else
+                echo "::warning::failed to delete cache id=$id"
+              fi
+              sleep 0.25
+            done
+
+            if ! $made_progress; then
+              echo "::warning::no progress in last batch (${#batch[@]} entries all failed or already seen); stopping"
+              break
+            fi
+          done
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "[dry-run] would have attempted to delete $skipped_preview entries (first 20 listed above)."
+          else
+            echo "Deleted $deleted entries."
+          fi
+
+      - name: Report post-cleanup usage
+        shell: bash
+        run: |
+          gh api "repos/${GH_REPO}/actions/cache/usage" \
+            --jq '"Remaining: \(.active_caches_count) entries, \(.active_caches_size_in_bytes / 1024 / 1024 | round) MB"'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,3 +148,44 @@ jobs:
           if ($svc) { throw "HoleBridge service still registered" }
           $path = [Environment]::GetEnvironmentVariable("Path", "Machine")
           if ($path -match [regex]::Escape($binDir)) { throw "$binDir still in PATH" }
+
+
+  cache-health:
+    name: Cache health
+    runs-on: ubuntu-latest
+    needs: [lint, test, test-installer]
+    if: always()    # report even when prior jobs failed — those are the runs most likely to leak cache
+    permissions:
+      actions: read
+    steps:
+      - name: Warn if Actions cache above 80% of quota
+        shell: python
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          # Mirrors the quota constant in cache-cleanup.yaml.
+          QUOTA_BYTES: "10737418240"       # 10 GiB
+          THRESHOLD_PCT: "80"
+        run: |
+          import json
+          import os
+          import subprocess
+
+          QUOTA = int(os.environ["QUOTA_BYTES"])
+          THRESHOLD_PCT = int(os.environ["THRESHOLD_PCT"])
+          resp = json.loads(subprocess.run(
+              ["gh", "api", "-X", "GET", f"repos/{os.environ['GH_REPO']}/actions/cache/usage"],
+              check=True, capture_output=True,
+          ).stdout)
+          usage = resp["active_caches_size_in_bytes"]
+          count = resp["active_caches_count"]
+          pct = usage * 100 // QUOTA
+          size_mb = usage // 1024 // 1024
+          print(f"Cache usage: {size_mb} MB across {count} entries ({pct}% of {QUOTA // 1024 // 1024} MB quota)")
+          if pct >= THRESHOLD_PCT:
+              print(
+                  f"::warning title=Actions cache filling up"
+                  f"::Cache at {pct}% of quota ({size_mb} MB, {count} entries). "
+                  f"cache-cleanup.yaml prunes stale entries nightly at 03:15 UTC; "
+                  f"manual trigger: gh workflow run cache-cleanup.yaml"
+              )

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,13 @@ jobs:
 
       - name: Install nextest
         shell: bash
-        run: cargo binstall --no-confirm cargo-nextest
+        env:
+          # Authenticated GitHub API has a 5000 req/h limit; without this,
+          # binstall can hit the 60 req/h unauthenticated limit and fall
+          # back to `cargo install`, which fails because nextest's
+          # `locked-tripwire` crate requires --locked.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo binstall --no-confirm --locked cargo-nextest
 
       - name: Test
         id: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,11 @@ jobs:
       - name: Build workspace (for dist-dir test fixture)
         run: cargo build --workspace
 
+      - uses: cargo-bins/cargo-binstall@v1.18.1
+
       - name: Install nextest
         shell: bash
-        run: cargo install cargo-nextest --locked
+        run: cargo binstall --no-confirm cargo-nextest
 
       - name: Test
         id: test


### PR DESCRIPTION
## Summary

- Replace `cargo install cargo-nextest --locked` (5:18-8:13 every job) with `cargo binstall cargo-nextest` (bootstrapped by `cargo-bins/cargo-binstall@v1.18.1`) — drops a prebuilt binary in ~10s.
- Add `.github/workflows/cache-cleanup.yaml`: runs daily, prunes only when cache is above 70% of quota (and only down to 50%, and never touches entries newer than 3 days). Holds the repo under its 10 GB quota without eating the cache during idle periods.

## Why

The repo cache hit 10.73 GB across 10,599 entries (over the 10 GB quota). sccache writes one GHA cache entry per compiled crate and never prunes — it relies on GHA's LRU, which at quota produces thousands of write errors (1,487 on the Apr-16 darwin/amd64 run). That failure mode turned a typical 14:33 job into 28:43.

`Swatinem/rust-cache` was rejected because it previously caused CI machines to hang in this repo.

Closes #216.

## Test plan

- [ ] CI green on this PR.
- [ ] Manual `workflow_dispatch` runs of cache-cleanup: one with `dry_run: true` at defaults (verifies prune path), one with `high_watermark_pct: 99` and `dry_run: true` (verifies idle-skip path).
- [ ] Push a follow-up source edit (single line in a test file) to the PR; confirm Test (darwin/amd64) and Test (windows/amd64) warm times drop below ~10 min.
- [ ] After merge: either `gh cache delete --all` for an instant reset, or let the scheduled workflow settle over a few days.
- [ ] 48 h later: `gh api repos/bindreams/hole/actions/cache/usage` — expect `active_caches_size_in_bytes` in the 3-5 GB band (between low and high watermarks).