### PR TITLE
Time apply_dns_settings sub-calls for #247 diagnosis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "tun-engine",
  "ureq",
  "webpki-roots",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -87,6 +87,9 @@ ferrisetw = "1.2.0"
 [dev-dependencies]
 skuld = { workspace = true }
 tokio = { version = "1", features = ["test-util"] }
+# For in-process log capture in tests — verifies the diagnostic spans and
+# per-call `elapsed_ms` debug logs added for #247.
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 shadowsocks-service = { version = "1", features = ["server"] }
 rcgen = "0.13"
 rand = "0.9"

--- a/crates/bridge/src/dns/system/windows.rs
+++ b/crates/bridge/src/dns/system/windows.rs
@@ -17,6 +17,7 @@
 use std::io;
 use std::net::IpAddr;
 use std::process::Command;
+use std::time::Instant;
 
 use super::AppliedAdapter;
 use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
@@ -29,6 +30,7 @@ const NETSH: &str = "netsh";
 /// that don't exist (e.g. the TUN alias hasn't been created yet) are
 /// silently skipped.
 pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
+    let started = Instant::now();
     let mut out = Vec::with_capacity(aliases.len());
     for alias in aliases {
         match capture_one(alias) {
@@ -41,6 +43,12 @@ pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> 
             }
         }
     }
+    tracing::debug!(
+        aliases = aliases.len(),
+        captured = out.len(),
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "capture_adapters"
+    );
     Ok(out)
 }
 
@@ -49,6 +57,7 @@ pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> 
 /// Callers flush the DNS cache separately (via [`flush_dns_cache`]) once
 /// the full adapter list is applied.
 pub fn apply_loopback(aliases: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
+    let started = Instant::now();
     let mut applied = Vec::with_capacity(aliases.len());
     for alias in aliases {
         if let Err(e) = set_dns_ipv4(alias, Some(loopback_ip)) {
@@ -61,15 +70,29 @@ pub fn apply_loopback(aliases: &[String], loopback_ip: IpAddr) -> io::Result<Vec
         });
     }
     flush_dns_cache();
+    tracing::debug!(
+        aliases = aliases.len(),
+        applied = applied.len(),
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "apply_loopback"
+    );
     Ok(applied)
 }
 
 /// Run `ipconfig /flushdns`. Best-effort; a failure here is a log line,
 /// not a return value.
+///
+/// Emits a DEBUG `elapsed_ms` log so Phase-2 observation of #247 can see
+/// how long `ipconfig /flushdns` actually takes on the user's machine —
+/// it is notoriously slow on Windows (often 1-5s) and was the prime
+/// suspect for the 10s stall.
 pub fn flush_dns_cache() {
+    let started = Instant::now();
     let res = Command::new("ipconfig").arg("/flushdns").output();
-    if let Err(e) = res {
-        tracing::warn!(error = %e, "ipconfig /flushdns failed");
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    match res {
+        Ok(_) => tracing::debug!(elapsed_ms, "flush_dns_cache"),
+        Err(e) => tracing::warn!(error = %e, elapsed_ms, "ipconfig /flushdns failed"),
     }
 }
 
@@ -89,11 +112,24 @@ pub fn platform_restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
 // Capture =============================================================================================================
 
 fn capture_one(alias: &str) -> io::Result<Option<DnsPriorAdapter>> {
+    let started = Instant::now();
     let v4 = match show_dnsservers("ipv4", alias)? {
         Some(out) => parse_netsh_dnsservers(&out),
-        None => return Ok(None),
+        None => {
+            tracing::debug!(
+                %alias,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "capture_one: adapter not found"
+            );
+            return Ok(None);
+        }
     };
     let v6 = show_dnsservers("ipv6", alias)?.map(|o| parse_netsh_dnsservers(&o));
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "capture_one"
+    );
     Ok(Some(DnsPriorAdapter {
         id: AdapterId::WindowsAlias {
             value: alias.to_string(),
@@ -105,10 +141,17 @@ fn capture_one(alias: &str) -> io::Result<Option<DnsPriorAdapter>> {
 }
 
 fn show_dnsservers(family: &str, alias: &str) -> io::Result<Option<String>> {
+    let started = Instant::now();
     let output = Command::new(NETSH)
         .args(["interface", family, "show", "dnsservers"])
         .arg(format!("name={alias}"))
         .output()?;
+    tracing::debug!(
+        %alias,
+        %family,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "show_dnsservers"
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // netsh emits "The system cannot find the file specified." on a
@@ -200,6 +243,7 @@ pub(super) fn parse_netsh_dnsservers(stdout: &str) -> DnsPrior {
 // Apply ===============================================================================================================
 
 fn set_dns_ipv4(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
+    let started = Instant::now();
     let mut cmd = Command::new(NETSH);
     cmd.args(["interface", "ipv4", "set", "dnsservers"])
         .arg(format!("name={alias}"));
@@ -212,6 +256,11 @@ fn set_dns_ipv4(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
         }
     }
     let status = cmd.status()?;
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "set_dns_ipv4"
+    );
     if !status.success() {
         return Err(io::Error::other(format!("netsh set dnsservers failed: {status}")));
     }
@@ -219,11 +268,17 @@ fn set_dns_ipv4(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
 }
 
 fn set_dhcp_ipv4(alias: &str) -> io::Result<()> {
+    let started = Instant::now();
     let status = Command::new(NETSH)
         .args(["interface", "ipv4", "set", "dnsservers"])
         .arg(format!("name={alias}"))
         .arg("dhcp")
         .status()?;
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "set_dhcp_ipv4"
+    );
     if !status.success() {
         return Err(io::Error::other(format!("netsh set dnsservers dhcp failed: {status}")));
     }
@@ -231,12 +286,18 @@ fn set_dhcp_ipv4(alias: &str) -> io::Result<()> {
 }
 
 fn add_dns_ipv4(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
+    let started = Instant::now();
     let status = Command::new(NETSH)
         .args(["interface", "ipv4", "add", "dnsservers"])
         .arg(format!("name={alias}"))
         .arg(ip.to_string())
         .arg(format!("index={index}"))
         .status()?;
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "add_dns_ipv4"
+    );
     if !status.success() {
         return Err(io::Error::other(format!("netsh add dnsservers failed: {status}")));
     }
@@ -244,6 +305,7 @@ fn add_dns_ipv4(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
 }
 
 fn set_dns_ipv6(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
+    let started = Instant::now();
     let mut cmd = Command::new(NETSH);
     cmd.args(["interface", "ipv6", "set", "dnsservers"])
         .arg(format!("name={alias}"));
@@ -256,6 +318,11 @@ fn set_dns_ipv6(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
         }
     }
     let status = cmd.status()?;
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "set_dns_ipv6"
+    );
     if !status.success() {
         return Err(io::Error::other(format!("netsh set dnsservers v6 failed: {status}")));
     }
@@ -263,11 +330,17 @@ fn set_dns_ipv6(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
 }
 
 fn set_dhcp_ipv6(alias: &str) -> io::Result<()> {
+    let started = Instant::now();
     let status = Command::new(NETSH)
         .args(["interface", "ipv6", "set", "dnsservers"])
         .arg(format!("name={alias}"))
         .arg("dhcp")
         .status()?;
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "set_dhcp_ipv6"
+    );
     if !status.success() {
         return Err(io::Error::other(format!(
             "netsh set dnsservers v6 dhcp failed: {status}"
@@ -277,12 +350,18 @@ fn set_dhcp_ipv6(alias: &str) -> io::Result<()> {
 }
 
 fn add_dns_ipv6(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
+    let started = Instant::now();
     let status = Command::new(NETSH)
         .args(["interface", "ipv6", "add", "dnsservers"])
         .arg(format!("name={alias}"))
         .arg(ip.to_string())
         .arg(format!("index={index}"))
         .status()?;
+    tracing::debug!(
+        %alias,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "add_dns_ipv6"
+    );
     if !status.success() {
         return Err(io::Error::other(format!("netsh add dnsservers v6 failed: {status}")));
     }

--- a/crates/bridge/src/dns/system_tests.rs
+++ b/crates/bridge/src/dns/system_tests.rs
@@ -6,6 +6,82 @@ use std::net::{IpAddr, Ipv4Addr};
 #[cfg(target_os = "windows")]
 use std::net::Ipv6Addr;
 
+// Timing-log instrumentation tests (#247) =============================================================================
+//
+// These tests verify that Phase 1 diagnostic logs fire. They live outside
+// the `windows_parsers` / `macos_parsers` modules because they exercise
+// real OS command invocations (netsh / networksetup), which the parser
+// tests deliberately avoid.
+
+#[cfg(target_os = "windows")]
+mod windows_timing_logs {
+    use crate::dns::system::windows::flush_dns_cache;
+    use crate::test_support::log_capture::VecWriter;
+    use tracing_subscriber::fmt;
+    use tracing_subscriber::layer::{Layer, SubscriberExt};
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    /// `flush_dns_cache` must emit a `DEBUG` log with an `elapsed_ms`
+    /// field so Phase 2 observation can see how long `ipconfig /flushdns`
+    /// actually takes. This is the minimum-viable timing probe — if this
+    /// test regresses, the entire Phase-1 diagnostic story is broken.
+    #[skuld::test]
+    fn flush_dns_cache_emits_elapsed_ms_debug_log() {
+        let writer = VecWriter::new();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .with_writer(writer.clone())
+                .with_ansi(false)
+                .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG),
+        );
+        let _guard = subscriber.set_default();
+
+        flush_dns_cache();
+
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains("elapsed_ms"),
+            "expected 'elapsed_ms' field in captured log; got:\n{output}"
+        );
+        assert!(output.contains("DEBUG"), "expected DEBUG-level log; got:\n{output}");
+        assert!(
+            output.contains("flush_dns_cache"),
+            "expected 'flush_dns_cache' target/message in log; got:\n{output}"
+        );
+    }
+
+    /// `capture_adapters` must emit per-alias DEBUG timing logs so a slow
+    /// netsh query against a freshly-created TUN adapter is visible in
+    /// Phase 2 logs. Uses a nonexistent adapter name so the test doesn't
+    /// depend on any specific network configuration — `netsh show` will
+    /// return "not found" quickly, and the timing log fires regardless.
+    #[skuld::test]
+    fn capture_adapters_emits_per_alias_elapsed_ms_debug_log() {
+        use crate::dns::system::capture_adapters;
+
+        let writer = VecWriter::new();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .with_writer(writer.clone())
+                .with_ansi(false)
+                .with_filter(tracing_subscriber::filter::LevelFilter::DEBUG),
+        );
+        let _guard = subscriber.set_default();
+
+        let _ = capture_adapters(&["hole-test-bogus-adapter-xyz".to_string()]);
+
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains("elapsed_ms"),
+            "expected 'elapsed_ms' in captured log; got:\n{output}"
+        );
+        assert!(
+            output.contains("hole-test-bogus-adapter-xyz"),
+            "expected alias in log; got:\n{output}"
+        );
+    }
+}
+
 // Windows parser tests ================================================================================================
 
 #[cfg(target_os = "windows")]

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -482,7 +482,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // our loopback IP). Persist the prior state to `bridge-dns.json`
         // BEFORE mutating so a mid-apply crash leaves a recoverable file.
         let dns_state = if let Some(srv) = local_dns_server.as_ref() {
-            apply_dns_settings(srv, &gw_info.interface_name, state_dir)
+            apply_dns_settings(srv, &gw_info.interface_name, state_dir).await
         } else {
             None
         };
@@ -752,13 +752,41 @@ async fn build_local_dns(
 /// persist the `bridge-dns.json` recovery file, then apply the loopback
 /// IP. Returns the captured prior state on success, which
 /// [`RunningDns::drop`] will later replay.
-fn apply_dns_settings(
+///
+/// Async because the underlying platform functions shell out to
+/// `netsh` / `networksetup` via `std::process::Command`. Keeping the
+/// body sync today (see `dns::system::windows`) blocks a tokio worker
+/// thread for the full duration, which #247 observed stalling the
+/// `start_inner` path by ~10s. The `async fn` signature is a
+/// Phase-1 no-behavior-change prerequisite for a Phase-4 swap to
+/// `tokio::process::Command`.
+///
+/// Instrumented with an `info_span!("apply_dns_settings")` entered via
+/// `.instrument()`. The happy-path exit logs
+/// `info!(elapsed_ms = ..., "apply_dns_settings done")` so Phase-2
+/// observation of #247 sees the total at INFO without needing to raise
+/// the log level — per-sub-call `elapsed_ms` lines live at DEBUG inside
+/// `dns::system::windows`.
+async fn apply_dns_settings(
     server: &crate::dns::server::LocalDnsServer,
     upstream_iface: &str,
     state_dir: Option<&std::path::Path>,
 ) -> Option<Vec<crate::dns_state::DnsPriorAdapter>> {
+    use tracing::Instrument;
+    let span = tracing::info_span!("apply_dns_settings", upstream_iface = %upstream_iface);
+    async { apply_dns_settings_body(server, upstream_iface, state_dir) }
+        .instrument(span)
+        .await
+}
+
+fn apply_dns_settings_body(
+    server: &crate::dns::server::LocalDnsServer,
+    upstream_iface: &str,
+    state_dir: Option<&std::path::Path>,
+) -> Option<Vec<crate::dns_state::DnsPriorAdapter>> {
+    let started = Instant::now();
     #[cfg(any(target_os = "windows", target_os = "macos"))]
-    {
+    let result = {
         use crate::dns::system;
         use crate::dns_state::{self, DnsState, SCHEMA_VERSION};
         use crate::proxy::TUN_DEVICE_NAME;
@@ -792,10 +820,16 @@ fn apply_dns_settings(
         }
 
         Some(prior)
-    }
+    };
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    {
+    let result: Option<Vec<crate::dns_state::DnsPriorAdapter>> = {
         let _ = (server, upstream_iface, state_dir);
         None
-    }
+    };
+
+    info!(
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "apply_dns_settings done"
+    );
+    result
 }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -848,3 +848,60 @@ fn reload_when_not_running_starts() {
         pm.stop().await.unwrap();
     });
 }
+
+// Phase-1 instrumentation tests for #247 ==============================================================================
+
+/// Smoke-test: `apply_dns_settings` emits an INFO log `"apply_dns_settings done"`
+/// with an `elapsed_ms` field. Phase-2 observation of #247 depends on this
+/// line appearing at INFO so users don't need to raise the log level to
+/// diagnose the ~10s stall.
+///
+/// Uses a nonexistent upstream interface name so the underlying `netsh` /
+/// `networksetup` calls fail fast (adapter not found), but the wrapping
+/// instrumentation still emits the diagnostic.
+#[skuld::test]
+fn apply_dns_settings_emits_done_info_log() {
+    use crate::dns::connector::DirectConnector;
+    use crate::dns::forwarder::DnsForwarder;
+    use crate::dns::server::LocalDnsServer;
+    use crate::test_support::log_capture::VecWriter;
+    use hole_common::config::DnsConfig;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tracing_subscriber::fmt;
+    use tracing_subscriber::layer::{Layer, SubscriberExt};
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    rt().block_on(async {
+        let writer = VecWriter::new();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .with_writer(writer.clone())
+                .with_ansi(false)
+                .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+        );
+        let _guard = subscriber.set_default();
+
+        // Bind LocalDnsServer to an ephemeral loopback port so the test
+        // doesn't fight with anything else on :53.
+        let forwarder = Arc::new(DnsForwarder::new(
+            DnsConfig::default(),
+            Arc::new(DirectConnector),
+            false,
+        ));
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let srv = LocalDnsServer::bind(addr, forwarder).await.expect("bind ephemeral");
+
+        let _ = apply_dns_settings(&srv, "hole-test-nonexistent-iface-xyz", None).await;
+
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains("apply_dns_settings done"),
+            "expected 'apply_dns_settings done' in INFO log; got:\n{output}"
+        );
+        assert!(
+            output.contains("elapsed_ms"),
+            "expected 'elapsed_ms' in INFO log; got:\n{output}"
+        );
+        assert!(output.contains("INFO"), "expected INFO level; got:\n{output}");
+    });
+}

--- a/crates/bridge/src/test_support.rs
+++ b/crates/bridge/src/test_support.rs
@@ -19,6 +19,7 @@ pub(crate) mod dist_fixture;
 pub(crate) mod dist_harness;
 pub(crate) mod http_connect_client;
 pub(crate) mod http_target;
+pub(crate) mod log_capture;
 pub(crate) mod net_discovery;
 pub(crate) mod port_alloc;
 pub(crate) mod skuld_fixtures;

--- a/crates/bridge/src/test_support/log_capture.rs
+++ b/crates/bridge/src/test_support/log_capture.rs
@@ -1,0 +1,51 @@
+//! In-process `tracing` log capture for tests.
+//!
+//! Mirrors the `VecWriter` pattern used by `crates/common/src/logging/
+//! logging_test_helpers.rs` but kept local to the bridge crate so callers
+//! don't have to depend on internals of `hole-common`'s test helpers.
+
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
+
+/// A `Write`-able sink that stores everything written to it in memory.
+/// Cloneable — both clones share the same backing `Vec<u8>`, so a
+/// `tracing_subscriber::fmt::layer().with_writer(writer.clone())` spun up
+/// for a test can be inspected from the test body via the original handle.
+#[derive(Clone, Default)]
+pub(crate) struct VecWriter {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl VecWriter {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot the bytes written so far.
+    pub(crate) fn snapshot(&self) -> Vec<u8> {
+        self.inner.lock().unwrap().clone()
+    }
+
+    /// Snapshot as a UTF-8 string (lossy on non-UTF-8).
+    pub(crate) fn snapshot_string(&self) -> String {
+        String::from_utf8_lossy(&self.snapshot()).into_owned()
+    }
+}
+
+impl Write for VecWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for VecWriter {
+    type Writer = VecWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}


### PR DESCRIPTION
Fixes part of #247 — Phase 1 instrumentation only, per the plan at `.claude/plans/a-test-run-via-floofy-sutton.md`.

## What this does

Adds the Phase-1 diagnostic instrumentation needed to localise the ~10s stall between routes-installed and `proxy started`. No behaviour changes — only log emission.

- **`apply_dns_settings` wraps itself in an async span** (`tracing::info_span!`, entered via `.instrument()` not `.in_scope()` to avoid the `!Send` entered-guard footgun across `.await`). Emits one `info!(elapsed_ms = …, "apply_dns_settings done")` on happy-path exit, so the total is visible at INFO level (production default) without having to raise log levels.

- **`apply_dns_settings` is now `async fn`.** Prerequisite for Phase-4 swap to `tokio::process::Command` / `tokio::task::spawn_blocking`. The sole caller (`proxy_manager.rs:485`) was already in an async context so the change is purely ergonomic.

- **Per-netsh-call `elapsed_ms` DEBUG logs** inside `dns/system/windows.rs`:
  - `show_dnsservers` (per family + alias)
  - `capture_one` (per alias)
  - `capture_adapters` (aggregate)
  - `set_dns_ipv4`, `set_dns_ipv6`, `set_dhcp_ipv4`, `set_dhcp_ipv6`, `add_dns_ipv4`, `add_dns_ipv6` (per alias)
  - `apply_loopback` (aggregate)
  - `flush_dns_cache`

Together these produce a Phase-2 breakdown like:
` ` `
apply_dns_settings done elapsed_ms=10234
  apply_loopback elapsed_ms=4210 applied=2
    set_dns_ipv4 alias=hole-tun elapsed_ms=1700
    set_dns_ipv4 alias=Wi-Fi elapsed_ms=800
    flush_dns_cache elapsed_ms=1710
  capture_adapters elapsed_ms=3400 captured=2
    show_dnsservers alias=hole-tun family=ipv4 elapsed_ms=3100
    ...
` ` `

## Tests

Three new Windows-only tests in `dns/system_tests.rs` + `proxy_manager_tests.rs`, all using a `VecWriter`-backed `tracing_subscriber::fmt::layer` to capture the in-process log output:

1. `flush_dns_cache_emits_elapsed_ms_debug_log` — verifies the per-call pattern.
2. `capture_adapters_emits_per_alias_elapsed_ms_debug_log` — verifies the per-alias logging via a bogus adapter name.
3. `apply_dns_settings_emits_done_info_log` — verifies the INFO-level span emission.

All use the existing `#[skuld::test]` convention. A new `crates/bridge/src/test_support/log_capture.rs` helper (mirroring the pattern from `hole-common`) provides the `VecWriter`. `tracing-subscriber` is added as a dev-dep.

## Test plan

- [x] `cargo test -p hole-bridge --lib` — 411 passed; 2 pre-existing e2e flakes on `main` (`e2e_socks5_udp_associate_roundtrip`, `lifecycle_reload_changes_local_port`), unrelated to this change.
- [x] `cargo clippy -p hole-bridge --lib --tests` — clean.
- [x] `cargo build --workspace` — clean.
- [ ] CI matrix green.