### PR TITLE
Add Dockerfile support to format-section-comments.py

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -50,7 +50,7 @@ id = "format-section-comments"
 name = "format section comments"
 entry = "python scripts/format-section-comments.py"
 language = "python"
-types_or = ["rust", "python", "toml", "javascript", "ts", "jsx", "tsx"]
+types_or = ["rust", "python", "toml", "javascript", "ts", "jsx", "tsx", "dockerfile"]
 
 [[repos.hooks]]
 id = "ty"

--- a/scripts/format-section-comments.py
+++ b/scripts/format-section-comments.py
@@ -4,14 +4,14 @@
 # [tool.uv]
 # dev-dependencies = ["pytest"]
 # ///
-"""Pre-commit hook: fix section comment formatting in Rust, Python, TOML, and JS/TS files.
+"""Pre-commit hook: fix section comment formatting in Rust, Python, TOML, JS/TS, and Dockerfiles.
 
 Section comments must follow the format:
 
     // Section name ======...=  (Rust/JS/TS primary, filled with '=' to column 120)
     // Section name ------...-  (Rust/JS/TS secondary, filled with '-' to column 120)
-    # Section name =======...=  (Python/TOML primary, filled with '=' to column 120)
-    # Section name -------...-  (Python/TOML secondary, filled with '-' to column 120)
+    # Section name =======...=  (Python/TOML/Dockerfile primary, filled with '=' to column 120)
+    # Section name -------...-  (Python/TOML/Dockerfile secondary, filled with '-' to column 120)
 
 Leading whitespace counts toward the column limit.
 
@@ -30,7 +30,20 @@ from typing import NamedTuple
 
 COLUMN_LIMIT = 120
 
-EXTENSION_PREFIX = {".rs": "//", ".py": "#", ".toml": "#", ".js": "//", ".ts": "//", ".jsx": "//", ".tsx": "//"}
+# Dispatch by exact filename (Dockerfiles with no extension).
+FILENAME_PREFIX = {"Dockerfile": "#"}
+
+EXTENSION_PREFIX = {
+    ".rs": "//",
+    ".py": "#",
+    ".toml": "#",
+    ".js": "//",
+    ".ts": "//",
+    ".jsx": "//",
+    ".tsx": "//",
+    ".Dockerfile": "#",
+    ".dockerfile": "#",
+}
 
 
 class Patterns(NamedTuple):
@@ -55,13 +68,20 @@ def make_patterns(prefix: str) -> Patterns:
     )
 
 
-def is_doc_comment(line: str, prefix: str) -> bool:
+def is_doc_comment(line: str, prefix: str, is_dockerfile: bool = False) -> bool:
     """Check if a line is a doc/special comment that should not be treated as a section name half."""
     stripped = line.lstrip()
     if prefix == "//":
         return stripped.startswith("///") or stripped.startswith("//!")
     if prefix == "#":
-        return stripped.startswith("#!") or stripped.startswith("# ///")
+        if stripped.startswith("#!") or stripped.startswith("# ///"):
+            return True
+        if is_dockerfile:
+            # Dockerfile parser directives must remain on their own line and
+            # must not be merged with a following fill-only line.
+            return (
+                stripped.startswith("# syntax=") or stripped.startswith("# escape=") or stripped.startswith("# check=")
+            )
     return False
 
 
@@ -74,7 +94,10 @@ def rebuild(indent: str, name: str, fill_char: str, prefix: str) -> str:
     return line + fill_char * fill_count
 
 
-def process_lines(lines: list[str], patterns: Patterns, prefix: str) -> tuple[list[str], bool]:
+def process_lines(lines: list[str],
+                  patterns: Patterns,
+                  prefix: str,
+                  is_dockerfile: bool = False) -> tuple[list[str], bool]:
     """Fix section comments in a list of lines. Returns (new_lines, changed)."""
     changed = False
     skip_next = False
@@ -93,7 +116,8 @@ def process_lines(lines: list[str], patterns: Patterns, prefix: str) -> tuple[li
             prev_line = new_lines[-1].rstrip("\r\n")
             name_m = patterns.name_half.match(prev_line)
             if (
-                name_m and not patterns.section.match(prev_line) and not is_doc_comment(prev_line, prefix)
+                name_m and not patterns.section.match(prev_line)
+                and not is_doc_comment(prev_line, prefix, is_dockerfile=is_dockerfile)
                 and name_m.group(2)  # has actual text after prefix
             ):
                 indent = name_m.group(1)
@@ -123,8 +147,8 @@ def process_lines(lines: list[str], patterns: Patterns, prefix: str) -> tuple[li
             if fill_m2:
                 name_m2 = patterns.name_half.match(line)
                 if (
-                    name_m2 and not patterns.section.match(line) and not is_doc_comment(line, prefix)
-                    and name_m2.group(2)
+                    name_m2 and not patterns.section.match(line)
+                    and not is_doc_comment(line, prefix, is_dockerfile=is_dockerfile) and name_m2.group(2)
                 ):
                     indent = name_m2.group(1)
                     name = name_m2.group(2).rstrip()
@@ -142,16 +166,21 @@ def process_lines(lines: list[str], patterns: Patterns, prefix: str) -> tuple[li
 
 def process_file(path: str) -> bool:
     """Process one file. Returns True if the file was modified."""
+    name = os.path.basename(path)
     ext = os.path.splitext(path)[1]
-    prefix = EXTENSION_PREFIX.get(ext)
+    prefix = FILENAME_PREFIX.get(name)
+    if prefix is None:
+        prefix = EXTENSION_PREFIX.get(ext)
     if prefix is None:
         return False
+
+    is_dockerfile = name == "Dockerfile" or ext in {".Dockerfile", ".dockerfile"}
 
     with open(path, encoding="utf-8", newline="") as f:
         lines = f.readlines()
 
     patterns = make_patterns(prefix)
-    new_lines, changed = process_lines(lines, patterns, prefix)
+    new_lines, changed = process_lines(lines, patterns, prefix, is_dockerfile=is_dockerfile)
 
     if changed:
         with open(path, "w", encoding="utf-8", newline="") as f:
@@ -497,3 +526,50 @@ def test_toml_reflow():
     line = result.rstrip()
     assert line.startswith("# External hooks -")
     assert len(line) == 120
+
+
+# Dockerfile tests -----------------------------------------------------------------------------------------------------
+
+
+def test_process_file_dockerfile_no_ext(tmp_path):
+    p = tmp_path / "Dockerfile"
+    p.write_text("# Stage " + "=" * 30 + "\n")
+    assert process_file(str(p))
+    assert len(p.read_text().rstrip()) == 120
+
+
+def test_process_file_dockerfile_capital_ext(tmp_path):
+    p = tmp_path / "nginx.Dockerfile"
+    p.write_text("# Stage " + "=" * 30 + "\n")
+    assert process_file(str(p))
+    assert len(p.read_text().rstrip()) == 120
+
+
+def test_process_file_dockerfile_lowercase_ext(tmp_path):
+    p = tmp_path / "nginx.dockerfile"
+    p.write_text("# Stage " + "=" * 30 + "\n")
+    assert process_file(str(p))
+    assert len(p.read_text().rstrip()) == 120
+
+
+def test_dockerfile_parser_directive_not_merged(tmp_path):
+    # Without the parser-directive guard, the script would collapse the
+    # `# syntax=...` line and the following fill-only line into one
+    # malformed line, silently disabling the directive.
+    p = tmp_path / "Dockerfile"
+    p.write_text("# syntax=docker/dockerfile:1\n# ==========\nFROM alpine\n")
+    process_file(str(p))
+    text = p.read_text()
+    assert text.startswith("# syntax=docker/dockerfile:1\n"), f"parser directive was modified: {text!r}"
+
+
+def test_python_syntax_comment_still_merged(tmp_path):
+    # Python files do NOT get the parser-directive exemption — the
+    # # syntax= immunity is Dockerfile-only. This pins the gate so a
+    # future refactor cannot make the exemption global.
+    p = tmp_path / "test.py"
+    p.write_text("# syntax=foo\n# ==========\n")
+    assert process_file(str(p))
+    text = p.read_text()
+    assert text.count("\n") == 1
+    assert len(text.rstrip()) == 120

--- a/scripts/format-section-comments.py
+++ b/scripts/format-section-comments.py
@@ -30,20 +30,32 @@ from typing import NamedTuple
 
 COLUMN_LIMIT = 120
 
-# Dispatch by exact filename (Dockerfiles with no extension).
-FILENAME_PREFIX = {"Dockerfile": "#"}
+EXTENSION_PREFIX = {".rs": "//", ".py": "#", ".toml": "#", ".js": "//", ".ts": "//", ".jsx": "//", ".tsx": "//"}
 
-EXTENSION_PREFIX = {
-    ".rs": "//",
-    ".py": "#",
-    ".toml": "#",
-    ".js": "//",
-    ".ts": "//",
-    ".jsx": "//",
-    ".tsx": "//",
-    ".Dockerfile": "#",
-    ".dockerfile": "#",
-}
+# Dockerfile detection. Mirrors the set of names that pre-commit's `identify`
+# library tags as `dockerfile`, plus lowercase `*.dockerfile` so direct CLI
+# invocation works (prek does not route lowercase-d files to this hook).
+_DOCKERFILE_NAME_PARTS = frozenset({"Dockerfile", "Containerfile"})
+
+
+def is_dockerfile_name(basename: str) -> bool:
+    """Return True if `basename` should be treated as a Dockerfile.
+
+    Matches: ``Dockerfile``, ``Containerfile``, ``foo.Dockerfile``,
+    ``foo.Containerfile``, ``Dockerfile.<anything>``, ``Containerfile.<anything>``,
+    and lowercase ``*.dockerfile``.
+    """
+    if any(part in _DOCKERFILE_NAME_PARTS for part in basename.split(".")):
+        return True
+    return basename.endswith(".dockerfile")
+
+
+# Dockerfile parser directives are case-insensitive on the directive name and
+# tolerate whitespace around `=` per the BuildKit spec. Per the Dockerfile
+# reference, directives are only valid before the first non-comment line, but
+# this script flags the form anywhere in the file — that errs toward not
+# modifying user content.
+_DOCKERFILE_DIRECTIVE_RE = re.compile(r"^#\s*(syntax|escape|check)\s*=", re.IGNORECASE)
 
 
 class Patterns(NamedTuple):
@@ -76,12 +88,8 @@ def is_doc_comment(line: str, prefix: str, is_dockerfile: bool = False) -> bool:
     if prefix == "#":
         if stripped.startswith("#!") or stripped.startswith("# ///"):
             return True
-        if is_dockerfile:
-            # Dockerfile parser directives must remain on their own line and
-            # must not be merged with a following fill-only line.
-            return (
-                stripped.startswith("# syntax=") or stripped.startswith("# escape=") or stripped.startswith("# check=")
-            )
+        if is_dockerfile and _DOCKERFILE_DIRECTIVE_RE.match(stripped):
+            return True
     return False
 
 
@@ -130,7 +138,7 @@ def process_lines(lines: list[str],
 
         # Case 2: single-line section comment with wrong format/length.
         sec_m = patterns.section.match(line)
-        if sec_m:
+        if sec_m and not is_doc_comment(line, prefix, is_dockerfile=is_dockerfile):
             can_m = patterns.canonical.match(line)
             if can_m:
                 indent, name, fill_char = can_m.group(1), can_m.group(2), can_m.group(3)
@@ -167,20 +175,20 @@ def process_lines(lines: list[str],
 def process_file(path: str) -> bool:
     """Process one file. Returns True if the file was modified."""
     name = os.path.basename(path)
-    ext = os.path.splitext(path)[1]
-    prefix = FILENAME_PREFIX.get(name)
-    if prefix is None:
-        prefix = EXTENSION_PREFIX.get(ext)
+    if is_dockerfile_name(name):
+        prefix = "#"
+        is_df = True
+    else:
+        prefix = EXTENSION_PREFIX.get(os.path.splitext(path)[1])
+        is_df = False
     if prefix is None:
         return False
-
-    is_dockerfile = name == "Dockerfile" or ext in {".Dockerfile", ".dockerfile"}
 
     with open(path, encoding="utf-8", newline="") as f:
         lines = f.readlines()
 
     patterns = make_patterns(prefix)
-    new_lines, changed = process_lines(lines, patterns, prefix, is_dockerfile=is_dockerfile)
+    new_lines, changed = process_lines(lines, patterns, prefix, is_dockerfile=is_df)
 
     if changed:
         with open(path, "w", encoding="utf-8", newline="") as f:
@@ -573,3 +581,79 @@ def test_python_syntax_comment_still_merged(tmp_path):
     text = p.read_text()
     assert text.count("\n") == 1
     assert len(text.rstrip()) == 120
+
+
+def test_dockerfile_inline_parser_directive_not_modified(tmp_path):
+    # Single-line shape: the directive sits on the same line as a fill run.
+    # Case 2 (single-line section reformatting) must skip it.
+    p = tmp_path / "Dockerfile"
+    p.write_text("# syntax=docker/dockerfile:1 ==========\nFROM alpine\n")
+    process_file(str(p))
+    text = p.read_text()
+    assert text.startswith("# syntax=docker/dockerfile:1 ==========\n"), f"inline directive was modified: {text!r}"
+
+
+def test_dockerfile_escape_directive_not_merged(tmp_path):
+    p = tmp_path / "Dockerfile"
+    p.write_text("# escape=`\n# ==========\nFROM alpine\n")
+    process_file(str(p))
+    text = p.read_text()
+    assert text.startswith("# escape=`\n"), f"escape directive was modified: {text!r}"
+
+
+def test_dockerfile_check_directive_not_merged(tmp_path):
+    p = tmp_path / "Dockerfile"
+    p.write_text("# check=skip=all\n# ==========\nFROM alpine\n")
+    process_file(str(p))
+    text = p.read_text()
+    assert text.startswith("# check=skip=all\n"), f"check directive was modified: {text!r}"
+
+
+def test_dockerfile_directive_case_insensitive(tmp_path):
+    # BuildKit accepts directive names case-insensitively (per the spec).
+    p = tmp_path / "Dockerfile"
+    p.write_text("# SYNTAX=docker/dockerfile:1\n# ==========\nFROM alpine\n")
+    process_file(str(p))
+    text = p.read_text()
+    assert text.startswith("# SYNTAX=docker/dockerfile:1\n"), f"uppercase directive was modified: {text!r}"
+
+
+def test_dockerfile_directive_whitespace_tolerant(tmp_path):
+    # BuildKit accepts whitespace around `=` and the directive name.
+    p = tmp_path / "Dockerfile"
+    p.write_text("#  syntax = docker/dockerfile:1\n# ==========\nFROM alpine\n")
+    process_file(str(p))
+    text = p.read_text()
+    assert text.startswith("#  syntax = docker/dockerfile:1\n"), \
+        f"whitespace-padded directive was modified: {text!r}"
+
+
+def test_process_file_containerfile(tmp_path):
+    # Podman-style Containerfile: identify tags it as `dockerfile`, so prek
+    # routes it here. The dispatch must handle it like a Dockerfile.
+    p = tmp_path / "Containerfile"
+    p.write_text("# Stage " + "=" * 30 + "\n")
+    assert process_file(str(p))
+    assert len(p.read_text().rstrip()) == 120
+
+
+def test_process_file_dockerfile_dotted(tmp_path):
+    # `Dockerfile.<suffix>` is a common pattern (e.g. Dockerfile.dev).
+    # identify tags these as `dockerfile`.
+    p = tmp_path / "Dockerfile.dev"
+    p.write_text("# Stage " + "=" * 30 + "\n")
+    assert process_file(str(p))
+    assert len(p.read_text().rstrip()) == 120
+
+
+def test_process_file_containerfile_dotted(tmp_path):
+    p = tmp_path / "Containerfile.dev"
+    p.write_text("# Stage " + "=" * 30 + "\n")
+    assert process_file(str(p))
+    assert len(p.read_text().rstrip()) == 120
+
+
+def test_is_dockerfile_name_negative(tmp_path):
+    # Files that look adjacent to Dockerfile but aren't.
+    for n in ["dockerfile", "DOCKERFILE", "MyDockerfile", "dockerfile.txt", "foo.txt"]:
+        assert not is_dockerfile_name(n), f"{n!r} should not match"


### PR DESCRIPTION
Closes #273.

Extends `scripts/format-section-comments.py` to handle Dockerfiles. Section comments use `#` prefix (same as Python/TOML).

Dispatch is by exact filename (`Dockerfile` with no extension) and by extension (`.Dockerfile` capital, `.dockerfile` lowercase). `prek.toml` is updated to add `"dockerfile"` to `types_or`.

Includes a parser-directive immunity guard so that `# syntax=...`, `# escape=...`, `# check=...` lines followed by a fill-only line are NOT collapsed into a malformed combined line. Without the guard the script would silently disable parser directives (Docker treats malformed directives as ordinary comments). The exemption is gated on `is_dockerfile` and a negative test pins that gate so a future refactor can't make the exemption global.

5 new tests; existing 40 still pass; total 45.

Aligns with the parallel postern PR https://github.com/bindreams/postern/pull/new/azhukova/4 — the two `format-section-comments.py` scripts will be byte-identical after both PRs merge.