### PR TITLE
renovate: re-enable npm with frontend-build CI safety gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "schedule": ["before 9am on monday"],
   "minimumReleaseAge": "7 days",
-  "postUpdateOptions": ["gomodTidy"],
+  "postUpdateOptions": ["gomodTidy", "npmDedupe"],
   "platformAutomerge": true,
   "customManagers": [
     {
@@ -45,9 +45,16 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     },
     {
-      "description": "Disable npm — no lockfile committed",
+      "description": "Group npm updates",
       "matchManagers": ["npm"],
-      "enabled": false
+      "groupName": "npm",
+      "automerge": true,
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "lockFileMaintenance": {
+        "enabled": true,
+        "automerge": true,
+        "schedule": ["before 9am on monday"]
+      }
     }
   ]
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -342,3 +342,37 @@ jobs:
           if ($svc) { throw "HoleBridge service still registered" }
           $path = [Environment]::GetEnvironmentVariable("Path", "Machine")
           if ($path -match [regex]::Escape($binDir)) { throw "$binDir still in PATH" }
+
+  # Renovate npm safety gate: builds the Vite bundle (via the `frontend-build`
+  # xtask target) and type-checks (via npm run check) on every PR. Required
+  # status check for npm dependency PRs to automerge — see .github/renovate.json.
+  # Single platform: `npm run check`/`vite build` are platform-independent;
+  # the per-OS Tauri shell is exercised by the release pipeline.
+  frontend-check:
+    name: Frontend check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
+
+      - name: Build frontend
+        run: cargo xtask build frontend-build
+
+      - name: Type-check frontend
+        run: npm run check

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: matrix.os == 'darwin'
         with:
-          node-version: "lts/*"
+          node-version-file: package.json
       - name: Install npm dependencies
         if: matrix.os == 'darwin'
         run: npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,11 @@ If the dev bridge is killed before clean shutdown and your internet breaks, run 
 
 - Rust toolchain
 - Go toolchain (for v2ray-plugin, built by `cargo xtask deps`)
-- Node.js (for frontend tooling)
+- Node.js ≥24 (constraint pinned via `engines.node` in [package.json](package.json); current Active LTS)
+
+### npm dependency management
+
+`scripts/dev.py` runs `npm install`, which updates `package-lock.json` to match `package.json` whenever the two have drifted. PR-time CI runs `npm ci` via the `frontend-build` xtask target, which is strict — it fails if `package-lock.json` and `package.json` are inconsistent. **If you modify `package.json` directly, commit the resulting `package-lock.json` change in the same commit, or CI will reject the PR.** Renovate handles routine npm updates automatically (see [.github/renovate.json](.github/renovate.json)).
 
 ## Development
 

--- a/build.yaml
+++ b/build.yaml
@@ -82,6 +82,19 @@ targets:
     platforms: [darwin/amd64, darwin/arm64]
     build: npx tauri build
 
+  frontend-build:
+    # Vite bundle of ui/ → ui/dist/. Pure JS/TS toolchain, platform-independent
+    # output, so we run on the cheapest CI host (linux/amd64) only. The
+    # `Frontend check` CI job pairs this with `npm run check` (tsc --noEmit) as
+    # a sibling step — the type-check is intentionally NOT here because it
+    # produces no artifact, and build.yaml targets are build-only by convention.
+    # Not depended on by hole-msi/hole-dmg: Tauri's beforeBuildCommand runs
+    # `npm run build` itself at packaging time.
+    platforms: linux/amd64
+    build:
+      - npm ci --no-audit --no-fund
+      - npm run build
+
   # ===== Test targets =======================================================
   # Convention: name ends in `-tests`. Compile test binaries only — the
   # orchestrator never runs them. CI / dev invokes `cargo nextest run` (with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "hole",
   "private": true,
+  "engines": {
+    "node": ">=24.0.0 <25.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -455,10 +455,49 @@ fn production_build_yaml_parses() {
     let yaml = include_str!("../../build.yaml");
     let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
     // Sanity: a few targets we always expect to exist.
-    for name in ["v2ray-plugin", "galoshes", "hole", "hole-msi", "hole-dmg", "hole-tests"] {
+    for name in [
+        "v2ray-plugin",
+        "galoshes",
+        "hole",
+        "hole-msi",
+        "hole-dmg",
+        "hole-tests",
+        "frontend-build",
+    ] {
         assert!(
             m.get(name).is_some(),
             "production build.yaml is missing expected target {name:?}"
         );
     }
+}
+
+#[skuld::test]
+fn frontend_build_target_shape() {
+    // The Renovate npm safety gate (see Frontend check CI job) depends on
+    // `frontend-build` producing ui/dist/ on linux/amd64 with strict-lockfile
+    // semantics. Pin the shape so a future edit can't silently weaken the gate.
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+    let t = m.get("frontend-build").expect("frontend-build target missing");
+
+    assert_eq!(t.platforms, vec![Platform::new(Os::Linux, Arch::Amd64)]);
+    assert_eq!(
+        t.build,
+        vec![
+            Step::Bash {
+                command: "npm ci --no-audit --no-fund".to_string(),
+                environment: HashMap::new(),
+            },
+            Step::Bash {
+                command: "npm run build".to_string(),
+                environment: HashMap::new(),
+            },
+        ],
+    );
+    // Adding a `depends:` would silently start compiling Rust on every PR
+    // (the gate is supposed to be JS-only). Adding a `-tests` suffix would
+    // flip Target::is_test() and change `cargo xtask {build,test} --all`
+    // selection. Both are load-bearing.
+    assert_eq!(t.depends, Vec::<String>::new());
+    assert!(!t.is_test());
 }


### PR DESCRIPTION
Closes #280.

## Summary

- Replaces the broken npm-disable rule in `.github/renovate.json` (whose stale comment claimed "no lockfile committed", but `package-lock.json` has been in the repo since #101) with an npm grouping rule mirroring Cargo / gomod / pep621 / github-actions, plus nested `lockFileMaintenance` (scoped to npm only — no churn for `Cargo.lock` / `go.sum` / `uv.lock`). Adds `npmDedupe` to top-level `postUpdateOptions`.
- Adds a `frontend-build` xtask target running `npm ci --no-audit --no-fund && npm run build` on `linux/amd64`. Produces `ui/dist/` as a real build artifact. `tsc --noEmit` is intentionally NOT in this target — it produces no artifact, so the calling CI job runs it as a sibling step (mirroring `cargo clippy` + `cargo nextest archive` coexistence in the existing `build` job).
- Adds a `Frontend check` CI job on `ubuntu-latest` invoking `cargo xtask build frontend-build` then `npm run check`. Lightweight inline setup (no `setup-build` composite, since the gate doesn't need Go / sccache / `cargo xtask deps`). Required-status-check candidate for Renovate npm automerge.
- Pins `engines.node` to `>=24.0.0 <25.0.0` (Node 24 LTS line). Single source of truth — `actions/setup-node` reads it via `node-version-file: package.json`. Updates `draft-release.yaml`'s setup-node to the same source.
- Documents the dev (`npm install`, lenient) vs CI (`npm ci`, strict) split in CONTRIBUTING.md.
- TDD: new `frontend_build_target_shape` regression test pins the gate's load-bearing properties (linux/amd64, two bash steps, no deps, not a test target). Extends `production_build_yaml_parses` to require `frontend-build`.

**This PR will NOT silence the four current `npm install` deprecation warnings** (`inflight`, `glob@8.1.0`, `glob@10.5.0`, `whatwg-encoding`) — they're transitives of `@wdio/*` and `cheerio`, both still pinning the deprecated versions in their own `package.json`. Renovate cannot rewrite a parent's `package.json`; the warnings persist until upstream releases.

**Manual follow-up after merge**: mark `Frontend check` as a required status check on `main` (Settings → Branches → main → required status checks). Without that step, automerge bypasses the gate. Verify "Allow auto-merge" is enabled in repo settings too.

## Test plan

- [x] `cargo nextest run -p xtask` — 53/53 pass (including new `frontend_build_target_shape`).
- [x] `cargo xtask list` — shows `frontend-build` with `linux/amd64` / `HOST: no` on darwin.
- [x] `cargo xtask build frontend-build` on darwin — errors with documented platform-mismatch message.
- [x] `npm run check` — no TS errors.
- [x] `npx --yes --package=renovate@latest -- renovate-config-validator .github/renovate.json` — `Config validated successfully`.
- [ ] CI green on this PR — particularly the new `Frontend check` job runs `cargo xtask build frontend-build` + `npm run check` on Linux.
- [ ] Post-merge: dependency dashboard shows pending npm updates; first npm group PR opens within ~7 days; required-status-check on main configured (manual step).