### PR TITLE
project settings: allow gh workflow run + target/{release,debug} bash

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,10 @@
       "Bash(uv run --directory msi-installer upgrade-wix *)",
       "Bash(cargo nextest run *)",
       "Bash(cargo xtask deps *)",
-      "Bash(cargo xtask stage *)"
+      "Bash(cargo xtask stage *)",
+      "Bash(gh workflow run ci.yaml)",
+      "Bash(./target/release/* *)",
+      "Bash(./target/debug/* *)"
     ]
   }
 }


### PR DESCRIPTION
Extend `.claude/settings.json` allow-list with three Bash permissions routinely used but currently prompting:

- `Bash(gh workflow run ci.yaml)`
- `Bash(./target/release/* *)`
- `Bash(./target/debug/* *)`

Closes #260.

## Test plan
- [x] Pre-commit hooks pass locally
- [ ] CI green