### PR TITLE
tun-engine-macros: add #[freeze] proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2576,7 +2576,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3547,7 +3547,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3755,7 +3755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4839,7 +4839,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5533,7 +5533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5856,6 +5856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tauri"
 version = "2.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6171,10 +6177,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6196,6 +6202,15 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -6444,6 +6459,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6679,6 +6709,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6706,6 +6751,17 @@ dependencies = [
  "tokio-util",
  "windows-sys 0.61.2",
  "wintun-bindings",
+]
+
+[[package]]
+name = "tun-engine-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "skuld",
+ "syn 2.0.117",
+ "trybuild",
 ]
 
 [[package]]
@@ -7362,7 +7418,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7963,7 +8019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/common", "crates/bridge", "crates/hole", "xtask", "xtask-lib"]
+members = ["crates/common", "crates/bridge", "crates/hole", "crates/tun-engine-macros", "xtask", "xtask-lib"]
 exclude = ["external/galoshes"]
 resolver = "2"
 

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tun-engine-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
+
+[dev-dependencies]
+skuld = "0.1"
+trybuild = "1"
+
+[[test]]
+name = "freeze_tests"
+path = "tests/freeze_tests.rs"
+harness = false

--- a/crates/tun-engine-macros/src/lib.rs
+++ b/crates/tun-engine-macros/src/lib.rs
@@ -1,0 +1,261 @@
+//! Proc-macro support crate for `tun-engine`.
+//!
+//! Provides `#[freeze]`: given a struct with `pub` fields, generates an
+//! immutable companion (field-syntax reads, mutation blocked at compile time)
+//! and a `MutXxx` builder companion with `.freeze()`.
+//!
+//! ```ignore
+//! #[freeze]
+//! pub struct EngineConfig {
+//!     pub max_connections: usize,
+//!     pub mtu: u16,
+//! }
+//!
+//! // Usage:
+//! let mut c = MutEngineConfig { max_connections: 0, mtu: 0 };
+//! c.max_connections = 4096;
+//! let config = c.freeze();
+//! assert_eq!(config.max_connections, 4096);  // field-syntax read
+//! // config.max_connections = 0;  // compile error
+//! ```
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, spanned::Spanned, Attribute, Error, Fields, ItemStruct, Meta, Visibility};
+
+// Entry point =========================================================================================================
+
+#[proc_macro_attribute]
+pub fn freeze(args: TokenStream, input: TokenStream) -> TokenStream {
+    if !args.is_empty() {
+        return Error::new(Span::call_site(), "#[freeze] does not accept arguments")
+            .to_compile_error()
+            .into();
+    }
+
+    let input = parse_macro_input!(input as ItemStruct);
+    match expand(input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+// Expansion ===========================================================================================================
+
+fn expand(input: ItemStruct) -> syn::Result<proc_macro2::TokenStream> {
+    validate(&input)?;
+
+    let derive_default = has_derive_default(&input.attrs)?;
+    let doc_attrs: Vec<&Attribute> = input.attrs.iter().filter(|a| is_doc_attr(a)).collect();
+
+    let vis = &input.vis;
+    let name = &input.ident;
+    let mut_name = format_ident!("Mut{}", name);
+    let sealed_mod = format_ident!("__freeze_sealed_{}", name);
+    let inner_ident = format_ident!("Inner");
+
+    let fields = named_fields(&input)?;
+    let field_names: Vec<_> = fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+    let field_types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
+    let field_vis: Vec<_> = fields.named.iter().map(|f| &f.vis).collect();
+    let field_docs: Vec<Vec<&Attribute>> = fields
+        .named
+        .iter()
+        .map(|f| f.attrs.iter().filter(|a| is_doc_attr(a)).collect())
+        .collect();
+
+    // Optional Default impls ------------------------------------------------------------------------------------------
+    let default_impls = if derive_default {
+        quote! {
+            impl ::core::default::Default for #mut_name {
+                #[inline]
+                fn default() -> Self {
+                    Self {
+                        #( #field_names: ::core::default::Default::default(), )*
+                    }
+                }
+            }
+
+            impl ::core::default::Default for #name {
+                #[inline]
+                fn default() -> Self {
+                    #mut_name::default().freeze()
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let expanded = quote! {
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #vis mod #sealed_mod {
+            use super::*;
+
+            // Pub-fielded shadow — reached via Deref from the frozen struct.
+            // Exposed (pub) so that field visibility carries through to readers
+            // outside the sealed module; construction requires going through
+            // `Mut...::freeze`, which is the only path that can set the
+            // private `inner` field below.
+            pub struct #inner_ident {
+                #(
+                    #( #field_docs )*
+                    #field_vis #field_names: #field_types,
+                )*
+            }
+
+            // The frozen struct. `inner` is private to this submodule — no
+            // code outside the submodule (not even the parent module) can
+            // mutate it, since field privacy is scoped to the defining
+            // module.
+            #( #doc_attrs )*
+            pub struct #name {
+                inner: #inner_ident,
+            }
+
+            impl ::core::ops::Deref for #name {
+                type Target = #inner_ident;
+                #[inline]
+                fn deref(&self) -> &Self::Target { &self.inner }
+            }
+
+            // The mutable companion — plain pub fields, user mutates freely
+            // during construction, then calls `.freeze()` to seal.
+            pub struct #mut_name {
+                #(
+                    #( #field_docs )*
+                    #field_vis #field_names: #field_types,
+                )*
+            }
+
+            impl #mut_name {
+                /// Freeze this mutable config into its immutable counterpart.
+                #[inline]
+                pub fn freeze(self) -> #name {
+                    #name {
+                        inner: #inner_ident {
+                            #( #field_names: self.#field_names, )*
+                        },
+                    }
+                }
+            }
+        }
+
+        #vis use #sealed_mod::{#name, #mut_name};
+
+        #default_impls
+    };
+
+    Ok(expanded)
+}
+
+// Validation ==========================================================================================================
+
+fn validate(input: &ItemStruct) -> syn::Result<()> {
+    if !input.generics.params.is_empty() {
+        return Err(Error::new(
+            input.generics.span(),
+            "#[freeze] does not support generic parameters yet (v1 restriction)",
+        ));
+    }
+    if let Some(where_clause) = &input.generics.where_clause {
+        return Err(Error::new(
+            where_clause.span(),
+            "#[freeze] does not support where-clauses yet (v1 restriction)",
+        ));
+    }
+
+    let fields = named_fields(input)?;
+    if fields.named.is_empty() {
+        return Err(Error::new(fields.span(), "#[freeze] requires at least one field"));
+    }
+
+    for field in &fields.named {
+        if !matches!(field.vis, Visibility::Public(_)) {
+            return Err(Error::new(field.span(), "#[freeze] requires all fields to be `pub`"));
+        }
+        for attr in &field.attrs {
+            if !is_doc_attr(attr) {
+                return Err(Error::new(
+                    attr.span(),
+                    "#[freeze] only supports doc-comment attributes on fields",
+                ));
+            }
+        }
+    }
+
+    for attr in &input.attrs {
+        if is_doc_attr(attr) {
+            continue;
+        }
+        if is_derive_default(attr)? {
+            continue;
+        }
+        if is_derive_attr(attr) {
+            return Err(Error::new(
+                attr.span(),
+                "#[freeze] only supports `#[derive(Default)]` on the source struct; other derives are not yet supported",
+            ));
+        }
+        return Err(Error::new(
+            attr.span(),
+            "#[freeze] only supports doc-comment and `#[derive(Default)]` attributes on the source struct",
+        ));
+    }
+
+    Ok(())
+}
+
+fn named_fields(input: &ItemStruct) -> syn::Result<&syn::FieldsNamed> {
+    match &input.fields {
+        Fields::Named(named) => Ok(named),
+        Fields::Unnamed(_) => Err(Error::new(
+            input.fields.span(),
+            "#[freeze] requires a struct with named fields; tuple structs are not supported",
+        )),
+        Fields::Unit => Err(Error::new(
+            input.fields.span(),
+            "#[freeze] requires a struct with named fields; unit structs are not supported",
+        )),
+    }
+}
+
+fn is_doc_attr(attr: &Attribute) -> bool {
+    attr.path().is_ident("doc")
+}
+
+fn is_derive_attr(attr: &Attribute) -> bool {
+    attr.path().is_ident("derive")
+}
+
+fn has_derive_default(attrs: &[Attribute]) -> syn::Result<bool> {
+    for attr in attrs {
+        if is_derive_default(attr)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn is_derive_default(attr: &Attribute) -> syn::Result<bool> {
+    if !is_derive_attr(attr) {
+        return Ok(false);
+    }
+    let Meta::List(list) = &attr.meta else {
+        return Ok(false);
+    };
+    let parsed = list.parse_args_with(syn::punctuated::Punctuated::<syn::Path, syn::Token![,]>::parse_terminated)?;
+    let only_default = parsed.len() == 1 && parsed.first().map(|p| p.is_ident("Default")).unwrap_or(false);
+    if only_default {
+        Ok(true)
+    } else if parsed.iter().any(|p| p.is_ident("Default")) {
+        Err(Error::new(
+            attr.span(),
+            "#[freeze] only supports a sole `#[derive(Default)]`; combining Default with other derives is not yet supported",
+        ))
+    } else {
+        Ok(false)
+    }
+}

--- a/crates/tun-engine-macros/tests/compile_fail/args.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/args.rs
@@ -1,0 +1,8 @@
+use tun_engine_macros::freeze;
+
+#[freeze(anything)]
+pub struct Bad {
+    pub x: u32,
+}
+
+fn main() {}

--- a/crates/tun-engine-macros/tests/compile_fail/args.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/args.stderr
@@ -1,0 +1,7 @@
+error: #[freeze] does not accept arguments
+ --> tests/compile_fail/args.rs:3:1
+  |
+3 | #[freeze(anything)]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `freeze` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/tun-engine-macros/tests/compile_fail/generic.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/generic.rs
@@ -1,0 +1,8 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+pub struct Bad<T> {
+    pub x: T,
+}
+
+fn main() {}

--- a/crates/tun-engine-macros/tests/compile_fail/generic.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/generic.stderr
@@ -1,0 +1,5 @@
+error: #[freeze] does not support generic parameters yet (v1 restriction)
+ --> tests/compile_fail/generic.rs:4:15
+  |
+4 | pub struct Bad<T> {
+  |               ^

--- a/crates/tun-engine-macros/tests/compile_fail/mutate_frozen.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/mutate_frozen.rs
@@ -1,0 +1,11 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+pub struct C {
+    pub x: u32,
+}
+
+fn main() {
+    let mut c = MutC { x: 0 }.freeze();
+    c.x = 1; // should fail: Deref only, no DerefMut.
+}

--- a/crates/tun-engine-macros/tests/compile_fail/mutate_frozen.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/mutate_frozen.stderr
@@ -1,0 +1,17 @@
+warning: variable does not need to be mutable
+ --> tests/compile_fail/mutate_frozen.rs:9:9
+  |
+9 |     let mut c = MutC { x: 0 }.freeze();
+  |         ----^
+  |         |
+  |         help: remove this `mut`
+  |
+  = note: `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+error[E0594]: cannot assign to data in dereference of `C`
+  --> tests/compile_fail/mutate_frozen.rs:10:5
+   |
+10 |     c.x = 1; // should fail: Deref only, no DerefMut.
+   |     ^^^^^^^ cannot assign
+   |
+   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `C`

--- a/crates/tun-engine-macros/tests/compile_fail/non_default_derive.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/non_default_derive.rs
@@ -1,0 +1,9 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+#[derive(Clone)]
+pub struct Bad {
+    pub x: u32,
+}
+
+fn main() {}

--- a/crates/tun-engine-macros/tests/compile_fail/non_default_derive.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/non_default_derive.stderr
@@ -1,0 +1,5 @@
+error: #[freeze] only supports `#[derive(Default)]` on the source struct; other derives are not yet supported
+ --> tests/compile_fail/non_default_derive.rs:4:1
+  |
+4 | #[derive(Clone)]
+  | ^

--- a/crates/tun-engine-macros/tests/compile_fail/non_pub_field.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/non_pub_field.rs
@@ -1,0 +1,9 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+pub struct Bad {
+    pub a: u32,
+    b: u32,
+}
+
+fn main() {}

--- a/crates/tun-engine-macros/tests/compile_fail/non_pub_field.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/non_pub_field.stderr
@@ -1,0 +1,5 @@
+error: #[freeze] requires all fields to be `pub`
+ --> tests/compile_fail/non_pub_field.rs:6:5
+  |
+6 |     b: u32,
+  |     ^

--- a/crates/tun-engine-macros/tests/compile_fail/tuple_struct.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/tuple_struct.rs
@@ -1,0 +1,6 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+pub struct Bad(pub u32, pub u32);
+
+fn main() {}

--- a/crates/tun-engine-macros/tests/compile_fail/tuple_struct.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/tuple_struct.stderr
@@ -1,0 +1,5 @@
+error: #[freeze] requires a struct with named fields; tuple structs are not supported
+ --> tests/compile_fail/tuple_struct.rs:4:15
+  |
+4 | pub struct Bad(pub u32, pub u32);
+  |               ^^^^^^^^^^^^^^^^^^

--- a/crates/tun-engine-macros/tests/compile_fail/unit_struct.rs
+++ b/crates/tun-engine-macros/tests/compile_fail/unit_struct.rs
@@ -1,0 +1,6 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+pub struct Bad;
+
+fn main() {}

--- a/crates/tun-engine-macros/tests/compile_fail/unit_struct.stderr
+++ b/crates/tun-engine-macros/tests/compile_fail/unit_struct.stderr
@@ -1,0 +1,7 @@
+error: #[freeze] requires a struct with named fields; unit structs are not supported
+ --> tests/compile_fail/unit_struct.rs:3:1
+  |
+3 | #[freeze]
+  | ^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `freeze` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/tun-engine-macros/tests/compile_pass/minimal.rs
+++ b/crates/tun-engine-macros/tests/compile_pass/minimal.rs
@@ -1,0 +1,13 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+pub struct Cfg {
+    pub x: u32,
+    pub y: String,
+}
+
+fn main() {
+    let f = MutCfg { x: 1, y: "hi".into() }.freeze();
+    let _ = f.x;
+    let _ = &f.y;
+}

--- a/crates/tun-engine-macros/tests/compile_pass/with_default.rs
+++ b/crates/tun-engine-macros/tests/compile_pass/with_default.rs
@@ -1,0 +1,16 @@
+use tun_engine_macros::freeze;
+
+#[freeze]
+#[derive(Default)]
+pub struct Cfg {
+    pub x: u32,
+    pub y: String,
+}
+
+fn main() {
+    let m = MutCfg::default();
+    let f = m.freeze();
+    assert_eq!(f.x, 0);
+    assert_eq!(f.y, "");
+    let _: Cfg = Default::default();
+}

--- a/crates/tun-engine-macros/tests/freeze_tests.rs
+++ b/crates/tun-engine-macros/tests/freeze_tests.rs
@@ -1,0 +1,196 @@
+//! Runtime behavior tests for `#[freeze]`.
+//!
+//! Compile-fail cases live under `tests/compile_fail/` and are driven via
+//! `trybuild` from the `compile_fail` test below.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tun_engine_macros::freeze;
+
+fn main() {
+    skuld::run_all();
+}
+
+// Basic ===============================================================================================================
+
+#[freeze]
+pub struct Basic {
+    pub a: usize,
+    pub b: u16,
+}
+
+#[skuld::test]
+fn basic_field_read() {
+    let mut m = MutBasic { a: 0, b: 0 };
+    m.a = 42;
+    m.b = 1337;
+    let b = m.freeze();
+    assert_eq!(b.a, 42);
+    assert_eq!(b.b, 1337);
+}
+
+#[skuld::test]
+fn basic_field_read_by_reference() {
+    // Ensure Deref works transitively — e.g. inside functions that take
+    // &Basic and read fields.
+    fn read_a(b: &Basic) -> usize {
+        b.a
+    }
+    let frozen = MutBasic { a: 7, b: 1 }.freeze();
+    assert_eq!(read_a(&frozen), 7);
+}
+
+// Various types =======================================================================================================
+
+#[freeze]
+pub struct Kitchen {
+    pub u: usize,
+    pub s: String,
+    pub opt: Option<u32>,
+    pub arc: Arc<str>,
+    pub vec: Vec<u8>,
+    pub dur: Duration,
+}
+
+#[skuld::test]
+fn kitchen_sink_types() {
+    let m = MutKitchen {
+        u: 1,
+        s: "hi".into(),
+        opt: Some(2),
+        arc: Arc::from("x"),
+        vec: vec![1, 2, 3],
+        dur: Duration::from_millis(500),
+    };
+    let f = m.freeze();
+    assert_eq!(f.u, 1);
+    assert_eq!(f.s, "hi");
+    assert_eq!(f.opt, Some(2));
+    assert_eq!(&*f.arc, "x");
+    assert_eq!(f.vec, vec![1, 2, 3]);
+    assert_eq!(f.dur, Duration::from_millis(500));
+}
+
+// Trait objects =======================================================================================================
+
+pub trait MyTrait: Send + Sync {
+    fn value(&self) -> u32;
+}
+
+struct Concrete(u32);
+impl MyTrait for Concrete {
+    fn value(&self) -> u32 {
+        self.0
+    }
+}
+
+#[freeze]
+pub struct WithDyn {
+    pub boxed: Box<dyn MyTrait>,
+    pub maybe: Option<Arc<dyn MyTrait>>,
+}
+
+#[skuld::test]
+fn dyn_fields_work() {
+    let m = MutWithDyn {
+        boxed: Box::new(Concrete(7)),
+        maybe: Some(Arc::new(Concrete(9))),
+    };
+    let f = m.freeze();
+    assert_eq!(f.boxed.value(), 7);
+    assert_eq!(f.maybe.as_ref().unwrap().value(), 9);
+}
+
+// Default derive ======================================================================================================
+
+#[freeze]
+#[derive(Default)]
+pub struct WithDefault {
+    pub count: usize,
+    pub name: String,
+    pub opt: Option<u16>,
+}
+
+#[skuld::test]
+fn default_derive_on_mut() {
+    let m: MutWithDefault = Default::default();
+    assert_eq!(m.count, 0);
+    assert_eq!(m.name, "");
+    assert_eq!(m.opt, None);
+}
+
+#[skuld::test]
+fn default_derive_on_frozen() {
+    let f: WithDefault = Default::default();
+    assert_eq!(f.count, 0);
+    assert_eq!(f.name, "");
+    assert_eq!(f.opt, None);
+}
+
+#[skuld::test]
+fn default_derive_closure_style() {
+    // The idiomatic `Engine::build(... , |c| {...})` usage — demonstrate
+    // that a caller with only Default and field access can assemble a
+    // frozen config without naming every field.
+    fn build_like<F: FnOnce(&mut MutWithDefault)>(f: F) -> WithDefault {
+        let mut c = MutWithDefault::default();
+        f(&mut c);
+        c.freeze()
+    }
+    let f = build_like(|c| {
+        c.count = 99;
+        c.name = "hello".into();
+    });
+    assert_eq!(f.count, 99);
+    assert_eq!(f.name, "hello");
+    assert_eq!(f.opt, None);
+}
+
+// Visibility ==========================================================================================================
+
+mod vis_check {
+    use tun_engine_macros::freeze;
+
+    #[freeze]
+    pub(crate) struct CrateVis {
+        pub x: u32,
+    }
+
+    pub(crate) fn make(x: u32) -> CrateVis {
+        MutCrateVis { x }.freeze()
+    }
+}
+
+#[skuld::test]
+fn pub_crate_visibility_propagates() {
+    let f = vis_check::make(5);
+    assert_eq!(f.x, 5);
+}
+
+// Doc comments ========================================================================================================
+
+#[freeze]
+/// An example struct with documentation.
+pub struct Documented {
+    /// Number of widgets.
+    pub widgets: usize,
+}
+
+#[skuld::test]
+fn documented_struct_constructs() {
+    let f = MutDocumented { widgets: 3 }.freeze();
+    assert_eq!(f.widgets, 3);
+}
+
+// Compile-fail tests driven by trybuild ===============================================================================
+
+#[skuld::test]
+fn compile_fail() {
+    // Runs only when explicitly invoked; skipped if the trybuild env var isn't set.
+    // On CI this runs as part of the test suite — a fresh build verifies each
+    // listed .rs file fails to compile with the expected error.
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+    t.pass("tests/compile_pass/*.rs");
+}


### PR DESCRIPTION
Closes #218. First of four PRs extracting a standalone `tun-engine` crate from `crates/bridge/`.

## What

Adds a new `crates/tun-engine-macros/` workspace crate providing the `#[freeze]` attribute macro. Given a struct with `pub` fields, it generates:

- An **immutable** counterpart with the original name, reachable via field syntax (no accessors, no `()`), where mutation fails to compile.
- A `Mut<Name>` companion with plain pub fields plus `.freeze() -> <Name>`.

Internally, the macro emits a sealed submodule with a private `inner: Inner` field on the frozen struct. `Deref<Target = Inner>` provides field-syntax reads; the lack of `DerefMut` blocks mutation. Because `inner` lives inside the sealed submodule, mutation is impossible even from the enclosing module.

```rust
#[freeze]
#[derive(Default)]
pub struct EngineConfig {
    pub max_connections: usize,
    pub mtu: u16,
}

let cfg = {
    let mut c = MutEngineConfig::default();
    c.max_connections = 4096;
    c.mtu = 1400;
    c.freeze()
};
assert_eq!(cfg.mtu, 1400);
// cfg.mtu = 0;  // compile error (no DerefMut)
```

## v1 scope

- Named-field structs with `pub` fields.
- `Option<T>`, `Box<dyn Trait>`, `Arc<dyn Trait>`, `Vec<T>`, owned concrete types.
- `#[derive(Default)]` detected and forwarded (both `MutXxx::default()` and `Xxx::default()` emitted).
- Doc comments on struct and fields preserved.
- Visibility (`pub`, `pub(crate)`, etc.) propagated.
- **Rejected** for now: generics, lifetimes, where-clauses, tuple/unit structs, non-pub fields, non-`Default` derives, arbitrary attributes.

Widening scope (Clone/Debug forwarding, `#[cfg]` support) is tracked as a post-PR-4 task.

## Testing

- 10 runtime tests in `tests/freeze_tests.rs` using `#[skuld::test]`.
- 7 `trybuild` compile-fail cases (non-pub field, generics, tuple/unit structs, bad args, non-Default derive, mutation attempt on frozen).
- 2 `trybuild` compile-pass cases (minimal, with Default).

All tests use `#[skuld::test]` per workspace convention.

## Test plan

- [x] `cargo test -p tun-engine-macros` — all green.
- [x] `cargo test --workspace` — no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.