### PR TITLE
tun-engine: docs + README + final cleanup (PR 4/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ GUI and bridge communicate over IPC (Unix socket on macOS, named pipe on Windows
 
 ### Bridge test-isolation contract
 
-All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` and `Routing` traits in `crates/bridge/src/`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in `clippy.toml` via the `disallowed_methods` list. See `crates/bridge/src/proxy.rs` and `crates/bridge/src/routing.rs` for trait contracts, and bindreams/hole#165 for the incident that motivated the rule.
+All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` trait in `crates/bridge/src/proxy.rs` and the `Routing` trait in `crates/tun-engine/src/routing.rs`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in the workspace root `clippy.toml` via the `disallowed_methods` list (`tun_engine::routing::setup_routes` / `teardown_routes`). See bindreams/hole#165 for the incident that motivated the rule.
 
 ### Spawn-retry architecture (file-contention diagnostics)
 
@@ -73,15 +73,18 @@ equivalent cleanup from outside (plugin reaping by name as a last resort).
 ## Workspace layout
 
 ```
-crates/common/   → hole-common (shared types: protocol, config, import)
-crates/bridge/   → hole-bridge (bridge library, no binary)
-crates/hole/     → hole (Tauri app + CLI + bridge entry point, binary name: "hole")
-xtask/           → workspace task runner (`cargo xtask <stage|deps|version|...>`)
-xtask-lib/       → shared helper crate used by xtask AND crates/hole/build.rs
-external/        → Third-party source (git subrepos)
-msi-installer/   → WiX MSI installer (Python project: thin wrapper around xtask + WiX)
-scripts/         → Utility scripts (dev.py, network-reset.py, sign-release.py, ...)
-ui/              → Frontend HTML/CSS/TypeScript (Vite)
+crates/common/            → hole-common (shared types: protocol, config, import)
+crates/bridge/            → hole-bridge (bridge library, no binary)
+crates/hole/              → hole (Tauri app + CLI + bridge entry point, binary name: "hole")
+crates/tun-engine/        → general-purpose TUN + routing + packet-loop engine
+                            (consumed by hole-bridge; intended for standalone reuse)
+crates/tun-engine-macros/ → proc-macro support crate for tun-engine (`#[freeze]`)
+xtask/                    → workspace task runner (`cargo xtask <stage|deps|version|...>`)
+xtask-lib/                → shared helper crate used by xtask AND crates/hole/build.rs
+external/                 → Third-party source (git subrepos)
+msi-installer/            → WiX MSI installer (Python project: thin wrapper around xtask + WiX)
+scripts/                  → Utility scripts (dev.py, network-reset.py, sign-release.py, ...)
+ui/                       → Frontend HTML/CSS/TypeScript (Vite)
 ```
 
 Build orchestration is owned by `xtask/`. The canonical list of files that

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -2,6 +2,9 @@
 name = "tun-engine-macros"
 version = "0.1.0"
 edition = "2021"
+description = "Proc-macro support for the tun-engine crate (provides #[freeze])."
+repository = "https://github.com/bindreams/hole"
+license = "GPL-3.0-or-later"
 
 [lib]
 proc-macro = true

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -2,6 +2,15 @@
 name = "tun-engine"
 version = "0.1.0"
 edition = "2021"
+description = "Cross-platform TUN device, OS routing, gateway discovery, and a smoltcp-backed packet-loop engine for building split-tunnel VPN/proxy daemons."
+readme = "README.md"
+repository = "https://github.com/bindreams/hole"
+license = "GPL-3.0-or-later"
+keywords = ["tun", "tun2socks", "vpn", "smoltcp", "routing"]
+categories = ["network-programming"]
+# Not yet published; this crate is currently consumed path-locally by
+# `hole-bridge`. When publishing to crates.io, strip the `path = "..."`
+# from `tun-engine-macros` below.
 
 [lints]
 workspace = true

--- a/crates/tun-engine/README.md
+++ b/crates/tun-engine/README.md
@@ -1,0 +1,102 @@
+# tun-engine
+
+Cross-platform TUN device, OS routing, gateway discovery, and a
+smoltcp-backed packet-loop engine for building split-tunnel VPN / proxy
+daemons in Rust.
+
+`tun-engine` is protocol-agnostic. It handles the mechanics common to any
+tun2socks-style forwarder — opening a TUN device, running a smoltcp TCP/IP
+stack over the packets it reads, and dispatching each inbound TCP
+connection or UDP flow to a caller-supplied `Router`. Policy (what to do
+with each connection) stays in the consumer.
+
+## Status
+
+**Pre-release.** Currently consumed path-locally by the `hole-bridge`
+crate in this repository. Published documentation, crates.io release, and
+API stabilization will happen once the public surface has proven itself
+across a second consumer.
+
+## Architecture
+
+Three independently-usable modules:
+
+- **`routing`** — an OS-level `Routing` trait plus a production
+  `SystemRouting` impl that shells out to `netsh` (Windows) or
+  `route(8)` (macOS), with a JSON state file for crash recovery.
+- **`device`** — cross-platform TUN open (`Device::build`). Windows
+  additionally provides `device::wintun` for `wintun.dll` pre-loading so
+  missing-DLL failures report a descriptive path list.
+- **`engine`** — the packet-loop `Engine`. Construction is closure-based
+  (no chained builders); per-connection dispatch goes through the
+  caller-supplied `Router` trait.
+
+Plus:
+
+- **`helpers`** — ready-made splice primitives (SOCKS5 CONNECT, SOCKS5
+  UDP ASSOCIATE, interface-bound bypass sockets) that a typical `Router`
+  impl uses inline.
+- **`gateway`** — detect the system's default gateway + interface.
+- **`net`** — small OS-level socket-binding utilities.
+
+## Quickstart
+
+```rust
+use std::sync::Arc;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+use tun_engine::{Device, Engine, Router, TcpFlow, TcpMeta, UdpFlow, UdpMeta};
+
+struct MyRouter;
+
+#[async_trait]
+impl Router for MyRouter {
+    async fn route_tcp(&self, meta: TcpMeta, mut flow: TcpFlow) -> std::io::Result<()> {
+        // Optionally peek at the first bytes (e.g. for SNI-based routing).
+        let peeked = flow.peek(2048, std::time::Duration::from_millis(100)).await?;
+        // ... decide + splice: tun_engine::helpers::socks5_connect(...), etc.
+        drop(peeked);
+        drop(flow);
+        Ok(())
+    }
+
+    async fn route_udp(&self, _meta: UdpMeta, mut flow: UdpFlow) -> std::io::Result<()> {
+        while let Some(_pkt) = flow.recv().await {
+            // ... dispatch, optionally reply via flow.send(...)
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device = Device::build(|c| {
+        c.tun_name = "my-tun".into();
+        c.mtu = 1400;
+        c.ipv4 = Some("10.255.0.1/24".parse().unwrap());
+    })?;
+
+    let engine = Engine::build(device, Arc::new(MyRouter), |c| {
+        c.max_connections = 4096;
+    })?;
+
+    let cancel = CancellationToken::new();
+    engine.run(cancel).await;
+    Ok(())
+}
+```
+
+## Test-isolation contract
+
+Production I/O that mutates the host's routing tables MUST go through the
+`Routing` trait. The free functions `setup_routes` / `teardown_routes` are
+lint-disallowed outside the crate's own internals (see workspace
+`clippy.toml`). Consumers that author their own `Routing` impls can ignore
+the lint; consumers that only use `SystemRouting` get the guard-rail for
+free. Motivation: see [bindreams/hole#165][issue-165].
+
+## License
+
+GPL-3.0-or-later. See [LICENSE.md](../../LICENSE.md).
+
+[issue-165]: https://github.com/bindreams/hole/issues/165

--- a/scripts/network-reset.py
+++ b/scripts/network-reset.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import _lib
 
-# Keep in sync with `crates/bridge/src/route_state.rs::STATE_FILE_NAME`.
+# Keep in sync with `crates/tun-engine/src/routing/state.rs::STATE_FILE_NAME`.
 STATE_FILE_NAME = "bridge-routes.json"
 
 


### PR DESCRIPTION
Closes #224. Final PR of the tun-engine extraction.

## What

- **Crates.io-ready metadata** on \`tun-engine/Cargo.toml\` and \`tun-engine-macros/Cargo.toml\` (description, repository, license, keywords, categories). Not yet publishing — current consumers are path-local — but the metadata is now in place.
- **\`crates/tun-engine/README.md\`** — concise overview + quickstart + pointer to the #165 test-isolation contract.
- **\`CLAUDE.md\` refresh** — workspace layout now lists \`crates/tun-engine/\` and \`crates/tun-engine-macros/\`; the bridge test-isolation section points at the new \`Routing\` trait location in tun-engine.
- **\`scripts/network-reset.py\`** — comment updated to reference the state file's new source-of-truth path.

## Verification

- \`cargo test --workspace\` — all platforms green. Test count preserved: bridge 280 (down 67 from the dispatcher subdir move), tun-engine 78, tun-engine-macros 10 — total covers the same ground.
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- \`cargo fmt --all -- --check\` — clean.
- \`cargo doc -p tun-engine -p tun-engine-macros --no-deps\` — no new warnings.
- \`scripts/network-reset.py\` state-file resolution unchanged (filename identical).
- \`cargo xtask stage --with-tests\` auto-extends to new crates via \`cargo test --no-run --workspace\`; no xtask code changes needed.

## Extraction recap

Across PRs #218/#219 → #220/#221 → #222/#223 → this PR:

- \`crates/tun-engine/\` is a self-contained, shadowsocks-agnostic crate with \`routing\`, \`device\`, \`engine\`, \`gateway\`, \`helpers\`, \`net\` modules.
- \`crates/tun-engine-macros/\` hosts the \`#[freeze]\` proc macro.
- \`crates/bridge/\` is a thin consumer: \`HoleRouter\` implements \`tun_engine::Router\`, dispatching filter decisions into \`helpers::socks5_connect\` / \`create_bypass_tcp\` / \`splice_udp_*\` as before.
- The #165 test-isolation lint survives the move via a workspace \`clippy.toml\` path rewrite (\`tun_engine::routing::*\`) and has been red-then-green verified.

## Test plan

- [x] Local tests, clippy, fmt, docs.
- [ ] CI green.