### PR TITLE
dns/forwarder: per-layer timing + byte counts + log_first_N for #248

### DIFF
--- a/crates/bridge/src/dns/connector.rs
+++ b/crates/bridge/src/dns/connector.rs
@@ -9,15 +9,23 @@
 //!   through the local shadowsocks SOCKS5 listener so user filter rules
 //!   cannot strand the forwarder.
 //!
-//! The trait deliberately returns type-erased streams so a SOCKS5 impl
-//! can substitute `tokio_socks::tcp::Socks5Stream<TcpStream>` at the same
-//! interface point as a bare `TcpStream`.
+//! The trait returns [`ConnectedStream`] — a `BoxedStream` paired with
+//! two `AtomicU64` byte counters observed by a [`CountingStream`] wrapper
+//! around the underlying socket. The counters are what lets the forwarder
+//! log `tcp_wrote` / `tcp_read` on a TLS-layer failure in #248
+//! diagnostics: `read=0` means the peer FIN'd before sending a byte;
+//! `read=<small>` means mid-handshake close; `read=<KBs>` means full
+//! handshake bytes delivered then close.
 
 use std::io;
 use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpStream, UdpSocket};
 
 /// Bidirectional byte stream used by every TCP-based DNS transport
@@ -28,8 +36,100 @@ pub trait AsyncDuplex: AsyncRead + AsyncWrite + Send + Unpin {}
 impl<T: AsyncRead + AsyncWrite + Send + Unpin + ?Sized> AsyncDuplex for T {}
 
 /// Boxed TCP stream — direct `TcpStream` or a SOCKS5-wrapped
-/// `Socks5Stream<TcpStream>` at runtime.
+/// `Socks5Stream<TcpStream>` at runtime. Always wrapped in a
+/// [`CountingStream`] before boxing, so its byte counts are observable
+/// via the paired [`StreamCounters`].
 pub type BoxedStream = Box<dyn AsyncDuplex>;
+
+/// Per-stream byte counters handed back by a connector alongside the
+/// stream itself. Cheap to clone (two `Arc` bumps).
+#[derive(Debug, Default, Clone)]
+pub struct StreamCounters {
+    read_bytes: Arc<AtomicU64>,
+    write_bytes: Arc<AtomicU64>,
+}
+
+impl StreamCounters {
+    pub fn read(&self) -> u64 {
+        self.read_bytes.load(Ordering::Relaxed)
+    }
+
+    pub fn written(&self) -> u64 {
+        self.write_bytes.load(Ordering::Relaxed)
+    }
+}
+
+/// A stream paired with its byte counters. Returned by
+/// [`UpstreamConnector::connect_tcp`]; callers keep the counters to read
+/// on error and hand the stream off to rustls / the plain-TCP exchange.
+pub struct ConnectedStream {
+    pub stream: BoxedStream,
+    pub counters: StreamCounters,
+}
+
+impl ConnectedStream {
+    /// Split into stream + counters so the stream can be moved into
+    /// rustls / framed-exchange while the counters are retained for the
+    /// error path.
+    pub fn into_parts(self) -> (BoxedStream, StreamCounters) {
+        (self.stream, self.counters)
+    }
+}
+
+/// Wraps an `AsyncRead + AsyncWrite` and increments a pair of
+/// `Arc<AtomicU64>` counters on every successful `poll_read` / `poll_write`
+/// call. Counts raw bytes on the wrapped stream, *not* decoded-TLS bytes —
+/// for SOCKS5-wrapped streams the bytes counted are post-SOCKS5-CONNECT
+/// payload bytes, i.e. what a DoH server / plain-TCP peer would see.
+pub struct CountingStream<S> {
+    inner: S,
+    counters: StreamCounters,
+}
+
+impl<S> CountingStream<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            counters: StreamCounters::default(),
+        }
+    }
+
+    pub fn counters(&self) -> StreamCounters {
+        self.counters.clone()
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for CountingStream<S> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let res = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &res {
+            let delta = (buf.filled().len() - before) as u64;
+            if delta > 0 {
+                self.counters.read_bytes.fetch_add(delta, Ordering::Relaxed);
+            }
+        }
+        res
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for CountingStream<S> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        let res = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &res {
+            self.counters.write_bytes.fetch_add(*n as u64, Ordering::Relaxed);
+        }
+        res
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
 
 /// UDP send/recv abstraction. Separate from [`AsyncDuplex`] because the
 /// SOCKS5 UDP ASSOCIATE path wraps an inner socket and prepends a header,
@@ -46,7 +146,9 @@ pub trait UpstreamUdp: Send + Sync {
 pub trait UpstreamConnector: Send + Sync {
     /// Open a TCP connection to `target`. SOCKS5 impls route via the
     /// shadowsocks listener; the direct impl just calls `TcpStream::connect`.
-    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<BoxedStream>;
+    /// Both wrap the resulting socket in a [`CountingStream`] so the
+    /// forwarder can log post-SOCKS5 byte counts on error.
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<ConnectedStream>;
 
     /// Open a UDP socket, bound locally and connected to `target`.
     /// SOCKS5 impls perform UDP ASSOCIATE, which only succeeds when the
@@ -63,9 +165,14 @@ pub struct DirectConnector;
 
 #[async_trait]
 impl UpstreamConnector for DirectConnector {
-    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<BoxedStream> {
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<ConnectedStream> {
         let stream = TcpStream::connect(target).await?;
-        Ok(Box::new(stream))
+        let counting = CountingStream::new(stream);
+        let counters = counting.counters();
+        Ok(ConnectedStream {
+            stream: Box::new(counting),
+            counters,
+        })
     }
 
     async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -11,7 +11,7 @@
 //! upstream interface has no IPv6 connectivity — matches the spec in the
 //! plan.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
@@ -23,16 +23,16 @@ use rustls::{ClientConfig, RootCertStore};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 
-use crate::dns::connector::UpstreamConnector;
+use crate::dns::connector::{StreamCounters, UpstreamConnector};
 use crate::dns::providers;
 
 // Typed errors ========================================================================================================
 
-/// Which layer of the upstream stack emitted the error. Lets Phase-2
-/// observation of #248 distinguish SOCKS5-layer failures from TLS
-/// handshake failures from mid-stream I/O EOFs — all of which currently
-/// surface as a bare `io::Error` with message `"tls handshake eof"` or
-/// similar.
+/// Which layer of the upstream stack emitted the error. Lets #248
+/// observation distinguish SOCKS5-layer failures from TLS handshake
+/// failures from mid-stream I/O EOFs from outer-budget timeout
+/// cancellation — all of which previously surfaced as a bare `io::Error`
+/// with message `"tls handshake eof"` or similar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpstreamLayer {
     /// TCP or UDP connect. For `Socks5Connector`, this includes the
@@ -47,6 +47,11 @@ pub enum UpstreamLayer {
     Http,
     /// Post-handshake read / write on the upstream stream.
     Io,
+    /// Outer `UPSTREAM_TIMEOUT` budget fired. Distinct from `Io` so
+    /// observers can tell "inner future completed with error at 2573ms"
+    /// from "outer timer cancelled the future at exactly 3000ms" —
+    /// different root causes, different fixes. Ref #248.
+    Timeout,
 }
 
 impl UpstreamLayer {
@@ -56,6 +61,7 @@ impl UpstreamLayer {
             Self::Tls => "tls",
             Self::Http => "http",
             Self::Io => "io",
+            Self::Timeout => "timeout",
         }
     }
 }
@@ -66,24 +72,67 @@ impl std::fmt::Display for UpstreamLayer {
     }
 }
 
-/// Tagged upstream failure: `{ layer, source, elapsed_ms }`. Logged via
-/// [`DnsForwarder::log_upstream_failure`] with the `source`-walk as a
-/// `caused_by=...` field. `io::Error` itself is `!Clone`, so `UpstreamErr`
-/// cannot be `Clone` — consumed once on the log path.
+/// Tagged upstream failure: `{ layer, source, elapsed_ms }` plus optional
+/// diagnostic context captured at the point of failure. `io::Error` is
+/// `!Clone`, so `UpstreamErr` cannot be `Clone` — consumed once on the
+/// log path.
 #[derive(Debug)]
 pub struct UpstreamErr {
     pub layer: UpstreamLayer,
     pub source: io::Error,
+    /// Wall-clock from `forward_one`'s `Instant::now()` to error emission.
+    /// Bounded above by [`UPSTREAM_TIMEOUT`].
     pub elapsed_ms: u64,
+    /// Time from `forward_one` start to return of `connector.connect_tcp`.
+    /// `Some` whenever the TCP/SOCKS5-level connection completed
+    /// (Tls/Io/Http failures); `None` when we errored at `Connect` or
+    /// `Timeout` fired before connect completed.
+    pub socks5_ms: Option<u64>,
+    /// Time spent inside `tokio_rustls::TlsConnector::connect(...)`.
+    /// `Some` on `Tls`/`Io`/`Http` layers; `None` otherwise.
+    pub tls_ms: Option<u64>,
+    /// Raw bytes written to / read from the underlying TCP stream,
+    /// observed by [`crate::dns::connector::CountingStream`]. `None` when
+    /// connect failed (no stream existed). Post-SOCKS5 byte counts —
+    /// what a DoH server would see.
+    pub tcp_wrote: Option<u64>,
+    pub tcp_read: Option<u64>,
+    /// First `io::Error::raw_os_error()` found walking
+    /// `std::error::Error::source()` from `source`. Distinguishes FIN
+    /// (graceful close, `None` on Windows since FIN surfaces as `Ok(0)`
+    /// with no errno) from RST (`WSAECONNRESET=10054`) and friends.
+    pub os_errno: Option<i32>,
 }
 
 impl UpstreamErr {
-    fn new(layer: UpstreamLayer, source: io::Error) -> Self {
+    pub fn new(layer: UpstreamLayer, source: io::Error) -> Self {
+        let os_errno = first_os_errno(&source);
         Self {
             layer,
             source,
             elapsed_ms: 0,
+            socks5_ms: None,
+            tls_ms: None,
+            tcp_wrote: None,
+            tcp_read: None,
+            os_errno,
         }
+    }
+
+    fn with_socks5_ms(mut self, ms: u64) -> Self {
+        self.socks5_ms = Some(ms);
+        self
+    }
+
+    fn with_tls_ms(mut self, ms: u64) -> Self {
+        self.tls_ms = Some(ms);
+        self
+    }
+
+    fn with_counters(mut self, c: &StreamCounters) -> Self {
+        self.tcp_read = Some(c.read());
+        self.tcp_wrote = Some(c.written());
+        self
     }
 }
 
@@ -99,6 +148,33 @@ fn format_error_chain(e: &(dyn std::error::Error + 'static)) -> String {
         current = c.source();
     }
     s
+}
+
+/// Walk `std::error::Error::source()` looking for the first
+/// `io::Error::raw_os_error()` value. Needed because tokio-rustls wraps
+/// its own `tls handshake eof` around a synthesized inner `io::Error`
+/// that has no errno — but if the root is a real socket error
+/// (`WSAECONNRESET` on Windows) it's further down the chain.
+///
+/// Special-cases `io::Error`: its `Error::source()` impl skips the
+/// Custom-wrapper and delegates to the *inner* error's `source()`,
+/// which would hide the inner `io::Error` entirely. Use `get_ref()` to
+/// descend through nested `io::Error` directly.
+fn first_os_errno(e: &(dyn std::error::Error + 'static)) -> Option<i32> {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(err) = current {
+        if let Some(io_err) = err.downcast_ref::<io::Error>() {
+            if let Some(errno) = io_err.raw_os_error() {
+                return Some(errno);
+            }
+            if let Some(inner) = io_err.get_ref() {
+                current = Some(inner);
+                continue;
+            }
+        }
+        current = err.source();
+    }
+    None
 }
 
 /// Upstream port for plain DNS (RFC 1035) and DoT (RFC 7858).
@@ -119,6 +195,63 @@ const MAX_REPLY_SIZE: usize = 16 * 1024;
 /// SERVFAIL rcode per RFC 1035 §4.1.1.
 const RCODE_SERVFAIL: u8 = 2;
 
+// Log throttle ========================================================================================================
+
+/// Max full log lines per server before suppressing.
+const LOG_FULL_LIMIT: u32 = 3;
+/// Minimum interval between summary lines per server.
+const SUMMARY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Per-server state for log-first-N-then-summarize. Replaces the previous
+/// per-server dedup-forever `log_once` on the upstream-failure path, which
+/// hid all but the first failure per server IP and blocked Phase-2
+/// observation of #248.
+///
+/// - First [`LOG_FULL_LIMIT`] failures per server are logged in full.
+/// - After that, a rolling summary line `upstream failed (N suppressed
+///   since first, window=Xs)` is emitted at most every
+///   [`SUMMARY_INTERVAL`], driven lazily by the next failure event.
+///
+/// Summary is lazy-not-timer: if failures stop, the residual suppressed
+/// count never gets flushed — acceptable tradeoff for avoiding a
+/// background task, and consistent with "the error was transient" being
+/// a valid outcome.
+#[derive(Debug)]
+struct ThrottleState {
+    logged: u32,
+    suppressed: u32,
+    first_at: Instant,
+    last_summary_at: Instant,
+}
+
+impl ThrottleState {
+    fn new(now: Instant) -> Self {
+        Self {
+            logged: 0,
+            suppressed: 0,
+            first_at: now,
+            last_summary_at: now,
+        }
+    }
+}
+
+/// Outcome of consulting the throttle for a new failure. Returned from
+/// the mutex-scoped decision function so the tracing macro invocation
+/// happens *outside* the lock (keeps the critical section short and
+/// avoids any surprise reentrancy).
+enum ThrottleDecision {
+    /// Emit the full log line, first/second/... occurrence.
+    LogFull,
+    /// Suppress; nothing to emit.
+    Suppress,
+    /// Suppress the current failure itself, but emit the rolling
+    /// summary line with the counts snapshot from the prior window.
+    SuppressAndSummary {
+        suppressed_count: u32,
+        window_elapsed: Duration,
+    },
+}
+
 // Public API ==========================================================================================================
 
 pub struct DnsForwarder {
@@ -126,10 +259,15 @@ pub struct DnsForwarder {
     connector: Arc<dyn UpstreamConnector>,
     tls_config: Arc<ClientConfig>,
     ipv6_bypass_available: bool,
-    /// Dedup state for per-server WARN log lines. Held in a `std::Mutex`
-    /// (never across an `await`) — each forward() call either hits or
-    /// misses the set and moves on.
-    logged_servers: Mutex<HashSet<IpAddr>>,
+    /// Per-server throttle state for upstream-failure logs. Held in a
+    /// `std::Mutex` (never across an `await`) — each forward() call
+    /// either hits or misses the map and moves on.
+    failure_throttle: Mutex<HashMap<IpAddr, ThrottleState>>,
+    /// Per-server set for the config-static IPv6-skip log. Separate
+    /// from [`Self::failure_throttle`] because the IPv6-skip condition
+    /// cannot change without a reconfigure; log-first-1-forever is
+    /// correct there.
+    ipv6_skip_logged: Mutex<HashSet<IpAddr>>,
 }
 
 impl DnsForwarder {
@@ -143,7 +281,8 @@ impl DnsForwarder {
             connector,
             tls_config,
             ipv6_bypass_available,
-            logged_servers: Mutex::new(HashSet::new()),
+            failure_throttle: Mutex::new(HashMap::new()),
+            ipv6_skip_logged: Mutex::new(HashSet::new()),
         }
     }
 
@@ -157,7 +296,7 @@ impl DnsForwarder {
 
         for &server in &self.config.servers {
             if server.is_ipv6() && !self.ipv6_bypass_available {
-                self.log_once(server, "skipping IPv6 upstream (no IPv6 bypass available)");
+                self.log_ipv6_skip_once(server);
                 continue;
             }
 
@@ -171,10 +310,10 @@ impl DnsForwarder {
         synthesize_servfail(query)
     }
 
-    /// Single-attempt forward against `target`. Callers build `target` from
-    /// the config'd server plus the protocol's well-known port; the
-    /// test-only `forward_with_ports` builds it from an ephemeral port so
-    /// stubs don't need privilege to bind 53/853/443.
+    /// Single-attempt forward against `target`. Callers build `target`
+    /// from the config'd server plus the protocol's well-known port;
+    /// the test-only `forward_with_ports` builds it from an ephemeral
+    /// port so stubs don't need privilege to bind 53/853/443.
     async fn forward_one(&self, target: SocketAddr, query: &[u8]) -> Result<Vec<u8>, UpstreamErr> {
         let started = Instant::now();
         let fut = async {
@@ -188,7 +327,7 @@ impl DnsForwarder {
         let result = match timeout(UPSTREAM_TIMEOUT, fut).await {
             Ok(res) => res,
             Err(_) => Err(UpstreamErr::new(
-                UpstreamLayer::Io,
+                UpstreamLayer::Timeout,
                 io::Error::new(io::ErrorKind::TimedOut, "upstream timeout"),
             )),
         };
@@ -198,32 +337,81 @@ impl DnsForwarder {
         })
     }
 
-    /// Log a server-static message exactly once per server IP. Used for
-    /// invariant-static conditions like "IPv6 server skipped because no
-    /// IPv6 bypass is available" where a counter/summary would be noise —
-    /// the condition cannot change without a reconfigure.
-    fn log_once(&self, server: IpAddr, msg: &str) {
-        let mut set = self.logged_servers.lock().expect("poisoned");
-        if set.insert(server) {
-            tracing::warn!(%server, protocol = ?self.config.protocol, "{msg}");
-        }
-    }
-
-    /// Log an upstream failure with the typed layer tag + elapsed + source
-    /// chain. Per-server deduplication mirrors `log_once` — Phase 4 of
-    /// #248 will replace this with log-first-3-then-summarize-every-60s
-    /// (tracked in the plan, separate PR).
-    fn log_upstream_failure(&self, server: IpAddr, e: &UpstreamErr) {
-        let mut set = self.logged_servers.lock().expect("poisoned");
+    /// Log a config-static server-skip message exactly once per server
+    /// IP. Used only for the IPv6-no-bypass case where the condition
+    /// cannot change without a reconfigure, so a rolling summary would
+    /// be noise.
+    fn log_ipv6_skip_once(&self, server: IpAddr) {
+        let mut set = self.ipv6_skip_logged.lock().expect("poisoned");
         if set.insert(server) {
             tracing::warn!(
                 %server,
                 protocol = ?self.config.protocol,
-                layer = %e.layer,
-                elapsed_ms = e.elapsed_ms,
-                caused_by = %format_error_chain(&e.source),
-                "upstream failed"
+                "skipping IPv6 upstream (no IPv6 bypass available)"
             );
+        }
+    }
+
+    /// Log an upstream failure with the typed layer tag + elapsed + source
+    /// chain + optional per-layer diagnostic context. Per-server
+    /// log-first-N-then-summarize throttle; see [`ThrottleState`].
+    fn log_upstream_failure(&self, server: IpAddr, e: &UpstreamErr) {
+        let decision = {
+            let mut map = self.failure_throttle.lock().expect("poisoned");
+            let now = Instant::now();
+            let state = map.entry(server).or_insert_with(|| ThrottleState::new(now));
+
+            if state.logged < LOG_FULL_LIMIT {
+                state.logged += 1;
+                ThrottleDecision::LogFull
+            } else {
+                state.suppressed += 1;
+                let since_summary = now.duration_since(state.last_summary_at);
+                if since_summary >= SUMMARY_INTERVAL {
+                    let count = state.suppressed;
+                    let window = now.duration_since(state.first_at);
+                    state.suppressed = 0;
+                    state.last_summary_at = now;
+                    ThrottleDecision::SuppressAndSummary {
+                        suppressed_count: count,
+                        window_elapsed: window,
+                    }
+                } else {
+                    ThrottleDecision::Suppress
+                }
+            }
+        };
+
+        match decision {
+            ThrottleDecision::LogFull => {
+                tracing::warn!(
+                    %server,
+                    protocol = ?self.config.protocol,
+                    layer = %e.layer,
+                    elapsed_ms = e.elapsed_ms,
+                    budget_ms = UPSTREAM_TIMEOUT.as_millis() as u64,
+                    socks5_ms = ?e.socks5_ms,
+                    tls_ms = ?e.tls_ms,
+                    tcp_wrote = ?e.tcp_wrote,
+                    tcp_read = ?e.tcp_read,
+                    os_errno = ?e.os_errno,
+                    caused_by = %format_error_chain(&e.source),
+                    "upstream failed"
+                );
+            }
+            ThrottleDecision::Suppress => {}
+            ThrottleDecision::SuppressAndSummary {
+                suppressed_count,
+                window_elapsed,
+            } => {
+                tracing::warn!(
+                    %server,
+                    protocol = ?self.config.protocol,
+                    suppressed = suppressed_count,
+                    window_s = window_elapsed.as_secs(),
+                    "upstream failed (summary — full logging resumed at next interval)"
+                );
+            }
         }
     }
 }
@@ -265,14 +453,19 @@ impl DnsForwarder {
 
 impl DnsForwarder {
     async fn forward_tcp(&self, target: SocketAddr, query: &[u8]) -> Result<Vec<u8>, UpstreamErr> {
-        let stream = self
+        let socks5_start = Instant::now();
+        let connected = self
             .connector
             .connect_tcp(target)
             .await
             .map_err(|e| UpstreamErr::new(UpstreamLayer::Connect, e))?;
-        exchange_tcp_framed(stream, query)
-            .await
-            .map_err(|e| UpstreamErr::new(UpstreamLayer::Io, e))
+        let socks5_ms = socks5_start.elapsed().as_millis() as u64;
+        let (stream, counters) = connected.into_parts();
+        exchange_tcp_framed(stream, query).await.map_err(|e| {
+            UpstreamErr::new(UpstreamLayer::Io, e)
+                .with_socks5_ms(socks5_ms)
+                .with_counters(&counters)
+        })
     }
 }
 
@@ -280,20 +473,35 @@ impl DnsForwarder {
 
 impl DnsForwarder {
     async fn forward_tls(&self, target: SocketAddr, query: &[u8]) -> Result<Vec<u8>, UpstreamErr> {
-        let stream = self
+        let socks5_start = Instant::now();
+        let connected = self
             .connector
             .connect_tcp(target)
             .await
             .map_err(|e| UpstreamErr::new(UpstreamLayer::Connect, e))?;
-        let server_name = tls_server_name_for(target.ip()).map_err(|e| UpstreamErr::new(UpstreamLayer::Tls, e))?;
-        let connector = tokio_rustls::TlsConnector::from(Arc::clone(&self.tls_config));
-        let tls = connector
-            .connect(server_name, stream)
-            .await
-            .map_err(|e| UpstreamErr::new(UpstreamLayer::Tls, e))?;
-        exchange_tcp_framed(tls, query)
-            .await
-            .map_err(|e| UpstreamErr::new(UpstreamLayer::Io, e))
+        let socks5_ms = socks5_start.elapsed().as_millis() as u64;
+        let (stream, counters) = connected.into_parts();
+
+        let server_name = tls_server_name_for(target.ip()).map_err(|e| {
+            UpstreamErr::new(UpstreamLayer::Tls, e)
+                .with_socks5_ms(socks5_ms)
+                .with_counters(&counters)
+        })?;
+        let tls_start = Instant::now();
+        let tls_connector = tokio_rustls::TlsConnector::from(Arc::clone(&self.tls_config));
+        let tls = tls_connector.connect(server_name, stream).await.map_err(|e| {
+            UpstreamErr::new(UpstreamLayer::Tls, e)
+                .with_socks5_ms(socks5_ms)
+                .with_tls_ms(tls_start.elapsed().as_millis() as u64)
+                .with_counters(&counters)
+        })?;
+        let tls_ms = tls_start.elapsed().as_millis() as u64;
+        exchange_tcp_framed(tls, query).await.map_err(|e| {
+            UpstreamErr::new(UpstreamLayer::Io, e)
+                .with_socks5_ms(socks5_ms)
+                .with_tls_ms(tls_ms)
+                .with_counters(&counters)
+        })
     }
 }
 
@@ -303,16 +511,25 @@ impl DnsForwarder {
     async fn forward_https(&self, target: SocketAddr, query: &[u8]) -> Result<Vec<u8>, UpstreamErr> {
         let (server_name, path_and_host) =
             https_target_for(target.ip()).map_err(|e| UpstreamErr::new(UpstreamLayer::Http, e))?;
-        let stream = self
+
+        let socks5_start = Instant::now();
+        let connected = self
             .connector
             .connect_tcp(target)
             .await
             .map_err(|e| UpstreamErr::new(UpstreamLayer::Connect, e))?;
-        let connector = tokio_rustls::TlsConnector::from(Arc::clone(&self.tls_config));
-        let mut tls = connector
-            .connect(server_name, stream)
-            .await
-            .map_err(|e| UpstreamErr::new(UpstreamLayer::Tls, e))?;
+        let socks5_ms = socks5_start.elapsed().as_millis() as u64;
+        let (stream, counters) = connected.into_parts();
+
+        let tls_start = Instant::now();
+        let tls_connector = tokio_rustls::TlsConnector::from(Arc::clone(&self.tls_config));
+        let mut tls = tls_connector.connect(server_name, stream).await.map_err(|e| {
+            UpstreamErr::new(UpstreamLayer::Tls, e)
+                .with_socks5_ms(socks5_ms)
+                .with_tls_ms(tls_start.elapsed().as_millis() as u64)
+                .with_counters(&counters)
+        })?;
+        let tls_ms = tls_start.elapsed().as_millis() as u64;
 
         let (host, path) = path_and_host;
         let mut req = Vec::with_capacity(256 + query.len());
@@ -330,19 +547,28 @@ impl DnsForwarder {
         .unwrap();
         req.extend_from_slice(query);
 
-        tls.write_all(&req)
-            .await
-            .map_err(|e| UpstreamErr::new(UpstreamLayer::Io, e))?;
-        tls.flush().await.map_err(|e| UpstreamErr::new(UpstreamLayer::Io, e))?;
+        let io_err = |e: io::Error| {
+            UpstreamErr::new(UpstreamLayer::Io, e)
+                .with_socks5_ms(socks5_ms)
+                .with_tls_ms(tls_ms)
+                .with_counters(&counters)
+        };
+        tls.write_all(&req).await.map_err(io_err)?;
+        tls.flush().await.map_err(io_err)?;
 
         let mut resp = Vec::with_capacity(4096);
         // Cap reads so a misbehaving server can't OOM us.
         tls.take((MAX_REPLY_SIZE * 4) as u64)
             .read_to_end(&mut resp)
             .await
-            .map_err(|e| UpstreamErr::new(UpstreamLayer::Io, e))?;
+            .map_err(io_err)?;
 
-        parse_http_dns_response(&resp).map_err(|e| UpstreamErr::new(UpstreamLayer::Http, e))
+        parse_http_dns_response(&resp).map_err(|e| {
+            UpstreamErr::new(UpstreamLayer::Http, e)
+                .with_socks5_ms(socks5_ms)
+                .with_tls_ms(tls_ms)
+                .with_counters(&counters)
+        })
     }
 }
 

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
@@ -259,11 +260,14 @@ async fn ipv6_upstream_skipped_when_no_v6_bypass() {
     assert_ne!(reply[3] & 0x0F, 2);
 }
 
-// Dedup ===============================================================================================================
+// Throttle ============================================================================================================
 
 #[skuld::test]
-async fn duplicate_server_in_list_logs_only_once() {
-    // Two identical dead addresses. Without dedup we'd log twice.
+async fn duplicate_server_in_list_creates_one_throttle_entry() {
+    // Two identical dead addresses share one per-IP throttle entry.
+    // The throttle counts `logged + suppressed` per server — in #248's
+    // Phase-2 shape, a single failure burst against the same server does
+    // not duplicate state across the map.
     let dead_addr = unused_tcp_port().await;
     let fwd = DnsForwarder::new(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), dead_addr.ip()]),
@@ -272,9 +276,57 @@ async fn duplicate_server_in_list_logs_only_once() {
     );
     let q = sample_query(0x0001);
     let _ = fwd.forward_with_ports(&q, &[dead_addr.port(), dead_addr.port()]).await;
-    // logged_servers should contain exactly one entry.
-    let set = fwd.logged_servers.lock().unwrap();
-    assert_eq!(set.len(), 1, "duplicate server logged only once");
+    let map = fwd.failure_throttle.lock().unwrap();
+    assert_eq!(map.len(), 1, "duplicate server has one throttle entry");
+    let state = map.get(&dead_addr.ip()).expect("throttle entry exists");
+    // Both attempts were below the full-limit, so both were logged in
+    // full — but `suppressed` remains 0 since we never crossed the
+    // limit.
+    assert_eq!(state.logged, 2, "both attempts counted as logged");
+    assert_eq!(state.suppressed, 0, "under limit, nothing suppressed");
+}
+
+#[skuld::test]
+async fn throttle_logs_first_n_then_suppresses() {
+    // The #248 bug was fully invisible after the first-per-server log
+    // line because of dedup-forever. This test pins the replacement
+    // behavior: first LOG_FULL_LIMIT=3 failures log in full, subsequent
+    // ones are counted as suppressed.
+    let dead_addr = unused_tcp_port().await;
+    let fwd = DnsForwarder::new(
+        build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+    );
+    let q = sample_query(0x0002);
+    // 5 attempts against the same server.
+    for _ in 0..5 {
+        let _ = fwd.forward_with_ports(&q, &[dead_addr.port()]).await;
+    }
+    let map = fwd.failure_throttle.lock().unwrap();
+    let state = map.get(&dead_addr.ip()).expect("throttle entry exists");
+    assert_eq!(state.logged, LOG_FULL_LIMIT, "first LOG_FULL_LIMIT logged in full");
+    assert_eq!(state.suppressed, 5 - LOG_FULL_LIMIT, "remainder suppressed");
+}
+
+// Error-chain errno extraction ========================================================================================
+
+#[skuld::test]
+fn first_os_errno_walks_nested_io_error() {
+    // Simulate the tokio-rustls shape: outer io::Error wrapping an
+    // inner io::Error that carries a raw_os_error (as rustls would from
+    // a real ECONNRESET on the underlying stream).
+    let inner = io::Error::from_raw_os_error(10054); // WSAECONNRESET
+    let outer = io::Error::other(inner);
+    assert_eq!(first_os_errno(&outer), Some(10054));
+}
+
+#[skuld::test]
+fn first_os_errno_returns_none_for_pure_custom_error() {
+    // tokio-rustls's `tls handshake eof` is a Custom error with no
+    // inner raw_os_error — represents a graceful FIN, not an RST.
+    let e = io::Error::new(io::ErrorKind::UnexpectedEof, "tls handshake eof");
+    assert_eq!(first_os_errno(&e), None);
 }
 
 // Short-query safety ==================================================================================================
@@ -310,7 +362,7 @@ impl DnsForwarder {
         }
         for (i, &server) in self.config.servers.iter().enumerate() {
             if server.is_ipv6() && !self.ipv6_bypass_available {
-                self.log_once(server, "skipping IPv6 upstream (no IPv6 bypass available)");
+                self.log_ipv6_skip_once(server);
                 continue;
             }
             let port = ports.get(i).copied().unwrap_or(match self.config.protocol {

--- a/crates/bridge/src/dns/socks5_connector.rs
+++ b/crates/bridge/src/dns/socks5_connector.rs
@@ -24,7 +24,7 @@ use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::Mutex;
 use tokio_socks::tcp::Socks5Stream;
 
-use crate::dns::connector::{BoxedStream, UpstreamConnector, UpstreamUdp};
+use crate::dns::connector::{ConnectedStream, CountingStream, UpstreamConnector, UpstreamUdp};
 
 const SOCKS5_VER: u8 = 0x05;
 const SOCKS5_NO_AUTH: u8 = 0x00;
@@ -50,7 +50,7 @@ impl Socks5Connector {
 
 #[async_trait]
 impl UpstreamConnector for Socks5Connector {
-    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<BoxedStream> {
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<ConnectedStream> {
         // Time the SOCKS5 handshake + CONNECT — per #248, this separates
         // "SOCKS5 handshake took 3s" from "handshake instant, but TLS
         // EOF'd immediately after" in the Phase-2 breakdown.
@@ -61,8 +61,15 @@ impl UpstreamConnector for Socks5Connector {
             Ok(stream) => {
                 tracing::debug!(%target, elapsed_ms, "Socks5Connector::connect_tcp");
                 // `into_inner()` returns the underlying `TcpStream` — after
-                // the CONNECT handshake the relay is a pure byte pipe.
-                Ok(Box::new(stream.into_inner()))
+                // the CONNECT handshake the relay is a pure byte pipe. Wrap
+                // in a CountingStream so the forwarder can read post-SOCKS5
+                // byte counts on TLS-layer failure (diagnostic for #248).
+                let counting = CountingStream::new(stream.into_inner());
+                let counters = counting.counters();
+                Ok(ConnectedStream {
+                    stream: Box::new(counting),
+                    counters,
+                })
             }
             Err(e) => {
                 tracing::debug!(%target, elapsed_ms, error = %e, "Socks5Connector::connect_tcp failed");

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1009,7 +1009,7 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
 #[cfg(test)]
 mod self_test {
     use super::*;
-    use crate::dns::connector::{BoxedStream, UpstreamConnector, UpstreamUdp};
+    use crate::dns::connector::{ConnectedStream, UpstreamConnector, UpstreamUdp};
     use crate::dns::forwarder::DnsForwarder;
     use crate::test_support::log_capture::VecWriter;
     use async_trait::async_trait;
@@ -1026,7 +1026,7 @@ mod self_test {
     struct DeadConnector;
     #[async_trait]
     impl UpstreamConnector for DeadConnector {
-        async fn connect_tcp(&self, _target: std::net::SocketAddr) -> io::Result<BoxedStream> {
+        async fn connect_tcp(&self, _target: std::net::SocketAddr) -> io::Result<ConnectedStream> {
             Err(io::Error::new(io::ErrorKind::ConnectionRefused, "dead connector"))
         }
         async fn connect_udp(&self, _target: std::net::SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {


### PR DESCRIPTION
## Summary

Stage 1 of the #248 root-cause investigation: close the diagnostic gaps that made Phase-2 observation inconclusive.

The [previous Phase-1 log](https://github.com/bindreams/hole/issues/248#issuecomment-2855996957) surfaced `elapsed_ms: 2573, layer: tls, caused_by: tls handshake eof` but bundled SOCKS5 + TLS timing into one number, deduplicated per-server forever, and could not distinguish "inner future errored near budget" from "outer `timeout(...)` cancelled the future." This PR fixes all of that with log-shape-only changes — zero behavior change outside the log, durable observability regardless of what Stage 3 ends up fixing.

## Changes (crates/bridge/src/dns)

- **Per-layer timing on `UpstreamErr`** (`socks5_ms`, `tls_ms`, `budget_ms`): forward_https / forward_tls now split the elapsed window between the SOCKS5 CONNECT and the TLS handshake so we can tell a slow tunnel from a slow TLS handshake from a cancelled future.
- **`UpstreamLayer::Timeout`** variant distinct from `Io`: outer `timeout(UPSTREAM_TIMEOUT, ...)` cancellation now logs as `layer=timeout` instead of synthesized `layer=io`. Disambiguates "budget ceiling" from genuine mid-handshake EOF.
- **`CountingStream<S>`** wraps every post-SOCKS5 stream in [crates/bridge/src/dns/connector.rs](crates/bridge/src/dns/connector.rs); counters surface on `UpstreamErr` as `tcp_wrote` / `tcp_read`. Raw-TCP byte counts, not TLS-frame counts — but enough to tell `read=0` (instant FIN) from `read=<KBs>` (full handshake then close).
- **`os_errno`**: walks `std::error::Error::source()` + `io::Error::get_ref()` chain for the first `raw_os_error()`. On Windows, `None` = FIN; `10054` = RST. `io::Error::source()` skips its own Custom-wrapper via delegation — this impl descends through `get_ref()` to reach the inner `io::Error` that tokio-rustls wraps around `"tls handshake eof"`.
- **`LogThrottle`** replaces the per-server dedup-forever `log_once` on the upstream-failure path: first 3 failures per server log in full; subsequent ones are counted as suppressed and rolled up in a single summary line at most every 60s per server. IPv6-skip path keeps its own log-first-1 helper (`log_ipv6_skip_once`) since that condition is config-static and log-per-query would be noise.
- `DnsForwarder::logged_servers` renamed to `failure_throttle: Mutex<HashMap<IpAddr, ThrottleState>>` + `ipv6_skip_logged: Mutex<HashSet<IpAddr>>`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` green.
- [x] `cargo fmt --check` green.
- [x] `cargo test -p hole-bridge --lib` — 396 passed, 17 filtered (dist-harness tests need `cargo xtask deps && cargo build`; unaffected by this PR, will be exercised by CI). New tests:
  - `duplicate_server_in_list_creates_one_throttle_entry` (renamed from `_logs_only_once` — pins HashMap shape).
  - `throttle_logs_first_n_then_suppresses` — pins first-3-then-suppress behavior.
  - `first_os_errno_walks_nested_io_error` — pins `io::Error::get_ref()`-descending semantics against the tokio-rustls shape.
  - `first_os_errno_returns_none_for_pure_custom_error` — FIN surfaces as `None`.
- [x] Pre-commit hooks all pass (`no-std-test`, `cargo-fmt`, `cargo-clippy`, `check-version`, `check-workspace-lints`, `format-section-comments`, `mixed-line-ending`, `editorconfig-checker`).

## What this PR does NOT do

- No fix. Stage 3 of the [#248 plan](https://github.com/bindreams/hole/issues/248#issuecomment-4308132002) commits to a root cause based on Stage 2 observations with this new log shape. Branches map to specific code paths (DoH-client / SOCKS5-handoff / tunnel / startup race / budget ceiling) documented in the pre-commitment comment.

Ref: #248