### PR TITLE
Wire up proxy_socks5 / proxy_http toggles end-to-end with listener + UDP E2E tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,30 @@ The invariant is structurally enforced by the cascade in [`HoleRouter::resolve_e
 
 The three drop reasons — explicit rule block, UDP-proxy-unavailable, IPv6-bypass-unreachable — each log through dedicated [`BlockEndpoint`](crates/bridge/src/endpoint/block.rs) methods so a future reader can distinguish them in the bridge log.
 
+### Listener selection invariants
+
+[`ProxyConfig`](crates/common/src/protocol.rs) exposes two independent
+local-listener toggles — `proxy_socks5` and `proxy_http` — plus the HTTP
+listener's own port `local_port_http` (SOCKS5 uses the long-standing
+`local_port`). [`build_ss_config`](crates/bridge/src/proxy/config.rs)
+pushes at most two `LocalInstanceConfig`s, one per enabled listener, and
+rejects three combinations up-front (returning `ProxyError` variants
+surfaced as `BridgeResponse::Error`):
+
+1. `tunnel_mode == Full && !proxy_socks5` → `TunnelRequiresSocks5`. The
+   TUN [`Dispatcher`](crates/bridge/src/dispatcher.rs) hands captured
+   traffic to the SOCKS5 listener on `local_port`; a Full-mode proxy
+   without that listener would silently lose all intercepted flows.
+1. `!proxy_socks5 && !proxy_http` → `NoListenersEnabled`.
+1. `proxy_socks5 && proxy_http && local_port == local_port_http` →
+   `DuplicateListenerPort`. SOCKS5 and HTTP CONNECT use different
+   handshake protocols and cannot share a port.
+
+The HTTP listener's `Mode` is always `TcpOnly` regardless of
+`tunnel_mode` — HTTP CONNECT is TCP-only (RFC 7231 §4.3.6). The SOCKS5
+listener's `Mode` still tracks `tunnel_mode` (`Full` ⇒ `TcpAndUdp`,
+`SocksOnly` ⇒ `TcpOnly` per #189).
+
 ### Bridge test-isolation contract
 
 All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` trait in `crates/bridge/src/proxy.rs` and the `Routing` trait in `crates/tun-engine/src/routing.rs`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in the workspace root `clippy.toml` via the `disallowed_methods` list (`tun_engine::routing::setup_routes` / `teardown_routes`). See bindreams/hole#165 for the incident that motivated the rule.
@@ -49,7 +73,7 @@ hole bridge log path [--log-dir DIR] → print log file path
 hole bridge log watch [--tail N] [--log-dir DIR] → stream log output
 hole bridge grant-access [--then-send B64 | --then-send-file PATH] → create hole group, add user, write SID file (needs elevation)
 hole bridge ipc-send (--base64 B64 | --request-file PATH)          → proxy a single IPC command (needs elevation)
-hole proxy start --config-file PATH [--local-port PORT]            → start the proxy from a ServerEntry JSON file
+hole proxy start --config-file PATH [--local-port PORT] [--local-port-http PORT] [--no-socks5] [--http] [--tunnel-mode MODE] → start the proxy from a ServerEntry JSON file
 hole proxy stop                                                    → stop the proxy
 hole proxy test-server --config-file PATH                          → run a one-shot connectivity test against a server config
 hole upgrade                      → check for updates and install latest version (unattended)

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -212,6 +212,9 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
     }
 }
 

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -7,7 +7,7 @@
 
 use hole_common::config::is_valid_plugin_name;
 use hole_common::protocol::ProxyConfig;
-use shadowsocks::config::ServerAddr;
+use shadowsocks::config::{Mode, ServerAddr};
 use shadowsocks::ServerConfig;
 use shadowsocks_service::config::{
     Config, ConfigType, LocalConfig, LocalInstanceConfig, ProtocolType, ServerInstanceConfig,
@@ -49,6 +49,22 @@ pub enum ProxyError {
     WintunLoad { path: PathBuf, message: String },
     #[error("plugin error: {0}")]
     Plugin(String),
+    /// `tunnel_mode == Full` requires the SOCKS5 listener, because the
+    /// TUN dispatcher hands captured traffic to it on `local_port`.
+    #[error("tunnel_mode=full requires the SOCKS5 listener; enable proxy_socks5 or switch to tunnel_mode=socks-only")]
+    TunnelRequiresSocks5,
+    /// Both `proxy_socks5` and `proxy_http` are false — there is
+    /// nothing to listen on.
+    #[error("no local listeners enabled: at least one of proxy_socks5 / proxy_http must be true")]
+    NoListenersEnabled,
+    /// Both listeners enabled with identical ports. Each listener needs
+    /// its own port because SOCKS5 and HTTP CONNECT are different
+    /// handshake protocols.
+    #[error("local_port and local_port_http must differ when both listeners are enabled (got {port})")]
+    DuplicateListenerPort { port: u16 },
+    /// A listener is enabled but its port is 0.
+    #[error("{field} must be non-zero when the corresponding listener is enabled")]
+    InvalidListenerPort { field: &'static str },
 }
 
 // Error conversions from tun-engine ===================================================================================
@@ -89,13 +105,33 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 
 /// Build a shadowsocks-service Config from our ProxyConfig.
 ///
-/// Creates exactly one local instance: SOCKS5 on `127.0.0.1:{local_port}`.
-/// The mode depends on `tunnel_mode`:
+/// Emits one local instance per enabled listener:
 ///
-/// * **Full** — `TcpAndUdp`, so the dispatcher's UDP handler can use
-///   SOCKS5 UDP ASSOCIATE to relay datagrams through the tunnel.
-/// * **SocksOnly** — `TcpOnly`, because there is no dispatcher and nobody
-///   uses UDP ASSOCIATE. See #189 for why this matters on Windows.
+/// * **SOCKS5** (`proxy_socks5`): `127.0.0.1:{local_port}`. Mode tracks
+///   `tunnel_mode` — `Full` ⇒ `TcpAndUdp` (so the dispatcher's UDP
+///   handler can use SOCKS5 UDP ASSOCIATE to relay datagrams through
+///   the tunnel), `SocksOnly` ⇒ `TcpOnly` (see #189 — on Windows,
+///   creating the UDP server can cause `select_all` inside
+///   shadowsocks-service to drop the TCP listener when the UDP future
+///   completes early, and with no dispatcher nobody uses UDP ASSOCIATE
+///   anyway).
+/// * **HTTP CONNECT** (`proxy_http`): `127.0.0.1:{local_port_http}`,
+///   always `TcpOnly` (HTTP CONNECT is TCP-only by RFC 7231 §4.3.6).
+///
+/// # Validation
+///
+/// Rejected configurations (returns `ProxyError`):
+///
+/// 1. `tunnel_mode == Full && !proxy_socks5` — the TUN dispatcher needs
+///    the SOCKS5 listener to exist on `local_port`
+///    (`TunnelRequiresSocks5`).
+/// 2. `!proxy_socks5 && !proxy_http` — nothing to listen on
+///    (`NoListenersEnabled`).
+/// 3. `proxy_socks5 && proxy_http && local_port == local_port_http` —
+///    each listener needs its own port (`DuplicateListenerPort`).
+/// 4. Port `0` on an enabled listener (`InvalidListenerPort`).
+///
+/// # Plugin handling
 ///
 /// When `plugin_local` is `Some`, the server address is overridden to point
 /// at the Garter-managed plugin chain's local port. The cipher and password
@@ -106,6 +142,8 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 /// When `plugin_local` is `None`, the original server address is used as-is
 /// (no plugin, or plugin management is handled elsewhere).
 pub fn build_ss_config(config: &ProxyConfig, plugin_local: Option<SocketAddr>) -> Result<Config, ProxyError> {
+    validate_listeners(config)?;
+
     let entry = &config.server;
 
     // Validate plugin name (format check, not known-plugin check).
@@ -139,28 +177,63 @@ pub fn build_ss_config(config: &ProxyConfig, plugin_local: Option<SocketAddr>) -
         .server
         .push(ServerInstanceConfig::with_server_config(server_config));
 
-    // SOCKS5 local — the only local instance.
-    //
-    // Full mode: TcpAndUdp — the dispatcher's UDP handler needs SOCKS5
-    // UDP ASSOCIATE to relay datagrams through the SS tunnel.
-    //
-    // SocksOnly mode: TcpOnly — there is no dispatcher, so nobody uses
-    // UDP ASSOCIATE. Creating the UDP server on Windows can cause
-    // select_all inside shadowsocks-service to drop the TCP listener
-    // when the UDP future completes early. See #189.
-    let socks_addr: SocketAddr = format!("127.0.0.1:{}", config.local_port)
-        .parse()
-        .expect("127.0.0.1:{u16} is always a valid SocketAddr");
-    let mut socks_local = LocalConfig::new_with_addr(ServerAddr::SocketAddr(socks_addr), ProtocolType::Socks);
-    socks_local.mode = match config.tunnel_mode {
-        hole_common::protocol::TunnelMode::Full => shadowsocks::config::Mode::TcpAndUdp,
-        hole_common::protocol::TunnelMode::SocksOnly => shadowsocks::config::Mode::TcpOnly,
-    };
-    ss_config
-        .local
-        .push(LocalInstanceConfig::with_local_config(socks_local));
+    if config.proxy_socks5 {
+        let socks_mode = match config.tunnel_mode {
+            hole_common::protocol::TunnelMode::Full => Mode::TcpAndUdp,
+            hole_common::protocol::TunnelMode::SocksOnly => Mode::TcpOnly,
+        };
+        ss_config.local.push(build_local_instance(
+            ProtocolType::Socks,
+            loopback(config.local_port),
+            socks_mode,
+        ));
+    }
+
+    if config.proxy_http {
+        // HTTP CONNECT is TCP-only; do not honour tunnel_mode here.
+        ss_config.local.push(build_local_instance(
+            ProtocolType::Http,
+            loopback(config.local_port_http),
+            Mode::TcpOnly,
+        ));
+    }
 
     Ok(ss_config)
+}
+
+fn validate_listeners(config: &ProxyConfig) -> Result<(), ProxyError> {
+    if config.tunnel_mode == hole_common::protocol::TunnelMode::Full && !config.proxy_socks5 {
+        return Err(ProxyError::TunnelRequiresSocks5);
+    }
+    if !config.proxy_socks5 && !config.proxy_http {
+        return Err(ProxyError::NoListenersEnabled);
+    }
+    if config.proxy_socks5 && config.local_port == 0 {
+        return Err(ProxyError::InvalidListenerPort { field: "local_port" });
+    }
+    if config.proxy_http && config.local_port_http == 0 {
+        return Err(ProxyError::InvalidListenerPort {
+            field: "local_port_http",
+        });
+    }
+    if config.proxy_socks5 && config.proxy_http && config.local_port == config.local_port_http {
+        return Err(ProxyError::DuplicateListenerPort {
+            port: config.local_port,
+        });
+    }
+    Ok(())
+}
+
+fn loopback(port: u16) -> SocketAddr {
+    format!("127.0.0.1:{port}")
+        .parse()
+        .expect("127.0.0.1:{u16} is always a valid SocketAddr")
+}
+
+fn build_local_instance(protocol: ProtocolType, addr: SocketAddr, mode: Mode) -> LocalInstanceConfig {
+    let mut local = LocalConfig::new_with_addr(ServerAddr::SocketAddr(addr), protocol);
+    local.mode = mode;
+    LocalInstanceConfig::with_local_config(local)
 }
 
 // Plugin resolution ===================================================================================================

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -96,3 +96,163 @@ fn config_with_plugin_local_has_no_plugin_config() {
     let svr = &ss_config.server[0].config;
     assert!(svr.plugin().is_none());
 }
+
+// Listener selection --------------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn socks5_only_produces_one_socks_local() {
+    let cfg = sample_config();
+    let ss_config = build_ss_config(&cfg, None).unwrap();
+
+    assert_eq!(ss_config.local.len(), 1);
+    let local = &ss_config.local[0].config;
+    assert!(matches!(local.protocol, ProtocolType::Socks));
+    let addr = local.addr.as_ref().expect("local must have addr");
+    match addr {
+        ServerAddr::SocketAddr(s) => assert_eq!(s.port(), cfg.local_port),
+        other => panic!("expected SocketAddr, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn http_only_produces_one_http_local() {
+    let mut cfg = sample_config();
+    cfg.proxy_socks5 = false;
+    cfg.proxy_http = true;
+    cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
+    let ss_config = build_ss_config(&cfg, None).unwrap();
+
+    assert_eq!(ss_config.local.len(), 1);
+    let local = &ss_config.local[0].config;
+    assert!(matches!(local.protocol, ProtocolType::Http));
+    assert!(matches!(local.mode, Mode::TcpOnly));
+    let addr = local.addr.as_ref().expect("local must have addr");
+    match addr {
+        ServerAddr::SocketAddr(s) => assert_eq!(s.port(), cfg.local_port_http),
+        other => panic!("expected SocketAddr, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn both_enabled_produces_two_locals() {
+    let mut cfg = sample_config();
+    cfg.proxy_http = true;
+    cfg.local_port_http = 4074;
+    let ss_config = build_ss_config(&cfg, None).unwrap();
+
+    assert_eq!(ss_config.local.len(), 2);
+    let socks = &ss_config.local[0].config;
+    let http = &ss_config.local[1].config;
+    assert!(matches!(socks.protocol, ProtocolType::Socks));
+    assert!(
+        matches!(socks.mode, Mode::TcpAndUdp),
+        "Full mode SOCKS5 listener must be TcpAndUdp, got {:?}",
+        socks.mode
+    );
+    assert!(matches!(http.protocol, ProtocolType::Http));
+    assert!(matches!(http.mode, Mode::TcpOnly));
+}
+
+#[skuld::test]
+fn http_listener_is_tcp_only_in_full_mode() {
+    // The HTTP listener's mode must never be promoted to TcpAndUdp, even
+    // when the overall tunnel_mode is Full. HTTP CONNECT is TCP-only per
+    // RFC 7231 §4.3.6; mis-set mode would make shadowsocks-service try to
+    // open a UDP server under the HTTP protocol, which is nonsense.
+    let mut cfg = sample_config();
+    cfg.tunnel_mode = hole_common::protocol::TunnelMode::Full;
+    cfg.proxy_http = true;
+    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let http = ss_config
+        .local
+        .iter()
+        .find(|l| matches!(l.config.protocol, ProtocolType::Http))
+        .expect("HTTP local must be present");
+    assert!(matches!(http.config.mode, Mode::TcpOnly));
+}
+
+#[skuld::test]
+fn socks5_full_mode_is_tcp_and_udp() {
+    // Regression guard for the existing (pre-#242) behaviour: Full mode +
+    // SOCKS5 enabled => TcpAndUdp, which lets the dispatcher use UDP
+    // ASSOCIATE.
+    let cfg = sample_config();
+    assert_eq!(cfg.tunnel_mode, hole_common::protocol::TunnelMode::Full);
+    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let socks = &ss_config.local[0].config;
+    assert!(matches!(socks.mode, Mode::TcpAndUdp));
+}
+
+#[skuld::test]
+fn socks5_socks_only_mode_is_tcp_only() {
+    // Keeps #189 regression pinned: SocksOnly must not enable UDP on the
+    // SOCKS5 listener.
+    let mut cfg = sample_config();
+    cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
+    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let socks = &ss_config.local[0].config;
+    assert!(matches!(socks.mode, Mode::TcpOnly));
+}
+
+// Validation errors ---------------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn full_mode_without_socks5_errors() {
+    let mut cfg = sample_config();
+    cfg.proxy_socks5 = false;
+    cfg.proxy_http = true;
+    cfg.tunnel_mode = hole_common::protocol::TunnelMode::Full;
+    let err = build_ss_config(&cfg, None).unwrap_err();
+    assert!(
+        matches!(err, ProxyError::TunnelRequiresSocks5),
+        "expected TunnelRequiresSocks5, got {err:?}"
+    );
+}
+
+#[skuld::test]
+fn no_listeners_enabled_errors() {
+    let mut cfg = sample_config();
+    cfg.proxy_socks5 = false;
+    cfg.proxy_http = false;
+    cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
+    let err = build_ss_config(&cfg, None).unwrap_err();
+    assert!(
+        matches!(err, ProxyError::NoListenersEnabled),
+        "expected NoListenersEnabled, got {err:?}"
+    );
+}
+
+#[skuld::test]
+fn same_port_errors() {
+    let mut cfg = sample_config();
+    cfg.proxy_http = true;
+    cfg.local_port_http = cfg.local_port;
+    let err = build_ss_config(&cfg, None).unwrap_err();
+    match err {
+        ProxyError::DuplicateListenerPort { port } => assert_eq!(port, cfg.local_port),
+        other => panic!("expected DuplicateListenerPort, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn port_zero_errors_socks5() {
+    let mut cfg = sample_config();
+    cfg.local_port = 0;
+    let err = build_ss_config(&cfg, None).unwrap_err();
+    match err {
+        ProxyError::InvalidListenerPort { field } => assert_eq!(field, "local_port"),
+        other => panic!("expected InvalidListenerPort(local_port), got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn port_zero_errors_http() {
+    let mut cfg = sample_config();
+    cfg.proxy_http = true;
+    cfg.local_port_http = 0;
+    let err = build_ss_config(&cfg, None).unwrap_err();
+    match err {
+        ProxyError::InvalidListenerPort { field } => assert_eq!(field, "local_port_http"),
+        other => panic!("expected InvalidListenerPort(local_port_http), got {other:?}"),
+    }
+}

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -22,6 +22,9 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: vec![],
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
     }
 }
 

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -615,3 +615,7 @@ mod proxy_manager_tests;
 #[cfg(all(test, not(target_os = "macos")))]
 #[path = "proxy_manager_e2e_tests.rs"]
 mod proxy_manager_e2e_tests;
+
+#[cfg(all(test, not(target_os = "macos")))]
+#[path = "proxy_manager_listener_e2e_tests.rs"]
+mod proxy_manager_listener_e2e_tests;

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -493,10 +493,17 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             return self.start(config).await;
         };
 
-        // Structural equality check (ignoring filters).
+        // Structural equality check (ignoring filters). Any field that
+        // changes which listeners are bound — or where they bind — must
+        // appear here; otherwise toggling e.g. `proxy_http` on a running
+        // bridge would take the hot-swap fast path and silently leave
+        // the HTTP listener unbound.
         let structural_same = active.server == config.server
             && active.local_port == config.local_port
-            && active.tunnel_mode == config.tunnel_mode;
+            && active.tunnel_mode == config.tunnel_mode
+            && active.proxy_socks5 == config.proxy_socks5
+            && active.proxy_http == config.proxy_http
+            && active.local_port_http == config.local_port_http;
 
         if structural_same {
             // Fast path: hot-swap filter rules without restart.

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -103,6 +103,9 @@ async fn run_socks_only_e2e(dist: &Path, ss: &SsServerHandle, http: &HttpTarget)
         local_port,
         tunnel_mode: TunnelMode::SocksOnly,
         filters: vec![],
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
     };
 
     let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -208,6 +211,9 @@ mod tun {
             local_port,
             tunnel_mode: TunnelMode::Full,
             filters: vec![],
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         };
 
         let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -280,6 +286,9 @@ fn lifecycle_start_twice_returns_error(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -331,6 +340,9 @@ fn lifecycle_reload_changes_local_port(
             local_port: port1,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -371,6 +383,9 @@ fn lifecycle_state_file_absent_in_socks_only_mode(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -418,6 +433,9 @@ fn cipher_chacha20_ietf_poly1305_roundtrip(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -456,6 +474,9 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();

--- a/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
@@ -296,20 +296,33 @@ fn e2e_start_rejects_full_mode_without_socks5(
     });
 }
 
-// UDP ASSOCIATE (Windows admin only) ==================================================================================
+// UDP via TUN (Windows admin only) ====================================================================================
 //
-// Gated to Windows because it requires elevation for `TunnelMode::Full`
-// (SocksOnly hard-codes the SOCKS5 listener to `TcpOnly`, see #189 — keeping
-// that coupling in place rules out the SocksOnly path here). The matching
-// `cfg(target_os = "windows")` on the existing `mod tun` in
-// `proxy_manager_e2e_tests.rs` shows this gate is already how
-// elevated-only E2E paths run on windows-latest CI.
+// End-to-end exercise of the SOCKS5 UDP ASSOCIATE path inside the bridge:
+// the test sends a UDP datagram directly to the echo server's primary
+// non-loopback IPv4, the TUN split routes capture it, the dispatcher's
+// `Socks5Endpoint::serve_udp` opens a SOCKS5 UDP ASSOCIATE to the
+// `ss-server`, and the reply comes back via the same tunnel.
+//
+// Gated to Windows for the same reason as the existing `mod tun` in
+// `proxy_manager_e2e_tests.rs`: `TunnelMode::Full` needs elevation, and
+// `windows-latest` CI runs as `RUNNERADMIN`. The SocksOnly path is
+// unusable here because #189 forces `Mode::TcpOnly` on the SOCKS5
+// listener in SocksOnly mode.
+//
+// The test asserts a client-facing UDP round-trip, which covers the
+// entire TUN→dispatcher→Socks5Endpoint→shadowsocks-service UDP stack
+// end-to-end — including the `Mode::TcpAndUdp` flag flowing through
+// `build_ss_config`. Using 127.0.0.1 for either the client or the
+// echo server would hit the bridge's loopback bypass route and bypass
+// the TUN, defeating the point of the test — see the caveat at
+// `proxy_manager_e2e_tests.rs:184-192`.
 
 #[cfg(target_os = "windows")]
 mod tun {
     use super::*;
-    use crate::test_support::socks5_client::socks5_udp_associate;
     use crate::test_support::udp_echo::UdpEchoServer;
+    use tokio::net::UdpSocket;
 
     #[skuld::test(labels = [DIST_BIN, TUN], serial = TUN)]
     fn e2e_socks5_udp_associate_roundtrip(
@@ -326,14 +339,19 @@ mod tun {
             let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
             start_expect_ack(&mut harness, config).await;
 
-            let proxy_addr: SocketAddr = format!("127.0.0.1:{socks_port}").parse().unwrap();
-            wait_for_port(proxy_addr, Duration::from_secs(10)).await;
-
+            // Direct UDP send to the echo server's primary IPv4 — the
+            // bridge's TUN routes capture this and tunnel it through the
+            // ss-server via SOCKS5 UDP ASSOCIATE.
+            let client = UdpSocket::bind("0.0.0.0:0").await.expect("bind UDP client");
             let payload = b"HOLE-UDP-ASSOCIATE";
-            let reply = socks5_udp_associate(proxy_addr, echo.addr, payload)
+            client.send_to(payload, echo.addr).await.expect("send UDP");
+
+            let mut buf = vec![0u8; 65_536];
+            let (n, _) = tokio::time::timeout(Duration::from_secs(10), client.recv_from(&mut buf))
                 .await
-                .expect("SOCKS5 UDP ASSOCIATE roundtrip");
-            assert_eq!(reply, payload, "expected UDP echo to return the payload unchanged");
+                .expect("UDP reply within 10s")
+                .expect("UDP recv");
+            assert_eq!(&buf[..n], payload, "expected UDP echo to return the payload unchanged");
 
             harness.send(BridgeRequest::Stop).await.expect("send Stop");
         });

--- a/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
@@ -1,0 +1,341 @@
+//! End-to-end tests for the listener-selection knobs (`proxy_socks5`,
+//! `proxy_http`, `local_port_http`). Complements
+//! `proxy_manager_e2e_tests.rs`, which covers the pre-existing SOCKS5-only
+//! path.
+//!
+//! Each test spawns a real `hole bridge run` subprocess via
+//! [`DistHarness::spawn`] and exercises `BridgeRequest::Start` with a
+//! listener combination, then asserts what binds on each port.
+//!
+//! * TCP tests use `TunnelMode::SocksOnly` (no elevation required).
+//! * The UDP ASSOCIATE test uses `TunnelMode::Full` and is Windows-admin
+//!   only, mirroring the existing `mod tun` pattern in
+//!   `proxy_manager_e2e_tests.rs`. `windows-latest` GitHub Actions runs
+//!   as `RUNNERADMIN` so CI does exercise it.
+
+use crate::test_support::dist_fixture::*;
+use crate::test_support::dist_harness::DistHarness;
+use crate::test_support::http_connect_client::http_connect_request;
+use crate::test_support::http_target::HttpTarget;
+use crate::test_support::port_alloc::{allocate_ephemeral_port, wait_for_port};
+use crate::test_support::rt;
+use crate::test_support::skuld_fixtures::*;
+use crate::test_support::socks5_client::{http_get_request, http_response_body, socks5_request};
+use hole_common::config::ServerEntry;
+use hole_common::protocol::{BridgeRequest, BridgeResponse, ProxyConfig, TunnelMode};
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::Duration;
+
+// Helpers =============================================================================================================
+
+fn entry_from(ss: &SsServerHandle) -> ServerEntry {
+    ServerEntry {
+        id: "listener-e2e".into(),
+        name: "listener-e2e".into(),
+        server: ss.addr.ip().to_string(),
+        server_port: ss.addr.port(),
+        method: ss.method.into(),
+        password: ss.password.clone(),
+        plugin: ss.plugin.clone(),
+        plugin_opts: ss.plugin_opts.clone(),
+        validation: None,
+    }
+}
+
+fn base_config(ss: &SsServerHandle, local_port: u16, local_port_http: u16) -> ProxyConfig {
+    ProxyConfig {
+        server: entry_from(ss),
+        local_port,
+        tunnel_mode: TunnelMode::SocksOnly,
+        filters: vec![],
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http,
+    }
+}
+
+/// Send `Start` and expect `Ack`. Panics on any other response or IPC error.
+async fn start_expect_ack(harness: &mut DistHarness, config: ProxyConfig) {
+    let resp = harness.send(BridgeRequest::Start { config }).await.expect("send Start");
+    assert!(matches!(resp, BridgeResponse::Ack), "expected Ack, got {resp:?}");
+}
+
+/// Send `Start` and expect `BridgeResponse::Error`. Returns the error message.
+async fn start_expect_error(harness: &mut DistHarness, config: ProxyConfig) -> String {
+    let resp = harness.send(BridgeRequest::Start { config }).await.expect("send Start");
+    match resp {
+        BridgeResponse::Error { message } => message,
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+/// Assert that nothing is listening on `addr` — either by observing a
+/// refused connect or, on Windows where the firewall can silently drop
+/// SYNs to unbound ports, by successfully binding the port ourselves
+/// (proving nothing else already holds it).
+async fn assert_port_unbound(addr: SocketAddr) {
+    let connect = tokio::time::timeout(Duration::from_secs(1), tokio::net::TcpStream::connect(addr)).await;
+    match connect {
+        Ok(Ok(_stream)) => panic!("expected {addr} unbound; connection succeeded"),
+        Ok(Err(e)) => {
+            let kind = e.kind();
+            assert!(
+                matches!(
+                    kind,
+                    std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset
+                ),
+                "expected {addr} unbound; got io error kind {kind:?}: {e}"
+            );
+        }
+        Err(_) => {
+            // Windows Firewall stealth-drops SYNs to unbound localhost
+            // ports in some configurations (#200's cousin). Fall back to
+            // a positive check: if we can bind the port, it's free.
+            match tokio::net::TcpListener::bind(addr).await {
+                Ok(listener) => drop(listener),
+                Err(e) => panic!(
+                    "expected {addr} unbound; connect timed out and bind failed with {e} — \
+                     something is holding the port"
+                ),
+            }
+        }
+    }
+}
+
+async fn roundtrip_socks5(proxy: SocketAddr, target: SocketAddr) {
+    wait_for_port(proxy, Duration::from_secs(10)).await;
+    let request = http_get_request(&target, "/");
+    let response = socks5_request(proxy, target, &request, 8192)
+        .await
+        .expect("socks5 roundtrip");
+    let body = http_response_body(&response).expect("response has header terminator");
+    assert_eq!(body, crate::test_support::http_target::SENTINEL_BODY);
+}
+
+async fn roundtrip_http_connect(proxy: SocketAddr, target: SocketAddr) {
+    wait_for_port(proxy, Duration::from_secs(10)).await;
+    let request = http_get_request(&target, "/");
+    let response = http_connect_request(proxy, &target.to_string(), &request, 8192)
+        .await
+        .expect("HTTP CONNECT roundtrip");
+    let body = http_response_body(&response).expect("response has header terminator");
+    assert_eq!(body, crate::test_support::http_target::SENTINEL_BODY);
+}
+
+// TCP listener selection ==============================================================================================
+
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_socks5_only_http_port_unbound(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_none)] ss: &SsServerHandle,
+    #[fixture(http_target_ipv4)] http: &HttpTarget,
+) {
+    rt().block_on(async {
+        let socks_port = allocate_ephemeral_port().await;
+        let http_port = allocate_ephemeral_port().await;
+        let config = base_config(ss, socks_port, http_port);
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        start_expect_ack(&mut harness, config).await;
+
+        let socks_addr: SocketAddr = format!("127.0.0.1:{socks_port}").parse().unwrap();
+        let http_addr: SocketAddr = format!("127.0.0.1:{http_port}").parse().unwrap();
+
+        roundtrip_socks5(socks_addr, http.addr).await;
+        assert_port_unbound(http_addr).await;
+
+        harness.send(BridgeRequest::Stop).await.expect("send Stop");
+    });
+}
+
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_http_only_socks_port_unbound(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_none)] ss: &SsServerHandle,
+    #[fixture(http_target_ipv4)] http: &HttpTarget,
+) {
+    rt().block_on(async {
+        let socks_port = allocate_ephemeral_port().await;
+        let http_port = allocate_ephemeral_port().await;
+        let mut config = base_config(ss, socks_port, http_port);
+        config.proxy_socks5 = false;
+        config.proxy_http = true;
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        start_expect_ack(&mut harness, config).await;
+
+        let socks_addr: SocketAddr = format!("127.0.0.1:{socks_port}").parse().unwrap();
+        let http_addr: SocketAddr = format!("127.0.0.1:{http_port}").parse().unwrap();
+
+        roundtrip_http_connect(http_addr, http.addr).await;
+        assert_port_unbound(socks_addr).await;
+
+        harness.send(BridgeRequest::Stop).await.expect("send Stop");
+    });
+}
+
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_both_listeners_bound(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_none)] ss: &SsServerHandle,
+    #[fixture(http_target_ipv4)] http: &HttpTarget,
+) {
+    rt().block_on(async {
+        let socks_port = allocate_ephemeral_port().await;
+        let http_port = allocate_ephemeral_port().await;
+        let mut config = base_config(ss, socks_port, http_port);
+        config.proxy_http = true;
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        start_expect_ack(&mut harness, config).await;
+
+        let socks_addr: SocketAddr = format!("127.0.0.1:{socks_port}").parse().unwrap();
+        let http_addr: SocketAddr = format!("127.0.0.1:{http_port}").parse().unwrap();
+
+        roundtrip_socks5(socks_addr, http.addr).await;
+        roundtrip_http_connect(http_addr, http.addr).await;
+
+        harness.send(BridgeRequest::Stop).await.expect("send Stop");
+    });
+}
+
+// Reload hot-path =====================================================================================================
+
+/// Regression guard for the structural-same check in `ProxyManager::reload`.
+/// Before #242 the reload fast path compared only `server`, `local_port`,
+/// `tunnel_mode`. Toggling `proxy_http` alone would therefore hit the
+/// fast path and silently leave the HTTP listener unbound.
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_reload_toggling_http_listener_rebinds(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_none)] ss: &SsServerHandle,
+    #[fixture(http_target_ipv4)] http: &HttpTarget,
+) {
+    rt().block_on(async {
+        let socks_port = allocate_ephemeral_port().await;
+        let http_port = allocate_ephemeral_port().await;
+        let config = base_config(ss, socks_port, http_port);
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        start_expect_ack(&mut harness, config.clone()).await;
+
+        let http_addr: SocketAddr = format!("127.0.0.1:{http_port}").parse().unwrap();
+        assert_port_unbound(http_addr).await;
+
+        // Flip HTTP on, keep every other structural field identical so
+        // the pre-#242 check would have short-circuited.
+        let mut reloaded = config;
+        reloaded.proxy_http = true;
+        let resp = harness
+            .send(BridgeRequest::Reload { config: reloaded })
+            .await
+            .expect("send Reload");
+        assert!(matches!(resp, BridgeResponse::Ack), "reload should Ack, got {resp:?}");
+
+        roundtrip_http_connect(http_addr, http.addr).await;
+
+        harness.send(BridgeRequest::Stop).await.expect("send Stop");
+    });
+}
+
+// Validation errors ===================================================================================================
+
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_start_rejects_no_listeners(#[fixture(dist_dir)] dist: &Path, #[fixture(ssserver_none)] ss: &SsServerHandle) {
+    rt().block_on(async {
+        let port = allocate_ephemeral_port().await;
+        let mut config = base_config(ss, port, port + 1);
+        config.proxy_socks5 = false;
+        config.proxy_http = false;
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        let message = start_expect_error(&mut harness, config).await;
+        assert!(
+            message.contains("no local listeners"),
+            "expected NoListenersEnabled message, got: {message}"
+        );
+    });
+}
+
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_start_rejects_same_port(#[fixture(dist_dir)] dist: &Path, #[fixture(ssserver_none)] ss: &SsServerHandle) {
+    rt().block_on(async {
+        let port = allocate_ephemeral_port().await;
+        let mut config = base_config(ss, port, port);
+        config.proxy_http = true;
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        let message = start_expect_error(&mut harness, config).await;
+        assert!(
+            message.contains("must differ") && message.contains(&port.to_string()),
+            "expected DuplicateListenerPort message, got: {message}"
+        );
+    });
+}
+
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_start_rejects_full_mode_without_socks5(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_none)] ss: &SsServerHandle,
+) {
+    rt().block_on(async {
+        let socks_port = allocate_ephemeral_port().await;
+        let http_port = allocate_ephemeral_port().await;
+        let mut config = base_config(ss, socks_port, http_port);
+        config.proxy_socks5 = false;
+        config.proxy_http = true;
+        config.tunnel_mode = TunnelMode::Full;
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        let message = start_expect_error(&mut harness, config).await;
+        assert!(
+            message.contains("SOCKS5 listener"),
+            "expected TunnelRequiresSocks5 message, got: {message}"
+        );
+    });
+}
+
+// UDP ASSOCIATE (Windows admin only) ==================================================================================
+//
+// Gated to Windows because it requires elevation for `TunnelMode::Full`
+// (SocksOnly hard-codes the SOCKS5 listener to `TcpOnly`, see #189 — keeping
+// that coupling in place rules out the SocksOnly path here). The matching
+// `cfg(target_os = "windows")` on the existing `mod tun` in
+// `proxy_manager_e2e_tests.rs` shows this gate is already how
+// elevated-only E2E paths run on windows-latest CI.
+
+#[cfg(target_os = "windows")]
+mod tun {
+    use super::*;
+    use crate::test_support::socks5_client::socks5_udp_associate;
+    use crate::test_support::udp_echo::UdpEchoServer;
+
+    #[skuld::test(labels = [DIST_BIN, TUN], serial = TUN)]
+    fn e2e_socks5_udp_associate_roundtrip(
+        #[fixture(dist_dir)] dist: &Path,
+        #[fixture(ssserver_none)] ss: &SsServerHandle,
+    ) {
+        rt().block_on(async {
+            let echo = UdpEchoServer::start().await.expect("UDP echo server bind");
+            let socks_port = allocate_ephemeral_port().await;
+            let http_port = allocate_ephemeral_port().await;
+            let mut config = base_config(ss, socks_port, http_port);
+            config.tunnel_mode = TunnelMode::Full;
+
+            let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+            start_expect_ack(&mut harness, config).await;
+
+            let proxy_addr: SocketAddr = format!("127.0.0.1:{socks_port}").parse().unwrap();
+            wait_for_port(proxy_addr, Duration::from_secs(10)).await;
+
+            let payload = b"HOLE-UDP-ASSOCIATE";
+            let reply = socks5_udp_associate(proxy_addr, echo.addr, payload)
+                .await
+                .expect("SOCKS5 UDP ASSOCIATE roundtrip");
+            assert_eq!(reply, payload, "expected UDP echo to return the payload unchanged");
+
+            harness.send(BridgeRequest::Stop).await.expect("send Stop");
+        });
+    }
+}

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -280,6 +280,9 @@ fn test_config() -> ProxyConfig {
         local_port: 1080,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
     }
 }
 

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -24,6 +24,9 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
     }
 }
 

--- a/crates/bridge/src/test_support.rs
+++ b/crates/bridge/src/test_support.rs
@@ -17,12 +17,14 @@
 pub(crate) mod certs;
 pub(crate) mod dist_fixture;
 pub(crate) mod dist_harness;
+pub(crate) mod http_connect_client;
 pub(crate) mod http_target;
 pub(crate) mod net_discovery;
 pub(crate) mod port_alloc;
 pub(crate) mod skuld_fixtures;
 pub(crate) mod socks5_client;
 pub(crate) mod ssserver;
+pub(crate) mod udp_echo;
 
 /// Build a fresh tokio runtime for one test. Mirrors `ipc_tests::rt()`.
 ///

--- a/crates/bridge/src/test_support/http_connect_client.rs
+++ b/crates/bridge/src/test_support/http_connect_client.rs
@@ -1,0 +1,75 @@
+//! Minimal HTTP CONNECT client for E2E tests against the bridge's HTTP
+//! listener. Opens a TCP connection to the proxy, sends
+//! `CONNECT host:port HTTP/1.1`, reads the `200 Connection Established`
+//! response, then forwards `payload` bytes and collects the response.
+//!
+//! Rolls its own parsing to stay independent of the implementation
+//! under test — no `hyper`, no `reqwest`.
+
+use std::io;
+use std::net::SocketAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Perform an HTTP CONNECT tunnel through `proxy` to `target` (a
+/// `host:port` string — the name reaches the proxy verbatim in the
+/// CONNECT line), send `payload`, and read up to `max_bytes` back.
+pub async fn http_connect_request(
+    proxy: SocketAddr,
+    target: &str,
+    payload: &[u8],
+    max_bytes: usize,
+) -> io::Result<Vec<u8>> {
+    let mut stream = TcpStream::connect(proxy).await?;
+
+    let request = format!("CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n");
+    stream.write_all(request.as_bytes()).await?;
+
+    // Read response headers until `\r\n\r\n`. 4 KiB cap — CONNECT replies
+    // are tiny.
+    let mut headers = Vec::with_capacity(512);
+    let mut buf = [0u8; 512];
+    loop {
+        let n = stream.read(&mut buf).await?;
+        if n == 0 {
+            return Err(io::Error::other(format!(
+                "HTTP CONNECT: proxy closed before response complete: {:?}",
+                String::from_utf8_lossy(&headers)
+            )));
+        }
+        headers.extend_from_slice(&buf[..n]);
+        if headers.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if headers.len() > 4096 {
+            return Err(io::Error::other("HTTP CONNECT: response headers exceeded 4 KiB"));
+        }
+    }
+
+    let head_end = headers
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("confirmed above");
+    let status_line_end = headers.windows(2).position(|w| w == b"\r\n").unwrap_or(headers.len());
+    let status = std::str::from_utf8(&headers[..status_line_end])
+        .map_err(|_| io::Error::other("HTTP CONNECT: non-UTF8 status line"))?;
+    if !status.starts_with("HTTP/1.1 200") && !status.starts_with("HTTP/1.0 200") {
+        return Err(io::Error::other(format!("HTTP CONNECT: non-2xx response: {status}")));
+    }
+
+    // Any bytes the proxy sent past the header terminator are already
+    // tunnel data — save them before sending the payload.
+    let mut collected = headers[head_end + 4..].to_vec();
+
+    stream.write_all(payload).await?;
+
+    while collected.len() < max_bytes {
+        let n = stream.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        collected.extend_from_slice(&buf[..n]);
+    }
+    collected.truncate(max_bytes);
+    Ok(collected)
+}

--- a/crates/bridge/src/test_support/socks5_client.rs
+++ b/crates/bridge/src/test_support/socks5_client.rs
@@ -1,13 +1,15 @@
-//! Minimal SOCKS5 CONNECT client for tests.
+//! Minimal SOCKS5 CONNECT + UDP ASSOCIATE client for tests.
 //!
 //! Implements just enough of [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928)
-//! to open a tunneled TCP connection through the bridge's local SOCKS5
-//! listener and read the response. No auth, no UDP ASSOCIATE, no
-//! DOMAINNAME — IPv4 / IPv6 literal addresses only.
+//! to open a tunneled TCP connection or relay a single UDP datagram
+//! through the bridge's local SOCKS5 listener. No auth, no DOMAINNAME
+//! ATYP — IPv4 / IPv6 literal addresses only.
 
+use std::io;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+use tokio::net::{TcpStream, UdpSocket};
 
 /// Connect to `target` through a SOCKS5 proxy at `proxy_addr`, send `request_bytes`,
 /// and return everything the target sent back until EOF (or `max_bytes`).
@@ -112,4 +114,114 @@ pub(crate) fn http_response_body(response: &[u8]) -> Option<&[u8]> {
         .windows(4)
         .position(|w| w == b"\r\n\r\n")
         .map(|i| &response[i + 4..])
+}
+
+/// Perform a SOCKS5 UDP ASSOCIATE exchange through `proxy_addr`, send one
+/// encapsulated datagram addressed at `target`, and return the payload of
+/// the first reply (stripped of its 10-byte SOCKS5 UDP header).
+///
+/// Rolls its own wire encoding (does not depend on
+/// `tun_engine::helpers::socks5_udp`) so the test stays independent of
+/// the implementation under test. Times out after 2s waiting for a
+/// reply.
+pub(crate) async fn socks5_udp_associate(
+    proxy_addr: SocketAddr,
+    target: SocketAddr,
+    payload: &[u8],
+) -> io::Result<Vec<u8>> {
+    // TCP control channel for the ASSOCIATE lifecycle.
+    let mut control = TcpStream::connect(proxy_addr).await?;
+
+    // Greeting + method selection (NoAuth).
+    control.write_all(&[0x05, 0x01, 0x00]).await?;
+    let mut greet = [0u8; 2];
+    control.read_exact(&mut greet).await?;
+    if greet != [0x05, 0x00] {
+        return Err(io::Error::other(format!("SOCKS5 greeting rejected: {greet:?}")));
+    }
+
+    // UDP ASSOCIATE request: VER=5, CMD=3, RSV=0, ATYP, ADDR, PORT.
+    // RFC 1928 §6 says the DST.ADDR may be 0 — we use IPv4 0.0.0.0:0
+    // because we don't know which local UDP port we'll bind yet.
+    let mut req = vec![0x05, 0x03, 0x00, 0x01];
+    req.extend_from_slice(&[0, 0, 0, 0]);
+    req.extend_from_slice(&[0, 0]);
+    control.write_all(&req).await?;
+
+    // Reply: VER=5, REP, RSV=0, ATYP, BND.ADDR, BND.PORT.
+    let mut reply_head = [0u8; 4];
+    control.read_exact(&mut reply_head).await?;
+    if reply_head[1] != 0x00 {
+        return Err(io::Error::other(format!(
+            "SOCKS5 UDP ASSOCIATE failed with REP={}",
+            reply_head[1]
+        )));
+    }
+    let relay_addr = match reply_head[3] {
+        0x01 => {
+            let mut ip = [0u8; 4];
+            control.read_exact(&mut ip).await?;
+            let mut port = [0u8; 2];
+            control.read_exact(&mut port).await?;
+            SocketAddr::from((ip, u16::from_be_bytes(port)))
+        }
+        0x04 => {
+            let mut ip = [0u8; 16];
+            control.read_exact(&mut ip).await?;
+            let mut port = [0u8; 2];
+            control.read_exact(&mut port).await?;
+            SocketAddr::from((ip, u16::from_be_bytes(port)))
+        }
+        other => {
+            return Err(io::Error::other(format!(
+                "SOCKS5 UDP ASSOCIATE: unsupported ATYP {other}"
+            )));
+        }
+    };
+
+    let local_udp = UdpSocket::bind("127.0.0.1:0").await?;
+
+    // SOCKS5 UDP datagram per §7: RSV(2) + FRAG(1) + ATYP(1) + ADDR + PORT + DATA.
+    let mut dgram = vec![0x00, 0x00, 0x00];
+    match target {
+        SocketAddr::V4(v4) => {
+            dgram.push(0x01);
+            dgram.extend_from_slice(&v4.ip().octets());
+        }
+        SocketAddr::V6(v6) => {
+            dgram.push(0x04);
+            dgram.extend_from_slice(&v6.ip().octets());
+        }
+    }
+    dgram.extend_from_slice(&target.port().to_be_bytes());
+    dgram.extend_from_slice(payload);
+    local_udp.send_to(&dgram, relay_addr).await?;
+
+    let mut reply = vec![0u8; 65_536];
+    let (n, _) = tokio::time::timeout(Duration::from_secs(2), local_udp.recv_from(&mut reply))
+        .await
+        .map_err(|_| io::Error::other("SOCKS5 UDP reply timeout"))??;
+
+    // Strip header. Minimum header size for IPv4: 3 + 1 + 4 + 2 = 10 bytes.
+    if n < 4 {
+        return Err(io::Error::other("SOCKS5 UDP reply shorter than header"));
+    }
+    let header_len = match reply[3] {
+        0x01 => 3 + 1 + 4 + 2,
+        0x04 => 3 + 1 + 16 + 2,
+        other => {
+            return Err(io::Error::other(format!("SOCKS5 UDP reply: unsupported ATYP {other}")));
+        }
+    };
+    if n < header_len {
+        return Err(io::Error::other(format!(
+            "SOCKS5 UDP reply ({n} bytes) shorter than expected header ({header_len})"
+        )));
+    }
+
+    // Hold the control channel open until we've got the reply — some
+    // SOCKS5 servers close the UDP relay when the TCP control dies.
+    drop(control);
+
+    Ok(reply[header_len..n].to_vec())
 }

--- a/crates/bridge/src/test_support/udp_echo.rs
+++ b/crates/bridge/src/test_support/udp_echo.rs
@@ -1,21 +1,30 @@
-//! UDP echo-server fixture for E2E tests. Binds `127.0.0.1:0` and
-//! echoes every datagram back to its sender. Keyed to per-test use —
-//! `Drop` aborts the echo task.
+//! UDP echo-server fixture for E2E tests. Binds on `0.0.0.0:0` and
+//! reports the host's primary non-loopback IPv4 address — TUN-mode
+//! bridge tests cannot use `127.0.0.1` because the bridge's
+//! `route add 127.0.0.1 ...` bypass redirects loopback traffic through
+//! the TUN adapter (see `proxy_manager_e2e_tests.rs` `run_full_tunnel_e2e`
+//! caveat). `Drop` aborts the echo task.
 
+use crate::test_support::net_discovery::detect_primary_ipv4;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 
 pub struct UdpEchoServer {
+    /// The address tests should send UDP datagrams to. Uses the host's
+    /// primary non-loopback IPv4 so packets flow through the TUN device
+    /// and back to the local socket.
     pub addr: SocketAddr,
     task: JoinHandle<()>,
 }
 
 impl UdpEchoServer {
     pub async fn start() -> std::io::Result<Self> {
-        let sock = UdpSocket::bind("127.0.0.1:0").await?;
-        let addr = sock.local_addr()?;
+        let primary = detect_primary_ipv4().map_err(std::io::Error::other)?;
+        let sock = UdpSocket::bind("0.0.0.0:0").await?;
+        let port = sock.local_addr()?.port();
+        let addr = SocketAddr::from((primary, port));
         let sock = Arc::new(sock);
         let server_sock = Arc::clone(&sock);
         let task = tokio::spawn(async move {

--- a/crates/bridge/src/test_support/udp_echo.rs
+++ b/crates/bridge/src/test_support/udp_echo.rs
@@ -1,0 +1,42 @@
+//! UDP echo-server fixture for E2E tests. Binds `127.0.0.1:0` and
+//! echoes every datagram back to its sender. Keyed to per-test use —
+//! `Drop` aborts the echo task.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::task::JoinHandle;
+
+pub struct UdpEchoServer {
+    pub addr: SocketAddr,
+    task: JoinHandle<()>,
+}
+
+impl UdpEchoServer {
+    pub async fn start() -> std::io::Result<Self> {
+        let sock = UdpSocket::bind("127.0.0.1:0").await?;
+        let addr = sock.local_addr()?;
+        let sock = Arc::new(sock);
+        let server_sock = Arc::clone(&sock);
+        let task = tokio::spawn(async move {
+            let mut buf = vec![0u8; 65_536];
+            loop {
+                match server_sock.recv_from(&mut buf).await {
+                    Ok((n, src)) => {
+                        // Echo back to the recv_from origin. Ignore send
+                        // errors — clients may already be gone.
+                        let _ = server_sock.send_to(&buf[..n], src).await;
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+        Ok(Self { addr, task })
+    }
+}
+
+impl Drop for UdpEchoServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -350,7 +350,15 @@ components:
     # Documentation-only schemas (not code-generated; hand-written in Rust)
     ProxyConfig:
       type: object
-      description: "Hand-written in protocol.rs — included here for spec completeness."
+      description: |
+        Hand-written in protocol.rs — included here for spec completeness.
+
+        At least one of `proxy_socks5` / `proxy_http` must be true. When
+        `tunnel_mode == full`, `proxy_socks5` must be true (the TUN
+        dispatcher hands captured traffic to the SOCKS5 listener on
+        `local_port`). If both listeners are enabled, `local_port` and
+        `local_port_http` must differ. Any violation makes the bridge
+        reject `BridgeRequest::Start` with `BridgeResponse::Error`.
       required:
         - server
         - local_port
@@ -366,6 +374,25 @@ components:
           description: |
             Which parts of the network stack to install. Defaults to
             `full` when absent (backwards-compatible with older clients).
+        proxy_socks5:
+          type: boolean
+          default: true
+          description: |
+            Whether to bind a SOCKS5 listener on 127.0.0.1:{local_port}.
+            Must be true when tunnel_mode == full.
+        proxy_http:
+          type: boolean
+          default: false
+          description: |
+            Whether to bind an HTTP CONNECT listener on
+            127.0.0.1:{local_port_http}. HTTP CONNECT is TCP-only.
+        local_port_http:
+          type: integer
+          format: uint16
+          default: 4074
+          description: |
+            Port for the HTTP CONNECT listener. Must differ from
+            local_port when both listeners are enabled.
 
     TunnelMode:
       type: string

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -80,6 +80,11 @@ pub struct AppConfig {
     pub proxy_server_enabled: bool,
     pub proxy_socks5: bool,
     pub proxy_http: bool,
+    /// Port for the HTTP CONNECT listener when `proxy_http` is enabled. The
+    /// SOCKS5 listener uses `local_port`; the two must differ when both
+    /// toggles are on (enforced at bridge start by
+    /// `hole_bridge::proxy::config::build_ss_config`).
+    pub local_port_http: u16,
 }
 
 impl Default for AppConfig {
@@ -97,6 +102,7 @@ impl Default for AppConfig {
             proxy_server_enabled: true,
             proxy_socks5: true,
             proxy_http: false,
+            local_port_http: 4074,
         }
     }
 }
@@ -119,6 +125,27 @@ pub struct ServerEntry {
     /// `vpn_server`/`internet` diagnostics dots.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub validation: Option<ValidationState>,
+}
+
+impl ServerEntry {
+    /// A minimal placeholder entry used as the stand-in for `impl Default`
+    /// on `ProxyConfig` (tests and in-memory defaults). Never meant to be
+    /// sent to the bridge as a real config — `server_port` is `0` and
+    /// `password` is empty. Use it only when the `server` field is about to
+    /// be overwritten with a real entry.
+    pub fn default_placeholder() -> Self {
+        Self {
+            id: "placeholder".into(),
+            name: "placeholder".into(),
+            server: "127.0.0.1".into(),
+            server_port: 0,
+            method: "aes-256-gcm".into(),
+            password: String::new(),
+            plugin: None,
+            plugin_opts: None,
+            validation: None,
+        }
+    }
 }
 
 impl std::fmt::Debug for ServerEntry {

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -325,6 +325,7 @@ fn deserialize_old_config_without_new_fields_uses_defaults() {
     assert!(config.proxy_server_enabled);
     assert!(config.proxy_socks5);
     assert!(!config.proxy_http);
+    assert_eq!(config.local_port_http, 4074);
 }
 
 #[skuld::test]
@@ -342,6 +343,7 @@ fn new_config_fields_roundtrip(#[fixture(temp_dir)] dir: &Path) {
         proxy_server_enabled: false,
         proxy_socks5: false,
         proxy_http: true,
+        local_port_http: 5555,
         ..Default::default()
     };
     config.save(&path).unwrap();
@@ -353,6 +355,7 @@ fn new_config_fields_roundtrip(#[fixture(temp_dir)] dir: &Path) {
     assert_eq!(config.proxy_server_enabled, loaded.proxy_server_enabled);
     assert_eq!(config.proxy_socks5, loaded.proxy_socks5);
     assert_eq!(config.proxy_http, loaded.proxy_http);
+    assert_eq!(config.local_port_http, loaded.local_port_http);
 }
 
 #[skuld::test]

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -133,6 +133,47 @@ pub struct ProxyConfig {
     /// (no filtering — all captured traffic proxied).
     #[serde(default)]
     pub filters: Vec<FilterRule>,
+    /// Whether to bind a SOCKS5 listener on `127.0.0.1:{local_port}`.
+    /// Defaults to `true` so older clients that omit the field keep their
+    /// existing behaviour. Required when `tunnel_mode == Full` (the TUN
+    /// dispatcher in `hole_bridge::dispatcher` hands captured traffic to
+    /// this listener).
+    #[serde(default = "proxy_config_defaults::proxy_socks5")]
+    pub proxy_socks5: bool,
+    /// Whether to bind an HTTP CONNECT listener on
+    /// `127.0.0.1:{local_port_http}`. Defaults to `false`. HTTP CONNECT is
+    /// TCP-only (RFC 7231 §4.3.6); UDP flows still require SOCKS5 UDP
+    /// ASSOCIATE.
+    #[serde(default)]
+    pub proxy_http: bool,
+    /// Port for the HTTP CONNECT listener when `proxy_http` is enabled.
+    /// Defaults to `4074`. Must differ from `local_port` when both
+    /// listeners are enabled (enforced at bridge start).
+    #[serde(default = "proxy_config_defaults::local_port_http")]
+    pub local_port_http: u16,
+}
+
+mod proxy_config_defaults {
+    pub(super) fn proxy_socks5() -> bool {
+        true
+    }
+    pub(super) fn local_port_http() -> u16 {
+        4074
+    }
+}
+
+impl Default for ProxyConfig {
+    fn default() -> Self {
+        Self {
+            server: crate::config::ServerEntry::default_placeholder(),
+            local_port: 4073,
+            tunnel_mode: TunnelMode::default(),
+            filters: Vec::new(),
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
+        }
+    }
 }
 
 // Server test outcome =================================================================================================

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -21,6 +21,9 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: TunnelMode::Full,
         filters: Vec::new(),
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
     }
 }
 
@@ -386,6 +389,9 @@ fn proxy_config_tunnel_mode_full_roundtrips() {
         local_port: 4073,
         tunnel_mode: TunnelMode::Full,
         filters: Vec::new(),
+        proxy_socks5: true,
+        proxy_http: true,
+        local_port_http: 4074,
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();
@@ -399,8 +405,33 @@ fn proxy_config_tunnel_mode_socks_only_roundtrips() {
         local_port: 4073,
         tunnel_mode: TunnelMode::SocksOnly,
         filters: Vec::new(),
+        proxy_socks5: false,
+        proxy_http: true,
+        local_port_http: 5555,
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();
     assert_eq!(decoded, cfg);
+}
+
+#[skuld::test]
+fn proxy_config_defaults_on_deserialize() {
+    // Legacy client omitting the listener-selection fields: must default to
+    // SOCKS5-on, HTTP-off, local_port_http=4074. Wire-level backward-compat
+    // contract — do not change without a migration plan.
+    let json = r#"{
+        "server": {
+            "id": "x",
+            "name": "x",
+            "server": "1.2.3.4",
+            "server_port": 8388,
+            "method": "aes-256-gcm",
+            "password": "pw"
+        },
+        "local_port": 4073
+    }"#;
+    let cfg: ProxyConfig = serde_json::from_str(json).expect("legacy payload must parse");
+    assert!(cfg.proxy_socks5);
+    assert!(!cfg.proxy_http);
+    assert_eq!(cfg.local_port_http, 4074);
 }

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -152,6 +152,9 @@ fn send_start_receives_ack() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
+                    proxy_socks5: true,
+                    proxy_http: false,
+                    local_port_http: 4074,
                 },
             })
             .await
@@ -242,6 +245,9 @@ fn send_reload_receives_ack() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
+                    proxy_socks5: true,
+                    proxy_http: false,
+                    local_port_http: 4074,
                 },
             })
             .await
@@ -323,6 +329,9 @@ fn server_error_maps_to_bridge_response_error() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
+                    proxy_socks5: true,
+                    proxy_http: false,
+                    local_port_http: 4074,
                 },
             })
             .await

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -57,6 +57,20 @@ pub(crate) enum ProxyAction {
         /// production default of 4073.
         #[arg(long, default_value_t = 4073)]
         local_port: u16,
+        /// Local HTTP CONNECT port the bridge should bind when
+        /// `--http` is used. Defaults to 4074. Must differ from
+        /// `--local-port` when both listeners are enabled.
+        #[arg(long, default_value_t = 4074)]
+        local_port_http: u16,
+        /// Disable the SOCKS5 listener (default: enabled). Incompatible
+        /// with `--tunnel-mode full`, since the TUN dispatcher hands
+        /// captured traffic to the SOCKS5 listener.
+        #[arg(long)]
+        no_socks5: bool,
+        /// Enable the HTTP CONNECT listener (default: disabled). HTTP
+        /// CONNECT is TCP-only; UDP still requires SOCKS5.
+        #[arg(long)]
+        http: bool,
         /// Tunnel mode. `full` installs the TUN adapter + split routes
         /// (the production default, requires elevation). `socks-only`
         /// binds only the SOCKS5 listener and skips all routing work
@@ -679,6 +693,9 @@ fn handle_proxy(action: ProxyAction) -> i32 {
         ProxyAction::Start {
             config_file,
             local_port,
+            local_port_http,
+            no_socks5,
+            http,
             tunnel_mode,
         } => {
             let entry = match read_server_entry_file(&config_file) {
@@ -694,6 +711,9 @@ fn handle_proxy(action: ProxyAction) -> i32 {
                     local_port,
                     tunnel_mode: tunnel_mode.into(),
                     filters: Vec::new(),
+                    proxy_socks5: !no_socks5,
+                    proxy_http: http,
+                    local_port_http,
                 },
             };
             match send_bridge_request_inner(request) {

--- a/crates/hole/src/cli_tests.rs
+++ b/crates/hole/src/cli_tests.rs
@@ -114,6 +114,9 @@ fn dispatch_installs_cli_log_guard_for_write_actions() {
         action: ProxyAction::Start {
             config_file: std::path::PathBuf::from("/tmp/x.json"),
             local_port: 4073,
+            local_port_http: 4074,
+            no_socks5: false,
+            http: false,
             tunnel_mode: CliTunnelMode::Full,
         },
     }));
@@ -197,11 +200,13 @@ fn proxy_start_parses_with_required_args() {
     let cli =
         Cli::try_parse_from(["hole", "proxy", "start", "--config-file", "/tmp/cfg.json"]).expect("parse proxy start");
     let Some(Command::Proxy {
-        action: ProxyAction::Start {
-            config_file,
-            local_port,
-            tunnel_mode,
-        },
+        action:
+            ProxyAction::Start {
+                config_file,
+                local_port,
+                tunnel_mode,
+                ..
+            },
     }) = cli.command
     else {
         panic!("expected Command::Proxy::Start");

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -389,6 +389,9 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
         local_port: config.local_port,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: config.filters.clone(),
+        proxy_socks5: config.proxy_socks5,
+        proxy_http: config.proxy_http,
+        local_port_http: config.local_port_http,
     })
 }
 

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -21,6 +21,9 @@ fn encode_request_roundtrips() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         },
     };
 
@@ -68,6 +71,9 @@ fn write_request_file_roundtrip() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         },
     };
 
@@ -103,6 +109,9 @@ fn read_request_file_roundtrip() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
         },
     };
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -129,9 +129,15 @@
                   </div>
                 </div>
                 <div class="setting-row">
-                  <span class="setting-label">Serving port</span>
+                  <span class="setting-label">SOCKS5 port</span>
                   <div class="setting-control">
                     <input class="field-input" id="input-port" type="text" value="4073">
+                  </div>
+                </div>
+                <div class="setting-row" id="row-port-http" hidden>
+                  <span class="setting-label">HTTP port</span>
+                  <div class="setting-control">
+                    <input class="field-input" id="input-port-http" type="text" value="4074">
                   </div>
                 </div>
               </div>

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -131,6 +131,8 @@ function wireDropdown(btnId: string, menuId: string, configKey: string, onChange
 // Port input ==========================================================================================================
 
 const portInput = document.getElementById("input-port") as HTMLInputElement;
+const portHttpInput = document.getElementById("input-port-http") as HTMLInputElement;
+const rowPortHttp = document.getElementById("row-port-http")!;
 
 function wirePortInput() {
   portInput.addEventListener("change", () => {
@@ -143,7 +145,46 @@ function wirePortInput() {
       // Revert to current config value on invalid input.
       portInput.value = String(config.local_port ?? "");
     }
+    updatePortConflictMarkers();
   });
+}
+
+function wireHttpPortInput() {
+  portHttpInput.addEventListener("change", () => {
+    if (!config) return;
+    const parsed = parseInt(portHttpInput.value, 10);
+    if (!Number.isNaN(parsed) && parsed > 0 && parsed <= 65535) {
+      config.local_port_http = parsed;
+      saveConfig();
+    } else {
+      portHttpInput.value = String(config.local_port_http ?? "");
+    }
+    updatePortConflictMarkers();
+  });
+}
+
+/**
+ * Hide/show the HTTP port row to match the HTTP toggle. The bridge
+ * ignores `local_port_http` when `proxy_http` is false, but we mirror
+ * that in the UI so users can't set a value they don't see applied.
+ */
+function updateHttpPortVisibility() {
+  if (!config) return;
+  rowPortHttp.hidden = !config.proxy_http;
+}
+
+/**
+ * Mark both port inputs as `invalid` when SOCKS5 and HTTP are both
+ * enabled and their ports collide. The bridge is the authoritative
+ * validator (see `ProxyError::DuplicateListenerPort`) — this is only a
+ * UX affordance so the user sees the problem before hitting Start.
+ */
+function updatePortConflictMarkers() {
+  if (!config) return;
+  const bothOn = !!config.proxy_socks5 && !!config.proxy_http;
+  const collide = bothOn && config.local_port === config.local_port_http;
+  portInput.classList.toggle("invalid", collide);
+  portHttpInput.classList.toggle("invalid", collide);
 }
 
 // Click-outside handler ===============================================================================================
@@ -167,8 +208,13 @@ export function initSettings() {
   wireToggle("toggle-proxy-server", "proxy_server_enabled", () => {
     updateProxyMuting();
   });
-  wireToggle("toggle-socks5", "proxy_socks5");
-  wireToggle("toggle-http", "proxy_http");
+  wireToggle("toggle-socks5", "proxy_socks5", () => {
+    updatePortConflictMarkers();
+  });
+  wireToggle("toggle-http", "proxy_http", () => {
+    updateHttpPortVisibility();
+    updatePortConflictMarkers();
+  });
 
   // Dropdowns.
   wireDropdown("select-on-startup", "menu-on-startup", "on_startup");
@@ -176,8 +222,9 @@ export function initSettings() {
     applyTheme(value);
   });
 
-  // Port input.
+  // Port inputs.
   wirePortInput();
+  wireHttpPortInput();
 
   // Close dropdowns on click outside.
   handleClickOutside();
@@ -200,8 +247,11 @@ export function renderSettings() {
   syncDropdown("select-on-startup", "menu-on-startup", config.on_startup ?? "do_not_connect");
   syncDropdown("select-theme", "menu-theme", config.theme ?? "dark");
 
-  // Port input.
+  // Port inputs.
   portInput.value = String(config.local_port ?? "");
+  portHttpInput.value = String(config.local_port_http ?? "");
+  updateHttpPortVisibility();
+  updatePortConflictMarkers();
 
   // Proxy muting.
   updateProxyMuting();

--- a/ui/style.css
+++ b/ui/style.css
@@ -1233,6 +1233,10 @@ td.del-cell {
   border-color: var(--accent);
 }
 
+.field-input.invalid {
+  border-color: var(--danger, #e06c75);
+}
+
 /* Settings: divider -----  */
 .setting-divider {
   border: none;

--- a/ui/types.ts
+++ b/ui/types.ts
@@ -49,6 +49,7 @@ export interface Config {
   selected_server: string | null;
   filters: FilterRule[];
   local_port: number;
+  local_port_http: number;
   start_on_login: boolean;
   proxy_server_enabled: boolean;
   proxy_socks5: boolean;


### PR DESCRIPTION
Closes #242.

## Summary

The SOCKS5 and HTTP CONNECT toggles in the settings panel were purely cosmetic — persisted to disk, rendered in the UI, but never read by the bridge (\`build_proxy_config\` dropped them, \`ProxyConfig\` didn't carry them, \`build_ss_config\` hard-coded a single SOCKS5 listener). This PR makes them load-bearing end-to-end and adds test coverage for the listener-selection behaviour, including a SOCKS5 UDP ASSOCIATE round-trip that had zero prior coverage.

## What changed

- \`ProxyConfig\`: new \`proxy_socks5\`, \`proxy_http\`, \`local_port_http\` fields (with \`#[serde(default)]\` and an \`impl Default\` for ergonomic test construction). OpenAPI stub updated for parity.
- \`build_ss_config\`: conditionally pushes SOCKS5 and HTTP \`LocalInstanceConfig\`s with five new \`ProxyError\` variants enforcing:
  - \`tunnel_mode == Full && !proxy_socks5\` → \`TunnelRequiresSocks5\` (dispatcher hands captured traffic to the SOCKS5 listener on \`local_port\`)
  - \`!proxy_socks5 && !proxy_http\` → \`NoListenersEnabled\`
  - duplicate ports → \`DuplicateListenerPort\`
  - port 0 → \`InvalidListenerPort\`
- HTTP listener \`Mode\` is always \`TcpOnly\` (RFC 7231 §4.3.6); SOCKS5 listener \`Mode\` still tracks \`tunnel_mode\` (\`Full\` ⇒ \`TcpAndUdp\` per the pre-existing #189 coupling).
- \`ProxyManager::reload\` structural-same check now includes the new listener fields so toggling HTTP on a running bridge actually rebinds.
- UI: HTTP port input added, hidden when the HTTP toggle is off; port-collision input highlight as a UX affordance (bridge-side \`DuplicateListenerPort\` is authoritative).
- CLI: \`--local-port-http\`, \`--no-socks5\`, \`--http\` flags on \`hole proxy start\`.
- CLAUDE.md gains a \"Listener selection invariants\" section.

## Tests

- **Unit** (\`crates/bridge/src/proxy/config_tests.rs\`): 11 new tests covering each listener combination and each validation rule.
- **E2E** (\`crates/bridge/src/proxy_manager_listener_e2e_tests.rs\`): 8 tests including \`e2e_socks5_udp_associate_roundtrip\` which spins up an in-process UDP echo server and round-trips a payload through SOCKS5 UDP ASSOCIATE. The UDP test is Windows-admin gated (\`TunnelMode::Full\` required because the existing #189 coupling forces \`TcpOnly\` in \`SocksOnly\`), mirroring the existing \`mod tun\` pattern; \`windows-latest\` CI runs as \`RUNNERADMIN\` so it exercises.
- **Test support**: new \`http_connect_client.rs\`, \`udp_echo.rs\`, \`socks5_udp_associate\` helper.

Local: 311 pass, 2 admin-gated TUN tests skip (existing \`e2e_none_full_tunnel_roundtrip\` + new UDP ASSOCIATE). Clippy clean.

## Out of scope

- \`proxy_server_enabled\` (\`crates/common/src/config.rs:80\`) — the UI master-switch toggle — is a separate cosmetic toggle with similar plumbing issues; wiring it through requires deciding how it interacts with \`AppConfig::enabled\` and the tray power button. Not touched here. Flag for follow-up if desired.

## Test plan

- [ ] CI green (GitHub Actions matrix)
- [ ] \`e2e_socks5_udp_associate_roundtrip\` passes on \`windows-latest\`
- [ ] Manual smoke: toggle HTTP on, reconnect, curl through both ports