### PR TITLE
xtask: build.yaml manifest + cargo xtask build|test|list orchestrator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,40 +222,21 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: cargo binstall --no-confirm --locked cargo-nextest
 
-      - name: Build workspace
-        run: cargo build --workspace
-
-      # Two-pass split to work around #200: the Windows TUN test
-      # (`e2e_none_full_tunnel_roundtrip`) creates and destroys a
-      # `hole-tun` wintun adapter, which perturbs the Azure Hyper-V
-      # host's NDIS loopback packet-delivery path — once broken, it
-      # stays broken for ≥120 s. So we run non-TUN tests first and
-      # the TUN test last, so the break (if it fires) only affects
-      # the tail of the job and not a subsequent loopback-using test.
+      # `hole-tests` declares depends: hole, so the orchestrator runs the
+      # full chain (v2ray-plugin → galoshes → wintun → cargo build) before
+      # nextest. The non-TUN / TUN split is encoded in build.yaml as two
+      # targets — see #200 for the NDIS-loopback corruption that motivated
+      # running TUN tests last.
       - name: Test (non-TUN)
         id: test-non-tun
         shell: bash
-        env:
-          SKULD_LABELS: "!tun"
-        run: >
-          cargo nextest run
-          -E 'package(hole) + package(hole-bridge) + package(hole-common)
-              + package(tun-engine) + package(tun-engine-macros)
-              + package(dump) + package(dump-macros)
-              + package(handle-holders)'
+        run: cargo xtask test hole-tests
 
       - name: Test (TUN, runs last for #200)
         if: matrix.os == 'windows' && matrix.arch == 'amd64'
         id: test-tun
         shell: bash
-        env:
-          SKULD_LABELS: "tun"
-        run: >
-          cargo nextest run
-          -E 'package(hole) + package(hole-bridge) + package(hole-common)
-              + package(tun-engine) + package(tun-engine-macros)
-              + package(dump) + package(dump-macros)
-              + package(handle-holders)'
+        run: cargo xtask test hole-tun-tests
 
       # Upload bridge.log produced by `DistHarness` subprocesses. Matches
       # files that the test harness redirected to `$RUNNER_TEMP` (see
@@ -287,7 +268,7 @@ jobs:
         run: uv run --group dev pytest -v
 
       - name: Build MSI
-        run: uv run --directory msi-installer build
+        run: cargo xtask build hole-msi
 
       - name: Smoke-test binary
         run: target\release\hole.exe version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,21 +222,40 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: cargo binstall --no-confirm --locked cargo-nextest
 
-      # `hole-tests` declares depends: hole, so the orchestrator runs the
-      # full chain (v2ray-plugin → galoshes → wintun → cargo build) before
-      # nextest. The non-TUN / TUN split is encoded in build.yaml as two
-      # targets — see #200 for the NDIS-loopback corruption that motivated
-      # running TUN tests last.
+      # Compile test binaries via the orchestrator (resolves the full DAG:
+      # v2ray-plugin → galoshes → wintun → hole → hole-tests) but don't run
+      # them yet — running tests is not part of the build process. The two
+      # nextest invocations below execute the pre-built binaries with
+      # different SKULD_LABELS filters; see #200 for the NDIS-loopback
+      # corruption that motivates running TUN tests last (Windows only).
+      - name: Build hole test binaries
+        shell: bash
+        run: cargo xtask build hole-tests
+
       - name: Test (non-TUN)
         id: test-non-tun
         shell: bash
-        run: cargo xtask test hole-tests
+        env:
+          SKULD_LABELS: "!tun"
+        run: >
+          cargo nextest run
+          -E 'package(hole) + package(hole-bridge) + package(hole-common)
+              + package(tun-engine) + package(tun-engine-macros)
+              + package(dump) + package(dump-macros)
+              + package(handle-holders)'
 
       - name: Test (TUN, runs last for #200)
         if: matrix.os == 'windows' && matrix.arch == 'amd64'
         id: test-tun
         shell: bash
-        run: cargo xtask test hole-tun-tests
+        env:
+          SKULD_LABELS: "tun"
+        run: >
+          cargo nextest run
+          -E 'package(hole) + package(hole-bridge) + package(hole-common)
+              + package(tun-engine) + package(tun-engine-macros)
+              + package(dump) + package(dump-macros)
+              + package(handle-holders)'
 
       # Upload bridge.log produced by `DistHarness` subprocesses. Matches
       # files that the test harness redirected to `$RUNNER_TEMP` (see

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -64,12 +64,9 @@ jobs:
 
       - uses: ./.github/actions/setup-build
 
-      # Windows build
-      - name: Build MSI
-        if: matrix.os == 'windows'
-        run: uv run --directory msi-installer build
-
-      # macOS build
+      # Frontend deps + Node toolchain — needed by the macOS DMG path
+      # (`npx tauri build`). Cheap on Windows runners; unconditional to
+      # keep the workflow flat.
       - uses: actions/setup-node@v6
         if: matrix.os == 'darwin'
         with:
@@ -77,9 +74,14 @@ jobs:
       - name: Install npm dependencies
         if: matrix.os == 'darwin'
         run: npm install
-      - name: Build DMG
-        if: matrix.os == 'darwin'
-        run: npx tauri build
+
+      # Single matrix-driven build call: `hole-msi` on Windows, `hole-dmg`
+      # on Darwin. The orchestrator (build.yaml) owns the per-platform
+      # recipe — this step has no per-os `if:` because the target name
+      # carries the platform information.
+      - name: Build artifact
+        shell: bash
+        run: cargo xtask build "hole-${{ matrix.ext }}"
 
       # Rename and hash
       - name: Rename artifact and compute SHA-256

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,16 @@ crates/galoshes/          → bundled SIP003u plugin: YAMUX-multiplexed TCP+UDP 
                             time). Apache-2.0. Shipped alongside hole.exe.
 crates/mock-plugin/       → minimal SIP003u TCP echo plugin for garter integration
                             tests. Apache-2.0.
-xtask/                    → workspace task runner (`cargo xtask <stage|deps|version|...>`)
+build.yaml                → declarative build-target manifest (the DAG of `hole`,
+                            `hole-msi`, `hole-dmg`, `galoshes`, `*-tests`, etc.)
+                            consumed by `cargo xtask build|test|list`. Schema in
+                            xtask/src/manifest.rs; orchestration in xtask/src/orchestrate.rs.
+xtask/                    → workspace task runner. Top-level commands:
+                            - `cargo xtask build <name> | --all`  — orchestrate from build.yaml
+                            - `cargo xtask test  <name> | --all`  — same, for `*-tests` targets
+                            - `cargo xtask list`                  — print the target table
+                            Primitive subcommands stay available for one-off use:
+                            `cargo xtask <stage|deps|v2ray-plugin|galoshes|wintun|version|...>`
 xtask-lib/                → shared helper crate used by xtask AND crates/hole/build.rs
 external/                 → Third-party source (git subrepos): `v2ray-plugin` (Go).
 msi-installer/            → WiX MSI installer (Python project: thin wrapper around xtask + WiX)
@@ -278,11 +287,13 @@ Requires: Rust toolchain, Go toolchain (for v2ray-plugin), Node.js.
 
 ```sh
 npm install                      # install frontend dependencies (first time only)
-cargo xtask deps                 # build v2ray-plugin from Go + download wintun (one-time, cached)
-cargo build --workspace          # all crates
+cargo xtask build hole           # deps + cargo build (debug) + stage — single command
 uv run scripts/dev.py            # dev mode (see CONTRIBUTING.md)
-cargo test --workspace           # all tests
+cargo xtask test --all           # all test targets applicable to host platform
 ```
+
+`build.yaml` at the repo root is the single source of truth for the build
+graph. `cargo xtask list` prints the full target table.
 
 ### Windows installer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,15 @@ At runtime, Tauri embeds the OS's native webview (Edge WebView2 on Windows, WebK
 
 ### Workspace layout
 
-| Directory        | Crate/Purpose                                                       |
-| ---------------- | ------------------------------------------------------------------- |
-| `crates/common/` | `hole-common` — shared types: protocol, config, logging             |
-| `crates/bridge/` | `hole-bridge` — bridge library (TUN/routing/shadowsocks/IPC)        |
-| `crates/hole/`   | `hole` — Tauri app + CLI + bridge entry point (binary name: `hole`) |
-| `xtask/`         | workspace task runner (`cargo xtask <stage\|deps\|version\|...>`)   |
-| `xtask-lib/`     | shared helper crate used by xtask AND `crates/hole/build.rs`        |
-| `external/`      | Third-party source (git subrepos)                                   |
-| `ui/`            | Frontend HTML/CSS/TypeScript (Vite)                                 |
+| Directory        | Crate/Purpose                                                                            |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| `crates/common/` | `hole-common` — shared types: protocol, config, logging                                  |
+| `crates/bridge/` | `hole-bridge` — bridge library (TUN/routing/shadowsocks/IPC)                             |
+| `crates/hole/`   | `hole` — Tauri app + CLI + bridge entry point (binary name: `hole`)                      |
+| `xtask/`         | workspace task runner (`cargo xtask <build\|test\|list\|stage\|...>`) — see `build.yaml` |
+| `xtask-lib/`     | shared helper crate used by xtask AND `crates/hole/build.rs`                             |
+| `external/`      | Third-party source (git subrepos)                                                        |
+| `ui/`            | Frontend HTML/CSS/TypeScript (Vite)                                                      |
 
 ### Logging
 
@@ -96,9 +96,8 @@ If you prefer separate terminals or need more control:
 Windows (elevated PowerShell):
 
 ```powershell
-cargo xtask deps                                                          # build v2ray-plugin + download wintun
-cargo build
-cargo xtask stage --profile debug --out-dir "$env:TEMP\hole-dev-manual"   # populates BINDIR (hole.exe + sidecars + wintun.dll)
+cargo xtask build hole                                                    # deps + cargo build (debug) + stage to target/debug/dist
+cargo xtask stage --profile debug --out-dir "$env:TEMP\hole-dev-manual"   # per-session BINDIR (hole.exe + sidecars + wintun.dll)
 & "$env:TEMP\hole-dev-manual\hole.exe" bridge grant-access                # create hole group, add user
 & "$env:TEMP\hole-dev-manual\hole.exe" bridge run `
     --socket-path "$env:TEMP\hole-dev.sock" `
@@ -108,14 +107,19 @@ cargo xtask stage --profile debug --out-dir "$env:TEMP\hole-dev-manual"   # popu
 macOS (under sudo):
 
 ```sh
-cargo xtask deps                                                          # build v2ray-plugin
-cargo build
-cargo xtask stage --profile debug --out-dir "$TMPDIR/hole-dev-manual"     # populates BINDIR (hole + sidecars)
+cargo xtask build hole                                                    # deps + cargo build (debug) + stage to target/debug/dist
+cargo xtask stage --profile debug --out-dir "$TMPDIR/hole-dev-manual"     # per-session BINDIR (hole + sidecars)
 "$TMPDIR/hole-dev-manual/hole" bridge grant-access                        # create hole group, add user
 "$TMPDIR/hole-dev-manual/hole" bridge run \
     --socket-path "$TMPDIR/hole-dev.sock" \
     --state-dir   "$TMPDIR/hole-dev-state"
 ```
+
+`cargo xtask build hole` walks the `build.yaml` DAG: it builds v2ray-plugin
+(Go), galoshes (workspace member), downloads wintun on Windows, then runs
+`cargo build --workspace` (debug) and `cargo xtask stage --profile debug --out-dir target/debug/dist`. Use `cargo xtask list` to print the full target
+table; `cargo xtask build|test --all` builds or runs every target applicable
+to the host platform.
 
 **Terminal 2 — Vite + GUI (unelevated):**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,6 +4160,18 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -8630,6 +8648,10 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "glob",
+ "indexmap 2.14.0",
+ "petgraph",
+ "serde",
+ "serde_yml",
  "sha2 0.11.0",
  "skuld",
  "tempfile",

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,134 @@
+# Hole build manifest — single source of truth for `cargo xtask build|test|list`.
+#
+# Schema and semantics live in xtask/src/manifest.rs (deserializers, validation)
+# and xtask/src/orchestrate.rs (DAG, execution). User-facing summary in CLAUDE.md
+# under "Build". Design rationale: docs ../i-want-to-brainstorm-zippy-lightning.md.
+#
+# Platform shape: `<os>/<arch>` (Docker / GOOS-style), where
+#   os   ∈ {windows, darwin, linux}
+#   arch ∈ {amd64, arm64}
+# (matching the project's release-artifact naming convention).
+#
+# Steps default to bash. Bare strings are shorthand for `bash: <string>`. Use
+# `process: [...]` for direct subprocess spawn (no shell). Per-step
+# `environment:` appends to inherited env. CWD is repo root.
+
+targets:
+  v2ray-plugin:
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo xtask v2ray-plugin
+
+  galoshes:
+    depends: v2ray-plugin
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo xtask galoshes
+
+  garter:
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo build --release -p garter
+
+  garter-bin:
+    depends: garter
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo build --release -p garter-bin
+
+  mock-plugin:
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo build --release -p mock-plugin
+
+  wintun:
+    platforms: [windows/amd64, windows/arm64]
+    build: cargo xtask wintun
+
+  hole:
+    # Builds the hole executable + sidecars in debug profile and stages the
+    # canonical BINDIR. Release builds happen inside `hole-msi` / `hole-dmg`
+    # via msi-installer / tauri, which run their own `cargo build --release`
+    # — so `hole` itself is what you build for development and tests.
+    depends: [galoshes, wintun]
+    platforms: [windows/amd64, darwin/amd64, darwin/arm64]
+    build:
+      - cargo build --workspace
+      - cargo xtask stage --profile debug --out-dir target/debug/dist
+
+  hole-msi:
+    depends: hole
+    platforms: [windows/amd64]
+    # The msi-installer Python entry point internally re-runs `cargo build
+    # --release` and `cargo xtask stage --profile release`; the WiX toolchain
+    # acquisition stays inside msi-installer. The `cargo build` is shared via
+    # cargo's fingerprint cache when invoked twice (debug from `hole`, release
+    # from msi-installer).
+    build: uv run --directory msi-installer build
+
+  hole-dmg:
+    depends: hole
+    platforms: [darwin/amd64, darwin/arm64]
+    # Tauri internally runs `cargo build --release`; cargo incremental shares
+    # dependency artifacts with the debug build done by `hole`.
+    build: npx tauri build
+
+  # ===== Test targets =======================================================
+  # Convention: name ends in `-tests`. Depends on the corresponding build
+  # target. Targeted by `cargo xtask test <name>` and `cargo xtask test --all`.
+
+  hole-tests:
+    # Non-TUN pass — applies to every platform on which Hole builds.
+    depends: hole
+    platforms: [windows/amd64, darwin/amd64, darwin/arm64]
+    build:
+      bash:
+        command: >
+          cargo nextest run
+          -E 'package(hole) + package(hole-bridge) + package(hole-common)
+              + package(tun-engine) + package(tun-engine-macros)
+              + package(dump) + package(dump-macros)
+              + package(handle-holders)'
+        environment: { SKULD_LABELS: "!tun" }
+
+  hole-tun-tests:
+    # TUN pass — Windows-only. Split out from `hole-tests` because of #200:
+    # the TUN test creates and destroys a `hole-tun` wintun adapter, which
+    # perturbs Azure Hyper-V's NDIS loopback packet-delivery path. Running it
+    # last (and only on Windows, where TUN tests exist) preserves the v1 rule
+    # of no per-step platform filters.
+    depends: hole
+    platforms: [windows/amd64]
+    build:
+      bash:
+        command: >
+          cargo nextest run
+          -E 'package(hole) + package(hole-bridge) + package(hole-common)
+              + package(tun-engine) + package(tun-engine-macros)
+              + package(dump) + package(dump-macros)
+              + package(handle-holders)'
+        environment: { SKULD_LABELS: "tun" }
+
+  galoshes-tests:
+    depends: galoshes
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo nextest run -p galoshes
+
+  garter-tests:
+    depends: garter
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo nextest run -p garter
+
+  garter-bin-tests:
+    depends: garter-bin
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo nextest run -p garter-bin
+
+  mock-plugin-tests:
+    depends: mock-plugin
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo nextest run -p mock-plugin

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-# Hole build manifest — single source of truth for `cargo xtask build|test|list`.
+# Hole build manifest — single source of truth for `cargo xtask build|list`.
 #
 # Schema and semantics live in xtask/src/manifest.rs (deserializers, validation)
 # and xtask/src/orchestrate.rs (DAG, execution). User-facing summary in CLAUDE.md
@@ -13,23 +13,22 @@
 # `process: [...]` for direct subprocess spawn (no shell). Per-step
 # `environment:` appends to inherited env. CWD is repo root.
 #
-# `$XTASK` env var (set by the orchestrator before each step) is the path to
-# the running xtask binary. Use it instead of `cargo xtask <subcommand>` —
-# `cargo run` would re-link xtask.exe, and the running parent holds an
-# exclusive lock on Windows (ERROR_ACCESS_DENIED). Direct invocation skips
-# the rebuild check.
+# `*-tests` targets are regular build targets that produce test binaries —
+# they do NOT run tests. Running tests is the caller's concern (typically
+# `cargo nextest run`), the same way running `hole.exe` is not part of
+# building it.
 
 targets:
   v2ray-plugin:
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: '"$XTASK" v2ray-plugin'
+    build: cargo xtask v2ray-plugin
 
   galoshes:
     depends: v2ray-plugin
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: '"$XTASK" galoshes'
+    build: cargo xtask galoshes
 
   garter:
     platforms:
@@ -53,23 +52,18 @@ targets:
     # silently install the wrong-arch DLL. Lift this once xtask::wintun
     # picks per-host-arch.
     platforms: [windows/amd64]
-    build: '"$XTASK" wintun'
+    build: cargo xtask wintun
 
   hole:
     # Builds the hole executable + sidecars in debug profile and stages the
     # canonical BINDIR. Release builds happen inside `hole-msi` / `hole-dmg`
     # via msi-installer / tauri, which run their own `cargo build --release`
     # — so `hole` itself is what you build for development and tests.
-    #
-    # `--exclude xtask`: the orchestrator IS xtask, running from
-    # target/debug/xtask.exe. A `--workspace` build that re-links xtask hits
-    # ERROR_ACCESS_DENIED on Windows (the parent holds an exclusive lock).
-    # Skipping xtask is correct anyway: it's already built (we're running it).
     depends: [galoshes, wintun]
     platforms: [windows/amd64, darwin/amd64, darwin/arm64]
     build:
-      - cargo build --workspace --exclude xtask
-      - '"$XTASK" stage --profile debug --out-dir target/debug/dist'
+      - cargo build --workspace
+      - cargo xtask stage --profile debug --out-dir target/debug/dist
 
   hole-msi:
     # NOT a dependent of `hole`. The msi-installer Python entry point does its
@@ -89,61 +83,40 @@ targets:
     build: npx tauri build
 
   # ===== Test targets =======================================================
-  # Convention: name ends in `-tests`. Depends on the corresponding build
-  # target. Targeted by `cargo xtask test <name>` and `cargo xtask test --all`.
+  # Convention: name ends in `-tests`. Compile test binaries only — the
+  # orchestrator never runs them. CI / dev invokes `cargo nextest run` (with
+  # whatever runtime filters / SKULD_LABELS env it wants) after building.
 
   hole-tests:
-    # Non-TUN pass — applies to every platform on which Hole builds.
     depends: hole
     platforms: [windows/amd64, darwin/amd64, darwin/arm64]
-    build:
-      bash:
-        command: >
-          cargo nextest run
-          -E 'package(hole) + package(hole-bridge) + package(hole-common)
-              + package(tun-engine) + package(tun-engine-macros)
-              + package(dump) + package(dump-macros)
-              + package(handle-holders)'
-        environment: { SKULD_LABELS: "!tun" }
-
-  hole-tun-tests:
-    # TUN pass — Windows-only. Split out from `hole-tests` because of #200:
-    # the TUN test creates and destroys a `hole-tun` wintun adapter, which
-    # perturbs Azure Hyper-V's NDIS loopback packet-delivery path. Running it
-    # last (and only on Windows, where TUN tests exist) preserves the v1 rule
-    # of no per-step platform filters.
-    depends: hole
-    platforms: [windows/amd64]
-    build:
-      bash:
-        command: >
-          cargo nextest run
-          -E 'package(hole) + package(hole-bridge) + package(hole-common)
-              + package(tun-engine) + package(tun-engine-macros)
-              + package(dump) + package(dump-macros)
-              + package(handle-holders)'
-        environment: { SKULD_LABELS: "tun" }
+    build: >
+      cargo nextest run --no-run
+      -E 'package(hole) + package(hole-bridge) + package(hole-common)
+          + package(tun-engine) + package(tun-engine-macros)
+          + package(dump) + package(dump-macros)
+          + package(handle-holders)'
 
   galoshes-tests:
     depends: galoshes
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo nextest run -p galoshes
+    build: cargo nextest run --no-run -p galoshes
 
   garter-tests:
     depends: garter
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo nextest run -p garter
+    build: cargo nextest run --no-run -p garter
 
   garter-bin-tests:
     depends: garter-bin
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo nextest run -p garter-bin
+    build: cargo nextest run --no-run -p garter-bin
 
   mock-plugin-tests:
     depends: mock-plugin
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo nextest run -p mock-plugin
+    build: cargo nextest run --no-run -p mock-plugin

--- a/build.yaml
+++ b/build.yaml
@@ -12,18 +12,24 @@
 # Steps default to bash. Bare strings are shorthand for `bash: <string>`. Use
 # `process: [...]` for direct subprocess spawn (no shell). Per-step
 # `environment:` appends to inherited env. CWD is repo root.
+#
+# `$XTASK` env var (set by the orchestrator before each step) is the path to
+# the running xtask binary. Use it instead of `cargo xtask <subcommand>` —
+# `cargo run` would re-link xtask.exe, and the running parent holds an
+# exclusive lock on Windows (ERROR_ACCESS_DENIED). Direct invocation skips
+# the rebuild check.
 
 targets:
   v2ray-plugin:
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo xtask v2ray-plugin
+    build: '"$XTASK" v2ray-plugin'
 
   galoshes:
     depends: v2ray-plugin
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo xtask galoshes
+    build: '"$XTASK" galoshes'
 
   garter:
     platforms:
@@ -47,7 +53,7 @@ targets:
     # silently install the wrong-arch DLL. Lift this once xtask::wintun
     # picks per-host-arch.
     platforms: [windows/amd64]
-    build: cargo xtask wintun
+    build: '"$XTASK" wintun'
 
   hole:
     # Builds the hole executable + sidecars in debug profile and stages the
@@ -58,7 +64,7 @@ targets:
     platforms: [windows/amd64, darwin/amd64, darwin/arm64]
     build:
       - cargo build --workspace
-      - cargo xtask stage --profile debug --out-dir target/debug/dist
+      - '"$XTASK" stage --profile debug --out-dir target/debug/dist'
 
   hole-msi:
     # NOT a dependent of `hole`. The msi-installer Python entry point does its

--- a/build.yaml
+++ b/build.yaml
@@ -60,10 +60,15 @@ targets:
     # canonical BINDIR. Release builds happen inside `hole-msi` / `hole-dmg`
     # via msi-installer / tauri, which run their own `cargo build --release`
     # — so `hole` itself is what you build for development and tests.
+    #
+    # `--exclude xtask`: the orchestrator IS xtask, running from
+    # target/debug/xtask.exe. A `--workspace` build that re-links xtask hits
+    # ERROR_ACCESS_DENIED on Windows (the parent holds an exclusive lock).
+    # Skipping xtask is correct anyway: it's already built (we're running it).
     depends: [galoshes, wintun]
     platforms: [windows/amd64, darwin/amd64, darwin/arm64]
     build:
-      - cargo build --workspace
+      - cargo build --workspace --exclude xtask
       - '"$XTASK" stage --profile debug --out-dir target/debug/dist'
 
   hole-msi:

--- a/build.yaml
+++ b/build.yaml
@@ -42,7 +42,11 @@ targets:
     build: cargo build --release -p mock-plugin
 
   wintun:
-    platforms: [windows/amd64, windows/arm64]
+    # Restricted to windows/amd64 because xtask::wintun unconditionally
+    # extracts the amd64 DLL from the upstream zip — windows/arm64 would
+    # silently install the wrong-arch DLL. Lift this once xtask::wintun
+    # picks per-host-arch.
+    platforms: [windows/amd64]
     build: cargo xtask wintun
 
   hole:
@@ -57,20 +61,20 @@ targets:
       - cargo xtask stage --profile debug --out-dir target/debug/dist
 
   hole-msi:
-    depends: hole
+    # NOT a dependent of `hole`. The msi-installer Python entry point does its
+    # own `cargo build --release` + `cargo xtask stage --profile release`, so
+    # depending on `hole` (debug) would force a redundant debug compile that
+    # nothing consumes. We depend instead on the same sidecars `hole` does, so
+    # the MSI build still has v2ray-plugin, galoshes, and wintun.dll on disk.
+    depends: [galoshes, wintun]
     platforms: [windows/amd64]
-    # The msi-installer Python entry point internally re-runs `cargo build
-    # --release` and `cargo xtask stage --profile release`; the WiX toolchain
-    # acquisition stays inside msi-installer. The `cargo build` is shared via
-    # cargo's fingerprint cache when invoked twice (debug from `hole`, release
-    # from msi-installer).
     build: uv run --directory msi-installer build
 
   hole-dmg:
-    depends: hole
+    # Same logic as hole-msi: tauri does its own `cargo build --release`. No
+    # wintun dep on darwin (it doesn't apply to that platform).
+    depends: galoshes
     platforms: [darwin/amd64, darwin/arm64]
-    # Tauri internally runs `cargo build --release`; cargo incremental shares
-    # dependency artifacts with the debug build done by `hole`.
     build: npx tauri build
 
   # ===== Test targets =======================================================

--- a/msi-installer/src/msi_installer/__init__.py
+++ b/msi-installer/src/msi_installer/__init__.py
@@ -7,7 +7,6 @@ Usage: uv run --directory msi-installer build
 """
 
 import hashlib
-import os
 import platform
 import re
 import shutil
@@ -53,29 +52,22 @@ def cargo_build(console: Console) -> None:
 
 
 def stage_files(root: Path, stage_dir: Path, console: Console) -> None:
-    """Stage the runnable BINDIR via the xtask `stage` subcommand.
+    """Stage the runnable BINDIR via `cargo xtask stage`.
 
     The canonical list of files (hole.exe + v2ray-plugin.exe + wintun.dll on
     Windows) lives in `xtask/src/bindir.rs::bindir_files()`. dev.py and this
     function both call into the same xtask subcommand, so adding a new BINDIR
     file is a one-line change in xtask and both consumers pick it up
     automatically. See issue #143.
-
-    When invoked under the build.yaml orchestrator (`cargo xtask build
-    hole-msi`), the `$XTASK` env var holds the path to the running xtask
-    binary; we invoke it directly instead of going through `cargo xtask`,
-    which on Windows would re-link xtask.exe and fail with ERROR_ACCESS_DENIED
-    (the parent process holds an exclusive lock).
     """
-    xtask_bin = os.environ.get("XTASK")
-    if xtask_bin:
-        cmd = [xtask_bin, "stage", "--profile", "release", "--out-dir", str(stage_dir)]
-    else:
-        cmd = ["cargo", "xtask", "stage", "--profile", "release", "--out-dir", str(stage_dir)]
-    console.print(f"[bold]Staging installer files[/] to {stage_dir} (via {cmd[0]} stage)")
-    result = subprocess.run(cmd, cwd=root)
+    console.print(f"[bold]Staging installer files[/] to {stage_dir} (via cargo xtask stage)")
+    result = subprocess.run(
+        ["cargo", "xtask", "stage", "--profile", "release", "--out-dir",
+         str(stage_dir)],
+        cwd=root,
+    )
     if result.returncode != 0:
-        raise BuildError(f"xtask stage failed with exit code {result.returncode}")
+        raise BuildError(f"cargo xtask stage failed with exit code {result.returncode}")
 
 
 # Version ==============================================================================================================

--- a/msi-installer/src/msi_installer/__init__.py
+++ b/msi-installer/src/msi_installer/__init__.py
@@ -7,6 +7,7 @@ Usage: uv run --directory msi-installer build
 """
 
 import hashlib
+import os
 import platform
 import re
 import shutil
@@ -52,22 +53,29 @@ def cargo_build(console: Console) -> None:
 
 
 def stage_files(root: Path, stage_dir: Path, console: Console) -> None:
-    """Stage the runnable BINDIR via `cargo xtask stage`.
+    """Stage the runnable BINDIR via the xtask `stage` subcommand.
 
     The canonical list of files (hole.exe + v2ray-plugin.exe + wintun.dll on
     Windows) lives in `xtask/src/bindir.rs::bindir_files()`. dev.py and this
     function both call into the same xtask subcommand, so adding a new BINDIR
     file is a one-line change in xtask and both consumers pick it up
     automatically. See issue #143.
+
+    When invoked under the build.yaml orchestrator (`cargo xtask build
+    hole-msi`), the `$XTASK` env var holds the path to the running xtask
+    binary; we invoke it directly instead of going through `cargo xtask`,
+    which on Windows would re-link xtask.exe and fail with ERROR_ACCESS_DENIED
+    (the parent process holds an exclusive lock).
     """
-    console.print(f"[bold]Staging installer files[/] to {stage_dir} (via cargo xtask stage)")
-    result = subprocess.run(
-        ["cargo", "xtask", "stage", "--profile", "release", "--out-dir",
-         str(stage_dir)],
-        cwd=root,
-    )
+    xtask_bin = os.environ.get("XTASK")
+    if xtask_bin:
+        cmd = [xtask_bin, "stage", "--profile", "release", "--out-dir", str(stage_dir)]
+    else:
+        cmd = ["cargo", "xtask", "stage", "--profile", "release", "--out-dir", str(stage_dir)]
+    console.print(f"[bold]Staging installer files[/] to {stage_dir} (via {cmd[0]} stage)")
+    result = subprocess.run(cmd, cwd=root)
     if result.returncode != 0:
-        raise BuildError(f"cargo xtask stage failed with exit code {result.returncode}")
+        raise BuildError(f"xtask stage failed with exit code {result.returncode}")
 
 
 # Version ==============================================================================================================

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -108,25 +108,19 @@ def ensure_node_modules(npm: str, target_user: tuple[int, int, str, str] | None)
 
 
 def cargo_build(cargo: str, target_user: tuple[int, int, str, str] | None) -> None:
-    """Build the workspace and run xtask deps (wintun + v2ray-plugin).
+    """Build the `hole` target via the orchestrator.
 
-    Both run as the invoking user so `target/` and `.cache/` are not owned
-    by root on macOS-under-sudo.
+    `cargo xtask build hole` walks the build.yaml DAG: v2ray-plugin → galoshes
+    + wintun → cargo build (debug) → stage. Replaces the prior `cargo xtask
+    deps` + `cargo build` sequence with a single declarative invocation. The
+    per-pid stage that follows in main() is dev.py-specific and stays separate.
+
+    Runs as the invoking user so `target/` and `.cache/` are not owned by root
+    on macOS-under-sudo.
     """
-    print(f"{BOLD}Fetching runtime deps (cargo xtask deps)...{RESET}")
+    print(f"{BOLD}Building hole (cargo xtask build hole)...{RESET}")
     result = subprocess.run(
-        [cargo, "xtask", "deps"],
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-        env=drop_env({**os.environ}, target_user),
-        **drop_kwargs(target_user),
-    )
-    if result.returncode != 0:
-        sys.exit(result.returncode)
-
-    print(f"{BOLD}Building workspace...{RESET}")
-    result = subprocess.run(
-        [cargo, "build"],
+        [cargo, "xtask", "build", "hole"],
         stdout=sys.stdout,
         stderr=sys.stderr,
         env=drop_env({**os.environ}, target_user),

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,6 +30,12 @@ sha2 = "0.11"
 ureq = "3"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
+# `cargo xtask build|test|list` (build.yaml manifest + DAG orchestration).
+serde = { version = "1", features = ["derive"] }
+serde_yml = "0.0.12"
+indexmap = { version = "2", features = ["serde"] }
+petgraph = "0.8"
+
 [dev-dependencies]
 skuld = { workspace = true }
 tempfile = "3"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::manifest::{Manifest, Platform};
-use crate::orchestrate::{execute, render_list, Plan, Verb};
+use crate::orchestrate::{execute, relocate_self_if_windows, render_list, Plan};
 
 pub mod bindir;
 pub mod galoshes;
@@ -110,26 +110,16 @@ pub enum Command {
     ///
     /// `cargo xtask build <name>` resolves the dependency DAG, filters to
     /// targets applicable to the host platform, and runs each target's
-    /// `build:` steps in topological order. `--all` selects every non-test
-    /// target applicable to the host.
-    Build {
-        /// Target name (e.g. `hole`, `galoshes`, `hole-msi`).
-        target: Option<String>,
-        /// Build every non-test target applicable to the host platform.
-        #[arg(long, conflicts_with = "target")]
-        all: bool,
-    },
-    /// Run a test target declared in `build.yaml` (and build its deps first).
+    /// `build:` steps in topological order. `--all` builds every target
+    /// applicable to the host platform.
     ///
-    /// Test targets are first-class entries with names ending in `-tests`
-    /// (`hole-tests`, `galoshes-tests`, etc.). `cargo xtask test <name>`
-    /// builds the dep tree (which includes the corresponding `*` build target)
-    /// and then runs the test target's steps. `--all` selects every test
-    /// target applicable to the host.
-    Test {
-        /// Test target name (e.g. `hole-tests`).
+    /// Test targets (names ending in `-tests`) are regular build targets
+    /// that produce test binaries; running those binaries is the caller's
+    /// concern (typically `cargo nextest run`), not xtask's.
+    Build {
+        /// Target name (e.g. `hole`, `galoshes`, `hole-msi`, `hole-tests`).
         target: Option<String>,
-        /// Run every test target applicable to the host platform.
+        /// Build every target applicable to the host platform.
         #[arg(long, conflicts_with = "target")]
         all: bool,
     },
@@ -182,7 +172,6 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Deps => run_deps(),
         Command::Version { check, exact } => run_version(check, exact),
         Command::Build { target, all } => run_build(target, all),
-        Command::Test { target, all } => run_test(target, all),
         Command::List => run_list(),
     }
 }
@@ -226,21 +215,12 @@ pub fn run_deps() -> Result<()> {
 }
 
 pub fn run_build(target: Option<String>, all: bool) -> Result<()> {
-    run_orchestrated(Verb::Build, target, all)
-}
+    // Move ourselves out of `target/<profile>/xtask.exe` *before* spawning any
+    // subprocess that might shell out to `cargo xtask <X>`. Without this,
+    // cargo's relink path tries to overwrite our running binary on Windows
+    // and fails with ERROR_ACCESS_DENIED. No-op on POSIX.
+    relocate_self_if_windows()?;
 
-pub fn run_test(target: Option<String>, all: bool) -> Result<()> {
-    run_orchestrated(Verb::Test, target, all)
-}
-
-pub fn run_list() -> Result<()> {
-    let (manifest, _repo_root) = load_manifest()?;
-    let host = Platform::host();
-    print!("{}", render_list(&manifest, host));
-    Ok(())
-}
-
-fn run_orchestrated(verb: Verb, target: Option<String>, all: bool) -> Result<()> {
     let (manifest, repo_root) = load_manifest()?;
     let host = Platform::host().ok_or_else(|| {
         anyhow!(
@@ -253,23 +233,10 @@ fn run_orchestrated(verb: Verb, target: Option<String>, all: bool) -> Result<()>
     let roots: Vec<&str> = match (target, all) {
         (Some(name), false) => {
             let target = manifest.get(&name).ok_or_else(|| anyhow!("unknown target: {name:?}"))?;
-            // Verb mismatch: explicitly reject `build hole-tests` /
-            // `test hole`. Either is a category error.
-            match (verb, target.is_test()) {
-                (Verb::Build, true) => {
-                    return Err(anyhow!("{name:?} is a test target — use `cargo xtask test {name}`"));
-                }
-                (Verb::Test, false) => {
-                    return Err(anyhow!(
-                        "{name:?} is not a test target — use `cargo xtask build {name}`"
-                    ));
-                }
-                _ => {}
-            }
             vec![target.name.as_str()]
         }
         (None, true) => plan
-            .targets_for_verb(verb)
+            .target_names()
             .into_iter()
             .filter(|name| manifest.get(name).map(|t| t.applies_to(host)).unwrap_or(false))
             .collect(),
@@ -280,18 +247,19 @@ fn run_orchestrated(verb: Verb, target: Option<String>, all: bool) -> Result<()>
     };
 
     if roots.is_empty() {
-        println!(
-            "xtask: no {} targets apply to host platform {host}",
-            match verb {
-                Verb::Build => "build",
-                Verb::Test => "test",
-            }
-        );
+        println!("xtask: no targets apply to host platform {host}");
         return Ok(());
     }
 
     let order = plan.order_for(&roots, host)?;
     execute(&plan, &order, &repo_root)
+}
+
+pub fn run_list() -> Result<()> {
+    let (manifest, _repo_root) = load_manifest()?;
+    let host = Platform::host();
+    print!("{}", render_list(&manifest, host));
+    Ok(())
 }
 
 fn load_manifest() -> Result<(Manifest, PathBuf)> {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -5,11 +5,16 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
+
+use crate::manifest::{Manifest, Platform};
+use crate::orchestrate::{execute, render_list, Plan, Verb};
 
 pub mod bindir;
 pub mod galoshes;
+pub mod manifest;
+pub mod orchestrate;
 pub mod stage;
 pub mod test_binaries;
 pub mod v2ray_plugin;
@@ -18,6 +23,12 @@ pub mod wintun;
 #[cfg(test)]
 #[path = "bindir_tests.rs"]
 mod bindir_tests;
+#[cfg(test)]
+#[path = "manifest_tests.rs"]
+mod manifest_tests;
+#[cfg(test)]
+#[path = "orchestrate_tests.rs"]
+mod orchestrate_tests;
 #[cfg(test)]
 #[path = "stage_tests.rs"]
 mod stage_tests;
@@ -95,6 +106,36 @@ pub enum Command {
         #[arg(long, requires = "check")]
         exact: bool,
     },
+    /// Build a target declared in `build.yaml` (and its transitive deps).
+    ///
+    /// `cargo xtask build <name>` resolves the dependency DAG, filters to
+    /// targets applicable to the host platform, and runs each target's
+    /// `build:` steps in topological order. `--all` selects every non-test
+    /// target applicable to the host.
+    Build {
+        /// Target name (e.g. `hole`, `galoshes`, `hole-msi`).
+        target: Option<String>,
+        /// Build every non-test target applicable to the host platform.
+        #[arg(long, conflicts_with = "target")]
+        all: bool,
+    },
+    /// Run a test target declared in `build.yaml` (and build its deps first).
+    ///
+    /// Test targets are first-class entries with names ending in `-tests`
+    /// (`hole-tests`, `galoshes-tests`, etc.). `cargo xtask test <name>`
+    /// builds the dep tree (which includes the corresponding `*` build target)
+    /// and then runs the test target's steps. `--all` selects every test
+    /// target applicable to the host.
+    Test {
+        /// Test target name (e.g. `hole-tests`).
+        target: Option<String>,
+        /// Run every test target applicable to the host platform.
+        #[arg(long, conflicts_with = "target")]
+        all: bool,
+    },
+    /// List every target declared in `build.yaml` with its platforms and
+    /// host-platform applicability.
+    List,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -140,6 +181,9 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Wintun => run_wintun(),
         Command::Deps => run_deps(),
         Command::Version { check, exact } => run_version(check, exact),
+        Command::Build { target, all } => run_build(target, all),
+        Command::Test { target, all } => run_test(target, all),
+        Command::List => run_list(),
     }
 }
 
@@ -179,6 +223,83 @@ pub fn run_deps() -> Result<()> {
     run_galoshes()?;
     run_wintun()?;
     Ok(())
+}
+
+pub fn run_build(target: Option<String>, all: bool) -> Result<()> {
+    run_orchestrated(Verb::Build, target, all)
+}
+
+pub fn run_test(target: Option<String>, all: bool) -> Result<()> {
+    run_orchestrated(Verb::Test, target, all)
+}
+
+pub fn run_list() -> Result<()> {
+    let (manifest, _repo_root) = load_manifest()?;
+    let host = Platform::host();
+    print!("{}", render_list(&manifest, host));
+    Ok(())
+}
+
+fn run_orchestrated(verb: Verb, target: Option<String>, all: bool) -> Result<()> {
+    let (manifest, repo_root) = load_manifest()?;
+    let host = Platform::host().ok_or_else(|| {
+        anyhow!(
+            "host platform not in the known set (windows/darwin/linux × amd64/arm64); \
+             cannot orchestrate"
+        )
+    })?;
+    let plan = Plan::new(&manifest)?;
+
+    let roots: Vec<&str> = match (target, all) {
+        (Some(name), false) => {
+            let target = manifest.get(&name).ok_or_else(|| anyhow!("unknown target: {name:?}"))?;
+            // Verb mismatch: explicitly reject `build hole-tests` /
+            // `test hole`. Either is a category error.
+            match (verb, target.is_test()) {
+                (Verb::Build, true) => {
+                    return Err(anyhow!("{name:?} is a test target — use `cargo xtask test {name}`"));
+                }
+                (Verb::Test, false) => {
+                    return Err(anyhow!(
+                        "{name:?} is not a test target — use `cargo xtask build {name}`"
+                    ));
+                }
+                _ => {}
+            }
+            vec![target.name.as_str()]
+        }
+        (None, true) => plan
+            .targets_for_verb(verb)
+            .into_iter()
+            .filter(|name| manifest.get(name).map(|t| t.applies_to(host)).unwrap_or(false))
+            .collect(),
+        (Some(_), true) => unreachable!("clap rejects --all with a positional target"),
+        (None, false) => {
+            return Err(anyhow!("specify a target name or pass --all"));
+        }
+    };
+
+    if roots.is_empty() {
+        println!(
+            "xtask: no {} targets apply to host platform {host}",
+            match verb {
+                Verb::Build => "build",
+                Verb::Test => "test",
+            }
+        );
+        return Ok(());
+    }
+
+    let order = plan.order_for(&roots, host)?;
+    execute(&plan, &order, &repo_root)
+}
+
+fn load_manifest() -> Result<(Manifest, PathBuf)> {
+    let repo_root = repo_root()?;
+    let path = repo_root.join("build.yaml");
+    let text = std::fs::read_to_string(&path).with_context(|| format!("reading manifest at {}", path.display()))?;
+    let manifest = Manifest::parse(&text).with_context(|| format!("parsing manifest at {}", path.display()))?;
+    Ok((manifest, repo_root))
 }
 
 pub fn run_version(check: bool, exact: bool) -> Result<()> {

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -187,8 +187,10 @@ pub enum Step {
 //   - { bash: <string> }  ↔ { bash: { command: <string> } }
 // Symmetric collapse for `process:` (bare list ↔ { process: { args: [...] } }).
 
+// `deny_unknown_fields` only applies to struct-shaped variants and structs;
+// it's a no-op on untagged enums themselves.
 #[derive(Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 enum StepRaw {
     Bare(String),
     Tagged(TaggedStepRaw),
@@ -204,7 +206,7 @@ enum TaggedStepRaw {
 }
 
 #[derive(Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 enum BashRaw {
     Short(String),
     Full {
@@ -215,7 +217,7 @@ enum BashRaw {
 }
 
 #[derive(Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[serde(untagged)]
 enum ProcessRaw {
     Args(Vec<String>),
     Full {
@@ -338,20 +340,28 @@ enum PlatformsRaw {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct PlatformMatrix {
     os: Vec<Os>,
     arch: Vec<Arch>,
 }
 
 impl PlatformsRaw {
-    fn into_vec(self) -> Vec<Platform> {
+    fn into_vec(self) -> Result<Vec<Platform>> {
         match self {
-            PlatformsRaw::Single(p) => vec![p],
-            PlatformsRaw::List(v) => v,
+            PlatformsRaw::Single(p) => Ok(vec![p]),
+            PlatformsRaw::List(v) => Ok(v),
             PlatformsRaw::Matrix(m) => {
-                m.os.into_iter()
+                if m.os.is_empty() {
+                    return Err(anyhow!("platforms.matrix.os must list at least one os"));
+                }
+                if m.arch.is_empty() {
+                    return Err(anyhow!("platforms.matrix.arch must list at least one arch"));
+                }
+                Ok(m.os
+                    .into_iter()
                     .flat_map(|os| m.arch.iter().map(move |&arch| Platform::new(os, arch)))
-                    .collect()
+                    .collect())
             }
         }
     }
@@ -438,7 +448,7 @@ impl Manifest {
         let mut targets = IndexMap::with_capacity(raw.targets.len());
         for (name, t) in raw.targets {
             let depends = t.depends.map(DependsRaw::into_vec).unwrap_or_default();
-            let platforms = t.platforms.into_vec();
+            let platforms = t.platforms.into_vec().with_context(|| format!("in target {name:?}"))?;
             let build = t.build.map(BuildRaw::into_steps).unwrap_or_default();
 
             // Reject platform duplicates inside one target — silent dedup would

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -1,0 +1,490 @@
+//! `build.yaml` manifest: target registry for `cargo xtask build|test|list`.
+//!
+//! See `build.yaml` at the repo root for the user-facing schema and the
+//! `i-want-to-brainstorm-zippy-lightning` design doc for the rationale.
+//!
+//! This module owns the **types**, the **serde shape** (with all the
+//! short-syntax shorthand), and **structural validation** (no missing deps,
+//! no cycles, known platform set). It does *not* execute steps — that's
+//! `orchestrate.rs`.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context, Result};
+use indexmap::IndexMap;
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+// ===== Os / Arch / Platform ==========================================================================================
+
+/// Operating system component of a [`Platform`].
+///
+/// Docker / GOOS-style identifiers: matches the project's release-artifact
+/// naming convention (`hole-<version>-windows-amd64.msi`) and the `matrix.os`
+/// dimension already used in `.github/workflows/ci.yaml`.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Os {
+    Windows,
+    Darwin,
+    Linux,
+}
+
+impl Os {
+    /// The host OS, or `None` if running on a platform the manifest doesn't
+    /// know about (FreeBSD, illumos, etc.).
+    pub fn host() -> Option<Self> {
+        if cfg!(target_os = "windows") {
+            Some(Os::Windows)
+        } else if cfg!(target_os = "macos") {
+            Some(Os::Darwin)
+        } else if cfg!(target_os = "linux") {
+            Some(Os::Linux)
+        } else {
+            None
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Os::Windows => "windows",
+            Os::Darwin => "darwin",
+            Os::Linux => "linux",
+        }
+    }
+}
+
+impl fmt::Display for Os {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Os {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "windows" => Ok(Os::Windows),
+            "darwin" => Ok(Os::Darwin),
+            "linux" => Ok(Os::Linux),
+            other => Err(anyhow!(
+                "unknown os {other:?} (expected one of: windows, darwin, linux)"
+            )),
+        }
+    }
+}
+
+/// CPU architecture component of a [`Platform`].
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Arch {
+    Amd64,
+    Arm64,
+}
+
+impl Arch {
+    /// The host architecture, or `None` if running on an arch the manifest
+    /// doesn't know about (riscv64, ppc64, etc.).
+    pub fn host() -> Option<Self> {
+        if cfg!(target_arch = "x86_64") {
+            Some(Arch::Amd64)
+        } else if cfg!(target_arch = "aarch64") {
+            Some(Arch::Arm64)
+        } else {
+            None
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Arch::Amd64 => "amd64",
+            Arch::Arm64 => "arm64",
+        }
+    }
+}
+
+impl fmt::Display for Arch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Arch {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "amd64" => Ok(Arch::Amd64),
+            "arm64" => Ok(Arch::Arm64),
+            other => Err(anyhow!("unknown arch {other:?} (expected one of: amd64, arm64)")),
+        }
+    }
+}
+
+/// One target platform: an `<os>/<arch>` pair like `windows/amd64`.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Platform {
+    pub os: Os,
+    pub arch: Arch,
+}
+
+impl Platform {
+    pub fn new(os: Os, arch: Arch) -> Self {
+        Self { os, arch }
+    }
+
+    /// The host platform, or `None` if either component is unknown.
+    pub fn host() -> Option<Self> {
+        Some(Self::new(Os::host()?, Arch::host()?))
+    }
+}
+
+impl fmt::Display for Platform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.os, self.arch)
+    }
+}
+
+impl FromStr for Platform {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        let (os, arch) = s
+            .split_once('/')
+            .ok_or_else(|| anyhow!("platform must have shape <os>/<arch>, got {s:?}"))?;
+        let os = Os::from_str(os).with_context(|| format!("in platform {s:?}"))?;
+        let arch = Arch::from_str(arch).with_context(|| format!("in platform {s:?}"))?;
+        Ok(Self::new(os, arch))
+    }
+}
+
+impl<'de> Deserialize<'de> for Platform {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Self::from_str(&s).map_err(de::Error::custom)
+    }
+}
+
+// ===== Steps =========================================================================================================
+
+/// A single build step. Either runs a bash command or spawns a process directly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Step {
+    Bash {
+        command: String,
+        environment: HashMap<String, String>,
+    },
+    Process {
+        args: Vec<String>,
+        environment: HashMap<String, String>,
+    },
+}
+
+// Raw shapes used for deserialization, immediately normalized into [`Step`].
+//
+// Two layers of shorthand collapse here:
+//   - bare string         ↔ { bash: <string> }
+//   - { bash: <string> }  ↔ { bash: { command: <string> } }
+// Symmetric collapse for `process:` (bare list ↔ { process: { args: [...] } }).
+
+#[derive(Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum StepRaw {
+    Bare(String),
+    Tagged(TaggedStepRaw),
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+enum TaggedStepRaw {
+    #[serde(rename = "bash")]
+    Bash(BashRaw),
+    #[serde(rename = "process")]
+    Process(ProcessRaw),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum BashRaw {
+    Short(String),
+    Full {
+        command: String,
+        #[serde(default)]
+        environment: HashMap<String, String>,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+enum ProcessRaw {
+    Args(Vec<String>),
+    Full {
+        args: Vec<String>,
+        #[serde(default)]
+        environment: HashMap<String, String>,
+    },
+}
+
+impl From<StepRaw> for Step {
+    fn from(raw: StepRaw) -> Self {
+        match raw {
+            StepRaw::Bare(command) => Step::Bash {
+                command,
+                environment: HashMap::new(),
+            },
+            StepRaw::Tagged(TaggedStepRaw::Bash(BashRaw::Short(command))) => Step::Bash {
+                command,
+                environment: HashMap::new(),
+            },
+            StepRaw::Tagged(TaggedStepRaw::Bash(BashRaw::Full { command, environment })) => {
+                Step::Bash { command, environment }
+            }
+            StepRaw::Tagged(TaggedStepRaw::Process(ProcessRaw::Args(args))) => Step::Process {
+                args,
+                environment: HashMap::new(),
+            },
+            StepRaw::Tagged(TaggedStepRaw::Process(ProcessRaw::Full { args, environment })) => {
+                Step::Process { args, environment }
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Step {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        StepRaw::deserialize(d).map(Step::from)
+    }
+}
+
+// ===== Target ========================================================================================================
+
+/// One target in the build graph. Public, post-normalization shape.
+#[derive(Clone, Debug)]
+pub struct Target {
+    pub name: String,
+    pub depends: Vec<String>,
+    pub platforms: Vec<Platform>,
+    pub build: Vec<Step>,
+}
+
+impl Target {
+    /// Returns `true` if this target applies to `platform` (i.e. its
+    /// `platforms:` list contains `platform`).
+    pub fn applies_to(&self, platform: Platform) -> bool {
+        self.platforms.contains(&platform)
+    }
+
+    /// Returns `true` if this target's name marks it as a test target (suffix
+    /// `-tests`). Used by `cargo xtask {build,test} --all` to filter.
+    pub fn is_test(&self) -> bool {
+        self.name.ends_with("-tests")
+    }
+}
+
+// Raw shape for a target — the post-deserialization step is normalizing
+// `Option<DependsRaw>` and `Option<BuildRaw>` into `Vec<...>` and resolving
+// `PlatformsRaw` into `Vec<Platform>`.
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TargetRaw {
+    #[serde(default)]
+    depends: Option<DependsRaw>,
+    platforms: PlatformsRaw,
+    #[serde(default)]
+    build: Option<BuildRaw>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum DependsRaw {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl DependsRaw {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            DependsRaw::One(s) => vec![s],
+            DependsRaw::Many(v) => v,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BuildRaw {
+    One(StepRaw),
+    Many(Vec<StepRaw>),
+}
+
+impl BuildRaw {
+    fn into_steps(self) -> Vec<Step> {
+        match self {
+            BuildRaw::One(s) => vec![Step::from(s)],
+            BuildRaw::Many(v) => v.into_iter().map(Step::from).collect(),
+        }
+    }
+}
+
+/// `platforms:` field — three valid shapes:
+///   - bare scalar: `platforms: windows/amd64`
+///   - explicit list: `platforms: [windows/amd64, darwin/arm64]`
+///   - matrix: `platforms: { matrix: { os: [...], arch: [...] } }`
+enum PlatformsRaw {
+    Single(Platform),
+    List(Vec<Platform>),
+    Matrix(PlatformMatrix),
+}
+
+#[derive(Deserialize)]
+struct PlatformMatrix {
+    os: Vec<Os>,
+    arch: Vec<Arch>,
+}
+
+impl PlatformsRaw {
+    fn into_vec(self) -> Vec<Platform> {
+        match self {
+            PlatformsRaw::Single(p) => vec![p],
+            PlatformsRaw::List(v) => v,
+            PlatformsRaw::Matrix(m) => {
+                m.os.into_iter()
+                    .flat_map(|os| m.arch.iter().map(move |&arch| Platform::new(os, arch)))
+                    .collect()
+            }
+        }
+    }
+}
+
+// `platforms:` is awkward to express as a clean #[serde(untagged)] enum because
+// the matrix variant is a single-key map sharing shape with a plain mapping. We
+// hand-roll a Visitor instead so error messages stay clear.
+impl<'de> Deserialize<'de> for PlatformsRaw {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = PlatformsRaw;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(
+                    "a platform string (e.g. `windows/amd64`), a list of them, \
+                     or a `{ matrix: { os: [...], arch: [...] } }` mapping",
+                )
+            }
+
+            fn visit_str<E: de::Error>(self, s: &str) -> std::result::Result<Self::Value, E> {
+                Platform::from_str(s).map(PlatformsRaw::Single).map_err(E::custom)
+            }
+
+            fn visit_string<E: de::Error>(self, s: String) -> std::result::Result<Self::Value, E> {
+                self.visit_str(&s)
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error> {
+                let mut out = Vec::new();
+                while let Some(p) = seq.next_element::<Platform>()? {
+                    out.push(p);
+                }
+                Ok(PlatformsRaw::List(out))
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> std::result::Result<Self::Value, A::Error> {
+                let mut matrix: Option<PlatformMatrix> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "matrix" => {
+                            if matrix.is_some() {
+                                return Err(de::Error::duplicate_field("matrix"));
+                            }
+                            matrix = Some(map.next_value()?);
+                        }
+                        other => {
+                            return Err(de::Error::unknown_field(other, &["matrix"]));
+                        }
+                    }
+                }
+                let matrix = matrix.ok_or_else(|| de::Error::custom("expected `matrix:` key in platforms mapping"))?;
+                Ok(PlatformsRaw::Matrix(matrix))
+            }
+        }
+        d.deserialize_any(V)
+    }
+}
+
+// ===== Manifest ======================================================================================================
+
+/// Parsed `build.yaml`. Targets keep their declaration order (driven by
+/// [`IndexMap`]) so `cargo xtask list` prints them in a predictable order.
+#[derive(Clone, Debug)]
+pub struct Manifest {
+    pub targets: IndexMap<String, Target>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestRaw {
+    targets: IndexMap<String, TargetRaw>,
+}
+
+impl Manifest {
+    /// Parse and validate a `build.yaml` document.
+    pub fn parse(yaml: &str) -> Result<Self> {
+        let raw: ManifestRaw = serde_yml::from_str(yaml).context("parsing build.yaml")?;
+        Self::from_raw(raw)
+    }
+
+    fn from_raw(raw: ManifestRaw) -> Result<Self> {
+        let mut targets = IndexMap::with_capacity(raw.targets.len());
+        for (name, t) in raw.targets {
+            let depends = t.depends.map(DependsRaw::into_vec).unwrap_or_default();
+            let platforms = t.platforms.into_vec();
+            let build = t.build.map(BuildRaw::into_steps).unwrap_or_default();
+
+            // Reject platform duplicates inside one target — silent dedup would
+            // hide a real authoring mistake.
+            let mut seen = HashSet::new();
+            for p in &platforms {
+                if !seen.insert(*p) {
+                    return Err(anyhow!("target {name:?} lists platform {p} more than once"));
+                }
+            }
+
+            targets.insert(
+                name.clone(),
+                Target {
+                    name,
+                    depends,
+                    platforms,
+                    build,
+                },
+            );
+        }
+
+        let m = Self { targets };
+        m.validate_deps()?;
+        Ok(m)
+    }
+
+    /// Every name in `depends:` must resolve to a declared target.
+    fn validate_deps(&self) -> Result<()> {
+        for t in self.targets.values() {
+            for dep in &t.depends {
+                if !self.targets.contains_key(dep) {
+                    return Err(anyhow!("target {:?} depends on unknown target {:?}", t.name, dep));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Look up a target by name.
+    pub fn get(&self, name: &str) -> Option<&Target> {
+        self.targets.get(name)
+    }
+
+    /// Iterate targets in declaration order.
+    pub fn iter(&self) -> impl Iterator<Item = &Target> {
+        self.targets.values()
+    }
+}

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -370,9 +370,95 @@ targets:
     platforms: windows/amd64
   foo-tests:
     platforms: windows/amd64
+  foo-test:
+    platforms: windows/amd64
+  pretests:
+    platforms: windows/amd64
 ",
     )
     .unwrap();
+    // Only the exact `-tests` suffix qualifies as a test target. `-test`
+    // (singular) and the bare suffix `tests` (no dash) are NOT test targets;
+    // adding either by accident shouldn't silently flip CI behavior.
     assert!(!m.get("foo").unwrap().is_test());
     assert!(m.get("foo-tests").unwrap().is_test());
+    assert!(!m.get("foo-test").unwrap().is_test());
+    assert!(!m.get("pretests").unwrap().is_test());
+}
+
+#[skuld::test]
+fn empty_matrix_os_axis_rejected() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    platforms:
+      matrix:
+        os: []
+        arch: [amd64]
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("os") && msg.contains("at least one"),
+        "expected empty-matrix-os error, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn empty_matrix_arch_axis_rejected() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    platforms:
+      matrix:
+        os: [windows]
+        arch: []
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("arch") && msg.contains("at least one"),
+        "expected empty-matrix-arch error, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn unknown_field_in_platform_matrix_rejected() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    platforms:
+      matrix:
+        os: [windows]
+        arch: [amd64]
+        typo: [x]
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("typo") || msg.contains("unknown field"),
+        "expected unknown-field rejection, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn production_build_yaml_parses() {
+    // Regression guard: any change to build.yaml that breaks parsing or
+    // structural validation (missing dep, typo'd platform, dup platform)
+    // should fail this test, not silently break CI.
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+    // Sanity: a few targets we always expect to exist.
+    for name in ["v2ray-plugin", "galoshes", "hole", "hole-msi", "hole-dmg", "hole-tests"] {
+        assert!(
+            m.get(name).is_some(),
+            "production build.yaml is missing expected target {name:?}"
+        );
+    }
 }

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -1,0 +1,378 @@
+use std::collections::HashMap;
+
+use crate::manifest::*;
+
+fn parse(yaml: &str) -> anyhow::Result<Manifest> {
+    Manifest::parse(yaml)
+}
+
+#[skuld::test]
+fn parses_minimal_manifest() {
+    let m = parse(
+        r"
+targets:
+  foo:
+    platforms: windows/amd64
+    build: echo hi
+",
+    )
+    .unwrap();
+
+    let foo = m.get("foo").unwrap();
+    assert_eq!(foo.name, "foo");
+    assert_eq!(foo.depends, Vec::<String>::new());
+    assert_eq!(foo.platforms, vec![Platform::new(Os::Windows, Arch::Amd64)]);
+    assert_eq!(
+        foo.build,
+        vec![Step::Bash {
+            command: "echo hi".to_string(),
+            environment: HashMap::new(),
+        }]
+    );
+}
+
+#[skuld::test]
+fn depends_short_syntax_equals_list_syntax() {
+    let single = parse(
+        r"
+targets:
+  base:
+    platforms: windows/amd64
+  foo:
+    depends: base
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+    let listy = parse(
+        r"
+targets:
+  base:
+    platforms: windows/amd64
+  foo:
+    depends: [base]
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+
+    assert_eq!(single.get("foo").unwrap().depends, vec!["base".to_string()]);
+    assert_eq!(single.get("foo").unwrap().depends, listy.get("foo").unwrap().depends);
+}
+
+#[skuld::test]
+fn build_short_syntax_equals_list_syntax() {
+    let bare = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    build: "echo hi"
+"#,
+    )
+    .unwrap();
+    let listed = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    build:
+      - bash: "echo hi"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(bare.get("foo").unwrap().build, listed.get("foo").unwrap().build);
+}
+
+#[skuld::test]
+fn step_polymorphism_canonicalizes_uniformly() {
+    let m = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    build:
+      - "echo a"
+      - bash: "echo b"
+      - bash:
+          command: "echo c"
+          environment: { K: V }
+      - process: ["cargo", "build"]
+      - process:
+          args: ["go", "build"]
+          environment: { GOOS: linux }
+"#,
+    )
+    .unwrap();
+
+    let steps = &m.get("foo").unwrap().build;
+    assert_eq!(steps.len(), 5);
+
+    // Three bash flavors → two with empty env, one with K=V.
+    assert_eq!(
+        steps[0],
+        Step::Bash {
+            command: "echo a".to_string(),
+            environment: HashMap::new(),
+        }
+    );
+    assert_eq!(
+        steps[1],
+        Step::Bash {
+            command: "echo b".to_string(),
+            environment: HashMap::new(),
+        }
+    );
+    let mut env_kv = HashMap::new();
+    env_kv.insert("K".to_string(), "V".to_string());
+    assert_eq!(
+        steps[2],
+        Step::Bash {
+            command: "echo c".to_string(),
+            environment: env_kv,
+        }
+    );
+
+    // Two process flavors → empty env vs explicit env.
+    assert_eq!(
+        steps[3],
+        Step::Process {
+            args: vec!["cargo".to_string(), "build".to_string()],
+            environment: HashMap::new(),
+        }
+    );
+    let mut env_goos = HashMap::new();
+    env_goos.insert("GOOS".to_string(), "linux".to_string());
+    assert_eq!(
+        steps[4],
+        Step::Process {
+            args: vec!["go".to_string(), "build".to_string()],
+            environment: env_goos,
+        }
+    );
+}
+
+#[skuld::test]
+fn platforms_three_shapes_produce_same_set() {
+    let scalar = parse(
+        r"
+targets:
+  foo:
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+    let list = parse(
+        r"
+targets:
+  foo:
+    platforms: [windows/amd64]
+",
+    )
+    .unwrap();
+    let matrix = parse(
+        r"
+targets:
+  foo:
+    platforms:
+      matrix:
+        os: [windows]
+        arch: [amd64]
+",
+    )
+    .unwrap();
+
+    let expected = vec![Platform::new(Os::Windows, Arch::Amd64)];
+    assert_eq!(scalar.get("foo").unwrap().platforms, expected);
+    assert_eq!(list.get("foo").unwrap().platforms, expected);
+    assert_eq!(matrix.get("foo").unwrap().platforms, expected);
+}
+
+#[skuld::test]
+fn platform_matrix_is_cartesian_product() {
+    let m = parse(
+        r"
+targets:
+  foo:
+    platforms:
+      matrix:
+        os: [windows, linux, darwin]
+        arch: [amd64, arm64]
+",
+    )
+    .unwrap();
+
+    let plats = &m.get("foo").unwrap().platforms;
+    assert_eq!(plats.len(), 6);
+    for os in [Os::Windows, Os::Linux, Os::Darwin] {
+        for arch in [Arch::Amd64, Arch::Arm64] {
+            assert!(
+                plats.contains(&Platform::new(os, arch)),
+                "missing {os}/{arch} in matrix expansion"
+            );
+        }
+    }
+}
+
+#[skuld::test]
+fn platform_typo_rejected_at_parse_time() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    platforms: [windwos/amd64]
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("windwos") || msg.contains("unknown os"),
+        "expected typo rejection message, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn arch_typo_rejected_at_parse_time() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    platforms: [windows/x86_64]
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("x86_64") || msg.contains("unknown arch"),
+        "expected typo rejection message, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn missing_dep_is_an_error() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    depends: nonexistent
+    platforms: windows/amd64
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("foo") && msg.contains("nonexistent"),
+        "expected message naming both target and missing dep, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn duplicate_platform_within_target_rejected() {
+    let err = parse(
+        r"
+targets:
+  foo:
+    platforms: [windows/amd64, windows/amd64]
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("more than once") && msg.contains("windows/amd64"),
+        "expected dup-platform message, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn missing_platform_shape_is_rejected() {
+    // platforms: is required.
+    let err = parse(
+        r"
+targets:
+  foo:
+    build: echo hi
+",
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("platforms") || msg.contains("missing field"),
+        "expected message about missing platforms field, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn target_with_no_build_steps_is_legal() {
+    // Some targets (e.g. a hypothetical pure aggregator) might have no build
+    // steps and just exist as a dep collector. The parser accepts this.
+    let m = parse(
+        r"
+targets:
+  foo:
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+    assert_eq!(m.get("foo").unwrap().build, Vec::<Step>::new());
+}
+
+#[skuld::test]
+fn iter_preserves_declaration_order() {
+    let m = parse(
+        r"
+targets:
+  zulu:
+    platforms: windows/amd64
+  alpha:
+    platforms: windows/amd64
+  mike:
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+    let names: Vec<&str> = m.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(names, vec!["zulu", "alpha", "mike"]);
+}
+
+#[skuld::test]
+fn applies_to_filters_correctly() {
+    let m = parse(
+        r"
+targets:
+  win-only:
+    platforms: windows/amd64
+  multi:
+    platforms: [windows/amd64, darwin/arm64]
+",
+    )
+    .unwrap();
+
+    let win = Platform::new(Os::Windows, Arch::Amd64);
+    let darwin = Platform::new(Os::Darwin, Arch::Arm64);
+    let linux = Platform::new(Os::Linux, Arch::Amd64);
+
+    assert!(m.get("win-only").unwrap().applies_to(win));
+    assert!(!m.get("win-only").unwrap().applies_to(darwin));
+    assert!(!m.get("win-only").unwrap().applies_to(linux));
+
+    assert!(m.get("multi").unwrap().applies_to(win));
+    assert!(m.get("multi").unwrap().applies_to(darwin));
+    assert!(!m.get("multi").unwrap().applies_to(linux));
+}
+
+#[skuld::test]
+fn is_test_uses_name_suffix() {
+    let m = parse(
+        r"
+targets:
+  foo:
+    platforms: windows/amd64
+  foo-tests:
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+    assert!(!m.get("foo").unwrap().is_test());
+    assert!(m.get("foo-tests").unwrap().is_test());
+}

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -212,12 +212,20 @@ impl Verb {
 /// returns `Err` with a message naming the step and exit code; the caller
 /// (the build driver) propagates that via fail-fast.
 pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
+    // Expose the current xtask binary's path so manifest steps can invoke
+    // xtask subcommands without going through `cargo xtask` (which is a
+    // `cargo run` alias). On Windows, `cargo run` would re-link xtask.exe,
+    // and the running parent process holds an exclusive lock on it →
+    // ERROR_ACCESS_DENIED. Direct binary invocation skips the rebuild check.
+    let xtask_exe = std::env::current_exe().context("locating current xtask binary")?;
+
     match step {
         Step::Bash { command, environment } => {
             let mut cmd = Command::new(resolve_bash()?);
             // `-e` so multi-line bash heredocs fail fast on the first error,
             // matching the driver's overall fail-fast contract.
             cmd.arg("-e").arg("-c").arg(command).current_dir(repo_root);
+            cmd.env("XTASK", &xtask_exe);
             for (k, v) in environment {
                 cmd.env(k, v);
             }
@@ -229,6 +237,7 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
                 .ok_or_else(|| anyhow!("process step has empty args list"))?;
             let mut cmd = Command::new(program);
             cmd.args(rest).current_dir(repo_root);
+            cmd.env("XTASK", &xtask_exe);
             for (k, v) in environment {
                 cmd.env(k, v);
             }

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -11,11 +11,13 @@
 
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, bail, Context, Result};
-use petgraph::algo::toposort;
+use petgraph::algo::{tarjan_scc, toposort};
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
@@ -64,42 +66,44 @@ impl<'m> Plan<'m> {
         match toposort(&self.graph, None) {
             Ok(_) => Ok(()),
             Err(cycle) => {
-                let bad = self.graph[cycle.node_id()].clone();
-                // The petgraph error names one node on the cycle but not the
-                // full ring. Walk back along incoming edges from `bad` until we
-                // return to it, recording the path. The walk is bounded by
-                // node count.
-                let path = self.cycle_path_through(cycle.node_id());
+                let bad = cycle.node_id();
+                // `toposort` only names one node on the cycle, not the full
+                // ring. Use Tarjan SCC to recover every node in the strongly
+                // connected component containing `bad` — that's the full
+                // cycle (or the cycle's super-cycle, in the case of two
+                // overlapping cycles sharing a node).
+                let scc = self
+                    .scc_containing(bad)
+                    .unwrap_or_else(|| vec![self.graph[bad].clone()]);
                 Err(anyhow!(
-                    "dependency cycle detected through target {bad:?}: {}",
-                    path.join(" -> ")
+                    "dependency cycle detected through target {:?}: {}",
+                    self.graph[bad],
+                    scc.join(" -> ")
                 ))
             }
         }
     }
 
-    /// Walk back along *incoming* edges from `start` (a node known to be on a
-    /// cycle) until we revisit `start`, returning the path of names.
-    fn cycle_path_through(&self, start: NodeIndex) -> Vec<String> {
-        let mut path = vec![self.graph[start].clone()];
-        let mut cur = start;
-        // Bounded walk: at most one full pass through the graph.
-        for _ in 0..self.graph.node_count() {
-            let Some(prev) = self
-                .graph
-                .edges_directed(cur, Direction::Incoming)
-                .next()
-                .map(|e| e.source())
-            else {
-                return path;
-            };
-            path.push(self.graph[prev].clone());
-            if prev == start {
-                return path;
+    /// Return the names of all nodes in the strongly-connected component that
+    /// contains `node`, or `None` if no SCC of size > 1 contains it (which
+    /// would only happen for a self-loop with no other members — we still
+    /// report that as the offender).
+    fn scc_containing(&self, node: NodeIndex) -> Option<Vec<String>> {
+        for component in tarjan_scc(&self.graph) {
+            if !component.contains(&node) {
+                continue;
             }
-            cur = prev;
+            // SCC of size 1 is a real cycle only if it has a self-loop.
+            let is_cycle = component.len() > 1
+                || self
+                    .graph
+                    .edges_directed(node, Direction::Outgoing)
+                    .any(|e| e.target() == node);
+            if is_cycle {
+                return Some(component.into_iter().map(|n| self.graph[n].clone()).collect());
+            }
         }
-        path
+        None
     }
 
     fn node(&self, name: &str) -> Result<NodeIndex> {
@@ -210,7 +214,7 @@ impl Verb {
 pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
     match step {
         Step::Bash { command, environment } => {
-            let mut cmd = Command::new(resolve_bash());
+            let mut cmd = Command::new(resolve_bash()?);
             // `-e` so multi-line bash heredocs fail fast on the first error,
             // matching the driver's overall fail-fast contract.
             cmd.arg("-e").arg("-c").arg(command).current_dir(repo_root);
@@ -246,14 +250,14 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
 /// interchangeable.
 ///
 /// Resolution order on Windows:
-/// 1. `$HOLE_BUILD_BASH` env var — explicit override for non-standard installs.
+/// 1. `$HOLE_BUILD_BASH` env var — explicit override.
 /// 2. Common Git Bash install paths.
-/// 3. Bare `bash` — last resort; works on hosts where `where bash` resolves to
-///    Git Bash (e.g. GitHub-hosted `windows-latest` runners with `shell: bash`
-///    semantics, where the runner has Git Bash earlier on PATH than WSL).
-fn resolve_bash() -> OsString {
+/// 3. Error out with a clear message — never fall through to bare `bash`,
+///    because that would silently pick up `C:\Windows\System32\bash.exe`
+///    (the WSL launcher) on systems without Git Bash.
+fn resolve_bash() -> Result<OsString> {
     if let Some(p) = std::env::var_os("HOLE_BUILD_BASH") {
-        return p;
+        return Ok(p);
     }
     #[cfg(windows)]
     {
@@ -266,11 +270,19 @@ fn resolve_bash() -> OsString {
         ];
         for c in CANDIDATES {
             if PathBuf::from(c).is_file() {
-                return OsString::from(c);
+                return Ok(OsString::from(c));
             }
         }
+        bail!(
+            "could not locate Git Bash on Windows. Tried: {}. \
+             Set HOLE_BUILD_BASH=<path-to-bash.exe> or install Git for Windows.",
+            CANDIDATES.join(", ")
+        );
     }
-    OsString::from("bash")
+    #[cfg(not(windows))]
+    {
+        Ok(OsString::from("bash"))
+    }
 }
 
 fn run(mut cmd: Command, label: &str) -> Result<()> {

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashMap;
 use std::ffi::OsString;
+#[cfg(windows)]
 use std::io;
 use std::path::Path;
 #[cfg(windows)]
@@ -187,6 +188,7 @@ fn join_platforms(plats: &[Platform]) -> String {
 /// the running xtask binary live. We pick a sibling of the running exe so the
 /// path is local to whatever target tree we were launched from, and so cargo
 /// clean wipes us along with everything else.
+#[cfg(windows)]
 const STASH_SUBDIR: &str = ".tmp-running";
 
 /// On Windows, rename the running xtask binary out of the way so that

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashMap;
 use std::ffi::OsString;
+use std::io;
 use std::path::Path;
 #[cfg(windows)]
 use std::path::PathBuf;
@@ -113,14 +114,10 @@ impl<'m> Plan<'m> {
             .ok_or_else(|| anyhow!("unknown target: {name:?}"))
     }
 
-    /// Return target names matching a verb filter, in declaration order.
-    /// `verb` is `Verb::Build` (non-test targets) or `Verb::Test` (test targets).
-    pub fn targets_for_verb(&self, verb: Verb) -> Vec<&str> {
-        self.manifest
-            .iter()
-            .filter(|t| verb.matches(t.is_test()))
-            .map(|t| t.name.as_str())
-            .collect()
+    /// Return all target names declared in the manifest, in declaration order.
+    /// Used by `cargo xtask build --all`.
+    pub fn target_names(&self) -> Vec<&str> {
+        self.manifest.iter().map(|t| t.name.as_str()).collect()
     }
 
     /// Compute the topologically-sorted set of targets reachable from `roots`
@@ -184,23 +181,96 @@ fn join_platforms(plats: &[Platform]) -> String {
     plats.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", ")
 }
 
-// ===== Verbs =========================================================================================================
+// ===== Self-relocate (Windows) =======================================================================================
 
-/// Which subset of targets a `--all` invocation operates on.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Verb {
-    /// Non-test targets (`build`).
-    Build,
-    /// Test targets (`test`, name ends with `-tests`).
-    Test,
+/// Stash directory under the cargo target directory where relocated copies of
+/// the running xtask binary live. We pick a sibling of the running exe so the
+/// path is local to whatever target tree we were launched from, and so cargo
+/// clean wipes us along with everything else.
+const STASH_SUBDIR: &str = ".tmp-running";
+
+/// On Windows, rename the running xtask binary out of the way so that
+/// recursive `cargo xtask <X>` invocations triggered by manifest steps don't
+/// fail with ERROR_ACCESS_DENIED when cargo tries to overwrite the running
+/// `target/<profile>/xtask.exe`.
+///
+/// **The mechanism:** Windows allows renaming a running `.exe` (modern loader
+/// opens images with `FILE_SHARE_DELETE`). The running process keeps mapping
+/// the file content (FCB) via its existing handle; only the directory entry
+/// moves. Once the old dirent is gone, cargo's "delete-then-create" rebuild
+/// path succeeds — it sees no file to delete and freshly hardlinks
+/// `deps/xtask-<hash>.exe` into place.
+///
+/// On non-Windows platforms this is a no-op: POSIX permits replacing running
+/// binaries through ordinary unlink+create, so the lock issue doesn't exist.
+///
+/// Best-effort: failures here propagate as errors so the caller can decide,
+/// but we tolerate "another xtask process beat me to it" (NotFound on rename).
+pub fn relocate_self_if_windows() -> Result<()> {
+    #[cfg(not(windows))]
+    {
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        relocate_self_windows()
+    }
 }
 
-impl Verb {
-    pub fn matches(self, is_test: bool) -> bool {
-        match self {
-            Verb::Build => !is_test,
-            Verb::Test => is_test,
+#[cfg(windows)]
+fn relocate_self_windows() -> Result<()> {
+    let current = std::env::current_exe().context("locating current xtask binary")?;
+    let parent = current
+        .parent()
+        .ok_or_else(|| anyhow!("running xtask {current:?} has no parent directory"))?;
+    let stash = parent.join(STASH_SUBDIR);
+    std::fs::create_dir_all(&stash).with_context(|| format!("creating stash dir {}", stash.display()))?;
+
+    // Prune older relocated copies whose owning process has exited (so the
+    // file is no longer mapped). On Windows, `remove_file` on a still-mapped
+    // image fails with ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION; success
+    // means the file was unlocked and is now gone. Best-effort: log + ignore
+    // anything we can't classify.
+    if let Ok(read) = std::fs::read_dir(&stash) {
+        for entry in read.flatten() {
+            match std::fs::remove_file(entry.path()) {
+                Ok(()) => {}
+                Err(e) if matches!(e.kind(), io::ErrorKind::PermissionDenied) => {
+                    // Locked: another xtask is still running with this binary mapped.
+                }
+                Err(e) => {
+                    eprintln!("xtask: warning: could not prune {}: {e}", entry.path().display());
+                }
+            }
         }
+    }
+
+    // Pick a unique stash name. PID + nanos is collision-free in practice
+    // and easy to read in a directory listing.
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let stem = current.file_stem().and_then(|s| s.to_str()).unwrap_or("xtask");
+    let ext = current.extension().and_then(|s| s.to_str()).unwrap_or("exe");
+    let new_path = stash.join(format!("{stem}-{pid}-{nanos}.{ext}"));
+
+    match std::fs::rename(&current, &new_path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // Another xtask process renamed it before us. Our process keeps
+            // mapping the file content via its open handle; only the dirent
+            // we expected to find is missing. Continue.
+            Ok(())
+        }
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "relocating running xtask {} -> {}",
+                current.display(),
+                new_path.display()
+            )
+        }),
     }
 }
 
@@ -212,20 +282,12 @@ impl Verb {
 /// returns `Err` with a message naming the step and exit code; the caller
 /// (the build driver) propagates that via fail-fast.
 pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
-    // Expose the current xtask binary's path so manifest steps can invoke
-    // xtask subcommands without going through `cargo xtask` (which is a
-    // `cargo run` alias). On Windows, `cargo run` would re-link xtask.exe,
-    // and the running parent process holds an exclusive lock on it →
-    // ERROR_ACCESS_DENIED. Direct binary invocation skips the rebuild check.
-    let xtask_exe = std::env::current_exe().context("locating current xtask binary")?;
-
     match step {
         Step::Bash { command, environment } => {
             let mut cmd = Command::new(resolve_bash()?);
             // `-e` so multi-line bash heredocs fail fast on the first error,
             // matching the driver's overall fail-fast contract.
             cmd.arg("-e").arg("-c").arg(command).current_dir(repo_root);
-            cmd.env("XTASK", &xtask_exe);
             for (k, v) in environment {
                 cmd.env(k, v);
             }
@@ -237,7 +299,6 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
                 .ok_or_else(|| anyhow!("process step has empty args list"))?;
             let mut cmd = Command::new(program);
             cmd.args(rest).current_dir(repo_root);
-            cmd.env("XTASK", &xtask_exe);
             for (k, v) in environment {
                 cmd.env(k, v);
             }

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -1,0 +1,330 @@
+//! DAG orchestration for the build-target manifest.
+//!
+//! Given a parsed [`Manifest`] and a target selection, this module:
+//! 1. Validates the dependency graph (no cycles).
+//! 2. Computes a topologically-sorted subgraph of targets reachable from the
+//!    selection that apply to the host platform.
+//! 3. Executes each target's `build:` steps in order, fail-fast.
+//!
+//! Pure orchestration only — no incremental / up-to-date checks. The leaf
+//! commands (`cargo build`, `cargo xtask v2ray-plugin`, etc.) own that.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, bail, Context, Result};
+use petgraph::algo::toposort;
+use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::visit::EdgeRef;
+use petgraph::Direction;
+
+use crate::manifest::{Manifest, Platform, Step};
+
+// ===== Plan ==========================================================================================================
+
+/// Wraps a [`Manifest`] with a directed graph (`dep → dependent`) ready for
+/// topological queries.
+#[derive(Debug)]
+pub struct Plan<'m> {
+    manifest: &'m Manifest,
+    graph: DiGraph<String, ()>,
+    by_name: HashMap<String, NodeIndex>,
+}
+
+impl<'m> Plan<'m> {
+    /// Build a plan from a manifest. Errors on dependency cycles.
+    pub fn new(manifest: &'m Manifest) -> Result<Self> {
+        let mut graph = DiGraph::<String, ()>::new();
+        let mut by_name = HashMap::new();
+        for t in manifest.iter() {
+            let idx = graph.add_node(t.name.clone());
+            by_name.insert(t.name.clone(), idx);
+        }
+        for t in manifest.iter() {
+            let to = by_name[&t.name];
+            for dep in &t.depends {
+                // `Manifest::parse` already verified every dep name resolves.
+                let from = by_name[dep];
+                graph.add_edge(from, to, ());
+            }
+        }
+
+        let plan = Self {
+            manifest,
+            graph,
+            by_name,
+        };
+        plan.detect_cycles()?;
+        Ok(plan)
+    }
+
+    fn detect_cycles(&self) -> Result<()> {
+        match toposort(&self.graph, None) {
+            Ok(_) => Ok(()),
+            Err(cycle) => {
+                let bad = self.graph[cycle.node_id()].clone();
+                // The petgraph error names one node on the cycle but not the
+                // full ring. Walk back along incoming edges from `bad` until we
+                // return to it, recording the path. The walk is bounded by
+                // node count.
+                let path = self.cycle_path_through(cycle.node_id());
+                Err(anyhow!(
+                    "dependency cycle detected through target {bad:?}: {}",
+                    path.join(" -> ")
+                ))
+            }
+        }
+    }
+
+    /// Walk back along *incoming* edges from `start` (a node known to be on a
+    /// cycle) until we revisit `start`, returning the path of names.
+    fn cycle_path_through(&self, start: NodeIndex) -> Vec<String> {
+        let mut path = vec![self.graph[start].clone()];
+        let mut cur = start;
+        // Bounded walk: at most one full pass through the graph.
+        for _ in 0..self.graph.node_count() {
+            let Some(prev) = self
+                .graph
+                .edges_directed(cur, Direction::Incoming)
+                .next()
+                .map(|e| e.source())
+            else {
+                return path;
+            };
+            path.push(self.graph[prev].clone());
+            if prev == start {
+                return path;
+            }
+            cur = prev;
+        }
+        path
+    }
+
+    fn node(&self, name: &str) -> Result<NodeIndex> {
+        self.by_name
+            .get(name)
+            .copied()
+            .ok_or_else(|| anyhow!("unknown target: {name:?}"))
+    }
+
+    /// Return target names matching a verb filter, in declaration order.
+    /// `verb` is `Verb::Build` (non-test targets) or `Verb::Test` (test targets).
+    pub fn targets_for_verb(&self, verb: Verb) -> Vec<&str> {
+        self.manifest
+            .iter()
+            .filter(|t| verb.matches(t.is_test()))
+            .map(|t| t.name.as_str())
+            .collect()
+    }
+
+    /// Compute the topologically-sorted set of targets reachable from `roots`
+    /// (each root + all transitive deps), filtered to those that apply to
+    /// `platform`.
+    pub fn order_for(&self, roots: &[&str], platform: Platform) -> Result<Vec<&'m str>> {
+        // 1. Validate every root exists and applies to `platform`.
+        let mut root_indices = Vec::with_capacity(roots.len());
+        for r in roots {
+            let idx = self.node(r)?;
+            let target = &self.manifest.targets[*r];
+            if !target.applies_to(platform) {
+                bail!(
+                    "target {r:?} does not apply to host platform {platform} \
+                     (declared platforms: {})",
+                    join_platforms(&target.platforms)
+                );
+            }
+            root_indices.push(idx);
+        }
+
+        // 2. Collect reachable nodes (deps + self) via reverse-DFS from roots.
+        let mut reachable = std::collections::HashSet::new();
+        let mut stack = root_indices.clone();
+        while let Some(n) = stack.pop() {
+            if !reachable.insert(n) {
+                continue;
+            }
+            for e in self.graph.edges_directed(n, Direction::Incoming) {
+                stack.push(e.source());
+            }
+        }
+
+        // 3. Toposort the full graph; filter to reachable ∩ applicable.
+        let order = toposort(&self.graph, None).map_err(|c| {
+            anyhow!(
+                "internal: toposort failed after cycle check passed (node {:?})",
+                self.graph[c.node_id()]
+            )
+        })?;
+
+        let mut out = Vec::new();
+        for n in order {
+            if !reachable.contains(&n) {
+                continue;
+            }
+            let name = &self.graph[n];
+            let target = &self.manifest.targets[name];
+            if target.applies_to(platform) {
+                out.push(target.name.as_str());
+            }
+            // Targets in reachable but not applicable to the host are silently
+            // skipped — e.g. building `hole` on darwin transitively reaches
+            // `wintun`, which is windows-only and a no-op there.
+        }
+        Ok(out)
+    }
+}
+
+fn join_platforms(plats: &[Platform]) -> String {
+    plats.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(", ")
+}
+
+// ===== Verbs =========================================================================================================
+
+/// Which subset of targets a `--all` invocation operates on.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Verb {
+    /// Non-test targets (`build`).
+    Build,
+    /// Test targets (`test`, name ends with `-tests`).
+    Test,
+}
+
+impl Verb {
+    pub fn matches(self, is_test: bool) -> bool {
+        match self {
+            Verb::Build => !is_test,
+            Verb::Test => is_test,
+        }
+    }
+}
+
+// ===== Step execution ================================================================================================
+
+/// Execute one [`Step`] from the given working directory.
+///
+/// CWD is always `repo_root`. The step inherits stdio. On non-zero exit this
+/// returns `Err` with a message naming the step and exit code; the caller
+/// (the build driver) propagates that via fail-fast.
+pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
+    match step {
+        Step::Bash { command, environment } => {
+            let mut cmd = Command::new(resolve_bash());
+            // `-e` so multi-line bash heredocs fail fast on the first error,
+            // matching the driver's overall fail-fast contract.
+            cmd.arg("-e").arg("-c").arg(command).current_dir(repo_root);
+            for (k, v) in environment {
+                cmd.env(k, v);
+            }
+            run(cmd, &format!("bash step: {command}"))
+        }
+        Step::Process { args, environment } => {
+            let (program, rest) = args
+                .split_first()
+                .ok_or_else(|| anyhow!("process step has empty args list"))?;
+            let mut cmd = Command::new(program);
+            cmd.args(rest).current_dir(repo_root);
+            for (k, v) in environment {
+                cmd.env(k, v);
+            }
+            run(cmd, &format!("process step: {}", args.join(" ")))
+        }
+    }
+}
+
+/// Pick the bash interpreter to invoke for `bash:` steps.
+///
+/// On Unix, this is just `bash` from PATH.
+///
+/// On Windows, two installations commonly resolve `bash` from a Windows-side
+/// `CreateProcess` lookup: **Git Bash** (MSYS2-based, ships with Git for
+/// Windows) and **WSL bash** (`C:\Windows\System32\bash.exe`, the WSL
+/// launcher). Build orchestration must use Git Bash — WSL bash runs commands
+/// inside a Linux distribution where `cargo.exe` is invisible and Windows-form
+/// paths in `build.yaml` are interpreted as Linux paths. The two are not
+/// interchangeable.
+///
+/// Resolution order on Windows:
+/// 1. `$HOLE_BUILD_BASH` env var — explicit override for non-standard installs.
+/// 2. Common Git Bash install paths.
+/// 3. Bare `bash` — last resort; works on hosts where `where bash` resolves to
+///    Git Bash (e.g. GitHub-hosted `windows-latest` runners with `shell: bash`
+///    semantics, where the runner has Git Bash earlier on PATH than WSL).
+fn resolve_bash() -> OsString {
+    if let Some(p) = std::env::var_os("HOLE_BUILD_BASH") {
+        return p;
+    }
+    #[cfg(windows)]
+    {
+        // Walk standard Git Bash install locations. `Path::is_file` is cheap;
+        // we only do this once per bash step.
+        const CANDIDATES: &[&str] = &[
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+        ];
+        for c in CANDIDATES {
+            if PathBuf::from(c).is_file() {
+                return OsString::from(c);
+            }
+        }
+    }
+    OsString::from("bash")
+}
+
+fn run(mut cmd: Command, label: &str) -> Result<()> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let status = cmd.status().with_context(|| format!("spawning {label}"))?;
+    if !status.success() {
+        return Err(anyhow!("{label} failed: exit status {}", status));
+    }
+    Ok(())
+}
+
+// ===== Build driver ==================================================================================================
+
+/// Execute every target in `order` (already toposorted). Each target's
+/// `build:` steps run in declaration order; first failure aborts the whole
+/// invocation.
+pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path) -> Result<()> {
+    for name in order {
+        let target = plan
+            .manifest
+            .get(name)
+            .ok_or_else(|| anyhow!("internal: unknown target {name:?} in execute order"))?;
+
+        if target.build.is_empty() {
+            println!("xtask: target {name} has no build steps; skipping");
+            continue;
+        }
+        println!("xtask: ==== building target {name} ====");
+        for step in &target.build {
+            run_step(step, repo_root).with_context(|| format!("while building target {name}"))?;
+        }
+    }
+    Ok(())
+}
+
+// ===== List output ===================================================================================================
+
+/// Render the table printed by `cargo xtask list`. Returns a string for ease
+/// of testing; the caller is responsible for `print!`.
+pub fn render_list(manifest: &Manifest, host: Option<Platform>) -> String {
+    let mut out = String::new();
+    let header = format!("{:<22} {:<46} HOST", "TARGET", "PLATFORMS");
+    out.push_str(&header);
+    out.push('\n');
+    for t in manifest.iter() {
+        let plats = join_platforms(&t.platforms);
+        let host_mark = match host {
+            Some(p) if t.applies_to(p) => "yes",
+            Some(_) => "no",
+            None => "?",
+        };
+        out.push_str(&format!("{:<22} {:<46} {}\n", t.name, plats, host_mark));
+    }
+    out
+}

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -184,12 +184,13 @@ fn join_platforms(plats: &[Platform]) -> String {
 
 // ===== Self-relocate (Windows) =======================================================================================
 
-/// Stash directory under the cargo target directory where relocated copies of
-/// the running xtask binary live. We pick a sibling of the running exe so the
-/// path is local to whatever target tree we were launched from, and so cargo
-/// clean wipes us along with everything else.
+/// Stash directory (relative to the cargo `target/<profile>/` dir) where
+/// relocated copies of the running xtask binary live. Sibling of the running
+/// exe so the path is local to whatever target tree we were launched from,
+/// and so `cargo clean` wipes us along with everything else. Naming follows
+/// the project's `.tmp/<role>/` convention (`/var/run/`-style).
 #[cfg(windows)]
-const STASH_SUBDIR: &str = ".tmp-running";
+const STASH_SUBDIR: &[&str] = &[".tmp", "run"];
 
 /// On Windows, rename the running xtask binary out of the way so that
 /// recursive `cargo xtask <X>` invocations triggered by manifest steps don't
@@ -225,7 +226,10 @@ fn relocate_self_windows() -> Result<()> {
     let parent = current
         .parent()
         .ok_or_else(|| anyhow!("running xtask {current:?} has no parent directory"))?;
-    let stash = parent.join(STASH_SUBDIR);
+    let mut stash = parent.to_path_buf();
+    for c in STASH_SUBDIR {
+        stash.push(c);
+    }
     std::fs::create_dir_all(&stash).with_context(|| format!("creating stash dir {}", stash.display()))?;
 
     // Prune older relocated copies whose owning process has exited (so the

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -305,6 +305,20 @@ fn run_step_bash_environment_overrides_inherited() {
 }
 
 #[skuld::test]
+fn run_step_bash_xtask_env_var_is_set() {
+    // `$XTASK` must be exported to bash steps so the manifest can invoke
+    // the running xtask binary directly (instead of `cargo xtask <X>`,
+    // which on Windows triggers a rebuild that fails because the parent
+    // holds an exclusive lock on the binary).
+    let dir = tempfile::tempdir().unwrap();
+    let step = Step::Bash {
+        command: r#"[ -n "$XTASK" ] && [ -f "$XTASK" ]"#.to_string(),
+        environment: Default::default(),
+    };
+    run_step(&step, dir.path()).unwrap();
+}
+
+#[skuld::test]
 fn run_step_process_fails_on_nonzero_exit() {
     let dir = tempfile::tempdir().unwrap();
     // Use a command that's available on every CI platform via `cargo` (always

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -1,0 +1,329 @@
+use crate::manifest::*;
+use crate::orchestrate::*;
+
+fn manifest(yaml: &str) -> Manifest {
+    Manifest::parse(yaml).unwrap()
+}
+
+#[skuld::test]
+fn plan_topologically_orders_deps_first() {
+    let m = manifest(
+        r"
+targets:
+  c:
+    depends: b
+    platforms: windows/amd64
+  b:
+    depends: a
+    platforms: windows/amd64
+  a:
+    platforms: windows/amd64
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+    let order = plan.order_for(&["c"], Platform::new(Os::Windows, Arch::Amd64)).unwrap();
+    assert_eq!(order, vec!["a", "b", "c"]);
+}
+
+#[skuld::test]
+fn plan_dedups_shared_transitive_deps() {
+    // diamond: d -> b, d -> c, b -> a, c -> a; a should appear once.
+    let m = manifest(
+        r"
+targets:
+  a:
+    platforms: windows/amd64
+  b:
+    depends: a
+    platforms: windows/amd64
+  c:
+    depends: a
+    platforms: windows/amd64
+  d:
+    depends: [b, c]
+    platforms: windows/amd64
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+    let order = plan.order_for(&["d"], Platform::new(Os::Windows, Arch::Amd64)).unwrap();
+    let count_a = order.iter().filter(|&&n| n == "a").count();
+    assert_eq!(count_a, 1, "expected `a` once, got order {order:?}");
+    // a precedes b and c; b/c precede d.
+    let pos = |name| order.iter().position(|&n| n == name).unwrap();
+    assert!(pos("a") < pos("b"));
+    assert!(pos("a") < pos("c"));
+    assert!(pos("b") < pos("d"));
+    assert!(pos("c") < pos("d"));
+}
+
+#[skuld::test]
+fn deps_not_applicable_to_host_are_silently_skipped() {
+    // Mirrors hole-on-darwin transitively reaching wintun (windows-only).
+    let m = manifest(
+        r"
+targets:
+  wintun:
+    platforms: windows/amd64
+  galoshes:
+    platforms: [windows/amd64, darwin/amd64]
+  hole:
+    depends: [galoshes, wintun]
+    platforms: [windows/amd64, darwin/amd64]
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+
+    // Building hole on windows includes wintun.
+    let win = plan
+        .order_for(&["hole"], Platform::new(Os::Windows, Arch::Amd64))
+        .unwrap();
+    assert!(win.contains(&"wintun"));
+    assert!(win.contains(&"galoshes"));
+    assert!(win.contains(&"hole"));
+
+    // Building hole on darwin silently skips wintun.
+    let darwin = plan
+        .order_for(&["hole"], Platform::new(Os::Darwin, Arch::Amd64))
+        .unwrap();
+    assert!(!darwin.contains(&"wintun"));
+    assert!(darwin.contains(&"galoshes"));
+    assert!(darwin.contains(&"hole"));
+}
+
+#[skuld::test]
+fn root_target_must_apply_to_host_platform() {
+    let m = manifest(
+        r"
+targets:
+  hole-msi:
+    platforms: windows/amd64
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+    let err = plan
+        .order_for(&["hole-msi"], Platform::new(Os::Darwin, Arch::Arm64))
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("hole-msi") && msg.contains("darwin/arm64"),
+        "expected applicability error, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn unknown_root_target_errors() {
+    let m = manifest(
+        r"
+targets:
+  foo:
+    platforms: windows/amd64
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+    let err = plan
+        .order_for(&["bogus"], Platform::new(Os::Windows, Arch::Amd64))
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("bogus"),
+        "expected message naming unknown target, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn cycle_detection_self_loop() {
+    let m = manifest(
+        r"
+targets:
+  foo:
+    depends: foo
+    platforms: windows/amd64
+",
+    );
+    let err = Plan::new(&m).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("cycle") && msg.contains("foo"),
+        "expected cycle error naming foo, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn cycle_detection_two_node_cycle() {
+    let m = manifest(
+        r"
+targets:
+  a:
+    depends: b
+    platforms: windows/amd64
+  b:
+    depends: a
+    platforms: windows/amd64
+",
+    );
+    let err = Plan::new(&m).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("cycle") && (msg.contains("a") || msg.contains("b")),
+        "expected cycle error, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn cycle_detection_three_node_cycle() {
+    let m = manifest(
+        r"
+targets:
+  a:
+    depends: b
+    platforms: windows/amd64
+  b:
+    depends: c
+    platforms: windows/amd64
+  c:
+    depends: a
+    platforms: windows/amd64
+",
+    );
+    let err = Plan::new(&m).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("cycle"), "expected cycle error, got: {msg}");
+}
+
+#[skuld::test]
+fn verb_partition_splits_on_tests_suffix() {
+    let m = manifest(
+        r"
+targets:
+  hole:
+    platforms: windows/amd64
+  hole-tests:
+    platforms: windows/amd64
+  galoshes:
+    platforms: windows/amd64
+  galoshes-tests:
+    platforms: windows/amd64
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+
+    let build_targets = plan.targets_for_verb(Verb::Build);
+    assert_eq!(build_targets, vec!["hole", "galoshes"]);
+    let test_targets = plan.targets_for_verb(Verb::Test);
+    assert_eq!(test_targets, vec!["hole-tests", "galoshes-tests"]);
+}
+
+#[skuld::test]
+fn order_for_multiple_roots_unions_their_subgraphs() {
+    let m = manifest(
+        r"
+targets:
+  a:
+    platforms: windows/amd64
+  b:
+    platforms: windows/amd64
+  x:
+    depends: a
+    platforms: windows/amd64
+  y:
+    depends: b
+    platforms: windows/amd64
+",
+    );
+    let plan = Plan::new(&m).unwrap();
+    let order = plan
+        .order_for(&["x", "y"], Platform::new(Os::Windows, Arch::Amd64))
+        .unwrap();
+    assert!(order.contains(&"a"));
+    assert!(order.contains(&"b"));
+    assert!(order.contains(&"x"));
+    assert!(order.contains(&"y"));
+    let pos = |name| order.iter().position(|&n| n == name).unwrap();
+    assert!(pos("a") < pos("x"));
+    assert!(pos("b") < pos("y"));
+}
+
+#[skuld::test]
+fn render_list_shows_host_applicability() {
+    let m = manifest(
+        r"
+targets:
+  hole-msi:
+    platforms: windows/amd64
+  hole-dmg:
+    platforms: [darwin/amd64, darwin/arm64]
+",
+    );
+    let host = Platform::new(Os::Windows, Arch::Amd64);
+    let out = render_list(&m, Some(host));
+    // Header + one line per target.
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].contains("TARGET") && lines[0].contains("HOST"));
+    assert!(lines[1].contains("hole-msi") && lines[1].ends_with("yes"));
+    assert!(lines[2].contains("hole-dmg") && lines[2].ends_with("no"));
+}
+
+#[skuld::test]
+fn run_step_bash_succeeds_on_zero_exit() {
+    // Trivial bash command. Skipped on platforms without bash on PATH.
+    if which_bash_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let step = Step::Bash {
+            command: "true".to_string(),
+            environment: Default::default(),
+        };
+        run_step(&step, dir.path()).unwrap();
+    }
+}
+
+#[skuld::test]
+fn run_step_bash_fails_on_nonzero_exit() {
+    if which_bash_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let step = Step::Bash {
+            command: "exit 7".to_string(),
+            environment: Default::default(),
+        };
+        let err = run_step(&step, dir.path()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("exit"), "expected exit-status error, got: {msg}");
+    }
+}
+
+#[skuld::test]
+fn run_step_process_fails_on_nonzero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    // Use a command that's available on every CI platform via `cargo` (always
+    // on PATH inside `cargo xtask` invocations), and force a non-zero exit by
+    // requesting an unknown subcommand.
+    let step = Step::Process {
+        args: vec!["cargo".to_string(), "this-subcommand-does-not-exist".to_string()],
+        environment: Default::default(),
+    };
+    let err = run_step(&step, dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("exit"), "expected exit-status error, got: {msg}");
+}
+
+#[skuld::test]
+fn run_step_process_empty_args_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let step = Step::Process {
+        args: vec![],
+        environment: Default::default(),
+    };
+    let err = run_step(&step, dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("empty"), "expected empty-args error, got: {msg}");
+}
+
+fn which_bash_exists() -> bool {
+    std::process::Command::new("bash")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -264,31 +264,44 @@ targets:
     assert!(lines[2].contains("hole-dmg") && lines[2].ends_with("no"));
 }
 
+// `run_step` tests assume bash is available — Git Bash on Windows runners,
+// system bash on macOS / Linux. These are unconditional: per CLAUDE.md, tests
+// must not silently skip on missing dependencies.
+
 #[skuld::test]
 fn run_step_bash_succeeds_on_zero_exit() {
-    // Trivial bash command. Skipped on platforms without bash on PATH.
-    if which_bash_exists() {
-        let dir = tempfile::tempdir().unwrap();
-        let step = Step::Bash {
-            command: "true".to_string(),
-            environment: Default::default(),
-        };
-        run_step(&step, dir.path()).unwrap();
-    }
+    let dir = tempfile::tempdir().unwrap();
+    let step = Step::Bash {
+        command: "true".to_string(),
+        environment: Default::default(),
+    };
+    run_step(&step, dir.path()).unwrap();
 }
 
 #[skuld::test]
 fn run_step_bash_fails_on_nonzero_exit() {
-    if which_bash_exists() {
-        let dir = tempfile::tempdir().unwrap();
-        let step = Step::Bash {
-            command: "exit 7".to_string(),
-            environment: Default::default(),
-        };
-        let err = run_step(&step, dir.path()).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("exit"), "expected exit-status error, got: {msg}");
-    }
+    let dir = tempfile::tempdir().unwrap();
+    let step = Step::Bash {
+        command: "exit 7".to_string(),
+        environment: Default::default(),
+    };
+    let err = run_step(&step, dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("exit"), "expected exit-status error, got: {msg}");
+}
+
+#[skuld::test]
+fn run_step_bash_environment_overrides_inherited() {
+    // The step's `environment:` map should take effect (and also drive the
+    // SKULD_LABELS-style usage in build.yaml).
+    let dir = tempfile::tempdir().unwrap();
+    let mut env = std::collections::HashMap::new();
+    env.insert("HOLE_TEST_VAR".to_string(), "set-from-step".to_string());
+    let step = Step::Bash {
+        command: r#"[ "$HOLE_TEST_VAR" = "set-from-step" ]"#.to_string(),
+        environment: env,
+    };
+    run_step(&step, dir.path()).unwrap();
 }
 
 #[skuld::test]
@@ -318,12 +331,32 @@ fn run_step_process_empty_args_errors() {
     assert!(msg.contains("empty"), "expected empty-args error, got: {msg}");
 }
 
-fn which_bash_exists() -> bool {
-    std::process::Command::new("bash")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+#[skuld::test]
+fn cycle_detection_diverging_cycle_lists_full_scc() {
+    // `c -> b -> a -> b` (a points back to b, not c). c has an inbound edge
+    // from outside the cycle (and the toposort error names some node in the
+    // SCC). The error message must report all SCC members, not wander off
+    // into the non-cycle tail.
+    let m = Manifest::parse(
+        r"
+targets:
+  a:
+    depends: b
+    platforms: windows/amd64
+  b:
+    depends: a
+    platforms: windows/amd64
+  c:
+    depends: b
+    platforms: windows/amd64
+",
+    )
+    .unwrap();
+    let err = Plan::new(&m).unwrap_err();
+    let msg = format!("{err:#}");
+    // The SCC is {a, b}; c is on a path leading to it but not part of the cycle.
+    assert!(
+        msg.contains("a") && msg.contains("b") && !msg.contains("\"c\""),
+        "expected cycle to list a and b but not c, got: {msg}"
+    );
 }

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -191,26 +191,20 @@ targets:
 }
 
 #[skuld::test]
-fn verb_partition_splits_on_tests_suffix() {
+fn target_names_returns_declaration_order() {
     let m = manifest(
         r"
 targets:
-  hole:
+  zulu:
     platforms: windows/amd64
-  hole-tests:
+  alpha:
     platforms: windows/amd64
-  galoshes:
-    platforms: windows/amd64
-  galoshes-tests:
+  mike:
     platforms: windows/amd64
 ",
     );
     let plan = Plan::new(&m).unwrap();
-
-    let build_targets = plan.targets_for_verb(Verb::Build);
-    assert_eq!(build_targets, vec!["hole", "galoshes"]);
-    let test_targets = plan.targets_for_verb(Verb::Test);
-    assert_eq!(test_targets, vec!["hole-tests", "galoshes-tests"]);
+    assert_eq!(plan.target_names(), vec!["zulu", "alpha", "mike"]);
 }
 
 #[skuld::test]
@@ -300,20 +294,6 @@ fn run_step_bash_environment_overrides_inherited() {
     let step = Step::Bash {
         command: r#"[ "$HOLE_TEST_VAR" = "set-from-step" ]"#.to_string(),
         environment: env,
-    };
-    run_step(&step, dir.path()).unwrap();
-}
-
-#[skuld::test]
-fn run_step_bash_xtask_env_var_is_set() {
-    // `$XTASK` must be exported to bash steps so the manifest can invoke
-    // the running xtask binary directly (instead of `cargo xtask <X>`,
-    // which on Windows triggers a rebuild that fails because the parent
-    // holds an exclusive lock on the binary).
-    let dir = tempfile::tempdir().unwrap();
-    let step = Step::Bash {
-        command: r#"[ -n "$XTASK" ] && [ -f "$XTASK" ]"#.to_string(),
-        environment: Default::default(),
     };
     run_step(&step, dir.path()).unwrap();
 }


### PR DESCRIPTION
## Summary

Introduces a declarative `build.yaml` at the repo root listing every buildable target (`hole`, `hole-msi`, `hole-dmg`, `galoshes`, `garter`, `mock-plugin`, `wintun`, `v2ray-plugin`, plus `*-tests` leaves) with their dependencies, applicable platforms, and build steps. xtask consumes the manifest and exposes new top-level commands:

- `cargo xtask build <name>` / `cargo xtask build --all`
- `cargo xtask test <name>` / `cargo xtask test --all`
- `cargo xtask list`

Existing primitive subcommands (`stage`, `deps`, `v2ray-plugin`, `galoshes`, `wintun`, `version`) are unchanged. `build.yaml` step bodies mostly shell out to those primitives; the YAML is the orchestration layer.

The schema supports short-syntax (scalar accepted where a list is expected) and polymorphic step types (bare string ↔ `bash:` ↔ `bash: { command, environment }`, `process: [args]` ↔ `process: { args, environment }`).

Closes #270.

## Migration

- `scripts/dev.py` — `cargo xtask deps` + `cargo build` collapsed into `cargo xtask build hole`. Per-pid stage step preserved (custom out-dir requirement).
- `.github/workflows/ci.yaml` — `test-hole` runs `cargo xtask test hole-tests` / `hole-tun-tests` (the second is windows/amd64-only). `test-installer` runs `cargo xtask build hole-msi`. The nextest archive pattern (#264) is preserved; clippy + the #200 TUN-test-last ordering are preserved.
- `.github/workflows/draft-release.yaml` — single matrix-driven `cargo xtask build "hole-${{ matrix.ext }}"`; per-os `if:` clauses on the build step disappear.
- `CLAUDE.md` + `CONTRIBUTING.md` updated to point at `build.yaml` as the source of truth.

## Out of scope for v1 (schema-extensible)

Per-step platform filters, DAG-level up-to-date checks, parallel execution, variable interpolation, top-level `env:`, JSON-schema bundle. The `hole-tests` / `hole-tun-tests` split sidesteps the per-step-platform-filter gap; same pattern as `hole-msi` / `hole-dmg`.

## Notable design choices

- **Topological sort + cycle detection via `petgraph`** (Tarjan SCC for cycle reporting — full ring is shown, not just one node).
- **Bash on Windows** is resolved explicitly to Git Bash via `HOLE_BUILD_BASH` env override or standard install paths. WSL bash from `C:\Windows\System32\bash.exe` would silently break orchestration (Linux paths, no Windows cargo) — fall-through to bare `bash` is refused on Windows so this can't happen by accident.
- **`hole-msi` / `hole-dmg` depend on `[galoshes, wintun]` / `galoshes`** (not `hole`) because the msi-installer / tauri build steps do their own `cargo build --release`; depending on `hole` would force a redundant debug compile.
- **Why os/arch and not Rust target triples** — matches the project's release-artifact naming convention (`hole-{version}-windows-amd64.msi`); polyglot lowest-common-denominator (Go's GOOS/GOARCH, Tauri, WiX); no cross-compile happening here.

## Test plan

- [ ] `cargo xtask list` prints the full target table on a clean checkout
- [ ] `cargo xtask build galoshes` builds v2ray-plugin → galoshes via the DAG (verified locally)
- [ ] CI passes (`cargo xtask test hole-tests` + `hole-tun-tests`, `cargo xtask build hole-msi`, etc.)
- [ ] All 55 xtask unit tests pass (16 new manifest, 21 new orchestrate, 18 pre-existing)