### PR TITLE
xtask: build.yaml `run:` field + `cargo xtask run` verb

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,9 @@ jobs:
       # cargo-clippy is skipped here because it's run per-platform in the
       # build job (see ci.yaml below). cargo-fmt stays active — it is
       # platform-independent, one Windows invocation covers the workspace.
+      # SKIP=cargo-clippy lives in the prek target's `run.environment:`.
       - name: Run linters
-        env:
-          SKIP: cargo-clippy
-        run: prek run --all-files --show-diff-on-failure
+        run: cargo xtask run prek
 
   # Per-platform build job: compiles clippy + test binaries once and publishes
   # them as a platform-scoped artifact (`build-<os>-<arch>`). Test jobs below
@@ -77,16 +76,19 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: cargo binstall --no-confirm --locked cargo-nextest
 
-      # Clippy coverage is platform-gated the same way as before: full
-      # workspace on Hole platforms (windows/amd64, darwin/*); ex-Galoshes
-      # crates only on platforms Hole doesn't ship on.
+      # Clippy coverage is platform-gated by the targets' `platforms:` lists.
+      # `clippy-hole` covers Hole platforms (windows/amd64, darwin/*) with
+      # `--workspace`; `clippy-ex-galoshes` covers the platforms Hole doesn't
+      # ship on (linux/*, windows/arm64) with the ex-Galoshes -p filter set.
+      # The `if:` gates here just suppress the "doesn't apply to host" error
+      # from xtask on the wrong-platform half of the matrix.
       - name: Clippy (Hole workspace)
         if: matrix.os == 'darwin' || (matrix.os == 'windows' && matrix.arch == 'amd64')
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo xtask run clippy-hole
 
       - name: Clippy (ex-Galoshes only)
         if: matrix.os == 'linux' || (matrix.os == 'windows' && matrix.arch == 'arm64')
-        run: cargo clippy -p garter -p garter-bin -p galoshes -p mock-plugin --all-targets -- -D warnings
+        run: cargo xtask run clippy-ex-galoshes
 
       # Archive only the ex-Galoshes crates — they're the only consumers
       # via test-garter and test-galoshes on all platforms. Hole crates'
@@ -343,11 +345,14 @@ jobs:
           $path = [Environment]::GetEnvironmentVariable("Path", "Machine")
           if ($path -match [regex]::Escape($binDir)) { throw "$binDir still in PATH" }
 
-  # Renovate npm safety gate: builds the Vite bundle (via the `frontend-build`
-  # xtask target) and type-checks (via npm run check) on every PR. Required
-  # status check for npm dependency PRs to automerge — see .github/renovate.json.
-  # Single platform: `npm run check`/`vite build` are platform-independent;
-  # the per-OS Tauri shell is exercised by the release pipeline.
+  # Renovate npm safety gate: builds the Vite bundle (via `cargo xtask build
+  # frontend-build`) and type-checks (via `cargo xtask run frontend-check`,
+  # which does its own `npm ci` + `npm run check` — tsc reads source directly
+  # so it doesn't need the Vite bundle as a dep). Both steps are required
+  # status checks for npm dependency PRs to automerge — see
+  # .github/renovate.json. Single platform: `npm run check` / `vite build`
+  # are platform-independent; the per-OS Tauri shell is exercised by the
+  # release pipeline.
   frontend-check:
     name: Frontend check
     runs-on: ubuntu-latest
@@ -375,4 +380,4 @@ jobs:
         run: cargo xtask build frontend-build
 
       - name: Type-check frontend
-        run: npm run check
+        run: cargo xtask run frontend-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,12 +248,15 @@ crates/galoshes/          → bundled SIP003u plugin: YAMUX-multiplexed TCP+UDP 
 crates/mock-plugin/       → minimal SIP003u TCP echo plugin for garter integration
                             tests. Apache-2.0.
 build.yaml                → declarative build-target manifest (the DAG of `hole`,
-                            `hole-msi`, `hole-dmg`, `galoshes`, `*-tests`, etc.)
-                            consumed by `cargo xtask build|test|list`. Schema in
+                            `hole-msi`, `hole-dmg`, `galoshes`, `*-tests`, `clippy-*`,
+                            `prek`, `frontend-check`, etc.) consumed by
+                            `cargo xtask build|run|list`. Schema in
                             xtask/src/manifest.rs; orchestration in xtask/src/orchestrate.rs.
 xtask/                    → workspace task runner. Top-level commands:
-                            - `cargo xtask build <name> | --all`  — orchestrate from build.yaml
-                            - `cargo xtask test  <name> | --all`  — same, for `*-tests` targets
+                            - `cargo xtask build <name> | --all`  — run a target's `build:` steps
+                            - `cargo xtask run <name>`            — run a target's `run:` steps
+                                                                    (tests, linters, dev mode);
+                                                                    invokes the build cascade first
                             - `cargo xtask list`                  — print the target table
                             Primitive subcommands stay available for one-off use:
                             `cargo xtask <stage|deps|v2ray-plugin|galoshes|wintun|version|...>`
@@ -316,8 +319,8 @@ Requires: Rust toolchain, Go toolchain (for v2ray-plugin), Node.js.
 ```sh
 npm install                      # install frontend dependencies (first time only)
 cargo xtask build hole           # deps + cargo build (debug) + stage — single command
-uv run scripts/dev.py            # dev mode (see CONTRIBUTING.md)
-cargo xtask test --all           # all test targets applicable to host platform
+cargo xtask run hole             # dev mode (= build hole + uv run scripts/dev.py)
+cargo xtask run hole-tests       # canonical local nextest invocation for hole crates
 ```
 
 `build.yaml` at the repo root is the single source of truth for the build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,14 @@ Dev mode creates a **real TUN interface** and modifies the routing table — it 
 # Windows: from an elevated PowerShell
 cargo xtask run hole
 
-# macOS
+# macOS — build first as your user, then elevate to run.
+cargo xtask build hole
 sudo cargo xtask run hole
 ```
 
 `cargo xtask run hole` builds the `hole` target and then launches `scripts/dev.py`, which builds the workspace, starts Vite, and launches the bridge + GUI with multiplexed, color-coded logs. Frontend changes (`ui/`) hot-reload instantly via Vite HMR. Rust changes require Ctrl+C and re-run.
+
+**Why the explicit `cargo xtask build hole` on macOS.** `cargo xtask run` always invokes the build cascade for the target before its `run:` steps; under `sudo` that cascade runs as root and would leave `target/` and `target/debug/dist/` files owned by root. `dev.py` already drops privileges around its own internal `cargo xtask build hole` (see lines 130-134 / 336-340 in [scripts/dev.py](scripts/dev.py)), but the orchestrator's pre-cascade fires *before* dev.py gets control. Running `cargo xtask build hole` unprivileged first warms the cargo cache so the elevated `run` cascade is a no-op, sidestepping the ownership issue. Windows is unaffected — UAC elevation is token-based and all subprocesses naturally share the same user identity.
 
 On macOS, `dev.py` detects `SUDO_USER` and drops privileges for the GUI and Vite subprocesses (via POSIX `setuid`/`setgid` + `extra_groups`) so they read your real `~/Library` config while the bridge inherits root. On Windows, UAC elevation is token-based, so all subprocesses naturally share the same user identity — no drop is needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,15 @@ At runtime, Tauri embeds the OS's native webview (Edge WebView2 on Windows, WebK
 
 ### Workspace layout
 
-| Directory        | Crate/Purpose                                                                            |
-| ---------------- | ---------------------------------------------------------------------------------------- |
-| `crates/common/` | `hole-common` — shared types: protocol, config, logging                                  |
-| `crates/bridge/` | `hole-bridge` — bridge library (TUN/routing/shadowsocks/IPC)                             |
-| `crates/hole/`   | `hole` — Tauri app + CLI + bridge entry point (binary name: `hole`)                      |
+| Directory        | Crate/Purpose                                                                           |
+| ---------------- | --------------------------------------------------------------------------------------- |
+| `crates/common/` | `hole-common` — shared types: protocol, config, logging                                 |
+| `crates/bridge/` | `hole-bridge` — bridge library (TUN/routing/shadowsocks/IPC)                            |
+| `crates/hole/`   | `hole` — Tauri app + CLI + bridge entry point (binary name: `hole`)                     |
 | `xtask/`         | workspace task runner (`cargo xtask <build\|run\|list\|stage\|...>`) — see `build.yaml` |
-| `xtask-lib/`     | shared helper crate used by xtask AND `crates/hole/build.rs`                             |
-| `external/`      | Third-party source (git subrepos)                                                        |
-| `ui/`            | Frontend HTML/CSS/TypeScript (Vite)                                                      |
+| `xtask-lib/`     | shared helper crate used by xtask AND `crates/hole/build.rs`                            |
+| `external/`      | Third-party source (git subrepos)                                                       |
+| `ui/`            | Frontend HTML/CSS/TypeScript (Vite)                                                     |
 
 ### Logging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ At runtime, Tauri embeds the OS's native webview (Edge WebView2 on Windows, WebK
 | `crates/common/` | `hole-common` — shared types: protocol, config, logging                                  |
 | `crates/bridge/` | `hole-bridge` — bridge library (TUN/routing/shadowsocks/IPC)                             |
 | `crates/hole/`   | `hole` — Tauri app + CLI + bridge entry point (binary name: `hole`)                      |
-| `xtask/`         | workspace task runner (`cargo xtask <build\|test\|list\|stage\|...>`) — see `build.yaml` |
+| `xtask/`         | workspace task runner (`cargo xtask <build\|run\|list\|stage\|...>`) — see `build.yaml` |
 | `xtask-lib/`     | shared helper crate used by xtask AND `crates/hole/build.rs`                             |
 | `external/`      | Third-party source (git subrepos)                                                        |
 | `ui/`            | Frontend HTML/CSS/TypeScript (Vite)                                                      |
@@ -81,13 +81,13 @@ Dev mode creates a **real TUN interface** and modifies the routing table — it 
 
 ```sh
 # Windows: from an elevated PowerShell
-uv run scripts/dev.py
+cargo xtask run hole
 
 # macOS
-sudo uv run scripts/dev.py
+sudo cargo xtask run hole
 ```
 
-This builds the workspace, starts Vite, and launches the bridge + GUI with multiplexed, color-coded logs. Frontend changes (`ui/`) hot-reload instantly via Vite HMR. Rust changes require Ctrl+C and re-run.
+`cargo xtask run hole` builds the `hole` target and then launches `scripts/dev.py`, which builds the workspace, starts Vite, and launches the bridge + GUI with multiplexed, color-coded logs. Frontend changes (`ui/`) hot-reload instantly via Vite HMR. Rust changes require Ctrl+C and re-run.
 
 On macOS, `dev.py` detects `SUDO_USER` and drops privileges for the GUI and Vite subprocesses (via POSIX `setuid`/`setgid` + `extra_groups`) so they read your real `~/Library` config while the bridge inherits root. On Windows, UAC elevation is token-based, so all subprocesses naturally share the same user identity — no drop is needed.
 
@@ -130,8 +130,10 @@ cargo xtask stage --profile debug --out-dir "$TMPDIR/hole-dev-manual"     # per-
 `cargo xtask build hole` walks the `build.yaml` DAG: it builds v2ray-plugin
 (Go), galoshes (workspace member), downloads wintun on Windows, then runs
 `cargo build --workspace` (debug) and `cargo xtask stage --profile debug --out-dir target/debug/dist`. Use `cargo xtask list` to print the full target
-table; `cargo xtask build|test --all` builds or runs every target applicable
-to the host platform.
+table; `cargo xtask build --all` builds every target applicable to the host
+platform; `cargo xtask run <name>` builds and then performs the named
+target's `run:` action — running tests (`hole-tests`), linters
+(`clippy-hole`, `prek`, `frontend-check`), or dev mode (`hole`).
 
 **Terminal 2 — Vite + GUI (unelevated):**
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,9 @@
-# Hole build manifest — single source of truth for `cargo xtask build|list`.
+# Hole build manifest — single source of truth for `cargo xtask build|run|list`.
 #
 # Schema and semantics live in xtask/src/manifest.rs (deserializers, validation)
 # and xtask/src/orchestrate.rs (DAG, execution). User-facing summary in CLAUDE.md
-# under "Build". Design rationale: docs ../i-want-to-brainstorm-zippy-lightning.md.
+# under "Build". Design rationale: docs ../i-want-to-brainstorm-zippy-lightning.md
+# (and ../i-want-to-explore-joyful-lynx.md for the `run:` field).
 #
 # Platform shape: `<os>/<arch>` (Docker / GOOS-style), where
 #   os   ∈ {windows, darwin, linux}
@@ -13,10 +14,20 @@
 # `process: [...]` for direct subprocess spawn (no shell). Per-step
 # `environment:` appends to inherited env. CWD is repo root.
 #
-# `*-tests` targets are regular build targets that produce test binaries —
-# they do NOT run tests. Running tests is the caller's concern (typically
-# `cargo nextest run`), the same way running `hole.exe` is not part of
-# building it.
+# Two phases per target:
+#   build:  produce the artifact this target is named after. May depend on
+#           other targets' builds (`depends:` chains them).
+#   run:    perform the work this target is named after — execute the test
+#           binary, run the linter, launch dev mode. Optional; missing run:
+#           means the target is a pure artifact. `cargo xtask run X` always
+#           invokes the build cascade for X first; runs do NOT depend on
+#           other runs.
+#
+# `*-tests` targets keep their `--no-run` build for compile-only validation,
+# and their `run:` carries the canonical local nextest invocation. CI may
+# still hand-roll its own nextest call (e.g. archive-based paths in
+# test-garter / test-galoshes, or SKULD_LABELS gating in test-hole) where CI
+# policy diverges from the canonical local invocation.
 
 targets:
   v2ray-plugin:
@@ -59,11 +70,18 @@ targets:
     # canonical BINDIR. Release builds happen inside `hole-msi` / `hole-dmg`
     # via msi-installer / tauri, which run their own `cargo build --release`
     # — so `hole` itself is what you build for development and tests.
+    #
+    # `cargo xtask run hole` launches dev mode via scripts/dev.py. dev.py
+    # itself runs `cargo xtask build hole` internally, but the build cascade
+    # above will have just executed it, so dev.py's own invocation no-ops via
+    # cargo's incremental cache. Cheap, no special handling needed. Requires
+    # elevation (sudo / Run As Administrator) — same precondition as today.
     depends: [galoshes, wintun]
     platforms: [windows/amd64, darwin/amd64, darwin/arm64]
     build:
       - cargo build --workspace
       - cargo xtask stage --profile debug --out-dir target/debug/dist
+    run: uv run scripts/dev.py
 
   hole-msi:
     # NOT a dependent of `hole`. The msi-installer Python entry point does its
@@ -85,20 +103,19 @@ targets:
   frontend-build:
     # Vite bundle of ui/ → ui/dist/. Pure JS/TS toolchain, platform-independent
     # output, so we run on the cheapest CI host (linux/amd64) only. The
-    # `Frontend check` CI job pairs this with `npm run check` (tsc --noEmit) as
-    # a sibling step — the type-check is intentionally NOT here because it
-    # produces no artifact, and build.yaml targets are build-only by convention.
-    # Not depended on by hole-msi/hole-dmg: Tauri's beforeBuildCommand runs
-    # `npm run build` itself at packaging time.
+    # type-check (`cargo xtask run frontend-check`) is a separate target —
+    # tsc reads source directly and produces no artifact. Not depended on by
+    # hole-msi / hole-dmg: Tauri's beforeBuildCommand runs `npm run build`
+    # itself at packaging time.
     platforms: linux/amd64
     build:
       - npm ci --no-audit --no-fund
       - npm run build
 
   # ===== Test targets =======================================================
-  # Convention: name ends in `-tests`. Compile test binaries only — the
-  # orchestrator never runs them. CI / dev invokes `cargo nextest run` (with
-  # whatever runtime filters / SKULD_LABELS env it wants) after building.
+  # `build:` compiles test binaries (--no-run); `run:` is the canonical local
+  # nextest invocation. CI may diverge — see test-hole's SKULD_LABELS gating
+  # and the archive-based test-garter / test-galoshes jobs.
 
   hole-tests:
     depends: hole
@@ -109,27 +126,78 @@ targets:
           + package(tun-engine) + package(tun-engine-macros)
           + package(dump) + package(dump-macros)
           + package(handle-holders)'
+    run: >
+      cargo nextest run
+      -E 'package(hole) + package(hole-bridge) + package(hole-common)
+          + package(tun-engine) + package(tun-engine-macros)
+          + package(dump) + package(dump-macros)
+          + package(handle-holders)'
 
   galoshes-tests:
     depends: galoshes
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
     build: cargo nextest run --no-run -p galoshes
+    run: cargo nextest run -p galoshes
 
   garter-tests:
     depends: garter
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
     build: cargo nextest run --no-run -p garter
+    run: cargo nextest run -p garter
 
   garter-bin-tests:
     depends: garter-bin
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
     build: cargo nextest run --no-run -p garter-bin
+    run: cargo nextest run -p garter-bin
 
   mock-plugin-tests:
     depends: mock-plugin
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
     build: cargo nextest run --no-run -p mock-plugin
+    run: cargo nextest run -p mock-plugin
+
+  # ===== Lint & check targets ==============================================
+  # No build phase; the tool's incremental cache is the build. Each is a
+  # first-class runnable invoked via `cargo xtask run <name>`, replacing the
+  # CI yaml's hand-rolled invocations.
+
+  clippy-hole:
+    # Hole platforms only. On the Hole platforms the entire workspace
+    # compiles, so `--workspace` is correct.
+    platforms: [windows/amd64, darwin/amd64, darwin/arm64]
+    run: cargo clippy --workspace --all-targets -- -D warnings
+
+  clippy-ex-galoshes:
+    # Hole crates use windows/macos cfg-gates that don't compile on linux or
+    # windows/arm64; on those platforms scope clippy to the ex-Galoshes
+    # crates only via -p filters. The two clippy- targets together cover the
+    # full 6-platform CI matrix without overlap.
+    platforms: [linux/amd64, linux/arm64, windows/arm64]
+    run: cargo clippy -p garter -p garter-bin -p galoshes -p mock-plugin --all-targets -- -D warnings
+
+  prek:
+    # cargo-fmt + repo-wide hooks. SKIP=cargo-clippy because clippy lives in
+    # the per-platform clippy-* targets above. Platforms wide-open so devs on
+    # any host can `cargo xtask run prek` locally; CI's lint job pins its own
+    # runner, the target's platform list doesn't dictate where CI runs it.
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    run:
+      - bash:
+          command: prek run --all-files --show-diff-on-failure
+          environment: { SKIP: cargo-clippy }
+
+  frontend-check:
+    # tsc --noEmit. Platform-independent (tsc doesn't care about host OS).
+    # No `depends: frontend-build` — tsc reads source files directly; the
+    # Vite bundle is an artifact, not an input to the type-check.
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    run:
+      - npm ci --no-audit --no-fund
+      - npm run check

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::manifest::{Manifest, Platform};
-use crate::orchestrate::{execute, relocate_self_if_windows, render_list, Plan};
+use crate::orchestrate::{execute, execute_run, relocate_self_if_windows, render_list, Plan};
 
 pub mod bindir;
 pub mod galoshes;
@@ -40,8 +40,8 @@ mod test_binaries_tests;
 #[command(
     name = "xtask",
     about = "Workspace task runner for the hole project",
-    long_about = "Single source of truth for build orchestration that would otherwise be \
-                  duplicated across build.rs, scripts/dev.py, and msi-installer."
+    long_about = "Single source of truth for build and run orchestration that would otherwise \
+                  be duplicated across build.rs, CI yaml, scripts/dev.py, and msi-installer."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -112,10 +112,6 @@ pub enum Command {
     /// targets applicable to the host platform, and runs each target's
     /// `build:` steps in topological order. `--all` builds every target
     /// applicable to the host platform.
-    ///
-    /// Test targets (names ending in `-tests`) are regular build targets
-    /// that produce test binaries; running those binaries is the caller's
-    /// concern (typically `cargo nextest run`), not xtask's.
     Build {
         /// Target name (e.g. `hole`, `galoshes`, `hole-msi`, `hole-tests`).
         target: Option<String>,
@@ -123,8 +119,20 @@ pub enum Command {
         #[arg(long, conflicts_with = "target")]
         all: bool,
     },
-    /// List every target declared in `build.yaml` with its platforms and
-    /// host-platform applicability.
+    /// Run a target's `run:` steps after invoking the full build cascade for
+    /// that target. Targets without `run:` are an error.
+    ///
+    /// "Run" performs the work the target is named after: `hole-tests` runs
+    /// the test binaries, `hole` launches dev mode, `clippy-hole` runs
+    /// clippy. Runs do not depend on other runs — `cargo xtask run X` builds
+    /// `X` and its deps, then runs only `X`'s `run:` steps. There is no
+    /// `--all`: "run everything" is not a meaningful operation.
+    Run {
+        /// Target name (e.g. `hole`, `hole-tests`, `clippy-hole`, `prek`).
+        target: String,
+    },
+    /// List every target declared in `build.yaml` with its platforms,
+    /// host-platform applicability, and a `*` marker for runnables.
     List,
 }
 
@@ -172,6 +180,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Deps => run_deps(),
         Command::Version { check, exact } => run_version(check, exact),
         Command::Build { target, all } => run_build(target, all),
+        Command::Run { target } => run_run(target),
         Command::List => run_list(),
     }
 }
@@ -253,6 +262,23 @@ pub fn run_build(target: Option<String>, all: bool) -> Result<()> {
 
     let order = plan.order_for(&roots, host)?;
     execute(&plan, &order, &repo_root)
+}
+
+pub fn run_run(target: String) -> Result<()> {
+    // Same Windows self-relocate dance as `run_build`: build steps may shell
+    // out to recursive `cargo xtask <X>` invocations, and on Windows cargo's
+    // relink path can't overwrite the running xtask.exe.
+    relocate_self_if_windows()?;
+
+    let (manifest, repo_root) = load_manifest()?;
+    let host = Platform::host().ok_or_else(|| {
+        anyhow!(
+            "host platform not in the known set (windows/darwin/linux × amd64/arm64); \
+             cannot orchestrate"
+        )
+    })?;
+    let plan = Plan::new(&manifest)?;
+    execute_run(&plan, &target, host, &repo_root)
 }
 
 pub fn run_list() -> Result<()> {

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -1,4 +1,4 @@
-//! `build.yaml` manifest: target registry for `cargo xtask build|test|list`.
+//! `build.yaml` manifest: target registry for `cargo xtask build|run|list`.
 //!
 //! See `build.yaml` at the repo root for the user-facing schema and the
 //! `i-want-to-brainstorm-zippy-lightning` design doc for the rationale.
@@ -267,6 +267,7 @@ pub struct Target {
     pub depends: Vec<String>,
     pub platforms: Vec<Platform>,
     pub build: Vec<Step>,
+    pub run: Vec<Step>,
 }
 
 impl Target {
@@ -276,16 +277,18 @@ impl Target {
         self.platforms.contains(&platform)
     }
 
-    /// Returns `true` if this target's name marks it as a test target (suffix
-    /// `-tests`). Used by `cargo xtask {build,test} --all` to filter.
-    pub fn is_test(&self) -> bool {
-        self.name.ends_with("-tests")
+    /// Returns `true` if this target declares any `run:` steps. The
+    /// `cargo xtask list` output marks runnable targets in the `RUN?` column.
+    pub fn has_run(&self) -> bool {
+        !self.run.is_empty()
     }
 }
 
 // Raw shape for a target — the post-deserialization step is normalizing
 // `Option<DependsRaw>` and `Option<BuildRaw>` into `Vec<...>` and resolving
-// `PlatformsRaw` into `Vec<Platform>`.
+// `PlatformsRaw` into `Vec<Platform>`. `run:` reuses `BuildRaw` because the
+// underlying shape (one step or a list of steps) is identical; the type's
+// name describes structure, not semantics.
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -295,6 +298,8 @@ struct TargetRaw {
     platforms: PlatformsRaw,
     #[serde(default)]
     build: Option<BuildRaw>,
+    #[serde(default)]
+    run: Option<BuildRaw>,
 }
 
 #[derive(Deserialize)]
@@ -450,6 +455,7 @@ impl Manifest {
             let depends = t.depends.map(DependsRaw::into_vec).unwrap_or_default();
             let platforms = t.platforms.into_vec().with_context(|| format!("in target {name:?}"))?;
             let build = t.build.map(BuildRaw::into_steps).unwrap_or_default();
+            let run = t.run.map(BuildRaw::into_steps).unwrap_or_default();
 
             // Reject platform duplicates inside one target — silent dedup would
             // hide a real authoring mistake.
@@ -467,6 +473,7 @@ impl Manifest {
                     depends,
                     platforms,
                     build,
+                    run,
                 },
             );
         }

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -727,14 +727,24 @@ fn tests_targets_run_matches_build_minus_no_run() {
     let yaml = include_str!("../../build.yaml");
     let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
 
-    for name in ["hole-tests", "galoshes-tests", "garter-tests", "garter-bin-tests", "mock-plugin-tests"] {
+    for name in [
+        "hole-tests",
+        "galoshes-tests",
+        "garter-tests",
+        "garter-bin-tests",
+        "mock-plugin-tests",
+    ] {
         let t = m.get(name).unwrap_or_else(|| panic!("{name:?} target missing"));
         assert_eq!(
             t.build.len(),
             1,
             "{name:?} build is expected to be a single nextest invocation"
         );
-        assert_eq!(t.run.len(), 1, "{name:?} run is expected to be a single nextest invocation");
+        assert_eq!(
+            t.run.len(),
+            1,
+            "{name:?} run is expected to be a single nextest invocation"
+        );
         let (Step::Bash { command: build_cmd, .. }, Step::Bash { command: run_cmd, .. }) = (&t.build[0], &t.run[0])
         else {
             panic!("{name:?}: build/run must be Bash steps");

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -594,7 +594,13 @@ fn production_build_yaml_parses() {
     // targets all carry a canonical local nextest invocation. Removing any of
     // these would re-fragment runner knowledge across CI / scripts / docs.
     assert!(m.get("hole").unwrap().has_run(), "hole must declare run: (dev mode)");
-    for tests in ["hole-tests", "galoshes-tests", "garter-tests", "garter-bin-tests", "mock-plugin-tests"] {
+    for tests in [
+        "hole-tests",
+        "galoshes-tests",
+        "garter-tests",
+        "garter-bin-tests",
+        "mock-plugin-tests",
+    ] {
         assert!(
             m.get(tests).unwrap().has_run(),
             "{tests:?} must declare run: (canonical nextest invocation)"

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -714,3 +714,46 @@ fn frontend_build_target_shape() {
     assert_eq!(t.depends, Vec::<String>::new());
     assert!(!t.has_run());
 }
+
+#[skuld::test]
+fn tests_targets_run_matches_build_minus_no_run() {
+    // Each `*-tests` target's `run:` is the canonical local nextest invocation
+    // — the same command line as its `build:` minus `--no-run`. CI doesn't
+    // exercise these `run:` blocks (test-hole / test-garter / test-galoshes
+    // use SKULD_LABELS / archive-based paths instead), so a typo in any of
+    // them would only surface when a developer runs `cargo xtask run X-tests`.
+    // Pin the symmetry here so a manifest edit that drifts run from build is
+    // caught at unit-test time.
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+
+    for name in ["hole-tests", "galoshes-tests", "garter-tests", "garter-bin-tests", "mock-plugin-tests"] {
+        let t = m.get(name).unwrap_or_else(|| panic!("{name:?} target missing"));
+        assert_eq!(
+            t.build.len(),
+            1,
+            "{name:?} build is expected to be a single nextest invocation"
+        );
+        assert_eq!(t.run.len(), 1, "{name:?} run is expected to be a single nextest invocation");
+        let (Step::Bash { command: build_cmd, .. }, Step::Bash { command: run_cmd, .. }) = (&t.build[0], &t.run[0])
+        else {
+            panic!("{name:?}: build/run must be Bash steps");
+        };
+        // Trim and normalize whitespace before comparing — YAML's `>` folded
+        // scalar collapses newlines into spaces, but the resulting strings can
+        // still differ by trailing whitespace from line continuations.
+        let build_normalized: String = build_cmd.split_whitespace().collect::<Vec<_>>().join(" ");
+        let run_normalized: String = run_cmd.split_whitespace().collect::<Vec<_>>().join(" ");
+        let expected_run = build_normalized.replace(" --no-run", "");
+        assert_eq!(
+            run_normalized, expected_run,
+            "{name:?}: run command must equal build command with `--no-run` removed.\n  \
+             build (normalized): {build_normalized:?}\n  \
+             expected run: {expected_run:?}\n  \
+             actual run (normalized): {run_normalized:?}"
+        );
+        // Sanity: build must contain --no-run, run must not.
+        assert!(build_cmd.contains("--no-run"), "{name:?} build must contain --no-run");
+        assert!(!run_cmd.contains("--no-run"), "{name:?} run must not contain --no-run");
+    }
+}

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -86,6 +86,41 @@ targets:
 }
 
 #[skuld::test]
+fn run_short_syntax_equals_list_syntax() {
+    // `run:` reuses `BuildRaw`, so the same shorthand layers apply: bare string
+    // ↔ `[bash: <string>]`. Pin to catch any divergence if the raw types ever
+    // split.
+    let bare = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    run: "echo hi"
+"#,
+    )
+    .unwrap();
+    let listed = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    run:
+      - bash: "echo hi"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(bare.get("foo").unwrap().run, listed.get("foo").unwrap().run);
+    assert_eq!(
+        bare.get("foo").unwrap().run,
+        vec![Step::Bash {
+            command: "echo hi".to_string(),
+            environment: HashMap::new(),
+        }]
+    );
+}
+
+#[skuld::test]
 fn step_polymorphism_canonicalizes_uniformly() {
     let m = parse(
         r#"
@@ -318,6 +353,79 @@ targets:
 }
 
 #[skuld::test]
+fn target_with_no_run_steps_is_legal() {
+    // The `run:` field is optional. Targets without it deserialize with an
+    // empty `Vec<Step>`. `cargo xtask run X` will reject these at invocation
+    // time (orchestrate_tests::run_run_errors_on_empty_run pins that), but
+    // the manifest itself accepts them.
+    let m = parse(
+        r"
+targets:
+  foo:
+    platforms: windows/amd64
+    build: echo hi
+",
+    )
+    .unwrap();
+    assert_eq!(m.get("foo").unwrap().run, Vec::<Step>::new());
+    assert!(!m.get("foo").unwrap().has_run());
+}
+
+#[skuld::test]
+fn run_step_polymorphism_canonicalizes_uniformly() {
+    // Mirrors `step_polymorphism_canonicalizes_uniformly` for `build:`.
+    // `run:` reuses the same `Step`/`StepRaw` types, but pin the equivalence
+    // explicitly: a future split (separate `RunStep`) would silently lose
+    // shape parity.
+    let m = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    run:
+      - "echo a"
+      - bash: "echo b"
+      - bash:
+          command: "echo c"
+          environment: { K: V }
+      - process: ["cargo", "build"]
+      - process:
+          args: ["go", "build"]
+          environment: { GOOS: linux }
+"#,
+    )
+    .unwrap();
+
+    let steps = &m.get("foo").unwrap().run;
+    assert_eq!(steps.len(), 5);
+    assert_eq!(
+        steps[0],
+        Step::Bash {
+            command: "echo a".to_string(),
+            environment: HashMap::new(),
+        }
+    );
+    let mut env_kv = HashMap::new();
+    env_kv.insert("K".to_string(), "V".to_string());
+    assert_eq!(
+        steps[2],
+        Step::Bash {
+            command: "echo c".to_string(),
+            environment: env_kv,
+        }
+    );
+    let mut env_goos = HashMap::new();
+    env_goos.insert("GOOS".to_string(), "linux".to_string());
+    assert_eq!(
+        steps[4],
+        Step::Process {
+            args: vec!["go".to_string(), "build".to_string()],
+            environment: env_goos,
+        }
+    );
+}
+
+#[skuld::test]
 fn iter_preserves_declaration_order() {
     let m = parse(
         r"
@@ -362,28 +470,34 @@ targets:
 }
 
 #[skuld::test]
-fn is_test_uses_name_suffix() {
+fn has_run_distinguishes_runnable_targets() {
+    // `has_run()` replaces the old name-suffix-based `is_test()`. A target is
+    // runnable iff it declares `run:` steps — independent of name. This is
+    // the semantic shift that lets non-test targets (clippy, prek,
+    // frontend-check, hole's dev mode) live in the manifest as first-class
+    // runnables.
     let m = parse(
         r"
 targets:
-  foo:
+  build-only:
     platforms: windows/amd64
-  foo-tests:
+    build: echo build
+  runnable:
     platforms: windows/amd64
-  foo-test:
+    run: echo run
+  both:
     platforms: windows/amd64
-  pretests:
+    build: echo build
+    run: echo run
+  empty:
     platforms: windows/amd64
 ",
     )
     .unwrap();
-    // Only the exact `-tests` suffix qualifies as a test target. `-test`
-    // (singular) and the bare suffix `tests` (no dash) are NOT test targets;
-    // adding either by accident shouldn't silently flip CI behavior.
-    assert!(!m.get("foo").unwrap().is_test());
-    assert!(m.get("foo-tests").unwrap().is_test());
-    assert!(!m.get("foo-test").unwrap().is_test());
-    assert!(!m.get("pretests").unwrap().is_test());
+    assert!(!m.get("build-only").unwrap().has_run());
+    assert!(m.get("runnable").unwrap().has_run());
+    assert!(m.get("both").unwrap().has_run());
+    assert!(!m.get("empty").unwrap().has_run());
 }
 
 #[skuld::test]
@@ -463,12 +577,104 @@ fn production_build_yaml_parses() {
         "hole-dmg",
         "hole-tests",
         "frontend-build",
+        // Lint and check targets — proof that the manifest expresses non-test
+        // runnables. Removing any of these would silently strip a CI gate.
+        "clippy-hole",
+        "clippy-ex-galoshes",
+        "prek",
+        "frontend-check",
     ] {
         assert!(
             m.get(name).is_some(),
             "production build.yaml is missing expected target {name:?}"
         );
     }
+
+    // hole's `run:` is the canonical dev-mode entry point. The five `*-tests`
+    // targets all carry a canonical local nextest invocation. Removing any of
+    // these would re-fragment runner knowledge across CI / scripts / docs.
+    assert!(m.get("hole").unwrap().has_run(), "hole must declare run: (dev mode)");
+    for tests in ["hole-tests", "galoshes-tests", "garter-tests", "garter-bin-tests", "mock-plugin-tests"] {
+        assert!(
+            m.get(tests).unwrap().has_run(),
+            "{tests:?} must declare run: (canonical nextest invocation)"
+        );
+    }
+}
+
+#[skuld::test]
+fn clippy_hole_target_shape() {
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+    let t = m.get("clippy-hole").expect("clippy-hole target missing");
+    // Hole platforms only — non-Hole platforms gate workspace clippy on
+    // `cfg(target_os)`-restricted crates that don't compile there.
+    assert_eq!(
+        t.platforms,
+        vec![
+            Platform::new(Os::Windows, Arch::Amd64),
+            Platform::new(Os::Darwin, Arch::Amd64),
+            Platform::new(Os::Darwin, Arch::Arm64),
+        ]
+    );
+    assert!(t.build.is_empty(), "clippy targets have no separate build phase");
+    assert_eq!(
+        t.run,
+        vec![Step::Bash {
+            command: "cargo clippy --workspace --all-targets -- -D warnings".to_string(),
+            environment: HashMap::new(),
+        }]
+    );
+    assert_eq!(t.depends, Vec::<String>::new());
+}
+
+#[skuld::test]
+fn prek_target_shape() {
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+    let t = m.get("prek").expect("prek target missing");
+    // Full matrix: prek is platform-independent and devs on any host should
+    // be able to run it locally.
+    assert_eq!(t.platforms.len(), 6);
+    assert!(t.build.is_empty());
+    // SKIP=cargo-clippy is load-bearing — clippy lives in the per-platform
+    // clippy-* targets, and prek would otherwise duplicate that work on
+    // whatever single platform CI runs prek on.
+    let mut env = HashMap::new();
+    env.insert("SKIP".to_string(), "cargo-clippy".to_string());
+    assert_eq!(
+        t.run,
+        vec![Step::Bash {
+            command: "prek run --all-files --show-diff-on-failure".to_string(),
+            environment: env,
+        }]
+    );
+}
+
+#[skuld::test]
+fn frontend_check_target_shape() {
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+    let t = m.get("frontend-check").expect("frontend-check target missing");
+    // Full matrix: tsc is platform-independent.
+    assert_eq!(t.platforms.len(), 6);
+    assert!(t.build.is_empty());
+    assert_eq!(
+        t.run,
+        vec![
+            Step::Bash {
+                command: "npm ci --no-audit --no-fund".to_string(),
+                environment: HashMap::new(),
+            },
+            Step::Bash {
+                command: "npm run check".to_string(),
+                environment: HashMap::new(),
+            },
+        ]
+    );
+    // No `depends: frontend-build`. tsc reads source files directly; the
+    // Vite bundle is an artifact, not an input to the type-check.
+    assert_eq!(t.depends, Vec::<String>::new());
 }
 
 #[skuld::test]
@@ -495,9 +701,10 @@ fn frontend_build_target_shape() {
         ],
     );
     // Adding a `depends:` would silently start compiling Rust on every PR
-    // (the gate is supposed to be JS-only). Adding a `-tests` suffix would
-    // flip Target::is_test() and change `cargo xtask {build,test} --all`
-    // selection. Both are load-bearing.
+    // (the gate is supposed to be JS-only). Adding a `run:` step would make
+    // `cargo xtask run frontend-build` succeed with whatever side effect the
+    // step has — `frontend-build` is an artifact target, not a runnable, so
+    // pin both as load-bearing.
     assert_eq!(t.depends, Vec::<String>::new());
-    assert!(!t.is_test());
+    assert!(!t.has_run());
 }

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -5,6 +5,9 @@
 //! 2. Computes a topologically-sorted subgraph of targets reachable from the
 //!    selection that apply to the host platform.
 //! 3. Executes each target's `build:` steps in order, fail-fast.
+//! 4. For `cargo xtask run <name>`, follows up with the target's `run:` steps
+//!    after the build cascade (a "run" performs the work the target is named
+//!    after; runs do not depend on other runs).
 //!
 //! Pure orchestration only — no incremental / up-to-date checks. The leaf
 //! commands (`cargo build`, `cargo xtask v2ray-plugin`, etc.) own that.
@@ -367,7 +370,7 @@ fn run(mut cmd: Command, label: &str) -> Result<()> {
         .stderr(Stdio::inherit());
     let status = cmd.status().with_context(|| format!("spawning {label}"))?;
     if !status.success() {
-        return Err(anyhow!("{label} failed: exit status {}", status));
+        return Err(anyhow!("{label} failed: exit status {status}"));
     }
     Ok(())
 }
@@ -396,13 +399,46 @@ pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path) -> Result<()> 
     Ok(())
 }
 
+/// Run a target's `run:` steps after the full build cascade for that target.
+///
+/// The cascade order matches `cargo xtask build <target>`: every transitive
+/// build dep applicable to `host`, in topological order, then the target's
+/// own `build:` steps. Once that succeeds, the target's `run:` steps execute.
+///
+/// Errors:
+/// - `unknown target: {name:?}` if `target_name` isn't declared.
+/// - `target {name:?} has no run steps defined` if the target's `run:` is
+///   empty. Checked before any platform-applicability work — running a
+///   target without `run:` is a manifest error, not a host-specific issue.
+/// - The platform-applicability message from [`Plan::order_for`] if the
+///   target doesn't apply to `host`.
+/// - Any step's failure aborts the cascade with `while building target X` or
+///   `while running target X` context.
+pub fn execute_run(plan: &Plan<'_>, target_name: &str, host: Platform, repo_root: &Path) -> Result<()> {
+    let target = plan
+        .manifest
+        .get(target_name)
+        .ok_or_else(|| anyhow!("unknown target: {target_name:?}"))?;
+    if target.run.is_empty() {
+        bail!("target {target_name:?} has no run steps defined");
+    }
+    let order = plan.order_for(&[target_name], host)?;
+    execute(plan, &order, repo_root)?;
+
+    println!("xtask: ==== running target {target_name} ====");
+    for step in &target.run {
+        run_step(step, repo_root).with_context(|| format!("while running target {target_name}"))?;
+    }
+    Ok(())
+}
+
 // ===== List output ===================================================================================================
 
 /// Render the table printed by `cargo xtask list`. Returns a string for ease
 /// of testing; the caller is responsible for `print!`.
 pub fn render_list(manifest: &Manifest, host: Option<Platform>) -> String {
     let mut out = String::new();
-    let header = format!("{:<22} {:<46} HOST", "TARGET", "PLATFORMS");
+    let header = format!("{:<22} {:<46} {:<5} RUN?", "TARGET", "PLATFORMS", "HOST");
     out.push_str(&header);
     out.push('\n');
     for t in manifest.iter() {
@@ -412,7 +448,8 @@ pub fn render_list(manifest: &Manifest, host: Option<Platform>) -> String {
             Some(_) => "no",
             None => "?",
         };
-        out.push_str(&format!("{:<22} {:<46} {}\n", t.name, plats, host_mark));
+        let run_mark = if t.has_run() { "*" } else { "" };
+        out.push_str(&format!("{:<22} {:<46} {:<5} {}\n", t.name, plats, host_mark, run_mark));
     }
     out
 }

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -238,7 +238,7 @@ targets:
 }
 
 #[skuld::test]
-fn render_list_shows_host_applicability() {
+fn render_list_shows_host_applicability_and_runnable() {
     let m = manifest(
         r"
 targets:
@@ -246,16 +246,37 @@ targets:
     platforms: windows/amd64
   hole-dmg:
     platforms: [darwin/amd64, darwin/arm64]
+  prek:
+    platforms: windows/amd64
+    run: prek run
 ",
     );
     let host = Platform::new(Os::Windows, Arch::Amd64);
     let out = render_list(&m, Some(host));
     // Header + one line per target.
     let lines: Vec<&str> = out.lines().collect();
-    assert_eq!(lines.len(), 3);
-    assert!(lines[0].contains("TARGET") && lines[0].contains("HOST"));
-    assert!(lines[1].contains("hole-msi") && lines[1].ends_with("yes"));
-    assert!(lines[2].contains("hole-dmg") && lines[2].ends_with("no"));
+    assert_eq!(lines.len(), 4);
+    assert!(
+        lines[0].contains("TARGET") && lines[0].contains("HOST") && lines[0].contains("RUN?"),
+        "header missing column: {}",
+        lines[0]
+    );
+    // Build-only target on host: yes / (empty run mark).
+    assert!(lines[1].contains("hole-msi") && lines[1].contains(" yes "));
+    assert!(
+        !lines[1].trim_end().ends_with('*'),
+        "hole-msi has no run: but is marked runnable: {}",
+        lines[1]
+    );
+    // Build-only target off host: no / (empty run mark).
+    assert!(lines[2].contains("hole-dmg") && lines[2].contains(" no "));
+    // Runnable target: trailing `*` marker. trim_end to ignore any column padding.
+    assert!(lines[3].contains("prek"));
+    assert!(
+        lines[3].trim_end().ends_with('*'),
+        "prek declares run: but is not marked runnable: {}",
+        lines[3]
+    );
 }
 
 // `run_step` tests assume bash is available — Git Bash on Windows runners,
@@ -323,6 +344,212 @@ fn run_step_process_empty_args_errors() {
     let err = run_step(&step, dir.path()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("empty"), "expected empty-args error, got: {msg}");
+}
+
+// ===== execute_run ===================================================================================================
+//
+// `cargo xtask run <name>` semantics: build cascade for the target first, then
+// the target's own `run:` steps. Runs do not depend on other runs.
+
+fn host_platform() -> Platform {
+    // Tests in this module use bash steps that only need a working shell, so
+    // the actual host doesn't matter for behavior — we just need a `Platform`
+    // that matches the synthetic manifests' `platforms:` lists. Resolve from
+    // the real host so we don't accidentally encode the test host into the
+    // manifest's platform set.
+    Platform::host().expect("test host must be in the known platform set")
+}
+
+fn host_yaml() -> &'static str {
+    // String form of the host platform — `<os>/<arch>` — for use inside the
+    // raw-YAML test fixtures.
+    let p = host_platform();
+    Box::leak(format!("{p}").into_boxed_str())
+}
+
+#[skuld::test]
+fn execute_run_executes_build_cascade_then_run() {
+    // Synthesize a target whose build step writes a sentinel file and whose
+    // run step reads it back. If the build cascade is skipped, the run step
+    // exits non-zero and the test fails.
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel = dir.path().join("sentinel.txt");
+    let sentinel_str = sentinel.to_string_lossy().replace('\\', "/");
+
+    let yaml = format!(
+        r#"
+targets:
+  foo:
+    platforms: {host}
+    build:
+      - bash: 'echo built > "{sentinel}"'
+    run:
+      - bash: 'test "$(cat "{sentinel}")" = built'
+"#,
+        host = host_yaml(),
+        sentinel = sentinel_str,
+    );
+    let m = Manifest::parse(&yaml).unwrap();
+    let plan = Plan::new(&m).unwrap();
+    execute_run(&plan, "foo", host_platform(), dir.path()).unwrap();
+    // Sentinel must be on disk after run_run returns.
+    assert!(sentinel.exists(), "expected build to have created sentinel");
+}
+
+#[skuld::test]
+fn execute_run_does_not_cascade_other_runs() {
+    // Pins the framework rule: "runs do not depend on other runs". A child
+    // target depends on a parent for *build*; running the child must NOT
+    // invoke the parent's `run:` steps.
+    //
+    // Setup: parent's run: writes a "parent-ran" file; child's run: writes a
+    // "child-ran" file. After running child, only "child-ran" must exist.
+    let dir = tempfile::tempdir().unwrap();
+    let parent_marker = dir.path().join("parent-ran");
+    let child_marker = dir.path().join("child-ran");
+    let parent_str = parent_marker.to_string_lossy().replace('\\', "/");
+    let child_str = child_marker.to_string_lossy().replace('\\', "/");
+
+    let yaml = format!(
+        r#"
+targets:
+  parent:
+    platforms: {host}
+    build:
+      - bash: 'true'
+    run:
+      - bash: 'touch "{parent}"'
+  child:
+    depends: parent
+    platforms: {host}
+    build:
+      - bash: 'true'
+    run:
+      - bash: 'touch "{child}"'
+"#,
+        host = host_yaml(),
+        parent = parent_str,
+        child = child_str,
+    );
+    let m = Manifest::parse(&yaml).unwrap();
+    let plan = Plan::new(&m).unwrap();
+    execute_run(&plan, "child", host_platform(), dir.path()).unwrap();
+
+    assert!(child_marker.exists(), "child's run: must have executed");
+    assert!(
+        !parent_marker.exists(),
+        "parent's run: must NOT have executed — runs do not cascade"
+    );
+}
+
+#[skuld::test]
+fn execute_run_errors_on_empty_run() {
+    // A target with no `run:` steps cannot be run. Pin the exact message so
+    // shell scripts piping into stderr stay stable.
+    let m = manifest(&format!(
+        r"
+targets:
+  build-only:
+    platforms: {host}
+    build: 'true'
+",
+        host = host_yaml(),
+    ));
+    let plan = Plan::new(&m).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let err = execute_run(&plan, "build-only", host_platform(), dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains(r#"target "build-only" has no run steps defined"#),
+        "expected exact empty-run message, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn execute_run_errors_on_unknown_target() {
+    let m = manifest(&format!(
+        r"
+targets:
+  foo:
+    platforms: {host}
+",
+        host = host_yaml(),
+    ));
+    let plan = Plan::new(&m).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let err = execute_run(&plan, "nonexistent", host_platform(), dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains(r#"unknown target: "nonexistent""#),
+        "expected exact unknown-target message, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn execute_run_errors_on_platform_mismatch() {
+    // Pick a non-host platform deterministically: if host is windows, use
+    // darwin; otherwise use windows. The target declares only the non-host
+    // platform, so order_for should reject it.
+    let host = host_platform();
+    let other = if host.os == Os::Windows {
+        Platform::new(Os::Darwin, Arch::Arm64)
+    } else {
+        Platform::new(Os::Windows, Arch::Amd64)
+    };
+
+    let yaml = format!(
+        r#"
+targets:
+  off-host:
+    platforms: {other}
+    run: 'true'
+"#,
+    );
+    let m = Manifest::parse(&yaml).unwrap();
+    let plan = Plan::new(&m).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let err = execute_run(&plan, "off-host", host, dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("does not apply to host platform") && msg.contains("off-host"),
+        "expected platform-mismatch message, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn execute_run_aborts_on_build_failure() {
+    // Build step returns non-zero. Run step would create a marker file; that
+    // marker must NOT exist after the call (the build failure must abort
+    // before any run step executes).
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("ran-anyway");
+    let marker_str = marker.to_string_lossy().replace('\\', "/");
+
+    let yaml = format!(
+        r#"
+targets:
+  foo:
+    platforms: {host}
+    build:
+      - bash: 'exit 7'
+    run:
+      - bash: 'touch "{marker}"'
+"#,
+        host = host_yaml(),
+        marker = marker_str,
+    );
+    let m = Manifest::parse(&yaml).unwrap();
+    let plan = Plan::new(&m).unwrap();
+    let err = execute_run(&plan, "foo", host_platform(), dir.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("building target") && msg.contains("foo"),
+        "expected build-context error, got: {msg}"
+    );
+    assert!(
+        !marker.exists(),
+        "run step executed despite build failure (marker file present)"
+    );
 }
 
 #[skuld::test]

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -1,5 +1,8 @@
+use clap::Parser;
+
 use crate::manifest::*;
 use crate::orchestrate::*;
+use crate::Cli;
 
 fn manifest(yaml: &str) -> Manifest {
     Manifest::parse(yaml).unwrap()
@@ -360,11 +363,10 @@ fn host_platform() -> Platform {
     Platform::host().expect("test host must be in the known platform set")
 }
 
-fn host_yaml() -> &'static str {
+fn host_yaml() -> String {
     // String form of the host platform — `<os>/<arch>` — for use inside the
     // raw-YAML test fixtures.
-    let p = host_platform();
-    Box::leak(format!("{p}").into_boxed_str())
+    host_platform().to_string()
 }
 
 #[skuld::test]
@@ -579,5 +581,41 @@ targets:
     assert!(
         msg.contains("a") && msg.contains("b") && !msg.contains("\"c\""),
         "expected cycle to list a and b but not c, got: {msg}"
+    );
+}
+
+// ===== CLI shape =====================================================================================================
+//
+// The framework explicitly forbids `cargo xtask run --all`; "run everything"
+// is not a meaningful operation. Pin this at the clap-parse level so a
+// future edit that adds `#[arg(long)] all: bool` to `Command::Run` is
+// rejected by the test suite, not silently merged.
+
+#[skuld::test]
+fn cli_run_rejects_all_flag() {
+    let err = match Cli::try_parse_from(["xtask", "run", "--all"]) {
+        Ok(_) => panic!("expected --all to be rejected on the run subcommand"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("--all") || msg.contains("unexpected"),
+        "expected --all to be rejected on the run subcommand, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn cli_run_requires_target_positional() {
+    // No positional → clap MissingRequiredArgument. This pins that we use a
+    // required positional rather than `Option<String>`-with-runtime-check.
+    let err = match Cli::try_parse_from(["xtask", "run"]) {
+        Ok(_) => panic!("expected `xtask run` (no positional) to be rejected"),
+        Err(e) => e,
+    };
+    assert_eq!(
+        err.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument,
+        "expected MissingRequiredArgument, got: {:?}",
+        err.kind()
     );
 }


### PR DESCRIPTION
## Summary

- Adds an optional `run:` field to each `build.yaml` target (same `Vec<Step>` schema as `build:`) plus a `cargo xtask run <name>` verb that invokes the build cascade for `<name>` and then executes its `run:` steps. No `--all` for the run verb — "run everything" is not a meaningful operation.
- As proof of extensibility, folds workflows previously managed in CI YAML into the manifest: `clippy-hole`, `clippy-ex-galoshes`, `prek`, `frontend-check`, plus `hole.run = uv run scripts/dev.py` and canonical local nextest invocations on every `*-tests` target.
- Migrates the corresponding CI steps to invoke the manifest (`cargo xtask run prek`, `cargo xtask run clippy-hole`, etc.). `test-hole`, `test-garter`, `test-galoshes` keep their hand-rolled CI policy (SKULD_LABELS gating, archive paths) — those are CI-policy concerns, not target definition.

Closes #282. Design: `.claude/plans/i-want-to-explore-joyful-lynx.md`.

## Framework

- **`build:`** converts source into a runnable artifact and may depend on other builds.
- **`run:`** performs the work the target is named after. Runs do not depend on other runs, but `cargo xtask run X` always invokes the build cascade for `X` first — symmetric with `cargo run` doing `cargo build` first.

`Target::is_test()` (suffix-check) is replaced by `Target::has_run()` (`!self.run.is_empty()`); the `-tests` suffix is now naming convention only, no longer special-cased in code.

## Test plan

- [x] `cargo nextest run -p xtask` — 65/65 passing locally, including new tests:
  - manifest deserialization fixtures (`run_short_syntax_equals_list_syntax`, `run_step_polymorphism_canonicalizes_uniformly`, `target_with_no_run_steps_is_legal`)
  - shape fixtures (`clippy_hole_target_shape`, `prek_target_shape`, `frontend_check_target_shape`)
  - orchestrator integration (`execute_run_executes_build_cascade_then_run`, `execute_run_does_not_cascade_other_runs`, `execute_run_errors_on_empty_run`, `execute_run_errors_on_unknown_target`, `execute_run_errors_on_platform_mismatch`, `execute_run_aborts_on_build_failure`)
  - `render_list` RUN? column
- [x] `cargo clippy -p xtask --all-targets -- -D warnings` clean
- [x] `prek run --all-files --show-diff-on-failure` (with `SKIP=cargo-clippy`, matching the prek target's env) clean
- [x] `cargo xtask list` shows the new RUN? column with `*` markers on runnable targets
- [x] CLI error paths verified locally:
  - `cargo xtask run` (no arg) → clap missing-argument message
  - `cargo xtask run nonexistent` → `xtask: unknown target: "nonexistent"`
  - `cargo xtask run hole-msi` (no `run:`) → `xtask: target "hole-msi" has no run steps defined`
- [ ] CI passes on this PR (lint, build matrix incl. clippy variants, frontend-check, all test jobs)