### PR TITLE
Bump vendored galoshes for drain-timeout fix + CI coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,26 @@ jobs:
           SKULD_LABELS: "!tun"
         run: cargo nextest run --workspace
 
+      # `external/galoshes/` is a vendored sub-workspace (hole's root Cargo.toml
+      # has `exclude = ["external/galoshes"]`), so the steps above don't cover
+      # it. Run garter's tests explicitly to catch regressions in the vendored
+      # copy — e.g. the `drain_timeout` bug that silently killed v2ray-plugin
+      # ~5s after proxy start (bindreams/galoshes#19). Scoped to `-p garter` so
+      # we don't require the Go toolchain for galoshes/build.rs's v2ray-plugin
+      # binary. Runs BEFORE the TUN step on Windows because the TUN step breaks
+      # NDIS loopback for ≥120s (see #200/#207), and garter's integration tests
+      # bind 127.0.0.1 listeners. The mock-plugin prebuild mirrors galoshes'
+      # own CI pattern — `chain_integration.rs` shells out to `cargo build -p
+      # mock-plugin` at runtime, and prebuilding keeps the test's cargo-within-
+      # nextest invocation predictable.
+      - name: Build galoshes mock-plugin (vendored sub-workspace)
+        shell: bash
+        run: cargo build --manifest-path external/galoshes/Cargo.toml -p mock-plugin
+
+      - name: Test galoshes (vendored sub-workspace, garter only)
+        shell: bash
+        run: cargo nextest run --manifest-path external/galoshes/Cargo.toml -p garter
+
       - name: Test (TUN, runs last for #200)
         id: test-tun
         if: matrix.os == 'windows'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Rust build artifacts
 /target
 
+# Git worktrees
+/.worktrees
+
 # Node.js
 node_modules/
 

--- a/external/galoshes/.gitignore
+++ b/external/galoshes/.gitignore
@@ -1,5 +1,6 @@
 /target
 /.cache
 /.tmp
+/.worktrees
 CLAUDE.local.md
 .claude/*.local.*

--- a/external/galoshes/.gitrepo
+++ b/external/galoshes/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/bindreams/galoshes.git
 	branch = main
-	commit = a2cb172daca0a38adcf62b068268cb9e14d36b2d
-	parent = c66ce344c94505f2d95bbdcf0daed8381c5f8317
+	commit = 88f51f6a51fd3dcf739398eb2d78930b6cc3e514
+	parent = 0f7a4de8d687b1872bda6fc48079cd29bec2be70
 	method = merge
 	cmdver = 0.4.9

--- a/external/galoshes/.gitrepo
+++ b/external/galoshes/.gitrepo
@@ -7,6 +7,6 @@
 	remote = https://github.com/bindreams/galoshes.git
 	branch = main
 	commit = a2cb172daca0a38adcf62b068268cb9e14d36b2d
-	parent = a4f5365e8c0c5f02d3187e8cfbb730529a577a2e
+	parent = c66ce344c94505f2d95bbdcf0daed8381c5f8317
 	method = merge
 	cmdver = 0.4.9

--- a/external/galoshes/CLAUDE.md
+++ b/external/galoshes/CLAUDE.md
@@ -43,7 +43,7 @@ cargo build -p galoshes              # build galoshes (requires prior xtask step
 - Unix: `libc` for SIGTERM, file permissions (`0o700`/`0o500`), `/proc/self/fd/N` for fd-pinned exec
 - Windows: `windows` crate (safe Rust) for `GenerateConsoleCtrlEvent`, Job Objects (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`), `OpenProcess`/`TerminateProcess`, `share_mode(1)` for deny-write file handles
 - Signal handling: Unix SIGTERM+SIGINT, Windows Ctrl+C
-- Graceful shutdown: 5s drain timeout (configurable via `ChainRunner::drain_timeout`)
+- Graceful shutdown: 5s drain timeout (configurable via `ChainRunner::drain_timeout`). The timeout bounds only the post-shutdown drain phase — the chain's own lifetime is unbounded, long-running plugins run until explicitly stopped.
 
 ## SIP003 option format
 

--- a/external/galoshes/garter/src/chain.rs
+++ b/external/galoshes/garter/src/chain.rs
@@ -83,6 +83,21 @@ impl ChainRunner {
     }
 
     /// Set the drain timeout for graceful shutdown.
+    ///
+    /// Bounds the post-shutdown *drain phase* only — the interval between
+    /// shutdown being requested (via external cancel, signal, or a plugin
+    /// exiting) and force-kill of any plugins that haven't exited yet. It
+    /// does NOT bound the chain's full lifetime: a long-running plugin that
+    /// has not been asked to stop will run indefinitely regardless of this
+    /// value.
+    ///
+    /// If the drain budget expires while plugins are still running,
+    /// [`ChainRunner::run`] calls `JoinSet::abort_all` and returns
+    /// `Err(Chain("drain timeout expired"))` — unless a plugin-level error
+    /// was already captured, in which case that error takes precedence.
+    /// Note that aborted tasks are not joined before the function returns;
+    /// their underlying `Drop` impls run as the `JoinSet` is dropped, but
+    /// any terminal error produced during the abort window is lost.
     pub fn drain_timeout(mut self, timeout: Duration) -> Self {
         self.drain_timeout = timeout;
         self
@@ -172,46 +187,76 @@ impl ChainRunner {
             });
         }
 
-        // Wait for plugins to exit. Any exit (clean or error) in a multi-plugin
-        // chain means data can no longer flow, so trigger shutdown for all others.
-        // The drain timeout bounds how long we wait for remaining plugins after
-        // shutdown is first triggered.
-        let wait_result = tokio::time::timeout(self.drain_timeout, async {
-            let mut first_error: Option<crate::Error> = None;
-            while let Some(result) = set.join_next().await {
-                match result {
-                    Ok((name, Ok(()))) => {
-                        tracing::info!(plugin = %name, "exited cleanly");
-                        shutdown.cancel();
-                    }
-                    Ok((name, Err(e))) => {
-                        tracing::error!(plugin = %name, error = %e, "exited with error");
-                        if first_error.is_none() {
-                            first_error = Some(e);
-                        }
-                        shutdown.cancel();
-                    }
-                    Err(join_err) => {
-                        tracing::error!(error = %join_err, "plugin task panicked");
-                        if first_error.is_none() {
-                            first_error = Some(crate::Error::Chain(format!("plugin panicked: {join_err}")));
-                        }
-                        shutdown.cancel();
-                    }
+        // Phase 1: run unbounded until either all plugins exit naturally or
+        // shutdown is requested. Any plugin exit (clean or error) also fires
+        // `shutdown.cancel()` via `record_exit`, so in a multi-plugin chain
+        // the first exit drives the whole chain into Phase 2. `drain_timeout`
+        // deliberately does NOT bound this phase — a long-running plugin is
+        // expected to run until something tells it to stop.
+        let mut first_error: Option<crate::Error> = None;
+        loop {
+            tokio::select! {
+                () = shutdown.cancelled() => break,
+                maybe_result = set.join_next() => {
+                    let Some(result) = maybe_result else { break }; // all plugins exited
+                    record_exit(result, &mut first_error, &shutdown);
                 }
             }
-            first_error
+        }
+
+        // Phase 2: drain remaining plugins, bounded by `drain_timeout`. An
+        // empty `JoinSet` completes the inner `while let` immediately without
+        // consuming any of the budget.
+        let drain_result = tokio::time::timeout(self.drain_timeout, async {
+            while let Some(result) = set.join_next().await {
+                record_exit(result, &mut first_error, &shutdown);
+            }
         })
         .await;
 
-        match wait_result {
-            Ok(Some(e)) => Err(e),
-            Ok(None) => Ok(()),
+        match drain_result {
+            Ok(()) => first_error.map_or(Ok(()), Err),
             Err(_timeout) => {
                 tracing::warn!("drain timeout expired, aborting remaining plugins");
                 set.abort_all();
-                Err(crate::Error::Chain("drain timeout expired".into()))
+                // A plugin-level error (if captured before drain) is more
+                // diagnostic than the drain-timeout error, so it takes
+                // precedence.
+                Err(first_error.unwrap_or_else(|| crate::Error::Chain("drain timeout expired".into())))
             }
+        }
+    }
+}
+
+// Helpers =============================================================
+
+/// Shared handler for a single plugin-task exit result. Updates
+/// `first_error` on a first-write-wins basis and fires `shutdown` so the
+/// rest of the chain stops. Called from both Phase 1 and Phase 2 of
+/// `ChainRunner::run`.
+fn record_exit(
+    result: Result<(String, crate::Result<()>), tokio::task::JoinError>,
+    first_error: &mut Option<crate::Error>,
+    shutdown: &CancellationToken,
+) {
+    match result {
+        Ok((name, Ok(()))) => {
+            tracing::info!(plugin = %name, "exited cleanly");
+            shutdown.cancel();
+        }
+        Ok((name, Err(e))) => {
+            tracing::error!(plugin = %name, error = %e, "exited with error");
+            if first_error.is_none() {
+                *first_error = Some(e);
+            }
+            shutdown.cancel();
+        }
+        Err(join_err) => {
+            tracing::error!(error = %join_err, "plugin task panicked");
+            if first_error.is_none() {
+                *first_error = Some(crate::Error::Chain(format!("plugin panicked: {join_err}")));
+            }
+            shutdown.cancel();
         }
     }
 }

--- a/external/galoshes/garter/src/chain_tests.rs
+++ b/external/galoshes/garter/src/chain_tests.rs
@@ -108,6 +108,49 @@ impl ChainPlugin for FailingPlugin {
     }
 }
 
+/// Plugin that never exits and deliberately ignores `shutdown`. Models a
+/// long-running plugin (e.g. v2ray-plugin) for drain-timeout regression
+/// tests.
+struct StubbornPlugin {
+    name: String,
+}
+
+#[async_trait::async_trait]
+impl ChainPlugin for StubbornPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn run(
+        self: Box<Self>,
+        _local: SocketAddr,
+        _remote: SocketAddr,
+        _shutdown: CancellationToken,
+    ) -> crate::Result<()> {
+        std::future::pending::<crate::Result<()>>().await
+    }
+}
+
+/// Plugin that panics immediately. Exercises the `JoinError` arm of
+/// `record_exit`.
+struct PanickingPlugin;
+
+#[async_trait::async_trait]
+impl ChainPlugin for PanickingPlugin {
+    fn name(&self) -> &str {
+        "panicking"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        _local: SocketAddr,
+        _remote: SocketAddr,
+        _shutdown: CancellationToken,
+    ) -> crate::Result<()> {
+        panic!("deliberate panic for testing")
+    }
+}
+
 // ChainRunner basic tests =====
 
 #[skuld::test]
@@ -222,4 +265,172 @@ async fn cancel_token_triggers_graceful_shutdown() {
         .unwrap();
 
     assert!(result.is_ok(), "chain should exit Ok on external cancellation");
+}
+
+// Drain-timeout semantics tests =====
+
+/// A long-running plugin (one that ignores `shutdown` and never exits on
+/// its own) must not be killed before shutdown is requested. This is the
+/// primary regression gate for the drain-timeout scope fix: pre-fix,
+/// `drain_timeout` was applied to the whole chain lifetime, so
+/// `StubbornPlugin` was aborted after ≈ drain_timeout.
+#[skuld::test]
+async fn long_running_plugin_survives_past_drain_timeout() {
+    let cancel = CancellationToken::new();
+    let drain_timeout = std::time::Duration::from_millis(200);
+
+    let runner = ChainRunner::new()
+        .add(Box::new(StubbornPlugin {
+            name: "stubborn".into(),
+        }))
+        .cancel_token(cancel.clone())
+        .drain_timeout(drain_timeout);
+
+    let mut env = test_env();
+    env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
+
+    let mut handle = tokio::spawn(runner.run(env));
+
+    // Wait past drain_timeout and confirm the plugin is still running.
+    tokio::time::sleep(drain_timeout * 3).await;
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(10), &mut handle)
+            .await
+            .is_err(),
+        "chain must still be running — drain_timeout must not bound the full lifetime"
+    );
+
+    // Cancel; chain should abort the stubborn plugin within drain_timeout
+    // (+ scheduler slack) and return the drain-timeout error.
+    cancel.cancel();
+    let result = tokio::time::timeout(drain_timeout + std::time::Duration::from_millis(500), handle)
+        .await
+        .expect("chain should exit within drain_timeout after cancel")
+        .expect("no JoinError");
+
+    match result {
+        Err(crate::Error::Chain(msg)) if msg.contains("drain timeout expired") => {}
+        other => panic!("expected drain-timeout error, got {other:?}"),
+    }
+}
+
+/// When a plugin errors — triggering shutdown — and another plugin in the
+/// chain outlives the drain budget, the plugin-level error must take
+/// precedence over the drain-timeout error. The plugin error is the more
+/// diagnostic of the two.
+#[skuld::test]
+async fn first_error_preserved_across_drain() {
+    let drain_timeout = std::time::Duration::from_millis(200);
+
+    let runner = ChainRunner::new()
+        .add(Box::new(FailingPlugin))
+        .add(Box::new(StubbornPlugin {
+            name: "stubborn".into(),
+        }))
+        .drain_timeout(drain_timeout);
+
+    let mut env = test_env();
+    env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
+
+    let handle = tokio::spawn(runner.run(env));
+    let result = tokio::time::timeout(drain_timeout + std::time::Duration::from_millis(500), handle)
+        .await
+        .expect("chain should exit within drain_timeout of plugin failure")
+        .expect("no JoinError");
+
+    match result {
+        Err(crate::Error::PluginExit { code: 1, .. }) => {}
+        other => panic!("expected FailingPlugin's PluginExit error to be preserved, got {other:?}"),
+    }
+}
+
+/// A single instant-exit plugin: the chain should return `Ok(())` as soon
+/// as the plugin exits, regardless of `drain_timeout`. Exercises the
+/// Phase 1 → Phase 2 transition with an empty JoinSet — the drain phase
+/// must not block on an empty set nor introduce a minimum wait time.
+#[skuld::test]
+async fn external_cancel_drains_empty_joinset_immediately() {
+    let cancel = CancellationToken::new();
+    let drain_timeout = std::time::Duration::from_secs(5);
+
+    let runner = ChainRunner::new()
+        .add(Box::new(InstantPlugin { name: "instant".into() }))
+        .cancel_token(cancel.clone())
+        .drain_timeout(drain_timeout);
+
+    let mut env = test_env();
+    env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
+
+    let start = std::time::Instant::now();
+    let result = runner.run(env).await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok(), "single InstantPlugin chain should return Ok(())");
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "chain should return promptly (well before drain_timeout), took {elapsed:?}"
+    );
+
+    // Cancelling after the chain already exited is a no-op.
+    cancel.cancel();
+}
+
+/// External cancel fires concurrently with a plugin errors — the plugin's
+/// error must still win over any drain-timeout wrapping, regardless of
+/// which wins the Phase 1 `select!` race.
+#[skuld::test]
+async fn external_cancel_concurrent_with_plugin_error_preserves_plugin_error() {
+    let cancel = CancellationToken::new();
+    let drain_timeout = std::time::Duration::from_millis(200);
+
+    let runner = ChainRunner::new()
+        .add(Box::new(FailingPlugin))
+        .add(Box::new(StubbornPlugin {
+            name: "stubborn".into(),
+        }))
+        .cancel_token(cancel.clone())
+        .drain_timeout(drain_timeout);
+
+    let mut env = test_env();
+    env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
+
+    // Fire the external cancel as close as we can to the plugin error. Whether
+    // Phase 1 observes the plugin exit first, or `shutdown.cancelled()` first,
+    // `record_exit` must still have captured `first_error` by the time the
+    // chain returns.
+    let handle = tokio::spawn(runner.run(env));
+    cancel.cancel();
+
+    let result = tokio::time::timeout(drain_timeout + std::time::Duration::from_millis(500), handle)
+        .await
+        .expect("chain should exit within drain_timeout")
+        .expect("no JoinError");
+
+    match result {
+        Err(crate::Error::PluginExit { code: 1, .. }) => {}
+        other => panic!("expected FailingPlugin's PluginExit error to be preserved, got {other:?}"),
+    }
+}
+
+/// A plugin panic surfaces through `record_exit`'s `JoinError` arm as a
+/// `Chain` error whose message identifies the panic.
+#[skuld::test]
+async fn plugin_panic_surfaces_as_chain_error() {
+    let runner = ChainRunner::new()
+        .add(Box::new(PanickingPlugin))
+        .drain_timeout(std::time::Duration::from_millis(200));
+
+    let mut env = test_env();
+    env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
+
+    // Suppress the panic's backtrace noise in the test output.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = runner.run(env).await;
+    std::panic::set_hook(prev_hook);
+
+    match result {
+        Err(crate::Error::Chain(msg)) if msg.contains("panicked") => {}
+        other => panic!("expected Chain(\"...panicked...\") error, got {other:?}"),
+    }
 }


### PR DESCRIPTION
Closes #228.

## Summary

- Bumps `external/galoshes/` to include [bindreams/galoshes#19](https://github.com/bindreams/galoshes/pull/19) (v2ray-plugin death ~5 s after proxy start).
- Adds a new CI step that runs `cargo nextest run --manifest-path external/galoshes/Cargo.toml -p garter`, so future regressions in the vendored sub-workspace are caught — hole's root `Cargo.toml` has `exclude = ["external/galoshes"]` so the existing `cargo nextest run --workspace` steps do not cover it.
- Step is scoped to `-p garter` so we don't require the Go toolchain for `galoshes/build.rs`'s v2ray-plugin binary in CI.

## Commits

1. `gitignore .worktrees/` — missed from the existing `.gitignore` alongside `/target` etc.
2. `subrepo: fix galoshes parent ref after rebase` — `.gitrepo`'s `parent` pointed at a commit that was no longer an ancestor (upstream history changed); retargeted to `c66ce344` per `git-subrepo`'s recovery guidance.
3. `git subrepo pull external/galoshes` — standard subrepo update.
4. `ci: run galoshes tests to catch vendored sub-workspace regressions` — the new CI step.

## Test plan

- [x] `cargo nextest run --manifest-path external/galoshes/Cargo.toml -p garter` — 38 passed, 0 skipped (includes `long_running_plugin_survives_past_drain_timeout` from the galoshes fix).
- [ ] CI green on this PR — the new galoshes step, plus existing hole workspace tests.
- [ ] End-to-end `uv run scripts/dev.py` with a v2ray-plugin server: no `drain timeout expired, aborting remaining plugins` in the bridge log during a 60-second run. (Run after merge; one-off tests need both this PR merged for the fix to land.)