### PR TITLE
DNS forwarder: carry DNS over TCP tunnel for TCP-only plugins (#241)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,19 @@ The invariant is structurally enforced by the cascade in [`HoleRouter::resolve_e
 
 The three drop reasons — explicit rule block, UDP-proxy-unavailable, IPv6-bypass-unreachable — each log through dedicated [`BlockEndpoint`](crates/bridge/src/endpoint/block.rs) methods so a future reader can distinguish them in the bridge log.
 
+**UDP/53 exception — the DNS forwarder.** When `DnsConfig.intercept_udp53` is enabled (default), UDP destined to port 53 is diverted to [`LocalDnsEndpoint`](crates/bridge/src/endpoint/local_dns.rs) *before* the cascade looks at the filter decision. The endpoint forwards the query through the [`DnsForwarder`](crates/bridge/src/dns/forwarder.rs), which upstreams via the local shadowsocks SOCKS5 listener over the encrypted tunnel. This lets apps that hardcode DNS destinations (Chrome DoH to 8.8.8.8, systemd-resolved stub) resolve even when paired with a TCP-only plugin. Non-DNS UDP still follows the drop invariant above.
+
+### DNS forwarder
+
+Clients on TCP-only plugins (v2ray-plugin, anything without UDP multiplexing) would otherwise have no working DNS in full-tunnel mode — the OS sends UDP/53 into the TUN, the cascade drops it for privacy. The bridge ships a built-in DNS forwarder that carries DNS over the TCP tunnel.
+
+- [`DnsForwarder`](crates/bridge/src/dns/forwarder.rs) — pure bytes-in/bytes-out forwarder. Supports PlainUdp / PlainTcp / DoT / DoH. Preserves the client's transaction ID so it can drop in as a forwarder for both [`LocalDnsServer`](crates/bridge/src/dns/server.rs) (OS-facing loopback:53) and [`LocalDnsEndpoint`](crates/bridge/src/endpoint/local_dns.rs) (in-tunnel UDP/53 intercept).
+- [`LocalDnsServer`](crates/bridge/src/dns/server.rs) — binds loopback `<ip>:53` UDP+TCP via a fallback ladder (`127.0.0.1:53` → `127.53.0.1..254:53` → fail). The bridge runs elevated, so port 53 binding never hits the privilege gate.
+- [`Socks5Connector`](crates/bridge/src/dns/socks5_connector.rs) — routes the forwarder's upstream connections through the SS SOCKS5 listener on `127.0.0.1:<ss-port>` so user filter rules that `Block` the resolver IP cannot strand the forwarder's own queries. TCP uses `tokio-socks`; UDP uses a hand-rolled SOCKS5 UDP ASSOCIATE per RFC 1928.
+- [`SystemDnsConfig`](crates/bridge/src/dns/system.rs) — platform-specific capture/apply/restore. Windows uses `netsh`, macOS uses `networksetup`. Applied on both the TUN adapter and the upstream physical adapter; captured prior (v4 + v6, three shapes: static list / DHCP / none) is persisted to `bridge-dns.json` for crash recovery.
+
+**Upgrade migration**: `AppConfig` already carries `#[serde(default)]`, so existing configs without a `dns` key deserialize with `DnsConfig::default()` — which has `enabled: true`, `protocol: Https`, `servers: [1.1.1.1, 1.0.0.1]`, `intercept_udp53: true`. This enables the forwarder silently on upgrade (per user spec: "enabled on upgrade, no notification").
+
 ### Bridge test-isolation contract
 
 All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` trait in `crates/bridge/src/proxy.rs` and the `Routing` trait in `crates/tun-engine/src/routing.rs`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in the workspace root `clippy.toml` via the `disallowed_methods` list (`tun_engine::routing::setup_routes` / `teardown_routes`). See bindreams/hole#165 for the incident that motivated the rule.
@@ -72,6 +85,14 @@ crash recovery, both in `<state_dir>/`:
   kills any tracked processes that are still alive (with PID-reuse
   safety via start-time verification). The same file is also read by the
   test harness (`DistHarness::drop`) to reap leaked plugins after tests.
+- **`bridge-dns.json`** — records the DNS loopback bind address and the
+  prior system-DNS configuration (per adapter, per v4/v6 family: static
+  list / DHCP / none). Written after `LocalDnsServer::bind_ladder` and
+  before `SystemDnsConfig::apply`; cleared on clean shutdown. On next
+  startup, `dns::recovery::recover_dns_config` restores prior settings
+  and deletes the file. The recovery runs *before* `routing::recover_routes`
+  so a mid-recovery crash leaves the user with functional DNS + broken
+  routes rather than the harder-to-debug inverse.
 - **ETW sessions** (Windows only) — the bridge opens a named ETW trace
   session `hole-bridge-etw-<pid>` for in-process network diagnostics
   (see `crates/bridge/src/diagnostics/etw.rs`). A crashed bridge leaves

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +665,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -771,6 +795,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "color_quant"
@@ -1738,6 +1771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2405,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-server"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "ipnet",
+ "prefix-trie",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +2504,9 @@ dependencies = [
  "garter",
  "handle-holders",
  "hex",
+ "hickory-proto",
+ "hickory-resolver",
+ "hickory-server",
  "hole-common",
  "http",
  "http-body-util",
@@ -2454,6 +2519,8 @@ dependencies = [
  "rand 0.9.4",
  "rcgen",
  "regex",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "shadowsocks",
@@ -2465,11 +2532,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tls-parser",
  "tokio",
+ "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower",
  "tracing",
  "tun-engine",
  "ureq",
+ "webpki-roots",
  "windows 0.62.2",
  "windows-service",
  "xtask",
@@ -2877,6 +2947,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iprange"
@@ -2983,6 +3056,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -4366,6 +4449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prefix-trie"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+dependencies = [
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,6 +5085,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5016,6 +5110,7 @@ version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6537,6 +6632,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,16 @@ resolver = "2"
 skuld = { version = "0.2", features = ["tokio"] }
 insta = { version = "1", features = ["yaml"] }
 trybuild = "1"
+# DNS forwarder deps — direct so a future shadowsocks-service bump cannot
+# silently change the forwarder's hickory/tokio-socks versions.
+hickory-proto = "0.25"
+hickory-resolver = "0.25"
+hickory-server = "0.25"
+tokio-socks = "0.5"
+tokio-rustls = "0.26"
+rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "ring"] }
+rustls-pki-types = "1"
+webpki-roots = "1"
 
 [workspace.lints.clippy]
 disallowed_methods = "deny"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -54,6 +54,15 @@ smoltcp = { version = "0.12", default-features = false, features = [
 ] }
 arc-swap = "1"
 async-trait = "0.1"
+# DNS forwarder — workspace-pinned direct deps; see workspace Cargo.toml.
+hickory-proto = { workspace = true }
+hickory-resolver = { workspace = true }
+hickory-server = { workspace = true }
+tokio-socks = { workspace = true }
+tokio-rustls = { workspace = true }
+rustls = { workspace = true }
+rustls-pki-types = { workspace = true }
+webpki-roots = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 use tun_engine::{Device, Engine, MutDeviceConfig};
 
-use crate::endpoint::{BlockEndpoint, InterfaceEndpoint, Socks5Endpoint};
+use crate::endpoint::{BlockEndpoint, InterfaceEndpoint, LocalDnsEndpoint, Socks5Endpoint};
 use crate::filter::rules::RuleSet;
 use crate::hole_router::HoleRouter;
 use crate::proxy::{TUN_DEVICE_NAME, TUN_SUBNET};
@@ -44,6 +44,10 @@ impl Dispatcher {
     ///   drops UDP flows whose rule resolved to `Proxy` instead of
     ///   falling back to the clear-text bypass (privacy invariant).
     /// - `rules`: compiled filter rules.
+    /// - `local_dns_endpoint`: optional in-tunnel DNS interceptor. When
+    ///   `Some`, the router diverts UDP/53 flows to it. Callers pass
+    ///   `Some` when the `DnsConfig.intercept_udp53` flag is set and the
+    ///   forwarder has bound successfully.
     pub fn new(
         local_port: u16,
         iface_index: u32,
@@ -51,6 +55,7 @@ impl Dispatcher {
         plugin_name: Option<String>,
         plugin_supports_udp: bool,
         rules: RuleSet,
+        local_dns_endpoint: Option<LocalDnsEndpoint>,
     ) -> std::io::Result<Self> {
         // Open the TUN device.
         let v4_cidr = TUN_SUBNET
@@ -71,7 +76,13 @@ impl Dispatcher {
         let proxy = Socks5Endpoint::new(proxy_addr, plugin_name, plugin_supports_udp);
         let bypass = InterfaceEndpoint::new(iface_index, ipv6_available);
         let block = BlockEndpoint::new();
-        let router = Arc::new(HoleRouter::new(proxy, bypass, block, rules));
+        let router = Arc::new(HoleRouter::with_local_dns(
+            proxy,
+            bypass,
+            block,
+            local_dns_endpoint,
+            rules,
+        ));
 
         // Build the engine. Hole no longer registers a DnsInterceptor —
         // DNS queries traverse the tunnel like any other traffic, and

--- a/crates/bridge/src/dns.rs
+++ b/crates/bridge/src/dns.rs
@@ -7,6 +7,7 @@
 pub mod connector;
 pub mod forwarder;
 pub mod providers;
+pub mod recovery;
 pub mod server;
 pub mod socks5_connector;
 pub mod system;

--- a/crates/bridge/src/dns.rs
+++ b/crates/bridge/src/dns.rs
@@ -1,0 +1,9 @@
+//! Built-in DNS forwarder — carries DNS over the shadowsocks tunnel so
+//! clients paired with TCP-only plugins (v2ray-plugin) can still resolve.
+//!
+//! See `CLAUDE.md` ("UDP policy" + "Crash recovery") for the architectural
+//! context.
+
+pub mod connector;
+pub mod forwarder;
+pub mod providers;

--- a/crates/bridge/src/dns.rs
+++ b/crates/bridge/src/dns.rs
@@ -7,3 +7,4 @@
 pub mod connector;
 pub mod forwarder;
 pub mod providers;
+pub mod socks5_connector;

--- a/crates/bridge/src/dns.rs
+++ b/crates/bridge/src/dns.rs
@@ -9,3 +9,4 @@ pub mod forwarder;
 pub mod providers;
 pub mod server;
 pub mod socks5_connector;
+pub mod system;

--- a/crates/bridge/src/dns.rs
+++ b/crates/bridge/src/dns.rs
@@ -7,4 +7,5 @@
 pub mod connector;
 pub mod forwarder;
 pub mod providers;
+pub mod server;
 pub mod socks5_connector;

--- a/crates/bridge/src/dns/connector.rs
+++ b/crates/bridge/src/dns/connector.rs
@@ -1,0 +1,96 @@
+//! Upstream connectors used by the DNS forwarder.
+//!
+//! Two impls live behind [`UpstreamConnector`]:
+//!
+//! - [`DirectConnector`] — plain loopback / direct connection to an
+//!   upstream resolver. Used in tests and in the not-yet-wired sub-step
+//!   (c) path.
+//! - `Socks5Connector` (sub-step d) — routes every outbound connection
+//!   through the local shadowsocks SOCKS5 listener so user filter rules
+//!   cannot strand the forwarder.
+//!
+//! The trait deliberately returns type-erased streams so a SOCKS5 impl
+//! can substitute `tokio_socks::tcp::Socks5Stream<TcpStream>` at the same
+//! interface point as a bare `TcpStream`.
+
+use std::io;
+use std::net::SocketAddr;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::{TcpStream, UdpSocket};
+
+/// Bidirectional byte stream used by every TCP-based DNS transport
+/// (`PlainTcp`, `Tls`, `Https`). Requiring `Unpin` keeps the
+/// `tokio::io::AsyncReadExt` / `AsyncWriteExt` free functions usable on a
+/// boxed trait object.
+pub trait AsyncDuplex: AsyncRead + AsyncWrite + Send + Unpin {}
+impl<T: AsyncRead + AsyncWrite + Send + Unpin + ?Sized> AsyncDuplex for T {}
+
+/// Boxed TCP stream — direct `TcpStream` or a SOCKS5-wrapped
+/// `Socks5Stream<TcpStream>` at runtime.
+pub type BoxedStream = Box<dyn AsyncDuplex>;
+
+/// UDP send/recv abstraction. Separate from [`AsyncDuplex`] because the
+/// SOCKS5 UDP ASSOCIATE path wraps an inner socket and prepends a header,
+/// which is orthogonal to the AsyncRead/AsyncWrite shape.
+#[async_trait]
+pub trait UpstreamUdp: Send + Sync {
+    /// Send one DNS datagram.
+    async fn send(&self, buf: &[u8]) -> io::Result<usize>;
+    /// Receive one DNS datagram. Returns the number of bytes read.
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize>;
+}
+
+#[async_trait]
+pub trait UpstreamConnector: Send + Sync {
+    /// Open a TCP connection to `target`. SOCKS5 impls route via the
+    /// shadowsocks listener; the direct impl just calls `TcpStream::connect`.
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<BoxedStream>;
+
+    /// Open a UDP socket, bound locally and connected to `target`.
+    /// SOCKS5 impls perform UDP ASSOCIATE, which only succeeds when the
+    /// plugin carries UDP.
+    async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn UpstreamUdp>>;
+}
+
+// Direct ==============================================================================================================
+
+/// Opens connections straight to the target, with no SOCKS5 wrapping.
+/// Used by tests and as a fallback when no SOCKS5 listener is available.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DirectConnector;
+
+#[async_trait]
+impl UpstreamConnector for DirectConnector {
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<BoxedStream> {
+        let stream = TcpStream::connect(target).await?;
+        Ok(Box::new(stream))
+    }
+
+    async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {
+        let local: SocketAddr = if target.is_ipv4() {
+            "0.0.0.0:0".parse().unwrap()
+        } else {
+            "[::]:0".parse().unwrap()
+        };
+        let socket = UdpSocket::bind(local).await?;
+        socket.connect(target).await?;
+        Ok(Box::new(DirectUdp { socket }))
+    }
+}
+
+struct DirectUdp {
+    socket: UdpSocket,
+}
+
+#[async_trait]
+impl UpstreamUdp for DirectUdp {
+    async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.send(buf).await
+    }
+
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.socket.recv(buf).await
+    }
+}

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -1,0 +1,414 @@
+//! `DnsForwarder` — pure-bytes DNS forwarding over one of four upstream
+//! transports. Preserves the client's transaction ID so it can serve as a
+//! drop-in forwarder for both `LocalDnsServer` (sub-step e) and
+//! `LocalDnsEndpoint` (sub-step f).
+//!
+//! Serving strategy: walk `DnsConfig.servers` in order, try each with the
+//! configured `DnsProtocol`, return the first successful reply. Return a
+//! synthesized SERVFAIL if every server fails.
+//!
+//! IPv6 server entries are skipped (with a deduplicated WARN) when the
+//! upstream interface has no IPv6 connectivity — matches the spec in the
+//! plan.
+
+use std::collections::HashSet;
+use std::io::{self, Write};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use hole_common::config::{DnsConfig, DnsProtocol};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, RootCertStore};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::timeout;
+
+use crate::dns::connector::UpstreamConnector;
+use crate::dns::providers;
+
+/// Upstream port for plain DNS (RFC 1035) and DoT (RFC 7858).
+const DNS_PORT_PLAIN: u16 = 53;
+const DNS_PORT_TLS: u16 = 853;
+/// DoH typically runs on 443 (RFC 8484 §3).
+const DNS_PORT_HTTPS: u16 = 443;
+
+/// Per-upstream attempt timeout. Shorter than the OS default TCP timeout
+/// so a dead server doesn't stall the whole forward loop.
+const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Maximum reply size we'll buffer (bytes). DNS messages cap around 65535
+/// but we cap even tighter — DoH servers never return more than ~8KB in
+/// practice, and this prevents a malicious upstream from flooding RAM.
+const MAX_REPLY_SIZE: usize = 16 * 1024;
+
+/// SERVFAIL rcode per RFC 1035 §4.1.1.
+const RCODE_SERVFAIL: u8 = 2;
+
+// Public API ==========================================================================================================
+
+pub struct DnsForwarder {
+    config: DnsConfig,
+    connector: Arc<dyn UpstreamConnector>,
+    tls_config: Arc<ClientConfig>,
+    ipv6_bypass_available: bool,
+    /// Dedup state for per-server WARN log lines. Held in a `std::Mutex`
+    /// (never across an `await`) — each forward() call either hits or
+    /// misses the set and moves on.
+    logged_servers: Mutex<HashSet<IpAddr>>,
+}
+
+impl DnsForwarder {
+    /// Construct a forwarder. `ipv6_bypass_available` reflects whether the
+    /// upstream interface has IPv6 connectivity — matches the value used
+    /// by the `InterfaceEndpoint` cascade in `hole_router`.
+    pub fn new(config: DnsConfig, connector: Arc<dyn UpstreamConnector>, ipv6_bypass_available: bool) -> Self {
+        let tls_config = Arc::new(build_tls_config());
+        Self {
+            config,
+            connector,
+            tls_config,
+            ipv6_bypass_available,
+            logged_servers: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Forward a wire-format DNS query. Returns wire-format reply bytes.
+    /// Never errors — on total failure returns a synthesized SERVFAIL so
+    /// the caller can always write a reply back.
+    pub async fn forward(&self, query: &[u8]) -> Vec<u8> {
+        if query.len() < 12 {
+            return synthesize_servfail(query);
+        }
+
+        for &server in &self.config.servers {
+            if server.is_ipv6() && !self.ipv6_bypass_available {
+                self.log_once(server, "skipping IPv6 upstream (no IPv6 bypass available)");
+                continue;
+            }
+
+            match self.forward_one(server, query).await {
+                Ok(reply) => return reply,
+                Err(e) => {
+                    self.log_once(server, &format!("upstream failed: {e}"));
+                }
+            }
+        }
+
+        synthesize_servfail(query)
+    }
+
+    async fn forward_one(&self, server: IpAddr, query: &[u8]) -> io::Result<Vec<u8>> {
+        let fut = async {
+            match self.config.protocol {
+                DnsProtocol::PlainUdp => self.forward_udp(server, query).await,
+                DnsProtocol::PlainTcp => self.forward_tcp(server, query).await,
+                DnsProtocol::Tls => self.forward_tls(server, query).await,
+                DnsProtocol::Https => self.forward_https(server, query).await,
+            }
+        };
+        match timeout(UPSTREAM_TIMEOUT, fut).await {
+            Ok(res) => res,
+            Err(_) => Err(io::Error::new(io::ErrorKind::TimedOut, "upstream timeout")),
+        }
+    }
+
+    fn log_once(&self, server: IpAddr, msg: &str) {
+        let mut set = self.logged_servers.lock().expect("poisoned");
+        if set.insert(server) {
+            tracing::warn!(%server, protocol = ?self.config.protocol, "{msg}");
+        }
+    }
+}
+
+// Transport: plain UDP ================================================================================================
+
+impl DnsForwarder {
+    async fn forward_udp(&self, server: IpAddr, query: &[u8]) -> io::Result<Vec<u8>> {
+        let target = SocketAddr::new(server, DNS_PORT_PLAIN);
+        let socket = self.connector.connect_udp(target).await?;
+        socket.send(query).await?;
+        let mut buf = vec![0u8; MAX_REPLY_SIZE];
+        let n = socket.recv(&mut buf).await?;
+        buf.truncate(n);
+        Ok(buf)
+    }
+}
+
+// Transport: plain TCP ================================================================================================
+
+impl DnsForwarder {
+    async fn forward_tcp(&self, server: IpAddr, query: &[u8]) -> io::Result<Vec<u8>> {
+        let target = SocketAddr::new(server, DNS_PORT_PLAIN);
+        let stream = self.connector.connect_tcp(target).await?;
+        exchange_tcp_framed(stream, query).await
+    }
+}
+
+// Transport: DoT (TLS over TCP) =======================================================================================
+
+impl DnsForwarder {
+    async fn forward_tls(&self, server: IpAddr, query: &[u8]) -> io::Result<Vec<u8>> {
+        let target = SocketAddr::new(server, DNS_PORT_TLS);
+        let stream = self.connector.connect_tcp(target).await?;
+        let server_name = tls_server_name_for(server)?;
+        let connector = tokio_rustls::TlsConnector::from(Arc::clone(&self.tls_config));
+        let tls = connector.connect(server_name, stream).await?;
+        exchange_tcp_framed(tls, query).await
+    }
+}
+
+// Transport: DoH (HTTP/1.1 over TLS) ==================================================================================
+
+impl DnsForwarder {
+    async fn forward_https(&self, server: IpAddr, query: &[u8]) -> io::Result<Vec<u8>> {
+        let target = SocketAddr::new(server, DNS_PORT_HTTPS);
+        let (server_name, path_and_host) = https_target_for(server)?;
+        let stream = self.connector.connect_tcp(target).await?;
+        let connector = tokio_rustls::TlsConnector::from(Arc::clone(&self.tls_config));
+        let mut tls = connector.connect(server_name, stream).await?;
+
+        let (host, path) = path_and_host;
+        let mut req = Vec::with_capacity(256 + query.len());
+        write!(
+            req,
+            "POST {path} HTTP/1.1\r\n\
+             Host: {host}\r\n\
+             User-Agent: hole-bridge/dns-forwarder\r\n\
+             Accept: application/dns-message\r\n\
+             Content-Type: application/dns-message\r\n\
+             Content-Length: {len}\r\n\
+             Connection: close\r\n\r\n",
+            len = query.len()
+        )
+        .unwrap();
+        req.extend_from_slice(query);
+
+        tls.write_all(&req).await?;
+        tls.flush().await?;
+
+        let mut resp = Vec::with_capacity(4096);
+        // Cap reads so a misbehaving server can't OOM us.
+        tls.take((MAX_REPLY_SIZE * 4) as u64).read_to_end(&mut resp).await?;
+
+        parse_http_dns_response(&resp)
+    }
+}
+
+// Helpers =============================================================================================================
+
+/// Send `query` prefixed with its 16-bit big-endian length, read the
+/// same-shaped reply. Used by both plain TCP and DoT transports.
+async fn exchange_tcp_framed<S>(mut stream: S, query: &[u8]) -> io::Result<Vec<u8>>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
+    let len = u16::try_from(query.len()).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "query too large"))?;
+    let mut framed = Vec::with_capacity(2 + query.len());
+    framed.extend_from_slice(&len.to_be_bytes());
+    framed.extend_from_slice(query);
+    stream.write_all(&framed).await?;
+    stream.flush().await?;
+
+    let mut len_buf = [0u8; 2];
+    stream.read_exact(&mut len_buf).await?;
+    let reply_len = u16::from_be_bytes(len_buf) as usize;
+    if reply_len > MAX_REPLY_SIZE {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "reply too large"));
+    }
+    let mut reply = vec![0u8; reply_len];
+    stream.read_exact(&mut reply).await?;
+    Ok(reply)
+}
+
+/// Select the TLS `ServerName` for a given upstream IP. Known providers
+/// use their hostname (so DNS-validated certs work); unknown IPs fall back
+/// to IP-SAN verification.
+fn tls_server_name_for(server: IpAddr) -> io::Result<ServerName<'static>> {
+    if let Some(p) = providers::lookup(server) {
+        ServerName::try_from(p.tls_dns_name)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid SNI: {e}")))
+    } else {
+        Ok(ServerName::IpAddress(server.into()))
+    }
+}
+
+/// Return `(ServerName, (Host-header, Path))` for a DoH request to
+/// `server`. Host + path come from the known-provider table, or from the
+/// literal IP + `/dns-query` path for unknown servers.
+fn https_target_for(server: IpAddr) -> io::Result<(ServerName<'static>, (String, String))> {
+    if let Some(p) = providers::lookup(server) {
+        let url = p.doh_url;
+        let (host, path) = split_https_url(url)?;
+        let name = ServerName::try_from(host.as_str())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid SNI: {e}")))?
+            .to_owned();
+        Ok((name, (host, path)))
+    } else {
+        let host = match server {
+            IpAddr::V4(v4) => v4.to_string(),
+            IpAddr::V6(v6) => format!("[{v6}]"),
+        };
+        Ok((ServerName::IpAddress(server.into()), (host, "/dns-query".into())))
+    }
+}
+
+fn split_https_url(url: &str) -> io::Result<(String, String)> {
+    let rest = url
+        .strip_prefix("https://")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "doh url missing https://"))?;
+    let (host, path) = rest
+        .split_once('/')
+        .map(|(h, p)| (h.to_string(), format!("/{p}")))
+        .unwrap_or_else(|| (rest.to_string(), "/".to_string()));
+    Ok((host, path))
+}
+
+fn build_tls_config() -> ClientConfig {
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    // Use the explicit `ring` provider. rustls 0.23 removed the implicit
+    // global default; builder() panics when multiple/zero crypto providers
+    // are feature-enabled and none is globally installed. We feature-gate
+    // `ring` via workspace deps, so pass it directly.
+    let mut config = ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        .with_safe_default_protocol_versions()
+        .expect("ring provider supports default protocol versions")
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    // DoH requires ALPN "h2" per RFC 8484, but we send HTTP/1.1 so list
+    // "http/1.1" first. Some providers (notably Google) reject unknown ALPN
+    // lists — http/1.1 is universally accepted.
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    config
+}
+
+/// Parse a minimal HTTP/1.1 response: `HTTP/1.1 200 ...\r\n` + headers +
+/// `\r\n\r\n` + body. Requires Content-Length (chunked encoding not
+/// supported — every DoH server we talk to emits a discrete fixed-length
+/// reply).
+fn parse_http_dns_response(resp: &[u8]) -> io::Result<Vec<u8>> {
+    let body_sep =
+        find_double_crlf(resp).ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no header/body separator"))?;
+    let head = &resp[..body_sep];
+    let body = &resp[body_sep + 4..];
+
+    let head_str =
+        std::str::from_utf8(head).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-utf8 response head"))?;
+    let mut lines = head_str.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing status line"))?;
+    let mut parts = status_line.splitn(3, ' ');
+    let _ver = parts.next();
+    let code = parts
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing status code"))?;
+    if code != "200" {
+        return Err(io::Error::other(format!("non-200 DoH response: {status_line}")));
+    }
+
+    let mut content_length: Option<usize> = None;
+    let mut content_type: Option<&str> = None;
+    for line in lines {
+        if let Some((k, v)) = line.split_once(':') {
+            let k = k.trim().to_ascii_lowercase();
+            let v = v.trim();
+            match k.as_str() {
+                "content-length" => content_length = v.parse().ok(),
+                "content-type" => content_type = Some(v),
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(ct) = content_type {
+        if !ct.eq_ignore_ascii_case("application/dns-message") {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected Content-Type: {ct}"),
+            ));
+        }
+    }
+
+    let n = content_length.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length"))?;
+    if n > MAX_REPLY_SIZE {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "reply too large"));
+    }
+    if body.len() < n {
+        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "short DoH body"));
+    }
+    Ok(body[..n].to_vec())
+}
+
+fn find_double_crlf(buf: &[u8]) -> Option<usize> {
+    const NEEDLE: &[u8] = b"\r\n\r\n";
+    buf.windows(NEEDLE.len()).position(|w| w == NEEDLE)
+}
+
+/// Build a SERVFAIL response from an incoming query. Preserves the
+/// transaction ID, question section, and QDCOUNT; zeros all
+/// answer/authority/additional counts; sets QR=1, RA=1, RCODE=2.
+pub fn synthesize_servfail(query: &[u8]) -> Vec<u8> {
+    // DNS header is 12 bytes: ID(2) | flags(2) | QDCOUNT(2) | ANCOUNT(2) |
+    // NSCOUNT(2) | ARCOUNT(2). If the query is shorter than that, we can
+    // still emit a minimal SERVFAIL header.
+    let mut reply = Vec::with_capacity(query.len().max(12));
+    // Preserve transaction ID (first 2 bytes) when present.
+    if query.len() >= 2 {
+        reply.extend_from_slice(&query[..2]);
+    } else {
+        reply.extend_from_slice(&[0, 0]);
+    }
+    // Flags: QR=1, OPCODE mirrored, AA=0, TC=0, RD mirrored, RA=1,
+    // Z=0, RCODE=2 (SERVFAIL).
+    let (opcode_rd, _) = if query.len() >= 4 {
+        (query[2] & 0b0111_1001, query[3])
+    } else {
+        (0, 0)
+    };
+    // Byte 2: QR(1) OPCODE(4) AA(1) TC(1) RD(1)
+    reply.push(0b1000_0000 | opcode_rd);
+    // Byte 3: RA(1) Z(3) RCODE(4)
+    reply.push(0b1000_0000 | (RCODE_SERVFAIL & 0x0F));
+    // QDCOUNT preserved when present, else 0.
+    let qdcount = if query.len() >= 6 { [query[4], query[5]] } else { [0, 0] };
+    reply.extend_from_slice(&qdcount);
+    // Zero ANCOUNT / NSCOUNT / ARCOUNT.
+    reply.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+    // Copy question section if present (everything after the 12-byte
+    // header up to the end of question, identified by the first 0 label +
+    // 4 bytes of qtype/qclass). Safe fallback: copy the rest of the query
+    // verbatim if we can't find the question terminator.
+    if query.len() > 12 {
+        if let Some(qend) = question_end(&query[12..]) {
+            reply.extend_from_slice(&query[12..12 + qend]);
+        }
+    }
+    reply
+}
+
+/// Find the end of the first question section relative to the question
+/// start. Returns `None` on malformed input.
+fn question_end(q: &[u8]) -> Option<usize> {
+    let mut i = 0;
+    loop {
+        let len = *q.get(i)? as usize;
+        if len == 0 {
+            // The 0-byte label-terminator, followed by qtype(2) + qclass(2).
+            return Some(i + 1 + 4);
+        }
+        if len & 0xC0 != 0 {
+            // Compression pointer in a QNAME isn't valid per RFC 1035,
+            // but tolerate it: the pointer is 2 bytes total.
+            return Some(i + 2 + 4);
+        }
+        i += 1 + len;
+        if i >= q.len() {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "forwarder_tests.rs"]
+mod forwarder_tests;

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -1,0 +1,483 @@
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+
+use hole_common::config::{DnsConfig, DnsProtocol};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, UdpSocket};
+
+use super::*;
+use crate::dns::connector::DirectConnector;
+
+// Helpers =============================================================================================================
+
+/// Build a minimal well-formed DNS query for the name `example.com.` A.
+/// Wire format:
+///   [id:2][flags:2 = 0x0100][qdcount:2 = 1][an=0][ns=0][ar=0]
+///   name: 7 "example" 3 "com" 0
+///   qtype=A(1), qclass=IN(1)
+fn sample_query(tx_id: u16) -> Vec<u8> {
+    let mut q = Vec::with_capacity(32);
+    q.extend_from_slice(&tx_id.to_be_bytes());
+    q.extend_from_slice(&[0x01, 0x00]); // flags: RD=1
+    q.extend_from_slice(&[0x00, 0x01]); // QDCOUNT=1
+    q.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    q.push(7);
+    q.extend_from_slice(b"example");
+    q.push(3);
+    q.extend_from_slice(b"com");
+    q.push(0);
+    q.extend_from_slice(&[0x00, 0x01]); // QTYPE=A
+    q.extend_from_slice(&[0x00, 0x01]); // QCLASS=IN
+    q
+}
+
+/// Build a DNS reply that echoes the query's id + question and adds a
+/// single A record pointing at 93.184.216.34 (the historical example.com).
+fn sample_reply(query: &[u8]) -> Vec<u8> {
+    let mut r = Vec::with_capacity(64);
+    r.extend_from_slice(&query[..2]); // id
+    r.extend_from_slice(&[0x81, 0x80]); // flags: QR=1, RD=1, RA=1
+    r.extend_from_slice(&[0x00, 0x01]); // QDCOUNT=1
+    r.extend_from_slice(&[0x00, 0x01]); // ANCOUNT=1
+    r.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+    // echo question from byte 12 onwards
+    r.extend_from_slice(&query[12..]);
+    // answer: name pointer to offset 12, type A, class IN, TTL 60, rdlen 4, IP
+    r.extend_from_slice(&[0xc0, 0x0c]);
+    r.extend_from_slice(&[0x00, 0x01]);
+    r.extend_from_slice(&[0x00, 0x01]);
+    r.extend_from_slice(&60_u32.to_be_bytes());
+    r.extend_from_slice(&[0x00, 0x04]);
+    r.extend_from_slice(&[93, 184, 216, 34]);
+    r
+}
+
+async fn start_udp_stub(reply_bytes: Option<Vec<u8>>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = sock.local_addr().unwrap();
+    let h = tokio::spawn(async move {
+        let mut buf = [0u8; 2048];
+        let Ok((n, peer)) = sock.recv_from(&mut buf).await else {
+            return;
+        };
+        if let Some(reply) = reply_bytes {
+            let _ = sock.send_to(&reply, peer).await;
+        } else {
+            // emulate "dead" server: echo answer shape based on query
+            let reply = sample_reply(&buf[..n]);
+            let _ = sock.send_to(&reply, peer).await;
+        }
+    });
+    (addr, h)
+}
+
+async fn start_tcp_stub(reply: Vec<u8>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let h = tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        let mut len_buf = [0u8; 2];
+        if stream.read_exact(&mut len_buf).await.is_err() {
+            return;
+        }
+        let n = u16::from_be_bytes(len_buf) as usize;
+        let mut q = vec![0u8; n];
+        if stream.read_exact(&mut q).await.is_err() {
+            return;
+        }
+        let reply = if reply.is_empty() { sample_reply(&q) } else { reply };
+        let len = (reply.len() as u16).to_be_bytes();
+        let _ = stream.write_all(&len).await;
+        let _ = stream.write_all(&reply).await;
+    });
+    (addr, h)
+}
+
+/// A closed listener, pre-computed so the connect attempt fails.
+async fn unused_tcp_port() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+fn build_cfg(protocol: DnsProtocol, servers: Vec<IpAddr>) -> DnsConfig {
+    DnsConfig {
+        enabled: true,
+        servers,
+        protocol,
+        intercept_udp53: true,
+    }
+}
+
+// SERVFAIL synthesis ==================================================================================================
+
+#[skuld::test]
+fn servfail_preserves_transaction_id() {
+    let q = sample_query(0xABCD);
+    let r = synthesize_servfail(&q);
+    assert_eq!(&r[..2], &[0xAB, 0xCD]);
+}
+
+#[skuld::test]
+fn servfail_sets_qr_ra_and_rcode() {
+    let q = sample_query(0x0001);
+    let r = synthesize_servfail(&q);
+    assert_eq!(r[2] & 0x80, 0x80, "QR bit set");
+    assert_eq!(r[3] & 0x80, 0x80, "RA bit set");
+    assert_eq!(r[3] & 0x0F, 2, "RCODE = SERVFAIL");
+}
+
+#[skuld::test]
+fn servfail_zeroes_answer_authority_additional_counts() {
+    let q = sample_query(0x0001);
+    let r = synthesize_servfail(&q);
+    assert_eq!(&r[6..8], &[0, 0]);
+    assert_eq!(&r[8..10], &[0, 0]);
+    assert_eq!(&r[10..12], &[0, 0]);
+}
+
+#[skuld::test]
+fn servfail_preserves_question_section() {
+    let q = sample_query(0x1234);
+    let r = synthesize_servfail(&q);
+    // Header(12) + question echoed verbatim.
+    assert_eq!(&r[12..], &q[12..]);
+}
+
+#[skuld::test]
+fn servfail_handles_short_input() {
+    let short = b"\x12\x34"; // only the tx id
+    let r = synthesize_servfail(short);
+    assert!(r.len() >= 12);
+    assert_eq!(&r[..2], &[0x12, 0x34]);
+    assert_eq!(r[3] & 0x0F, 2);
+}
+
+// Forward: UDP ========================================================================================================
+
+#[skuld::test]
+async fn plain_udp_primary_succeeds() {
+    let q = sample_query(0x0042);
+    let (addr, _h) = start_udp_stub(None).await;
+    let fwd = DnsForwarder::new(
+        build_cfg(DnsProtocol::PlainUdp, vec![addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+    );
+    // Override server list to include the ephemeral port via the connector
+    // layer: the forwarder always targets port 53, but our stub listens on
+    // ephemeral — so we swap via a test-only helper.
+    let reply = fwd.forward_on_port(&q, addr.port()).await;
+    assert_eq!(&reply[..2], &[0x00, 0x42], "tx id echoed");
+    assert_eq!(reply[2] & 0x80, 0x80, "QR set (real reply, not SERVFAIL)");
+    assert_ne!(reply[3] & 0x0F, 2, "RCODE is not SERVFAIL");
+}
+
+#[skuld::test]
+async fn plain_udp_primary_fails_secondary_succeeds() {
+    let q = sample_query(0x0001);
+    // Primary: bind then drop to get a closed port.
+    let dead = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = dead.local_addr().unwrap();
+    drop(dead);
+    let (live_addr, _h) = start_udp_stub(None).await;
+
+    let fwd = DnsForwarder::new(
+        DnsConfig {
+            enabled: true,
+            servers: vec![dead_addr.ip(), live_addr.ip()],
+            protocol: DnsProtocol::PlainUdp,
+            intercept_udp53: true,
+        },
+        Arc::new(DirectConnector),
+        true,
+    );
+    // Both stubs live on 127.0.0.1 but different ports; the test helper
+    // overrides the forwarder's port. Since we can only override one port,
+    // use two distinct addresses via the `forward_with_ports` helper.
+    let reply = fwd.forward_with_ports(&q, &[dead_addr.port(), live_addr.port()]).await;
+    // We expect success from the second server.
+    assert_ne!(reply[3] & 0x0F, 2, "secondary succeeded, not SERVFAIL");
+}
+
+#[skuld::test]
+async fn all_servers_fail_returns_servfail() {
+    let q = sample_query(0x5678);
+    // Two closed addresses.
+    let s1 = UdpSocket::bind("127.0.0.1:0").await.unwrap().local_addr().unwrap();
+    let s2 = UdpSocket::bind("127.0.0.1:0").await.unwrap().local_addr().unwrap();
+    let fwd = DnsForwarder::new(
+        build_cfg(DnsProtocol::PlainTcp, vec![s1.ip(), s2.ip()]),
+        Arc::new(DirectConnector),
+        true,
+    );
+    // Use TCP (closed address → immediate RST or connect failure).
+    let reply = fwd.forward_with_ports(&q, &[s1.port(), s2.port()]).await;
+    assert_eq!(reply[3] & 0x0F, 2, "RCODE=SERVFAIL");
+    assert_eq!(&reply[..2], &[0x56, 0x78]);
+}
+
+// Forward: TCP ========================================================================================================
+
+#[skuld::test]
+async fn plain_tcp_primary_succeeds() {
+    let q = sample_query(0x00AA);
+    let (addr, _h) = start_tcp_stub(Vec::new()).await;
+    let fwd = DnsForwarder::new(
+        build_cfg(DnsProtocol::PlainTcp, vec![addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+    );
+    let reply = fwd.forward_on_port(&q, addr.port()).await;
+    assert_eq!(&reply[..2], &[0x00, 0xAA]);
+    assert_eq!(reply[2] & 0x80, 0x80);
+    assert_ne!(reply[3] & 0x0F, 2);
+}
+
+// IPv6 skip ===========================================================================================================
+
+#[skuld::test]
+async fn ipv6_upstream_skipped_when_no_v6_bypass() {
+    let q = sample_query(0x0003);
+    let v6: IpAddr = "2001:db8::1".parse().unwrap();
+    let (v4_addr, _h) = start_udp_stub(None).await;
+    let fwd = DnsForwarder::new(
+        DnsConfig {
+            enabled: true,
+            servers: vec![v6, v4_addr.ip()],
+            protocol: DnsProtocol::PlainUdp,
+            intercept_udp53: true,
+        },
+        Arc::new(DirectConnector),
+        false, // no v6 bypass
+    );
+    let reply = fwd.forward_with_ports(&q, &[0, v4_addr.port()]).await;
+    // The v6 server was skipped; v4 answered.
+    assert_ne!(reply[3] & 0x0F, 2);
+}
+
+// Dedup ===============================================================================================================
+
+#[skuld::test]
+async fn duplicate_server_in_list_logs_only_once() {
+    // Two identical dead addresses. Without dedup we'd log twice.
+    let dead_addr = unused_tcp_port().await;
+    let fwd = DnsForwarder::new(
+        build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), dead_addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+    );
+    let q = sample_query(0x0001);
+    let _ = fwd.forward_with_ports(&q, &[dead_addr.port(), dead_addr.port()]).await;
+    // logged_servers should contain exactly one entry.
+    let set = fwd.logged_servers.lock().unwrap();
+    assert_eq!(set.len(), 1, "duplicate server logged only once");
+}
+
+// Short-query safety ==================================================================================================
+
+#[skuld::test]
+async fn forward_on_short_query_returns_servfail() {
+    let short = b"abc"; // below 12-byte DNS header
+    let (addr, _h) = start_udp_stub(None).await;
+    let fwd = DnsForwarder::new(
+        build_cfg(DnsProtocol::PlainUdp, vec![addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+    );
+    let reply = fwd.forward_on_port(short, addr.port()).await;
+    assert!(reply.len() >= 12);
+    assert_eq!(reply[3] & 0x0F, 2);
+}
+
+// Test-only helpers allowing ephemeral-port stubs =====================================================================
+//
+// The forwarder always targets fixed well-known ports (53/853/443). Tests
+// need ephemeral ports to run without privilege. These helpers mirror the
+// public API but let tests substitute the port.
+
+impl DnsForwarder {
+    async fn forward_on_port(&self, query: &[u8], port: u16) -> Vec<u8> {
+        self.forward_with_ports(query, &[port]).await
+    }
+
+    async fn forward_with_ports(&self, query: &[u8], ports: &[u16]) -> Vec<u8> {
+        if query.len() < 12 {
+            return synthesize_servfail(query);
+        }
+        for (i, &server) in self.config.servers.iter().enumerate() {
+            if server.is_ipv6() && !self.ipv6_bypass_available {
+                self.log_once(server, "skipping IPv6 upstream (no IPv6 bypass available)");
+                continue;
+            }
+            let port = ports.get(i).copied().unwrap_or(match self.config.protocol {
+                DnsProtocol::PlainUdp | DnsProtocol::PlainTcp => 53,
+                DnsProtocol::Tls => 853,
+                DnsProtocol::Https => 443,
+            });
+            let target = SocketAddr::new(server, port);
+            let fut = async {
+                match self.config.protocol {
+                    DnsProtocol::PlainUdp => {
+                        let s = self.connector.connect_udp(target).await?;
+                        s.send(query).await?;
+                        let mut buf = vec![0u8; MAX_REPLY_SIZE];
+                        let n = s.recv(&mut buf).await?;
+                        buf.truncate(n);
+                        Ok::<Vec<u8>, io::Error>(buf)
+                    }
+                    DnsProtocol::PlainTcp => {
+                        let s = self.connector.connect_tcp(target).await?;
+                        exchange_tcp_framed(s, query).await
+                    }
+                    DnsProtocol::Tls | DnsProtocol::Https => {
+                        // Ephemeral-port TLS stubs are out of scope for unit tests — these branches
+                        // would need a full rustls server setup. Covered by integration tests.
+                        self.forward_one(server, query).await
+                    }
+                }
+            };
+            match timeout(UPSTREAM_TIMEOUT, fut).await {
+                Ok(Ok(reply)) => return reply,
+                Ok(Err(e)) => self.log_once(server, &format!("upstream failed: {e}")),
+                Err(_) => self.log_once(server, "upstream timeout"),
+            }
+        }
+        synthesize_servfail(query)
+    }
+}
+
+// URL split helpers (whitebox) ========================================================================================
+
+#[skuld::test]
+fn split_https_url_recovers_host_and_path() {
+    let (h, p) = split_https_url("https://cloudflare-dns.com/dns-query").unwrap();
+    assert_eq!(h, "cloudflare-dns.com");
+    assert_eq!(p, "/dns-query");
+}
+
+#[skuld::test]
+fn split_https_url_rejects_non_https() {
+    assert!(split_https_url("http://foo/bar").is_err());
+}
+
+#[skuld::test]
+fn https_target_for_known_ip_uses_hostname_sni() {
+    let v4: IpAddr = "1.1.1.1".parse().unwrap();
+    let (name, (host, path)) = https_target_for(v4).unwrap();
+    assert_eq!(host, "cloudflare-dns.com");
+    assert_eq!(path, "/dns-query");
+    match name {
+        ServerName::DnsName(dns) => assert_eq!(dns.as_ref(), "cloudflare-dns.com"),
+        other => panic!("expected DnsName SNI, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn https_target_for_unknown_ip_uses_literal() {
+    let v4: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    let (name, (host, path)) = https_target_for(v4).unwrap();
+    assert_eq!(host, "192.0.2.1");
+    assert_eq!(path, "/dns-query");
+    match name {
+        ServerName::IpAddress(_) => {}
+        other => panic!("expected IP SNI, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn https_target_for_unknown_ipv6_brackets_host() {
+    let v6: IpAddr = "2001:db8::1".parse().unwrap();
+    let (_name, (host, _path)) = https_target_for(v6).unwrap();
+    assert_eq!(host, "[2001:db8::1]");
+}
+
+#[skuld::test]
+fn tls_server_name_known_ip() {
+    let v4: IpAddr = "8.8.8.8".parse().unwrap();
+    match tls_server_name_for(v4).unwrap() {
+        ServerName::DnsName(n) => assert_eq!(n.as_ref(), "dns.google"),
+        _ => panic!("expected DnsName"),
+    }
+}
+
+#[skuld::test]
+fn tls_server_name_unknown_ip() {
+    let v4: IpAddr = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
+    match tls_server_name_for(v4).unwrap() {
+        ServerName::IpAddress(_) => {}
+        _ => panic!("expected IpAddress"),
+    }
+}
+
+// HTTP response parsing ===============================================================================================
+
+#[skuld::test]
+fn parse_http_dns_rejects_non_200() {
+    let resp = b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+    assert!(parse_http_dns_response(resp).is_err());
+}
+
+#[skuld::test]
+fn parse_http_dns_extracts_body() {
+    let body: &[u8] = b"\x12\x34\x81\x80\x00\x00\x00\x00\x00\x00\x00\x00";
+    let mut resp = Vec::new();
+    resp.extend_from_slice(
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/dns-message\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        )
+        .as_bytes(),
+    );
+    resp.extend_from_slice(body);
+    let out = parse_http_dns_response(&resp).unwrap();
+    assert_eq!(out, body);
+}
+
+#[skuld::test]
+fn parse_http_dns_rejects_wrong_content_type() {
+    let body: &[u8] = b"hi";
+    let mut resp = Vec::new();
+    resp.extend_from_slice(
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        )
+        .as_bytes(),
+    );
+    resp.extend_from_slice(body);
+    assert!(parse_http_dns_response(&resp).is_err());
+}
+
+#[skuld::test]
+fn parse_http_dns_rejects_missing_content_length() {
+    let resp = b"HTTP/1.1 200 OK\r\nContent-Type: application/dns-message\r\n\r\nbody";
+    assert!(parse_http_dns_response(resp).is_err());
+}
+
+#[skuld::test]
+fn parse_http_dns_rejects_oversize_content_length() {
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/dns-message\r\nContent-Length: {}\r\n\r\n",
+        MAX_REPLY_SIZE + 1
+    );
+    assert!(parse_http_dns_response(resp.as_bytes()).is_err());
+}
+
+// Question-section parsing ============================================================================================
+
+#[skuld::test]
+fn question_end_normal_name() {
+    // 7 example 3 com 0 + qtype(2) + qclass(2) = 17 bytes
+    let q = b"\x07example\x03com\x00\x00\x01\x00\x01";
+    assert_eq!(question_end(q), Some(q.len()));
+}
+
+#[skuld::test]
+fn question_end_rejects_truncated() {
+    let q = b"\x07example"; // no null terminator
+    assert!(question_end(q).is_none());
+}

--- a/crates/bridge/src/dns/providers.rs
+++ b/crates/bridge/src/dns/providers.rs
@@ -1,0 +1,75 @@
+//! Known-provider table: maps a resolver IP to hostname-form metadata
+//! for DoT (SNI / cert verification) and DoH (full URL).
+//!
+//! IPs not in the table fall back to IP-SAN cert verification for TLS and
+//! URL shape `https://<ip>/dns-query` for DoH — which works for Cloudflare
+//! / Google / Quad9 today but requires the provider to continue shipping
+//! IP-SAN-bearing certs.
+
+use std::net::IpAddr;
+
+/// Hostname-form metadata for a known DNS provider IP.
+#[derive(Debug, Clone, Copy)]
+pub struct KnownProvider {
+    pub tls_dns_name: &'static str,
+    pub doh_url: &'static str,
+}
+
+/// Lookup metadata by IP. Returns `None` for free-form addresses.
+pub fn lookup(ip: IpAddr) -> Option<KnownProvider> {
+    for (addr, provider) in TABLE {
+        if addr.parse::<IpAddr>().ok() == Some(ip) {
+            return Some(**provider);
+        }
+    }
+    None
+}
+
+const CLOUDFLARE: KnownProvider = KnownProvider {
+    tls_dns_name: "cloudflare-dns.com",
+    doh_url: "https://cloudflare-dns.com/dns-query",
+};
+
+const GOOGLE: KnownProvider = KnownProvider {
+    tls_dns_name: "dns.google",
+    doh_url: "https://dns.google/dns-query",
+};
+
+const QUAD9: KnownProvider = KnownProvider {
+    tls_dns_name: "dns.quad9.net",
+    doh_url: "https://dns.quad9.net/dns-query",
+};
+
+const OPENDNS: KnownProvider = KnownProvider {
+    tls_dns_name: "dns.opendns.com",
+    doh_url: "https://doh.opendns.com/dns-query",
+};
+
+const ADGUARD: KnownProvider = KnownProvider {
+    tls_dns_name: "dns.adguard-dns.com",
+    doh_url: "https://dns.adguard-dns.com/dns-query",
+};
+
+// Stable order — tests match on this to catch accidental reshuffling.
+const TABLE: &[(&str, &KnownProvider)] = &[
+    ("1.1.1.1", &CLOUDFLARE),
+    ("1.0.0.1", &CLOUDFLARE),
+    ("2606:4700:4700::1111", &CLOUDFLARE),
+    ("2606:4700:4700::1001", &CLOUDFLARE),
+    ("8.8.8.8", &GOOGLE),
+    ("8.8.4.4", &GOOGLE),
+    ("2001:4860:4860::8888", &GOOGLE),
+    ("2001:4860:4860::8844", &GOOGLE),
+    ("9.9.9.9", &QUAD9),
+    ("149.112.112.112", &QUAD9),
+    ("2620:fe::fe", &QUAD9),
+    ("2620:fe::9", &QUAD9),
+    ("208.67.222.222", &OPENDNS),
+    ("208.67.220.220", &OPENDNS),
+    ("94.140.14.14", &ADGUARD),
+    ("94.140.15.15", &ADGUARD),
+];
+
+#[cfg(test)]
+#[path = "providers_tests.rs"]
+mod providers_tests;

--- a/crates/bridge/src/dns/providers_tests.rs
+++ b/crates/bridge/src/dns/providers_tests.rs
@@ -1,0 +1,58 @@
+use std::net::IpAddr;
+
+use super::*;
+
+#[skuld::test]
+fn cloudflare_by_ip_returns_cloudflare_dns_com() {
+    let p = lookup("1.1.1.1".parse::<IpAddr>().unwrap()).expect("1.1.1.1 is known");
+    assert_eq!(p.tls_dns_name, "cloudflare-dns.com");
+    assert_eq!(p.doh_url, "https://cloudflare-dns.com/dns-query");
+}
+
+#[skuld::test]
+fn cloudflare_secondary_matches() {
+    let p = lookup("1.0.0.1".parse::<IpAddr>().unwrap()).expect("1.0.0.1 is known");
+    assert_eq!(p.tls_dns_name, "cloudflare-dns.com");
+}
+
+#[skuld::test]
+fn cloudflare_ipv6_matches() {
+    let p = lookup("2606:4700:4700::1111".parse::<IpAddr>().unwrap()).expect("v6 is known");
+    assert_eq!(p.tls_dns_name, "cloudflare-dns.com");
+}
+
+#[skuld::test]
+fn google_matches() {
+    let p = lookup("8.8.8.8".parse::<IpAddr>().unwrap()).expect("8.8.8.8 is known");
+    assert_eq!(p.tls_dns_name, "dns.google");
+    assert_eq!(p.doh_url, "https://dns.google/dns-query");
+}
+
+#[skuld::test]
+fn quad9_matches() {
+    let p = lookup("9.9.9.9".parse::<IpAddr>().unwrap()).expect("9.9.9.9 is known");
+    assert_eq!(p.tls_dns_name, "dns.quad9.net");
+}
+
+#[skuld::test]
+fn unknown_ip_returns_none() {
+    assert!(lookup("203.0.113.42".parse::<IpAddr>().unwrap()).is_none());
+}
+
+#[skuld::test]
+fn all_doh_urls_start_with_https() {
+    for (_, p) in TABLE {
+        assert!(
+            p.doh_url.starts_with("https://"),
+            "doh_url should be https: {}",
+            p.doh_url
+        );
+    }
+}
+
+#[skuld::test]
+fn all_keys_parse_as_ip() {
+    for (addr, _) in TABLE {
+        addr.parse::<IpAddr>().unwrap_or_else(|_| panic!("not an IP: {addr}"));
+    }
+}

--- a/crates/bridge/src/dns/recovery.rs
+++ b/crates/bridge/src/dns/recovery.rs
@@ -1,0 +1,50 @@
+//! DNS crash recovery.
+//!
+//! Called at bridge startup *after* the IPC socket bind succeeds — matches
+//! the existing convention in [`crate::plugin_recovery`] /
+//! [`tun_engine::routing::recover_routes`]. Reads `bridge-dns.json`,
+//! restores each adapter's prior DNS, deletes the file.
+//!
+//! **Order in the startup cascade:** this runs *before*
+//! `routing::recover_routes` (plan §Components / §Lifecycle). If the
+//! process is killed mid-recovery, the user is more likely left with
+//! functional DNS + broken routes (fixable via `route delete`) than
+//! broken DNS + functional routes (much harder for the user to diagnose).
+//! DNS restore is also cheaper (2–4 `netsh`/`networksetup` calls per
+//! adapter) than route recovery, so this front-loads the cheap cleanup.
+
+use std::path::Path;
+
+use crate::dns::system;
+use crate::dns_state;
+
+/// Clean up system DNS settings left behind by a previous bridge run.
+/// Best-effort — errors logged at `warn`, returns `()`.
+pub fn recover_dns_config(state_dir: &Path) {
+    let Some(state) = dns_state::load(state_dir) else {
+        return;
+    };
+
+    tracing::info!(
+        loopback = %state.chosen_loopback,
+        adapter_count = state.adapters.len(),
+        "dns_recovery: restoring prior DNS for leaked state"
+    );
+
+    let errors = system::restore_all(&state.adapters);
+    if !errors.is_empty() {
+        tracing::warn!(
+            count = errors.len(),
+            "dns_recovery: {} adapter restores failed (see prior WARNs)",
+            errors.len()
+        );
+    }
+
+    if let Err(e) = dns_state::clear(state_dir) {
+        tracing::warn!(error = %e, "failed to clear DNS state file after recovery");
+    }
+}
+
+#[cfg(test)]
+#[path = "recovery_tests.rs"]
+mod recovery_tests;

--- a/crates/bridge/src/dns/recovery_tests.rs
+++ b/crates/bridge/src/dns/recovery_tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+#[skuld::test]
+fn recover_when_no_state_file_is_noop() {
+    let dir = tempfile::tempdir().unwrap();
+    // Should not panic, should not create any files.
+    recover_dns_config(dir.path());
+    assert!(!dir.path().join(dns_state::STATE_FILE_NAME).exists());
+}
+
+#[skuld::test]
+fn recover_clears_state_file_after_restore() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dns_state::DnsState {
+        version: dns_state::SCHEMA_VERSION,
+        chosen_loopback: std::net::SocketAddr::from(([127, 0, 0, 1], 53)),
+        // Empty adapters list — restore_all is a no-op so no platform
+        // commands get invoked (safe in CI).
+        adapters: Vec::new(),
+    };
+    dns_state::save(dir.path(), &state).unwrap();
+    assert!(dir.path().join(dns_state::STATE_FILE_NAME).exists());
+    recover_dns_config(dir.path());
+    assert!(!dir.path().join(dns_state::STATE_FILE_NAME).exists());
+}
+
+#[skuld::test]
+fn recover_wrong_version_leaves_state_file_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": 99,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [],
+    });
+    std::fs::write(dir.path().join(dns_state::STATE_FILE_NAME), json.to_string()).unwrap();
+    recover_dns_config(dir.path());
+    // load() returns None for wrong version → early exit → file intact.
+    assert!(dir.path().join(dns_state::STATE_FILE_NAME).exists());
+}

--- a/crates/bridge/src/dns/server.rs
+++ b/crates/bridge/src/dns/server.rs
@@ -1,0 +1,198 @@
+//! [`LocalDnsServer`] — binds loopback `<ip>:53` UDP+TCP and forwards
+//! every incoming query through a shared [`DnsForwarder`]. Hand-rolled
+//! instead of using `hickory-server` because the forwarder's I/O is pure
+//! bytes-in/bytes-out — no zone database, no authority records, no
+//! response caching. A `RequestHandler` wrapper would add serialization
+//! overhead and conceptual weight for no gain.
+//!
+//! Loopback bind ladder (per plan "Loopback bind-fallback ladder"):
+//!
+//! 1. `127.0.0.1:53` — the conventional default
+//! 2. `127.53.0.1:53 .. 127.53.0.254:53` — Hole-dedicated /24 sweep
+//! 3. Bind fails loudly
+//!
+//! UDP and TCP must bind *together* on the same IP (if UDP succeeds but
+//! TCP fails on an IP, both are released and the ladder moves on — this
+//! avoids a split-brain state where system DNS clients might only reach
+//! one transport).
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::task::JoinHandle;
+
+use crate::dns::forwarder::DnsForwarder;
+
+/// DNS port. Both UDP and TCP use 53 per RFC 1035.
+const DNS_PORT: u16 = 53;
+
+/// Maximum inbound DNS message (both UDP and TCP). DNS over UDP is
+/// capped at 512 bytes (or EDNS0's max_udp_payload) but we accept up to
+/// `MAX_INBOUND_MESSAGE` — in practice the OS DNS client caps queries well
+/// below this.
+const MAX_INBOUND_MESSAGE: usize = 4 * 1024;
+
+/// A loopback DNS server. Dropping the server aborts both listener tasks.
+pub struct LocalDnsServer {
+    addr: SocketAddr,
+    udp_task: JoinHandle<()>,
+    tcp_task: JoinHandle<()>,
+}
+
+impl LocalDnsServer {
+    /// Bind a specific address (UDP + TCP). Used by tests to inject an
+    /// ephemeral port; production code uses [`bind_ladder`].
+    ///
+    /// Binds UDP first, then TCP on the same (possibly ephemeral) port —
+    /// passing `port = 0` would otherwise hand the two sockets distinct
+    /// OS-assigned ports, which callers never want: system DNS clients
+    /// need UDP and TCP on the same address.
+    pub async fn bind(addr: SocketAddr, forwarder: Arc<DnsForwarder>) -> io::Result<Self> {
+        let udp = UdpSocket::bind(addr).await?;
+        let actual_addr = udp.local_addr()?;
+        let tcp = TcpListener::bind(actual_addr).await?;
+
+        let fwd_udp = Arc::clone(&forwarder);
+        let udp_task = tokio::spawn(async move { run_udp_loop(udp, fwd_udp).await });
+
+        let fwd_tcp = forwarder;
+        let tcp_task = tokio::spawn(async move { run_tcp_loop(tcp, fwd_tcp).await });
+
+        Ok(Self {
+            addr: actual_addr,
+            udp_task,
+            tcp_task,
+        })
+    }
+
+    /// Bind `<ip>:53` via the fallback ladder. Tries `127.0.0.1` first,
+    /// then `127.53.0.1..=127.53.0.254`, returning the first IP where BOTH
+    /// UDP and TCP bind succeeds. Returns an explicit error when the whole
+    /// ladder is exhausted.
+    pub async fn bind_ladder(forwarder: Arc<DnsForwarder>) -> io::Result<Self> {
+        let candidates = ladder_candidates();
+        let mut last_err: Option<io::Error> = None;
+        for addr in candidates {
+            match Self::bind(addr, Arc::clone(&forwarder)).await {
+                Ok(srv) => return Ok(srv),
+                Err(e) => {
+                    tracing::debug!(%addr, error = %e, "LocalDnsServer bind candidate failed");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(io::Error::other(format!(
+            "LocalDnsServer could not bind any :53 loopback; last error: {}. \
+             Disable DNS forwarder in settings, or stop the conflicting service \
+             (Pi-hole, Acrylic, Docker Desktop, dnscrypt-proxy).",
+            last_err.expect("ladder non-empty")
+        )))
+    }
+
+    /// Address the server is actually bound to. Differs from the
+    /// requested address when the caller used [`bind_ladder`] or the OS
+    /// substituted an ephemeral port.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+impl Drop for LocalDnsServer {
+    fn drop(&mut self) {
+        // Aborting the tasks closes the underlying sockets via Drop,
+        // which releases the loopback port + interrupts pending
+        // recv_from/accept calls so in-flight clients get immediate EOF.
+        self.udp_task.abort();
+        self.tcp_task.abort();
+    }
+}
+
+// Loop bodies =========================================================================================================
+
+async fn run_udp_loop(socket: UdpSocket, forwarder: Arc<DnsForwarder>) {
+    let socket = Arc::new(socket);
+    loop {
+        let mut buf = vec![0u8; MAX_INBOUND_MESSAGE];
+        let (n, peer) = match socket.recv_from(&mut buf).await {
+            Ok(v) => v,
+            Err(e) => {
+                // If the socket was closed (server dropped), recv_from
+                // returns an error and we exit. Any other error is worth
+                // logging but not fatal to the loop.
+                tracing::debug!(error = %e, "LocalDnsServer UDP recv_from error; ending loop");
+                return;
+            }
+        };
+        buf.truncate(n);
+        let socket = Arc::clone(&socket);
+        let forwarder = Arc::clone(&forwarder);
+        tokio::spawn(async move {
+            let reply = forwarder.forward(&buf).await;
+            if let Err(e) = socket.send_to(&reply, peer).await {
+                tracing::debug!(error = %e, %peer, "LocalDnsServer UDP send_to error");
+            }
+        });
+    }
+}
+
+async fn run_tcp_loop(listener: TcpListener, forwarder: Arc<DnsForwarder>) {
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!(error = %e, "LocalDnsServer TCP accept error; ending loop");
+                return;
+            }
+        };
+        let forwarder = Arc::clone(&forwarder);
+        tokio::spawn(async move {
+            if let Err(e) = handle_tcp_connection(stream, forwarder).await {
+                tracing::debug!(error = %e, %peer, "LocalDnsServer TCP connection error");
+            }
+        });
+    }
+}
+
+async fn handle_tcp_connection(mut stream: TcpStream, forwarder: Arc<DnsForwarder>) -> io::Result<()> {
+    loop {
+        let mut len_buf = [0u8; 2];
+        match stream.read_exact(&mut len_buf).await {
+            Ok(_) => {}
+            // A clean close at message boundary is expected when the
+            // client finished its queries.
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(e) => return Err(e),
+        }
+        let n = u16::from_be_bytes(len_buf) as usize;
+        if n > MAX_INBOUND_MESSAGE {
+            return Err(io::Error::other("DNS query too large"));
+        }
+        let mut query = vec![0u8; n];
+        stream.read_exact(&mut query).await?;
+
+        let reply = forwarder.forward(&query).await;
+        let reply_len = u16::try_from(reply.len()).map_err(|_| io::Error::other("reply too large"))?;
+        stream.write_all(&reply_len.to_be_bytes()).await?;
+        stream.write_all(&reply).await?;
+    }
+}
+
+// Ladder ==============================================================================================================
+
+/// Build the list of candidate addresses in priority order. The ladder
+/// lives in one spot so tests can assert its contents.
+pub(super) fn ladder_candidates() -> Vec<SocketAddr> {
+    let mut v = Vec::with_capacity(1 + 254);
+    v.push(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), DNS_PORT));
+    for host in 1..=254u8 {
+        v.push(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 53, 0, host)), DNS_PORT));
+    }
+    v
+}
+
+#[cfg(test)]
+#[path = "server_tests.rs"]
+mod server_tests;

--- a/crates/bridge/src/dns/server_tests.rs
+++ b/crates/bridge/src/dns/server_tests.rs
@@ -1,0 +1,185 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use hole_common::config::{DnsConfig, DnsProtocol};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::time::timeout;
+
+use super::*;
+use crate::dns::connector::DirectConnector;
+
+// Ladder ==============================================================================================================
+
+#[skuld::test]
+fn ladder_first_is_127_0_0_1() {
+    let list = ladder_candidates();
+    assert_eq!(list[0], SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 53));
+}
+
+#[skuld::test]
+fn ladder_sweeps_127_53_0_1_through_254() {
+    let list = ladder_candidates();
+    assert_eq!(list.len(), 1 + 254);
+    assert_eq!(list[1].ip(), IpAddr::V4(Ipv4Addr::new(127, 53, 0, 1)));
+    assert_eq!(list.last().unwrap().ip(), IpAddr::V4(Ipv4Addr::new(127, 53, 0, 254)));
+    for addr in &list {
+        assert_eq!(addr.port(), 53, "every ladder candidate uses port 53");
+    }
+}
+
+// End-to-end with stub upstream =======================================================================================
+
+/// Spin up a stub UDP DNS upstream on an ephemeral port. Replies with a
+/// minimal well-formed response.
+async fn start_stub_upstream() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let sock = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let addr = sock.local_addr().unwrap();
+    let h = tokio::spawn(async move {
+        loop {
+            let mut buf = [0u8; 1500];
+            let Ok((n, peer)) = sock.recv_from(&mut buf).await else {
+                return;
+            };
+            // Build a reply: copy id, set QR/RA, zero counts, include question verbatim.
+            let mut r = Vec::with_capacity(n + 16);
+            r.extend_from_slice(&buf[..2]); // id
+            r.extend_from_slice(&[0x81, 0x80]); // QR=1, RD=1, RA=1
+            r.extend_from_slice(&[0x00, 0x01]); // QDCOUNT=1
+            r.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            if n > 12 {
+                r.extend_from_slice(&buf[12..n]);
+            }
+            let _ = sock.send_to(&r, peer).await;
+        }
+    });
+    (addr, h)
+}
+
+fn sample_query(tx_id: u16) -> Vec<u8> {
+    let mut q = Vec::with_capacity(32);
+    q.extend_from_slice(&tx_id.to_be_bytes());
+    q.extend_from_slice(&[0x01, 0x00]);
+    q.extend_from_slice(&[0x00, 0x01]);
+    q.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    q.push(7);
+    q.extend_from_slice(b"example");
+    q.push(3);
+    q.extend_from_slice(b"com");
+    q.push(0);
+    q.extend_from_slice(&[0x00, 0x01]);
+    q.extend_from_slice(&[0x00, 0x01]);
+    q
+}
+
+/// Build a forwarder + start a DnsServer on 127.0.0.1:0 (ephemeral).
+/// Returns the bound server, its address, and the stub upstream task
+/// handle so the test can keep it alive.
+async fn start_server_with_stub() -> (LocalDnsServer, SocketAddr, tokio::task::JoinHandle<()>) {
+    let (upstream, up_task) = start_stub_upstream().await;
+
+    // Direct-connector forwarder targeting the stub UDP upstream via the
+    // forwarder's `forward_on_port` wouldn't fit the real API; instead we
+    // pass the upstream IP as the forwarder's server, but the forwarder
+    // hard-codes DNS_PORT_PLAIN=53. The stub is on an ephemeral port, so
+    // direct-connector UDP would not reach it. Work around by running the
+    // whole thing through the forwarder's public `forward` with an
+    // upstream on :53 — but we have no privilege to bind :53 in CI.
+    //
+    // Instead: use a forwarder with a *broken* server list and rely on
+    // SERVFAIL being a well-formed reply for the server-layer tests.
+    // (Separate forwarder-layer tests already cover upstream wiring.)
+    let _ = upstream; // kept alive via `up_task`
+    let cfg = DnsConfig {
+        enabled: true,
+        servers: vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))], // TEST-NET-1, unroutable
+        protocol: DnsProtocol::PlainUdp,
+        intercept_udp53: true,
+    };
+    let fwd = Arc::new(DnsForwarder::new(cfg, Arc::new(DirectConnector), true));
+    let srv = LocalDnsServer::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0), fwd)
+        .await
+        .expect("bind ephemeral");
+    let addr = srv.addr();
+    (srv, addr, up_task)
+}
+
+#[skuld::test]
+async fn udp_end_to_end_returns_servfail_on_dead_upstream() {
+    let (_srv, addr, _up) = start_server_with_stub().await;
+
+    // Send a UDP query from a loopback socket.
+    let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    client.connect(addr).await.unwrap();
+    let q = sample_query(0xFEED);
+    client.send(&q).await.unwrap();
+    let mut rbuf = [0u8; 1500];
+    let n = timeout(Duration::from_secs(10), client.recv(&mut rbuf))
+        .await
+        .expect("forwarder responded in time")
+        .unwrap();
+    let reply = &rbuf[..n];
+    assert_eq!(&reply[..2], &[0xFE, 0xED], "tx id preserved");
+    assert_eq!(reply[3] & 0x0F, 2, "RCODE=SERVFAIL (no upstream reachable)");
+}
+
+#[skuld::test]
+async fn tcp_end_to_end_returns_servfail_on_dead_upstream() {
+    let (_srv, addr, _up) = start_server_with_stub().await;
+
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let q = sample_query(0xBEEF);
+    let len = (q.len() as u16).to_be_bytes();
+    stream.write_all(&len).await.unwrap();
+    stream.write_all(&q).await.unwrap();
+    let mut len_buf = [0u8; 2];
+    timeout(Duration::from_secs(10), stream.read_exact(&mut len_buf))
+        .await
+        .expect("TCP reply framing arrived")
+        .unwrap();
+    let reply_len = u16::from_be_bytes(len_buf) as usize;
+    let mut reply = vec![0u8; reply_len];
+    stream.read_exact(&mut reply).await.unwrap();
+    assert_eq!(&reply[..2], &[0xBE, 0xEF]);
+    assert_eq!(reply[3] & 0x0F, 2, "RCODE=SERVFAIL");
+}
+
+#[skuld::test]
+async fn drop_releases_udp_and_tcp_ports() {
+    let cfg = DnsConfig {
+        enabled: true,
+        servers: vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))],
+        protocol: DnsProtocol::PlainUdp,
+        intercept_udp53: true,
+    };
+    let fwd = Arc::new(DnsForwarder::new(cfg, Arc::new(DirectConnector), true));
+    let srv = LocalDnsServer::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0), fwd)
+        .await
+        .unwrap();
+    let addr = srv.addr();
+    drop(srv);
+    // Give the runtime a tick to process the abort/close.
+    tokio::task::yield_now().await;
+    // The port should be rebindable after drop.
+    let rebind = UdpSocket::bind(addr).await;
+    assert!(rebind.is_ok(), "UDP port released after server drop: {rebind:?}");
+    let rebind_tcp = tokio::net::TcpListener::bind(addr).await;
+    assert!(rebind_tcp.is_ok(), "TCP port released after server drop");
+}
+
+#[skuld::test]
+async fn bind_fails_when_port_in_use_on_preferred_ip() {
+    // Hold 127.0.0.1:<ephemeral> hostage and try to bind the same addr.
+    let hostage_udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let busy_addr = hostage_udp.local_addr().unwrap();
+    let cfg = DnsConfig {
+        enabled: true,
+        servers: vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))],
+        protocol: DnsProtocol::PlainUdp,
+        intercept_udp53: true,
+    };
+    let fwd = Arc::new(DnsForwarder::new(cfg, Arc::new(DirectConnector), true));
+    let res = LocalDnsServer::bind(busy_addr, fwd).await;
+    assert!(res.is_err(), "bind should fail on busy port");
+}

--- a/crates/bridge/src/dns/socks5_connector.rs
+++ b/crates/bridge/src/dns/socks5_connector.rs
@@ -1,0 +1,274 @@
+//! [`Socks5Connector`] — routes DNS forwarder upstream I/O through the
+//! local shadowsocks SOCKS5 listener so user filter rules that `Block`
+//! the resolver IP cannot strand the forwarder's own queries.
+//!
+//! TCP (PlainTcp / DoT / DoH) uses [`tokio_socks::tcp::Socks5Stream`]:
+//! SOCKS5 CONNECT, then treat the resulting stream as a bare TCP pipe.
+//!
+//! UDP (PlainUdp) uses a hand-rolled SOCKS5 UDP ASSOCIATE per RFC 1928 —
+//! `tokio-socks` 0.5 ships no UDP helper. The shadowsocks listener can
+//! only relay UDP when the configured plugin supports UDP (e.g. galoshes,
+//! NOT plain v2ray-plugin). For TCP-only plugins the ASSOCIATE command
+//! fails at the SS listener; the forwarder surfaces this as an
+//! [`io::Error`] and the dedup'd WARN log in
+//! [`super::forwarder::DnsForwarder`] fires exactly once per upstream IP.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::sync::Mutex;
+use tokio_socks::tcp::Socks5Stream;
+
+use crate::dns::connector::{BoxedStream, UpstreamConnector, UpstreamUdp};
+
+const SOCKS5_VER: u8 = 0x05;
+const SOCKS5_NO_AUTH: u8 = 0x00;
+const SOCKS5_CMD_UDP_ASSOCIATE: u8 = 0x03;
+const SOCKS5_ATYP_IPV4: u8 = 0x01;
+const SOCKS5_ATYP_IPV6: u8 = 0x04;
+const SOCKS5_ATYP_DOMAIN: u8 = 0x03;
+
+/// Routes every outbound connection through the shadowsocks SOCKS5
+/// listener.
+#[derive(Debug, Clone, Copy)]
+pub struct Socks5Connector {
+    /// Address of the shadowsocks-service local SOCKS5 listener. Always
+    /// loopback in production, injectable for tests.
+    pub socks5_listener: SocketAddr,
+}
+
+impl Socks5Connector {
+    pub fn new(socks5_listener: SocketAddr) -> Self {
+        Self { socks5_listener }
+    }
+}
+
+#[async_trait]
+impl UpstreamConnector for Socks5Connector {
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<BoxedStream> {
+        let stream = Socks5Stream::connect(self.socks5_listener, target)
+            .await
+            .map_err(|e| io::Error::other(format!("SOCKS5 CONNECT to {target}: {e}")))?;
+        // `into_inner()` returns the underlying `TcpStream` — after the
+        // CONNECT handshake the relay is a pure byte pipe.
+        Ok(Box::new(stream.into_inner()))
+    }
+
+    async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {
+        let (control, udp, relay) = udp_associate(self.socks5_listener).await?;
+        Ok(Box::new(Socks5Udp {
+            _control: Arc::new(Mutex::new(control)),
+            udp,
+            relay,
+            target,
+        }))
+    }
+}
+
+// UDP ASSOCIATE protocol ==============================================================================================
+
+/// Negotiate a SOCKS5 UDP ASSOCIATE session with the proxy. Returns
+/// `(control_tcp, local_udp, relay_addr)`:
+///
+/// - `control_tcp`: the TCP control channel; must stay alive for the
+///   duration of the UDP session (its close signals "teardown").
+/// - `local_udp`: a freshly bound local UDP socket; the caller sends
+///   RFC 1928 §7 UDP request datagrams to `relay_addr`.
+/// - `relay_addr`: the UDP relay endpoint reported by the SOCKS5 server.
+async fn udp_associate(proxy: SocketAddr) -> io::Result<(TcpStream, UdpSocket, SocketAddr)> {
+    let mut tcp = TcpStream::connect(proxy).await?;
+
+    // Greeting: VER | NMETHODS=1 | METHOD=NoAuth
+    tcp.write_all(&[SOCKS5_VER, 1, SOCKS5_NO_AUTH]).await?;
+    let mut greeting_resp = [0u8; 2];
+    tcp.read_exact(&mut greeting_resp).await?;
+    if greeting_resp[0] != SOCKS5_VER {
+        return Err(io::Error::other(format!(
+            "SOCKS5 greeting: bad version {}",
+            greeting_resp[0]
+        )));
+    }
+    if greeting_resp[1] != SOCKS5_NO_AUTH {
+        return Err(io::Error::other(format!(
+            "SOCKS5 greeting: unexpected method {}",
+            greeting_resp[1]
+        )));
+    }
+
+    // Request: VER | CMD=UDP_ASSOCIATE | RSV=0 | ATYP=IPV4 | DST.ADDR=0 | DST.PORT=0
+    // `0.0.0.0:0` tells the server "use the IP+port from which I'll be sending".
+    let req = [
+        SOCKS5_VER,
+        SOCKS5_CMD_UDP_ASSOCIATE,
+        0,
+        SOCKS5_ATYP_IPV4,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ];
+    tcp.write_all(&req).await?;
+
+    // Reply: VER | REP | RSV | ATYP | BND.ADDR | BND.PORT
+    let mut head = [0u8; 4];
+    tcp.read_exact(&mut head).await?;
+    if head[0] != SOCKS5_VER {
+        return Err(io::Error::other(format!("SOCKS5 reply: bad version {}", head[0])));
+    }
+    if head[1] != 0 {
+        return Err(io::Error::other(format!(
+            "SOCKS5 UDP ASSOCIATE rejected (REP={}) — plugin likely TCP-only",
+            head[1]
+        )));
+    }
+
+    let relay_ip: IpAddr = match head[3] {
+        SOCKS5_ATYP_IPV4 => {
+            let mut a = [0u8; 4];
+            tcp.read_exact(&mut a).await?;
+            IpAddr::V4(a.into())
+        }
+        SOCKS5_ATYP_IPV6 => {
+            let mut a = [0u8; 16];
+            tcp.read_exact(&mut a).await?;
+            IpAddr::V6(a.into())
+        }
+        SOCKS5_ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            tcp.read_exact(&mut len).await?;
+            let mut name = vec![0u8; len[0] as usize];
+            tcp.read_exact(&mut name).await?;
+            let name = std::str::from_utf8(&name).map_err(|_| io::Error::other("SOCKS5 reply: non-UTF8 BND domain"))?;
+            // Most SS implementations return a concrete IP; resolving a
+            // domain here would loop through the OS resolver — the very
+            // thing the forwarder is meant to replace. Reject.
+            return Err(io::Error::other(format!(
+                "SOCKS5 UDP ASSOCIATE returned domain BND ('{name}'); expected IP"
+            )));
+        }
+        other => return Err(io::Error::other(format!("SOCKS5 reply: unknown ATYP {other}"))),
+    };
+    let mut port_bytes = [0u8; 2];
+    tcp.read_exact(&mut port_bytes).await?;
+    let relay_port = u16::from_be_bytes(port_bytes);
+    let relay_reported = SocketAddr::new(relay_ip, relay_port);
+
+    // Some SS implementations return `0.0.0.0` as the BND — meaning
+    // "reuse the proxy's IP". Normalize to the proxy IP in that case.
+    let relay = if relay_reported.ip().is_unspecified() {
+        SocketAddr::new(proxy.ip(), relay_reported.port())
+    } else {
+        relay_reported
+    };
+
+    // Bind a local UDP socket in the family matching the relay.
+    let bind_addr: SocketAddr = if relay.is_ipv4() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+    } else {
+        SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED), 0)
+    };
+    let udp = UdpSocket::bind(bind_addr).await?;
+
+    Ok((tcp, udp, relay))
+}
+
+struct Socks5Udp {
+    /// Control TCP connection — held to keep the UDP association alive.
+    /// Wrapped in `Arc<Mutex<_>>` only so the struct is `Send + Sync`; we
+    /// never need to lock it except at drop time.
+    _control: Arc<Mutex<TcpStream>>,
+    udp: UdpSocket,
+    relay: SocketAddr,
+    target: SocketAddr,
+}
+
+#[async_trait]
+impl UpstreamUdp for Socks5Udp {
+    async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        let header = socks5_udp_header(self.target);
+        let mut framed = Vec::with_capacity(header.len() + buf.len());
+        framed.extend_from_slice(&header);
+        framed.extend_from_slice(buf);
+        self.udp.send_to(&framed, self.relay).await?;
+        Ok(buf.len())
+    }
+
+    async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        // Max SOCKS5 UDP frame header is RSV(2)+FRAG(1)+ATYP(1)+ADDR(16)+PORT(2) = 22
+        // bytes. Plus the payload. Read into a big temp buffer, then strip.
+        let mut tmp = vec![0u8; buf.len() + 64];
+        let (n, _from) = self.udp.recv_from(&mut tmp).await?;
+        let (payload_off, _dst) = parse_socks5_udp_header(&tmp[..n])?;
+        let payload_len = n - payload_off;
+        if payload_len > buf.len() {
+            return Err(io::Error::other("SOCKS5 UDP recv: payload overflows caller buffer"));
+        }
+        buf[..payload_len].copy_from_slice(&tmp[payload_off..n]);
+        Ok(payload_len)
+    }
+}
+
+fn socks5_udp_header(target: SocketAddr) -> Vec<u8> {
+    // RSV(2)=0 | FRAG(1)=0 | ATYP | DST.ADDR | DST.PORT
+    let mut h = vec![0u8, 0, 0];
+    match target.ip() {
+        IpAddr::V4(v4) => {
+            h.push(SOCKS5_ATYP_IPV4);
+            h.extend_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            h.push(SOCKS5_ATYP_IPV6);
+            h.extend_from_slice(&v6.octets());
+        }
+    }
+    h.extend_from_slice(&target.port().to_be_bytes());
+    h
+}
+
+/// Parse a SOCKS5 UDP reply header. Returns the byte offset where the
+/// payload starts, and the reported source address.
+fn parse_socks5_udp_header(buf: &[u8]) -> io::Result<(usize, SocketAddr)> {
+    if buf.len() < 10 {
+        return Err(io::Error::other("SOCKS5 UDP reply too short"));
+    }
+    // RSV(2) | FRAG(1) | ATYP | ...
+    if buf[2] != 0 {
+        return Err(io::Error::other("SOCKS5 UDP: fragmented replies not supported"));
+    }
+    let atyp = buf[3];
+    let (ip, port_offset) = match atyp {
+        SOCKS5_ATYP_IPV4 => {
+            let ip = IpAddr::V4(Ipv4Addr::new(buf[4], buf[5], buf[6], buf[7]));
+            (ip, 8)
+        }
+        SOCKS5_ATYP_IPV6 => {
+            if buf.len() < 4 + 16 + 2 {
+                return Err(io::Error::other("SOCKS5 UDP: truncated IPv6 reply"));
+            }
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(&buf[4..20]);
+            (IpAddr::V6(octets.into()), 20)
+        }
+        SOCKS5_ATYP_DOMAIN => {
+            let len = buf[4] as usize;
+            if buf.len() < 5 + len + 2 {
+                return Err(io::Error::other("SOCKS5 UDP: truncated domain reply"));
+            }
+            // Don't resolve — treat the source as unknown.
+            return Ok((5 + len + 2, SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)));
+        }
+        other => return Err(io::Error::other(format!("SOCKS5 UDP: unknown ATYP {other}"))),
+    };
+    let port = u16::from_be_bytes([buf[port_offset], buf[port_offset + 1]]);
+    Ok((port_offset + 2, SocketAddr::new(ip, port)))
+}
+
+#[cfg(test)]
+#[path = "socks5_connector_tests.rs"]
+mod socks5_connector_tests;

--- a/crates/bridge/src/dns/socks5_connector_tests.rs
+++ b/crates/bridge/src/dns/socks5_connector_tests.rs
@@ -1,0 +1,131 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use super::*;
+
+// Wire-format helpers =================================================================================================
+
+#[skuld::test]
+fn socks5_udp_header_v4_shape() {
+    let addr: SocketAddr = "8.8.8.8:53".parse().unwrap();
+    let h = socks5_udp_header(addr);
+    assert_eq!(h[0..3], [0, 0, 0], "RSV=0 FRAG=0");
+    assert_eq!(h[3], SOCKS5_ATYP_IPV4);
+    assert_eq!(&h[4..8], &[8, 8, 8, 8]);
+    assert_eq!(&h[8..10], &53_u16.to_be_bytes());
+}
+
+#[skuld::test]
+fn socks5_udp_header_v6_shape() {
+    let addr: SocketAddr = "[2001:db8::1]:853".parse().unwrap();
+    let h = socks5_udp_header(addr);
+    assert_eq!(h[0..3], [0, 0, 0]);
+    assert_eq!(h[3], SOCKS5_ATYP_IPV6);
+    assert_eq!(h.len(), 3 + 1 + 16 + 2);
+}
+
+#[skuld::test]
+fn parse_socks5_udp_header_v4() {
+    // Server replies with source 1.2.3.4:5353 + 5 bytes of payload.
+    let mut buf = vec![0u8, 0, 0, SOCKS5_ATYP_IPV4, 1, 2, 3, 4, 0x14, 0xE9];
+    buf.extend_from_slice(b"hello");
+    let (off, src) = parse_socks5_udp_header(&buf).unwrap();
+    assert_eq!(off, 10);
+    assert_eq!(src, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 0x14E9));
+}
+
+#[skuld::test]
+fn parse_socks5_udp_header_v6() {
+    let mut buf = vec![0u8, 0, 0, SOCKS5_ATYP_IPV6];
+    let v6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+    buf.extend_from_slice(&v6.octets());
+    buf.extend_from_slice(&53_u16.to_be_bytes());
+    buf.extend_from_slice(b"p");
+    let (off, src) = parse_socks5_udp_header(&buf).unwrap();
+    assert_eq!(off, 3 + 1 + 16 + 2);
+    assert_eq!(src.ip(), IpAddr::V6(v6));
+    assert_eq!(src.port(), 53);
+}
+
+#[skuld::test]
+fn parse_socks5_udp_header_rejects_fragmented() {
+    let buf = [0u8, 0, 1, SOCKS5_ATYP_IPV4, 0, 0, 0, 0, 0, 0];
+    assert!(parse_socks5_udp_header(&buf).is_err());
+}
+
+#[skuld::test]
+fn parse_socks5_udp_header_rejects_too_short() {
+    let buf = [0u8, 0, 0, SOCKS5_ATYP_IPV4, 0, 0, 0]; // 7 bytes
+    assert!(parse_socks5_udp_header(&buf).is_err());
+}
+
+#[skuld::test]
+fn parse_socks5_udp_header_rejects_unknown_atyp() {
+    let buf = [0u8, 0, 0, 0x7F, 0, 0, 0, 0, 0, 0];
+    assert!(parse_socks5_udp_header(&buf).is_err());
+}
+
+// Protocol negotiation ================================================================================================
+
+/// Start a fake SOCKS5 proxy that rejects UDP ASSOCIATE (simulating a
+/// TCP-only shadowsocks plugin). Returns the proxy's listen address.
+async fn start_udp_rejecting_proxy() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        // Expect greeting: VER | NMETHODS | METHOD...
+        let mut greeting = [0u8; 3];
+        let _ = sock.read_exact(&mut greeting).await;
+        let _ = sock.write_all(&[SOCKS5_VER, SOCKS5_NO_AUTH]).await;
+        // Expect request: VER | CMD | RSV | ATYP | ... (v4: 4 more bytes + port 2)
+        let mut head = [0u8; 4];
+        let _ = sock.read_exact(&mut head).await;
+        // Consume addr(4) + port(2) for v4
+        let mut addr_tail = [0u8; 6];
+        let _ = sock.read_exact(&mut addr_tail).await;
+        // Reply with REP=7 (Command not supported), signaling a TCP-only plugin.
+        let _ = sock
+            .write_all(&[SOCKS5_VER, 7, 0, SOCKS5_ATYP_IPV4, 0, 0, 0, 0, 0, 0])
+            .await;
+    });
+    addr
+}
+
+#[skuld::test]
+async fn udp_associate_rejected_for_tcp_only_plugin() {
+    let proxy = start_udp_rejecting_proxy().await;
+    let err = udp_associate(proxy).await.expect_err("expected rejection");
+    let s = format!("{err}");
+    assert!(s.contains("ASSOCIATE rejected"), "error msg includes reason: {s}");
+}
+
+/// Start a fake SOCKS5 proxy that accepts UDP ASSOCIATE and advertises a
+/// relay on 127.0.0.1 at a preset port. Returns both addresses.
+async fn start_udp_accepting_proxy(relay_port: u16) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut greeting = [0u8; 3];
+        let _ = sock.read_exact(&mut greeting).await;
+        let _ = sock.write_all(&[SOCKS5_VER, SOCKS5_NO_AUTH]).await;
+        let mut req = [0u8; 10];
+        let _ = sock.read_exact(&mut req).await;
+        let mut reply = vec![SOCKS5_VER, 0, 0, SOCKS5_ATYP_IPV4, 127, 0, 0, 1];
+        reply.extend_from_slice(&relay_port.to_be_bytes());
+        let _ = sock.write_all(&reply).await;
+        // Hold the control connection open.
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    });
+    addr
+}
+
+#[skuld::test]
+async fn udp_associate_returns_relay_address_from_reply() {
+    let proxy = start_udp_accepting_proxy(65300).await;
+    let (_ctl, _udp, relay) = udp_associate(proxy).await.unwrap();
+    assert_eq!(relay, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 65300));
+}

--- a/crates/bridge/src/dns/system.rs
+++ b/crates/bridge/src/dns/system.rs
@@ -1,0 +1,125 @@
+//! System DNS capture/apply/restore.
+//!
+//! The bridge re-points OS DNS clients at the `LocalDnsServer` loopback IP
+//! while a proxy is running, then restores the prior per-adapter / per-
+//! address-family DNS configuration on clean shutdown or crash recovery.
+//!
+//! ## Per-adapter, per-family, three prior kinds
+//!
+//! Each adapter carries two independent DNS lists (v4, v6); each list is
+//! in one of three states — static, DHCP-assigned, or unset. The restore
+//! path dispatches on the captured [`DnsPrior`] variant so a prior that
+//! was DHCP-assigned doesn't get reapplied as a static list (which would
+//! freeze DHCP renewal).
+//!
+//! ## Which adapters?
+//!
+//! Capture targets two adapters: the TUN adapter (we want the best-route
+//! resolver lookup to land here so the OS picks *our* DNS) and the
+//! upstream physical adapter (defense in depth against multi-homed
+//! resolvers). Apply sets the same loopback on both. Restore replays the
+//! captured state per adapter.
+//!
+//! ## Platform implementations
+//!
+//! - **Windows** — `netsh interface {ipv4,ipv6} {show,set} dnsservers`.
+//!   Adapter identity is the LUID (stable for physical adapters across
+//!   reboots; the TUN adapter is recreated per-connect so its LUID is
+//!   fresh each time).
+//! - **macOS** — `networksetup -{getdnsservers,setdnsservers}`. Adapter
+//!   identity is the service name (e.g. "Wi-Fi"). Service names are
+//!   reasonably stable across short periods; a user who renames a
+//!   service mid-session will see that service skipped on restore.
+
+use std::io;
+
+use crate::dns_state::{AdapterId, DnsPriorAdapter};
+
+#[cfg(target_os = "windows")]
+pub mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::*;
+
+/// One applied DNS change, returned so a rollback on partial failure can
+/// restore exactly what was touched. Production code persists
+/// `Vec<DnsPriorAdapter>` to `bridge-dns.json` and feeds it to
+/// [`restore_all`] on shutdown.
+#[derive(Debug, Clone)]
+pub struct AppliedAdapter {
+    pub id: AdapterId,
+    pub name_at_capture: String,
+}
+
+/// Restore all adapters listed in `prior`. Each adapter is restored
+/// independently — one failure is logged and the rest proceed. This
+/// matches the crash-recovery contract (best-effort).
+pub fn restore_all(prior: &[DnsPriorAdapter]) -> Vec<(AdapterId, io::Error)> {
+    let mut errors = Vec::new();
+    for adapter in prior {
+        if let Err(e) = restore_adapter(adapter) {
+            tracing::warn!(
+                id = ?adapter.id,
+                name = %adapter.name_at_capture,
+                error = %e,
+                "DNS restore failed for adapter; continuing"
+            );
+            errors.push((adapter.id.clone(), e));
+        }
+    }
+    errors
+}
+
+/// Summary of the DNS state that was in effect before `apply` ran. The
+/// caller persists this (via `dns_state::save`) and feeds it to
+/// [`restore_all`] on shutdown or crash recovery.
+#[derive(Debug, Clone)]
+pub struct PriorSnapshot {
+    pub adapters: Vec<DnsPriorAdapter>,
+}
+
+impl PriorSnapshot {
+    pub fn empty() -> Self {
+        Self { adapters: Vec::new() }
+    }
+}
+
+/// Dispatch a single adapter's restore to the platform implementation.
+/// The concrete function lives in `windows.rs` / `macos.rs`; this wrapper
+/// keeps the error type uniform across platforms and is usable from
+/// non-platform-gated callers.
+fn restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
+    platform_restore_adapter(adapter)
+}
+
+// Placeholder when building on an unsupported platform — keeps the
+// module's surface area compilable for test-only targets like `cargo
+// check` on Linux in CI. The bridge is only shipped for Windows and
+// macOS so this branch never runs in production.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub fn platform_restore_adapter(_adapter: &DnsPriorAdapter) -> io::Result<()> {
+    Err(io::Error::other("system DNS restore not implemented on this target OS"))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub fn capture_adapters(_aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
+    Err(io::Error::other("system DNS capture not implemented on this target OS"))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+pub fn apply_loopback(_aliases: &[String], _loopback_ip: std::net::IpAddr) -> io::Result<Vec<AppliedAdapter>> {
+    Err(io::Error::other("system DNS apply not implemented on this target OS"))
+}
+
+// Re-export DnsPrior helpers so callers don't need a separate import just
+// for the "construct from raw netsh lines" side.
+pub use crate::dns_state::DnsPrior as Prior;
+pub use crate::dns_state::DnsPriorAdapter as PriorAdapter;
+
+#[cfg(test)]
+#[path = "system_tests.rs"]
+mod system_tests;

--- a/crates/bridge/src/dns/system/macos.rs
+++ b/crates/bridge/src/dns/system/macos.rs
@@ -65,12 +65,9 @@ pub fn platform_restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
     let mut combined: Vec<IpAddr> = Vec::new();
     let mut saw_static = false;
     for p in [&adapter.v4, &adapter.v6] {
-        match p {
-            DnsPrior::Static { servers } => {
-                saw_static = true;
-                combined.extend_from_slice(servers);
-            }
-            _ => {}
+        if let DnsPrior::Static { servers } = p {
+            saw_static = true;
+            combined.extend_from_slice(servers);
         }
     }
     if saw_static {

--- a/crates/bridge/src/dns/system/macos.rs
+++ b/crates/bridge/src/dns/system/macos.rs
@@ -1,0 +1,184 @@
+//! macOS `networksetup`-based system DNS capture / apply / restore.
+//!
+//! Identifier is the *network service* name (e.g. "Wi-Fi") as reported by
+//! `networksetup -listallnetworkservices`. This is what the set/get DNS
+//! subcommands accept directly, avoiding a separate name-to-GUID lookup
+//! via `scutil`.
+
+use std::io;
+use std::net::IpAddr;
+use std::process::Command;
+
+use super::AppliedAdapter;
+use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
+
+const NETWORKSETUP: &str = "networksetup";
+
+pub fn capture_adapters(services: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
+    let mut out = Vec::with_capacity(services.len());
+    for svc in services {
+        match capture_one(svc) {
+            Ok(Some(p)) => out.push(p),
+            Ok(None) => {
+                tracing::debug!(service = %svc, "DNS capture: service not found; skipping");
+            }
+            Err(e) => {
+                tracing::warn!(service = %svc, error = %e, "DNS capture failed for service");
+            }
+        }
+    }
+    Ok(out)
+}
+
+pub fn apply_loopback(services: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
+    let mut applied = Vec::with_capacity(services.len());
+    for svc in services {
+        if let Err(e) = set_dnsservers(svc, &[loopback_ip]) {
+            tracing::warn!(service = %svc, error = %e, "DNS apply failed; continuing");
+            continue;
+        }
+        applied.push(AppliedAdapter {
+            id: AdapterId::MacosServiceName { value: svc.clone() },
+            name_at_capture: svc.clone(),
+        });
+    }
+    flush_dns_cache();
+    Ok(applied)
+}
+
+/// Flush the macOS DNS cache (dscacheutil + mDNSResponder signal).
+pub fn flush_dns_cache() {
+    let _ = Command::new("dscacheutil").arg("-flushcache").status();
+    let _ = Command::new("killall").args(["-HUP", "mDNSResponder"]).status();
+}
+
+pub fn platform_restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
+    let AdapterId::MacosServiceName { value: svc } = &adapter.id else {
+        return Err(io::Error::other(format!(
+            "expected MacosServiceName in DnsPriorAdapter.id, got {:?}",
+            adapter.id
+        )));
+    };
+    // macOS restores v4 and v6 via the same `setdnsservers` invocation —
+    // it takes a mixed list. The captured v4/v6 priors must be merged
+    // into a single list.
+    let mut combined: Vec<IpAddr> = Vec::new();
+    let mut saw_static = false;
+    for p in [&adapter.v4, &adapter.v6] {
+        match p {
+            DnsPrior::Static { servers } => {
+                saw_static = true;
+                combined.extend_from_slice(servers);
+            }
+            _ => {}
+        }
+    }
+    if saw_static {
+        set_dnsservers(svc, &combined)
+    } else {
+        // Both v4 and v6 were DHCP or None — macOS collapses these to
+        // `Empty`, which means "clear all DNS for this service, rely on
+        // DHCP".
+        clear_dnsservers(svc)
+    }
+}
+
+fn capture_one(svc: &str) -> io::Result<Option<DnsPriorAdapter>> {
+    let output = Command::new(NETWORKSETUP).args(["-getdnsservers", svc]).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("not a recognized network service") {
+            return Ok(None);
+        }
+        return Err(io::Error::other(format!(
+            "networksetup -getdnsservers failed: {} (stderr={})",
+            output.status, stderr
+        )));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let (v4, v6) = split_v4_v6(parse_networksetup_output(&stdout));
+    Ok(Some(DnsPriorAdapter {
+        id: AdapterId::MacosServiceName { value: svc.to_string() },
+        name_at_capture: svc.to_string(),
+        v4,
+        v6,
+    }))
+}
+
+/// Parse the stdout of `networksetup -getdnsservers <svc>` into a
+/// [`DnsPrior`]. Shapes:
+///
+/// ```text
+/// There aren't any DNS Servers set on Wi-Fi.
+/// ```
+/// →  [`DnsPrior::Dhcp`] (macOS uses this exact phrasing for both
+///     DHCP-assigned and unset; we cannot distinguish, so bias to Dhcp).
+///
+/// ```text
+/// 1.1.1.1
+/// 2606:4700:4700::1111
+/// ```
+/// → [`DnsPrior::Static`] with both IPs.
+pub(super) fn parse_networksetup_output(stdout: &str) -> DnsPrior {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() || trimmed.to_ascii_lowercase().contains("aren't any dns servers") {
+        return DnsPrior::Dhcp;
+    }
+    let mut servers: Vec<IpAddr> = Vec::new();
+    for line in trimmed.lines() {
+        if let Ok(ip) = line.trim().parse::<IpAddr>() {
+            servers.push(ip);
+        }
+    }
+    if servers.is_empty() {
+        DnsPrior::Dhcp
+    } else {
+        DnsPrior::Static { servers }
+    }
+}
+
+/// Split a combined IP list (as `networksetup` returns) into v4 and v6
+/// [`DnsPrior`] records. DHCP/None collapses into both families.
+fn split_v4_v6(combined: DnsPrior) -> (DnsPrior, DnsPrior) {
+    match combined {
+        DnsPrior::None => (DnsPrior::None, DnsPrior::None),
+        DnsPrior::Dhcp => (DnsPrior::Dhcp, DnsPrior::Dhcp),
+        DnsPrior::Static { servers } => {
+            let (v4, v6): (Vec<_>, Vec<_>) = servers.into_iter().partition(|ip| ip.is_ipv4());
+            let v4p = if v4.is_empty() {
+                DnsPrior::None
+            } else {
+                DnsPrior::Static { servers: v4 }
+            };
+            let v6p = if v6.is_empty() {
+                DnsPrior::None
+            } else {
+                DnsPrior::Static { servers: v6 }
+            };
+            (v4p, v6p)
+        }
+    }
+}
+
+fn set_dnsservers(svc: &str, ips: &[IpAddr]) -> io::Result<()> {
+    let mut cmd = Command::new(NETWORKSETUP);
+    cmd.arg("-setdnsservers").arg(svc);
+    if ips.is_empty() {
+        cmd.arg("Empty");
+    } else {
+        for ip in ips {
+            cmd.arg(ip.to_string());
+        }
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!(
+            "networksetup -setdnsservers failed: {status}"
+        )));
+    }
+    Ok(())
+}
+
+fn clear_dnsservers(svc: &str) -> io::Result<()> {
+    set_dnsservers(svc, &[])
+}

--- a/crates/bridge/src/dns/system/windows.rs
+++ b/crates/bridge/src/dns/system/windows.rs
@@ -1,0 +1,330 @@
+//! Windows `netsh`-based system DNS capture / apply / restore.
+//!
+//! Shelling out rather than calling `SetInterfaceDnsSettings` directly is
+//! deliberate: `netsh` output is forward-compatible and the equivalent
+//! Win32 API has a narrow Windows-version window. The existing routing
+//! layer also uses `netsh`, so we match that convention.
+//!
+//! ## Command surface
+//!
+//! - **Capture**: `netsh interface {ipv4,ipv6} show dnsservers name="<alias>"`
+//!   parses into [`DnsPrior::Static`], [`DnsPrior::Dhcp`], or
+//!   [`DnsPrior::None`].
+//! - **Apply**: `netsh interface ipv4 set dnsservers name="<alias>" static
+//!   <ip> primary` (plus `ipconfig /flushdns` after).
+//! - **Restore**: dispatches on the captured variant.
+
+use std::io;
+use std::net::IpAddr;
+use std::process::Command;
+
+use super::AppliedAdapter;
+use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
+
+const NETSH: &str = "netsh";
+
+// Public API ==========================================================================================================
+
+/// Capture the v4+v6 DNS state of every adapter in `aliases`. Adapters
+/// that don't exist (e.g. the TUN alias hasn't been created yet) are
+/// silently skipped.
+pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
+    let mut out = Vec::with_capacity(aliases.len());
+    for alias in aliases {
+        match capture_one(alias) {
+            Ok(Some(p)) => out.push(p),
+            Ok(None) => {
+                tracing::debug!(%alias, "DNS capture: adapter not found; skipping");
+            }
+            Err(e) => {
+                tracing::warn!(%alias, error = %e, "DNS capture failed for adapter");
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Apply `loopback_ip` as the DNS server on each adapter in `aliases`.
+/// Returns one [`AppliedAdapter`] per adapter that was successfully set.
+/// Callers flush the DNS cache separately (via [`flush_dns_cache`]) once
+/// the full adapter list is applied.
+pub fn apply_loopback(aliases: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
+    let mut applied = Vec::with_capacity(aliases.len());
+    for alias in aliases {
+        if let Err(e) = set_dns_ipv4(alias, Some(loopback_ip)) {
+            tracing::warn!(%alias, error = %e, "DNS apply failed; continuing");
+            continue;
+        }
+        applied.push(AppliedAdapter {
+            id: AdapterId::WindowsAlias { value: alias.clone() },
+            name_at_capture: alias.clone(),
+        });
+    }
+    flush_dns_cache();
+    Ok(applied)
+}
+
+/// Run `ipconfig /flushdns`. Best-effort; a failure here is a log line,
+/// not a return value.
+pub fn flush_dns_cache() {
+    let res = Command::new("ipconfig").arg("/flushdns").output();
+    if let Err(e) = res {
+        tracing::warn!(error = %e, "ipconfig /flushdns failed");
+    }
+}
+
+/// Restore one adapter. Invoked from [`super::restore_all`].
+pub fn platform_restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
+    let AdapterId::WindowsAlias { value: alias } = &adapter.id else {
+        return Err(io::Error::other(format!(
+            "expected WindowsAlias in DnsPriorAdapter.id, got {:?}",
+            adapter.id
+        )));
+    };
+    restore_v4(alias, &adapter.v4)?;
+    restore_v6(alias, &adapter.v6)?;
+    Ok(())
+}
+
+// Capture =============================================================================================================
+
+fn capture_one(alias: &str) -> io::Result<Option<DnsPriorAdapter>> {
+    let v4 = match show_dnsservers("ipv4", alias)? {
+        Some(out) => parse_netsh_dnsservers(&out),
+        None => return Ok(None),
+    };
+    let v6 = show_dnsservers("ipv6", alias)?.map(|o| parse_netsh_dnsservers(&o));
+    Ok(Some(DnsPriorAdapter {
+        id: AdapterId::WindowsAlias {
+            value: alias.to_string(),
+        },
+        name_at_capture: alias.to_string(),
+        v4,
+        v6: v6.unwrap_or(DnsPrior::None),
+    }))
+}
+
+fn show_dnsservers(family: &str, alias: &str) -> io::Result<Option<String>> {
+    let output = Command::new(NETSH)
+        .args(["interface", family, "show", "dnsservers"])
+        .arg(format!("name={alias}"))
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // netsh emits "The system cannot find the file specified." on a
+        // nonexistent alias; treat that as "adapter not found" not error.
+        if stderr.contains("cannot find") || stderr.contains("not found") {
+            return Ok(None);
+        }
+        return Err(io::Error::other(format!(
+            "netsh show dnsservers failed: {} (stderr={})",
+            output.status, stderr
+        )));
+    }
+    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
+}
+
+/// Parse `netsh interface {ipv4,ipv6} show dnsservers name=...` output
+/// into a [`DnsPrior`]. The expected shapes (English Windows) are:
+///
+/// ```text
+/// Configuration for interface "Ethernet"
+///     Statically Configured DNS Servers:  1.1.1.1
+///                                         8.8.8.8
+///     Register with which suffix:         Primary only
+/// ```
+/// or
+/// ```text
+/// Configuration for interface "Ethernet"
+///     DNS servers configured through DHCP:  192.168.1.1
+///     Register with which suffix:           Primary only
+/// ```
+/// or
+/// ```text
+///     DNS servers configured through DHCP:  None
+/// ```
+///
+/// Localized Windows installs produce different strings and will be
+/// misparsed. The feature is opt-in and the failure mode is "we don't
+/// know the prior state; treat as Dhcp" — covered by defaulting.
+pub(super) fn parse_netsh_dnsservers(stdout: &str) -> DnsPrior {
+    let mut kind: Option<&'static str> = None;
+    let mut ips: Vec<IpAddr> = Vec::new();
+
+    for raw_line in stdout.lines() {
+        let line = raw_line.trim();
+        if line.starts_with("Statically Configured DNS Servers") {
+            kind = Some("static");
+            // Use the *first* colon only — IPv6 addresses contain colons
+            // too, so `split(':')` would truncate them.
+            if let Some(rhs) = line.find(':').map(|idx| line[idx + 1..].trim()) {
+                if let Ok(ip) = rhs.parse::<IpAddr>() {
+                    ips.push(ip);
+                }
+            }
+            continue;
+        }
+        if line.starts_with("DNS servers configured through DHCP") {
+            kind = Some("dhcp");
+            if let Some(rhs) = line.find(':').map(|idx| line[idx + 1..].trim().to_string()) {
+                if rhs.eq_ignore_ascii_case("none") {
+                    kind = Some("none");
+                } else if let Ok(ip) = rhs.parse::<IpAddr>() {
+                    ips.push(ip);
+                }
+            }
+            continue;
+        }
+        // Continuation line: a raw IP on its own line (the netsh layout
+        // aligns multiple IPs under the first column). Only append if the
+        // line parses cleanly.
+        if let Ok(ip) = line.parse::<IpAddr>() {
+            ips.push(ip);
+        }
+    }
+
+    match kind {
+        Some("static") => {
+            if ips.is_empty() {
+                DnsPrior::None
+            } else {
+                DnsPrior::Static { servers: ips }
+            }
+        }
+        Some("dhcp") => DnsPrior::Dhcp,
+        Some("none") | None => DnsPrior::None,
+        Some(_) => DnsPrior::None,
+    }
+}
+
+// Apply ===============================================================================================================
+
+fn set_dns_ipv4(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
+    let mut cmd = Command::new(NETSH);
+    cmd.args(["interface", "ipv4", "set", "dnsservers"])
+        .arg(format!("name={alias}"));
+    match ip {
+        Some(ip) => {
+            cmd.arg("static").arg(ip.to_string()).arg("primary");
+        }
+        None => {
+            cmd.arg("static").arg("none");
+        }
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("netsh set dnsservers failed: {status}")));
+    }
+    Ok(())
+}
+
+fn set_dhcp_ipv4(alias: &str) -> io::Result<()> {
+    let status = Command::new(NETSH)
+        .args(["interface", "ipv4", "set", "dnsservers"])
+        .arg(format!("name={alias}"))
+        .arg("dhcp")
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("netsh set dnsservers dhcp failed: {status}")));
+    }
+    Ok(())
+}
+
+fn add_dns_ipv4(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
+    let status = Command::new(NETSH)
+        .args(["interface", "ipv4", "add", "dnsservers"])
+        .arg(format!("name={alias}"))
+        .arg(ip.to_string())
+        .arg(format!("index={index}"))
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("netsh add dnsservers failed: {status}")));
+    }
+    Ok(())
+}
+
+fn set_dns_ipv6(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
+    let mut cmd = Command::new(NETSH);
+    cmd.args(["interface", "ipv6", "set", "dnsservers"])
+        .arg(format!("name={alias}"));
+    match ip {
+        Some(ip) => {
+            cmd.arg("static").arg(ip.to_string()).arg("primary");
+        }
+        None => {
+            cmd.arg("static").arg("none");
+        }
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("netsh set dnsservers v6 failed: {status}")));
+    }
+    Ok(())
+}
+
+fn set_dhcp_ipv6(alias: &str) -> io::Result<()> {
+    let status = Command::new(NETSH)
+        .args(["interface", "ipv6", "set", "dnsservers"])
+        .arg(format!("name={alias}"))
+        .arg("dhcp")
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!(
+            "netsh set dnsservers v6 dhcp failed: {status}"
+        )));
+    }
+    Ok(())
+}
+
+fn add_dns_ipv6(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
+    let status = Command::new(NETSH)
+        .args(["interface", "ipv6", "add", "dnsservers"])
+        .arg(format!("name={alias}"))
+        .arg(ip.to_string())
+        .arg(format!("index={index}"))
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("netsh add dnsservers v6 failed: {status}")));
+    }
+    Ok(())
+}
+
+// Restore =============================================================================================================
+
+fn restore_v4(alias: &str, prior: &DnsPrior) -> io::Result<()> {
+    match prior {
+        DnsPrior::None => set_dns_ipv4(alias, None),
+        DnsPrior::Dhcp => set_dhcp_ipv4(alias),
+        DnsPrior::Static { servers } => {
+            let mut iter = servers.iter();
+            if let Some(first) = iter.next() {
+                set_dns_ipv4(alias, Some(*first))?;
+                for (i, s) in iter.enumerate() {
+                    add_dns_ipv4(alias, *s, (i + 2) as u32)?;
+                }
+                Ok(())
+            } else {
+                set_dns_ipv4(alias, None)
+            }
+        }
+    }
+}
+
+fn restore_v6(alias: &str, prior: &DnsPrior) -> io::Result<()> {
+    match prior {
+        DnsPrior::None => set_dns_ipv6(alias, None),
+        DnsPrior::Dhcp => set_dhcp_ipv6(alias),
+        DnsPrior::Static { servers } => {
+            let mut iter = servers.iter();
+            if let Some(first) = iter.next() {
+                set_dns_ipv6(alias, Some(*first))?;
+                for (i, s) in iter.enumerate() {
+                    add_dns_ipv6(alias, *s, (i + 2) as u32)?;
+                }
+                Ok(())
+            } else {
+                set_dns_ipv6(alias, None)
+            }
+        }
+    }
+}

--- a/crates/bridge/src/dns/system_tests.rs
+++ b/crates/bridge/src/dns/system_tests.rs
@@ -1,0 +1,129 @@
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use crate::dns_state::DnsPrior;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::net::{IpAddr, Ipv4Addr};
+
+#[cfg(target_os = "windows")]
+use std::net::Ipv6Addr;
+
+// Windows parser tests ================================================================================================
+
+#[cfg(target_os = "windows")]
+mod windows_parsers {
+    use super::{DnsPrior, IpAddr, Ipv4Addr, Ipv6Addr};
+    use crate::dns::system::windows::parse_netsh_dnsservers;
+
+    #[skuld::test]
+    fn parse_static_single() {
+        let out = "
+Configuration for interface \"Ethernet\"
+    Statically Configured DNS Servers:  1.1.1.1
+    Register with which suffix:         Primary only
+";
+        let p = parse_netsh_dnsservers(out);
+        match p {
+            DnsPrior::Static { servers } => {
+                assert_eq!(servers, vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))]);
+            }
+            other => panic!("expected Static, got {other:?}"),
+        }
+    }
+
+    #[skuld::test]
+    fn parse_static_multiple() {
+        let out = "
+Configuration for interface \"Ethernet\"
+    Statically Configured DNS Servers:  1.1.1.1
+                                        8.8.8.8
+                                        9.9.9.9
+    Register with which suffix:         Primary only
+";
+        let p = parse_netsh_dnsservers(out);
+        match p {
+            DnsPrior::Static { servers } => {
+                assert_eq!(
+                    servers,
+                    vec![
+                        IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+                        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+                        IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)),
+                    ]
+                );
+            }
+            other => panic!("expected Static, got {other:?}"),
+        }
+    }
+
+    #[skuld::test]
+    fn parse_dhcp_with_ip() {
+        let out = "
+Configuration for interface \"Ethernet\"
+    DNS servers configured through DHCP:  192.168.1.1
+    Register with which suffix:           Primary only
+";
+        let p = parse_netsh_dnsservers(out);
+        assert!(matches!(p, DnsPrior::Dhcp));
+    }
+
+    #[skuld::test]
+    fn parse_dhcp_none() {
+        let out = "
+Configuration for interface \"Wi-Fi\"
+    DNS servers configured through DHCP:  None
+    Register with which suffix:           Primary only
+";
+        let p = parse_netsh_dnsservers(out);
+        assert!(matches!(p, DnsPrior::None));
+    }
+
+    #[skuld::test]
+    fn parse_empty_output_returns_none() {
+        let p = parse_netsh_dnsservers("");
+        assert!(matches!(p, DnsPrior::None));
+    }
+
+    #[skuld::test]
+    fn parse_ipv6_static() {
+        let out = "
+    Statically Configured DNS Servers:  2606:4700:4700::1111
+";
+        let p = parse_netsh_dnsservers(out);
+        match p {
+            DnsPrior::Static { servers } => {
+                assert_eq!(
+                    servers,
+                    vec![IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111))]
+                );
+            }
+            other => panic!("expected Static, got {other:?}"),
+        }
+    }
+}
+
+// macOS parser tests ==================================================================================================
+
+#[cfg(target_os = "macos")]
+mod macos_parsers {
+    use super::{DnsPrior, IpAddr, Ipv4Addr};
+    use crate::dns::system::macos::parse_networksetup_output;
+
+    #[skuld::test]
+    fn parse_empty_reports_dhcp() {
+        let out = "There aren't any DNS Servers set on Wi-Fi.\n";
+        let p = parse_networksetup_output(out);
+        assert!(matches!(p, DnsPrior::Dhcp));
+    }
+
+    #[skuld::test]
+    fn parse_multiple_ips() {
+        let out = "1.1.1.1\n2606:4700:4700::1111\n";
+        let p = parse_networksetup_output(out);
+        match p {
+            DnsPrior::Static { servers } => {
+                assert_eq!(servers.len(), 2);
+                assert!(servers.contains(&IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+            }
+            other => panic!("expected Static, got {other:?}"),
+        }
+    }
+}

--- a/crates/bridge/src/dns_state.rs
+++ b/crates/bridge/src/dns_state.rs
@@ -52,15 +52,24 @@ pub struct DnsPriorAdapter {
 /// self-describing so `scripts/network-reset.py` can dispatch on `kind`
 /// without inferring from platform. Inner field is named `value` in every
 /// variant so readers can extract it uniformly without branching on `kind`.
+///
+/// ## Why alias/name not LUID/GUID
+///
+/// `netsh` (Windows) and `networksetup` (macOS) both accept the adapter's
+/// friendly *name* as their identifier. Going through LUID (Windows) or
+/// service-GUID (macOS) would require an extra name-round-trip at restore
+/// time. Stability: interface aliases survive reboots; macOS service
+/// names survive reboots. Rename mid-session is the only failure mode,
+/// matching the plan's "skip silently on restore" semantics.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum AdapterId {
-    /// Windows interface LUID as the 64-bit `NET_LUID_LH.Value` union field
-    /// (combined representation, not the bit-fielded `Info` decomposition).
-    WindowsLuid { value: u64 },
-    /// macOS network service identifier (GUID-shaped string from
-    /// `networksetup -listallnetworkservices` / `scutil`).
-    MacosServiceId { value: String },
+    /// Windows adapter friendly name (alias), e.g. "Ethernet" or "Wi-Fi".
+    /// Passed directly to `netsh interface ... name="<value>"`.
+    WindowsAlias { value: String },
+    /// macOS network service name, e.g. "Wi-Fi" or "Ethernet". Passed
+    /// directly to `networksetup -setdnsservers <value>`.
+    MacosServiceName { value: String },
 }
 
 /// Prior DNS configuration for a single adapter + address family.

--- a/crates/bridge/src/dns_state.rs
+++ b/crates/bridge/src/dns_state.rs
@@ -1,0 +1,149 @@
+//! Persisted DNS state for crash recovery.
+//!
+//! The bridge writes the chosen loopback bind address and prior system-DNS
+//! settings to a JSON file when the DNS forwarder starts, clears it on clean
+//! shutdown, and reads it on startup to restore DNS leaked by a previous
+//! crashed run. Mirrors the `route_state.rs` / `plugin_state.rs`
+//! crash-recovery pattern.
+//!
+//! Single-writer assumption: the bridge is the only writer of this file
+//! within a process, and only one bridge runs at a time (the IPC socket bind
+//! enforces single-instance). Concurrent `save` calls are not supported.
+
+use std::io::Write;
+use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+// Types ===============================================================================================================
+
+/// Schema version for [`DnsState`]. Bump when the struct changes in a
+/// backwards-incompatible way; [`load`] rejects mismatched versions to force
+/// a fresh run rather than corrupt recovery.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Filename of the persisted state file under `state_dir`. Exported so
+/// external tooling (notably `scripts/network-reset.py`) can reference the
+/// single source of truth.
+pub const STATE_FILE_NAME: &str = "bridge-dns.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DnsState {
+    pub version: u32,
+    pub chosen_loopback: SocketAddr,
+    pub adapters: Vec<DnsPriorAdapter>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DnsPriorAdapter {
+    pub id: AdapterId,
+    /// Friendly adapter name captured at `capture` time, for diagnostic
+    /// logging only. Not used by restore. Empty string is acceptable when
+    /// the capture code cannot derive a name.
+    pub name_at_capture: String,
+    pub v4: DnsPrior,
+    pub v6: DnsPrior,
+}
+
+/// OS-stable adapter identifier. Tagged to keep the on-disk format
+/// self-describing so `scripts/network-reset.py` can dispatch on `kind`
+/// without inferring from platform. Inner field is named `value` in every
+/// variant so readers can extract it uniformly without branching on `kind`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AdapterId {
+    /// Windows interface LUID as the 64-bit `NET_LUID_LH.Value` union field
+    /// (combined representation, not the bit-fielded `Info` decomposition).
+    WindowsLuid { value: u64 },
+    /// macOS network service identifier (GUID-shaped string from
+    /// `networksetup -listallnetworkservices` / `scutil`).
+    MacosServiceId { value: String },
+}
+
+/// Prior DNS configuration for a single adapter + address family.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DnsPrior {
+    /// No DNS was configured for this family (restore: clear to empty). On
+    /// macOS the restore operation is identical to [`DnsPrior::Dhcp`] —
+    /// `networksetup -setdnsservers <service> Empty` covers both — but the
+    /// variants are kept distinct so Windows can dispatch precisely.
+    None,
+    /// DNS was DHCP-assigned (restore: re-enable DHCP for DNS).
+    Dhcp,
+    /// DNS was statically configured to `servers` (restore: re-apply list).
+    Static { servers: Vec<IpAddr> },
+}
+
+fn state_file(state_dir: &Path) -> PathBuf {
+    state_dir.join(STATE_FILE_NAME)
+}
+
+// I/O =================================================================================================================
+
+/// Write `state` to `<state_dir>/bridge-dns.json` atomically via a
+/// same-directory temp file + rename. Contents are `sync_all`'d before
+/// persist so a process crash sees either the old contents or the new
+/// contents, never a truncated file. Creates `state_dir` if missing.
+///
+/// Does NOT fsync the parent directory after the rename — power-loss
+/// durability is out of scope. The design target is process-crash recovery.
+pub fn save(state_dir: &Path, state: &DnsState) -> std::io::Result<()> {
+    std::fs::create_dir_all(state_dir)?;
+
+    let json = serde_json::to_vec_pretty(state).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    let mut tmp = tempfile::NamedTempFile::new_in(state_dir)?;
+    tmp.write_all(&json)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(state_file(state_dir)).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Load the state file. Returns `None` for any error — missing file,
+/// corrupted JSON, unknown fields, version mismatch — and logs at `warn`
+/// level. Crash recovery is best-effort and should never fail the caller.
+pub fn load(state_dir: &Path) -> Option<DnsState> {
+    let path = state_file(state_dir);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "dns-state read failed");
+            return None;
+        }
+    };
+    match serde_json::from_slice::<DnsState>(&bytes) {
+        Ok(state) if state.version == SCHEMA_VERSION => Some(state),
+        Ok(other) => {
+            tracing::warn!(
+                got = other.version,
+                want = SCHEMA_VERSION,
+                "dns-state schema mismatch, discarding"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "dns-state parse failed");
+            None
+        }
+    }
+}
+
+/// Delete the state file. Tolerates a missing file (returns `Ok`). Returns
+/// `Err` only on actual I/O errors (permissions, etc.).
+pub fn clear(state_dir: &Path) -> std::io::Result<()> {
+    let path = state_file(state_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+#[path = "dns_state_tests.rs"]
+mod dns_state_tests;

--- a/crates/bridge/src/dns_state_tests.rs
+++ b/crates/bridge/src/dns_state_tests.rs
@@ -1,0 +1,295 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use super::*;
+
+fn sample_windows_state() -> DnsState {
+    DnsState {
+        version: SCHEMA_VERSION,
+        chosen_loopback: SocketAddr::from(([127, 0, 0, 1], 53)),
+        adapters: vec![
+            DnsPriorAdapter {
+                id: AdapterId::WindowsLuid {
+                    value: 0x0001_0000_0000_0001,
+                },
+                name_at_capture: "Ethernet".into(),
+                v4: DnsPrior::Static {
+                    servers: vec![
+                        IpAddr::V4(Ipv4Addr::new(89, 216, 1, 40)),
+                        IpAddr::V4(Ipv4Addr::new(89, 216, 1, 50)),
+                    ],
+                },
+                v6: DnsPrior::None,
+            },
+            DnsPriorAdapter {
+                id: AdapterId::WindowsLuid {
+                    value: 0x0002_0000_0000_0002,
+                },
+                name_at_capture: "hole-tun".into(),
+                v4: DnsPrior::Dhcp,
+                v6: DnsPrior::Static {
+                    servers: vec![IpAddr::V6(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888))],
+                },
+            },
+        ],
+    }
+}
+
+fn sample_macos_state() -> DnsState {
+    DnsState {
+        version: SCHEMA_VERSION,
+        chosen_loopback: SocketAddr::from(([127, 53, 0, 1], 53)),
+        adapters: vec![DnsPriorAdapter {
+            id: AdapterId::MacosServiceId {
+                value: "BE3F4D41-1234-5678-ABCD-0123456789AB".into(),
+            },
+            name_at_capture: "Wi-Fi".into(),
+            v4: DnsPrior::Dhcp,
+            v6: DnsPrior::None,
+        }],
+    }
+}
+
+#[skuld::test]
+fn save_then_load_roundtrip_windows() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = sample_windows_state();
+    save(dir.path(), &state).unwrap();
+    let loaded = load(dir.path()).unwrap();
+    assert_eq!(loaded, state);
+}
+
+#[skuld::test]
+fn save_then_load_roundtrip_macos() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = sample_macos_state();
+    save(dir.path(), &state).unwrap();
+    let loaded = load(dir.path()).unwrap();
+    assert_eq!(loaded, state);
+}
+
+#[skuld::test]
+fn save_then_load_roundtrip_fallback_loopback() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = DnsState {
+        version: SCHEMA_VERSION,
+        chosen_loopback: SocketAddr::from(([127, 53, 0, 254], 53)),
+        adapters: vec![],
+    };
+    save(dir.path(), &state).unwrap();
+    let loaded = load(dir.path()).unwrap();
+    assert_eq!(loaded, state);
+}
+
+#[skuld::test]
+fn load_missing_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_corrupted_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(STATE_FILE_NAME), b"not valid json { .").unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_wrong_version_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": 99,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [],
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_unknown_top_level_field_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": SCHEMA_VERSION,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [],
+        "extra_field": "should be rejected",
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_unknown_adapter_field_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": SCHEMA_VERSION,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [{
+            "id": { "kind": "windows_luid", "value": 42 },
+            "name_at_capture": "Ethernet",
+            "v4": { "kind": "none" },
+            "v6": { "kind": "none" },
+            "surprise": true,
+        }],
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_unknown_dns_prior_variant_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": SCHEMA_VERSION,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [{
+            "id": { "kind": "windows_luid", "value": 42 },
+            "name_at_capture": "Ethernet",
+            "v4": { "kind": "mystery_mode" },
+            "v6": { "kind": "none" },
+        }],
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn dns_prior_variants_serialize_snake_case() {
+    let none_json = serde_json::to_value(DnsPrior::None).unwrap();
+    assert_eq!(none_json, serde_json::json!({ "kind": "none" }));
+
+    let dhcp_json = serde_json::to_value(DnsPrior::Dhcp).unwrap();
+    assert_eq!(dhcp_json, serde_json::json!({ "kind": "dhcp" }));
+
+    let static_json = serde_json::to_value(DnsPrior::Static {
+        servers: vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))],
+    })
+    .unwrap();
+    assert_eq!(
+        static_json,
+        serde_json::json!({ "kind": "static", "servers": ["1.1.1.1"] })
+    );
+}
+
+#[skuld::test]
+fn adapter_id_variants_serialize_snake_case() {
+    let win = serde_json::to_value(AdapterId::WindowsLuid { value: 42 }).unwrap();
+    assert_eq!(win, serde_json::json!({ "kind": "windows_luid", "value": 42 }));
+
+    let mac = serde_json::to_value(AdapterId::MacosServiceId { value: "abc".into() }).unwrap();
+    assert_eq!(mac, serde_json::json!({ "kind": "macos_service_id", "value": "abc" }));
+}
+
+#[skuld::test]
+fn load_rejects_unknown_field_in_static_variant() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": SCHEMA_VERSION,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [{
+            "id": { "kind": "windows_luid", "value": 42 },
+            "name_at_capture": "Ethernet",
+            "v4": { "kind": "static", "servers": ["1.1.1.1"], "mystery": true },
+            "v6": { "kind": "none" },
+        }],
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_rejects_unknown_field_in_macos_service_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": SCHEMA_VERSION,
+        "chosen_loopback": "127.0.0.1:53",
+        "adapters": [{
+            "id": { "kind": "macos_service_id", "value": "abc", "extra": 1 },
+            "name_at_capture": "Wi-Fi",
+            "v4": { "kind": "none" },
+            "v6": { "kind": "none" },
+        }],
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn load_rejects_missing_required_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let json = serde_json::json!({
+        "version": SCHEMA_VERSION,
+        // chosen_loopback missing
+        "adapters": [],
+    });
+    std::fs::write(dir.path().join(STATE_FILE_NAME), json.to_string()).unwrap();
+    assert!(load(dir.path()).is_none());
+}
+
+#[skuld::test]
+fn save_then_load_roundtrip_ipv6_loopback() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = DnsState {
+        version: SCHEMA_VERSION,
+        chosen_loopback: SocketAddr::from((Ipv6Addr::LOCALHOST, 53)),
+        adapters: vec![],
+    };
+    save(dir.path(), &state).unwrap();
+    let loaded = load(dir.path()).unwrap();
+    assert_eq!(loaded, state);
+}
+
+#[skuld::test]
+fn save_overwrites_prior_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = sample_windows_state();
+    save(dir.path(), &first).unwrap();
+
+    let second = sample_macos_state();
+    save(dir.path(), &second).unwrap();
+
+    let loaded = load(dir.path()).unwrap();
+    assert_eq!(loaded, second);
+}
+
+#[skuld::test]
+fn save_leaves_no_stray_temp_files() {
+    // Guards against a future refactor that replaces `NamedTempFile` with
+    // a manual write+rename that leaks `.tmpXXX` siblings.
+    let dir = tempfile::tempdir().unwrap();
+    save(dir.path(), &sample_windows_state()).unwrap();
+    save(dir.path(), &sample_macos_state()).unwrap();
+    let entries: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    assert_eq!(entries, vec![std::ffi::OsString::from(STATE_FILE_NAME)]);
+}
+
+#[skuld::test]
+fn clear_missing_is_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    clear(dir.path()).unwrap();
+}
+
+#[skuld::test]
+fn clear_existing_removes_file() {
+    let dir = tempfile::tempdir().unwrap();
+    save(dir.path(), &sample_windows_state()).unwrap();
+    assert!(dir.path().join(STATE_FILE_NAME).exists());
+    clear(dir.path()).unwrap();
+    assert!(!dir.path().join(STATE_FILE_NAME).exists());
+}
+
+#[skuld::test]
+fn save_creates_missing_dir() {
+    let parent = tempfile::tempdir().unwrap();
+    let nested = parent.path().join("a").join("b").join("c");
+    save(&nested, &sample_windows_state()).unwrap();
+    assert!(nested.join(STATE_FILE_NAME).exists());
+}
+
+#[skuld::test]
+fn state_file_name_is_bridge_dns_json() {
+    assert_eq!(STATE_FILE_NAME, "bridge-dns.json");
+}

--- a/crates/bridge/src/dns_state_tests.rs
+++ b/crates/bridge/src/dns_state_tests.rs
@@ -8,8 +8,8 @@ fn sample_windows_state() -> DnsState {
         chosen_loopback: SocketAddr::from(([127, 0, 0, 1], 53)),
         adapters: vec![
             DnsPriorAdapter {
-                id: AdapterId::WindowsLuid {
-                    value: 0x0001_0000_0000_0001,
+                id: AdapterId::WindowsAlias {
+                    value: "Ethernet".into(),
                 },
                 name_at_capture: "Ethernet".into(),
                 v4: DnsPrior::Static {
@@ -21,8 +21,8 @@ fn sample_windows_state() -> DnsState {
                 v6: DnsPrior::None,
             },
             DnsPriorAdapter {
-                id: AdapterId::WindowsLuid {
-                    value: 0x0002_0000_0000_0002,
+                id: AdapterId::WindowsAlias {
+                    value: "hole-tun".into(),
                 },
                 name_at_capture: "hole-tun".into(),
                 v4: DnsPrior::Dhcp,
@@ -39,9 +39,7 @@ fn sample_macos_state() -> DnsState {
         version: SCHEMA_VERSION,
         chosen_loopback: SocketAddr::from(([127, 53, 0, 1], 53)),
         adapters: vec![DnsPriorAdapter {
-            id: AdapterId::MacosServiceId {
-                value: "BE3F4D41-1234-5678-ABCD-0123456789AB".into(),
-            },
+            id: AdapterId::MacosServiceName { value: "Wi-Fi".into() },
             name_at_capture: "Wi-Fi".into(),
             v4: DnsPrior::Dhcp,
             v6: DnsPrior::None,
@@ -125,7 +123,7 @@ fn load_unknown_adapter_field_returns_none() {
         "version": SCHEMA_VERSION,
         "chosen_loopback": "127.0.0.1:53",
         "adapters": [{
-            "id": { "kind": "windows_luid", "value": 42 },
+            "id": { "kind": "windows_alias", "value": "Ethernet" },
             "name_at_capture": "Ethernet",
             "v4": { "kind": "none" },
             "v6": { "kind": "none" },
@@ -143,7 +141,7 @@ fn load_unknown_dns_prior_variant_returns_none() {
         "version": SCHEMA_VERSION,
         "chosen_loopback": "127.0.0.1:53",
         "adapters": [{
-            "id": { "kind": "windows_luid", "value": 42 },
+            "id": { "kind": "windows_alias", "value": "Ethernet" },
             "name_at_capture": "Ethernet",
             "v4": { "kind": "mystery_mode" },
             "v6": { "kind": "none" },
@@ -173,11 +171,14 @@ fn dns_prior_variants_serialize_snake_case() {
 
 #[skuld::test]
 fn adapter_id_variants_serialize_snake_case() {
-    let win = serde_json::to_value(AdapterId::WindowsLuid { value: 42 }).unwrap();
-    assert_eq!(win, serde_json::json!({ "kind": "windows_luid", "value": 42 }));
+    let win = serde_json::to_value(AdapterId::WindowsAlias {
+        value: "Ethernet".into(),
+    })
+    .unwrap();
+    assert_eq!(win, serde_json::json!({ "kind": "windows_alias", "value": "Ethernet" }));
 
-    let mac = serde_json::to_value(AdapterId::MacosServiceId { value: "abc".into() }).unwrap();
-    assert_eq!(mac, serde_json::json!({ "kind": "macos_service_id", "value": "abc" }));
+    let mac = serde_json::to_value(AdapterId::MacosServiceName { value: "abc".into() }).unwrap();
+    assert_eq!(mac, serde_json::json!({ "kind": "macos_service_name", "value": "abc" }));
 }
 
 #[skuld::test]
@@ -187,7 +188,7 @@ fn load_rejects_unknown_field_in_static_variant() {
         "version": SCHEMA_VERSION,
         "chosen_loopback": "127.0.0.1:53",
         "adapters": [{
-            "id": { "kind": "windows_luid", "value": 42 },
+            "id": { "kind": "windows_alias", "value": "Ethernet" },
             "name_at_capture": "Ethernet",
             "v4": { "kind": "static", "servers": ["1.1.1.1"], "mystery": true },
             "v6": { "kind": "none" },
@@ -198,13 +199,13 @@ fn load_rejects_unknown_field_in_static_variant() {
 }
 
 #[skuld::test]
-fn load_rejects_unknown_field_in_macos_service_id() {
+fn load_rejects_unknown_field_in_macos_service_name() {
     let dir = tempfile::tempdir().unwrap();
     let json = serde_json::json!({
         "version": SCHEMA_VERSION,
         "chosen_loopback": "127.0.0.1:53",
         "adapters": [{
-            "id": { "kind": "macos_service_id", "value": "abc", "extra": 1 },
+            "id": { "kind": "macos_service_name", "value": "abc", "extra": 1 },
             "name_at_capture": "Wi-Fi",
             "v4": { "kind": "none" },
             "v6": { "kind": "none" },

--- a/crates/bridge/src/endpoint.rs
+++ b/crates/bridge/src/endpoint.rs
@@ -30,6 +30,7 @@
 
 pub mod block;
 pub mod interface;
+pub mod local_dns;
 pub mod socks5;
 
 use std::io;
@@ -40,6 +41,7 @@ use tun_engine::{TcpFlow, UdpFlow};
 
 pub use block::BlockEndpoint;
 pub use interface::InterfaceEndpoint;
+pub use local_dns::LocalDnsEndpoint;
 pub use socks5::Socks5Endpoint;
 
 /// A flow-carrying mechanism. Implementations take ownership of a flow

--- a/crates/bridge/src/endpoint/local_dns.rs
+++ b/crates/bridge/src/endpoint/local_dns.rs
@@ -1,0 +1,89 @@
+//! `LocalDnsEndpoint` — the router's sink for in-tunnel UDP/53 flows.
+//!
+//! When the HoleRouter cascade matches `proto == Udp && dst.port() == 53
+//! && dns.intercept_udp53`, it dispatches to this endpoint instead of the
+//! [`Socks5Endpoint`](super::Socks5Endpoint). This catches apps that hard-
+//! code DNS destinations (Chrome DoH to 8.8.8.8, systemd-resolved stub)
+//! so they never hit the UDP-drop privacy invariant.
+//!
+//! The endpoint owns an `Arc<DnsForwarder>` and runs each incoming UDP
+//! datagram through `forward()` directly — no OS-loopback hop, no
+//! `LocalDnsServer` detour. That's the point: the flow arrived via the
+//! TUN, we resolve in-process, and we write the reply back into the same
+//! flow.
+//!
+//! TCP is not served: DNS-over-TCP to external IPs bypasses this endpoint
+//! — those flows take the normal proxy cascade. Serving TCP here would
+//! complicate the router's cascade semantics (port 53 TCP isn't
+//! necessarily DNS — it could be zone-transfer AXFR or any service
+//! running on port 53) with no known user benefit.
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tun_engine::{TcpFlow, UdpFlow, UdpSender};
+
+use crate::dns::forwarder::DnsForwarder;
+use crate::endpoint::Endpoint;
+
+pub struct LocalDnsEndpoint {
+    forwarder: Arc<DnsForwarder>,
+}
+
+impl LocalDnsEndpoint {
+    pub fn new(forwarder: Arc<DnsForwarder>) -> Self {
+        Self { forwarder }
+    }
+}
+
+#[async_trait]
+impl Endpoint for LocalDnsEndpoint {
+    async fn serve_tcp(&self, _flow: &mut TcpFlow, _dst: SocketAddr) -> io::Result<()> {
+        // TCP/53 is not intercepted here. If the router routes TCP to this
+        // endpoint, that's a cascade bug — debug_assert + drop silently.
+        debug_assert!(
+            false,
+            "LocalDnsEndpoint::serve_tcp called; router cascade misconfigured"
+        );
+        Ok(())
+    }
+
+    async fn serve_udp(&self, mut flow: UdpFlow, _dst: SocketAddr) -> io::Result<()> {
+        let sender: UdpSender = flow.sender();
+        let forwarder = Arc::clone(&self.forwarder);
+        // Per-datagram: forward through the DnsForwarder, write reply back
+        // into the same 5-tuple via `sender.send`. Each datagram is an
+        // independent DNS request — we don't batch or keep state.
+        while let Some(payload) = flow.recv().await {
+            let sender = sender.clone();
+            let forwarder = Arc::clone(&forwarder);
+            tokio::spawn(async move {
+                let reply = forwarder.forward(&payload).await;
+                let _ = sender.send(&reply).await;
+            });
+        }
+        Ok(())
+    }
+
+    fn supports_udp(&self) -> bool {
+        true
+    }
+
+    fn supports_ipv6_dst(&self) -> bool {
+        // The forwarder reaches upstream via the shadowsocks tunnel, which
+        // carries IPv6 via the SS ATYP field; the destination address the
+        // *client* used is irrelevant — the local endpoint answers any
+        // destination. Match `Socks5Endpoint` by reporting `true`.
+        true
+    }
+
+    fn name(&self) -> &str {
+        "local-dns"
+    }
+}
+
+#[cfg(test)]
+#[path = "local_dns_tests.rs"]
+mod local_dns_tests;

--- a/crates/bridge/src/endpoint/local_dns_tests.rs
+++ b/crates/bridge/src/endpoint/local_dns_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+#[skuld::test]
+fn capabilities_are_stable() {
+    let cfg = hole_common::config::DnsConfig {
+        enabled: true,
+        servers: vec!["192.0.2.1".parse().unwrap()],
+        protocol: hole_common::config::DnsProtocol::PlainUdp,
+        intercept_udp53: true,
+    };
+    let fwd = Arc::new(DnsForwarder::new(
+        cfg,
+        Arc::new(crate::dns::connector::DirectConnector),
+        true,
+    ));
+    let ep = LocalDnsEndpoint::new(fwd);
+    assert!(ep.supports_udp(), "LocalDnsEndpoint carries UDP by definition");
+    assert!(
+        ep.supports_ipv6_dst(),
+        "destination IPv6 is irrelevant — endpoint answers locally"
+    );
+    assert_eq!(ep.name(), "local-dns");
+}
+
+#[skuld::test]
+fn serve_tcp_returns_ok_immediately() {
+    // TCP isn't served by this endpoint — it's a cascade bug if the
+    // router sends one here. The method drops the flow and returns Ok(())
+    // in release; the debug_assert fires only in debug tests, and we
+    // don't exercise serve_tcp directly here because constructing a
+    // TcpFlow requires a live engine.
+    let cfg = hole_common::config::DnsConfig {
+        enabled: true,
+        servers: vec!["192.0.2.1".parse().unwrap()],
+        protocol: hole_common::config::DnsProtocol::PlainUdp,
+        intercept_udp53: true,
+    };
+    let fwd = Arc::new(DnsForwarder::new(
+        cfg,
+        Arc::new(crate::dns::connector::DirectConnector),
+        true,
+    ));
+    let ep = LocalDnsEndpoint::new(fwd);
+    // Sanity: the endpoint exists and reports its name.
+    assert_eq!(ep.name(), "local-dns");
+}

--- a/crates/bridge/src/foreground.rs
+++ b/crates/bridge/src/foreground.rs
@@ -34,6 +34,16 @@ async fn run_inner(socket_path: &Path, state_dir: &Path, log_dir: &Path) -> Resu
     // bind() fails and we exit without touching any routing state.
     let server = crate::ipc::IpcServer::bind(socket_path, proxy)?;
 
+    // DNS recovery runs *before* route recovery. Rationale: mid-recovery
+    // crash leaves the user with functional DNS + broken routes (easier
+    // diagnosis path) instead of broken DNS + functional routes. See
+    // crate::dns::recovery module docs.
+    let state_dir_dns = state_dir.to_path_buf();
+    if let Err(e) = tokio::task::spawn_blocking(move || crate::dns::recovery::recover_dns_config(&state_dir_dns)).await
+    {
+        tracing::warn!(error = %e, "recover_dns_config task panicked");
+    }
+
     // Offload route recovery to a blocking thread so a hung netsh/route
     // command cannot wedge the runtime while the IPC socket is bound but
     // not yet serving.

--- a/crates/bridge/src/hole_router.rs
+++ b/crates/bridge/src/hole_router.rs
@@ -48,7 +48,7 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use tun_engine::{Router, TcpFlow, TcpMeta, UdpFlow, UdpMeta};
 
-use crate::endpoint::{BlockEndpoint, Endpoint, InterfaceEndpoint, Socks5Endpoint};
+use crate::endpoint::{BlockEndpoint, Endpoint, InterfaceEndpoint, LocalDnsEndpoint, Socks5Endpoint};
 use crate::filter;
 use crate::filter::engine::{decide, ConnInfo, L4Proto};
 use crate::filter::rules::RuleSet;
@@ -68,6 +68,11 @@ pub struct HoleRouter {
     proxy: Socks5Endpoint,
     bypass: InterfaceEndpoint,
     block: BlockEndpoint,
+    /// Optional in-tunnel DNS interceptor. When present *and*
+    /// `DnsConfig.intercept_udp53 == true`, the cascade diverts UDP/53
+    /// flows to this endpoint instead of the proxy. `None` disables
+    /// interception (user config or SocksOnly mode).
+    local_dns: Option<LocalDnsEndpoint>,
     rules: Arc<ArcSwap<RuleSet>>,
 }
 
@@ -77,6 +82,26 @@ impl HoleRouter {
             proxy,
             bypass,
             block,
+            local_dns: None,
+            rules: Arc::new(ArcSwap::from_pointee(rules)),
+        }
+    }
+
+    /// Construct with an in-tunnel DNS interceptor attached. When
+    /// `Some(_)`, the UDP/53 cascade diverts to `local_dns` before
+    /// falling through to the proxy path. `None` disables interception.
+    pub fn with_local_dns(
+        proxy: Socks5Endpoint,
+        bypass: InterfaceEndpoint,
+        block: BlockEndpoint,
+        local_dns: Option<LocalDnsEndpoint>,
+        rules: RuleSet,
+    ) -> Self {
+        Self {
+            proxy,
+            bypass,
+            block,
+            local_dns,
             rules: Arc::new(ArcSwap::from_pointee(rules)),
         }
     }
@@ -126,6 +151,16 @@ impl HoleRouter {
         rule_index: Option<u32>,
     ) -> Dispatch<'_> {
         let rule_index = rule_index.unwrap_or(0);
+        // Intercept UDP/53 *before* the action cascade — a LocalDnsEndpoint
+        // takes precedence over any FilterAction decision. This ensures
+        // the forwarder answers even for flows whose rule would otherwise
+        // Block/Bypass/Proxy (e.g. a user rule `Block 8.8.8.8` still sends
+        // Chrome's hardcoded-DoH DNS through the local forwarder).
+        if l4 == L4Proto::Udp && dst.port() == 53 {
+            if let Some(local) = self.local_dns.as_ref() {
+                return Dispatch::Endpoint(local);
+            }
+        }
         match action {
             FilterAction::Proxy => {
                 // Privacy invariant: if proxy can't carry this UDP flow,

--- a/crates/bridge/src/hole_router_tests.rs
+++ b/crates/bridge/src/hole_router_tests.rs
@@ -11,9 +11,13 @@ use super::*;
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use crate::endpoint::{BlockEndpoint, InterfaceEndpoint, Socks5Endpoint};
+use std::sync::Arc;
+
+use crate::dns::connector::DirectConnector;
+use crate::dns::forwarder::DnsForwarder;
+use crate::endpoint::{BlockEndpoint, InterfaceEndpoint, LocalDnsEndpoint, Socks5Endpoint};
 use crate::filter::rules::RuleSet;
-use hole_common::config::FilterAction;
+use hole_common::config::{DnsConfig, DnsProtocol, FilterAction};
 
 fn v4(s: &str, port: u16) -> SocketAddr {
     SocketAddr::new(IpAddr::V4(s.parse::<Ipv4Addr>().unwrap()), port)
@@ -97,6 +101,14 @@ enum ExpectedEndpoint {
     Drop { reason: &'static str },
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum DnsExpectedEndpoint {
+    Proxy,
+    Bypass,
+    LocalDns,
+    Drop { reason: &'static str },
+}
+
 fn classify(d: Dispatch<'_>, router: &HoleRouter) -> ExpectedEndpoint {
     match d {
         Dispatch::Endpoint(e) => {
@@ -117,6 +129,46 @@ fn classify(d: Dispatch<'_>, router: &HoleRouter) -> ExpectedEndpoint {
             ExpectedEndpoint::Drop { reason }
         }
     }
+}
+
+fn classify_with_dns(d: Dispatch<'_>, router: &HoleRouter) -> DnsExpectedEndpoint {
+    match d {
+        Dispatch::Endpoint(e) => {
+            if std::ptr::eq(e as *const _ as *const (), &router.proxy as *const _ as *const ()) {
+                DnsExpectedEndpoint::Proxy
+            } else if std::ptr::eq(e as *const _ as *const (), &router.bypass as *const _ as *const ()) {
+                DnsExpectedEndpoint::Bypass
+            } else {
+                DnsExpectedEndpoint::LocalDns
+            }
+        }
+        Dispatch::Drop(r) => {
+            let reason = match r {
+                DropReason::RuleBlock { .. } => "rule_block",
+                DropReason::UdpProxyUnavailable { .. } => "udp_proxy_unavailable",
+                DropReason::Ipv6BypassUnreachable { .. } => "ipv6_bypass_unreachable",
+            };
+            DnsExpectedEndpoint::Drop { reason }
+        }
+    }
+}
+
+fn sample_dns_cfg() -> DnsConfig {
+    DnsConfig {
+        enabled: true,
+        servers: vec!["192.0.2.1".parse().unwrap()],
+        protocol: DnsProtocol::PlainUdp,
+        intercept_udp53: true,
+    }
+}
+
+fn router_with_local_dns(proxy_udp: bool, bypass_v6: bool) -> HoleRouter {
+    let proxy = Socks5Endpoint::new(v4("127.0.0.1", 1080), Some("test-plugin".into()), proxy_udp);
+    let bypass = InterfaceEndpoint::new(1, bypass_v6);
+    let block = BlockEndpoint::new();
+    let fwd = Arc::new(DnsForwarder::new(sample_dns_cfg(), Arc::new(DirectConnector), true));
+    let local_dns = LocalDnsEndpoint::new(fwd);
+    HoleRouter::with_local_dns(proxy, bypass, block, Some(local_dns), RuleSet::default())
 }
 
 #[skuld::test]
@@ -210,6 +262,100 @@ fn cascade_table() {
             "resolve_endpoint({action:?}, {l4:?}, {dst}, proxy_udp={proxy_udp}, bypass_v6={bypass_v6})"
         );
     }
+}
+
+// BlockEndpoint log-methods — rate-limit and one-shot behavior ========================================================
+
+// LocalDns interception ===============================================================================================
+
+#[skuld::test]
+fn udp53_to_external_ip_intercepted_when_local_dns_present() {
+    let r = router_with_local_dns(false, true);
+    // UDP/53 to an external resolver — normally this would be dropped by
+    // the UDP-proxy-unavailable invariant (proxy_udp=false), but the
+    // LocalDnsEndpoint precedes the action cascade.
+    let got = classify_with_dns(
+        r.resolve_endpoint(FilterAction::Proxy, L4Proto::Udp, v4("8.8.8.8", 53), Some(0)),
+        &r,
+    );
+    assert_eq!(got, DnsExpectedEndpoint::LocalDns);
+}
+
+#[skuld::test]
+fn udp53_intercepted_even_when_rule_says_block() {
+    // The hardcoded-DoH case: user has a rule `Block 1.1.1.1`, but Chrome
+    // hits 1.1.1.1:53 for DoH. We still serve via local DNS.
+    let r = router_with_local_dns(true, true);
+    let got = classify_with_dns(
+        r.resolve_endpoint(FilterAction::Block, L4Proto::Udp, v4("1.1.1.1", 53), Some(0)),
+        &r,
+    );
+    assert_eq!(got, DnsExpectedEndpoint::LocalDns);
+}
+
+#[skuld::test]
+fn udp53_intercepted_even_when_rule_says_bypass() {
+    let r = router_with_local_dns(true, true);
+    let got = classify_with_dns(
+        r.resolve_endpoint(FilterAction::Bypass, L4Proto::Udp, v4("8.8.4.4", 53), Some(0)),
+        &r,
+    );
+    assert_eq!(got, DnsExpectedEndpoint::LocalDns);
+}
+
+#[skuld::test]
+fn tcp53_not_intercepted_even_with_local_dns() {
+    // TCP/53 is out of scope for LocalDnsEndpoint (could be AXFR etc.).
+    let r = router_with_local_dns(true, true);
+    let got = classify_with_dns(
+        r.resolve_endpoint(FilterAction::Proxy, L4Proto::Tcp, v4("1.1.1.1", 53), Some(0)),
+        &r,
+    );
+    assert_eq!(got, DnsExpectedEndpoint::Proxy);
+}
+
+#[skuld::test]
+fn udp53_v6_destination_also_intercepted() {
+    let r = router_with_local_dns(false, false);
+    let got = classify_with_dns(
+        r.resolve_endpoint(
+            FilterAction::Proxy,
+            L4Proto::Udp,
+            v6("2001:4860:4860::8888", 53),
+            Some(0),
+        ),
+        &r,
+    );
+    assert_eq!(got, DnsExpectedEndpoint::LocalDns);
+}
+
+#[skuld::test]
+fn udp53_without_local_dns_keeps_existing_behavior() {
+    // When local_dns is None (intercept_udp53 disabled), the cascade
+    // reverts to the pre-refactor behavior: Proxy + UDP + !proxy_udp
+    // drops via the privacy invariant.
+    let r = router_with(false, true);
+    let got = classify(
+        r.resolve_endpoint(FilterAction::Proxy, L4Proto::Udp, v4("8.8.8.8", 53), Some(0)),
+        &r,
+    );
+    assert_eq!(
+        got,
+        ExpectedEndpoint::Drop {
+            reason: "udp_proxy_unavailable"
+        }
+    );
+}
+
+#[skuld::test]
+fn udp_non53_not_intercepted_by_local_dns() {
+    // Non-53 UDP should not hit LocalDnsEndpoint even when it's present.
+    let r = router_with_local_dns(true, true);
+    let got = classify_with_dns(
+        r.resolve_endpoint(FilterAction::Proxy, L4Proto::Udp, v4("8.8.8.8", 443), Some(0)),
+        &r,
+    );
+    assert_eq!(got, DnsExpectedEndpoint::Proxy);
 }
 
 // BlockEndpoint log-methods — rate-limit and one-shot behavior ========================================================

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -212,6 +212,7 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
+        dns: hole_common::config::DnsConfig::default(),
     }
 }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod diagnostics;
 pub mod dispatcher;
+pub mod dns_state;
 pub mod endpoint;
 pub mod filter;
 pub mod foreground;

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod diagnostics;
 pub mod dispatcher;
+pub mod dns;
 pub mod dns_state;
 pub mod endpoint;
 pub mod filter;

--- a/crates/bridge/src/platform/macos.rs
+++ b/crates/bridge/src/platform/macos.rs
@@ -229,6 +229,13 @@ pub fn run(
         // spawn_blocking so a hung netsh/route command cannot wedge the
         // runtime while the IPC socket is bound but not yet serving.
         let server = crate::ipc::IpcServer::bind(socket_path, proxy)?;
+        // DNS recovery runs first; see crate::dns::recovery docs for ordering.
+        let state_dir_dns = state_dir.to_path_buf();
+        if let Err(e) =
+            tokio::task::spawn_blocking(move || crate::dns::recovery::recover_dns_config(&state_dir_dns)).await
+        {
+            tracing::warn!(error = %e, "recover_dns_config task panicked");
+        }
         let state_dir_routes = state_dir.to_path_buf();
         if let Err(e) =
             tokio::task::spawn_blocking(move || tun_engine::routing::recover_routes(&state_dir_routes)).await

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -108,6 +108,13 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
         // spawn_blocking so a hung netsh/route command cannot wedge the
         // runtime while the IPC socket is bound but not yet serving.
         let server = crate::ipc::IpcServer::bind(&socket_path, proxy)?;
+        // DNS recovery runs first; see crate::dns::recovery docs for ordering.
+        let state_dir_for_dns = state_dir.clone();
+        if let Err(e) =
+            tokio::task::spawn_blocking(move || crate::dns::recovery::recover_dns_config(&state_dir_for_dns)).await
+        {
+            tracing::warn!(error = %e, "recover_dns_config task panicked");
+        }
         let state_dir_for_recover = state_dir.clone();
         if let Err(e) =
             tokio::task::spawn_blocking(move || tun_engine::routing::recover_routes(&state_dir_for_recover)).await

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -22,6 +22,7 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: vec![],
+        dns: hole_common::config::DnsConfig::default(),
     }
 }
 

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -32,7 +32,7 @@ use std::time::Instant;
 use dump::{dump, DeriveDump};
 use hole_common::protocol::{ProxyConfig, TunnelMode};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use tun_engine::gateway::GatewayInfo;
 use tun_engine::routing::{Routing, SystemRouting};
 
@@ -65,14 +65,22 @@ pub enum ProxyState {
 
 /// Per-cycle state owned only while a proxy is running.
 ///
-/// **Field declaration order is load-bearing.** Dispatcher drops first
+/// **Field declaration order is load-bearing.** DNS drops first (restores
+/// the user's OS DNS while routes + dispatcher + SS are still live so any
+/// in-flight OS DNS queries egress the restored path), then dispatcher
 /// (closes TUN, cancels handlers), then plugin chain (graceful stop via
 /// SIGTERM/CTRL_BREAK), then routes (teardown commands), then proxy
 /// (releases SS). `None` fields for SocksOnly mode where
-/// routing/dispatcher are skipped, or when no plugin is configured.
+/// routing/dispatcher/DNS are skipped, or when no plugin is configured.
 struct RunningState<P: Proxy, R: Routing> {
+    /// DNS interception: system-DNS apply + LocalDnsServer. Drops FIRST
+    /// so the user's prior resolvers are restored before anything else
+    /// tears down. `None` when DNS forwarder is disabled or in SocksOnly
+    /// mode.
+    #[allow(dead_code)]
+    dns: Option<RunningDns>,
     /// TCP dispatcher — owns TUN device, smoltcp, and per-connection
-    /// handler tasks. Drops FIRST. `None` in SocksOnly mode and under
+    /// handler tasks. Drops SECOND. `None` in SocksOnly mode and under
     /// `#[cfg(test)]`.
     #[allow(dead_code)]
     dispatcher: Option<crate::dispatcher::Dispatcher>,
@@ -93,6 +101,41 @@ struct RunningState<P: Proxy, R: Routing> {
     udp_proxy_available: bool,
     /// Whether IPv6 bypass is available (from gateway info).
     ipv6_bypass_available: bool,
+}
+
+/// DNS interception state held for the proxy's lifetime. Drop restores
+/// system DNS (via `system::restore_all`) and clears `bridge-dns.json`,
+/// then drops `local_dns_server` (aborts its tasks, releasing the
+/// loopback port). Drop is synchronous because all underlying OS
+/// commands block; this matches the existing `SystemRoutes::drop`
+/// convention.
+struct RunningDns {
+    applied_prior: Vec<crate::dns_state::DnsPriorAdapter>,
+    /// State directory for the `bridge-dns.json` persisted file. `None`
+    /// when the caller didn't configure one (dev harness without a
+    /// state dir — a case the existing plugin / routes paths also
+    /// tolerate).
+    state_dir: Option<std::path::PathBuf>,
+    /// Held to keep the loopback `<ip>:53` bound and to keep the
+    /// forwarder tasks running. Dropped after system DNS is restored.
+    _local_dns_server: crate::dns::server::LocalDnsServer,
+}
+
+impl Drop for RunningDns {
+    fn drop(&mut self) {
+        let errors = crate::dns::system::restore_all(&self.applied_prior);
+        if !errors.is_empty() {
+            warn!(
+                count = errors.len(),
+                "RunningDns::drop: some adapters failed to restore"
+            );
+        }
+        if let Some(dir) = &self.state_dir {
+            if let Err(e) = crate::dns_state::clear(dir) {
+                warn!(error = %e, "RunningDns::drop: failed to clear bridge-dns.json");
+            }
+        }
+    }
 }
 
 // ProxyManager ========================================================================================================
@@ -371,6 +414,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             }
 
             return Ok(RunningState {
+                dns: None,
                 dispatcher: None,
                 plugin_chain,
                 routes: None,
@@ -399,6 +443,15 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // Start the SS SOCKS5 proxy.
         let running_proxy = proxy.start(ss_config).await?;
 
+        // DNS forwarder wiring. Must happen BEFORE Dispatcher::new so the
+        // LocalDnsEndpoint can be passed in as a constructor argument —
+        // HoleRouter has no mutable registration API. We wire the
+        // forwarder's upstream through the just-started SS SOCKS5
+        // listener (Socks5Connector) so user filter rules that Block the
+        // resolver IP cannot strand our own queries. See `dns/mod.rs`.
+        let (local_dns_server, local_dns_endpoint) =
+            build_local_dns(&config.dns, config.local_port, gw_info.ipv6_available).await;
+
         // Start the dispatcher (owns TUN device + smoltcp). Skipped
         // under #[cfg(test)] because creating a TUN requires elevation.
         #[cfg(not(test))]
@@ -410,19 +463,38 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 config.server.plugin.clone(),
                 crate::proxy::plugin_supports_udp(config),
                 ruleset,
+                local_dns_endpoint,
             )?;
             Some(d)
         };
         #[cfg(test)]
         let dispatcher: Option<crate::dispatcher::Dispatcher> = {
             let _ = ruleset; // suppress unused warning
+            let _ = local_dns_endpoint;
             None
         };
 
         // Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
+        // Apply system DNS AFTER routes install so the OS "best-route to
+        // DNS server" lookup resolves through the TUN (its DNS setting is
+        // our loopback IP). Persist the prior state to `bridge-dns.json`
+        // BEFORE mutating so a mid-apply crash leaves a recoverable file.
+        let dns_state = if let Some(srv) = local_dns_server.as_ref() {
+            apply_dns_settings(srv, &gw_info.interface_name, state_dir)
+        } else {
+            None
+        };
+
+        let dns = local_dns_server.zip(dns_state).map(|(srv, applied)| RunningDns {
+            applied_prior: applied,
+            state_dir: state_dir.map(std::path::Path::to_path_buf),
+            _local_dns_server: srv,
+        });
+
         Ok(RunningState {
+            dns,
             dispatcher,
             plugin_chain,
             routes: Some(routes),
@@ -439,6 +511,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             return Ok(());
         };
         let RunningState {
+            dns,
             dispatcher,
             plugin_chain,
             proxy,
@@ -448,6 +521,10 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             udp_proxy_available: _,
             ipv6_bypass_available: _,
         } = state;
+
+        // 0. Restore system DNS FIRST (while routes + SS are still live
+        // so any in-flight OS queries egress via the restored resolver).
+        drop(dns);
 
         // 1. Shut down dispatcher (closes TUN, cancels all handlers).
         if let Some(mut d) = dispatcher {
@@ -493,10 +570,12 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             return self.start(config).await;
         };
 
-        // Structural equality check (ignoring filters).
+        // Structural equality check (ignoring filters). A DnsConfig edit
+        // forces the slow path (full stop + start) — see plan.
         let structural_same = active.server == config.server
             && active.local_port == config.local_port
-            && active.tunnel_mode == config.tunnel_mode;
+            && active.tunnel_mode == config.tunnel_mode
+            && active.dns == config.dns;
 
         if structural_same {
             // Fast path: hot-swap filter rules without restart.
@@ -608,3 +687,103 @@ mod proxy_manager_tests;
 #[cfg(all(test, not(target_os = "macos")))]
 #[path = "proxy_manager_e2e_tests.rs"]
 mod proxy_manager_e2e_tests;
+
+// DNS wiring helpers ==================================================================================================
+
+/// Build the local DNS server + endpoint, if the config enables it. The
+/// forwarder's upstream runs via [`crate::dns::socks5_connector::Socks5Connector`]
+/// targeting the just-started SS SOCKS5 listener, so user filter rules
+/// cannot strand our own queries.
+async fn build_local_dns(
+    dns_cfg: &hole_common::config::DnsConfig,
+    local_ss_port: u16,
+    ipv6_bypass_available: bool,
+) -> (
+    Option<crate::dns::server::LocalDnsServer>,
+    Option<crate::endpoint::LocalDnsEndpoint>,
+) {
+    if !dns_cfg.enabled {
+        return (None, None);
+    }
+
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    let socks_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), local_ss_port);
+    let connector = Arc::new(crate::dns::socks5_connector::Socks5Connector::new(socks_addr))
+        as Arc<dyn crate::dns::connector::UpstreamConnector>;
+    let forwarder = Arc::new(crate::dns::forwarder::DnsForwarder::new(
+        dns_cfg.clone(),
+        connector,
+        ipv6_bypass_available,
+    ));
+
+    let server = match crate::dns::server::LocalDnsServer::bind_ladder(Arc::clone(&forwarder)).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!(error = %e, "LocalDnsServer::bind_ladder failed; DNS forwarder disabled for this session");
+            return (None, None);
+        }
+    };
+    info!(addr = %server.addr(), "LocalDnsServer bound");
+
+    let endpoint = if dns_cfg.intercept_udp53 {
+        Some(crate::endpoint::LocalDnsEndpoint::new(Arc::clone(&forwarder)))
+    } else {
+        None
+    };
+
+    (Some(server), endpoint)
+}
+
+/// Capture prior system DNS for the adapters we're about to override,
+/// persist the `bridge-dns.json` recovery file, then apply the loopback
+/// IP. Returns the captured prior state on success, which
+/// [`RunningDns::drop`] will later replay.
+fn apply_dns_settings(
+    server: &crate::dns::server::LocalDnsServer,
+    upstream_iface: &str,
+    state_dir: Option<&std::path::Path>,
+) -> Option<Vec<crate::dns_state::DnsPriorAdapter>> {
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    {
+        use crate::dns::system;
+        use crate::dns_state::{self, DnsState, SCHEMA_VERSION};
+        use crate::proxy::TUN_DEVICE_NAME;
+
+        let aliases: Vec<String> = vec![TUN_DEVICE_NAME.into(), upstream_iface.to_string()];
+        let prior = match system::capture_adapters(&aliases) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "system DNS capture failed; skipping apply");
+                return None;
+            }
+        };
+
+        // Persist BEFORE mutating so a mid-apply crash has a recoverable
+        // file. Matches the `tun_engine::routing::SystemRouting::install`
+        // precondition.
+        if let Some(dir) = state_dir {
+            let state = DnsState {
+                version: SCHEMA_VERSION,
+                chosen_loopback: server.addr(),
+                adapters: prior.clone(),
+            };
+            if let Err(e) = dns_state::save(dir, &state) {
+                warn!(error = %e, "dns_state::save failed; continuing without crash-recovery file");
+            }
+        }
+
+        if let Err(e) = system::apply_loopback(&aliases, server.addr().ip()) {
+            warn!(error = %e, "system DNS apply failed; DNS forwarder unreachable by OS clients");
+            return None;
+        }
+
+        Some(prior)
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        let _ = (server, upstream_iface, state_dir);
+        None
+    }
+}

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -103,6 +103,7 @@ async fn run_socks_only_e2e(dist: &Path, ss: &SsServerHandle, http: &HttpTarget)
         local_port,
         tunnel_mode: TunnelMode::SocksOnly,
         filters: vec![],
+        dns: hole_common::config::DnsConfig::default(),
     };
 
     let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -208,6 +209,7 @@ mod tun {
             local_port,
             tunnel_mode: TunnelMode::Full,
             filters: vec![],
+            dns: hole_common::config::DnsConfig::default(),
         };
 
         let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -280,6 +282,7 @@ fn lifecycle_start_twice_returns_error(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            dns: hole_common::config::DnsConfig::default(),
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -331,6 +334,7 @@ fn lifecycle_reload_changes_local_port(
             local_port: port1,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            dns: hole_common::config::DnsConfig::default(),
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -371,6 +375,7 @@ fn lifecycle_state_file_absent_in_socks_only_mode(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            dns: hole_common::config::DnsConfig::default(),
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -418,6 +423,7 @@ fn cipher_chacha20_ietf_poly1305_roundtrip(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            dns: hole_common::config::DnsConfig::default(),
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -456,6 +462,7 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            dns: hole_common::config::DnsConfig::default(),
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -280,6 +280,7 @@ fn test_config() -> ProxyConfig {
         local_port: 1080,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
+        dns: hole_common::config::DnsConfig::default(),
     }
 }
 

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -24,6 +24,7 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
+        dns: hole_common::config::DnsConfig::default(),
     }
 }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1,5 +1,6 @@
 use crate::protocol::ServerTestOutcome;
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 use std::path::Path;
 use thiserror::Error;
 use time::OffsetDateTime;
@@ -58,6 +59,62 @@ pub enum Theme {
     System,
 }
 
+// DNS forwarder =======================================================================================================
+
+/// Transport used by the built-in DNS forwarder when talking upstream to
+/// [`DnsConfig::servers`].
+///
+/// `PlainUdp` works only when the configured plugin can carry UDP (galoshes)
+/// OR the upstream IP is covered by a bypass rule — otherwise the
+/// forwarder's own UDP/53 queries are dropped by the HoleRouter the same way
+/// the original bug drops OS queries. `PlainTcp`, `Tls`, `Https` all go over
+/// TCP and ride through any plugin.
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DnsProtocol {
+    PlainUdp,
+    PlainTcp,
+    Tls,
+    #[default]
+    Https,
+}
+
+/// Built-in DNS forwarder configuration.
+///
+/// The bridge binds a loopback DNS server when `enabled`, reconfigures the
+/// OS resolver to point at it, and forwards queries upstream via
+/// [`DnsProtocol`]. Queries travel through the shadowsocks SOCKS5 listener,
+/// so they're carried over the TCP tunnel even when the plugin is TCP-only.
+///
+/// `servers` is ordered: the first entry is primary, subsequent entries are
+/// tried on failure. The UI currently renders exactly two rows
+/// (primary + secondary), but the model accepts any number.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DnsConfig {
+    pub enabled: bool,
+    pub servers: Vec<IpAddr>,
+    pub protocol: DnsProtocol,
+    /// When `true`, the HoleRouter redirects any in-tunnel UDP/53 flow to
+    /// the loopback forwarder (not only queries to the OS-configured
+    /// resolver). Catches apps that hardcode DNS destinations like
+    /// Chrome's Secure DNS to `8.8.8.8`.
+    pub intercept_udp53: bool,
+}
+
+impl Default for DnsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            servers: vec![
+                IpAddr::V4(std::net::Ipv4Addr::new(1, 1, 1, 1)),
+                IpAddr::V4(std::net::Ipv4Addr::new(1, 0, 0, 1)),
+            ],
+            protocol: DnsProtocol::Https,
+            intercept_udp53: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct AppConfig {
@@ -80,6 +137,7 @@ pub struct AppConfig {
     pub proxy_server_enabled: bool,
     pub proxy_socks5: bool,
     pub proxy_http: bool,
+    pub dns: DnsConfig,
 }
 
 impl Default for AppConfig {
@@ -97,6 +155,7 @@ impl Default for AppConfig {
             proxy_server_enabled: true,
             proxy_socks5: true,
             proxy_http: false,
+            dns: DnsConfig::default(),
         }
     }
 }

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -377,6 +377,83 @@ fn theme_all_variants_roundtrip() {
     }
 }
 
+// DNS config ==========================================================================================================
+
+#[skuld::test]
+fn dns_config_default_is_doh_cloudflare() {
+    let cfg = DnsConfig::default();
+    assert!(cfg.enabled);
+    assert_eq!(cfg.protocol, DnsProtocol::Https);
+    assert!(cfg.intercept_udp53);
+    assert_eq!(cfg.servers.len(), 2);
+    assert_eq!(cfg.servers[0], "1.1.1.1".parse::<std::net::IpAddr>().unwrap());
+    assert_eq!(cfg.servers[1], "1.0.0.1".parse::<std::net::IpAddr>().unwrap());
+}
+
+#[skuld::test]
+fn deserialize_without_dns_field_uses_default() {
+    // Pre-DnsConfig configs omit the field entirely. Must deserialize cleanly
+    // with DnsConfig::default() applied on upgrade — "enabled on upgrade,
+    // no notification" migration decision.
+    let json = r#"{"servers": [], "local_port": 4073, "enabled": false}"#;
+    let config: AppConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.dns, DnsConfig::default());
+    assert!(config.dns.enabled);
+}
+
+#[skuld::test]
+fn dns_config_roundtrips_via_json(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    let config = AppConfig {
+        dns: DnsConfig {
+            enabled: false,
+            servers: vec!["9.9.9.9".parse().unwrap(), "149.112.112.112".parse().unwrap()],
+            protocol: DnsProtocol::Tls,
+            intercept_udp53: false,
+        },
+        ..Default::default()
+    };
+    config.save(&path).unwrap();
+    let loaded = AppConfig::load(&path).unwrap();
+    assert_eq!(config.dns, loaded.dns);
+}
+
+#[skuld::test]
+fn dns_protocol_variants_serialize_as_snake_case() {
+    assert_eq!(serde_json::to_string(&DnsProtocol::PlainUdp).unwrap(), r#""plain_udp""#);
+    assert_eq!(serde_json::to_string(&DnsProtocol::PlainTcp).unwrap(), r#""plain_tcp""#);
+    assert_eq!(serde_json::to_string(&DnsProtocol::Tls).unwrap(), r#""tls""#);
+    assert_eq!(serde_json::to_string(&DnsProtocol::Https).unwrap(), r#""https""#);
+}
+
+#[skuld::test]
+fn dns_protocol_variants_all_roundtrip() {
+    for variant in [
+        DnsProtocol::PlainUdp,
+        DnsProtocol::PlainTcp,
+        DnsProtocol::Tls,
+        DnsProtocol::Https,
+    ] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let parsed: DnsProtocol = serde_json::from_str(&json).unwrap();
+        assert_eq!(variant, parsed);
+    }
+}
+
+#[skuld::test]
+fn dns_config_accepts_mixed_v4_v6_servers() {
+    let cfg = DnsConfig {
+        enabled: true,
+        servers: vec!["1.1.1.1".parse().unwrap(), "2606:4700:4700::1111".parse().unwrap()],
+        protocol: DnsProtocol::Https,
+        intercept_udp53: true,
+    };
+    let json = serde_json::to_string(&cfg).unwrap();
+    let parsed: DnsConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(cfg, parsed);
+    assert!(parsed.servers[1].is_ipv6());
+}
+
 // Plugin name validation ==============================================================================================
 
 #[skuld::test]

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -133,6 +133,12 @@ pub struct ProxyConfig {
     /// (no filtering — all captured traffic proxied).
     #[serde(default)]
     pub filters: Vec<FilterRule>,
+    /// Built-in DNS forwarder configuration. Defaults to
+    /// [`DnsConfig::default()`] (enabled, DoH to Cloudflare). Older clients
+    /// that don't send this field get the default, which silently enables
+    /// the forwarder on upgrade.
+    #[serde(default)]
+    pub dns: crate::config::DnsConfig,
 }
 
 // Server test outcome =================================================================================================

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -21,6 +21,7 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: TunnelMode::Full,
         filters: Vec::new(),
+        dns: crate::config::DnsConfig::default(),
     }
 }
 
@@ -386,6 +387,7 @@ fn proxy_config_tunnel_mode_full_roundtrips() {
         local_port: 4073,
         tunnel_mode: TunnelMode::Full,
         filters: Vec::new(),
+        dns: crate::config::DnsConfig::default(),
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();
@@ -399,6 +401,7 @@ fn proxy_config_tunnel_mode_socks_only_roundtrips() {
         local_port: 4073,
         tunnel_mode: TunnelMode::SocksOnly,
         filters: Vec::new(),
+        dns: crate::config::DnsConfig::default(),
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -152,6 +152,7 @@ fn send_start_receives_ack() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
+                    dns: hole_common::config::DnsConfig::default(),
                 },
             })
             .await
@@ -242,6 +243,7 @@ fn send_reload_receives_ack() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
+                    dns: hole_common::config::DnsConfig::default(),
                 },
             })
             .await
@@ -323,6 +325,7 @@ fn server_error_maps_to_bridge_response_error() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
+                    dns: hole_common::config::DnsConfig::default(),
                 },
             })
             .await

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -694,6 +694,7 @@ fn handle_proxy(action: ProxyAction) -> i32 {
                     local_port,
                     tunnel_mode: tunnel_mode.into(),
                     filters: Vec::new(),
+                    dns: hole_common::config::DnsConfig::default(),
                 },
             };
             match send_bridge_request_inner(request) {

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -389,6 +389,7 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
         local_port: config.local_port,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: config.filters.clone(),
+        dns: config.dns.clone(),
     })
 }
 

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -21,6 +21,7 @@ fn encode_request_roundtrips() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
+            dns: hole_common::config::DnsConfig::default(),
         },
     };
 
@@ -68,6 +69,7 @@ fn write_request_file_roundtrip() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
+            dns: hole_common::config::DnsConfig::default(),
         },
     };
 
@@ -103,6 +105,7 @@ fn read_request_file_roundtrip() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
+            dns: hole_common::config::DnsConfig::default(),
         },
     };
 

--- a/scripts/network-reset.py
+++ b/scripts/network-reset.py
@@ -27,6 +27,119 @@ import _lib
 
 # Keep in sync with `crates/tun-engine/src/routing/state.rs::STATE_FILE_NAME`.
 STATE_FILE_NAME = "bridge-routes.json"
+# Keep in sync with `crates/bridge/src/dns_state.rs::STATE_FILE_NAME`.
+DNS_STATE_FILE_NAME = "bridge-dns.json"
+
+
+def load_dns_state_file() -> dict | None:
+    """Return the first valid parsed bridge-dns.json found across candidate
+    state directories, or None. Mirrors `load_state_file` but for DNS."""
+    for d in candidate_state_dirs():
+        path = d / DNS_STATE_FILE_NAME
+        if not path.exists():
+            continue
+        try:
+            with path.open() as f:
+                data = json.load(f)
+            print(f"  Found DNS state file at {path}")
+            return data
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"  Skipping {path} (parse error: {e})")
+    return None
+
+
+def restore_dns_windows(state: dict) -> None:
+    print("Restoring prior DNS settings (Windows)...")
+    for adapter in state.get("adapters", []):
+        id_obj = adapter.get("id", {})
+        if id_obj.get("kind") != "windows_alias":
+            continue
+        alias = id_obj.get("value")
+        if not alias:
+            continue
+        for family, field in (("ipv4", "v4"), ("ipv6", "v6")):
+            prior = adapter.get(field, {})
+            kind = prior.get("kind")
+            if kind == "dhcp":
+                run([
+                    "netsh",
+                    "interface",
+                    family,
+                    "set",
+                    "dnsservers",
+                    f"name={alias}",
+                    "dhcp",
+                ])
+            elif kind == "none":
+                run([
+                    "netsh",
+                    "interface",
+                    family,
+                    "set",
+                    "dnsservers",
+                    f"name={alias}",
+                    "static",
+                    "none",
+                ])
+            elif kind == "static":
+                servers = prior.get("servers", [])
+                if not servers:
+                    continue
+                run([
+                    "netsh",
+                    "interface",
+                    family,
+                    "set",
+                    "dnsservers",
+                    f"name={alias}",
+                    "static",
+                    servers[0],
+                    "primary",
+                ])
+                for idx, ip in enumerate(servers[1:], start=2):
+                    run([
+                        "netsh",
+                        "interface",
+                        family,
+                        "add",
+                        "dnsservers",
+                        f"name={alias}",
+                        ip,
+                        f"index={idx}",
+                    ])
+
+
+def restore_dns_macos(state: dict) -> None:
+    print("Restoring prior DNS settings (macOS)...")
+    for adapter in state.get("adapters", []):
+        id_obj = adapter.get("id", {})
+        if id_obj.get("kind") != "macos_service_name":
+            continue
+        svc = id_obj.get("value")
+        if not svc:
+            continue
+        combined: list[str] = []
+        saw_static = False
+        for field in ("v4", "v6"):
+            prior = adapter.get(field, {})
+            if prior.get("kind") == "static":
+                saw_static = True
+                combined.extend(prior.get("servers", []))
+        if saw_static and combined:
+            run(["networksetup", "-setdnsservers", svc, *combined])
+        else:
+            run(["networksetup", "-setdnsservers", svc, "Empty"])
+
+
+def clear_dns_state_files() -> None:
+    for d in candidate_state_dirs():
+        path = d / DNS_STATE_FILE_NAME
+        if path.exists():
+            try:
+                path.unlink()
+                print(f"  Removed {path}")
+            except OSError as e:
+                print(f"  Failed to remove {path}: {e}")
 
 
 def run(cmd: list[str], *, check: bool = False) -> subprocess.CompletedProcess[str]:
@@ -196,14 +309,25 @@ def main() -> None:
     state = load_state_file()
     print()
 
+    print("Looking for DNS-state file...")
+    dns_state = load_dns_state_file()
+    print()
+
     system = platform.system()
     if system == "Darwin":
+        if dns_state is not None:
+            restore_dns_macos(dns_state)
         reset_macos(state)
     elif system == "Windows":
+        if dns_state is not None:
+            restore_dns_windows(dns_state)
         reset_windows(state)
     else:
         print(f"Unsupported platform: {system}", file=sys.stderr)
         sys.exit(1)
+
+    if dns_state is not None:
+        clear_dns_state_files()
 
     print()
     print("Done. Test connectivity: curl -I https://example.com")

--- a/ui/index.html
+++ b/ui/index.html
@@ -135,6 +135,38 @@
                   </div>
                 </div>
               </div>
+              <hr class="setting-divider">
+              <div class="setting-row">
+                <span class="setting-label">DNS forwarder</span>
+                <div class="setting-control">
+                  <div class="toggle" id="toggle-dns-enabled"></div>
+                </div>
+              </div>
+              <div class="setting-nested" id="dns-nested">
+                <div class="setting-row">
+                  <span class="setting-label">Protocol</span>
+                  <div class="setting-control">
+                    <div class="custom-select-wrap">
+                      <div class="custom-select-btn" id="select-dns-protocol">DNS over HTTPS</div>
+                      <div class="custom-select-menu" id="menu-dns-protocol">
+                        <div class="custom-select-opt" data-value="plain-udp">Plain UDP</div>
+                        <div class="custom-select-opt" data-value="plain-tcp">Plain TCP</div>
+                        <div class="custom-select-opt" data-value="tls">DNS over TLS</div>
+                        <div class="custom-select-opt selected" data-value="https">DNS over HTTPS</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="setting-row">
+                  <span class="setting-label">Intercept UDP/53 to other servers</span>
+                  <div class="setting-control">
+                    <div class="toggle" id="toggle-dns-intercept"></div>
+                  </div>
+                </div>
+                <div class="setting-row setting-note">
+                  <span class="setting-label">Settings apply on reconnect. Edit the config file to change server list.</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -1,6 +1,14 @@
 // Settings section: toggle switches, custom dropdowns, theme switching, proxy config.
 
 import { config, saveConfig } from "./main";
+import type { DnsConfig, DnsProtocol } from "./types";
+
+const DNS_DEFAULT: DnsConfig = {
+  enabled: true,
+  servers: ["1.1.1.1", "1.0.0.1"],
+  protocol: "https",
+  intercept_udp53: true,
+};
 
 // Theme management ====================================================================================================
 
@@ -34,6 +42,7 @@ function applyTheme(value: string) {
 // Proxy muting ========================================================================================================
 
 const proxyNested = document.getElementById("proxy-nested")!;
+const dnsNested = document.getElementById("dns-nested")!;
 
 function updateProxyMuting() {
   if (!config) return;
@@ -42,6 +51,27 @@ function updateProxyMuting() {
   } else {
     proxyNested.classList.add("muted");
   }
+}
+
+function currentDns(): DnsConfig {
+  return (config?.dns as DnsConfig | undefined) ?? DNS_DEFAULT;
+}
+
+function updateDnsMuting() {
+  const dns = currentDns();
+  if (dns.enabled) {
+    dnsNested.classList.remove("muted");
+  } else {
+    dnsNested.classList.add("muted");
+  }
+}
+
+function patchDns(partial: Partial<DnsConfig>) {
+  if (!config) return;
+  const next: DnsConfig = { ...currentDns(), ...partial };
+  config.dns = next;
+  updateDnsMuting();
+  saveConfig();
 }
 
 // Toggle component ====================================================================================================
@@ -179,8 +209,54 @@ export function initSettings() {
   // Port input.
   wirePortInput();
 
+  // DNS forwarder controls.
+  wireDnsControls();
+
   // Close dropdowns on click outside.
   handleClickOutside();
+}
+
+/**
+ * Wire the DNS forwarder UI. The sub-setting group (`#dns-nested`) mirrors
+ * the proxy-server muting pattern: when the enable toggle is off, the
+ * nested controls are visually greyed.
+ */
+function wireDnsControls() {
+  const enabledEl = document.getElementById("toggle-dns-enabled")!;
+  enabledEl.addEventListener("click", () => {
+    const on = !enabledEl.classList.contains("on");
+    enabledEl.classList.toggle("on", on);
+    patchDns({ enabled: on });
+  });
+
+  const interceptEl = document.getElementById("toggle-dns-intercept")!;
+  interceptEl.addEventListener("click", () => {
+    const on = !interceptEl.classList.contains("on");
+    interceptEl.classList.toggle("on", on);
+    patchDns({ intercept_udp53: on });
+  });
+
+  // DNS protocol dropdown — kebab-to-snake with the same helper used by
+  // the theme/on-startup dropdowns; maps "plain-udp" → "plain_udp", etc.
+  const btn = document.getElementById("select-dns-protocol")!;
+  const menu = document.getElementById("menu-dns-protocol")!;
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    for (const m of document.querySelectorAll(".custom-select-menu.open")) {
+      if (m !== menu) m.classList.remove("open");
+    }
+    menu.classList.toggle("open");
+  });
+  for (const opt of menu.querySelectorAll<HTMLElement>(".custom-select-opt")) {
+    opt.addEventListener("click", (e) => {
+      e.stopPropagation();
+      for (const o of menu.querySelectorAll(".custom-select-opt")) o.classList.remove("selected");
+      opt.classList.add("selected");
+      btn.textContent = opt.textContent;
+      menu.classList.remove("open");
+      patchDns({ protocol: kebabToSnake(opt.dataset.value ?? "") as DnsProtocol });
+    });
+  }
 }
 
 /**
@@ -205,6 +281,13 @@ export function renderSettings() {
 
   // Proxy muting.
   updateProxyMuting();
+
+  // DNS forwarder state.
+  const dns = currentDns();
+  document.getElementById("toggle-dns-enabled")!.classList.toggle("on", dns.enabled);
+  document.getElementById("toggle-dns-intercept")!.classList.toggle("on", dns.intercept_udp53);
+  syncDropdown("select-dns-protocol", "menu-dns-protocol", dns.protocol);
+  updateDnsMuting();
 
   // Theme.
   applyTheme(config.theme ?? "dark");

--- a/ui/types.ts
+++ b/ui/types.ts
@@ -44,6 +44,21 @@ export interface FilterRule {
   action: "proxy" | "bypass" | "block";
 }
 
+/// DNS upstream transport. Mirrors the Rust `DnsProtocol` enum in
+/// `crates/common/src/config.rs`. Values are snake_case to match the
+/// serde representation on the wire.
+export type DnsProtocol = "plain_udp" | "plain_tcp" | "tls" | "https";
+
+/// Built-in DNS forwarder configuration. Mirrors the Rust `DnsConfig`
+/// struct in `crates/common/src/config.rs`. Saved as part of
+/// `Config.dns`; the bridge reads it at proxy start.
+export interface DnsConfig {
+  enabled: boolean;
+  servers: string[];
+  protocol: DnsProtocol;
+  intercept_udp53: boolean;
+}
+
 export interface Config {
   servers: Server[];
   selected_server: string | null;
@@ -55,6 +70,7 @@ export interface Config {
   proxy_http: boolean;
   on_startup: string;
   theme: string;
+  dns?: DnsConfig;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Adds a built-in DNS forwarder so Hole + TCP-only plugins (v2ray-plugin) produce a working internet connection. Resolves #241.

- `DnsConfig` + `DnsProtocol` in `hole-common` (sub-step a, committed)
- `DnsState` + `bridge-dns.json` atomic crash-recovery persistence (sub-step b, committed)
- `DnsForwarder` core + SOCKS5-wrapped upstream (sub-steps c–d, in progress)
- `LocalDnsServer` + `LocalDnsEndpoint` hooked into `HoleRouter` UDP/53 cascade (sub-steps e–f, in progress)
- `SystemDnsConfig` per platform — `netsh` on Windows, `networksetup` on macOS (sub-step g, in progress)
- `dns_recovery` in the startup crash-recovery cascade + `scripts/network-reset.py` parity (sub-steps h–i, in progress)
- `proxy_manager` lifecycle wiring with `RunningState` drop ordering (sub-step j, in progress)
- Settings UI "DNS" tab + WebDriverIO spec (sub-step k, in progress)
- `CLAUDE.md` update (sub-step l, in progress)

Opened as draft while implementation continues; will un-draft once CI is green.

## Test plan

- [ ] `cargo test --workspace` green on CI
- [ ] `cargo clippy --workspace --all-targets` clean
- [ ] Manual repro from #241: connect to v2ray-plugin server, confirm `Resolve-DnsName google.com` succeeds and `bridge-dns.json` is written + cleared on clean disconnect
- [ ] Crash recovery: `taskkill /F` mid-session, restart, confirm DNS is restored before route recovery runs
- [ ] `scripts/network-reset.py` restores DNS when bridge cannot restart