### PR TITLE
Upgrade skuld 0.1 -> 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "boolean_expression"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a13b46d1f5df9cd15e0215e96839bda5eb21a8718ca7e8c9e3ee168cb7e7c0"
+dependencies = [
+ "itertools",
+ "smallvec",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,6 +2882,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -5565,10 +5584,11 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skuld"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e06310cbdf3dc4c1db21297f396f41d27c2516a4f12d78cc7dcb3e3702090f9"
+checksum = "a8d0825b5522fe0fd51aa8ba7c437859bcf3afddc17059e3f81872fc7385a599"
 dependencies = [
+ "boolean_expression",
  "clap",
  "inventory",
  "libc",
@@ -5587,9 +5607,9 @@ dependencies = [
 
 [[package]]
 name = "skuld-macros"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81615ca2f468ee03c84b12390845c27f0e5a036231ecc3ed1f7dd952544b0d88"
+checksum = "548dce223d11a154daab629ef7b02e0837d973ae713d1dfc932d842132e387ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,8 @@ members = ["crates/common", "crates/bridge", "crates/handle-holders", "crates/ho
 exclude = ["external/galoshes"]
 resolver = "2"
 
+[workspace.dependencies]
+skuld = { version = "0.2", features = ["tokio"] }
+
 [workspace.lints.clippy]
 disallowed_methods = "deny"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -77,7 +77,7 @@ windows = { version = "0.62", features = [
 ferrisetw = "1.2.0"
 
 [dev-dependencies]
-skuld = { version = "0.1", features = ["tokio"] }
+skuld = { workspace = true }
 tokio = { version = "1", features = ["test-util"] }
 shadowsocks-service = { version = "1", features = ["server"] }
 rcgen = "0.13"

--- a/crates/bridge/src/test_support/skuld_fixtures.rs
+++ b/crates/bridge/src/test_support/skuld_fixtures.rs
@@ -26,10 +26,14 @@
 
 // Labels ==============================================================================================================
 
-skuld::new_label!(pub(crate) DIST_BIN, "dist_bin");
-skuld::new_label!(pub(crate) PORT_ALLOC, "port_alloc");
-skuld::new_label!(pub(crate) TUN, "tun");
-skuld::new_label!(pub(crate) IPV6, "ipv6");
+#[skuld::label]
+pub(crate) const DIST_BIN: skuld::Label;
+#[skuld::label]
+pub(crate) const PORT_ALLOC: skuld::Label;
+#[skuld::label]
+pub(crate) const TUN: skuld::Label;
+#[skuld::label]
+pub(crate) const IPV6: skuld::Label;
 
 // Fixtures ============================================================================================================
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -43,6 +43,6 @@ serde_json = "1"
 yaml_serde = "0.10"
 
 [dev-dependencies]
-skuld = "0.1"
+skuld = { workspace = true }
 log = "0.4"
 tempfile = "3"

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -29,5 +29,5 @@ windows = { version = "0.62", features = [
 ] }
 
 [dev-dependencies]
-skuld = { version = "0.1", features = ["tokio"] }
+skuld = { workspace = true }
 tempfile = "3"

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -56,7 +56,7 @@ windows = { version = "0.62", features = [
 ] }
 
 [dev-dependencies]
-skuld = "0.1"
+skuld = { workspace = true }
 axum = { version = "0.8", default-features = false, features = ["json"] }
 tower = { version = "0.5", features = ["util"] }
 tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -18,7 +18,7 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-skuld = "0.1"
+skuld = { workspace = true }
 trybuild = "1"
 
 [[test]]

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -57,4 +57,4 @@ windows = { version = "0.62", features = [
 wintun-bindings = "0.7"
 
 [dev-dependencies]
-skuld = { version = "0.1", features = ["tokio"] }
+skuld = { workspace = true }

--- a/xtask-lib/Cargo.toml
+++ b/xtask-lib/Cargo.toml
@@ -17,5 +17,5 @@ anyhow = "1"
 semver = "1"
 
 [dev-dependencies]
-skuld = "0.1"
+skuld = { workspace = true }
 tempfile = "3"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -31,5 +31,5 @@ ureq = "3"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-skuld = "0.1"
+skuld = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
Fixes #230.

## Summary

Mechanical upgrade of the `skuld` test framework from 0.1.0 to 0.2.0 across the Hole workspace. One source file + 9 manifests + lockfile.

## What changed

- `crates/bridge/src/test_support/skuld_fixtures.rs` — four label declarations migrated from the removed `skuld::new_label!` declarative macro to the new `#[skuld::label] pub(crate) const NAME: skuld::Label;` attribute form. Label strings are preserved by skuld 0.2's identifier-lowercasing (`DIST_BIN` → `"dist_bin"`, etc.), so no call-site changes are needed at `#[skuld::test(labels = [...])]` or `serial = TUN` sites.
- Root `Cargo.toml` — new `[workspace.dependencies]` section with `skuld = { version = "0.2", features = ["tokio"] }`.
- 8 per-crate `Cargo.toml` files — switched from explicit `skuld = "0.1"` pins to `skuld = { workspace = true }`.
- `Cargo.lock` — skuld + skuld-macros bumped to 0.2.0, new transitives `boolean_expression 0.4.4` and `itertools 0.9.0`. No unrelated crate changes.

## Upstream changes picked up

- Breaking: `new_label!` / `get_label!` declarative macros removed in favour of `#[skuld::label]` attribute macro.
- Non-breaking: `SKULD_LABELS` / `LabelFilter` / `serial = ...` matching is now case-insensitive.
- Non-breaking: `LabelFilter` storage canonicalised via BDDs; the `.skuld.db` SQLite coordinator performs a one-time canonicalisation scrub on first 0.2 run.
- Fix: `coordinate()` no longer panics on `SQLITE_BUSY` / `SQLITE_LOCKED` under heavy concurrency.

Release notes: https://github.com/bindreams/skuld/releases/tag/v0.2.0

## Out of scope

- `external/galoshes/` declares skuld in its own workspace. Separate repo, separate migration issue.

## Test plan

- [x] `cargo build --workspace` — clean resolve of skuld 0.2
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `SKULD_LABELS="!tun" cargo nextest run --workspace` — 780 passed, 2 skipped locally
- [ ] `SKULD_LABELS="tun" cargo nextest run --workspace` — requires elevation; validated by CI's TUN job
- [ ] CI green across `lint`, `test` (windows/amd64 non-TUN + TUN, darwin/amd64, darwin/arm64), `test-installer`, `cache-health`

## Notes

- First CI run triggers the automatic `.skuld.db` canonicalisation scrub if the runner has a cached 0.1 DB. Expected behaviour, not a migration warning.
- Local label-filter regression sanity check: under `!tun` nextest ran 780 tests; under `tun` exactly 1 test was filtered in (`e2e_none_full_tunnel_roundtrip`). Label filtering is working correctly under 0.2.