### PR TITLE
garter: TapPlugin decorator for plugin-chain data-plane diagnostics (#267)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,33 @@ TRACE line per TCP connection (≥100/sec under Chrome). Use for
 debugging sessions only; `bridge.log` rotates via
 `MAX_LOG_BYTES`/`MAX_ROTATED_LOGS` so the cap is bounded.
 
+### Plugin tap (HOLE_BRIDGE_PLUGIN_TAP)
+
+When the bridge's local SOCKS5 listener relays a connection to the
+plugin chain, the boundary in between is normally invisible — the
+plugin process (`v2ray-plugin`, `galoshes`) runs out-of-process and
+its network I/O is not captured by the bridge's ETW consumer. Setting
+`HOLE_BRIDGE_PLUGIN_TAP=1` interposes
+[`garter::TapPlugin`](crates/garter/src/tap.rs) between
+shadowsocks-service and the inner plugin. Per-TCP-connection it logs:
+
+- `bytes_to_plugin` / `bytes_from_plugin` — raw byte counts in each
+  direction, observed by [`garter::CountingStream`](crates/garter/src/counting.rs).
+- `ttfb_ms` — milliseconds from `accept` to the first non-zero
+  upstream read. `None` means the connection closed without ever
+  receiving a byte from the plugin chain — the load-bearing diagnostic
+  for #248-class "tunnel returns nothing" cases.
+- `close_kind` — taxonomy of how the connection ended (`graceful`,
+  `rst`, `abort`, `eof`, `timeout`, `broken_pipe`, `other`),
+  cross-platform via Win32+POSIX errno mapping.
+- `close_dir` is implicit in the byte-count asymmetry: if
+  `bytes_inbound_read != bytes_inbound_written` an inflight cancel hit.
+
+**Dev-mode only.** Service-mode bridges (Windows SCM / launchd) do not
+inherit user shell env, so the gate is meant for `scripts/dev.py` and
+hand-run `hole bridge run`. Cost: an extra loopback round-trip per
+byte, fine for a debugging session, inappropriate as default.
+
 ### CLI
 
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "windows 0.61.3",
 ]
 

--- a/crates/bridge/src/dns/connector.rs
+++ b/crates/bridge/src/dns/connector.rs
@@ -10,23 +10,26 @@
 //!   cannot strand the forwarder.
 //!
 //! The trait returns [`ConnectedStream`] — a `BoxedStream` paired with
-//! two `AtomicU64` byte counters observed by a [`CountingStream`] wrapper
-//! around the underlying socket. The counters are what lets the forwarder
-//! log `tcp_wrote` / `tcp_read` on a TLS-layer failure in #248
+//! [`StreamCounters`] observed by a [`CountingStream`] wrapper around
+//! the underlying socket. The counters are what lets the forwarder log
+//! `tcp_wrote` / `tcp_read` on a TLS-layer failure in #248
 //! diagnostics: `read=0` means the peer FIN'd before sending a byte;
 //! `read=<small>` means mid-handshake close; `read=<KBs>` means full
 //! handshake bytes delivered then close.
+//!
+//! `CountingStream` and `StreamCounters` were lifted to
+//! [`garter::counting`] in #267 so the new `TapPlugin` decorator and
+//! this DNS forwarder can share one wrapper. Apache → GPL one-way
+//! direction is preserved.
 
 use std::io;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpStream, UdpSocket};
+
+pub use garter::counting::{CountingStream, StreamCounters};
 
 /// Bidirectional byte stream used by every TCP-based DNS transport
 /// (`PlainTcp`, `Tls`, `Https`). Requiring `Unpin` keeps the
@@ -40,24 +43,6 @@ impl<T: AsyncRead + AsyncWrite + Send + Unpin + ?Sized> AsyncDuplex for T {}
 /// [`CountingStream`] before boxing, so its byte counts are observable
 /// via the paired [`StreamCounters`].
 pub type BoxedStream = Box<dyn AsyncDuplex>;
-
-/// Per-stream byte counters handed back by a connector alongside the
-/// stream itself. Cheap to clone (two `Arc` bumps).
-#[derive(Debug, Default, Clone)]
-pub struct StreamCounters {
-    read_bytes: Arc<AtomicU64>,
-    write_bytes: Arc<AtomicU64>,
-}
-
-impl StreamCounters {
-    pub fn read(&self) -> u64 {
-        self.read_bytes.load(Ordering::Relaxed)
-    }
-
-    pub fn written(&self) -> u64 {
-        self.write_bytes.load(Ordering::Relaxed)
-    }
-}
 
 /// A stream paired with its byte counters. Returned by
 /// [`UpstreamConnector::connect_tcp`]; callers keep the counters to read
@@ -73,61 +58,6 @@ impl ConnectedStream {
     /// error path.
     pub fn into_parts(self) -> (BoxedStream, StreamCounters) {
         (self.stream, self.counters)
-    }
-}
-
-/// Wraps an `AsyncRead + AsyncWrite` and increments a pair of
-/// `Arc<AtomicU64>` counters on every successful `poll_read` / `poll_write`
-/// call. Counts raw bytes on the wrapped stream, *not* decoded-TLS bytes —
-/// for SOCKS5-wrapped streams the bytes counted are post-SOCKS5-CONNECT
-/// payload bytes, i.e. what a DoH server / plain-TCP peer would see.
-pub struct CountingStream<S> {
-    inner: S,
-    counters: StreamCounters,
-}
-
-impl<S> CountingStream<S> {
-    pub fn new(inner: S) -> Self {
-        Self {
-            inner,
-            counters: StreamCounters::default(),
-        }
-    }
-
-    pub fn counters(&self) -> StreamCounters {
-        self.counters.clone()
-    }
-}
-
-impl<S: AsyncRead + Unpin> AsyncRead for CountingStream<S> {
-    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
-        let before = buf.filled().len();
-        let res = Pin::new(&mut self.inner).poll_read(cx, buf);
-        if let Poll::Ready(Ok(())) = &res {
-            let delta = (buf.filled().len() - before) as u64;
-            if delta > 0 {
-                self.counters.read_bytes.fetch_add(delta, Ordering::Relaxed);
-            }
-        }
-        res
-    }
-}
-
-impl<S: AsyncWrite + Unpin> AsyncWrite for CountingStream<S> {
-    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
-        let res = Pin::new(&mut self.inner).poll_write(cx, buf);
-        if let Poll::Ready(Ok(n)) = &res {
-            self.counters.write_bytes.fetch_add(*n as u64, Ordering::Relaxed);
-        }
-        res
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }
 

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -137,8 +137,25 @@ pub async fn start_plugin_chain(
         plugin_options: plugin_opts.map(String::from),
     };
 
+    // #267: when `HOLE_BRIDGE_PLUGIN_TAP=1` is set, wrap the plugin in a
+    // counting tap so per-connection byte flow becomes visible in
+    // `bridge.log` (`bytes_to_plugin`, `bytes_from_plugin`, `ttfb_ms`,
+    // `close_kind`). Dev-mode only — env vars do not survive into
+    // SCM/launchd service contexts. Off by default; the extra loopback
+    // hop is cheap on debug-mode reproduction but inappropriate at
+    // browser-traffic scale.
+    let plugin: Box<dyn garter::ChainPlugin> = if std::env::var_os("HOLE_BRIDGE_PLUGIN_TAP").is_some() {
+        tracing::info!(
+            plugin = plugin_name,
+            "HOLE_BRIDGE_PLUGIN_TAP=1: wrapping plugin in TapPlugin"
+        );
+        Box::new(garter::TapPlugin::wrap(Box::new(plugin)))
+    } else {
+        Box::new(plugin)
+    };
+
     let runner = garter::ChainRunner::new()
-        .add(Box::new(plugin))
+        .add(plugin)
         .cancel_token(cancel.clone())
         .on_ready(ready_tx);
 

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -20,10 +20,17 @@ harness = false
 
 [dev-dependencies]
 skuld = { workspace = true }
+socket2 = "0.6"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [[test]]
 name = "chain_integration"
 path = "tests/chain_integration.rs"
+harness = false
+
+[[test]]
+name = "tap_integration"
+path = "tests/tap_integration.rs"
 harness = false
 
 [target.'cfg(unix)'.dependencies]
@@ -38,5 +45,4 @@ windows = { version = "0.61", features = [
 ] }
 
 [target.'cfg(windows)'.dev-dependencies]
-socket2 = "0.6"
 windows = { version = "0.61", features = ["Win32_Networking_WinSock"] }

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -291,7 +291,10 @@ fn record_exit(
 ///
 /// Each connect attempt races against the shutdown token so that a
 /// cancellation during an OS-level TCP timeout is not delayed.
-async fn poll_ready(addr: SocketAddr, shutdown: CancellationToken) -> Option<SocketAddr> {
+///
+/// `pub(crate)` so the [`crate::tap`] module can reuse the same backoff
+/// schedule when waiting for the inner plugin to bind.
+pub(crate) async fn poll_ready(addr: SocketAddr, shutdown: CancellationToken) -> Option<SocketAddr> {
     let mut delay = Duration::from_millis(10);
     let max_delay = Duration::from_secs(1);
 

--- a/crates/garter/src/counting.rs
+++ b/crates/garter/src/counting.rs
@@ -1,0 +1,114 @@
+//! Byte-counting wrapper for bidirectional async streams.
+//!
+//! `CountingStream<S>` wraps any `AsyncRead + AsyncWrite` and increments
+//! a pair of `Arc<AtomicU64>` counters on every successful poll. The
+//! counters live in a separately-cloneable [`StreamCounters`] handle so
+//! callers can read them after the stream itself has been moved into
+//! e.g. `tokio::io::copy_bidirectional`.
+//!
+//! In addition to byte counts, the counters track the `Instant` of the
+//! first non-zero `poll_read` (via a `OnceLock`). This lets a tap log a
+//! "time to first upstream byte" signal — the diagnostic field that
+//! distinguishes "upstream sent nothing for the whole connection" from
+//! "upstream sent some bytes then closed."
+//!
+//! Lifted into `garter` (Apache-2.0) from `hole-bridge`'s DNS forwarder
+//! (which had its own copy at `dns/connector.rs`) so both the bridge's
+//! DNS path and the new `TapPlugin` decorator can share the type
+//! without cycling Apache → GPL → Apache. Bridge re-imports from here.
+
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// Per-stream byte counters and first-read timestamp. Cheap to clone
+/// (three `Arc` bumps).
+#[derive(Debug, Default, Clone)]
+pub struct StreamCounters {
+    read_bytes: Arc<AtomicU64>,
+    write_bytes: Arc<AtomicU64>,
+    /// Instant of the first non-zero `poll_read`. Set exactly once via
+    /// `OnceLock::set`; subsequent reads do not update it. Use with the
+    /// connection's `started` instant to compute time-to-first-upstream-byte.
+    first_read_at: Arc<OnceLock<Instant>>,
+}
+
+impl StreamCounters {
+    /// Total bytes successfully read from the wrapped stream so far.
+    pub fn read(&self) -> u64 {
+        self.read_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes successfully written to the wrapped stream so far.
+    pub fn written(&self) -> u64 {
+        self.write_bytes.load(Ordering::Relaxed)
+    }
+
+    /// `Instant` of the first non-zero read on the wrapped stream, if any.
+    /// `None` means the stream was closed without ever delivering a byte —
+    /// the load-bearing diagnostic for tunnel-silent-then-FIN cases.
+    pub fn first_read_at(&self) -> Option<Instant> {
+        self.first_read_at.get().copied()
+    }
+}
+
+/// Wraps any `AsyncRead + AsyncWrite` and increments [`StreamCounters`]
+/// on every successful `poll_read` / `poll_write`. Counts raw bytes on
+/// the wrapped stream (not transformed bytes) — for SOCKS5-wrapped
+/// streams, that's post-CONNECT payload bytes; what a peer would see.
+pub struct CountingStream<S> {
+    inner: S,
+    counters: StreamCounters,
+}
+
+impl<S> CountingStream<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            counters: StreamCounters::default(),
+        }
+    }
+
+    /// Cheap clone of the counter handle — outlives the wrapped stream.
+    pub fn counters(&self) -> StreamCounters {
+        self.counters.clone()
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for CountingStream<S> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let res = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &res {
+            let delta = (buf.filled().len() - before) as u64;
+            if delta > 0 {
+                self.counters.read_bytes.fetch_add(delta, Ordering::Relaxed);
+                // OnceLock::set is no-op on subsequent calls — first wins.
+                let _ = self.counters.first_read_at.set(Instant::now());
+            }
+        }
+        res
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for CountingStream<S> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+        let res = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &res {
+            self.counters.write_bytes.fetch_add(*n as u64, Ordering::Relaxed);
+        }
+        res
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/crates/garter/src/counting_tests.rs
+++ b/crates/garter/src/counting_tests.rs
@@ -1,0 +1,94 @@
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use super::*;
+
+/// Round-trip a known payload through a CountingStream pair and assert
+/// the counters match. Runs in its own one-shot tokio runtime so the
+/// test doesn't entangle with skuld's scheduler.
+#[skuld::test]
+async fn counts_bytes_roundtripped() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut s, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 5];
+        s.read_exact(&mut buf).await.unwrap();
+        s.write_all(&buf).await.unwrap();
+        s.flush().await.unwrap();
+    });
+
+    let raw = TcpStream::connect(addr).await.unwrap();
+    let mut counted = CountingStream::new(raw);
+    let counters = counted.counters();
+
+    counted.write_all(b"hello").await.unwrap();
+    counted.flush().await.unwrap();
+    let mut buf = [0u8; 5];
+    counted.read_exact(&mut buf).await.unwrap();
+
+    assert_eq!(&buf, b"hello");
+    assert_eq!(counters.written(), 5);
+    assert_eq!(counters.read(), 5);
+    assert!(counters.first_read_at().is_some(), "first_read_at set after first byte");
+
+    server.await.unwrap();
+}
+
+#[skuld::test]
+async fn first_read_at_is_none_when_no_bytes_arrive() {
+    // Server accepts but immediately closes without writing anything.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (s, _) = listener.accept().await.unwrap();
+        drop(s);
+    });
+
+    let raw = TcpStream::connect(addr).await.unwrap();
+    let mut counted = CountingStream::new(raw);
+    let counters = counted.counters();
+
+    let mut buf = [0u8; 4];
+    // Reading from a peer-closed stream returns Ok(0) (EOF) on first read.
+    let n = counted.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+    assert_eq!(counters.read(), 0);
+    assert!(
+        counters.first_read_at().is_none(),
+        "first_read_at must remain None when no non-zero read ever happened"
+    );
+
+    server.await.unwrap();
+}
+
+#[skuld::test]
+async fn first_read_at_does_not_update_after_first_set() {
+    // Two separate writes from the server; counter must reflect the FIRST one's time.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut s, _) = listener.accept().await.unwrap();
+        s.write_all(b"a").await.unwrap();
+        s.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        s.write_all(b"b").await.unwrap();
+        s.flush().await.unwrap();
+    });
+
+    let raw = TcpStream::connect(addr).await.unwrap();
+    let mut counted = CountingStream::new(raw);
+    let counters = counted.counters();
+
+    let mut buf = [0u8; 1];
+    counted.read_exact(&mut buf).await.unwrap();
+    let first_at = counters.first_read_at().expect("first_read_at set after byte 1");
+    counted.read_exact(&mut buf).await.unwrap();
+    let still = counters.first_read_at().expect("first_read_at survives byte 2");
+    assert_eq!(first_at, still, "first_read_at should not update on subsequent reads");
+    assert_eq!(counters.read(), 2);
+
+    server.await.unwrap();
+}

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -1,21 +1,27 @@
 pub mod binary;
 pub mod chain;
+pub mod counting;
 pub mod error;
 pub mod plugin;
 pub mod shutdown;
 pub mod sip003;
+pub mod tap;
 
 pub use binary::{BinaryPlugin, PidSink};
 pub use chain::ChainRunner;
+pub use counting::{CountingStream, StreamCounters};
 pub use error::{Error, Result};
 pub use plugin::ChainPlugin;
 pub use sip003::parse_plugin_options;
 pub use sip003::PluginEnv;
+pub use tap::TapPlugin;
 
 #[cfg(test)]
 mod binary_tests;
 #[cfg(test)]
 mod chain_tests;
+#[cfg(test)]
+mod counting_tests;
 #[cfg(test)]
 mod error_tests;
 #[cfg(test)]
@@ -24,6 +30,8 @@ mod plugin_tests;
 mod shutdown_tests;
 #[cfg(test)]
 mod sip003_tests;
+#[cfg(test)]
+mod tap_tests;
 
 #[cfg(test)]
 fn main() {

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -1,0 +1,369 @@
+//! [`TapPlugin`] — counting decorator over any [`ChainPlugin`].
+//!
+//! Inserts an instrumented loopback hop between `local` (the chain-public
+//! address shadowsocks-service connects to) and an internal port the
+//! inner plugin actually binds. For each accepted TCP connection the tap
+//! emits an `info!` line on `accept` and a structured `info!` line on
+//! `close` with byte counters (toward and from the inner plugin),
+//! time-to-first-upstream-byte, and a Win32+POSIX-aware `close_kind`
+//! taxonomy.
+//!
+//! Designed for diagnostic mode — the extra loopback round-trip per byte
+//! is fine for an on-demand tap but inappropriate as default. Bridge gates
+//! it behind `HOLE_BRIDGE_PLUGIN_TAP=1`.
+//!
+//! Lifecycle:
+//! 1. Allocate an internal port for the inner plugin via probe-and-drop
+//!    on `(ip, 0)`. Wrap in a small bind-race retry loop in case Windows
+//!    excluded-port-range tables would refuse the second bind.
+//! 2. Spawn the inner plugin's `run` future in a task, configured to bind
+//!    that internal port.
+//! 3. Wait for the inner plugin to actually accept TCP via
+//!    [`crate::chain::poll_ready`] (same backoff schedule [`ChainRunner`]
+//!    uses for its own readiness probe). Bounded at 30s; on timeout the
+//!    inner task is aborted and `Error::Chain` propagates.
+//! 4. Bind the tap's public listener on `local` (only after step 3 — the
+//!    bind has to be observable to `ChainRunner::poll_ready` only when
+//!    the data plane is actually wired through).
+//! 5. Accept loop in a `JoinSet`; per-connection forwarder calls
+//!    `tokio::io::copy_bidirectional` with [`CountingStream`] wrappers.
+//! 6. On shutdown: abort all in-flight forwarders, await the inner task,
+//!    propagate its exit status as ours.
+//!
+//! License: this module is part of `garter` (Apache-2.0). The bridge
+//! (GPL-3.0-or-later) imports it; one-way Apache → GPL compatibility
+//! per the workspace `NOTICES.md`.
+
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use crate::counting::CountingStream;
+use crate::plugin::ChainPlugin;
+
+/// Process-wide monotonic id assigned to each tap connection. Logged as
+/// `tap_conn_id` so log readers can correlate the `accepted` and
+/// `closed` lines for a single connection.
+static NEXT_TAP_CONN_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Maximum time we wait for the inner plugin to bind its internal port
+/// before the tap gives up. Mirrors [`crate::chain::ChainRunner`]'s 30s
+/// readiness budget for the outermost listener.
+const INNER_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Budget for retrying the inner-plugin connect on transient
+/// `ECONNREFUSED`. Absorbs the (small) residual race between
+/// [`poll_ready`](crate::chain::poll_ready) returning and a brand-new
+/// inbound flow opening before the inner accept loop has spun up
+/// per-connection state.
+const INNER_CONNECT_RETRY_BUDGET: Duration = Duration::from_millis(250);
+
+/// Maximum attempts to allocate an internal port. One round of
+/// alloc-then-bind is usually enough on Linux/macOS; on Windows the
+/// excluded-port-range table can flake briefly, so up to N retries.
+const INNER_PORT_ALLOC_ATTEMPTS: u32 = 4;
+
+/// Decorator that wraps any [`ChainPlugin`] in a counting loopback hop.
+///
+/// `wrap(inner)` produces a new plugin whose `run` performs the lifecycle
+/// described in the module docs. The inner plugin is moved by value;
+/// `pid_sink` and other configuration on `BinaryPlugin` are preserved
+/// (the tap delegates to `inner.run`).
+pub struct TapPlugin {
+    inner: Box<dyn ChainPlugin>,
+}
+
+impl TapPlugin {
+    pub fn wrap(inner: Box<dyn ChainPlugin>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl ChainPlugin for TapPlugin {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        remote: SocketAddr,
+        shutdown: CancellationToken,
+    ) -> crate::Result<()> {
+        let plugin_name = self.inner.name().to_string();
+
+        // 1. Allocate inner port (probe-and-drop, with bind-race retry).
+        let inner_local = allocate_inner_port(local.ip())
+            .map_err(|e| crate::Error::Chain(format!("tap[{plugin_name}]: alloc inner port: {e}")))?;
+
+        // 2. Spawn the inner plugin against `inner_local`.
+        let inner_shutdown = shutdown.clone();
+        let mut inner_handle = tokio::spawn(self.inner.run(inner_local, remote, inner_shutdown));
+
+        // 3. Wait for the inner plugin to bind the inner port. Race
+        //    against the inner task itself so an early plugin failure
+        //    doesn't leave us blocked on a port that will never bind.
+        let ready_token = shutdown.clone();
+        let ready_outcome = tokio::select! {
+            ready = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => {
+                Some(ready)
+            }
+            join = &mut inner_handle => {
+                // Inner exited before binding — propagate its result. No
+                // tap listener was ever opened, so nothing to clean up.
+                return match join {
+                    Ok(result) => result,
+                    Err(je) => Err(crate::Error::Chain(format!("tap[{plugin_name}]: inner task: {je}"))),
+                };
+            }
+        };
+        match ready_outcome {
+            Some(Ok(Some(_))) => {}
+            Some(Ok(None)) => {
+                // Shutdown fired before inner was ready. Wait for inner to
+                // unwind and propagate its result.
+                return drain_inner(plugin_name.as_str(), inner_handle).await;
+            }
+            Some(Err(_)) => {
+                inner_handle.abort();
+                let _ = inner_handle.await;
+                return Err(crate::Error::Chain(format!(
+                    "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
+                )));
+            }
+            None => unreachable!(),
+        }
+
+        // 4. Bind the public-facing tap listener.
+        let listener = TcpListener::bind(local)
+            .await
+            .map_err(|e| crate::Error::Chain(format!("tap[{plugin_name}]: bind {local}: {e}")))?;
+        tracing::info!(
+            plugin = %plugin_name,
+            %local,
+            %inner_local,
+            "plugin tap: ready"
+        );
+
+        // 5. Accept loop. Per-connection forwarders go into a JoinSet so
+        //    shutdown can abort them; we never leak a forwarder past the
+        //    plugin's lifetime.
+        let mut connections: JoinSet<()> = JoinSet::new();
+        loop {
+            // Use boolean state to drive control flow because tokio::select!
+            // arms cannot embed `break`/`return` cleanly across multi-arm
+            // match blocks (parser disambiguation gets unhappy). We set
+            // intent here, drop out of select, then act.
+            enum Step {
+                Continue,
+                Break,
+                InnerExited(std::result::Result<crate::Result<()>, tokio::task::JoinError>),
+            }
+            let step = tokio::select! {
+                _ = shutdown.cancelled() => Step::Break,
+                accept = listener.accept() => match accept {
+                    Ok((inbound, peer)) => {
+                        let inbound_token = shutdown.clone();
+                        connections.spawn(async move {
+                            handle_tap_connection(inbound, peer, inner_local, inbound_token).await;
+                        });
+                        Step::Continue
+                    }
+                    Err(e) => {
+                        // accept() failure on a previously-bound listener
+                        // is unusual (FD exhaustion / kernel error) — log
+                        // and break so the inner plugin can exit cleanly.
+                        tracing::warn!(plugin = %plugin_name, error = %e, "plugin tap: accept failed");
+                        Step::Break
+                    }
+                },
+                // Inner exiting on its own (clean or error) is a terminal
+                // condition for the chain; surface its result.
+                join = &mut inner_handle => Step::InnerExited(join),
+            };
+            match step {
+                Step::Continue => continue,
+                Step::Break => break,
+                Step::InnerExited(join) => {
+                    drop(listener);
+                    connections.abort_all();
+                    while connections.join_next().await.is_some() {}
+                    return match join {
+                        Ok(result) => result,
+                        Err(je) => Err(crate::Error::Chain(format!("tap[{plugin_name}]: inner task: {je}"))),
+                    };
+                }
+            }
+        }
+
+        // 6. Shutdown path: drop listener, abort forwarders, await inner.
+        drop(listener);
+        connections.abort_all();
+        while connections.join_next().await.is_some() {}
+        drain_inner(plugin_name.as_str(), inner_handle).await
+    }
+}
+
+async fn drain_inner(plugin_name: &str, inner_handle: tokio::task::JoinHandle<crate::Result<()>>) -> crate::Result<()> {
+    match inner_handle.await {
+        Ok(result) => result,
+        Err(je) if je.is_cancelled() => Ok(()),
+        Err(je) => Err(crate::Error::Chain(format!("tap[{plugin_name}]: inner task: {je}"))),
+    }
+}
+
+/// Probe-and-drop a free TCP port on `(ip, 0)`. Retries on
+/// `AddrInUse` / `PermissionDenied` (the Windows excluded-port-range
+/// flake) up to [`INNER_PORT_ALLOC_ATTEMPTS`] times.
+fn allocate_inner_port(ip: IpAddr) -> io::Result<SocketAddr> {
+    let mut last_err: Option<io::Error> = None;
+    for _ in 0..INNER_PORT_ALLOC_ATTEMPTS {
+        match std::net::TcpListener::bind(SocketAddr::new(ip, 0)).and_then(|l| l.local_addr()) {
+            Ok(addr) => return Ok(addr),
+            Err(e) => match e.kind() {
+                io::ErrorKind::AddrInUse | io::ErrorKind::PermissionDenied | io::ErrorKind::AddrNotAvailable => {
+                    last_err = Some(e);
+                    continue;
+                }
+                _ => return Err(e),
+            },
+        }
+    }
+    Err(last_err.unwrap_or_else(|| io::Error::other("alloc_inner_port: no error captured")))
+}
+
+async fn handle_tap_connection(
+    inbound: TcpStream,
+    peer: SocketAddr,
+    inner_local: SocketAddr,
+    shutdown: CancellationToken,
+) {
+    let conn_id = NEXT_TAP_CONN_ID.fetch_add(1, Ordering::Relaxed);
+    let started = Instant::now();
+    tracing::info!(tap_conn_id = conn_id, %peer, %inner_local, "plugin tap: accepted");
+
+    let upstream = match retry_connect_inner(inner_local, INNER_CONNECT_RETRY_BUDGET, &shutdown).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                tap_conn_id = conn_id,
+                error = %e,
+                "plugin tap: inner connect failed"
+            );
+            return;
+        }
+    };
+
+    let mut inbound = CountingStream::new(inbound);
+    let mut upstream = CountingStream::new(upstream);
+    let inbound_counters = inbound.counters();
+    let upstream_counters = upstream.counters();
+
+    let close_err: Option<io::Error> = tokio::select! {
+        result = tokio::io::copy_bidirectional(&mut inbound, &mut upstream) => result.err(),
+        _ = shutdown.cancelled() => None,
+    };
+
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    let bytes_to_plugin = upstream_counters.written();
+    let bytes_from_plugin = upstream_counters.read();
+    let ttfb_ms = upstream_counters
+        .first_read_at()
+        .map(|t| t.duration_since(started).as_millis() as u64);
+    let close_kind = classify_close(close_err.as_ref());
+    let os_errno = close_err.as_ref().and_then(|e| e.raw_os_error());
+
+    tracing::info!(
+        tap_conn_id = conn_id,
+        %peer,
+        elapsed_ms,
+        ttfb_ms = ?ttfb_ms,
+        bytes_to_plugin,
+        bytes_from_plugin,
+        // Sanity-check fields: inbound.read should equal upstream.written
+        // and inbound.written should equal upstream.read on a clean copy.
+        // Logged separately so a future tap regression surfaces as a
+        // counter mismatch in the field shape.
+        bytes_inbound_read = inbound_counters.read(),
+        bytes_inbound_written = inbound_counters.written(),
+        close_kind = %close_kind,
+        os_errno = ?os_errno,
+        "plugin tap: closed"
+    );
+}
+
+async fn retry_connect_inner(
+    addr: SocketAddr,
+    budget: Duration,
+    shutdown: &CancellationToken,
+) -> io::Result<TcpStream> {
+    let deadline = Instant::now() + budget;
+    let mut delay = Duration::from_millis(5);
+    let max_delay = Duration::from_millis(50);
+    loop {
+        tokio::select! {
+            result = TcpStream::connect(addr) => match result {
+                Ok(s) => return Ok(s),
+                Err(e) if e.kind() == io::ErrorKind::ConnectionRefused && Instant::now() < deadline => {
+                    // fall through to backoff
+                }
+                Err(e) => return Err(e),
+            },
+            _ = shutdown.cancelled() => {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "tap: shutdown during inner connect"));
+            }
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(delay) => {
+                delay = (delay * 2).min(max_delay);
+            }
+            _ = shutdown.cancelled() => {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "tap: shutdown during inner connect"));
+            }
+        }
+    }
+}
+
+/// Map a connection-close error onto a small enumeration friendly to
+/// log readers. Covers both Windows (`WSAE*`) and POSIX errnos plus the
+/// portable `io::ErrorKind` variants `tokio::io::copy_bidirectional`
+/// surfaces. `None` means the bidirectional copy returned `Ok` (graceful
+/// FIN both directions) or shutdown cancelled the relay.
+fn classify_close(err: Option<&io::Error>) -> &'static str {
+    let Some(e) = err else { return "graceful" };
+    if let Some(errno) = e.raw_os_error() {
+        return match errno {
+            // Windows
+            10054 => "rst",       // WSAECONNRESET
+            10053 => "abort",     // WSAECONNABORTED
+            10052 => "net_reset", // WSAENETRESET
+            10058 => "shutdown",  // WSAESHUTDOWN
+            10060 => "timeout",   // WSAETIMEDOUT
+            // POSIX
+            104 => "rst",        // ECONNRESET
+            103 => "abort",      // ECONNABORTED
+            110 => "timeout",    // ETIMEDOUT
+            32 => "broken_pipe", // EPIPE
+            _ => fallback_kind(e),
+        };
+    }
+    fallback_kind(e)
+}
+
+fn fallback_kind(e: &io::Error) -> &'static str {
+    match e.kind() {
+        io::ErrorKind::UnexpectedEof => "eof",
+        io::ErrorKind::TimedOut => "timeout",
+        io::ErrorKind::BrokenPipe => "broken_pipe",
+        io::ErrorKind::ConnectionReset => "rst",
+        io::ErrorKind::ConnectionAborted => "abort",
+        _ => "other",
+    }
+}

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -1,0 +1,419 @@
+//! TapPlugin behavioral tests.
+//!
+//! Tests use stub `ChainPlugin` impls (defined locally per scenario) that
+//! bind a TCP listener on `local` and exercise a specific failure mode
+//! the tap should classify. The tap forwards inbound connections via an
+//! internal port to the stub, so the tests assert on the structured
+//! tracing fields the tap emits on close: `bytes_to_plugin`,
+//! `bytes_from_plugin`, `ttfb_ms`, `close_kind`.
+//!
+//! Subscriber capture uses `tracing::subscriber::with_default` (thread-
+//! local) so each test sees only its own events. The tokio runtime is
+//! single-threaded for the same reason — `set_default` does not cross
+//! `tokio::spawn` on a multi-thread runtime per the project memory.
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+
+use crate::counting::CountingStream;
+use crate::plugin::ChainPlugin;
+use crate::tap::TapPlugin;
+
+// Subscriber capture ==================================================================================================
+
+#[derive(Clone, Default)]
+struct VecWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for VecWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for VecWriter {
+    type Writer = VecWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn make_subscriber() -> (impl tracing::Subscriber + Send + Sync, VecWriter) {
+    let writer = VecWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .with_ansi(false)
+        .with_target(true)
+        .finish();
+    (subscriber, writer)
+}
+
+fn captured_text(writer: &VecWriter) -> String {
+    String::from_utf8_lossy(&writer.0.lock().unwrap().clone()).into_owned()
+}
+
+// Stubs ===============================================================================================================
+
+/// Test plugin that binds `local` and runs one of several behaviors per
+/// accepted TCP connection.
+struct StubPlugin {
+    behavior: Behavior,
+}
+
+#[derive(Clone, Copy)]
+enum Behavior {
+    /// Read N bytes, echo them back, then close.
+    Echo { read_bytes: usize },
+    /// Accept and immediately drop the connection (no bytes either way).
+    SilentDrop,
+    /// Set SO_LINGER=0 and drop — sends RST instead of FIN. Cross-platform via socket2.
+    Reset,
+    /// Read N bytes, sleep, close without writing (the #248 shape).
+    SilentAfterRead { read_bytes: usize, delay: Duration },
+}
+
+#[async_trait::async_trait]
+impl ChainPlugin for StubPlugin {
+    fn name(&self) -> &str {
+        "stub"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        _remote: SocketAddr,
+        shutdown: CancellationToken,
+    ) -> crate::Result<()> {
+        let listener = TcpListener::bind(local)
+            .await
+            .map_err(|e| crate::Error::Chain(format!("stub bind {local}: {e}")))?;
+        let behavior = self.behavior;
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => return Ok(()),
+                accept = listener.accept() => match accept {
+                    Ok((stream, _peer)) => {
+                        tokio::spawn(handle_stub_conn(stream, behavior));
+                    }
+                    Err(_) => return Ok(()),
+                }
+            }
+        }
+    }
+}
+
+async fn handle_stub_conn(mut stream: TcpStream, behavior: Behavior) {
+    match behavior {
+        Behavior::Echo { read_bytes } => {
+            let mut buf = vec![0u8; read_bytes];
+            if stream.read_exact(&mut buf).await.is_ok() {
+                let _ = stream.write_all(&buf).await;
+                let _ = stream.flush().await;
+                let _ = stream.shutdown().await;
+            }
+        }
+        Behavior::SilentDrop => {
+            drop(stream);
+        }
+        Behavior::Reset => {
+            // SO_LINGER=0 + drop → RST. Use socket2 to flip the option.
+            let std_stream: std::net::TcpStream = stream.into_std().expect("into_std");
+            let socket = socket2::Socket::from(std_stream);
+            let _ = socket.set_linger(Some(Duration::ZERO));
+            drop(socket);
+        }
+        Behavior::SilentAfterRead { read_bytes, delay } => {
+            let mut buf = vec![0u8; read_bytes];
+            if stream.read_exact(&mut buf).await.is_ok() {
+                tokio::time::sleep(delay).await;
+                drop(stream);
+            }
+        }
+    }
+}
+
+fn unused_remote() -> SocketAddr {
+    // The stubs ignore `remote`; any valid address works.
+    "127.0.0.1:1".parse().unwrap()
+}
+
+async fn pick_local() -> SocketAddr {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    drop(l);
+    addr
+}
+
+// Test runner =========================================================================================================
+
+/// Run a test scenario: spawn the tap-wrapped plugin, run `client_body`,
+/// then cancel shutdown and await the plugin to exit. Returns the
+/// captured subscriber output.
+async fn run_with_tap<F, Fut>(behavior: Behavior, client_body: F) -> String
+where
+    F: FnOnce(SocketAddr) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let (subscriber, writer) = make_subscriber();
+    let _g = tracing::subscriber::set_default(subscriber);
+
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new();
+    let inner = Box::new(StubPlugin { behavior }) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let plugin_shutdown = shutdown.clone();
+    let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown).await });
+
+    // Wait for tap to be ready by polling its public listener.
+    let ready = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if TcpStream::connect(local).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    ready.expect("tap public listener never became ready");
+
+    // Run the user-supplied client interaction.
+    client_body(local).await;
+
+    // Give the tap's spawn_tap a moment to log the close line (it runs
+    // off the same runtime; the close log fires after copy_bidirectional
+    // returns, which can be up to one tokio scheduling tick after the
+    // OS-side close). 200ms is plenty in practice for these stubs.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(3), plugin_handle).await;
+
+    captured_text(&writer)
+}
+
+// Tests ===============================================================================================================
+
+#[skuld::test]
+async fn echo_records_round_trip_byte_counts_and_ttfb() {
+    let captured = run_with_tap(Behavior::Echo { read_bytes: 5 }, |local| async move {
+        let mut s = TcpStream::connect(local).await.unwrap();
+        s.write_all(b"hello").await.unwrap();
+        s.flush().await.unwrap();
+        let mut buf = [0u8; 5];
+        s.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+        let _ = s.shutdown().await;
+    })
+    .await;
+
+    assert!(
+        captured.contains("plugin tap: accepted"),
+        "missing accept line:\n{captured}"
+    );
+    assert!(
+        captured.contains("plugin tap: closed"),
+        "missing close line:\n{captured}"
+    );
+    assert!(
+        captured.contains("bytes_to_plugin=5"),
+        "want bytes_to_plugin=5:\n{captured}"
+    );
+    assert!(
+        captured.contains("bytes_from_plugin=5"),
+        "want bytes_from_plugin=5:\n{captured}"
+    );
+    assert!(
+        captured.contains("close_kind=graceful"),
+        "want close_kind=graceful:\n{captured}"
+    );
+    assert!(
+        captured.contains("ttfb_ms=Some("),
+        "ttfb_ms must be Some(_) when bytes flowed back:\n{captured}"
+    );
+}
+
+#[skuld::test]
+async fn silent_drop_records_zero_bytes_and_no_ttfb() {
+    let captured = run_with_tap(Behavior::SilentDrop, |local| async move {
+        let mut s = TcpStream::connect(local).await.unwrap();
+        // No writes — let the stub close on us.
+        let mut buf = [0u8; 1];
+        let _ = s.read(&mut buf).await; // returns 0 (EOF)
+    })
+    .await;
+
+    assert!(
+        captured.contains("plugin tap: closed"),
+        "missing close line:\n{captured}"
+    );
+    assert!(
+        captured.contains("bytes_to_plugin=0") && captured.contains("bytes_from_plugin=0"),
+        "expected zero byte counts:\n{captured}"
+    );
+    assert!(
+        captured.contains("ttfb_ms=None"),
+        "ttfb_ms must be None when no upstream bytes ever read:\n{captured}"
+    );
+}
+
+#[skuld::test]
+async fn silent_after_read_matches_248_shape() {
+    // The #248 shape: client writes some bytes, upstream reads them,
+    // upstream NEVER replies, then closes. Tap must record bytes_to=N,
+    // bytes_from=0, ttfb=None.
+    let captured = run_with_tap(
+        Behavior::SilentAfterRead {
+            read_bytes: 16,
+            delay: Duration::from_millis(50),
+        },
+        |local| async move {
+            let mut s = TcpStream::connect(local).await.unwrap();
+            s.write_all(b"silent-after-rd1").await.unwrap();
+            s.flush().await.unwrap();
+            let mut buf = [0u8; 1];
+            let _ = s.read(&mut buf).await; // returns 0 once stub drops
+        },
+    )
+    .await;
+
+    assert!(
+        captured.contains("plugin tap: closed"),
+        "missing close line:\n{captured}"
+    );
+    assert!(
+        captured.contains("bytes_to_plugin=16"),
+        "want bytes_to_plugin=16:\n{captured}"
+    );
+    assert!(
+        captured.contains("bytes_from_plugin=0"),
+        "want bytes_from_plugin=0:\n{captured}"
+    );
+    assert!(
+        captured.contains("ttfb_ms=None"),
+        "ttfb_ms must be None for the #248 silent-then-FIN shape:\n{captured}"
+    );
+}
+
+#[skuld::test]
+async fn rst_close_classified_as_rst_with_os_errno() {
+    let captured = run_with_tap(Behavior::Reset, |local| async move {
+        let mut s = TcpStream::connect(local).await.unwrap();
+        // Touch the connection so the kernel actually accepts it before
+        // SO_LINGER+drop fires the RST.
+        let _ = s.write_all(b"x").await;
+        let _ = s.flush().await;
+        // Drain whatever the kernel surfaces (likely ConnectionReset).
+        let mut buf = [0u8; 1];
+        let _ = s.read(&mut buf).await;
+    })
+    .await;
+
+    assert!(
+        captured.contains("plugin tap: closed"),
+        "missing close line:\n{captured}"
+    );
+    let close_ok = captured.contains("close_kind=rst") || captured.contains("close_kind=broken_pipe");
+    assert!(
+        close_ok,
+        "expected close_kind=rst (or broken_pipe on platforms that surface RST as such):\n{captured}"
+    );
+    // os_errno is platform-dependent; just assert it's recorded as Some(_).
+    assert!(
+        captured.contains("os_errno=Some("),
+        "os_errno must be Some(_) for RST-class close:\n{captured}"
+    );
+}
+
+#[skuld::test]
+async fn shutdown_cancels_in_flight_connection_without_panic() {
+    let (subscriber, _writer) = make_subscriber();
+    let _g = tracing::subscriber::set_default(subscriber);
+
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new();
+
+    // Echo plugin so the connection stays open while client holds it.
+    let inner = Box::new(StubPlugin {
+        behavior: Behavior::Echo { read_bytes: 4096 },
+    }) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let plugin_shutdown = shutdown.clone();
+    let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown).await });
+
+    // Wait for tap ready.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if TcpStream::connect(local).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("tap ready");
+
+    // Open a connection that the echo plugin will hold (waiting on
+    // read_exact for 4096 bytes — we send only 1).
+    let _client = TcpStream::connect(local).await.unwrap();
+
+    // Cancel shutdown and assert the plugin exits within budget.
+    shutdown.cancel();
+    let result = tokio::time::timeout(Duration::from_secs(3), plugin_handle).await;
+    assert!(result.is_ok(), "tap plugin did not exit within 3s of shutdown");
+}
+
+#[skuld::test]
+async fn cross_check_inbound_and_upstream_counters_match() {
+    // Sanity invariant: on a clean roundtrip, inbound.read == upstream.written
+    // and inbound.written == upstream.read. Catches future tap regressions
+    // where one direction's counter wires up wrong.
+    let captured = run_with_tap(Behavior::Echo { read_bytes: 7 }, |local| async move {
+        let mut s = TcpStream::connect(local).await.unwrap();
+        s.write_all(b"abcdefg").await.unwrap();
+        s.flush().await.unwrap();
+        let mut buf = [0u8; 7];
+        s.read_exact(&mut buf).await.unwrap();
+        let _ = s.shutdown().await;
+    })
+    .await;
+
+    assert!(captured.contains("bytes_to_plugin=7"), "to_plugin=7:\n{captured}");
+    assert!(captured.contains("bytes_from_plugin=7"), "from_plugin=7:\n{captured}");
+    assert!(captured.contains("bytes_inbound_read=7"), "inbound_read=7:\n{captured}");
+    assert!(
+        captured.contains("bytes_inbound_written=7"),
+        "inbound_written=7:\n{captured}"
+    );
+}
+
+// CountingStream sanity (delegated to its own test module, kept here as a smoke check).
+#[skuld::test]
+async fn counting_stream_smoke() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut s, _) = listener.accept().await.unwrap();
+        s.write_all(b"abc").await.unwrap();
+        s.flush().await.unwrap();
+    });
+    let raw = TcpStream::connect(addr).await.unwrap();
+    let mut counted = CountingStream::new(raw);
+    let counters = counted.counters();
+    let mut buf = [0u8; 3];
+    counted.read_exact(&mut buf).await.unwrap();
+    assert_eq!(counters.read(), 3);
+    server.await.unwrap();
+}

--- a/crates/garter/tests/tap_integration.rs
+++ b/crates/garter/tests/tap_integration.rs
@@ -1,0 +1,118 @@
+//! Integration test: wrap a real `mock-plugin` subprocess in a `TapPlugin`
+//! and confirm bytes round-trip end-to-end. Exists as a smoke-level
+//! check that TapPlugin's `inner.run()` handoff works against a
+//! `BinaryPlugin` (subprocess) — the unit tests in
+//! `crates/garter/src/tap_tests.rs` exercise the tap mechanics against
+//! Rust `StubPlugin`s, which is faster but doesn't verify
+//! Apache-2.0-process-boundary behavior.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+
+use garter::{BinaryPlugin, ChainPlugin, TapPlugin};
+
+fn mock_plugin_path() -> PathBuf {
+    let status = std::process::Command::new("cargo")
+        .args(["build", "-p", "mock-plugin"])
+        .status()
+        .expect("failed to build mock-plugin");
+    assert!(status.success(), "mock-plugin build failed");
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop(); // crates/garter -> crates/
+    path.pop(); // crates/ -> workspace root
+    path.push("target");
+    path.push(if cfg!(debug_assertions) { "debug" } else { "release" });
+    path.push(if cfg!(windows) {
+        "mock-plugin.exe"
+    } else {
+        "mock-plugin"
+    });
+    assert!(path.exists(), "mock-plugin not found at {}", path.display());
+    path
+}
+
+#[skuld::test]
+async fn tap_relays_data_through_binary_plugin_to_echo_server() {
+    // Install a subscriber that prints to test stderr so mock-plugin's
+    // own stderr (captured by BinaryPlugin and re-emitted as
+    // tracing::warn) and the tap's info events are visible when this
+    // test is debugged.
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_test_writer()
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    let _g = tracing::subscriber::set_default(subscriber);
+
+    let mock_path = mock_plugin_path();
+
+    // Multi-connection echo server. The TapPlugin's readiness probe
+    // (TCP-connect to inner_local) is forwarded through mock-plugin to
+    // the echo server, consuming an accept slot before the real client
+    // connection arrives. So the echo server must loop to handle every
+    // forwarded connection — otherwise the second one (the real client
+    // payload) hangs forever.
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    let echo_task = tokio::spawn(async move {
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut reader, mut writer) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut reader, &mut writer).await;
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    // Pick a public local for the tap.
+    let pick_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = pick_listener.local_addr().unwrap();
+    drop(pick_listener);
+
+    let inner: Box<dyn ChainPlugin> = Box::new(BinaryPlugin::new(&mock_path, None));
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let shutdown = CancellationToken::new();
+    let plugin_shutdown = shutdown.clone();
+    let plugin_handle = tokio::spawn(async move { tap.run(chain_local, echo_addr, plugin_shutdown).await });
+
+    // Wait for tap public listener to come up.
+    let mut client = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            match TcpStream::connect(chain_local).await {
+                Ok(s) => break s,
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Err(e) => panic!("tap did not start accepting within 10s: {e}"),
+            }
+        }
+    };
+
+    client.write_all(b"hello through tap+mock").await.unwrap();
+    let mut buf = [0u8; 1024];
+    let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .unwrap();
+    assert_eq!(&buf[..n], b"hello through tap+mock");
+
+    drop(client);
+    echo_task.abort();
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), plugin_handle).await;
+}
+
+fn main() {
+    skuld::run_all();
+}


### PR DESCRIPTION
## Summary

Layer 2 of [#267](https://github.com/bindreams/hole/issues/267).
Inserts a counting loopback hop between shadowsocks-service and the
inner plugin (binary or galoshes/Rust), turning the plugin chain's data
plane into a structured `bridge.log` field set:

- `bytes_to_plugin` / `bytes_from_plugin` — raw byte counts in each
  direction.
- `ttfb_ms` — milliseconds from `accept` to the first non-zero
  upstream read. `None` is the load-bearing diagnostic for
  [#248](https://github.com/bindreams/hole/issues/248)-class
  "tunnel returns nothing back" cases.
- `close_kind` — taxonomy of how the connection ended (`graceful` /
  `rst` / `abort` / `eof` / `timeout` / `broken_pipe` / `other`),
  cross-platform Win32+POSIX errno mapping.

Gated by ``HOLE_BRIDGE_PLUGIN_TAP=1`` env var (dev-mode only — env
vars don't survive into Windows SCM / launchd service contexts).
Layer 1 (PR #268, merged) is the precondition that surfaces
shadowsocks-service's complementary TRACE byte counts via
``HOLE_BRIDGE_LOG=hole_bridge=debug,shadowsocks_service=trace``.

## Changes

### `crates/garter/` (Apache-2.0)

- **`counting.rs`** (NEW): `CountingStream<S>` + `StreamCounters` lifted from
  the bridge's DNS forwarder so both the forwarder and the new tap share one
  wrapper. Adds `first_read_at: Arc<OnceLock<Instant>>` for the time-to-first-byte signal.
- **`tap.rs`** (NEW): `TapPlugin` decorator over any `ChainPlugin`. Lifecycle:
  alloc inner port → spawn inner → wait for inner readiness via reused
  `chain::poll_ready` → bind public listener → per-connection forwarder
  in a `JoinSet` calling `tokio::io::copy_bidirectional`. Inner-connect
  retry on transient `ECONNREFUSED` (250ms budget). Cancel cascades.
- **`chain.rs`**: `poll_ready` made `pub(crate)` so the tap reuses the
  same backoff schedule as `ChainRunner`.
- **`tap_tests.rs`** (NEW): unit tests covering echo, silent-drop,
  silent-after-read (#248 shape), RST, in-flight cancel, counter
  cross-check, time-to-first-byte semantics.
- **`counting_tests.rs`** (NEW): `CountingStream` round-trip,
  `first_read_at` semantics (None when no byte arrived, no update on
  subsequent reads).
- **`tests/tap_integration.rs`** (NEW): end-to-end test wrapping a real
  `mock-plugin` subprocess in a `TapPlugin` against an in-test echo
  server. Smoke check that the inner.run() handoff works against
  `BinaryPlugin` (subprocess) not just Rust stubs.

### `crates/bridge/`

- **`dns/connector.rs`**: `CountingStream` + `StreamCounters` re-imported
  from `garter::counting` (was a local copy). Public API unchanged for
  callers; bridge crate still owns `AsyncDuplex` / `BoxedStream` /
  `ConnectedStream` since those are bridge-DNS-specific.
- **`proxy/plugin.rs`**: when `HOLE_BRIDGE_PLUGIN_TAP=1`, wrap the
  inner `BinaryPlugin` in `TapPlugin` before adding to the chain.

### `CLAUDE.md`

New "Plugin tap (HOLE_BRIDGE_PLUGIN_TAP)" subsection documenting the
gate, log shape, and dev-mode-only caveat.

## Test plan

- [x] `cargo clippy --workspace --all-targets` green.
- [x] `cargo fmt --check` green.
- [x] `cargo test -p garter --lib` — 47 passed including 10 new tests
  (`echo_records_round_trip_byte_counts_and_ttfb`,
  `silent_drop_records_zero_bytes_and_no_ttfb`,
  `silent_after_read_matches_248_shape`,
  `rst_close_classified_as_rst_with_os_errno`,
  `shutdown_cancels_in_flight_connection_without_panic`,
  `cross_check_inbound_and_upstream_counters_match`,
  `counts_bytes_roundtripped`,
  `first_read_at_is_none_when_no_bytes_arrive`,
  `first_read_at_does_not_update_after_first_set`,
  `counting_stream_smoke`).
- [x] `cargo test -p garter --test tap_integration` — green
  (mock-plugin subprocess + tap + echo).
- [x] `cargo test -p hole-bridge --lib` (skipping `e2e_`/`lifecycle_`/`cipher_`
  which need staged dist) — 403 passed including all DNS forwarder
  tests after the CountingStream lift.
- [ ] Manual on the user's #248 reproduction: `HOLE_BRIDGE_PLUGIN_TAP=1`
  + `HOLE_BRIDGE_LOG=hole_bridge=debug,shadowsocks_service=trace`,
  one DNS query through the broken tunnel. Expected log line for the
  observed shape:

  ```
  INFO garter::tap: plugin tap: closed
    tap_conn_id: ...
    elapsed_ms: ~2500
    ttfb_ms: None             # <- decisive: plugin chain itself never received a byte back
    bytes_to_plugin: 260
    bytes_from_plugin: 0
    close_kind: graceful | eof
  ```

  `ttfb_ms: None` settles "C.1 vs C.2 vs deeper" against current
  evidence: it confirms the tunnel-internal data plane is silent, not
  just our SOCKS5 listener side.

Ref #248, #267.