### PR TITLE
Add `dump` crate: YAML-shaped logging representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "default-net",
+ "dump",
  "ferrisetw",
  "garter",
  "handle-holders",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ name = "dump"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "serde",
  "skuld",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ name = "dump"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "dump-macros",
  "serde",
  "skuld",
 ]
@@ -1401,8 +1402,10 @@ dependencies = [
 name = "dump-macros"
 version = "0.1.0"
 dependencies = [
+ "dump",
  "proc-macro2",
  "quote",
+ "skuld",
  "syn 2.0.117",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,7 @@ dependencies = [
 name = "dump"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "skuld",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dump"
+version = "0.1.0"
+dependencies = [
+ "skuld",
+]
+
+[[package]]
+name = "dump-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
-members = ["crates/common", "crates/bridge", "crates/handle-holders", "crates/hole", "crates/tun-engine", "crates/tun-engine-macros", "xtask", "xtask-lib"]
+members = ["crates/common", "crates/bridge", "crates/dump", "crates/dump-macros", "crates/handle-holders", "crates/hole", "crates/tun-engine", "crates/tun-engine-macros", "xtask", "xtask-lib"]
 exclude = ["external/galoshes"]
 resolver = "2"
 
 [workspace.dependencies]
 skuld = { version = "0.2", features = ["tokio"] }
+insta = { version = "1", features = ["yaml"] }
+trybuild = "1"
 
 [workspace.lints.clippy]
 disallowed_methods = "deny"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -14,6 +14,7 @@ harness = false
 hole-common = { path = "../common" }
 handle-holders = { path = "../handle-holders" }
 tun-engine = { path = "../tun-engine" }
+dump = { path = "../dump" }
 garter = { path = "../../external/galoshes/garter" }
 shadowsocks-service = { version = "1", features = ["local", "local-http", "aead-cipher-2022"] }
 shadowsocks = "=1.24.0"

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -29,6 +29,7 @@
 use std::net::IpAddr;
 use std::time::Instant;
 
+use dump::{dump, DeriveDump};
 use hole_common::protocol::{ProxyConfig, TunnelMode};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
@@ -36,6 +37,21 @@ use tun_engine::gateway::GatewayInfo;
 use tun_engine::routing::{Routing, SystemRouting};
 
 use crate::proxy::{build_ss_config, Proxy, ProxyError, RunningProxy, ShadowsocksProxy, TUN_DEVICE_NAME};
+
+/// Non-secret diagnostic view of a proxy-start event — suitable for
+/// YAML-shaped logging via `dump!`. Deliberately excludes password /
+/// PSK fields; `ServerEntry` itself is not `Dump` so it cannot be
+/// dropped into a log by mistake.
+#[derive(DeriveDump)]
+struct ProxyStartedDiag<'a> {
+    server_ip: Option<IpAddr>,
+    server_host: &'a str,
+    server_port: u16,
+    local_port: u16,
+    tunnel_mode: &'a str,
+    udp_proxy_available: bool,
+    ipv6_bypass_available: bool,
+}
 
 // State ===============================================================================================================
 
@@ -237,11 +253,21 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 let server_ip = state.server_ip;
                 self.udp_proxy_available = state.udp_proxy_available;
                 self.ipv6_bypass_available = state.ipv6_bypass_available;
+                let udp_proxy_available = self.udp_proxy_available;
+                let ipv6_bypass_available = self.ipv6_bypass_available;
                 self.running = Some(state);
                 self.active_config = Some(config.clone());
                 self.last_error = None;
-                info!(server_ip = ?server_ip, "proxy started");
-                debug!(local_port = config.local_port, "proxy started (debug)");
+                let diag = ProxyStartedDiag {
+                    server_ip,
+                    server_host: &config.server.server,
+                    server_port: config.server.server_port,
+                    local_port: config.local_port,
+                    tunnel_mode: tunnel_mode_label(&config.tunnel_mode),
+                    udp_proxy_available,
+                    ipv6_bypass_available,
+                };
+                info!(started = %dump!(&diag), "proxy started");
                 Ok(())
             }
             Err(ProxyError::Cancelled) => {
@@ -540,6 +566,16 @@ async fn resolve_server_ip(host: &str, port: u16) -> Result<IpAddr, ProxyError> 
         })?;
 
     Ok(addr.ip())
+}
+
+/// Stable human-readable label for a `TunnelMode` — used by
+/// `ProxyStartedDiag` so the dump output doesn't vary with Debug
+/// formatting changes.
+fn tunnel_mode_label(mode: &TunnelMode) -> &'static str {
+    match mode {
+        TunnelMode::Full => "full",
+        TunnelMode::SocksOnly => "socks_only",
+    }
 }
 
 #[cfg(test)]

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -16,3 +16,12 @@ workspace = true
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
+
+[dev-dependencies]
+dump = { path = "../dump" }
+skuld = { workspace = true }
+
+[[test]]
+name = "derive_tests"
+path = "tests/derive_tests.rs"
+harness = false

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dump-macros"
+version = "0.1.0"
+edition = "2021"
+description = "Proc-macro support for the dump crate (provides #[derive(Dump)])."
+repository = "https://github.com/bindreams/hole"
+license = "GPL-3.0-or-later"
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crates/dump-macros/src/lib.rs
+++ b/crates/dump-macros/src/lib.rs
@@ -1,5 +1,208 @@
-//! Proc-macro support for the `dump` crate.
+//! Proc-macro support for the `dump` crate — provides
+//! `#[derive(Dump)]`.
 //!
-//! The `#[derive(Dump)]` macro ships in a subsequent commit; this file
-//! currently exists only as a skeleton so that the workspace includes
-//! the crate and other crates can depend on it as work lands.
+//! v1 attribute vocabulary:
+//!
+//! - Field: `#[dump(skip)]`, `#[dump(rename = "...")]`,
+//!   `#[dump(secret)]`.
+//! - Container: (none yet.)
+//!
+//! Future commits may add `rename_all`, `flatten`, `via`, and `tag`.
+//! The derive emits absolute paths (`::dump::...`) so it works from any
+//! downstream crate.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{parse_macro_input, Data, DataEnum, DataStruct, DeriveInput, Fields, Ident, LitStr};
+
+#[proc_macro_derive(Dump, attributes(dump))]
+pub fn derive_dump(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match derive_impl(&input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let name = &input.ident;
+    // Add `T: ::dump::Dump` bound for every type parameter, matching
+    // what `#[derive(Debug)]` does for its own bound.
+    let mut generics = input.generics.clone();
+    for p in generics.type_params_mut() {
+        p.bounds.push(syn::parse_quote!(::dump::Dump));
+    }
+    let (impl_gen, type_gen, where_clause) = generics.split_for_impl();
+
+    let body = match &input.data {
+        Data::Struct(s) => gen_struct(s)?,
+        Data::Enum(e) => gen_enum(e, name)?,
+        Data::Union(_) => {
+            return Err(syn::Error::new_spanned(name, "Dump cannot be derived for unions"));
+        }
+    };
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_gen ::dump::Dump for #name #type_gen #where_clause {
+            fn dump(&self) -> ::dump::DumpValue {
+                #body
+            }
+        }
+    })
+}
+
+#[derive(Default)]
+struct FieldConfig {
+    skip: bool,
+    secret: bool,
+    rename: Option<String>,
+}
+
+fn parse_field_attrs(attrs: &[syn::Attribute]) -> syn::Result<FieldConfig> {
+    let mut c = FieldConfig::default();
+    for attr in attrs {
+        if !attr.path().is_ident("dump") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("skip") {
+                c.skip = true;
+            } else if meta.path.is_ident("secret") {
+                c.secret = true;
+            } else if meta.path.is_ident("rename") {
+                let s: LitStr = meta.value()?.parse()?;
+                c.rename = Some(s.value());
+            } else {
+                return Err(meta.error("unknown `dump` attribute"));
+            }
+            Ok(())
+        })?;
+    }
+    Ok(c)
+}
+
+fn wrap_secret(expr: TokenStream2, secret: bool) -> TokenStream2 {
+    if secret {
+        quote! {
+            ::dump::DumpValue::tagged(::dump::tag::SECRET, #expr)
+        }
+    } else {
+        expr
+    }
+}
+
+fn gen_struct(s: &DataStruct) -> syn::Result<TokenStream2> {
+    match &s.fields {
+        Fields::Named(named) => {
+            let mut entries = Vec::new();
+            for f in &named.named {
+                let cfg = parse_field_attrs(&f.attrs)?;
+                if cfg.skip {
+                    continue;
+                }
+                let ident = f.ident.as_ref().unwrap();
+                let key = cfg.rename.unwrap_or_else(|| ident.to_string());
+                let value = wrap_secret(quote! { ::dump::Dump::dump(&self.#ident) }, cfg.secret);
+                entries.push(quote! {
+                    (::dump::DumpValue::String(#key.into()), #value)
+                });
+            }
+            Ok(quote! {
+                ::dump::DumpValue::Map(vec![#(#entries),*])
+            })
+        }
+        Fields::Unnamed(unnamed) => {
+            let mut items = Vec::new();
+            for (i, f) in unnamed.unnamed.iter().enumerate() {
+                let cfg = parse_field_attrs(&f.attrs)?;
+                if cfg.skip {
+                    continue;
+                }
+                let idx = syn::Index::from(i);
+                let value = wrap_secret(quote! { ::dump::Dump::dump(&self.#idx) }, cfg.secret);
+                items.push(value);
+            }
+            Ok(quote! {
+                ::dump::DumpValue::Seq(vec![#(#items),*])
+            })
+        }
+        Fields::Unit => Ok(quote! { ::dump::DumpValue::Null }),
+    }
+}
+
+fn gen_enum(e: &DataEnum, name: &Ident) -> syn::Result<TokenStream2> {
+    let mut arms = Vec::new();
+    for v in &e.variants {
+        let vname = &v.ident;
+        let vname_str = vname.to_string();
+        let arm = match &v.fields {
+            Fields::Unit => quote! {
+                #name::#vname => ::dump::DumpValue::String(#vname_str.into())
+            },
+            Fields::Unnamed(unnamed) => {
+                let n = unnamed.unnamed.len();
+                let fields: Vec<_> = (0..n)
+                    .map(|i| Ident::new(&format!("__f{}", i), proc_macro2::Span::call_site()))
+                    .collect();
+
+                if n == 1 {
+                    let f = &fields[0];
+                    let cfg = parse_field_attrs(&unnamed.unnamed[0].attrs)?;
+                    let value = wrap_secret(quote! { ::dump::Dump::dump(#f) }, cfg.secret);
+                    quote! {
+                        #name::#vname(#f) => ::dump::DumpValue::Map(vec![(
+                            ::dump::DumpValue::String(#vname_str.into()),
+                            #value,
+                        )])
+                    }
+                } else {
+                    let mut dumps = Vec::new();
+                    for (i, raw) in unnamed.unnamed.iter().enumerate() {
+                        let cfg = parse_field_attrs(&raw.attrs)?;
+                        if cfg.skip {
+                            continue;
+                        }
+                        let fi = &fields[i];
+                        dumps.push(wrap_secret(quote! { ::dump::Dump::dump(#fi) }, cfg.secret));
+                    }
+                    quote! {
+                        #name::#vname(#(#fields),*) => ::dump::DumpValue::Map(vec![(
+                            ::dump::DumpValue::String(#vname_str.into()),
+                            ::dump::DumpValue::Seq(vec![#(#dumps),*]),
+                        )])
+                    }
+                }
+            }
+            Fields::Named(named) => {
+                let field_idents: Vec<&Ident> = named.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+                let mut entries = Vec::new();
+                for f in &named.named {
+                    let cfg = parse_field_attrs(&f.attrs)?;
+                    if cfg.skip {
+                        continue;
+                    }
+                    let fi = f.ident.as_ref().unwrap();
+                    let key = cfg.rename.unwrap_or_else(|| fi.to_string());
+                    let value = wrap_secret(quote! { ::dump::Dump::dump(#fi) }, cfg.secret);
+                    entries.push(quote! {
+                        (::dump::DumpValue::String(#key.into()), #value)
+                    });
+                }
+                quote! {
+                    #name::#vname { #(#field_idents),* } => ::dump::DumpValue::Map(vec![(
+                        ::dump::DumpValue::String(#vname_str.into()),
+                        ::dump::DumpValue::Map(vec![#(#entries),*]),
+                    )])
+                }
+            }
+        };
+        arms.push(arm);
+    }
+    Ok(quote! {
+        match self {
+            #(#arms,)*
+        }
+    })
+}

--- a/crates/dump-macros/src/lib.rs
+++ b/crates/dump-macros/src/lib.rs
@@ -1,0 +1,5 @@
+//! Proc-macro support for the `dump` crate.
+//!
+//! The `#[derive(Dump)]` macro ships in a subsequent commit; this file
+//! currently exists only as a skeleton so that the workspace includes
+//! the crate and other crates can depend on it as work lands.

--- a/crates/dump-macros/tests/derive_tests.rs
+++ b/crates/dump-macros/tests/derive_tests.rs
@@ -1,0 +1,148 @@
+//! Integration tests for `#[derive(Dump)]`.
+//!
+//! Kept as an integration test rather than a unit test because the
+//! derive macro emits `::dump::...` paths, which resolve to the `dump`
+//! crate only from a separate compilation unit.
+
+use dump::{tag, Dump, DumpValue};
+use dump_macros::Dump as DeriveDump;
+
+fn main() {
+    skuld::run_all();
+}
+
+// Structs =============================================================================================================
+
+#[derive(DeriveDump)]
+struct Empty;
+
+#[derive(DeriveDump)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(DeriveDump)]
+struct Pair(i32, i32);
+
+#[derive(DeriveDump)]
+struct Credentials {
+    user: String,
+    #[dump(secret)]
+    password: String,
+    #[dump(skip)]
+    _internal: i32,
+    #[dump(rename = "api-key")]
+    api_key: String,
+}
+
+#[skuld::test]
+fn unit_struct_dumps_as_null() {
+    assert_eq!(Empty.dump(), DumpValue::Null);
+}
+
+#[skuld::test]
+fn named_struct_dumps_as_map_in_declaration_order() {
+    let p = Point { x: 1, y: 2 };
+    assert_eq!(
+        p.dump(),
+        DumpValue::Map(vec![
+            (DumpValue::String("x".into()), DumpValue::Int(1)),
+            (DumpValue::String("y".into()), DumpValue::Int(2)),
+        ])
+    );
+}
+
+#[skuld::test]
+fn tuple_struct_dumps_as_seq() {
+    assert_eq!(
+        Pair(10, 20).dump(),
+        DumpValue::Seq(vec![DumpValue::Int(10), DumpValue::Int(20)])
+    );
+}
+
+#[skuld::test]
+fn field_attributes_work() {
+    let c = Credentials {
+        user: "alice".into(),
+        password: "hunter2".into(),
+        _internal: 99,
+        api_key: "xyz".into(),
+    };
+    assert_eq!(
+        c.dump(),
+        DumpValue::Map(vec![
+            (DumpValue::String("user".into()), DumpValue::String("alice".into())),
+            (
+                DumpValue::String("password".into()),
+                DumpValue::tagged(tag::SECRET, DumpValue::String("hunter2".into())),
+            ),
+            // _internal is skipped.
+            (DumpValue::String("api-key".into()), DumpValue::String("xyz".into()),),
+        ])
+    );
+}
+
+// Enums ===============================================================================================================
+
+#[derive(DeriveDump)]
+enum Shape {
+    Dot,
+    Line(i32),
+    Segment(i32, i32),
+    Rect { w: i32, h: i32 },
+}
+
+#[skuld::test]
+fn unit_variant_dumps_as_string() {
+    assert_eq!(Shape::Dot.dump(), DumpValue::String("Dot".into()));
+}
+
+#[skuld::test]
+fn newtype_variant_dumps_as_single_key_map() {
+    assert_eq!(
+        Shape::Line(5).dump(),
+        DumpValue::Map(vec![(DumpValue::String("Line".into()), DumpValue::Int(5),)])
+    );
+}
+
+#[skuld::test]
+fn tuple_variant_dumps_as_map_with_seq_payload() {
+    assert_eq!(
+        Shape::Segment(1, 2).dump(),
+        DumpValue::Map(vec![(
+            DumpValue::String("Segment".into()),
+            DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2)]),
+        )])
+    );
+}
+
+#[skuld::test]
+fn struct_variant_dumps_as_map_with_map_payload() {
+    assert_eq!(
+        Shape::Rect { w: 3, h: 4 }.dump(),
+        DumpValue::Map(vec![(
+            DumpValue::String("Rect".into()),
+            DumpValue::Map(vec![
+                (DumpValue::String("w".into()), DumpValue::Int(3)),
+                (DumpValue::String("h".into()), DumpValue::Int(4)),
+            ]),
+        )])
+    );
+}
+
+// Generic structs =====================================================================================================
+
+#[derive(DeriveDump)]
+struct Wrapper<T> {
+    inner: T,
+}
+
+#[skuld::test]
+fn generic_struct_works_with_dump_bound() {
+    let w = Wrapper { inner: 7_i32 };
+    assert_eq!(
+        w.dump(),
+        DumpValue::Map(vec![(DumpValue::String("inner".into()), DumpValue::Int(7),)])
+    );
+}

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dump"
+version = "0.1.0"
+edition = "2021"
+description = "YAML-shaped representation for logging, analogous to Python's dump() alongside str()/repr()."
+repository = "https://github.com/bindreams/hole"
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+harness = false
+
+[dependencies]
+
+[dev-dependencies]
+skuld = { workspace = true }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -14,6 +14,7 @@ harness = false
 
 [dependencies]
 base64 = "0.22"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 skuld = { workspace = true }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 harness = false
 
 [dependencies]
+base64 = "0.22"
 
 [dev-dependencies]
 skuld = { workspace = true }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -14,6 +14,7 @@ harness = false
 
 [dependencies]
 base64 = "0.22"
+dump-macros = { path = "../dump-macros" }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/dump/src/debug_bridge.rs
+++ b/crates/dump/src/debug_bridge.rs
@@ -1,0 +1,11 @@
+//! Debug-fallback rung of the autoref ladder.
+
+use std::fmt::Debug;
+
+use crate::value::tag;
+use crate::DumpValue;
+
+/// Emit any `Debug` value as `!debug "<formatted>"`.
+pub(crate) fn to_dump_value<T: Debug + ?Sized>(value: &T) -> DumpValue {
+    DumpValue::tagged(tag::DEBUG, DumpValue::String(format!("{:?}", value)))
+}

--- a/crates/dump/src/display.rs
+++ b/crates/dump/src/display.rs
@@ -1,0 +1,41 @@
+//! [`DumpDisplay`] — a [`std::fmt::Display`] wrapper around a
+//! [`DumpValue`].
+
+use std::fmt;
+
+use crate::format::YamlFormatter;
+use crate::DumpValue;
+
+/// Owns a [`DumpValue`] and renders it as YAML via [`std::fmt::Display`].
+///
+/// This is what the `dump!` macro (added in a later commit) returns.
+/// `Clone` is derived because `tracing` captures field values into
+/// span storage, and non-`Clone` wrappers are an ergonomic trap.
+#[derive(Clone, Debug)]
+pub struct DumpDisplay {
+    value: DumpValue,
+}
+
+impl DumpDisplay {
+    pub fn new(value: DumpValue) -> Self {
+        Self { value }
+    }
+
+    pub fn value(&self) -> &DumpValue {
+        &self.value
+    }
+
+    pub fn into_value(self) -> DumpValue {
+        self.value
+    }
+}
+
+impl fmt::Display for DumpDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        YamlFormatter::default().write(f, &self.value)
+    }
+}
+
+#[cfg(test)]
+#[path = "display_tests.rs"]
+mod display_tests;

--- a/crates/dump/src/display_tests.rs
+++ b/crates/dump/src/display_tests.rs
@@ -1,0 +1,22 @@
+use super::DumpDisplay;
+use crate::value::tag;
+use crate::DumpValue;
+
+#[skuld::test]
+fn display_renders_via_default_formatter() {
+    let d = DumpDisplay::new(DumpValue::String("hi".into()));
+    assert_eq!(format!("{}", d), "hi");
+}
+
+#[skuld::test]
+fn display_redacts_secrets_by_default() {
+    let d = DumpDisplay::new(DumpValue::tagged(tag::SECRET, DumpValue::String("pw".into())));
+    assert_eq!(format!("{}", d), "!secret [REDACTED]");
+}
+
+#[skuld::test]
+fn display_is_cloneable() {
+    let d = DumpDisplay::new(DumpValue::Int(1));
+    let d2 = d.clone();
+    assert_eq!(format!("{}", d), format!("{}", d2));
+}

--- a/crates/dump/src/dump_trait.rs
+++ b/crates/dump/src/dump_trait.rs
@@ -1,0 +1,33 @@
+//! The [`Dump`] trait.
+
+use crate::DumpValue;
+
+/// Produce a YAML-shaped representation of a value for logging.
+///
+/// Unlike [`std::fmt::Debug`], `Dump` is allowed (and encouraged) to
+/// omit fields, reorder, tag values as secret, or otherwise present
+/// information in a form that serves a human reader. A failing Dump
+/// impl reports the failure as `DumpValue::tagged(tag::ERROR, ...)`
+/// rather than panicking — the trait is infallible by construction so
+/// that logging can never itself fail.
+pub trait Dump {
+    fn dump(&self) -> DumpValue;
+}
+
+/// Blanket `&T`: referencing a Dump type dumps the same way.
+impl<T: Dump + ?Sized> Dump for &T {
+    fn dump(&self) -> DumpValue {
+        (**self).dump()
+    }
+}
+
+/// Blanket `&mut T`: mutably-referencing a Dump type dumps the same way.
+impl<T: Dump + ?Sized> Dump for &mut T {
+    fn dump(&self) -> DumpValue {
+        (**self).dump()
+    }
+}
+
+#[cfg(test)]
+#[path = "dump_trait_tests.rs"]
+mod dump_trait_tests;

--- a/crates/dump/src/dump_trait_tests.rs
+++ b/crates/dump/src/dump_trait_tests.rs
@@ -1,0 +1,31 @@
+use super::Dump;
+use crate::DumpValue;
+
+struct Marker;
+
+impl Dump for Marker {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String("marker".into())
+    }
+}
+
+#[skuld::test]
+fn ref_and_mut_ref_delegate_to_inner() {
+    let m = Marker;
+    let r = &m;
+    let expected = DumpValue::String("marker".into());
+    assert_eq!(m.dump(), expected);
+    assert_eq!(r.dump(), expected);
+
+    let mut m2 = Marker;
+    let rm: &mut Marker = &mut m2;
+    assert_eq!(rm.dump(), expected);
+}
+
+#[skuld::test]
+fn double_ref_also_delegates() {
+    let m = Marker;
+    let r = &m;
+    let rr = &r;
+    assert_eq!(rr.dump(), DumpValue::String("marker".into()));
+}

--- a/crates/dump/src/format.rs
+++ b/crates/dump/src/format.rs
@@ -1,0 +1,306 @@
+//! YAML emitter for [`DumpValue`].
+//!
+//! This is an in-crate emitter rather than a third-party YAML library
+//! because our output surface is narrow (block style only, a small
+//! set of tagged nodes, log-specific redaction) and we want full
+//! control over how blessed tags render. The plan authorized this
+//! fallback in place of `saphyr-emitter`.
+
+use std::fmt::{self, Write};
+
+use base64::Engine;
+
+use crate::value::tag;
+use crate::DumpValue;
+
+/// Configurable YAML emitter.
+#[derive(Debug, Clone)]
+pub struct YamlFormatter {
+    pub indent: usize,
+    pub max_width: usize,
+    pub redact_secrets: bool,
+}
+
+impl Default for YamlFormatter {
+    fn default() -> Self {
+        Self {
+            indent: 2,
+            max_width: 100,
+            redact_secrets: true,
+        }
+    }
+}
+
+impl YamlFormatter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn indent(mut self, n: usize) -> Self {
+        self.indent = n;
+        self
+    }
+
+    pub fn max_width(mut self, n: usize) -> Self {
+        self.max_width = n;
+        self
+    }
+
+    pub fn redact_secrets(mut self, b: bool) -> Self {
+        self.redact_secrets = b;
+        self
+    }
+
+    pub fn to_string(&self, value: &DumpValue) -> String {
+        let mut s = String::new();
+        self.write(&mut s, value).expect("fmt::Write on String is infallible");
+        s
+    }
+
+    pub fn write<W: Write>(&self, w: &mut W, value: &DumpValue) -> fmt::Result {
+        match value {
+            DumpValue::Seq(items) if items.is_empty() => w.write_str("[]"),
+            DumpValue::Seq(items) => write_seq_items(self, w, items, 0),
+            DumpValue::Map(entries) if entries.is_empty() => w.write_str("{}"),
+            DumpValue::Map(entries) => write_map_entries(self, w, entries, 0),
+            DumpValue::Tagged(t, inner) => write_tagged(self, w, t, inner, 0),
+            scalar => write_scalar(w, scalar, 0),
+        }
+    }
+}
+
+fn write_seq_items<W: Write>(fmt: &YamlFormatter, w: &mut W, items: &[DumpValue], indent: usize) -> fmt::Result {
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            w.write_char('\n')?;
+        }
+        write_indent(w, indent)?;
+        w.write_char('-')?;
+        write_continuation(fmt, w, item, indent + fmt.indent)?;
+    }
+    Ok(())
+}
+
+fn write_map_entries<W: Write>(
+    fmt: &YamlFormatter,
+    w: &mut W,
+    entries: &[(DumpValue, DumpValue)],
+    indent: usize,
+) -> fmt::Result {
+    for (i, (k, v)) in entries.iter().enumerate() {
+        if i > 0 {
+            w.write_char('\n')?;
+        }
+        write_indent(w, indent)?;
+        match k {
+            DumpValue::String(s) if key_is_plain(s) => {
+                w.write_str(s)?;
+                w.write_char(':')?;
+            }
+            DumpValue::String(s) => {
+                write_double_quoted(w, s)?;
+                w.write_char(':')?;
+            }
+            other => {
+                w.write_char('?')?;
+                write_continuation(fmt, w, other, indent + fmt.indent)?;
+                w.write_char('\n')?;
+                write_indent(w, indent)?;
+                w.write_char(':')?;
+            }
+        }
+        write_continuation(fmt, w, v, indent + fmt.indent)?;
+    }
+    Ok(())
+}
+
+/// Write a value following a prefix that ends in `-`, `:`, or `?` (no
+/// trailing space). Scalars get a leading space; block values get a
+/// leading newline and proper indentation.
+fn write_continuation<W: Write>(fmt: &YamlFormatter, w: &mut W, v: &DumpValue, indent: usize) -> fmt::Result {
+    match v {
+        DumpValue::Seq(items) if items.is_empty() => w.write_str(" []"),
+        DumpValue::Seq(items) => {
+            w.write_char('\n')?;
+            write_seq_items(fmt, w, items, indent)
+        }
+        DumpValue::Map(entries) if entries.is_empty() => w.write_str(" {}"),
+        DumpValue::Map(entries) => {
+            w.write_char('\n')?;
+            write_map_entries(fmt, w, entries, indent)
+        }
+        DumpValue::Tagged(t, inner) => {
+            w.write_char(' ')?;
+            write_tagged(fmt, w, t, inner, indent)
+        }
+        scalar => {
+            w.write_char(' ')?;
+            write_scalar(w, scalar, indent)
+        }
+    }
+}
+
+fn write_tagged<W: Write>(fmt: &YamlFormatter, w: &mut W, tag: &str, inner: &DumpValue, indent: usize) -> fmt::Result {
+    if fmt.redact_secrets && tag == tag::SECRET {
+        return w.write_str("!secret [REDACTED]");
+    }
+    if tag == tag::ELIDED {
+        if let DumpValue::String(reason) = inner {
+            return write!(w, "!elided [elided: {}]", reason);
+        }
+    }
+    w.write_char('!')?;
+    w.write_str(tag)?;
+    write_continuation(fmt, w, inner, indent)
+}
+
+fn write_scalar<W: Write>(w: &mut W, v: &DumpValue, indent: usize) -> fmt::Result {
+    match v {
+        DumpValue::Null => w.write_str("~"),
+        DumpValue::Bool(b) => w.write_str(if *b { "true" } else { "false" }),
+        DumpValue::Int(i) => write!(w, "{}", i),
+        DumpValue::UInt(u) => write!(w, "{}", u),
+        DumpValue::Float(f) => write_float(w, *f),
+        DumpValue::String(s) => write_scalar_string(w, s, indent),
+        DumpValue::Bytes(b) => write_bytes(w, b),
+        DumpValue::Seq(_) | DumpValue::Map(_) | DumpValue::Tagged(_, _) => {
+            debug_assert!(false, "write_scalar called with a non-scalar variant");
+            Ok(())
+        }
+    }
+}
+
+fn write_indent<W: Write>(w: &mut W, indent: usize) -> fmt::Result {
+    for _ in 0..indent {
+        w.write_char(' ')?;
+    }
+    Ok(())
+}
+
+fn write_float<W: Write>(w: &mut W, f: f64) -> fmt::Result {
+    if f.is_nan() {
+        return w.write_str(".nan");
+    }
+    if f.is_infinite() {
+        return w.write_str(if f > 0.0 { ".inf" } else { "-.inf" });
+    }
+    let s = format!("{}", f);
+    if !s.contains('.') && !s.contains('e') && !s.contains('E') {
+        // "1" -> "1.0" so downstream YAML parsers see a float.
+        write!(w, "{}.0", s)
+    } else {
+        w.write_str(&s)
+    }
+}
+
+fn write_scalar_string<W: Write>(w: &mut W, s: &str, indent: usize) -> fmt::Result {
+    if s.contains('\n') {
+        w.write_str("|-")?;
+        for line in s.split('\n') {
+            w.write_char('\n')?;
+            write_indent(w, indent)?;
+            w.write_str(line)?;
+        }
+        Ok(())
+    } else if needs_quoting(s) {
+        write_double_quoted(w, s)
+    } else {
+        w.write_str(s)
+    }
+}
+
+fn write_bytes<W: Write>(w: &mut W, bytes: &[u8]) -> fmt::Result {
+    w.write_str("!!binary ")?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    w.write_str(&encoded)
+}
+
+fn write_double_quoted<W: Write>(w: &mut W, s: &str) -> fmt::Result {
+    w.write_char('"')?;
+    for c in s.chars() {
+        match c {
+            '"' => w.write_str("\\\"")?,
+            '\\' => w.write_str("\\\\")?,
+            '\n' => w.write_str("\\n")?,
+            '\r' => w.write_str("\\r")?,
+            '\t' => w.write_str("\\t")?,
+            '\0' => w.write_str("\\0")?,
+            c if (c as u32) < 0x20 => write!(w, "\\x{:02x}", c as u32)?,
+            c => w.write_char(c)?,
+        }
+    }
+    w.write_char('"')
+}
+
+fn key_is_plain(s: &str) -> bool {
+    !s.contains('\n') && !needs_quoting(s)
+}
+
+fn needs_quoting(s: &str) -> bool {
+    if s.is_empty() {
+        return true;
+    }
+    if matches!(
+        s,
+        "null"
+            | "~"
+            | "true"
+            | "false"
+            | "yes"
+            | "no"
+            | "True"
+            | "False"
+            | "TRUE"
+            | "FALSE"
+            | "NULL"
+            | "Null"
+            | ".inf"
+            | "-.inf"
+            | ".nan"
+    ) {
+        return true;
+    }
+    let first = s.chars().next().unwrap();
+    if matches!(
+        first,
+        '-' | ':'
+            | '?'
+            | ','
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | '#'
+            | '&'
+            | '*'
+            | '!'
+            | '|'
+            | '>'
+            | '\''
+            | '"'
+            | '%'
+            | '@'
+            | '`'
+            | ' '
+            | '\t'
+    ) {
+        return true;
+    }
+    if s.ends_with(' ') || s.ends_with('\t') {
+        return true;
+    }
+    if s.contains(": ") || s.contains(" #") {
+        return true;
+    }
+    if s.chars().any(|c| c.is_control()) {
+        return true;
+    }
+    if s.parse::<f64>().is_ok() {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+#[path = "format_tests.rs"]
+mod format_tests;

--- a/crates/dump/src/format_tests.rs
+++ b/crates/dump/src/format_tests.rs
@@ -1,0 +1,211 @@
+use super::YamlFormatter;
+use crate::value::tag;
+use crate::DumpValue;
+
+fn emit(v: &DumpValue) -> String {
+    YamlFormatter::default().to_string(v)
+}
+
+// Scalars =============================================================================================================
+
+#[skuld::test]
+fn null_emits_tilde() {
+    assert_eq!(emit(&DumpValue::Null), "~");
+}
+
+#[skuld::test]
+fn bools() {
+    assert_eq!(emit(&DumpValue::Bool(true)), "true");
+    assert_eq!(emit(&DumpValue::Bool(false)), "false");
+}
+
+#[skuld::test]
+fn ints() {
+    assert_eq!(emit(&DumpValue::Int(0)), "0");
+    assert_eq!(emit(&DumpValue::Int(-42)), "-42");
+    assert_eq!(emit(&DumpValue::Int(i128::MAX)), i128::MAX.to_string());
+    assert_eq!(emit(&DumpValue::UInt(u128::MAX)), u128::MAX.to_string());
+}
+
+#[skuld::test]
+fn floats_including_specials() {
+    assert_eq!(emit(&DumpValue::Float(2.5)), "2.5");
+    // Integer-valued floats gain ".0" so YAML readers parse them as floats.
+    assert_eq!(emit(&DumpValue::Float(1.0)), "1.0");
+    assert_eq!(emit(&DumpValue::Float(f64::NAN)), ".nan");
+    assert_eq!(emit(&DumpValue::Float(f64::INFINITY)), ".inf");
+    assert_eq!(emit(&DumpValue::Float(f64::NEG_INFINITY)), "-.inf");
+}
+
+#[skuld::test]
+fn plain_string() {
+    assert_eq!(emit(&DumpValue::String("hello".into())), "hello");
+}
+
+#[skuld::test]
+fn string_that_looks_like_bool_gets_quoted() {
+    assert_eq!(emit(&DumpValue::String("true".into())), r#""true""#);
+    assert_eq!(emit(&DumpValue::String("null".into())), r#""null""#);
+}
+
+#[skuld::test]
+fn string_that_looks_like_number_gets_quoted() {
+    assert_eq!(emit(&DumpValue::String("42".into())), r#""42""#);
+    assert_eq!(emit(&DumpValue::String("3.14".into())), r#""3.14""#);
+}
+
+#[skuld::test]
+fn string_with_leading_indicator_gets_quoted() {
+    assert_eq!(emit(&DumpValue::String("- item".into())), r#""- item""#);
+    assert_eq!(emit(&DumpValue::String("#hash".into())), "\"#hash\"");
+}
+
+#[skuld::test]
+fn string_with_colon_space_gets_quoted() {
+    assert_eq!(emit(&DumpValue::String("a: b".into())), r#""a: b""#);
+}
+
+#[skuld::test]
+fn string_with_control_char_escapes() {
+    assert_eq!(emit(&DumpValue::String("\t".into())), r#""\t""#);
+    assert_eq!(emit(&DumpValue::String("\x01".into())), r#""\x01""#);
+}
+
+#[skuld::test]
+fn multiline_string_uses_block_scalar() {
+    let out = emit(&DumpValue::String("line1\nline2".into()));
+    assert_eq!(out, "|-\nline1\nline2");
+}
+
+#[skuld::test]
+fn bytes_emit_as_yaml_binary_base64() {
+    assert_eq!(emit(&DumpValue::Bytes(b"hi".to_vec())), "!!binary aGk=");
+    assert_eq!(emit(&DumpValue::Bytes(vec![])), "!!binary ");
+}
+
+// Seq / Map ===========================================================================================================
+
+#[skuld::test]
+fn empty_seq_and_map_use_flow_form() {
+    assert_eq!(emit(&DumpValue::Seq(vec![])), "[]");
+    assert_eq!(emit(&DumpValue::Map(vec![])), "{}");
+}
+
+#[skuld::test]
+fn simple_seq() {
+    let v = DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2), DumpValue::Int(3)]);
+    assert_eq!(emit(&v), "- 1\n- 2\n- 3");
+}
+
+#[skuld::test]
+fn simple_map() {
+    let v = DumpValue::Map(vec![
+        (DumpValue::String("a".into()), DumpValue::Int(1)),
+        (DumpValue::String("b".into()), DumpValue::Int(2)),
+    ]);
+    assert_eq!(emit(&v), "a: 1\nb: 2");
+}
+
+#[skuld::test]
+fn nested_map_in_map() {
+    let inner = DumpValue::Map(vec![
+        (DumpValue::String("x".into()), DumpValue::Int(1)),
+        (DumpValue::String("y".into()), DumpValue::Int(2)),
+    ]);
+    let outer = DumpValue::Map(vec![(DumpValue::String("pt".into()), inner)]);
+    assert_eq!(emit(&outer), "pt:\n  x: 1\n  y: 2");
+}
+
+#[skuld::test]
+fn nested_seq_in_map() {
+    let v = DumpValue::Map(vec![(
+        DumpValue::String("xs".into()),
+        DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2)]),
+    )]);
+    assert_eq!(emit(&v), "xs:\n  - 1\n  - 2");
+}
+
+#[skuld::test]
+fn nested_map_in_seq() {
+    let v = DumpValue::Seq(vec![DumpValue::Map(vec![(
+        DumpValue::String("a".into()),
+        DumpValue::Int(1),
+    )])]);
+    assert_eq!(emit(&v), "-\n  a: 1");
+}
+
+#[skuld::test]
+fn non_string_map_key_uses_complex_form() {
+    let v = DumpValue::Map(vec![(DumpValue::Int(1), DumpValue::String("one".into()))]);
+    assert_eq!(emit(&v), "? 1\n: one");
+}
+
+// Tagged values =======================================================================================================
+
+#[skuld::test]
+fn secret_redacts_by_default() {
+    let v = DumpValue::tagged(tag::SECRET, DumpValue::String("hunter2".into()));
+    assert_eq!(emit(&v), "!secret [REDACTED]");
+}
+
+#[skuld::test]
+fn secret_shown_when_redaction_disabled() {
+    let v = DumpValue::tagged(tag::SECRET, DumpValue::String("hunter2".into()));
+    let out = YamlFormatter::new().redact_secrets(false).to_string(&v);
+    assert_eq!(out, "!secret hunter2");
+}
+
+#[skuld::test]
+fn elided_renders_with_reason() {
+    let v = DumpValue::tagged(tag::ELIDED, DumpValue::String("Instant".into()));
+    assert_eq!(emit(&v), "!elided [elided: Instant]");
+}
+
+#[skuld::test]
+fn debug_tag_emits_inline_string() {
+    let v = DumpValue::tagged(tag::DEBUG, DumpValue::String("Foo(42)".into()));
+    assert_eq!(emit(&v), "!debug Foo(42)");
+}
+
+#[skuld::test]
+fn user_tag_passthrough() {
+    let v = DumpValue::tagged_owned("MyApp:thing".into(), DumpValue::Int(7));
+    assert_eq!(emit(&v), "!MyApp:thing 7");
+}
+
+#[skuld::test]
+fn tagged_map_goes_on_new_line() {
+    let v = DumpValue::tagged(
+        tag::TRUNCATED,
+        DumpValue::Map(vec![
+            (DumpValue::String("shown".into()), DumpValue::Int(3)),
+            (DumpValue::String("total".into()), DumpValue::Int(10)),
+        ]),
+    );
+    assert_eq!(emit(&v), "!truncated\nshown: 3\ntotal: 10");
+}
+
+// Secret redaction at depth ===========================================================================================
+
+#[skuld::test]
+fn secret_redacts_even_inside_structure() {
+    let v = DumpValue::Map(vec![
+        (DumpValue::String("user".into()), DumpValue::String("alice".into())),
+        (
+            DumpValue::String("password".into()),
+            DumpValue::tagged(tag::SECRET, DumpValue::String("hunter2".into())),
+        ),
+    ]);
+    assert_eq!(emit(&v), "user: alice\npassword: !secret [REDACTED]");
+}
+
+// Configurable indent =================================================================================================
+
+#[skuld::test]
+fn indent_width_is_configurable() {
+    let v = DumpValue::Map(vec![(
+        DumpValue::String("a".into()),
+        DumpValue::Map(vec![(DumpValue::String("b".into()), DumpValue::Int(1))]),
+    )]);
+    assert_eq!(YamlFormatter::new().indent(4).to_string(&v), "a:\n    b: 1");
+}

--- a/crates/dump/src/impls.rs
+++ b/crates/dump/src/impls.rs
@@ -1,0 +1,284 @@
+//! Built-in [`Dump`] impls for common standard-library types.
+//!
+//! Kept in one file for v1 so the set is easy to audit. Each section is
+//! demarcated with the workspace section-comment style. A future commit
+//! may split this into `impls/` topic files if it outgrows ergonomics.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::Hash;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128, NonZeroU16, NonZeroU32,
+    NonZeroU64, NonZeroU8, NonZeroUsize,
+};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::{Dump, DumpValue, YamlFormatter};
+
+// Primitives ==========================================================================================================
+
+macro_rules! impl_dump_signed_int {
+    ($($t:ty),*) => {
+        $(
+            impl Dump for $t {
+                fn dump(&self) -> DumpValue {
+                    DumpValue::Int(*self as i128)
+                }
+            }
+        )*
+    };
+}
+
+impl_dump_signed_int!(i8, i16, i32, i64, i128, isize);
+
+macro_rules! impl_dump_unsigned_int {
+    ($($t:ty),*) => {
+        $(
+            impl Dump for $t {
+                fn dump(&self) -> DumpValue {
+                    DumpValue::UInt(*self as u128)
+                }
+            }
+        )*
+    };
+}
+
+impl_dump_unsigned_int!(u8, u16, u32, u64, u128, usize);
+
+impl Dump for f32 {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Float(*self as f64)
+    }
+}
+
+impl Dump for f64 {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Float(*self)
+    }
+}
+
+impl Dump for bool {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Bool(*self)
+    }
+}
+
+impl Dump for char {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String(self.to_string())
+    }
+}
+
+// NonZero =============================================================================================================
+
+macro_rules! impl_dump_nonzero_signed {
+    ($($t:ident),*) => {
+        $(
+            impl Dump for $t {
+                fn dump(&self) -> DumpValue {
+                    DumpValue::Int(self.get() as i128)
+                }
+            }
+        )*
+    };
+}
+
+impl_dump_nonzero_signed!(NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize);
+
+macro_rules! impl_dump_nonzero_unsigned {
+    ($($t:ident),*) => {
+        $(
+            impl Dump for $t {
+                fn dump(&self) -> DumpValue {
+                    DumpValue::UInt(self.get() as u128)
+                }
+            }
+        )*
+    };
+}
+
+impl_dump_nonzero_unsigned!(NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize);
+
+// Strings =============================================================================================================
+
+impl Dump for String {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String(self.clone())
+    }
+}
+
+impl Dump for str {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String(self.to_owned())
+    }
+}
+
+// Box<str> is covered by the `Box<T: Dump>` blanket below.
+
+impl Dump for Cow<'_, str> {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String(self.to_string())
+    }
+}
+
+// Paths ===============================================================================================================
+
+impl Dump for Path {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String(self.display().to_string())
+    }
+}
+
+impl Dump for PathBuf {
+    fn dump(&self) -> DumpValue {
+        self.as_path().dump()
+    }
+}
+
+// Option / Result =====================================================================================================
+
+impl<T: Dump> Dump for Option<T> {
+    fn dump(&self) -> DumpValue {
+        match self {
+            Some(v) => v.dump(),
+            None => DumpValue::Null,
+        }
+    }
+}
+
+impl<T: Dump, E: Dump> Dump for Result<T, E> {
+    fn dump(&self) -> DumpValue {
+        match self {
+            Ok(v) => DumpValue::Map(vec![(DumpValue::String("Ok".into()), v.dump())]),
+            Err(e) => DumpValue::Map(vec![(DumpValue::String("Err".into()), e.dump())]),
+        }
+    }
+}
+
+// Collections =========================================================================================================
+
+impl<T: Dump> Dump for [T] {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Seq(self.iter().map(Dump::dump).collect())
+    }
+}
+
+impl<T: Dump> Dump for Vec<T> {
+    fn dump(&self) -> DumpValue {
+        self.as_slice().dump()
+    }
+}
+
+impl<T: Dump, const N: usize> Dump for [T; N] {
+    fn dump(&self) -> DumpValue {
+        self.as_slice().dump()
+    }
+}
+
+impl Dump for () {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Null
+    }
+}
+
+macro_rules! impl_dump_tuple {
+    ($($n:tt $t:ident),*) => {
+        impl<$($t: Dump),*> Dump for ($($t,)*) {
+            fn dump(&self) -> DumpValue {
+                DumpValue::Seq(vec![$(self.$n.dump()),*])
+            }
+        }
+    };
+}
+
+impl_dump_tuple!(0 T0);
+impl_dump_tuple!(0 T0, 1 T1);
+impl_dump_tuple!(0 T0, 1 T1, 2 T2);
+impl_dump_tuple!(0 T0, 1 T1, 2 T2, 3 T3);
+impl_dump_tuple!(0 T0, 1 T1, 2 T2, 3 T3, 4 T4);
+impl_dump_tuple!(0 T0, 1 T1, 2 T2, 3 T3, 4 T4, 5 T5);
+
+impl<K: Dump, V: Dump> Dump for BTreeMap<K, V> {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Map(self.iter().map(|(k, v)| (k.dump(), v.dump())).collect())
+    }
+}
+
+impl<K: Dump + Hash + Eq, V: Dump, S> Dump for HashMap<K, V, S> {
+    fn dump(&self) -> DumpValue {
+        let mut entries: Vec<(DumpValue, DumpValue)> = self.iter().map(|(k, v)| (k.dump(), v.dump())).collect();
+        // Sort by the rendered form of the key so HashMap output is
+        // byte-deterministic across runs / hasher states.
+        let fmt = YamlFormatter::default();
+        entries.sort_by_cached_key(|(k, _)| fmt.to_string(k));
+        DumpValue::Map(entries)
+    }
+}
+
+impl<T: Dump> Dump for BTreeSet<T> {
+    fn dump(&self) -> DumpValue {
+        DumpValue::Seq(self.iter().map(Dump::dump).collect())
+    }
+}
+
+impl<T: Dump + Hash + Eq, S> Dump for HashSet<T, S> {
+    fn dump(&self) -> DumpValue {
+        let mut items: Vec<DumpValue> = self.iter().map(Dump::dump).collect();
+        let fmt = YamlFormatter::default();
+        items.sort_by_cached_key(|v| fmt.to_string(v));
+        DumpValue::Seq(items)
+    }
+}
+
+// Smart pointers ======================================================================================================
+
+impl<T: Dump + ?Sized> Dump for Box<T> {
+    fn dump(&self) -> DumpValue {
+        (**self).dump()
+    }
+}
+
+impl<T: Dump + ?Sized> Dump for Rc<T> {
+    fn dump(&self) -> DumpValue {
+        (**self).dump()
+    }
+}
+
+impl<T: Dump + ?Sized> Dump for Arc<T> {
+    fn dump(&self) -> DumpValue {
+        (**self).dump()
+    }
+}
+
+// Net =================================================================================================================
+
+macro_rules! impl_dump_via_display {
+    ($($t:ty),*) => {
+        $(
+            impl Dump for $t {
+                fn dump(&self) -> DumpValue {
+                    DumpValue::String(self.to_string())
+                }
+            }
+        )*
+    };
+}
+
+impl_dump_via_display!(IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6);
+
+// Time ================================================================================================================
+
+impl Dump for Duration {
+    fn dump(&self) -> DumpValue {
+        // "1.234s" style — human-readable, precise to milliseconds.
+        DumpValue::String(format!("{:.3}s", self.as_secs_f64()))
+    }
+}
+
+#[cfg(test)]
+#[path = "impls_tests.rs"]
+mod impls_tests;

--- a/crates/dump/src/impls_tests.rs
+++ b/crates/dump/src/impls_tests.rs
@@ -1,0 +1,194 @@
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::num::{NonZeroI16, NonZeroU32};
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::{Dump, DumpValue};
+
+// Primitives ==========================================================================================================
+
+#[skuld::test]
+fn int_variants_use_int_or_uint() {
+    assert_eq!((-3_i32).dump(), DumpValue::Int(-3));
+    assert_eq!(42_u64.dump(), DumpValue::UInt(42));
+    assert_eq!(0_u128.dump(), DumpValue::UInt(0));
+    assert_eq!(i128::MIN.dump(), DumpValue::Int(i128::MIN));
+    assert_eq!(u128::MAX.dump(), DumpValue::UInt(u128::MAX));
+}
+
+#[skuld::test]
+fn bool_and_char() {
+    assert_eq!(true.dump(), DumpValue::Bool(true));
+    assert_eq!('x'.dump(), DumpValue::String("x".into()));
+}
+
+#[skuld::test]
+fn floats() {
+    assert_eq!(1.5_f32.dump(), DumpValue::Float(1.5));
+    assert_eq!(2.5_f64.dump(), DumpValue::Float(2.5));
+}
+
+#[skuld::test]
+fn nonzero_ints() {
+    assert_eq!(NonZeroU32::new(7).unwrap().dump(), DumpValue::UInt(7));
+    assert_eq!(NonZeroI16::new(-3).unwrap().dump(), DumpValue::Int(-3));
+}
+
+// Strings + paths =====================================================================================================
+
+#[skuld::test]
+fn strings_and_refs() {
+    let s = String::from("hi");
+    assert_eq!(s.dump(), DumpValue::String("hi".into()));
+    assert_eq!("hi".dump(), DumpValue::String("hi".into()));
+    let cow: Cow<'_, str> = Cow::Borrowed("x");
+    assert_eq!(cow.dump(), DumpValue::String("x".into()));
+}
+
+#[skuld::test]
+fn paths() {
+    let p = PathBuf::from("foo/bar");
+    // PathBuf::display uses platform separators, so just check round-trip via the Path trait.
+    assert_eq!(p.dump(), DumpValue::String(p.display().to_string()));
+}
+
+// Option / Result =====================================================================================================
+
+#[skuld::test]
+fn option_some_and_none() {
+    assert_eq!(Some(5_i32).dump(), DumpValue::Int(5));
+    assert_eq!(None::<i32>.dump(), DumpValue::Null);
+}
+
+#[skuld::test]
+fn result_shape() {
+    let ok: Result<i32, i32> = Ok(1);
+    let err: Result<i32, i32> = Err(2);
+    assert_eq!(
+        ok.dump(),
+        DumpValue::Map(vec![(DumpValue::String("Ok".into()), DumpValue::Int(1))])
+    );
+    assert_eq!(
+        err.dump(),
+        DumpValue::Map(vec![(DumpValue::String("Err".into()), DumpValue::Int(2))])
+    );
+}
+
+// Collections =========================================================================================================
+
+#[skuld::test]
+fn vec_and_array() {
+    let v = vec![1_i32, 2, 3];
+    assert_eq!(
+        v.dump(),
+        DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2), DumpValue::Int(3)])
+    );
+    let a: [i32; 2] = [7, 8];
+    assert_eq!(a.dump(), DumpValue::Seq(vec![DumpValue::Int(7), DumpValue::Int(8)]));
+}
+
+#[skuld::test]
+fn tuple() {
+    assert_eq!(
+        (1_i32, "two").dump(),
+        DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::String("two".into()),])
+    );
+}
+
+#[skuld::test]
+fn btreemap_preserves_key_order() {
+    let mut m = BTreeMap::new();
+    m.insert("b", 2_i32);
+    m.insert("a", 1);
+    assert_eq!(
+        m.dump(),
+        DumpValue::Map(vec![
+            (DumpValue::String("a".into()), DumpValue::Int(1)),
+            (DumpValue::String("b".into()), DumpValue::Int(2)),
+        ])
+    );
+}
+
+#[skuld::test]
+fn hashmap_output_is_deterministic() {
+    // Sort order is by YAML-rendered key. Build the same map twice and
+    // confirm identical output regardless of hasher state.
+    let mut m1 = HashMap::new();
+    m1.insert("zoo", 1_i32);
+    m1.insert("apple", 2);
+    m1.insert("mid", 3);
+
+    let mut m2 = HashMap::new();
+    m2.insert("mid", 3_i32);
+    m2.insert("apple", 2);
+    m2.insert("zoo", 1);
+
+    assert_eq!(m1.dump(), m2.dump());
+    // Also confirm the actual sort order is alphabetical.
+    let DumpValue::Map(entries) = m1.dump() else {
+        panic!("expected map")
+    };
+    let keys: Vec<_> = entries
+        .into_iter()
+        .map(|(k, _)| match k {
+            DumpValue::String(s) => s,
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(keys, vec!["apple", "mid", "zoo"]);
+}
+
+#[skuld::test]
+fn sets() {
+    let bt: BTreeSet<i32> = [3, 1, 2].into_iter().collect();
+    assert_eq!(
+        bt.dump(),
+        DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2), DumpValue::Int(3)])
+    );
+    let hs: HashSet<&'static str> = ["zoo", "apple", "mid"].into_iter().collect();
+    let DumpValue::Seq(items) = hs.dump() else {
+        panic!("expected seq")
+    };
+    let rendered: Vec<_> = items
+        .into_iter()
+        .map(|v| match v {
+            DumpValue::String(s) => s,
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(rendered, vec!["apple", "mid", "zoo"]);
+}
+
+// Smart pointers ======================================================================================================
+
+#[skuld::test]
+fn smart_pointers_delegate() {
+    let b: Box<i32> = Box::new(5);
+    let r: Rc<i32> = Rc::new(7);
+    let a: Arc<i32> = Arc::new(9);
+    assert_eq!(b.dump(), DumpValue::Int(5));
+    assert_eq!(r.dump(), DumpValue::Int(7));
+    assert_eq!(a.dump(), DumpValue::Int(9));
+}
+
+// Net =================================================================================================================
+
+#[skuld::test]
+fn net_types_render_as_strings() {
+    let ip: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+    assert_eq!(ip.dump(), DumpValue::String("10.0.0.1".into()));
+    let sa: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    assert_eq!(sa.dump(), DumpValue::String("127.0.0.1:8080".into()));
+}
+
+// Time ================================================================================================================
+
+#[skuld::test]
+fn duration_renders_with_millisecond_precision() {
+    assert_eq!(Duration::from_millis(1_234).dump(), DumpValue::String("1.234s".into()));
+    assert_eq!(Duration::from_secs(0).dump(), DumpValue::String("0.000s".into()));
+}

--- a/crates/dump/src/ladder.rs
+++ b/crates/dump/src/ladder.rs
@@ -1,0 +1,69 @@
+//! Compile-time trait-priority resolution for `dump!`.
+//!
+//! On stable Rust we cannot write `if constexpr (T: Dump) ... else if
+//! (T: Serialize) ...` directly — the trait solver forbids overlapping
+//! blanket impls. The canonical workaround is *autoref-specialization*:
+//! define three same-named methods on types at different reference
+//! depths. The `dump!` macro calls through a `(&&&Wrap(&v)).__pick__()`
+//! receiver, and Rust's method resolution starts at the deepest level
+//! and auto-derefs down on each failed rung. Result: Dump > Serialize >
+//! Debug at compile time with no runtime cost.
+//!
+//! This module is `#[doc(hidden)]` via the `__private` re-export in
+//! `lib.rs`; the only intended caller is the `dump!` macro.
+
+use std::fmt::Debug;
+
+use serde::Serialize;
+
+use crate::{debug_bridge, serde_bridge, Dump, DumpValue};
+
+/// Transparent wrapper used by the `dump!` macro. Holds a `&T` so the
+/// macro can evaluate its argument into a temp via `match &$v {...}`
+/// and pass it through the ladder without moving.
+#[doc(hidden)]
+pub struct Wrap<T>(pub T);
+
+// Level 1 — highest priority, picked first because method resolution
+// checks this ref depth before auto-dereffing down.
+#[doc(hidden)]
+pub trait DumpPick {
+    fn __pick__(self) -> DumpValue;
+}
+
+impl<T: Dump + ?Sized> DumpPick for &&&Wrap<&T> {
+    #[inline]
+    fn __pick__(self) -> DumpValue {
+        self.0.dump()
+    }
+}
+
+// Level 2 — one auto-deref down from the call-site receiver.
+#[doc(hidden)]
+pub trait SerializePick {
+    fn __pick__(self) -> DumpValue;
+}
+
+impl<T: Serialize + ?Sized> SerializePick for &&Wrap<&T> {
+    #[inline]
+    fn __pick__(self) -> DumpValue {
+        serde_bridge::to_dump_value(self.0)
+    }
+}
+
+// Level 3 — two auto-derefs down.
+#[doc(hidden)]
+pub trait DebugPick {
+    fn __pick__(self) -> DumpValue;
+}
+
+impl<T: Debug + ?Sized> DebugPick for &Wrap<&T> {
+    #[inline]
+    fn __pick__(self) -> DumpValue {
+        debug_bridge::to_dump_value(self.0)
+    }
+}
+
+#[cfg(test)]
+#[path = "ladder_tests.rs"]
+mod ladder_tests;

--- a/crates/dump/src/ladder_tests.rs
+++ b/crates/dump/src/ladder_tests.rs
@@ -1,0 +1,122 @@
+//! Ladder priority tests.
+//!
+//! We construct types that implement specific combinations of Dump,
+//! Serialize, and Debug, then invoke `dump!` through each and confirm
+//! the expected rung was picked. The macro lives in `lib.rs`; this
+//! module exercises it indirectly.
+
+use serde::Serialize;
+
+use crate::value::tag;
+use crate::{dump, DumpDisplay, DumpValue};
+
+fn dv(d: &DumpDisplay) -> DumpValue {
+    d.value().clone()
+}
+
+// Type that implements Dump with an easily recognizable output.
+struct OnlyDump;
+impl crate::Dump for OnlyDump {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String("from-Dump".into())
+    }
+}
+
+// Type that implements only Serialize.
+#[derive(Serialize)]
+struct OnlySerialize {
+    tag: &'static str,
+}
+
+// Type that implements only Debug.
+struct OnlyDebug;
+impl std::fmt::Debug for OnlyDebug {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("from-Debug")
+    }
+}
+
+// Type that implements Dump + Serialize. Dump wins.
+struct DumpAndSerialize;
+impl crate::Dump for DumpAndSerialize {
+    fn dump(&self) -> DumpValue {
+        DumpValue::String("chose-Dump".into())
+    }
+}
+impl Serialize for DumpAndSerialize {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str("chose-Serialize")
+    }
+}
+
+#[skuld::test]
+fn picks_dump_when_available() {
+    let d = dump!(OnlyDump);
+    assert_eq!(dv(&d), DumpValue::String("from-Dump".into()));
+}
+
+#[skuld::test]
+fn picks_serde_when_no_dump() {
+    let d = dump!(OnlySerialize { tag: "via-serde" });
+    assert_eq!(
+        dv(&d),
+        DumpValue::Map(vec![(
+            DumpValue::String("tag".into()),
+            DumpValue::String("via-serde".into()),
+        )])
+    );
+}
+
+#[skuld::test]
+fn picks_debug_when_no_dump_no_serde() {
+    let d = dump!(OnlyDebug);
+    assert_eq!(
+        dv(&d),
+        DumpValue::tagged(tag::DEBUG, DumpValue::String("from-Debug".into()))
+    );
+}
+
+#[skuld::test]
+fn dump_beats_serialize_in_priority() {
+    let d = dump!(DumpAndSerialize);
+    assert_eq!(dv(&d), DumpValue::String("chose-Dump".into()));
+}
+
+// References, double references, rvalues, and Box all produce the same
+// output for a given inner type.
+
+#[skuld::test]
+fn same_output_for_references_and_rvalues() {
+    // Rvalue, value, reference, double reference — all produce identical
+    // output when the inner type implements Dump. (Box<T>: Dump ships in
+    // the impls commit.)
+    let x = OnlyDump;
+    let rx = &x;
+    let rrx = &rx;
+
+    let a = dv(&dump!(OnlyDump));
+    let b = dv(&dump!(x));
+    let c = dv(&dump!(rx));
+    let d = dv(&dump!(rrx));
+    assert_eq!(a, b);
+    assert_eq!(a, c);
+    assert_eq!(a, d);
+}
+
+#[skuld::test]
+fn rvalue_expression_evaluates_once() {
+    // If the macro double-evaluated its argument, the counter would
+    // advance twice.
+    use std::cell::Cell;
+    thread_local! {
+        static COUNTER: Cell<i32> = const { Cell::new(0) };
+    }
+    fn bump() -> i32 {
+        COUNTER.with(|c| {
+            c.set(c.get() + 1);
+            c.get()
+        })
+    }
+    let _ = dump!(bump());
+    assert_eq!(COUNTER.with(|c| c.get()), 1);
+}

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -11,15 +11,52 @@
 //! macro, YAML formatter, derive macro, and built-in impls ship in
 //! subsequent commits.
 
+mod debug_bridge;
 mod display;
 mod dump_trait;
 mod format;
+mod ladder;
+mod serde_bridge;
 mod value;
 
 pub use display::DumpDisplay;
 pub use dump_trait::Dump;
 pub use format::YamlFormatter;
 pub use value::{tag, DumpValue};
+
+/// Convenience: render a [`DumpValue`] to a YAML string with default
+/// formatter settings.
+pub fn to_yaml(value: &DumpValue) -> String {
+    YamlFormatter::default().to_string(value)
+}
+
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::ladder::{DebugPick, DumpPick, SerializePick, Wrap};
+}
+
+/// Render any value as YAML for logging, picking at compile time
+/// between [`Dump`], [`serde::Serialize`], and [`std::fmt::Debug`] in
+/// that priority order.
+///
+/// Returns a [`DumpDisplay`] that implements [`std::fmt::Display`], so
+/// it drops into `tracing::info!("state: {}", dump!(state))` and into
+/// field positions as `info!(state = %dump!(state), "...")`.
+#[macro_export]
+macro_rules! dump {
+    ($v:expr) => {{
+        // `match &$v { tmp => ... }` extends temporaries' lifetime to
+        // cover the arm, so `dump!(some_function())` sees the rvalue
+        // through a borrow without moving.
+        match &$v {
+            __dump_tmp => {
+                #[allow(unused_imports)]
+                use $crate::__private::{DebugPick as _, DumpPick as _, SerializePick as _};
+                $crate::DumpDisplay::new((&&&$crate::__private::Wrap(__dump_tmp)).__pick__())
+            }
+        }
+    }};
+}
 
 #[cfg(test)]
 fn main() {

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -1,0 +1,23 @@
+//! YAML-shaped representation for logging.
+//!
+//! `Dump` complements [`std::fmt::Debug`] and [`std::fmt::Display`]. Debug
+//! favors unambiguous, Rust-syntax output (closer to Python's `__repr__`);
+//! Display favors compact user-facing strings (closer to `__str__`). Dump
+//! is the third leg: human-readable, multi-line, YAML-shaped output
+//! suited for logging large structured values where Debug jams everything
+//! onto one unreadable line.
+//!
+//! This commit introduces only the data model and trait; the `dump!`
+//! macro, YAML formatter, derive macro, and built-in impls ship in
+//! subsequent commits.
+
+mod dump_trait;
+mod value;
+
+pub use dump_trait::Dump;
+pub use value::{tag, DumpValue};
+
+#[cfg(test)]
+fn main() {
+    skuld::run_all();
+}

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -11,10 +11,14 @@
 //! macro, YAML formatter, derive macro, and built-in impls ship in
 //! subsequent commits.
 
+mod display;
 mod dump_trait;
+mod format;
 mod value;
 
+pub use display::DumpDisplay;
 pub use dump_trait::Dump;
+pub use format::YamlFormatter;
 pub use value::{tag, DumpValue};
 
 #[cfg(test)]

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -15,6 +15,7 @@ mod debug_bridge;
 mod display;
 mod dump_trait;
 mod format;
+mod impls;
 mod ladder;
 mod serde_bridge;
 mod value;

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -21,6 +21,7 @@ mod serde_bridge;
 mod value;
 
 pub use display::DumpDisplay;
+pub use dump_macros::Dump as DeriveDump;
 pub use dump_trait::Dump;
 pub use format::YamlFormatter;
 pub use value::{tag, DumpValue};

--- a/crates/dump/src/serde_bridge.rs
+++ b/crates/dump/src/serde_bridge.rs
@@ -1,0 +1,309 @@
+//! Serde `Serializer` that builds a [`DumpValue`].
+//!
+//! Any serializer-internal error is caught and returned as a
+//! `!error` tagged string so that `Dump` remains infallible end-to-end.
+
+use std::fmt;
+
+use serde::ser::{
+    self, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+    SerializeTupleStruct, SerializeTupleVariant, Serializer,
+};
+
+use crate::value::tag;
+use crate::DumpValue;
+
+/// Public entry point used by the autoref ladder.
+pub(crate) fn to_dump_value<T: Serialize + ?Sized>(value: &T) -> DumpValue {
+    match value.serialize(DumpSerializer) {
+        Ok(dv) => dv,
+        Err(SerError(msg)) => DumpValue::tagged(tag::ERROR, DumpValue::String(msg)),
+    }
+}
+
+#[derive(Debug)]
+pub struct SerError(pub String);
+
+impl fmt::Display for SerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SerError {}
+
+impl ser::Error for SerError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        SerError(msg.to_string())
+    }
+}
+
+pub struct DumpSerializer;
+
+impl Serializer for DumpSerializer {
+    type Ok = DumpValue;
+    type Error = SerError;
+    type SerializeSeq = SeqBuilder;
+    type SerializeTuple = SeqBuilder;
+    type SerializeTupleStruct = SeqBuilder;
+    type SerializeTupleVariant = TupleVariantBuilder;
+    type SerializeMap = MapBuilder;
+    type SerializeStruct = StructBuilder;
+    type SerializeStructVariant = StructVariantBuilder;
+
+    fn serialize_bool(self, v: bool) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Bool(v))
+    }
+    fn serialize_i8(self, v: i8) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Int(v.into()))
+    }
+    fn serialize_i16(self, v: i16) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Int(v.into()))
+    }
+    fn serialize_i32(self, v: i32) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Int(v.into()))
+    }
+    fn serialize_i64(self, v: i64) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Int(v.into()))
+    }
+    fn serialize_i128(self, v: i128) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Int(v))
+    }
+    fn serialize_u8(self, v: u8) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::UInt(v.into()))
+    }
+    fn serialize_u16(self, v: u16) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::UInt(v.into()))
+    }
+    fn serialize_u32(self, v: u32) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::UInt(v.into()))
+    }
+    fn serialize_u64(self, v: u64) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::UInt(v.into()))
+    }
+    fn serialize_u128(self, v: u128) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::UInt(v))
+    }
+    fn serialize_f32(self, v: f32) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Float(v.into()))
+    }
+    fn serialize_f64(self, v: f64) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Float(v))
+    }
+    fn serialize_char(self, v: char) -> Result<DumpValue, SerError> {
+        let mut buf = [0u8; 4];
+        Ok(DumpValue::String(v.encode_utf8(&mut buf).to_owned()))
+    }
+    fn serialize_str(self, v: &str) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::String(v.to_owned()))
+    }
+    fn serialize_bytes(self, v: &[u8]) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Bytes(v.to_vec()))
+    }
+    fn serialize_none(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Null)
+    }
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<DumpValue, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_unit(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Null)
+    }
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Null)
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        variant: &'static str,
+    ) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::String(variant.to_owned()))
+    }
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<DumpValue, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<DumpValue, SerError> {
+        let inner = value.serialize(DumpSerializer)?;
+        Ok(DumpValue::Map(vec![(DumpValue::String(variant.to_owned()), inner)]))
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<SeqBuilder, SerError> {
+        Ok(SeqBuilder { items: Vec::new() })
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<SeqBuilder, SerError> {
+        Ok(SeqBuilder { items: Vec::new() })
+    }
+    fn serialize_tuple_struct(self, _name: &'static str, _len: usize) -> Result<SeqBuilder, SerError> {
+        Ok(SeqBuilder { items: Vec::new() })
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<TupleVariantBuilder, SerError> {
+        Ok(TupleVariantBuilder {
+            variant,
+            items: Vec::new(),
+        })
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<MapBuilder, SerError> {
+        Ok(MapBuilder {
+            entries: Vec::new(),
+            pending_key: None,
+        })
+    }
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<StructBuilder, SerError> {
+        Ok(StructBuilder { entries: Vec::new() })
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<StructVariantBuilder, SerError> {
+        Ok(StructVariantBuilder {
+            variant,
+            entries: Vec::new(),
+        })
+    }
+}
+
+pub struct SeqBuilder {
+    items: Vec<DumpValue>,
+}
+
+impl SerializeSeq for SeqBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(DumpSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Seq(self.items))
+    }
+}
+
+impl SerializeTuple for SeqBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(DumpSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Seq(self.items))
+    }
+}
+
+impl SerializeTupleStruct for SeqBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(DumpSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Seq(self.items))
+    }
+}
+
+pub struct TupleVariantBuilder {
+    variant: &'static str,
+    items: Vec<DumpValue>,
+}
+
+impl SerializeTupleVariant for TupleVariantBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(DumpSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Map(vec![(
+            DumpValue::String(self.variant.to_owned()),
+            DumpValue::Seq(self.items),
+        )]))
+    }
+}
+
+pub struct MapBuilder {
+    entries: Vec<(DumpValue, DumpValue)>,
+    pending_key: Option<DumpValue>,
+}
+
+impl SerializeMap for MapBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), SerError> {
+        self.pending_key = Some(key.serialize(DumpSerializer)?);
+        Ok(())
+    }
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        let key = self
+            .pending_key
+            .take()
+            .ok_or_else(|| SerError("serialize_value called before serialize_key".into()))?;
+        self.entries.push((key, value.serialize(DumpSerializer)?));
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Map(self.entries))
+    }
+}
+
+pub struct StructBuilder {
+    entries: Vec<(DumpValue, DumpValue)>,
+}
+
+impl SerializeStruct for StructBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> Result<(), SerError> {
+        self.entries
+            .push((DumpValue::String(key.to_owned()), value.serialize(DumpSerializer)?));
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Map(self.entries))
+    }
+}
+
+pub struct StructVariantBuilder {
+    variant: &'static str,
+    entries: Vec<(DumpValue, DumpValue)>,
+}
+
+impl SerializeStructVariant for StructVariantBuilder {
+    type Ok = DumpValue;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> Result<(), SerError> {
+        self.entries
+            .push((DumpValue::String(key.to_owned()), value.serialize(DumpSerializer)?));
+        Ok(())
+    }
+    fn end(self) -> Result<DumpValue, SerError> {
+        Ok(DumpValue::Map(vec![(
+            DumpValue::String(self.variant.to_owned()),
+            DumpValue::Map(self.entries),
+        )]))
+    }
+}
+
+#[cfg(test)]
+#[path = "serde_bridge_tests.rs"]
+mod serde_bridge_tests;

--- a/crates/dump/src/serde_bridge_tests.rs
+++ b/crates/dump/src/serde_bridge_tests.rs
@@ -1,0 +1,104 @@
+use serde::Serialize;
+
+use super::to_dump_value;
+use crate::DumpValue;
+
+#[skuld::test]
+fn scalars_via_serde() {
+    assert_eq!(to_dump_value(&true), DumpValue::Bool(true));
+    assert_eq!(to_dump_value(&-3_i32), DumpValue::Int(-3));
+    assert_eq!(to_dump_value(&42_u64), DumpValue::UInt(42));
+    assert_eq!(to_dump_value(&1.5_f64), DumpValue::Float(1.5));
+    assert_eq!(to_dump_value("hi"), DumpValue::String("hi".into()));
+}
+
+#[skuld::test]
+fn option_some_and_none() {
+    let some: Option<i32> = Some(7);
+    let none: Option<i32> = None;
+    assert_eq!(to_dump_value(&some), DumpValue::Int(7));
+    assert_eq!(to_dump_value(&none), DumpValue::Null);
+}
+
+#[skuld::test]
+fn vec_becomes_seq() {
+    let v = vec![1_i32, 2, 3];
+    assert_eq!(
+        to_dump_value(&v),
+        DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2), DumpValue::Int(3)])
+    );
+}
+
+#[skuld::test]
+fn struct_becomes_map_with_declaration_order() {
+    #[derive(Serialize)]
+    struct S {
+        b: i32,
+        a: i32,
+    }
+    let got = to_dump_value(&S { b: 2, a: 1 });
+    assert_eq!(
+        got,
+        DumpValue::Map(vec![
+            (DumpValue::String("b".into()), DumpValue::Int(2)),
+            (DumpValue::String("a".into()), DumpValue::Int(1)),
+        ])
+    );
+}
+
+#[skuld::test]
+fn enum_variant_shapes() {
+    #[derive(Serialize)]
+    enum E {
+        Unit,
+        Newtype(i32),
+        Tuple(i32, i32),
+        Struct { a: i32 },
+    }
+    // Unit variant → string
+    assert_eq!(to_dump_value(&E::Unit), DumpValue::String("Unit".into()));
+    // Newtype → map { Newtype: inner }
+    assert_eq!(
+        to_dump_value(&E::Newtype(5)),
+        DumpValue::Map(vec![(DumpValue::String("Newtype".into()), DumpValue::Int(5))])
+    );
+    // Tuple → map { Tuple: [...] }
+    assert_eq!(
+        to_dump_value(&E::Tuple(1, 2)),
+        DumpValue::Map(vec![(
+            DumpValue::String("Tuple".into()),
+            DumpValue::Seq(vec![DumpValue::Int(1), DumpValue::Int(2)]),
+        )])
+    );
+    // Struct variant → map { Struct: { a: 1 } }
+    assert_eq!(
+        to_dump_value(&E::Struct { a: 1 }),
+        DumpValue::Map(vec![(
+            DumpValue::String("Struct".into()),
+            DumpValue::Map(vec![(DumpValue::String("a".into()), DumpValue::Int(1))]),
+        )])
+    );
+}
+
+#[skuld::test]
+fn bytes_roundtrip() {
+    // serde_bytes would normally be used; serialize_bytes is only called
+    // via the ByteBuf / Bytes wrappers. Check the method directly.
+    use serde::Serializer;
+    let got = super::DumpSerializer.serialize_bytes(&[1, 2, 3]).unwrap();
+    assert_eq!(got, DumpValue::Bytes(vec![1, 2, 3]));
+}
+
+#[skuld::test]
+fn unit_variants_in_collections() {
+    #[derive(Serialize)]
+    enum Color {
+        Red,
+        Blue,
+    }
+    let v = vec![Color::Red, Color::Blue];
+    assert_eq!(
+        to_dump_value(&v),
+        DumpValue::Seq(vec![DumpValue::String("Red".into()), DumpValue::String("Blue".into()),])
+    );
+}

--- a/crates/dump/src/value.rs
+++ b/crates/dump/src/value.rs
@@ -1,0 +1,65 @@
+//! The [`DumpValue`] data model.
+
+use std::borrow::Cow;
+
+/// A YAML-shaped value produced by [`crate::Dump::dump`] and consumed
+/// by the formatter.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DumpValue {
+    /// YAML `null` / `~`.
+    Null,
+    Bool(bool),
+    /// Signed integer up to `i128`. `UInt` exists separately so that
+    /// the `i64::MAX..=u128::MAX` range round-trips losslessly.
+    Int(i128),
+    UInt(u128),
+    /// NaN and ±infinity are emitted as `.nan` / `.inf` / `-.inf` per
+    /// YAML 1.2.
+    Float(f64),
+    String(String),
+    /// Arbitrary byte sequence, emitted as `!!binary` (base64).
+    Bytes(Vec<u8>),
+    Seq(Vec<DumpValue>),
+    /// Keys may be any `DumpValue`, not just strings. Built-in impls
+    /// for unordered collections sort their entries so output is
+    /// byte-deterministic.
+    Map(Vec<(DumpValue, DumpValue)>),
+    /// Tagged node. Certain blessed tag names (see [`tag`]) trigger
+    /// formatter behavior such as redaction or elision.
+    Tagged(Cow<'static, str>, Box<DumpValue>),
+}
+
+impl DumpValue {
+    /// Convenience constructor for a tagged node with a `'static` tag.
+    pub fn tagged(tag: &'static str, value: DumpValue) -> Self {
+        DumpValue::Tagged(Cow::Borrowed(tag), Box::new(value))
+    }
+
+    /// Convenience constructor for a tagged node with an owned tag.
+    pub fn tagged_owned(tag: String, value: DumpValue) -> Self {
+        DumpValue::Tagged(Cow::Owned(tag), Box::new(value))
+    }
+}
+
+/// Blessed tag names that trigger specific formatter behavior.
+///
+/// Tags matching `^[a-z][a-z0-9_-]*$` are reserved for this crate.
+/// User-defined tags should start with an uppercase ASCII letter or use
+/// a `Namespace:name` form to avoid collisions.
+pub mod tag {
+    /// Formatter renders as `[REDACTED]` (unless redaction is disabled).
+    pub const SECRET: &str = "secret";
+    /// Inner value must be a `String` describing what was elided.
+    pub const ELIDED: &str = "elided";
+    /// Inner value must be a `Map` with entries `value`, `shown`, `total`.
+    pub const TRUNCATED: &str = "truncated";
+    /// Inner value must be a `String` from `format!("{:?}", x)`. Used by
+    /// the Debug-fallback rung of the autoref ladder.
+    pub const DEBUG: &str = "debug";
+    /// Inner value must be a `String` describing a dump-impl failure.
+    pub const ERROR: &str = "error";
+}
+
+#[cfg(test)]
+#[path = "value_tests.rs"]
+mod value_tests;

--- a/crates/dump/src/value_tests.rs
+++ b/crates/dump/src/value_tests.rs
@@ -1,0 +1,67 @@
+use std::borrow::Cow;
+
+use super::tag;
+use super::DumpValue;
+
+#[skuld::test]
+fn int_and_uint_are_distinct_variants() {
+    // i64 and u64 at value 1 are the same number but carry different
+    // semantics: Int preserves signedness, UInt preserves range above
+    // i64::MAX. These must not compare equal — downstream formatters
+    // may emit them differently (e.g. with or without a sign-safe tag).
+    assert_ne!(DumpValue::Int(1), DumpValue::UInt(1));
+}
+
+#[skuld::test]
+fn tagged_helper_borrows_static_tag() {
+    let v = DumpValue::tagged(tag::SECRET, DumpValue::String("pw".into()));
+    match v {
+        DumpValue::Tagged(Cow::Borrowed(t), inner) => {
+            assert_eq!(t, "secret");
+            assert_eq!(*inner, DumpValue::String("pw".into()));
+        }
+        _ => panic!("expected borrowed tag"),
+    }
+}
+
+#[skuld::test]
+fn tagged_owned_helper_stores_owned_tag() {
+    let v = DumpValue::tagged_owned("MyApp:thing".into(), DumpValue::Null);
+    match v {
+        DumpValue::Tagged(Cow::Owned(t), _) => assert_eq!(t, "MyApp:thing"),
+        _ => panic!("expected owned tag"),
+    }
+}
+
+#[skuld::test]
+fn blessed_tag_constants_match_documented_values() {
+    // These strings are part of the public contract between Dump impls,
+    // the derive macro, and the formatter. Pinning them in a test stops
+    // accidental renames.
+    assert_eq!(tag::SECRET, "secret");
+    assert_eq!(tag::ELIDED, "elided");
+    assert_eq!(tag::TRUNCATED, "truncated");
+    assert_eq!(tag::DEBUG, "debug");
+    assert_eq!(tag::ERROR, "error");
+}
+
+#[skuld::test]
+fn map_preserves_insertion_order() {
+    let m = DumpValue::Map(vec![
+        (DumpValue::String("b".into()), DumpValue::Int(2)),
+        (DumpValue::String("a".into()), DumpValue::Int(1)),
+        (DumpValue::String("c".into()), DumpValue::Int(3)),
+    ]);
+    let DumpValue::Map(entries) = m else {
+        panic!("expected Map")
+    };
+    let keys: Vec<_> = entries.into_iter().map(|(k, _)| k).collect();
+    assert_eq!(
+        keys,
+        vec![
+            DumpValue::String("b".into()),
+            DumpValue::String("a".into()),
+            DumpValue::String("c".into()),
+        ]
+    );
+}


### PR DESCRIPTION
Closes #237.

## Summary

New workspace crate `crates/dump/` (+ proc-macro sibling `crates/dump-macros/`) providing a third text-representation primitive alongside `Debug` / `Display`, analogous to Python's `dump()` alongside `str()` / `repr()`.

`Debug` is `repr()` — unambiguous, Rust-syntax, single-line. `Dump` is the logging-oriented third: YAML-shaped, multi-line, human-readable. For the kinds of structured values that show up in bridge logs (server configs, routing state, IPC payloads), `{:?}` collapses everything onto one unreadable line. `dump!(state)` produces proper block-style YAML instead.

## Design

**`Dump` trait** returns a `DumpValue` enum (YAML core + log-specific `Tagged` / `Bytes`). A `YamlFormatter` emits it. `DumpDisplay` is a `Display`-wrapping newtype for ergonomics.

**Compile-time three-way trait resolution** via autoref-specialization:

1. `T: Dump` → use it
2. else `T: Serialize` → route through a `DumpValue`-producing `serde::Serializer`
3. else `T: Debug` → wrap `format!(\"{:?}\", x)` in `!debug`
4. else → compile error

The `dump!` macro drives the ladder. On stable Rust this is the only way to get \"compile-time `if constexpr` on trait bounds\" — the technique used by `anyhow::ensure!` and a handful of other crates.

**Log-specific tags** (`!secret`, `!elided`, `!truncated`, `!debug`, `!error`) render specially. `!secret [REDACTED]` by default; can be disabled on the formatter. `#[derive(Dump)]` supports `#[dump(secret)]`, `#[dump(skip)]`, `#[dump(rename = \"...\")]`.

**Built-in impls** cover primitives, strings, paths, Option/Result, Vec/slice/array/tuple, HashMap/BTreeMap (with deterministic HashMap output), smart pointers, net addresses, Duration, NonZero ints.

## Dogfood

One log site in `proxy_manager.rs` (`ProxyManager::start_cancellable` success arm) was migrated. Emits a new `ProxyStartedDiag` struct derived with `#[derive(Dump)]` — explicitly excludes password fields so secret-leak-by-drift isn't possible.

## Scope NOT included

- Optional `valuable` integration (plan deferred — Display path works without it).
- `#[dump(flatten)]`, `#[dump(via)]`, `#[dump(tag)]`, `#[dump(rename_all)]` container attrs.
- `saphyr` / `saphyr-emitter` deps (plan authorized fallback to in-crate emitter — our scope is narrow enough that a ~250-line emitter was less risk than an unknown dep surface).

These are noted in comments as future work.

## Test plan

- [x] `cargo test -p dump` — 66 unit tests, all pass
- [x] `cargo test -p dump-macros` — 9 derive integration tests, all pass
- [x] `cargo check --workspace` — full workspace compiles
- [x] `cargo clippy -p dump -p dump-macros -p hole-bridge` — clean
- [ ] CI green on all platforms
- [ ] No regressions in existing tests