### PR TITLE
fix: restore SOCKS5 UDP-ASSOCIATE in SocksOnly mode + add UDP tests (#250)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,12 @@ surfaced as `BridgeResponse::Error`):
 
 The HTTP listener's `Mode` is always `TcpOnly` regardless of
 `tunnel_mode` — HTTP CONNECT is TCP-only (RFC 7231 §4.3.6). The SOCKS5
-listener's `Mode` still tracks `tunnel_mode` (`Full` ⇒ `TcpAndUdp`,
-`SocksOnly` ⇒ `TcpOnly` per #189).
+listener's `Mode` is always `TcpAndUdp`: in Full mode the dispatcher
+relays UDP through SOCKS5 UDP ASSOCIATE, and in SocksOnly mode the
+listener exposes UDP ASSOCIATE to local SOCKS5 clients. Pre-#250 the
+SocksOnly path was forced to `TcpOnly` under #189's mis-attributed
+"select_all" hypothesis; the real fix for the original symptom is PR
+#207's two-pass test ordering (#200).
 
 ### DNS forwarder
 

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -107,14 +107,21 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 ///
 /// Emits one local instance per enabled listener:
 ///
-/// * **SOCKS5** (`proxy_socks5`): `127.0.0.1:{local_port}`. Mode tracks
-///   `tunnel_mode` — `Full` ⇒ `TcpAndUdp` (so the dispatcher's UDP
-///   handler can use SOCKS5 UDP ASSOCIATE to relay datagrams through
-///   the tunnel), `SocksOnly` ⇒ `TcpOnly` (see #189 — on Windows,
-///   creating the UDP server can cause `select_all` inside
-///   shadowsocks-service to drop the TCP listener when the UDP future
-///   completes early, and with no dispatcher nobody uses UDP ASSOCIATE
-///   anyway).
+/// * **SOCKS5** (`proxy_socks5`): `127.0.0.1:{local_port}`, always
+///   `TcpAndUdp`. In Full mode the TUN dispatcher uses UDP ASSOCIATE
+///   to relay datagrams through the SS tunnel; in SocksOnly mode the
+///   listener exposes UDP ASSOCIATE to local SOCKS5 clients
+///   (hev-socks5-tunnel, ss-tunnel, proxychains-ng UDP, …).
+///
+///   Pre-#250, SocksOnly forced `TcpOnly` under #189's "select_all
+///   drops the TCP listener when UDP completes early" attribution.
+///   That attribution had no log evidence — `LogTracer` was never
+///   installed so shadowsocks-service's `log::*!` events were silently
+///   dropped. The original symptom was actually wintun-induced
+///   loopback breakage on the Azure-hosted Windows runner (#200), and
+///   it was correctly addressed by PR #207's two-pass test ordering
+///   (`SKULD_LABELS=tun` runs last so loopback-using tests precede
+///   any wintun adapter destruction).
 /// * **HTTP CONNECT** (`proxy_http`): `127.0.0.1:{local_port_http}`,
 ///   always `TcpOnly` (HTTP CONNECT is TCP-only by RFC 7231 §4.3.6).
 ///
@@ -178,14 +185,10 @@ pub fn build_ss_config(config: &ProxyConfig, plugin_local: Option<SocketAddr>) -
         .push(ServerInstanceConfig::with_server_config(server_config));
 
     if config.proxy_socks5 {
-        let socks_mode = match config.tunnel_mode {
-            hole_common::protocol::TunnelMode::Full => Mode::TcpAndUdp,
-            hole_common::protocol::TunnelMode::SocksOnly => Mode::TcpOnly,
-        };
         ss_config.local.push(build_local_instance(
             ProtocolType::Socks,
             loopback(config.local_port),
-            socks_mode,
+            Mode::TcpAndUdp,
         ));
     }
 

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -185,14 +185,16 @@ fn socks5_full_mode_is_tcp_and_udp() {
 }
 
 #[skuld::test]
-fn socks5_socks_only_mode_is_tcp_only() {
-    // Keeps #189 regression pinned: SocksOnly must not enable UDP on the
-    // SOCKS5 listener.
+fn socks5_socks_only_mode_is_tcp_and_udp() {
+    // Post-#250: SocksOnly exposes UDP-ASSOCIATE to local SOCKS5 clients
+    // (hev-socks5-tunnel, ss-tunnel, proxychains-ng UDP, the in-bridge
+    // DNS forwarder's UDP path). Pre-#250 this asserted TcpOnly under
+    // #189's mis-attributed select_all hypothesis.
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
     let ss_config = build_ss_config(&cfg, None).unwrap();
     let socks = &ss_config.local[0].config;
-    assert!(matches!(socks.mode, Mode::TcpOnly));
+    assert!(matches!(socks.mode, Mode::TcpAndUdp));
 }
 
 // Validation errors ---------------------------------------------------------------------------------------------------

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -420,7 +420,9 @@ fn cipher_chacha20_ietf_poly1305_roundtrip(
     rt().block_on(async {
         let method = CipherKind::CHACHA20_POLY1305;
         let password = random_password_for(method);
-        let (ss_addr, _ss_handle) = crate::test_support::ssserver::start_real_ss_server(method, &password).await;
+        let ss_port = allocate_ephemeral_port().await;
+        let (ss_addr, _ss_handle) =
+            crate::test_support::ssserver::start_real_ss_server(method, &password, ss_port).await;
 
         let local_port = allocate_ephemeral_port().await;
         let config = ProxyConfig {
@@ -462,7 +464,9 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
     rt().block_on(async {
         let method = CipherKind::AEAD2022_BLAKE3_AES_256_GCM;
         let password = random_password_for(method);
-        let (ss_addr, _ss_handle) = crate::test_support::ssserver::start_real_ss_server(method, &password).await;
+        let ss_port = allocate_ephemeral_port().await;
+        let (ss_addr, _ss_handle) =
+            crate::test_support::ssserver::start_real_ss_server(method, &password, ss_port).await;
 
         let local_port = allocate_ephemeral_port().await;
         let config = ProxyConfig {

--- a/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
@@ -307,9 +307,10 @@ fn e2e_start_rejects_full_mode_without_socks5(
 //
 // Gated to Windows for the same reason as the existing `mod tun` in
 // `proxy_manager_e2e_tests.rs`: `TunnelMode::Full` needs elevation, and
-// `windows-latest` CI runs as `RUNNERADMIN`. The SocksOnly path is
-// unusable here because #189 forces `Mode::TcpOnly` on the SOCKS5
-// listener in SocksOnly mode.
+// `windows-latest` CI runs as `RUNNERADMIN`. The SocksOnly UDP path is
+// covered by `mod socks_only_udp` below — it runs on every job
+// (Linux + Windows pass-1; the galoshes variant is additionally
+// Windows-skipped under #197).
 //
 // The test asserts a client-facing UDP round-trip, which covers the
 // entire TUN→dispatcher→Socks5Endpoint→shadowsocks-service UDP stack
@@ -354,6 +355,83 @@ mod tun {
                 .expect("UDP recv");
             assert_eq!(&buf[..n], payload, "expected UDP echo to return the payload unchanged");
 
+            harness.send(BridgeRequest::Stop).await.expect("send Stop");
+        });
+    }
+}
+
+// UDP via SocksOnly ===================================================================================================
+//
+// End-to-end exercise of SOCKS5 UDP ASSOCIATE in `TunnelMode::SocksOnly`,
+// where there is no TUN dispatcher and no loopback bypass route. The
+// test client opens UDP-ASSOCIATE through the bridge's SOCKS5 listener
+// at `127.0.0.1:<socks_port>`, the bridge relays datagrams via the SS
+// tunnel to the upstream ss-server, the ss-server sends them on to the
+// loopback echo, and replies follow the reverse path.
+//
+// Two variants:
+// * `e2e_socks_only_udp_associate_no_plugin` — direct ss tunnel.
+// * `e2e_socks_only_udp_associate_galoshes` — UDP through galoshes'
+//   YAMUX-multiplexed plugin chain. Skipped on Windows under #197 (same
+//   `PluginConfig` bind race that gates `e2e_ws_socks_only_roundtrip`).
+//
+// Both labeled `[DIST_BIN]` (no `TUN`) → run in pass-1
+// (`SKULD_LABELS="!tun"`) where loopback delivery is intact (PR #207).
+// The galoshes variant additionally carries `PORT_ALLOC` because
+// `ssserver_ws` is `serial = PORT_ALLOC`.
+
+mod socks_only_udp {
+    use super::*;
+    use crate::test_support::socks5_client::socks5_udp_associate;
+    use crate::test_support::udp_echo::UdpEchoServer;
+
+    async fn run_udp_roundtrip(socks_addr: SocketAddr) {
+        let echo = UdpEchoServer::start_loopback().await.expect("UDP echo bind");
+        wait_for_port(socks_addr, Duration::from_secs(10)).await;
+        let payload = b"HOLE-SOCKS-ONLY-UDP";
+        let echoed = tokio::time::timeout(
+            Duration::from_secs(5),
+            socks5_udp_associate(socks_addr, echo.addr, payload),
+        )
+        .await
+        .expect("UDP-ASSOCIATE within 5s")
+        .expect("UDP-ASSOCIATE roundtrip");
+        assert_eq!(echoed, payload, "expected UDP echo to return the payload unchanged");
+    }
+
+    #[skuld::test(labels = [DIST_BIN])]
+    fn e2e_socks_only_udp_associate_no_plugin(
+        #[fixture(dist_dir)] dist: &Path,
+        #[fixture(ssserver_none)] ss: &SsServerHandle,
+    ) {
+        rt().block_on(async {
+            let socks_port = allocate_ephemeral_port().await;
+            let http_port = allocate_ephemeral_port().await;
+            let config = base_config(ss, socks_port, http_port);
+
+            let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+            start_expect_ack(&mut harness, config).await;
+            run_udp_roundtrip(format!("127.0.0.1:{socks_port}").parse().unwrap()).await;
+            harness.send(BridgeRequest::Stop).await.expect("send Stop");
+        });
+    }
+
+    /// Skipped on Windows: same #197 galoshes `PluginConfig` bind race as
+    /// `e2e_ws_socks_only_roundtrip`. Lift this gate once #197 is fixed.
+    #[cfg(not(target_os = "windows"))]
+    #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
+    fn e2e_socks_only_udp_associate_galoshes(
+        #[fixture(dist_dir)] dist: &Path,
+        #[fixture(ssserver_ws)] ss: &SsServerHandle,
+    ) {
+        rt().block_on(async {
+            let socks_port = allocate_ephemeral_port().await;
+            let http_port = allocate_ephemeral_port().await;
+            let config = base_config(ss, socks_port, http_port);
+
+            let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+            start_expect_ack(&mut harness, config).await;
+            run_udp_roundtrip(format!("127.0.0.1:{socks_port}").parse().unwrap()).await;
             harness.send(BridgeRequest::Stop).await.expect("send Stop");
         });
     }

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -91,12 +91,13 @@ fn full_mode_socks5_is_tcp_and_udp() {
 }
 
 #[skuld::test]
-fn socks_only_mode_socks5_is_tcp_only() {
+fn socks_only_mode_socks5_is_tcp_and_udp() {
+    // Post-#250: SocksOnly listener also exposes UDP-ASSOCIATE.
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
     let ss = build_ss_config(&cfg, None).unwrap();
     let mode = ss.local[0].config.mode;
-    assert_eq!(format!("{mode:?}"), "TcpOnly");
+    assert_eq!(format!("{mode:?}"), "TcpAndUdp");
 }
 
 #[skuld::test]

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -66,7 +66,8 @@ fn fast_test_config(sentinel_a: SocketAddr, sentinel_b: SocketAddr) -> TestConfi
 #[skuld::test]
 fn fixture_starts_real_ss_server() {
     rt().block_on(async {
-        let (svr_addr, _svr_handle) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr_handle) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         assert!(svr_addr.ip().is_loopback(), "server bound to non-loopback");
         assert_ne!(svr_addr.port(), 0, "server port not assigned");
 
@@ -97,7 +98,8 @@ fn preflight_only_config() -> TestConfig {
 #[skuld::test]
 fn run_test_returns_reachable_for_valid_credentials() {
     rt().block_on(async {
-        let (svr_addr, _svr_handle) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr_handle) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         let (sentinel_a, _sa) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
         let (sentinel_b, _sb) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
 
@@ -185,7 +187,8 @@ fn run_test_returns_tcp_refused_for_closed_port() {
 #[skuld::test]
 fn run_test_returns_tunnel_handshake_failed_for_wrong_password() {
     rt().block_on(async {
-        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         let (sentinel_a, _sa) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
         let (sentinel_b, _sb) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
 
@@ -213,7 +216,8 @@ fn run_test_returns_tunnel_handshake_failed_for_wrong_password() {
 #[skuld::test]
 fn run_test_returns_tunnel_handshake_failed_for_wrong_cipher() {
     rt().block_on(async {
-        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         let (sentinel_a, _sa) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
         let (sentinel_b, _sb) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
 
@@ -239,7 +243,8 @@ fn run_test_returns_tunnel_handshake_failed_for_wrong_cipher() {
 #[skuld::test]
 fn run_test_returns_sentinel_mismatch_for_garbage_response() {
     rt().block_on(async {
-        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         // Six all-zero bytes — definitely not "HTTP".
         let (sentinel_a, _sa) = start_fake_sentinel(vec![0u8, 0, 0, 0, 0, 0]).await;
         let (sentinel_b, _sb) = start_fake_sentinel(vec![0u8, 0, 0, 0, 0, 0]).await;
@@ -276,7 +281,8 @@ fn run_test_returns_sentinel_mismatch_for_garbage_response() {
 #[skuld::test]
 fn run_test_returns_server_cannot_reach_internet_when_sentinels_close_empty() {
     rt().block_on(async {
-        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         // Empty response — fake sentinel reads our HEAD, writes nothing,
         // closes its socket. This is the cleanest simulation of "upstream
         // accepted connection but had nothing to say".
@@ -308,7 +314,8 @@ fn run_test_returns_server_cannot_reach_internet_when_sentinels_close_empty() {
 #[skuld::test]
 fn run_test_returns_plugin_start_failed_for_bad_plugin_path() {
     rt().block_on(async {
-        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD).await;
+        let port = crate::test_support::port_alloc::allocate_ephemeral_port().await;
+        let (svr_addr, _svr) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, port).await;
         let (sentinel_a, _sa) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
         let (sentinel_b, _sb) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
 

--- a/crates/bridge/src/test_support/skuld_fixtures.rs
+++ b/crates/bridge/src/test_support/skuld_fixtures.rs
@@ -80,10 +80,18 @@ pub(crate) fn test_certs() -> Result<TestCerts, String> {
 }
 
 /// Plain shadowsocks server, no plugin.
-#[skuld::fixture(scope = process)]
+///
+/// `serial = PORT_ALLOC` because `start_real_ss_server` requires a
+/// pre-allocated port (see the docstring there for why) — and pre-allocation
+/// has a TOCTOU window with concurrent fixture inits.
+#[skuld::fixture(scope = process, serial = PORT_ALLOC)]
 pub(crate) fn ssserver_none() -> Result<SsServerHandle, String> {
     let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
-    let (addr, _handle) = runtime.block_on(start_real_ss_server(TEST_METHOD, TEST_PASSWORD));
+    let addr = runtime.block_on(async {
+        let public_port = allocate_ephemeral_port().await;
+        let (addr, _handle) = start_real_ss_server(TEST_METHOD, TEST_PASSWORD, public_port).await;
+        addr
+    });
     Ok(SsServerHandle {
         addr,
         method: TEST_METHOD_STR,

--- a/crates/bridge/src/test_support/ssserver.rs
+++ b/crates/bridge/src/test_support/ssserver.rs
@@ -39,23 +39,28 @@ pub(crate) fn random_password_for(method: CipherKind) -> String {
     }
 }
 
-/// Spin up a real shadowsocks server bound to `127.0.0.1:0` with the given
-/// cipher/password. Returns the bound TCP address and a handle to the
-/// running server task. The server relays anything the client asks for.
-pub(crate) async fn start_real_ss_server(method: CipherKind, password: &str) -> (SocketAddr, JoinHandle<()>) {
-    let mut svr_cfg = ServerConfig::new(("127.0.0.1", 0u16), password.to_string(), method).unwrap();
+/// Spin up a real shadowsocks server bound to `127.0.0.1:public_port` with
+/// the given cipher/password. Returns the bound TCP address and a handle to
+/// the running server task. The server relays anything the client asks for.
+///
+/// The caller must pre-allocate `public_port` (via
+/// [`crate::test_support::port_alloc::allocate_ephemeral_port`]) instead of
+/// passing 0: shadowsocks-rust's `ServerBuilder` clones `svr_cfg` when
+/// constructing both `TcpServer` and `UdpServer`. With port 0 each side
+/// would bind to a *different* kernel-allocated port, so UDP datagrams
+/// addressed at the TCP port (the only address the bridge knows) would
+/// arrive at a port with no UDP listener and be silently dropped.
+pub(crate) async fn start_real_ss_server(
+    method: CipherKind,
+    password: &str,
+    public_port: u16,
+) -> (SocketAddr, JoinHandle<()>) {
+    let mut svr_cfg = ServerConfig::new(("127.0.0.1", public_port), password.to_string(), method).unwrap();
     svr_cfg.set_mode(Mode::TcpAndUdp);
 
     let server = SsServerBuilder::new(svr_cfg).build().await.unwrap();
 
-    // Read the bound address BEFORE moving `server` into the spawn closure.
-    // The `&TcpServer` borrow ends at the semicolon.
-    let addr = server
-        .tcp_server()
-        .expect("TCP mode is enabled, tcp_server should exist")
-        .local_addr()
-        .unwrap();
-
+    let addr: SocketAddr = format!("127.0.0.1:{public_port}").parse().unwrap();
     let handle = tokio::spawn(async move {
         // Server::run consumes self and only ever returns Err on teardown
         // ("server exited unexpectedly"). The test ignores the error.

--- a/crates/bridge/src/test_support/ssserver.rs
+++ b/crates/bridge/src/test_support/ssserver.rs
@@ -44,7 +44,7 @@ pub(crate) fn random_password_for(method: CipherKind) -> String {
 /// running server task. The server relays anything the client asks for.
 pub(crate) async fn start_real_ss_server(method: CipherKind, password: &str) -> (SocketAddr, JoinHandle<()>) {
     let mut svr_cfg = ServerConfig::new(("127.0.0.1", 0u16), password.to_string(), method).unwrap();
-    svr_cfg.set_mode(Mode::TcpOnly); // skip UDP — the runner is TCP-only
+    svr_cfg.set_mode(Mode::TcpAndUdp);
 
     let server = SsServerBuilder::new(svr_cfg).build().await.unwrap();
 
@@ -125,13 +125,13 @@ async fn spawn_ss_with_plugin(
     plugin_opts: &str,
 ) -> (SocketAddr, JoinHandle<()>) {
     let mut svr_cfg = ServerConfig::new(("127.0.0.1", public_port), password.to_string(), method).unwrap();
-    svr_cfg.set_mode(Mode::TcpOnly);
+    svr_cfg.set_mode(Mode::TcpAndUdp);
 
     svr_cfg.set_plugin(PluginConfig {
         plugin: plugin_path.to_string(),
         plugin_opts: Some(plugin_opts.to_string()),
         plugin_args: vec![],
-        plugin_mode: Mode::TcpOnly,
+        plugin_mode: Mode::TcpAndUdp,
     });
 
     let server = SsServerBuilder::new(svr_cfg).build().await.unwrap();

--- a/crates/bridge/src/test_support/udp_echo.rs
+++ b/crates/bridge/src/test_support/udp_echo.rs
@@ -1,9 +1,17 @@
-//! UDP echo-server fixture for E2E tests. Binds on `0.0.0.0:0` and
-//! reports the host's primary non-loopback IPv4 address — TUN-mode
-//! bridge tests cannot use `127.0.0.1` because the bridge's
-//! `route add 127.0.0.1 ...` bypass redirects loopback traffic through
-//! the TUN adapter (see `proxy_manager_e2e_tests.rs` `run_full_tunnel_e2e`
-//! caveat). `Drop` aborts the echo task.
+//! UDP echo-server fixture for E2E tests.
+//!
+//! Two binding shapes:
+//!
+//! * [`UdpEchoServer::start`] — binds `0.0.0.0:0` and reports the host's
+//!   primary non-loopback IPv4. Required for TUN-mode tests because the
+//!   bridge's `route add 127.0.0.1 ...` bypass redirects loopback
+//!   traffic around the TUN adapter (see
+//!   `proxy_manager_e2e_tests.rs` `run_full_tunnel_e2e` caveat).
+//! * [`UdpEchoServer::start_loopback`] — binds and reports
+//!   `127.0.0.1:0`. For SocksOnly-mode tests, where there is no TUN
+//!   and therefore no loopback bypass; loopback delivery is direct.
+//!
+//! `Drop` aborts the echo task.
 
 use crate::test_support::net_discovery::detect_primary_ipv4;
 use std::net::SocketAddr;
@@ -12,19 +20,29 @@ use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 
 pub struct UdpEchoServer {
-    /// The address tests should send UDP datagrams to. Uses the host's
-    /// primary non-loopback IPv4 so packets flow through the TUN device
-    /// and back to the local socket.
+    /// The address tests should send UDP datagrams to.
     pub addr: SocketAddr,
     task: JoinHandle<()>,
 }
 
 impl UdpEchoServer {
+    /// Bind `0.0.0.0:0` and report the host's primary non-loopback IPv4.
     pub async fn start() -> std::io::Result<Self> {
         let primary = detect_primary_ipv4().map_err(std::io::Error::other)?;
         let sock = UdpSocket::bind("0.0.0.0:0").await?;
         let port = sock.local_addr()?.port();
-        let addr = SocketAddr::from((primary, port));
+        let reported = SocketAddr::from((primary, port));
+        Ok(Self::spawn(sock, reported))
+    }
+
+    /// Bind and report `127.0.0.1:0`. For tests that don't go through TUN.
+    pub async fn start_loopback() -> std::io::Result<Self> {
+        let sock = UdpSocket::bind("127.0.0.1:0").await?;
+        let reported = sock.local_addr()?;
+        Ok(Self::spawn(sock, reported))
+    }
+
+    fn spawn(sock: UdpSocket, reported: SocketAddr) -> Self {
         let sock = Arc::new(sock);
         let server_sock = Arc::clone(&sock);
         let task = tokio::spawn(async move {
@@ -40,7 +58,7 @@ impl UdpEchoServer {
                 }
             }
         });
-        Ok(Self { addr, task })
+        Self { addr: reported, task }
     }
 }
 


### PR DESCRIPTION
Closes #250.

## Summary

Reverts the [#189 workaround](https://github.com/bindreams/hole/pull/192) that force-downgrades the SocksOnly SOCKS5 listener to `Mode::TcpOnly`, restoring SOCKS5 UDP-ASSOCIATE for SocksOnly users (real-world clients like hev-socks5-tunnel, ss-tunnel, proxychains-ng UDP, and the in-bridge DNS forwarder's UDP path).

The original attribution — "select_all inside shadowsocks-service drops the TCP listener when the UDP future completes early on Windows" — was unsupported by log evidence. The CI bridge.log artifact for the failing #189 run has zero shadowsocks-service log lines, because `tracing-log`'s `LogTracer` is not installed (`tracing-subscriber` is declared without the `tracing-log` feature). The actual cause was wintun-NDIS-loopback breakage on the Azure-hosted Windows runner (#200), correctly fixed by PR #207's two-pass test ordering.

## Changes

| file | change |
| --- | --- |
| `crates/bridge/src/proxy/config.rs` | drop the `match` on `tunnel_mode`; SOCKS5 listener is always `Mode::TcpAndUdp`. Rewrite the doc comment to cite the real story. |
| `crates/bridge/src/test_support/ssserver.rs` | enable `Mode::TcpAndUdp` server-side in `start_real_ss_server` and `spawn_ss_with_plugin` (`plugin_mode` too). Without this, encapsulated UDP datagrams arriving at the test ss-server would be dropped. |
| `crates/bridge/src/test_support/udp_echo.rs` | add `UdpEchoServer::start_loopback` (sibling of the existing primary-IPv4 `start`). Refactor common spawn logic into a private helper. |
| `crates/bridge/src/proxy_manager_listener_e2e_tests.rs` | new `mod socks_only_udp` with two tests; update the `mod tun` preamble comment to drop the now-stale "#189 forces TcpOnly" claim. |
| `CLAUDE.md` | rewrite the "Listener selection invariants" SOCKS5 mode paragraph. |

## New tests

- `e2e_socks_only_udp_associate_no_plugin` — `[DIST_BIN]`, no plugin. UDP-ASSOCIATE through the bridge to a loopback echo server.
- `e2e_socks_only_udp_associate_galoshes` — `[DIST_BIN, PORT_ALLOC]`, galoshes (websocket). Skipped on Windows under #197 (same `PluginConfig` bind race that gates `e2e_ws_socks_only_roundtrip`). Lifts when #197 lands.

Both labels: pass-1 (`SKULD_LABELS="!tun"`) where loopback delivery is intact (PR #207).

## Audit of PR #192's other Windows skips

Per #250's body: `aa59b86` (cipher_chacha20) and `35821ee` (cipher_2022) were already reverted; `eab93f2` (server_test_tests on Windows + macOS) is still gated and is likely safely reversible on Windows under PR #207's two-pass ordering. Tracked as a follow-up; not changed in this PR.

## Test plan

- [ ] CI green: Linux + macOS run both new tests; Windows pass-1 runs `e2e_socks_only_udp_associate_no_plugin` (galoshes variant skipped under #197).
- [ ] Windows pass-2 (`SKULD_LABELS="tun"`) still runs the existing `mod tun` UDP test green.
- [ ] No regressions in TCP-only tests using `ssserver_none` / `ssserver_ws` / `ssserver_ws_tls` / `ssserver_quic` (the server fixtures now also bind UDP server-side, which is benign for TCP-only callers).