### PR TITLE
ETW diagnostics: switch to dump crate for YAML-shaped logs (#240)

### DIFF
--- a/crates/bridge/src/diagnostics/etw.rs
+++ b/crates/bridge/src/diagnostics/etw.rs
@@ -94,11 +94,13 @@
 //! the kernel level and silently dropped events 1004 and 1077, both
 //! of which are critical to the #200 narrative.
 
+use dump::{dump, DeriveDump};
 use ferrisetw::parser::Parser;
 use ferrisetw::provider::Provider;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::{TraceProperties, TraceTrait, UserTrace};
 use ferrisetw::{EventRecord, GUID};
+use std::borrow::Cow;
 use std::net::{IpAddr, SocketAddr};
 use std::thread::JoinHandle;
 use tracing::{debug, info, warn};
@@ -453,15 +455,25 @@ pub(crate) unsafe fn read_wide_string(ptr: *const u16) -> String {
 /// - **1077 `SendRetransmitRound`**: `Tcb`, `SndUna`, `SndNxt`,
 ///   `SegmentSize`, `RexmitCount`.
 ///
+/// Every event in the "has address" group above ships its IP and port
+/// atomically inside the same `win:SocketAddress` binary blob (SOCKADDR_IN
+/// / SOCKADDR_IN6), so `local` / `remote` are `Option<SocketAddr>` — not
+/// two independent `Option<IpAddr>` + `Option<u16>` pairs. A previous
+/// iteration of [`extract_fields`] also tried discrete `LocalPort` /
+/// `RemotePort` scalar fields as a fallback, but none of the subscribed
+/// events deliver a port scalar without an address blob. That fallback
+/// was removed in azhukova/240; see [`socket_addr_field`] for the
+/// replacement and its `debug!` breadcrumb. If a future Windows schema
+/// adds an event with a port-only shape, both fields will surface as
+/// `None` and the breadcrumb will surface in bridge.log.
+///
 /// The `tcb` field is a kernel-internal 64-bit TCB pointer / cookie
 /// that correlates events belonging to the same TCP connection across
 /// the connect-path, send-path, and close-path event IDs.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct ParsedFields {
-    pub local_port: Option<u16>,
-    pub local_addr: Option<IpAddr>,
-    pub remote_port: Option<u16>,
-    pub remote_addr: Option<IpAddr>,
+    pub local: Option<SocketAddr>,
+    pub remote: Option<SocketAddr>,
     pub status: Option<u32>,
     pub rexmit_count: Option<u32>,
     pub tcb: Option<u64>,
@@ -615,73 +627,95 @@ fn handle_event(record: &EventRecord, schema_locator: &SchemaLocator, bridge_pid
 ///
 /// Address handling: TCPIP and Winsock-AFD encode addresses as
 /// `win:Binary` blobs with the `win:SocketAddress` outType. We decode
-/// those via [`parse_socket_address`]. A minority of events expose
-/// discrete `LocalPort` / `RemotePort` scalars; we try those too and
-/// prefer whichever resolves. Empty on both paths → `None`.
+/// those via [`parse_socket_address`] into a full `SocketAddr`. Every
+/// subscribed event in [`ParsedFields`]' coverage table either ships
+/// this blob (carrying IP and port together) or ships neither — see
+/// the `ParsedFields` doc for the full table. No subscribed event
+/// delivers a discrete `LocalPort` / `RemotePort` scalar without a
+/// matching address blob.
 fn extract_fields(parser: &Parser) -> ParsedFields {
-    let (local_addr, local_port_from_addr) = parser
-        .try_parse::<Vec<u8>>("LocalAddress")
-        .ok()
-        .and_then(|bytes| parse_socket_address(&bytes))
-        .map_or((None, None), |sa| (Some(sa.ip()), Some(sa.port())));
-    let (remote_addr, remote_port_from_addr) = parser
-        .try_parse::<Vec<u8>>("RemoteAddress")
-        .ok()
-        .and_then(|bytes| parse_socket_address(&bytes))
-        .map_or((None, None), |sa| (Some(sa.ip()), Some(sa.port())));
+    let local = socket_addr_field(parser, "LocalAddress");
+    let remote = socket_addr_field(parser, "RemoteAddress");
 
     ParsedFields {
-        tcb: parser.try_parse::<u64>("Tcb").ok(),
-        local_port: parser.try_parse::<u16>("LocalPort").ok().or(local_port_from_addr),
-        local_addr,
-        remote_port: parser.try_parse::<u16>("RemotePort").ok().or(remote_port_from_addr),
-        remote_addr,
+        local,
+        remote,
         status: parser.try_parse::<u32>("Status").ok(),
         rexmit_count: parser.try_parse::<u32>("RexmitCount").ok(),
+        tcb: parser.try_parse::<u64>("Tcb").ok(),
     }
 }
 
+/// Decode one SOCKADDR-blob field. Logs a `debug!` breadcrumb when the
+/// field is present but unparseable — a signal that ETW schema drift
+/// might be eating endpoints before they reach the emitter. Silent
+/// `None` is reserved for the expected "field absent" case.
+fn socket_addr_field(parser: &Parser, field: &str) -> Option<SocketAddr> {
+    let bytes = parser.try_parse::<Vec<u8>>(field).ok()?;
+    match parse_socket_address(&bytes) {
+        Some(sa) => Some(sa),
+        None => {
+            debug!(field, len = bytes.len(), "etw: address blob failed to parse");
+            None
+        }
+    }
+}
+
+/// YAML-shaped logging view of a decoded ETW event. Fed into
+/// [`dump!`] at emission time so the bridge log reads as block YAML
+/// (null-safe, no `Some(_)` / `None` Debug noise, kebab-case keys).
+///
+/// Distinct from [`ParsedFields`]: this struct is the *logging* shape,
+/// whereas `ParsedFields` is the *extraction* shape. They are allowed
+/// to diverge — e.g. a future change might elide `tcb` from logs
+/// without touching the extraction path.
+#[derive(DeriveDump)]
+#[dump(rename_all = "kebab-case")]
+pub(crate) struct EventView<'a> {
+    pub event_id: u16,
+    pub opcode: u8,
+    pub provider: &'a str,
+    /// Kernel TCB correlator — kept third (right after `provider`) so
+    /// readers grepping bridge.log by TCB cookie don't have to scroll past
+    /// the endpoint block.
+    pub tcb: Option<u64>,
+    pub local: Option<SocketAddr>,
+    pub remote: Option<SocketAddr>,
+    pub status: Option<u32>,
+    pub rexmit_count: Option<u32>,
+}
+
 /// Translate an [`Emission`] into the appropriate `tracing::event!`
-/// invocation. All emissions include `event_id`, `pid`, and parsed
-/// fields as structured key-values.
+/// invocation, carrying a `dump!`-rendered [`EventView`] in the
+/// `event` field. The bridge's `YamlFormat` layer renders multi-line
+/// field values as block scalars, so the YAML body lands under the
+/// event message in human-readable form.
 fn emit(emission: Emission, record: &EventRecord, fields: &ParsedFields) {
-    let event_id = record.event_id();
-    let opcode = record.opcode();
-    let provider_id = format!("{:?}", record.provider_id());
+    let provider = provider_name(record.provider_id());
+    let view = EventView {
+        event_id: record.event_id(),
+        opcode: record.opcode(),
+        provider: &provider,
+        tcb: fields.tcb,
+        local: fields.local,
+        remote: fields.remote,
+        status: fields.status,
+        rexmit_count: fields.rexmit_count,
+    };
     match emission {
         Emission::Info { msg } => info!(
             target: "hole_bridge::diagnostics::etw",
-            event_id,
-            opcode,
-            provider = %provider_id,
-            tcb = ?fields.tcb,
-            local_addr = ?fields.local_addr,
-            local_port = ?fields.local_port,
-            remote_addr = ?fields.remote_addr,
-            remote_port = ?fields.remote_port,
-            status = ?fields.status,
-            rexmit_count = ?fields.rexmit_count,
-            msg,
+            event = %dump!(&view),
+            "{msg}",
         ),
         Emission::Warn { msg } => warn!(
             target: "hole_bridge::diagnostics::etw",
-            event_id,
-            opcode,
-            provider = %provider_id,
-            tcb = ?fields.tcb,
-            local_addr = ?fields.local_addr,
-            local_port = ?fields.local_port,
-            remote_addr = ?fields.remote_addr,
-            remote_port = ?fields.remote_port,
-            status = ?fields.status,
-            rexmit_count = ?fields.rexmit_count,
-            msg,
+            event = %dump!(&view),
+            "{msg}",
         ),
         Emission::Unknown => debug!(
             target: "hole_bridge::diagnostics::etw",
-            event_id,
-            opcode,
-            provider = %provider_id,
+            event = %dump!(&view),
             "etw: unknown event",
         ),
     }
@@ -692,13 +726,31 @@ fn emit(emission: Emission, record: &EventRecord, fields: &ParsedFields) {
 /// Test whether a provider GUID identifies the Microsoft-Windows-TCPIP
 /// provider declared by [`TCPIP_PROVIDER`]. Extracted as a standalone
 /// predicate so [`dispatch`] can apply TCPIP-specific filters without
-/// string-parsing the GUID at every event.
+/// re-parsing the constant string at every event.
 fn is_tcpip_provider(provider: GUID) -> bool {
-    // Parse the compile-time constant at the seam rather than duplicating
-    // the bytes. `GUID::from_u128` would require a hex literal; using the
-    // same parser the `ferrisetw::Provider::by_guid` constructor uses
-    // keeps the declarations aligned.
+    // `GUID::from(&str)` parses at call time, not at compile time —
+    // `ferrisetw` doesn't expose a `const` constructor for GUIDs. This
+    // is fine for the predicate's call volume (one check per raw event,
+    // pre-drop-list); keeping the constant as a string keeps the
+    // declarations aligned with `ferrisetw::Provider::by_guid`.
     provider == GUID::from(TCPIP_PROVIDER)
+}
+
+/// Render a provider GUID as its Microsoft-assigned name, falling back to
+/// the Debug form of the raw GUID if we don't recognise it. Called once
+/// per emitted event inside [`emit`] — after the high-volume drop list has
+/// already filtered the noisy events — so the branch is not on the hot
+/// path and is allowed to allocate in the fallback arm.
+fn provider_name(provider: GUID) -> Cow<'static, str> {
+    if provider == GUID::from(TCPIP_PROVIDER) {
+        Cow::Borrowed("Microsoft-Windows-TCPIP")
+    } else if provider == GUID::from(WFP_PROVIDER) {
+        Cow::Borrowed("Microsoft-Windows-WFP")
+    } else if provider == GUID::from(AFD_PROVIDER) {
+        Cow::Borrowed("Microsoft-Windows-Winsock-AFD")
+    } else {
+        Cow::Owned(format!("{provider:?}"))
+    }
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/diagnostics/etw_tests.rs
+++ b/crates/bridge/src/diagnostics/etw_tests.rs
@@ -4,6 +4,7 @@
 //! required.
 
 use super::*;
+use dump::dump;
 
 // Zeroed GUID — matches no subscribed provider, used where the test is
 // about PID filtering or severity rules and not provider-scoped filters.
@@ -303,4 +304,129 @@ fn parse_socket_address_unknown_family_returns_none() {
     // family = 17 (AF_NETBIOS) — not one we handle
     let bytes = [0x11, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     assert_eq!(parse_socket_address(&bytes), None);
+}
+
+// ParsedFields shape ==================================================================================================
+
+#[skuld::test]
+fn parsed_fields_default_has_no_endpoints() {
+    let pf = ParsedFields::default();
+    assert!(pf.local.is_none());
+    assert!(pf.remote.is_none());
+    assert!(pf.status.is_none());
+    assert!(pf.rexmit_count.is_none());
+    assert!(pf.tcb.is_none());
+}
+
+#[skuld::test]
+fn parsed_fields_populated_with_socketaddr() {
+    let pf = ParsedFields {
+        local: Some("192.168.1.5:54321".parse().unwrap()),
+        remote: Some("8.8.8.8:443".parse().unwrap()),
+        status: Some(0),
+        rexmit_count: Some(2),
+        tcb: Some(0xDEAD_BEEF),
+    };
+    assert_eq!(pf.local.unwrap().port(), 54321);
+    assert_eq!(pf.remote.unwrap().ip().to_string(), "8.8.8.8");
+}
+
+// Provider name decoding ==============================================================================================
+
+#[skuld::test]
+fn provider_name_known_tcpip_returns_microsoft_name() {
+    assert_eq!(provider_name(GUID::from(TCPIP_PROVIDER)), "Microsoft-Windows-TCPIP");
+}
+
+#[skuld::test]
+fn provider_name_known_wfp_returns_microsoft_name() {
+    assert_eq!(provider_name(GUID::from(WFP_PROVIDER)), "Microsoft-Windows-WFP");
+}
+
+#[skuld::test]
+fn provider_name_known_afd_returns_microsoft_name() {
+    assert_eq!(provider_name(GUID::from(AFD_PROVIDER)), "Microsoft-Windows-Winsock-AFD");
+}
+
+// EventView dump rendering ============================================================================================
+
+#[skuld::test]
+fn event_view_dump_uses_kebab_case_keys_and_yaml_primitives() {
+    let view = EventView {
+        event_id: 1002,
+        opcode: 16,
+        provider: "Microsoft-Windows-TCPIP",
+        tcb: Some(0x1234_ABCD),
+        local: Some("192.168.1.5:54321".parse().unwrap()),
+        remote: Some("8.8.8.8:443".parse().unwrap()),
+        status: Some(0),
+        rexmit_count: None,
+    };
+    let yaml = format!("{}", dump!(&view));
+    assert_eq!(
+        yaml,
+        "\
+event-id: 1002
+opcode: 16
+provider: Microsoft-Windows-TCPIP
+tcb: 305441741
+local: 192.168.1.5:54321
+remote: 8.8.8.8:443
+status: 0
+rexmit-count: ~"
+    );
+}
+
+#[skuld::test]
+fn event_view_dump_renders_all_none_endpoints_as_tilde() {
+    let view = EventView {
+        event_id: 1004,
+        opcode: 1,
+        provider: "Microsoft-Windows-TCPIP",
+        tcb: Some(42),
+        local: None,
+        remote: None,
+        status: None,
+        rexmit_count: None,
+    };
+    let yaml = format!("{}", dump!(&view));
+    assert!(yaml.contains("local: ~"), "expected `local: ~`, got:\n{yaml}");
+    assert!(yaml.contains("remote: ~"), "expected `remote: ~`, got:\n{yaml}");
+    assert!(yaml.contains("status: ~"), "expected `status: ~`, got:\n{yaml}");
+    assert!(yaml.contains("tcb: 42"), "expected `tcb: 42`, got:\n{yaml}");
+}
+
+#[skuld::test]
+fn event_view_dump_renders_socketaddr_inline_not_nested() {
+    let view = EventView {
+        event_id: 1033,
+        opcode: 16,
+        provider: "Microsoft-Windows-TCPIP",
+        tcb: None,
+        local: Some("[::1]:443".parse().unwrap()),
+        remote: None,
+        status: None,
+        rexmit_count: None,
+    };
+    let yaml = format!("{}", dump!(&view));
+    // Bracket form is the standard IPv6 `SocketAddr::Display` output;
+    // the leading `[` triggers YAML quoting per `dump::format::needs_quoting`.
+    assert!(
+        yaml.contains("local: \"[::1]:443\""),
+        "expected quoted IPv6 socket addr, got:\n{yaml}"
+    );
+}
+
+#[skuld::test]
+fn provider_name_unknown_returns_guid_string() {
+    // An unknown GUID must still carry diagnostic value — we fall back to
+    // the raw GUID rendering so logs don't lose the provider identity when
+    // the table ages out of date.
+    let unknown = GUID::from_u128(0xDEAD_BEEF_CAFE_F00D_1234_5678_9ABC_DEF0);
+    let got = provider_name(unknown);
+    assert!(
+        got.contains("DEAD") || got.contains("dead"),
+        "expected unknown GUID to be rendered, got {got:?}"
+    );
+    assert_ne!(got, "unknown", "must preserve GUID, not return literal \"unknown\"");
 }

--- a/crates/dump-macros/src/lib.rs
+++ b/crates/dump-macros/src/lib.rs
@@ -5,11 +5,23 @@
 //!
 //! - Field: `#[dump(skip)]`, `#[dump(rename = "...")]`,
 //!   `#[dump(secret)]`.
-//! - Container: (none yet.)
+//! - Container: `#[dump(rename_all = "kebab-case" | "snake_case")]`.
 //!
-//! Future commits may add `rename_all`, `flatten`, `via`, and `tag`.
-//! The derive emits absolute paths (`::dump::...`) so it works from any
-//! downstream crate.
+//! ## `rename_all` scope
+//!
+//! `rename_all` applies to **struct field names** and **struct-variant
+//! field names** only. Enum variant names themselves are never rewritten
+//! (use `#[dump(rename = "...")]` on the variant if you need this).
+//!
+//! The rename is a plain `_` → `-` substitution — there is no
+//! camelCase / PascalCase splitting. A field named `fooBar` stays as
+//! `fooBar` under `kebab-case`; use `#[dump(rename = "foo-bar")]`
+//! explicitly. Raw identifiers (`r#type`) have their `r#` prefix
+//! stripped before the substitution runs, matching what the YAML key
+//! should look like to a reader.
+//!
+//! Future commits may add `flatten`, `via`, and `tag`. The derive emits
+//! absolute paths (`::dump::...`) so it works from any downstream crate.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -35,9 +47,10 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
     }
     let (impl_gen, type_gen, where_clause) = generics.split_for_impl();
 
+    let container = parse_container_attrs(&input.attrs)?;
     let body = match &input.data {
-        Data::Struct(s) => gen_struct(s)?,
-        Data::Enum(e) => gen_enum(e, name)?,
+        Data::Struct(s) => gen_struct(s, &container)?,
+        Data::Enum(e) => gen_enum(e, name, &container)?,
         Data::Union(_) => {
             return Err(syn::Error::new_spanned(name, "Dump cannot be derived for unions"));
         }
@@ -51,6 +64,59 @@ fn derive_impl(input: &DeriveInput) -> syn::Result<TokenStream2> {
             }
         }
     })
+}
+
+#[derive(Clone, Copy, Default)]
+enum RenameRule {
+    #[default]
+    None,
+    KebabCase,
+    SnakeCase,
+}
+
+impl RenameRule {
+    /// Apply the rename rule to a raw `Ident::to_string()` value. Strips
+    /// the `r#` raw-identifier prefix first so the resulting YAML key
+    /// reflects the reader's mental model, not Rust's escape syntax.
+    fn apply(self, s: String) -> String {
+        let s = s.strip_prefix("r#").map(str::to_owned).unwrap_or(s);
+        match self {
+            RenameRule::None | RenameRule::SnakeCase => s,
+            RenameRule::KebabCase => s.replace('_', "-"),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ContainerConfig {
+    rename_all: RenameRule,
+}
+
+fn parse_container_attrs(attrs: &[syn::Attribute]) -> syn::Result<ContainerConfig> {
+    let mut c = ContainerConfig::default();
+    for attr in attrs {
+        if !attr.path().is_ident("dump") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename_all") {
+                let s: LitStr = meta.value()?.parse()?;
+                c.rename_all = match s.value().as_str() {
+                    "kebab-case" => RenameRule::KebabCase,
+                    "snake_case" => RenameRule::SnakeCase,
+                    other => {
+                        return Err(meta.error(format!(
+                            "unknown `rename_all` value {other:?}; expected \"kebab-case\" or \"snake_case\""
+                        )));
+                    }
+                };
+            } else {
+                return Err(meta.error("unknown container-level `dump` attribute"));
+            }
+            Ok(())
+        })?;
+    }
+    Ok(c)
 }
 
 #[derive(Default)]
@@ -93,7 +159,7 @@ fn wrap_secret(expr: TokenStream2, secret: bool) -> TokenStream2 {
     }
 }
 
-fn gen_struct(s: &DataStruct) -> syn::Result<TokenStream2> {
+fn gen_struct(s: &DataStruct, container: &ContainerConfig) -> syn::Result<TokenStream2> {
     match &s.fields {
         Fields::Named(named) => {
             let mut entries = Vec::new();
@@ -103,7 +169,9 @@ fn gen_struct(s: &DataStruct) -> syn::Result<TokenStream2> {
                     continue;
                 }
                 let ident = f.ident.as_ref().unwrap();
-                let key = cfg.rename.unwrap_or_else(|| ident.to_string());
+                let key = cfg
+                    .rename
+                    .unwrap_or_else(|| container.rename_all.apply(ident.to_string()));
                 let value = wrap_secret(quote! { ::dump::Dump::dump(&self.#ident) }, cfg.secret);
                 entries.push(quote! {
                     (::dump::DumpValue::String(#key.into()), #value)
@@ -132,7 +200,7 @@ fn gen_struct(s: &DataStruct) -> syn::Result<TokenStream2> {
     }
 }
 
-fn gen_enum(e: &DataEnum, name: &Ident) -> syn::Result<TokenStream2> {
+fn gen_enum(e: &DataEnum, name: &Ident, container: &ContainerConfig) -> syn::Result<TokenStream2> {
     let mut arms = Vec::new();
     for v in &e.variants {
         let vname = &v.ident;
@@ -184,7 +252,7 @@ fn gen_enum(e: &DataEnum, name: &Ident) -> syn::Result<TokenStream2> {
                         continue;
                     }
                     let fi = f.ident.as_ref().unwrap();
-                    let key = cfg.rename.unwrap_or_else(|| fi.to_string());
+                    let key = cfg.rename.unwrap_or_else(|| container.rename_all.apply(fi.to_string()));
                     let value = wrap_secret(quote! { ::dump::Dump::dump(#fi) }, cfg.secret);
                     entries.push(quote! {
                         (::dump::DumpValue::String(#key.into()), #value)

--- a/crates/dump-macros/tests/derive_tests.rs
+++ b/crates/dump-macros/tests/derive_tests.rs
@@ -146,3 +146,116 @@ fn generic_struct_works_with_dump_bound() {
         DumpValue::Map(vec![(DumpValue::String("inner".into()), DumpValue::Int(7),)])
     );
 }
+
+// Container rename_all ================================================================================================
+
+#[derive(DeriveDump)]
+#[dump(rename_all = "kebab-case")]
+struct KebabStruct {
+    field_one: i32,
+    another_field_name: i32,
+}
+
+#[skuld::test]
+fn rename_all_kebab_case_converts_field_names() {
+    let k = KebabStruct {
+        field_one: 1,
+        another_field_name: 2,
+    };
+    assert_eq!(
+        k.dump(),
+        DumpValue::Map(vec![
+            (DumpValue::String("field-one".into()), DumpValue::Int(1)),
+            (DumpValue::String("another-field-name".into()), DumpValue::Int(2)),
+        ])
+    );
+}
+
+#[derive(DeriveDump)]
+#[dump(rename_all = "kebab-case")]
+struct KebabWithOverride {
+    field_one: i32,
+    #[dump(rename = "EXPLICIT")]
+    field_two: i32,
+}
+
+#[skuld::test]
+fn field_rename_overrides_rename_all() {
+    let k = KebabWithOverride {
+        field_one: 1,
+        field_two: 2,
+    };
+    assert_eq!(
+        k.dump(),
+        DumpValue::Map(vec![
+            (DumpValue::String("field-one".into()), DumpValue::Int(1)),
+            (DumpValue::String("EXPLICIT".into()), DumpValue::Int(2)),
+        ])
+    );
+}
+
+#[derive(DeriveDump)]
+#[dump(rename_all = "kebab-case")]
+enum KebabEnum {
+    TheVariant {
+        inner_field: i32,
+        #[dump(rename = "override-me")]
+        other_field: i32,
+    },
+}
+
+#[skuld::test]
+fn rename_all_on_enum_struct_variant_with_field_override() {
+    let v = KebabEnum::TheVariant {
+        inner_field: 7,
+        other_field: 8,
+    };
+    assert_eq!(
+        v.dump(),
+        DumpValue::Map(vec![(
+            // Variant name itself is NOT renamed — documented scope decision.
+            DumpValue::String("TheVariant".into()),
+            DumpValue::Map(vec![
+                (DumpValue::String("inner-field".into()), DumpValue::Int(7)),
+                (DumpValue::String("override-me".into()), DumpValue::Int(8)),
+            ]),
+        )])
+    );
+}
+
+#[derive(DeriveDump)]
+#[dump(rename_all = "kebab-case")]
+struct RawIdentStruct {
+    r#type: i32,
+    r#for_each: i32,
+}
+
+#[skuld::test]
+fn rename_all_strips_raw_ident_prefix_before_substitution() {
+    let r = RawIdentStruct {
+        r#type: 1,
+        r#for_each: 2,
+    };
+    assert_eq!(
+        r.dump(),
+        DumpValue::Map(vec![
+            (DumpValue::String("type".into()), DumpValue::Int(1)),
+            (DumpValue::String("for-each".into()), DumpValue::Int(2)),
+        ])
+    );
+}
+
+#[derive(DeriveDump)]
+#[dump(rename_all = "snake_case")]
+struct SnakeStruct {
+    already_snake: i32,
+}
+
+#[skuld::test]
+fn rename_all_snake_case_is_noop() {
+    let s = SnakeStruct { already_snake: 42 };
+    assert_eq!(
+        s.dump(),
+        DumpValue::Map(vec![(DumpValue::String("already_snake".into()), DumpValue::Int(42))])
+    );
+}


### PR DESCRIPTION
## Summary

Routes `hole_bridge::diagnostics::etw` event emission through the in-tree `dump` crate so `bridge.log` renders as human-readable YAML instead of Rust-`Debug` field splat.

Before (each field splatted separately, Debug-formatted):
```
hole_bridge::diagnostics::etw:
  event_id: 1002
  opcode: 16
  provider: 2F07E2EE-15DB-40F1-90EF-9D7BA282188A
  tcb: None
  local_addr: None
  local_port: None
  remote_addr: None
  remote_port: None
  status: Some(0)
  rexmit_count: None
```

After (single `event:` key with a YAML block; kebab-case, real `~`/integers, decoded provider, collapsed socket endpoints):
```
hole_bridge::diagnostics::etw: tcp event:
  event: |-
    event-id: 1002
    opcode: 16
    provider: Microsoft-Windows-TCPIP
    tcb: 305441741
    local: 192.168.1.5:54321
    remote: 8.8.8.8:443
    status: 0
    rexmit-count: ~
```

### Changes

- **`dump-macros`**: adds container-level `#[dump(rename_all = "kebab-case" | "snake_case")]`. Strips `r#` raw-ident prefix before substitution. Rejects unknown values. Scope limitations (no enum-variant rename, no camelCase splitting) are documented in the module doc. (Plan reserved `rename_all` to these two variants by design; other serde-style variants can be added later.)
- **`etw.rs`**: new `provider_name(GUID) -> Cow<'static, str>` maps the three subscribed provider GUIDs to their Microsoft-assigned names; unknown GUIDs fall back to `{guid:?}` so we don't lose information. `is_tcpip_provider` stays a direct `==` (per-event hot path; not delegated).
- **`ParsedFields`**: collapses `(local_addr, local_port)` / `(remote_addr, remote_port)` pairs into `Option<SocketAddr>`. Investigation confirmed no subscribed event delivers a port without an address (see doc comment). Address-blob parse failures now log a `debug!` breadcrumb via the new `socket_addr_field` helper.
- **New `EventView` struct** with `#[derive(DeriveDump)] #[dump(rename_all = "kebab-case")]` — the logging shape, separate from `ParsedFields` (the extraction shape). `Emission::Unknown` now carries the full field set (intentional — diagnostic completeness).
- **Tests**: 4 new `rename_all` tests in dump-macros (kebab/snake/override/raw-ident), 4 new `provider_name` tests, 2 new `parsed_fields` shape tests, 3 new `event_view_dump` rendering tests.

Closes #240.

### Test plan

- [x] `cargo test -p dump-macros` — 14/14 pass
- [x] `cargo test -p dump` — 66/66 pass  
- [x] `cargo test -p hole-bridge --lib` — 302/303 pass; one pre-existing failure (`e2e_none_full_tunnel_roundtrip`, ETW session-name collision from prior crashed tests — confirmed also failing on `main`, unrelated to this PR)
- [ ] CI green on this branch
- [ ] Manual verification on Windows: live bridge log shows the new YAML shape (to be done locally after CI passes)

### Known gaps called out in review

- No unit test for the `parse_container_attrs` error-path (would require `trybuild` or moving internal helpers to integration tests; neither was in scope). The error-arm is 6 lines and is covered by visual review.
- No `extract_fields` integration test — mocking `ferrisetw::Parser` is a separate fixture investment. Underlying `parse_socket_address` is fully tested.
- No end-to-end integration test of `info!(event = %dump!(&view), ...)` through `YamlFormat`; the block-scalar rendering is asserted via `event_view_dump_*` but not exercised through the live tracing-subscriber stack.