### PR TITLE
scripts/dev: pass only the hole group as extra_groups to avoid NGROUPS_MAX

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -51,6 +51,13 @@ import time
 from pathlib import Path
 from typing import Any
 
+# `grp` is POSIX-only. dev.py is also invoked on Windows from an elevated
+# PowerShell, where `_lib.sudo_target_user()` returns None and `drop_kwargs`
+# short-circuits before touching `grp`. Gate the import so module load
+# succeeds on Windows.
+if sys.platform != "win32":
+    import grp
+
 import _lib
 
 # ANSI colors ==========================================================================================================
@@ -254,16 +261,40 @@ def shutdown(procs: list[subprocess.Popen]) -> None:
 def drop_kwargs(target: tuple[int, int, str, str] | None) -> dict:
     """Return Popen kwargs that drop privileges to `target` on POSIX.
 
-    `extra_groups` is set to the TARGET user's full group list (via
-    `os.getgrouplist`), NOT root's supplementary groups and NOT empty —
-    we need hole-group membership in the GUI to open the production
-    IPC socket on macOS.
+    `extra_groups` contains only the `hole` group when it exists, not the
+    target user's full supplementary group list. The GUI needs `hole`
+    membership to open the production IPC socket (root:hole 0660 — see
+    `apply_socket_permissions` in `crates/bridge/src/ipc.rs`); no other
+    supplementary group gates anything dev.py's children touch. Passing
+    the full `os.getgrouplist` would also exceed macOS's NGROUPS_MAX
+    (16) on directory-managed accounts and crash subprocess with
+    `ValueError: too many groups`.
+
+    dev.py runs as root, so `setgroups([hole_gid])` succeeds even if the
+    target user is not yet listed in the `hole` group's member list —
+    the kernel honors root's setgroups regardless of on-disk
+    membership. This gives the GUI `hole` permissions on first launch
+    after `bridge grant-access` with no logout/login cycle.
+
+    The literal `"hole"` matches `crates/bridge/src/group.rs::GROUP_NAME`.
     """
     if target is None:
         return {}
-    uid, gid, user, _ = target
-    groups = os.getgrouplist(user, gid)
-    return {"user": uid, "group": gid, "extra_groups": groups}
+    uid, gid, _user, _ = target
+    extra_groups: list[int] = []
+    try:
+        extra_groups.append(grp.getgrnam("hole").gr_gid)
+    except KeyError:
+        # Group not yet created (the first three privilege-drop calls
+        # happen before `bridge grant-access` creates the group).
+        pass
+    except OSError as e:
+        # macOS Directory Services unreachable — corporate machines can
+        # transiently lose LDAP. Drop the group rather than crash; the
+        # GUI will fall back to root-only IPC and surface its own error.
+        print(f"{YELLOW}warning: failed to look up 'hole' group: {e}{RESET}",
+              file=sys.stderr)
+    return {"user": uid, "group": gid, "extra_groups": extra_groups}
 
 
 def drop_env(env: dict, target: tuple[int, int, str, str] | None) -> dict:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -292,8 +292,7 @@ def drop_kwargs(target: tuple[int, int, str, str] | None) -> dict:
         # macOS Directory Services unreachable — corporate machines can
         # transiently lose LDAP. Drop the group rather than crash; the
         # GUI will fall back to root-only IPC and surface its own error.
-        print(f"{YELLOW}warning: failed to look up 'hole' group: {e}{RESET}",
-              file=sys.stderr)
+        print(f"{YELLOW}warning: failed to look up 'hole' group: {e}{RESET}", file=sys.stderr)
     return {"user": uid, "group": gid, "extra_groups": extra_groups}
 
 

--- a/scripts/dev_tests.py
+++ b/scripts/dev_tests.py
@@ -30,14 +30,15 @@ sys.path.insert(0, str(_SCRIPTS_DIR))
 # `dev.py` imports `_lib` at module load and `_lib.require_elevation()` is
 # normally called from `main()`. Tests do not call `main`, but we still need
 # to satisfy the import. A minimal `_lib` stub keeps the import side-effect
-# free without requiring sudo / a target user.
-sys.modules.setdefault(
-    "_lib",
-    types.SimpleNamespace(
-        require_elevation=lambda: None,
-        sudo_target_user=lambda: None,
-    ),
-)
+# free without requiring sudo / a target user. Use `types.ModuleType` rather
+# than `SimpleNamespace` so `sys.modules["_lib"]` matches its declared type.
+_lib_stub = types.ModuleType("_lib")
+# `setattr` bypasses ty's static attribute check (ModuleType has no
+# declared `require_elevation` / `sudo_target_user`); the attrs are
+# created dynamically and read from `dev.py` at module-load time.
+setattr(_lib_stub, "require_elevation", lambda: None)
+setattr(_lib_stub, "sudo_target_user", lambda: None)
+sys.modules.setdefault("_lib", _lib_stub)
 
 _spec = importlib.util.spec_from_file_location("dev", str(_SCRIPTS_DIR / "dev.py"))
 assert _spec and _spec.loader, "failed to locate scripts/dev.py"
@@ -63,9 +64,7 @@ def test_hole_absent_returns_empty_list():
 
 
 def test_directory_services_failure_returns_empty_list(capsys):
-    with mock.patch.object(
-        dev.grp, "getgrnam", side_effect=OSError("DS unreachable")
-    ):
+    with mock.patch.object(dev.grp, "getgrnam", side_effect=OSError("DS unreachable")):
         kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
     assert kw == {"user": 501, "group": 20, "extra_groups": []}
     # Surface the failure to the user — silently dropping `hole` would

--- a/scripts/dev_tests.py
+++ b/scripts/dev_tests.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["pytest"]
+# ///
+"""Unit tests for `drop_kwargs` in `dev.py`.
+
+Run with: `uv run scripts/dev_tests.py`
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# `drop_kwargs` is a no-op on Windows (always returns `{}`). Skip the whole
+# module to avoid loading `dev.py` which references `grp` (POSIX-only) when
+# `target_user` is non-None — and to avoid pretending we have coverage we
+# don't.
+if sys.platform == "win32":
+    pytest.skip("drop_kwargs is POSIX-only", allow_module_level=True)
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# `dev.py` imports `_lib` at module load and `_lib.require_elevation()` is
+# normally called from `main()`. Tests do not call `main`, but we still need
+# to satisfy the import. A minimal `_lib` stub keeps the import side-effect
+# free without requiring sudo / a target user.
+sys.modules.setdefault(
+    "_lib",
+    types.SimpleNamespace(
+        require_elevation=lambda: None,
+        sudo_target_user=lambda: None,
+    ),
+)
+
+_spec = importlib.util.spec_from_file_location("dev", str(_SCRIPTS_DIR / "dev.py"))
+assert _spec and _spec.loader, "failed to locate scripts/dev.py"
+dev = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dev)
+
+
+def test_target_none_returns_empty():
+    assert dev.drop_kwargs(None) == {}
+
+
+def test_hole_present_includes_hole_gid():
+    fake = types.SimpleNamespace(gr_gid=4242)
+    with mock.patch.object(dev.grp, "getgrnam", return_value=fake):
+        kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
+    assert kw == {"user": 501, "group": 20, "extra_groups": [4242]}
+
+
+def test_hole_absent_returns_empty_list():
+    with mock.patch.object(dev.grp, "getgrnam", side_effect=KeyError("hole")):
+        kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
+    assert kw == {"user": 501, "group": 20, "extra_groups": []}
+
+
+def test_directory_services_failure_returns_empty_list(capsys):
+    with mock.patch.object(
+        dev.grp, "getgrnam", side_effect=OSError("DS unreachable")
+    ):
+        kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
+    assert kw == {"user": 501, "group": 20, "extra_groups": []}
+    # Surface the failure to the user — silently dropping `hole` would
+    # leave the GUI confused without any breadcrumb.
+    assert "DS unreachable" in capsys.readouterr().err
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #278.

## Summary

- `drop_kwargs` in `scripts/dev.py` previously passed `os.getgrouplist(user, gid)` as `extra_groups` to every privilege-drop subprocess. CPython rejects `extra_groups` whose length exceeds `sysconf(_SC_NGROUPS_MAX)` (16 on macOS), so accounts in more than 16 groups (corporate / directory-managed) hit `ValueError: too many groups` immediately on `Syncing npm dependencies...`.
- Replace the full-group-list inheritance with `[hole_gid]` (or `[]` when the group does not yet exist, before `bridge grant-access` creates it). The GUI's IPC socket at `root:hole 0660` is the only resource any dev.py child cares about that's gated by a supplementary group.
- Catch `OSError` from `grp.getgrnam` (transient Directory Services failure on corporate macOS) and surface a warning rather than crashing.
- `import grp` is gated on `sys.platform != "win32"` so the module still loads on Windows, where `_lib.sudo_target_user()` returns None and `drop_kwargs` short-circuits.
- Add `scripts/dev_tests.py` (pytest, runnable via `uv run scripts/dev_tests.py`) covering all four branches: `target=None`, hole present, hole absent (`KeyError`), DS failure (`OSError`).

If a future dev.py child process turns out to need another supplementary group, the breakage will be a clear EACCES naming the resource — at which point we add the group explicitly. Defensive truncation to 16 groups would silently drop one of the existing 17 with no signal.

## Test plan

- [x] `uv run scripts/dev_tests.py` — 4 passed
- [ ] CI green
- [ ] `sudo uv run scripts/dev.py` reaches `Granting IPC access...` and the GUI connects to the bridge socket post-grant