### PR TITLE
tun-engine + bridge: collapse coupled (IpAddr, u16) into SocketAddr

### DIFF
--- a/crates/bridge/src/diagnostics/etw.rs
+++ b/crates/bridge/src/diagnostics/etw.rs
@@ -99,7 +99,7 @@ use ferrisetw::provider::Provider;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::{TraceProperties, TraceTrait, UserTrace};
 use ferrisetw::{EventRecord, GUID};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::thread::JoinHandle;
 use tracing::{debug, info, warn};
 
@@ -486,7 +486,7 @@ pub(crate) struct ParsedFields {
 ///
 /// Returns `None` if bytes are too short for either family or the
 /// family field is neither AF_INET nor AF_INET6.
-pub(crate) fn parse_socket_address(bytes: &[u8]) -> Option<(IpAddr, u16)> {
+pub(crate) fn parse_socket_address(bytes: &[u8]) -> Option<SocketAddr> {
     if bytes.len() < 4 {
         return None;
     }
@@ -499,7 +499,7 @@ pub(crate) fn parse_socket_address(bytes: &[u8]) -> Option<(IpAddr, u16)> {
                 return None;
             }
             let ip = std::net::Ipv4Addr::new(bytes[4], bytes[5], bytes[6], bytes[7]);
-            Some((IpAddr::V4(ip), port))
+            Some(SocketAddr::new(IpAddr::V4(ip), port))
         }
         // AF_INET6
         23 => {
@@ -508,7 +508,7 @@ pub(crate) fn parse_socket_address(bytes: &[u8]) -> Option<(IpAddr, u16)> {
             }
             let mut octets = [0u8; 16];
             octets.copy_from_slice(&bytes[8..24]);
-            Some((IpAddr::V6(std::net::Ipv6Addr::from(octets)), port))
+            Some(SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::from(octets)), port))
         }
         _ => None,
     }
@@ -623,12 +623,12 @@ fn extract_fields(parser: &Parser) -> ParsedFields {
         .try_parse::<Vec<u8>>("LocalAddress")
         .ok()
         .and_then(|bytes| parse_socket_address(&bytes))
-        .map_or((None, None), |(a, p)| (Some(a), Some(p)));
+        .map_or((None, None), |sa| (Some(sa.ip()), Some(sa.port())));
     let (remote_addr, remote_port_from_addr) = parser
         .try_parse::<Vec<u8>>("RemoteAddress")
         .ok()
         .and_then(|bytes| parse_socket_address(&bytes))
-        .map_or((None, None), |(a, p)| (Some(a), Some(p)));
+        .map_or((None, None), |sa| (Some(sa.ip()), Some(sa.port())));
 
     ParsedFields {
         tcb: parser.try_parse::<u64>("Tcb").ok(),

--- a/crates/bridge/src/diagnostics/etw_tests.rs
+++ b/crates/bridge/src/diagnostics/etw_tests.rs
@@ -242,7 +242,10 @@ fn parse_socket_address_ipv4_loopback_port_8080() {
         0, 0, 0, 0, 0, 0, 0, 0, // sin_zero padding
     ];
     let got = parse_socket_address(&bytes);
-    assert_eq!(got, Some((IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), 8080)));
+    assert_eq!(
+        got,
+        Some(SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), 8080))
+    );
 }
 
 #[skuld::test]
@@ -254,7 +257,13 @@ fn parse_socket_address_ipv4_arbitrary_port() {
         0, 0, 0, 0, 0, 0, 0, 0,
     ];
     let got = parse_socket_address(&bytes);
-    assert_eq!(got, Some((IpAddr::V4(std::net::Ipv4Addr::new(10, 20, 30, 40)), 49152)));
+    assert_eq!(
+        got,
+        Some(SocketAddr::new(
+            IpAddr::V4(std::net::Ipv4Addr::new(10, 20, 30, 40)),
+            49152
+        ))
+    );
 }
 
 #[skuld::test]
@@ -272,7 +281,7 @@ fn parse_socket_address_ipv6_loopback() {
 
     let got = parse_socket_address(&bytes);
     let expected_addr = std::net::Ipv6Addr::LOCALHOST;
-    assert_eq!(got, Some((IpAddr::V6(expected_addr), 80)));
+    assert_eq!(got, Some(SocketAddr::new(IpAddr::V6(expected_addr), 80)));
 }
 
 #[skuld::test]

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -4,7 +4,7 @@
 //! terminal fallback is `Proxy` — this matches the bridge's
 //! "everything is proxied by default" contract.
 
-use std::net::IpAddr;
+use std::net::SocketAddr;
 
 use hole_common::config::FilterAction;
 
@@ -22,8 +22,7 @@ pub enum L4Proto {
 /// dispatcher fills this in immediately before calling `decide`.
 #[derive(Debug, Clone)]
 pub struct ConnInfo {
-    pub dst_ip: IpAddr,
-    pub dst_port: u16,
+    pub dst: SocketAddr,
     /// Set when the dispatcher recovered a domain via fake DNS reverse
     /// lookup or the TLS/HTTP sniffer. `None` for raw IP destinations.
     ///

--- a/crates/bridge/src/filter/engine_tests.rs
+++ b/crates/bridge/src/filter/engine_tests.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use hole_common::config::{FilterAction, FilterRule, MatchType};
 
@@ -17,8 +17,7 @@ fn rule(addr: &str, kind: MatchType, action: FilterAction) -> FilterRule {
 
 fn conn(dst: &str, port: u16, domain: Option<&str>) -> ConnInfo {
     ConnInfo {
-        dst_ip: dst.parse::<IpAddr>().unwrap(),
-        dst_port: port,
+        dst: SocketAddr::new(dst.parse::<IpAddr>().unwrap(), port),
         domain: domain.map(|s| s.to_string()),
         proto: L4Proto::Tcp,
     }

--- a/crates/bridge/src/filter/matcher.rs
+++ b/crates/bridge/src/filter/matcher.rs
@@ -1,6 +1,6 @@
 //! Compiled matchers for `FilterRule`s.
 //!
-//! Each `Matcher` checks one connection-level field (`domain` or `dst_ip`)
+//! Each `Matcher` checks one connection-level field (`domain` or `dst`)
 //! and reports whether it matches. Construction is fallible (`compile`)
 //! because user input may be malformed; matching itself is infallible and
 //! cheap (no allocation, no I/O).
@@ -98,8 +98,8 @@ impl Matcher {
                 let got_canon = canonicalize_for_match(got);
                 re.is_match(&got_canon)
             }
-            Matcher::ExactIp(want) => canonicalize_ip(conn.dst_ip) == *want,
-            Matcher::Subnet(net) => net.contains(&canonicalize_ip(conn.dst_ip)),
+            Matcher::ExactIp(want) => canonicalize_ip(conn.dst.ip()) == *want,
+            Matcher::Subnet(net) => net.contains(&canonicalize_ip(conn.dst.ip())),
         }
     }
 }

--- a/crates/bridge/src/filter/matcher_tests.rs
+++ b/crates/bridge/src/filter/matcher_tests.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use hole_common::config::MatchType;
 
@@ -9,8 +9,7 @@ use crate::filter::engine::{ConnInfo, L4Proto};
 
 fn ip_conn(dst: &str) -> ConnInfo {
     ConnInfo {
-        dst_ip: dst.parse().unwrap(),
-        dst_port: 443,
+        dst: SocketAddr::new(dst.parse().unwrap(), 443),
         domain: None,
         proto: L4Proto::Tcp,
     }
@@ -18,8 +17,7 @@ fn ip_conn(dst: &str) -> ConnInfo {
 
 fn dom_conn(dst: &str, domain: &str) -> ConnInfo {
     ConnInfo {
-        dst_ip: dst.parse().unwrap(),
-        dst_port: 443,
+        dst: SocketAddr::new(dst.parse().unwrap(), 443),
         domain: Some(domain.to_string()),
         proto: L4Proto::Tcp,
     }
@@ -223,8 +221,7 @@ fn exact_ip_matches_regardless_of_domain_presence() {
 fn exact_ipv4_canonicalizes_v4_mapped_v6() {
     let m = compile("1.2.3.4", MatchType::Exactly);
     let conn = ConnInfo {
-        dst_ip: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304)),
-        dst_port: 443,
+        dst: SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0102, 0x0304)), 443),
         domain: None,
         proto: L4Proto::Tcp,
     };
@@ -274,8 +271,7 @@ fn subnet_max_prefix_is_single_host() {
 fn subnet_canonicalizes_v4_mapped_v6() {
     let m = compile("10.0.0.0/8", MatchType::Subnet);
     let conn = ConnInfo {
-        dst_ip: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)),
-        dst_port: 443,
+        dst: SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001)), 443),
         domain: None,
         proto: L4Proto::Tcp,
     };
@@ -294,8 +290,7 @@ fn subnet_skips_when_family_mismatched() {
 fn loopback_ip_in_zero_subnet() {
     let m = compile("127.0.0.1", MatchType::Exactly);
     assert!(m.matches(&ConnInfo {
-        dst_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-        dst_port: 80,
+        dst: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
         domain: None,
         proto: L4Proto::Tcp,
     }));
@@ -305,8 +300,7 @@ fn loopback_ip_in_zero_subnet() {
 fn ipv6_unspecified_match() {
     let m = compile("::", MatchType::Exactly);
     assert!(m.matches(&ConnInfo {
-        dst_ip: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-        dst_port: 80,
+        dst: SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 80),
         domain: None,
         proto: L4Proto::Tcp,
     }));

--- a/crates/bridge/src/filter_tests.rs
+++ b/crates/bridge/src/filter_tests.rs
@@ -1,6 +1,8 @@
 //! Cross-module smoke tests for the filter engine. Per-module unit tests
 //! live in `filter/{rules,matcher,engine}_tests.rs`.
 
+use std::net::SocketAddr;
+
 use hole_common::config::{FilterAction, FilterRule, MatchType};
 
 use super::{decide, ConnInfo, L4Proto, RuleSet};
@@ -15,8 +17,7 @@ fn re_exports_decide_constructable_from_user_rules() {
 
     let rs = RuleSet::from_user_rules(&user_rules);
     let conn = ConnInfo {
-        dst_ip: "1.2.3.4".parse().unwrap(),
-        dst_port: 443,
+        dst: SocketAddr::new("1.2.3.4".parse().unwrap(), 443),
         domain: Some("example.com".into()),
         proto: L4Proto::Tcp,
     };

--- a/crates/bridge/src/hole_router.rs
+++ b/crates/bridge/src/hole_router.rs
@@ -114,11 +114,10 @@ impl HoleRouter {
 #[async_trait]
 impl Router for HoleRouter {
     async fn route_tcp(&self, meta: TcpMeta, mut flow: TcpFlow) -> io::Result<()> {
-        let dst_ip = meta.dst.ip();
-        let dst_port = meta.dst.port();
+        let dst = meta.dst;
 
         // Step 1: Port 53 fast path — DNS over TCP.
-        if dst_port == 53 {
+        if dst.port() == 53 {
             if let Some(ref dns) = self.fake_dns {
                 return dns.handle_tcp(&mut flow).await;
             }
@@ -129,18 +128,18 @@ impl Router for HoleRouter {
         let mut pinned = false;
 
         if let Some(ref dns) = self.fake_dns {
-            if let Some(d) = dns.reverse_lookup(dst_ip) {
+            if let Some(d) = dns.reverse_lookup(dst.ip()) {
                 domain = Some(d.to_string());
-                dns.pin(dst_ip);
+                dns.pin(dst.ip());
                 pinned = true;
             }
         }
 
-        let result = self.dispatch_tcp(&mut flow, dst_ip, dst_port, &mut domain).await;
+        let result = self.dispatch_tcp(&mut flow, dst, &mut domain).await;
 
         if pinned {
             if let Some(ref dns) = self.fake_dns {
-                dns.unpin(dst_ip);
+                dns.unpin(dst.ip());
             }
         }
 
@@ -196,13 +195,7 @@ impl DnsInterceptor for FakeDnsInterceptor {
 // TCP dispatch ========================================================================================================
 
 impl HoleRouter {
-    async fn dispatch_tcp(
-        &self,
-        flow: &mut TcpFlow,
-        dst_ip: IpAddr,
-        dst_port: u16,
-        domain: &mut Option<String>,
-    ) -> io::Result<()> {
+    async fn dispatch_tcp(&self, flow: &mut TcpFlow, dst: SocketAddr, domain: &mut Option<String>) -> io::Result<()> {
         let current_rules = self.rules.load();
 
         // Sniffer peek — only when domain is unknown AND domain rules exist.
@@ -220,8 +213,7 @@ impl HoleRouter {
         }
 
         let conn_info = ConnInfo {
-            dst_ip,
-            dst_port,
+            dst,
             domain: domain.clone(),
             proto: L4Proto::Tcp,
         };
@@ -229,15 +221,15 @@ impl HoleRouter {
         drop(current_rules);
 
         match decision.action {
-            FilterAction::Proxy => self.dispatch_tcp_proxy(flow, dst_ip, dst_port, domain).await,
-            FilterAction::Bypass => self.dispatch_tcp_bypass(flow, dst_ip, dst_port, domain).await,
+            FilterAction::Proxy => self.dispatch_tcp_proxy(flow, dst, domain).await,
+            FilterAction::Bypass => self.dispatch_tcp_bypass(flow, dst, domain).await,
             FilterAction::Block => {
                 let rule_index = decision.rule_index.unwrap_or(0) as u32;
-                let should_log = self.block_log.lock().unwrap().should_log(rule_index, dst_ip, dst_port);
+                let should_log = self.block_log.lock().unwrap().should_log(rule_index, dst);
                 if should_log {
                     match domain.as_deref() {
-                        Some(d) => debug!("blocked {d} ({dst_ip}:{dst_port}) by rule #{rule_index}"),
-                        None => debug!("blocked {dst_ip}:{dst_port} by rule #{rule_index}"),
+                        Some(d) => debug!("blocked {d} ({dst}) by rule #{rule_index}"),
+                        None => debug!("blocked {dst} by rule #{rule_index}"),
                     }
                 }
                 // Drop the flow — smoltcp sends RST.
@@ -246,14 +238,8 @@ impl HoleRouter {
         }
     }
 
-    async fn dispatch_tcp_proxy(
-        &self,
-        flow: &mut TcpFlow,
-        dst_ip: IpAddr,
-        dst_port: u16,
-        domain: &Option<String>,
-    ) -> io::Result<()> {
-        let mut upstream = socks5_connect(self.local_port, dst_ip, dst_port, domain.as_deref()).await?;
+    async fn dispatch_tcp_proxy(&self, flow: &mut TcpFlow, dst: SocketAddr, domain: &Option<String>) -> io::Result<()> {
+        let mut upstream = socks5_connect(self.local_port, dst, domain.as_deref()).await?;
         // Peeked bytes are still buffered inside `flow` — copy_bidirectional
         // will include them naturally.
         tokio::io::copy_bidirectional(flow, &mut upstream).await?;
@@ -263,11 +249,10 @@ impl HoleRouter {
     async fn dispatch_tcp_bypass(
         &self,
         flow: &mut TcpFlow,
-        dst_ip: IpAddr,
-        dst_port: u16,
+        dst: SocketAddr,
         domain: &Option<String>,
     ) -> io::Result<()> {
-        let real_ip = self.resolve_bypass_ip(dst_ip, domain.as_deref()).await?;
+        let real_ip = self.resolve_bypass_ip(dst.ip(), domain.as_deref()).await?;
 
         if real_ip.is_ipv6() && !self.ipv6_available {
             if !self.ipv6_bypass_warned.swap(true, Ordering::Relaxed) {
@@ -276,7 +261,7 @@ impl HoleRouter {
             return Ok(());
         }
 
-        let mut upstream = create_bypass_tcp(real_ip, dst_port, self.iface_index).await?;
+        let mut upstream = create_bypass_tcp(SocketAddr::new(real_ip, dst.port()), self.iface_index).await?;
         tokio::io::copy_bidirectional(flow, &mut upstream).await?;
         Ok(())
     }
@@ -300,12 +285,10 @@ impl HoleRouter {
 
 impl HoleRouter {
     async fn dispatch_udp(&self, meta: UdpMeta, flow: UdpFlow, domain: &Option<String>) -> io::Result<()> {
-        let dst_ip = meta.dst.ip();
-        let dst_port = meta.dst.port();
+        let dst = meta.dst;
 
         let conn_info = ConnInfo {
-            dst_ip,
-            dst_port,
+            dst,
             domain: domain.clone(),
             proto: L4Proto::Udp,
         };
@@ -317,19 +300,20 @@ impl HoleRouter {
 
         if action == FilterAction::Proxy && !self.udp_proxy_available {
             let mut log = self.block_log.lock().unwrap();
-            if log.should_log(decision.rule_index.unwrap_or(0) as u32, dst_ip, dst_port) {
-                warn!(dst_ip = %dst_ip, dst_port, "UDP proxy unavailable (v2ray-plugin), blocking");
+            if log.should_log(decision.rule_index.unwrap_or(0) as u32, dst) {
+                warn!(%dst, "UDP proxy unavailable (v2ray-plugin), blocking");
             }
             action = FilterAction::Block;
         }
 
-        let real_ip = if action == FilterAction::Bypass {
-            self.resolve_bypass_ip(dst_ip, domain.as_deref()).await?
+        let real_dst = if action == FilterAction::Bypass {
+            let real_ip = self.resolve_bypass_ip(dst.ip(), domain.as_deref()).await?;
+            SocketAddr::new(real_ip, dst.port())
         } else {
-            dst_ip
+            dst
         };
 
-        if action == FilterAction::Bypass && real_ip.is_ipv6() && !self.ipv6_available {
+        if action == FilterAction::Bypass && real_dst.is_ipv6() && !self.ipv6_available {
             if !self.ipv6_bypass_warned.swap(true, Ordering::Relaxed) {
                 warn!("IPv6 bypass unavailable for UDP, blocking");
             }
@@ -337,13 +321,13 @@ impl HoleRouter {
         }
 
         match action {
-            FilterAction::Proxy => splice_udp_proxy(flow, self.local_port, real_ip, dst_port, domain.clone()).await,
-            FilterAction::Bypass => splice_udp_bypass(flow, real_ip, dst_port, self.iface_index).await,
+            FilterAction::Proxy => splice_udp_proxy(flow, self.local_port, real_dst, domain.clone()).await,
+            FilterAction::Bypass => splice_udp_bypass(flow, real_dst, self.iface_index).await,
             FilterAction::Block => {
                 let rule_index = decision.rule_index.unwrap_or(0) as u32;
                 let mut log = self.block_log.lock().unwrap();
-                if log.should_log(rule_index, dst_ip, dst_port) {
-                    info!(dst_ip = %dst_ip, dst_port, domain = ?domain, "blocked UDP flow");
+                if log.should_log(rule_index, dst) {
+                    info!(%dst, domain = ?domain, "blocked UDP flow");
                 }
                 // Dropping the flow ends route_udp; any further datagrams
                 // for the 5-tuple silently fail to enqueue until the
@@ -360,8 +344,7 @@ impl HoleRouter {
 async fn splice_udp_proxy(
     mut flow: UdpFlow,
     local_port: u16,
-    real_ip: IpAddr,
-    dst_port: u16,
+    dst: SocketAddr,
     domain: Option<String>,
 ) -> io::Result<()> {
     let relay = Arc::new(Socks5UdpRelay::associate(local_port).await?);
@@ -371,7 +354,7 @@ async fn splice_udp_proxy(
     let sender: UdpSender = flow.sender();
     tokio::spawn(async move {
         let mut buf = vec![0u8; 65536];
-        while let Ok((n, _src_ip, _src_port)) = relay_rx.recv_from(&mut buf).await {
+        while let Ok((n, _src)) = relay_rx.recv_from(&mut buf).await {
             if sender.send(&buf[..n]).await.is_err() {
                 break;
             }
@@ -380,11 +363,7 @@ async fn splice_udp_proxy(
 
     // Forwarder: pull inbound datagrams from the flow, send via relay.
     while let Some(payload) = flow.recv().await {
-        if relay
-            .send_to(real_ip, dst_port, domain.as_deref(), &payload)
-            .await
-            .is_err()
-        {
+        if relay.send_to(dst, domain.as_deref(), &payload).await.is_err() {
             break;
         }
     }
@@ -393,9 +372,9 @@ async fn splice_udp_proxy(
 
 /// Relay a UdpFlow through a bypass UDP socket bound to an upstream
 /// interface.
-async fn splice_udp_bypass(mut flow: UdpFlow, real_ip: IpAddr, dst_port: u16, iface_index: u32) -> io::Result<()> {
-    let socket = create_bypass_udp(iface_index, real_ip.is_ipv6()).await?;
-    socket.connect(SocketAddr::new(real_ip, dst_port)).await?;
+async fn splice_udp_bypass(mut flow: UdpFlow, dst: SocketAddr, iface_index: u32) -> io::Result<()> {
+    let socket = create_bypass_udp(iface_index, dst.is_ipv6()).await?;
+    socket.connect(dst).await?;
     let socket = Arc::new(socket);
 
     let socket_rx = Arc::clone(&socket);

--- a/crates/bridge/src/hole_router/block_log.rs
+++ b/crates/bridge/src/hole_router/block_log.rs
@@ -1,12 +1,12 @@
 use lru::LruCache;
-use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::time::Instant;
 
 const BLOCK_LOG_LRU_CAPACITY: usize = 1024;
 const SUPPRESS_DURATION: std::time::Duration = std::time::Duration::from_secs(1);
 
-type BlockKey = (u32, IpAddr, u16);
+type BlockKey = (u32, SocketAddr);
 
 pub struct BlockLog {
     cache: LruCache<BlockKey, Instant>,
@@ -30,8 +30,8 @@ impl BlockLog {
     }
 
     /// Returns true if this block should be logged (not suppressed).
-    pub fn should_log(&mut self, rule_index: u32, dst_ip: IpAddr, dst_port: u16) -> bool {
-        let key = (rule_index, dst_ip, dst_port);
+    pub fn should_log(&mut self, rule_index: u32, dst: SocketAddr) -> bool {
+        let key = (rule_index, dst);
         let now = Instant::now();
         if let Some(last) = self.cache.get(&key) {
             if now.duration_since(*last) < SUPPRESS_DURATION {

--- a/crates/bridge/src/hole_router/block_log_tests.rs
+++ b/crates/bridge/src/hole_router/block_log_tests.rs
@@ -1,61 +1,62 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use super::BlockLog;
+
+fn sa(ip: &str, port: u16) -> SocketAddr {
+    SocketAddr::new(ip.parse::<IpAddr>().unwrap(), port)
+}
 
 #[skuld::test]
 fn first_block_is_always_logged() {
     let mut log = BlockLog::new();
-    let ip: IpAddr = "10.0.0.1".parse().unwrap();
-    assert!(log.should_log(0, ip, 443));
+    assert!(log.should_log(0, sa("10.0.0.1", 443)));
 }
 
 #[skuld::test]
 fn same_tuple_suppressed_within_one_second() {
     let mut log = BlockLog::new();
-    let ip: IpAddr = "10.0.0.1".parse().unwrap();
+    let dst = sa("10.0.0.1", 443);
 
-    assert!(log.should_log(0, ip, 443));
-    assert!(!log.should_log(0, ip, 443));
-    assert!(!log.should_log(0, ip, 443));
+    assert!(log.should_log(0, dst));
+    assert!(!log.should_log(0, dst));
+    assert!(!log.should_log(0, dst));
 }
 
 #[skuld::test]
 fn different_tuple_is_not_suppressed() {
     let mut log = BlockLog::new();
-    let ip1: IpAddr = "10.0.0.1".parse().unwrap();
-    let ip2: IpAddr = "10.0.0.2".parse().unwrap();
 
-    assert!(log.should_log(0, ip1, 443));
-    assert!(log.should_log(0, ip2, 443));
-    assert!(log.should_log(0, ip1, 80));
+    assert!(log.should_log(0, sa("10.0.0.1", 443)));
+    assert!(log.should_log(0, sa("10.0.0.2", 443)));
+    assert!(log.should_log(0, sa("10.0.0.1", 80)));
 }
 
 #[skuld::test]
 fn different_rule_index_not_suppressed() {
     let mut log = BlockLog::new();
-    let ip: IpAddr = "10.0.0.1".parse().unwrap();
+    let dst = sa("10.0.0.1", 443);
 
-    assert!(log.should_log(0, ip, 443));
-    assert!(log.should_log(1, ip, 443));
+    assert!(log.should_log(0, dst));
+    assert!(log.should_log(1, dst));
 }
 
 #[skuld::test]
 fn lru_eviction_allows_re_logging() {
     let mut log = BlockLog::with_capacity(2);
-    let ip1: IpAddr = "10.0.0.1".parse().unwrap();
-    let ip2: IpAddr = "10.0.0.2".parse().unwrap();
-    let ip3: IpAddr = "10.0.0.3".parse().unwrap();
+    let dst1 = sa("10.0.0.1", 443);
+    let dst2 = sa("10.0.0.2", 443);
+    let dst3 = sa("10.0.0.3", 443);
 
     // Fill the cache with two entries.
-    assert!(log.should_log(0, ip1, 443));
-    assert!(log.should_log(0, ip2, 443));
+    assert!(log.should_log(0, dst1));
+    assert!(log.should_log(0, dst2));
 
-    // Third entry evicts ip1.
-    assert!(log.should_log(0, ip3, 443));
+    // Third entry evicts dst1.
+    assert!(log.should_log(0, dst3));
 
-    // ip1 was evicted, so it should be logged again.
-    assert!(log.should_log(0, ip1, 443));
+    // dst1 was evicted, so it should be logged again.
+    assert!(log.should_log(0, dst1));
 
-    // ip2 and ip3 are still suppressed.
-    assert!(!log.should_log(0, ip3, 443));
+    // dst2 and dst3 are still suppressed.
+    assert!(!log.should_log(0, dst3));
 }

--- a/crates/tun-engine/src/engine/driver.rs
+++ b/crates/tun-engine/src/engine/driver.rs
@@ -400,11 +400,11 @@ impl Driver {
         let payload = &packet[payload_start..payload_end];
 
         // Port-53 DNS interception.
-        if parsed.dst_port == 53 {
+        if parsed.dst.port() == 53 {
             if let Some(interceptor) = self.dns_interceptor.clone() {
                 if let Some(reply) = interceptor.intercept(payload).await {
                     // Construct reply packet with swapped 5-tuple.
-                    let pkt = build_udp_packet(parsed.dst_ip, parsed.dst_port, parsed.src_ip, parsed.src_port, &reply);
+                    let pkt = build_udp_packet(parsed.dst, parsed.src, &reply);
                     if !pkt.is_empty() {
                         self.pending_tun_writes.push(pkt);
                     }
@@ -415,10 +415,8 @@ impl Driver {
         }
 
         let key = FlowKey {
-            src_ip: parsed.src_ip,
-            src_port: parsed.src_port,
-            dst_ip: parsed.dst_ip,
-            dst_port: parsed.dst_port,
+            src: parsed.src,
+            dst: parsed.dst,
         };
 
         // Existing flow: forward the datagram.
@@ -437,8 +435,8 @@ impl Driver {
         }
 
         let meta = UdpMeta {
-            src: SocketAddr::new(parsed.src_ip, parsed.src_port),
-            dst: SocketAddr::new(parsed.dst_ip, parsed.dst_port),
+            src: parsed.src,
+            dst: parsed.dst,
         };
         let router = Arc::clone(&self.router);
         let cancel = self.cancel.clone();
@@ -449,7 +447,7 @@ impl Driver {
                 r = router.route_udp(meta, flow) => r,
             };
             if let Err(e) = result {
-                debug!("UDP Router error for {}:{}: {e}", parsed.dst_ip, parsed.dst_port);
+                debug!("UDP Router error for {}: {e}", parsed.dst);
             }
         });
 
@@ -458,13 +456,7 @@ impl Driver {
 
     fn process_udp_replies(&mut self) {
         while let Ok(reply) = self.reply_rx.try_recv() {
-            let pkt = build_udp_packet(
-                reply.src_ip,
-                reply.src_port,
-                reply.dst_ip,
-                reply.dst_port,
-                &reply.payload,
-            );
+            let pkt = build_udp_packet(reply.src, reply.dst, &reply.payload);
             if !pkt.is_empty() {
                 self.pending_tun_writes.push(pkt);
             }
@@ -543,10 +535,8 @@ fn parse_ipv6_dst(packet: &[u8]) -> Option<(u16, IpProto)> {
 }
 
 struct ParsedPacket {
-    src_ip: IpAddr,
-    src_port: u16,
-    dst_ip: IpAddr,
-    dst_port: u16,
+    src: SocketAddr,
+    dst: SocketAddr,
     proto: IpProto,
     payload_offset: usize,
     payload_len: usize,
@@ -598,10 +588,8 @@ fn parse_ipv4_full(packet: &[u8]) -> Option<ParsedPacket> {
     };
 
     Some(ParsedPacket {
-        src_ip,
-        src_port,
-        dst_ip,
-        dst_port,
+        src: SocketAddr::new(src_ip, src_port),
+        dst: SocketAddr::new(dst_ip, dst_port),
         proto,
         payload_offset,
         payload_len,
@@ -644,10 +632,8 @@ fn parse_ipv6_full(packet: &[u8]) -> Option<ParsedPacket> {
     };
 
     Some(ParsedPacket {
-        src_ip,
-        src_port,
-        dst_ip,
-        dst_port,
+        src: SocketAddr::new(src_ip, src_port),
+        dst: SocketAddr::new(dst_ip, dst_port),
         proto,
         payload_offset,
         payload_len,
@@ -657,11 +643,15 @@ fn parse_ipv6_full(packet: &[u8]) -> Option<ParsedPacket> {
 // Reply packet construction ===========================================================================================
 
 /// Build a raw IP+UDP packet from the given fields, with correct checksums.
-fn build_udp_packet(src_ip: IpAddr, src_port: u16, dst_ip: IpAddr, dst_port: u16, payload: &[u8]) -> Vec<u8> {
+fn build_udp_packet(src: SocketAddr, dst: SocketAddr, payload: &[u8]) -> Vec<u8> {
+    debug_assert!(src.is_ipv4() == dst.is_ipv4(), "src/dst IP family mismatch");
+
     let udp_len = 8 + payload.len();
     let checksums = ChecksumCapabilities::default();
+    let src_port = src.port();
+    let dst_port = dst.port();
 
-    match (src_ip, dst_ip) {
+    match (src.ip(), dst.ip()) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
             let ip_repr = Ipv4Repr {
                 src_addr: src,

--- a/crates/tun-engine/src/engine/udp_flow.rs
+++ b/crates/tun-engine/src/engine/udp_flow.rs
@@ -11,31 +11,27 @@
 
 use std::collections::HashMap;
 use std::io;
-use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc;
 
 // Public ==============================================================================================================
 
-/// 5-tuple identifying a UDP flow (technically 4-tuple — the IP protocol
-/// field is implicit).
+/// 5-tuple identifying a UDP flow (src addr + src port + dst addr + dst
+/// port + implicit proto = UDP).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FlowKey {
-    pub src_ip: IpAddr,
-    pub src_port: u16,
-    pub dst_ip: IpAddr,
-    pub dst_port: u16,
+    pub src: SocketAddr,
+    pub dst: SocketAddr,
 }
 
 /// A UDP reply destined for the TUN side — the engine's driver wraps it
 /// into an IP+UDP packet with source/dest swapped from the Router's flow
 /// and writes it back to the TUN.
 pub(crate) struct UdpReply {
-    pub src_ip: IpAddr,
-    pub src_port: u16,
-    pub dst_ip: IpAddr,
-    pub dst_port: u16,
+    pub src: SocketAddr,
+    pub dst: SocketAddr,
     pub payload: Vec<u8>,
 }
 
@@ -118,10 +114,8 @@ impl UdpSender {
 async fn send_reply(reply_tx: &mpsc::Sender<UdpReply>, key: FlowKey, payload: &[u8]) -> io::Result<()> {
     reply_tx
         .send(UdpReply {
-            src_ip: key.dst_ip,
-            src_port: key.dst_port,
-            dst_ip: key.src_ip,
-            dst_port: key.src_port,
+            src: key.dst,
+            dst: key.src,
             payload: payload.to_vec(),
         })
         .await

--- a/crates/tun-engine/src/engine/udp_flow_tests.rs
+++ b/crates/tun-engine/src/engine/udp_flow_tests.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -11,10 +11,8 @@ fn rt() -> tokio::runtime::Runtime {
 
 fn key() -> FlowKey {
     FlowKey {
-        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-        src_port: 12345,
-        dst_ip: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
-        dst_port: 53,
+        src: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 12345),
+        dst: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
     }
 }
 
@@ -91,10 +89,8 @@ fn flow_send_constructs_reply_with_swapped_tuple() {
         flow.send(b"pong").await.unwrap();
 
         let reply = reply_rx.recv().await.unwrap();
-        assert_eq!(reply.src_ip, key().dst_ip);
-        assert_eq!(reply.src_port, key().dst_port);
-        assert_eq!(reply.dst_ip, key().src_ip);
-        assert_eq!(reply.dst_port, key().src_port);
+        assert_eq!(reply.src, key().dst);
+        assert_eq!(reply.dst, key().src);
         assert_eq!(reply.payload, b"pong");
     });
 }

--- a/crates/tun-engine/src/helpers/bypass.rs
+++ b/crates/tun-engine/src/helpers/bypass.rs
@@ -1,6 +1,6 @@
 //! Bypass-path socket helpers — interface binding + TCP/UDP connect.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 use tokio::net::TcpStream;
 
@@ -10,16 +10,15 @@ use crate::net::{bind_to_interface_v4, bind_to_interface_v6};
 
 /// Open a TCP connection via a specific upstream interface, bypassing any
 /// TUN device on the host.
-pub async fn create_bypass_tcp(dst_ip: IpAddr, dst_port: u16, iface_index: u32) -> std::io::Result<TcpStream> {
-    let dst = SocketAddr::new(dst_ip, dst_port);
-    let tcp_socket = match dst_ip {
-        IpAddr::V4(_) => {
+pub async fn create_bypass_tcp(dst: SocketAddr, iface_index: u32) -> std::io::Result<TcpStream> {
+    let tcp_socket = match dst {
+        SocketAddr::V4(_) => {
             let sock = tokio::net::TcpSocket::new_v4()?;
             let raw = socket2::SockRef::from(&sock);
             bind_to_interface_v4(&raw, iface_index)?;
             sock
         }
-        IpAddr::V6(_) => {
+        SocketAddr::V6(_) => {
             let sock = tokio::net::TcpSocket::new_v6()?;
             let raw = socket2::SockRef::from(&sock);
             bind_to_interface_v6(&raw, iface_index)?;

--- a/crates/tun-engine/src/helpers/bypass_tests.rs
+++ b/crates/tun-engine/src/helpers/bypass_tests.rs
@@ -11,7 +11,7 @@ fn bypass_socket_connects_to_loopback() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         // interface_index=1 is typically the loopback on both Windows and macOS.
-        let (connect_result, _accept) = tokio::join!(create_bypass_tcp(addr.ip(), addr.port(), 1), listener.accept());
+        let (connect_result, _accept) = tokio::join!(create_bypass_tcp(addr, 1), listener.accept());
         assert!(
             connect_result.is_ok(),
             "bypass connect failed: {:?}",

--- a/crates/tun-engine/src/helpers/socks5_client.rs
+++ b/crates/tun-engine/src/helpers/socks5_client.rs
@@ -1,6 +1,6 @@
 //! SOCKS5 CONNECT client for the proxy dispatch path.
 
-use std::net::IpAddr;
+use std::net::SocketAddr;
 
 use tokio::net::TcpStream;
 use tokio_socks::tcp::Socks5Stream;
@@ -8,30 +8,21 @@ use tokio_socks::tcp::Socks5Stream;
 /// Connect to the target through a SOCKS5 upstream.
 ///
 /// - `local_port`: SOCKS5 server's listen port on 127.0.0.1.
-/// - `dst_ip`: the connection's destination IP (may be a fake-DNS IP).
-/// - `dst_port`: the connection's destination port.
+/// - `dst`: the connection's destination address (IP may be a fake-DNS IP).
 /// - `domain`: if available, used as the SOCKS5 target (preferred to
 ///   prevent DNS leaks).
-pub async fn socks5_connect(
-    local_port: u16,
-    dst_ip: IpAddr,
-    dst_port: u16,
-    domain: Option<&str>,
-) -> std::io::Result<TcpStream> {
+pub async fn socks5_connect(local_port: u16, dst: SocketAddr, domain: Option<&str>) -> std::io::Result<TcpStream> {
     let proxy_addr = format!("127.0.0.1:{local_port}");
     let stream = match domain {
         Some(d) => {
-            let target = format!("{d}:{dst_port}");
+            let target = format!("{d}:{}", dst.port());
             Socks5Stream::connect(proxy_addr.as_str(), target.as_str())
                 .await
                 .map_err(|e| std::io::Error::other(format!("SOCKS5 connect (domain) failed: {e}")))?
         }
-        None => {
-            let target = std::net::SocketAddr::new(dst_ip, dst_port);
-            Socks5Stream::connect(proxy_addr.as_str(), target)
-                .await
-                .map_err(|e| std::io::Error::other(format!("SOCKS5 connect (IP) failed: {e}")))?
-        }
+        None => Socks5Stream::connect(proxy_addr.as_str(), dst)
+            .await
+            .map_err(|e| std::io::Error::other(format!("SOCKS5 connect (IP) failed: {e}")))?,
     };
     Ok(stream.into_inner())
 }

--- a/crates/tun-engine/src/helpers/socks5_client_tests.rs
+++ b/crates/tun-engine/src/helpers/socks5_client_tests.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use super::*;
 
@@ -9,7 +9,8 @@ fn socks5_connect_refuses_when_no_server() {
         .build()
         .unwrap();
 
-    let result = rt.block_on(socks5_connect(1, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 80, None));
+    let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 80);
+    let result = rt.block_on(socks5_connect(1, dst, None));
 
     assert!(result.is_err(), "expected error when no SOCKS5 server is listening");
 }

--- a/crates/tun-engine/src/helpers/socks5_udp.rs
+++ b/crates/tun-engine/src/helpers/socks5_udp.rs
@@ -15,8 +15,9 @@ use tokio::net::{TcpStream, UdpSocket};
 ///
 /// When `domain` is `Some`, the ATYP=Domain form is used (preferred —
 /// it lets the proxy resolve the name and avoids DNS leaks). Otherwise
-/// ATYP=IPv4/IPv6 is used with `dst_ip`.
-pub fn encode_socks5_udp(dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, payload: &[u8]) -> Vec<u8> {
+/// ATYP=IPv4/IPv6 is used with `dst.ip()`. In both cases the port comes
+/// from `dst.port()`.
+pub fn encode_socks5_udp(dst: SocketAddr, domain: Option<&str>, payload: &[u8]) -> Vec<u8> {
     let mut buf = Vec::new();
     // RSV (2 bytes) + FRAG (1 byte)
     buf.extend_from_slice(&[0x00, 0x00, 0x00]);
@@ -30,7 +31,7 @@ pub fn encode_socks5_udp(dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, pa
         buf.push(domain_bytes.len().min(255) as u8);
         buf.extend_from_slice(&domain_bytes[..domain_bytes.len().min(255)]);
     } else {
-        match dst_ip {
+        match dst.ip() {
             IpAddr::V4(v4) => {
                 buf.push(0x01); // ATYP = IPv4
                 buf.extend_from_slice(&v4.octets());
@@ -43,7 +44,7 @@ pub fn encode_socks5_udp(dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, pa
     }
 
     // DST.PORT (2 bytes, big-endian)
-    buf.extend_from_slice(&dst_port.to_be_bytes());
+    buf.extend_from_slice(&dst.port().to_be_bytes());
     // DATA
     buf.extend_from_slice(payload);
     buf
@@ -51,10 +52,17 @@ pub fn encode_socks5_udp(dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, pa
 
 /// Decode a SOCKS5 UDP datagram header (RFC 1928 §7).
 ///
-/// Returns `(src_ip, src_port, header_len)` so the payload starts at
+/// Returns `(src_addr, header_len)` so the payload starts at
 /// `data[header_len..]`. Returns `None` if the datagram is malformed or
 /// fragmented (FRAG != 0).
-pub fn decode_socks5_udp(data: &[u8]) -> Option<(IpAddr, u16, usize)> {
+///
+/// If the datagram's ATYP is `Domain` (0x03), the returned `SocketAddr`
+/// carries `IpAddr::V4(Ipv4Addr::UNSPECIFIED)` (i.e. `0.0.0.0`) as a
+/// sentinel — callers must NOT use it as a connect target. This is a
+/// pre-existing contract retained from the split-return shape; a richer
+/// return type distinguishing IP vs Domain is tracked as a follow-up
+/// (see bindreams/hole#229).
+pub fn decode_socks5_udp(data: &[u8]) -> Option<(SocketAddr, usize)> {
     // Minimum: RSV(2) + FRAG(1) + ATYP(1) + addr(4 for IPv4) + port(2) = 10
     if data.len() < 10 {
         return None;
@@ -74,7 +82,7 @@ pub fn decode_socks5_udp(data: &[u8]) -> Option<(IpAddr, u16, usize)> {
             }
             let ip = IpAddr::V4(Ipv4Addr::new(data[4], data[5], data[6], data[7]));
             let port = u16::from_be_bytes([data[8], data[9]]);
-            Some((ip, port, 10))
+            Some((SocketAddr::new(ip, port), 10))
         }
         0x03 => {
             // Domain: 1-byte length + domain string (we return 0.0.0.0 as IP
@@ -85,7 +93,7 @@ pub fn decode_socks5_udp(data: &[u8]) -> Option<(IpAddr, u16, usize)> {
                 return None;
             }
             let port = u16::from_be_bytes([data[4 + 1 + dlen], data[4 + 1 + dlen + 1]]);
-            Some((IpAddr::V4(Ipv4Addr::UNSPECIFIED), port, header_len))
+            Some((SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port), header_len))
         }
         0x04 => {
             // IPv6: 16 bytes address
@@ -97,7 +105,7 @@ pub fn decode_socks5_udp(data: &[u8]) -> Option<(IpAddr, u16, usize)> {
             octets.copy_from_slice(&data[4..20]);
             let ip = IpAddr::V6(octets.into());
             let port = u16::from_be_bytes([data[20], data[21]]);
-            Some((ip, port, header_len))
+            Some((SocketAddr::new(ip, port), header_len))
         }
         _ => None,
     }
@@ -201,27 +209,32 @@ impl Socks5UdpRelay {
     }
 
     /// Send a datagram through the relay.
-    pub async fn send_to(&self, dst_ip: IpAddr, dst_port: u16, domain: Option<&str>, payload: &[u8]) -> io::Result<()> {
-        let pkt = encode_socks5_udp(dst_ip, dst_port, domain, payload);
+    pub async fn send_to(&self, dst: SocketAddr, domain: Option<&str>, payload: &[u8]) -> io::Result<()> {
+        let pkt = encode_socks5_udp(dst, domain, payload);
         self.socket.send(&pkt).await?;
         Ok(())
     }
 
-    /// Receive a datagram from the relay. Returns `(payload_len, src_ip, src_port)`.
+    /// Receive a datagram from the relay. Returns `(payload_len, src_addr)`.
     ///
     /// The caller's `buf` receives the full SOCKS5 UDP datagram; the payload
     /// starts at `buf[header_len..]` where `header_len` is derived from
     /// [`decode_socks5_udp`].
-    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, IpAddr, u16)> {
+    ///
+    /// If the reply's ATYP is `Domain`, `src_addr` carries
+    /// `IpAddr::V4(Ipv4Addr::UNSPECIFIED)` (`0.0.0.0`) as a sentinel —
+    /// callers must NOT use it as a connect target. See
+    /// [`decode_socks5_udp`] for the full contract.
+    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         let n = self.socket.recv(buf).await?;
-        let (src_ip, src_port, header_len) =
+        let (src, header_len) =
             decode_socks5_udp(&buf[..n]).ok_or_else(|| io::Error::other("malformed SOCKS5 UDP reply"))?;
 
         // Shift payload to the front of buf for convenience.
         let payload_len = n - header_len;
         buf.copy_within(header_len..n, 0);
 
-        Ok((payload_len, src_ip, src_port))
+        Ok((payload_len, src))
     }
 
     /// The relay address returned by the SOCKS5 server.

--- a/crates/tun-engine/src/helpers/socks5_udp_tests.rs
+++ b/crates/tun-engine/src/helpers/socks5_udp_tests.rs
@@ -1,57 +1,52 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use super::*;
 
 #[skuld::test]
 fn encode_decode_roundtrip_ipv4() {
-    let dst_ip = IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34));
-    let dst_port = 443;
+    let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
     let payload = b"hello world";
 
-    let encoded = encode_socks5_udp(dst_ip, dst_port, None, payload);
-    let (ip, port, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
+    let encoded = encode_socks5_udp(dst, None, payload);
+    let (src, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
 
-    assert_eq!(ip, dst_ip);
-    assert_eq!(port, dst_port);
+    assert_eq!(src, dst);
     assert_eq!(&encoded[header_len..], payload);
 }
 
 #[skuld::test]
 fn encode_decode_roundtrip_ipv6() {
-    let dst_ip = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
-    let dst_port = 8080;
+    let dst = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)), 8080);
     let payload = b"ipv6 test";
 
-    let encoded = encode_socks5_udp(dst_ip, dst_port, None, payload);
-    let (ip, port, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
+    let encoded = encode_socks5_udp(dst, None, payload);
+    let (src, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
 
-    assert_eq!(ip, dst_ip);
-    assert_eq!(port, dst_port);
+    assert_eq!(src, dst);
     assert_eq!(&encoded[header_len..], payload);
 }
 
 #[skuld::test]
 fn encode_domain_decodes_as_unspecified_ip() {
-    let dst_ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
-    let dst_port = 53;
+    let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 53);
     let payload = b"dns query";
     let domain = "example.com";
 
-    let encoded = encode_socks5_udp(dst_ip, dst_port, Some(domain), payload);
+    let encoded = encode_socks5_udp(dst, Some(domain), payload);
 
     // ATYP should be 0x03 (domain).
     assert_eq!(encoded[3], 0x03);
 
-    let (ip, port, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
-    // Domain-type decode returns 0.0.0.0 as the IP.
-    assert_eq!(ip, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
-    assert_eq!(port, dst_port);
+    let (src, header_len) = decode_socks5_udp(&encoded).expect("decode should succeed");
+    // Domain-type decode returns 0.0.0.0 as the IP sentinel.
+    assert_eq!(src.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    assert_eq!(src.port(), dst.port());
     assert_eq!(&encoded[header_len..], payload);
 }
 
 #[skuld::test]
 fn frag_nonzero_returns_none() {
-    let mut encoded = encode_socks5_udp(IpAddr::V4(Ipv4Addr::LOCALHOST), 80, None, b"data");
+    let mut encoded = encode_socks5_udp(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80), None, b"data");
     // Set FRAG byte to non-zero.
     encoded[2] = 0x01;
     assert!(decode_socks5_udp(&encoded).is_none());
@@ -65,7 +60,7 @@ fn truncated_packet_returns_none() {
 
 #[skuld::test]
 fn unknown_atyp_returns_none() {
-    let mut encoded = encode_socks5_udp(IpAddr::V4(Ipv4Addr::LOCALHOST), 80, None, b"data");
+    let mut encoded = encode_socks5_udp(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 80), None, b"data");
     // Replace ATYP with an invalid value.
     encoded[3] = 0x05;
     assert!(decode_socks5_udp(&encoded).is_none());


### PR DESCRIPTION
## Summary

Collapse ~16 surfaces across `tun-engine` and `hole-bridge` that carry an `IpAddr` and a `u16` port as two separate fields/arguments but always use them as a pair. Closes #229.

**Breaking change to the `tun-engine` public API** (`FlowKey`, `create_bypass_tcp`, `socks5_connect`, `encode_socks5_udp`, `decode_socks5_udp`, `Socks5UdpRelay::{send_to,recv_from}`). `hole-bridge` is the only in-tree consumer today, and the crate is still pre-stabilization per its README. This is hygiene before the public surface hardens.

### Surfaces refactored

**tun-engine internals:** `ParsedPacket`, `build_udp_packet`, `UdpReply`.

**tun-engine public API:** `FlowKey`, `create_bypass_tcp`, `socks5_connect`, `encode_socks5_udp` / `decode_socks5_udp`, `Socks5UdpRelay::{send_to,recv_from}`.

**hole-bridge:** `ConnInfo`, `splice_udp_proxy`, `splice_udp_bypass`, `BlockKey` / `BlockLog::should_log`, `parse_socket_address` (which now lives up to its name).

### Notes

- `build_udp_packet` gains a `debug_assert!(src.is_ipv4() == dst.is_ipv4())` — mismatched IP families were a silent `Vec::new()` failure path.
- `decode_socks5_udp` / `Socks5UdpRelay::recv_from` preserve the pre-existing ATYP=Domain sentinel (IP = `0.0.0.0`), loudly documented in rustdoc. A richer return type (enum IP vs Domain) is out of scope; a follow-up TODO pointing at #229 is noted in the rustdoc.
- ETW `ParsedFields` stays split by design — ETW can emit a scalar `LocalPort` without a `LocalAddress` blob (see the `.or(local_port_from_addr)` fallback at `etw.rs:635`).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 317 pass; the single failure (`e2e_none_full_tunnel_roundtrip`) is a pre-existing ETW access-denied requiring admin, reproduced identically on `main`.
- [ ] Verify CI green on this PR.