### PR TITLE
bridge/logging: honor multi-directive HOLE_BRIDGE_LOG (#267)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,32 @@ Getting a free port for local binding or SIP003 subprocess handoff goes through 
 
 The retry exists because Windows maintains **independent TCP/UDP excluded-port-range tables** (Hyper-V / WSL / Docker Desktop reservations, visible via `netsh int ipv4 show excludedportrange`); an OS-picked ephemeral port for one transport may be reserved for the other and the paired bind transiently fails. Galoshes's `garter::chain::allocate_one_port` hits the same class of bug — see bindreams/galoshes#21 for the deterministic `SO_EXCLUSIVEADDRUSE`-wildcard reproducer.
 
+### Logging directives
+
+`HOLE_BRIDGE_LOG` accepts a comma-separated list of `tracing` filter
+directives, all of which are honored
+([`crates/bridge/src/logging.rs`](crates/bridge/src/logging.rs)). The
+default is `hole_bridge=info`. Examples:
+
+- `HOLE_BRIDGE_LOG=hole_bridge=debug` — bridge-only debug.
+- `HOLE_BRIDGE_LOG=hole_bridge=debug,shadowsocks_service=trace` —
+  bridge debug + shadowsocks-service per-relay byte counts. The TRACE
+  line shape from
+  [`shadowsocks-service local/utils.rs`](https://docs.rs/shadowsocks-service/1.24.0/src/shadowsocks_service/local/utils.rs.html)
+  is `tcp tunnel <peer> <-> <target> (proxied) closed, L2R N bytes, R2L M bytes`. Load-bearing diagnostic for #248-class tunnel issues
+  ("did the plugin chain receive any bytes back?"). `LogTracer` is
+  installed automatically via `tracing-subscriber 0.3`'s default
+  features so `log::*!` events from third-party crates surface as
+  tracing events.
+
+`RUST_LOG` is also honored (read by
+`EnvFilter::from_env_lossy()` upstream of `add_directive`); both
+compose. Setting `shadowsocks_service=trace` in production is
+expensive — Full-tunnel mode + heavy browsing produces roughly one
+TRACE line per TCP connection (≥100/sec under Chrome). Use for
+debugging sessions only; `bridge.log` rotates via
+`MAX_LOG_BYTES`/`MAX_ROTATED_LOGS` so the cap is bounded.
+
 ### CLI
 
 ```

--- a/crates/bridge/src/logging.rs
+++ b/crates/bridge/src/logging.rs
@@ -7,25 +7,90 @@ use std::path::Path;
 ///
 /// The default directive is `hole_bridge=info`. Set `HOLE_BRIDGE_LOG` to
 /// override — a single directive (`hole_bridge=debug`) or a comma-separated
-/// list (`hole_bridge=debug,shadowsocks_service=debug`).
+/// list (`hole_bridge=debug,shadowsocks_service=trace`).
 ///
-/// `hole_common::logging::init` accepts only a single directive string, so
-/// when the env var contains commas we split here and pass through the
-/// first directive (the one most likely to be the "interesting" one for
-/// the bridge crate). Additional directives are dropped — callers that
-/// need multi-crate filtering should set `RUST_LOG` instead, which is read
-/// by `from_env_lossy()` upstream.
+/// All comma-separated directives are honored: the env var is split, each
+/// piece is trimmed, blanks are dropped, and the rest are passed to
+/// `EnvFilter::add_directive` in order via [`hole_common::logging::init_multi`].
+/// Pre-#267 only the first directive made it through, which silently hid
+/// shadowsocks-service's relay byte-count TRACE logs (`L2R N bytes, R2L M
+/// bytes`) — the load-bearing diagnostic for #248.
 ///
-/// We deliberately rely on leaving `RUST_LOG` unset (when only
-/// `HOLE_BRIDGE_LOG` is set) so `from_env_lossy()` yields an empty filter
-/// that does not compete with our directive at equal specificity.
+/// `RUST_LOG` is also still honored upstream of the directive list (via
+/// `EnvFilter::from_env_lossy` inside `init_multi`), so e.g.
+/// `RUST_LOG=shadowsocks_service=trace HOLE_BRIDGE_LOG=hole_bridge=debug`
+/// composes the same way.
 pub fn init(log_dir: &Path) -> LogGuard {
     let raw = std::env::var("HOLE_BRIDGE_LOG").unwrap_or_else(|_| "hole_bridge=info".to_string());
-    // `add_directive` parses ONE directive. Split on commas and pass each
-    // through; any well-formed prefix wins. To avoid changing the common
-    // init signature, we forward the first directive and let callers union
-    // additional ones via RUST_LOG (read by `from_env_lossy`). For our
-    // primary use case (bridge debug only), one directive is enough.
-    let primary = raw.split(',').next().unwrap_or("hole_bridge=info").trim();
-    hole_common::logging::init(log_dir, "bridge.log", primary)
+    let directives = parse_directives(&raw);
+    // Empty / whitespace-only env var falls back to the default rather than
+    // passing zero directives to `init_multi` (which would let the global
+    // INFO default win without any bridge-specific override).
+    if directives.is_empty() {
+        hole_common::logging::init_multi(log_dir, "bridge.log", ["hole_bridge=info"])
+    } else {
+        hole_common::logging::init_multi(log_dir, "bridge.log", directives)
+    }
+}
+
+/// Split a comma-separated `HOLE_BRIDGE_LOG`-style value into its
+/// component directives. Trims whitespace around each piece and drops
+/// blanks (so trailing commas / `a,, b` don't produce empty filters).
+///
+/// Pulled into a named function so the splitting rules are unit-testable
+/// without standing up the global subscriber.
+fn parse_directives(raw: &str) -> Vec<&str> {
+    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_directives;
+
+    #[skuld::test]
+    fn single_directive_yields_one_element() {
+        assert_eq!(parse_directives("hole_bridge=debug"), vec!["hole_bridge=debug"]);
+    }
+
+    #[skuld::test]
+    fn comma_separated_yields_each_directive_in_order() {
+        assert_eq!(
+            parse_directives("hole_bridge=debug,shadowsocks_service=trace"),
+            vec!["hole_bridge=debug", "shadowsocks_service=trace"],
+        );
+    }
+
+    #[skuld::test]
+    fn whitespace_around_directives_is_trimmed() {
+        assert_eq!(
+            parse_directives("  hole_bridge=debug ,\tshadowsocks_service=trace  "),
+            vec!["hole_bridge=debug", "shadowsocks_service=trace"],
+        );
+    }
+
+    #[skuld::test]
+    fn empty_string_yields_no_directives() {
+        assert!(parse_directives("").is_empty());
+    }
+
+    #[skuld::test]
+    fn whitespace_only_yields_no_directives() {
+        assert!(parse_directives("   \t  ").is_empty());
+    }
+
+    #[skuld::test]
+    fn trailing_and_doubled_commas_drop_blanks() {
+        assert_eq!(
+            parse_directives("hole_bridge=debug,,shadowsocks_service=trace,"),
+            vec!["hole_bridge=debug", "shadowsocks_service=trace"],
+        );
+    }
+
+    #[skuld::test]
+    fn three_directives_preserved() {
+        assert_eq!(
+            parse_directives("hole_bridge=debug,shadowsocks_service=trace,hyper=warn"),
+            vec!["hole_bridge=debug", "shadowsocks_service=trace", "hyper=warn"],
+        );
+    }
 }

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -115,13 +115,16 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 ///
 ///   Pre-#250, SocksOnly forced `TcpOnly` under #189's "select_all
 ///   drops the TCP listener when UDP completes early" attribution.
-///   That attribution had no log evidence — `LogTracer` was never
-///   installed so shadowsocks-service's `log::*!` events were silently
-///   dropped. The original symptom was actually wintun-induced
-///   loopback breakage on the Azure-hosted Windows runner (#200), and
-///   it was correctly addressed by PR #207's two-pass test ordering
-///   (`SKULD_LABELS=tun` runs last so loopback-using tests precede
-///   any wintun adapter destruction).
+///   That attribution had no log evidence: `LogTracer` *is* installed
+///   (via `tracing-subscriber`'s default features → `try_init`), but
+///   the bridge's `HOLE_BRIDGE_LOG` parser dropped every directive
+///   after the first comma, so `shadowsocks_service=*` directives in
+///   a multi-crate filter were silently lost. #267 fixes that. The
+///   original symptom for #189 was actually wintun-induced loopback
+///   breakage on the Azure-hosted Windows runner (#200), correctly
+///   addressed by PR #207's two-pass test ordering (`SKULD_LABELS=tun`
+///   runs last so loopback-using tests precede any wintun adapter
+///   destruction).
 /// * **HTTP CONNECT** (`proxy_http`): `127.0.0.1:{local_port_http}`,
 ///   always `TcpOnly` (HTTP CONNECT is TCP-only by RFC 7231 §4.3.6).
 ///

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -384,12 +384,37 @@ const MAX_LOG_BYTES: usize = 10 * 1024 * 1024;
 /// With a value of 1, the on-disk layout is `<name>` (current) + `<name>.1` (previous).
 const MAX_ROTATED_LOGS: usize = 1;
 
-/// Initialize logging.
+/// Initialize logging with one caller-supplied filter directive.
 ///
-/// Creates `log_dir` if it doesn't exist. Returns a guard that must be held
-/// for the process lifetime to ensure logs are flushed and the relay reader
-/// threads stay alive.
+/// Thin wrapper around [`init_multi`] preserved for callers that only have
+/// one directive to pass. Creates `log_dir` if it doesn't exist; returns a
+/// guard that must be held for the process lifetime to ensure logs are
+/// flushed and the relay reader threads stay alive.
 pub fn init(log_dir: &Path, log_filename: &str, default_directive: &str) -> LogGuard {
+    init_multi(log_dir, log_filename, [default_directive])
+}
+
+/// Initialize logging with one or more caller-supplied filter directives.
+///
+/// Each directive is parsed and added to the env filter via
+/// `EnvFilter::add_directive`, in the order given. Later directives override
+/// earlier ones at equal specificity per `tracing-subscriber`'s rules.
+///
+/// The global default of `info` is set first; `RUST_LOG` (read by
+/// `from_env_lossy`) is layered next; the caller's directives are layered on
+/// top; finally `hole::logging=debug` is pinned so the logging subsystem
+/// itself emits lifecycle events.
+///
+/// Use this rather than [`init`] when the caller wants to honor a
+/// comma-separated env var like
+/// `HOLE_BRIDGE_LOG=hole_bridge=debug,shadowsocks_service=trace` —
+/// `init` accepts only one directive and silently dropping the rest is the
+/// kind of thing that hides production diagnostics (#248).
+pub fn init_multi<I>(log_dir: &Path, log_filename: &str, directives: I) -> LogGuard
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+{
     let _ = std::fs::create_dir_all(log_dir);
     cleanup_legacy_daily_logs(log_dir, log_filename);
 
@@ -431,16 +456,19 @@ pub fn init(log_dir: &Path, log_filename: &str, default_directive: &str) -> LogG
 
     // Global default is INFO so third-party crates (shadowsocks-service,
     // hickory, hyper, etc.) emit useful startup/warning diagnostics without
-    // needing per-crate directives. The caller's `default_directive` can
-    // still override specific crates (e.g. "hole_bridge=debug").
+    // needing per-crate directives. Caller directives are layered on top,
+    // each one independently parseable (e.g. `hole_bridge=debug` and
+    // `shadowsocks_service=trace` together).
     //
     // `hole::logging=debug` is the only pin below INFO — it lets the
     // logging subsystem itself emit debug-level lifecycle events.
-    let env_filter = EnvFilter::builder()
+    let mut env_filter = EnvFilter::builder()
         .with_default_directive("info".parse().expect("valid directive"))
-        .from_env_lossy()
-        .add_directive(default_directive.parse().expect("valid tracing directive"))
-        .add_directive("hole::logging=debug".parse().expect("valid directive"));
+        .from_env_lossy();
+    for d in directives {
+        env_filter = env_filter.add_directive(d.as_ref().parse().expect("valid tracing directive"));
+    }
+    let env_filter = env_filter.add_directive("hole::logging=debug".parse().expect("valid directive"));
 
     // Filter that excludes the relay's own events from the stderr layer to
     // prevent any feedback loop in either direction. The file layer has no


### PR DESCRIPTION
## Summary

Layer 1 of [#267](https://github.com/bindreams/hole/issues/267). Pre-existing
behavior of `HOLE_BRIDGE_LOG` parser silently dropped every directive after
the first comma — so e.g. `HOLE_BRIDGE_LOG=hole_bridge=debug,shadowsocks_service=trace`
kept only `hole_bridge=debug` and the `shadowsocks_service=trace` directive
was lost. shadowsocks-service emits per-relay byte counts at TRACE
([`local/utils.rs:72`](https://docs.rs/shadowsocks-service/1.24.0/src/shadowsocks_service/local/utils.rs.html)) — `tcp tunnel <peer> <-> <target> (proxied) closed, L2R N bytes, R2L M bytes` — which is the diagnostic
[#248](https://github.com/bindreams/hole/issues/248) needs to settle "did
the plugin chain receive bytes back from the remote?". With this PR, that
TRACE line reaches `bridge.log` whenever the user sets the multi-directive
form.

## Changes

- `crates/common/src/logging.rs` — new `init_multi(log_dir, filename, directives: I)` accepting any `IntoIterator<Item: AsRef<str>>`. Calls `EnvFilter::add_directive` once per element. Existing `init(...)` becomes a one-element wrapper.
- `crates/bridge/src/logging.rs` — split `HOLE_BRIDGE_LOG` on `,`, trim each piece, drop blanks, hand the resulting `Vec<&str>` to `init_multi`. Empty / whitespace-only env var falls back to default `hole_bridge=info`.
- `crates/bridge/src/proxy/config.rs` — corrected the misleading comment that attributed missing shadowsocks-service log evidence to `LogTracer` not being installed. `LogTracer` *is* installed (via `tracing-subscriber 0.3`'s default features → `try_init`); the gap was the directive parser.
- `CLAUDE.md` — new "Logging directives" section documenting the recipe + log-volume warning.

## Test plan

- [x] `cargo clippy --workspace --all-targets` green.
- [x] `cargo fmt --check` green.
- [x] New unit tests in `crates/bridge/src/logging.rs::tests` for `parse_directives`: single, comma-separated, whitespace-trim, empty, all-blank, doubled/trailing commas, three-element. All pass.
- [x] Existing `log_crate_macros_reach_file` integration test in `crates/common/src/logging/logging_tests.rs` still passes — exercises the single-directive `init` path through `init_multi`.
- [ ] Manual on the user's #248 reproduction host: with `HOLE_BRIDGE_LOG=hole_bridge=debug,shadowsocks_service=trace`, run `nslookup example.com 127.0.0.1`. Expected new line in `bridge.log`:

  ```
  TRACE shadowsocks_service::local::utils: tcp tunnel <127.0.0.1:NNNN> <-> <1.1.1.1:443> (proxied) closed, L2R 260 bytes, R2L 0 bytes
  ```

  `R2L = 0` corroborates [PR #265](https://github.com/bindreams/hole/pull/265)'s view from inside SS. `R2L > 0` would indicate a different bug class.

## What this PR does NOT do

Layer 2 (Garter `TapPlugin` decorator with per-direction logging + time-to-first-upstream-byte field) is the follow-up — separate PR rebased onto this one.

Ref #248, #267.