### PR TITLE
bridge/group: make grant-access idempotent on macOS via getgrnam

### DIFF
--- a/crates/bridge/src/group.rs
+++ b/crates/bridge/src/group.rs
@@ -75,7 +75,7 @@ mod os {
     use std::io;
     use std::process::Command;
 
-    use super::{GROUP_NAME, group_exists};
+    use super::{group_exists, GROUP_NAME};
 
     pub fn create_group() -> io::Result<()> {
         // EAFP: just try to create. On macOS `dseditgroup -o create` is

--- a/crates/bridge/src/group.rs
+++ b/crates/bridge/src/group.rs
@@ -23,6 +23,29 @@ pub fn add_user_to_group(username: &str) -> io::Result<()> {
     os::add_user_to_group(username)
 }
 
+/// Returns `true` if a local group with the given name exists.
+///
+/// macOS: wraps POSIX `getgrnam(3)` (locale-independent; queries the same
+/// `opendirectoryd` backend `dseditgroup` writes to). A name containing a
+/// NUL byte is, by definition, not a valid POSIX group name and returns
+/// `false` rather than panicking.
+///
+/// Used internally by `create_group` and `delete_group` for EAFP-style
+/// idempotency. `pub(crate)` for the test module.
+#[cfg(target_os = "macos")]
+pub(crate) fn group_exists(name: &str) -> bool {
+    // A name with an embedded NUL is not a valid POSIX group name; libc
+    // would see only the prefix. Return `false` rather than panic.
+    let Ok(cname) = std::ffi::CString::new(name) else {
+        return false;
+    };
+    // SAFETY: getgrnam returns a pointer into a libc-owned process-wide
+    // static buffer (or NULL). We only `is_null`-check, never dereference
+    // — so concurrent callers racing the static buffer cannot corrupt our
+    // observation. The CString outlives the call.
+    unsafe { !libc::getgrnam(cname.as_ptr()).is_null() }
+}
+
 /// Detect the real interactive user behind an elevated session.
 ///
 /// On macOS: reads `SUDO_USER`, then `stat -f %Su /dev/console`, then `logname`.
@@ -52,47 +75,50 @@ mod os {
     use std::io;
     use std::process::Command;
 
-    use super::GROUP_NAME;
+    use super::{GROUP_NAME, group_exists};
 
     pub fn create_group() -> io::Result<()> {
+        // EAFP: just try to create. On macOS `dseditgroup -o create` is
+        // non-idempotent — when the record already exists it tries to prompt
+        // ("Operation cancelled because record could not be replaced", or
+        // "Create called on existing record - do you want to overwrite, y or
+        // n :", depending on whether stdin is a tty) and exits non-zero. We
+        // can't tell that case apart from a real failure by parsing stderr
+        // (the messages are localized). Instead, on failure we ask `getgrnam`
+        // whether the group exists; if it does, our caller's intent is met
+        // and we return success — broadening the success condition from
+        // "create succeeded" to "the group exists at end of attempt", which
+        // is what idempotency requires.
         let output = Command::new("dseditgroup")
             .args(["-o", "create", GROUP_NAME])
             .output()?;
 
-        if output.status.success() {
-            return Ok(());
-        }
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // "already exists" is not an error for our purposes
-        if stderr.contains("already exists") {
+        if output.status.success() || group_exists(GROUP_NAME) {
             return Ok(());
         }
 
         Err(io::Error::other(format!(
             "dseditgroup create failed: {}",
-            stderr.trim()
+            String::from_utf8_lossy(&output.stderr).trim()
         )))
     }
 
     pub fn delete_group() -> io::Result<()> {
+        // EAFP, mirror of `create_group`: macOS `dseditgroup -o delete` on a
+        // missing group exits non-zero with a localized "not found" stderr.
+        // Use `getgrnam` to verify post-failure and avoid stderr-substring
+        // matching that breaks under non-English locales.
         let output = Command::new("dseditgroup")
             .args(["-o", "delete", GROUP_NAME])
             .output()?;
 
-        if output.status.success() {
-            return Ok(());
-        }
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // Group not found is not an error for deletion
-        if stderr.contains("not found") {
+        if output.status.success() || !group_exists(GROUP_NAME) {
             return Ok(());
         }
 
         Err(io::Error::other(format!(
             "dseditgroup delete failed: {}",
-            stderr.trim()
+            String::from_utf8_lossy(&output.stderr).trim()
         )))
     }
 

--- a/crates/bridge/src/group_tests.rs
+++ b/crates/bridge/src/group_tests.rs
@@ -28,6 +28,39 @@ mod windows {
     }
 }
 
+// macOS-specific tests ================================================================================================
+
+#[cfg(target_os = "macos")]
+mod macos {
+    /// Per-process suffix for the "missing group" test name. Vanishingly
+    /// unlikely to collide with a real group on the test machine, even
+    /// under parallel runs. macOS local-group names cap around 32 chars;
+    /// `hole_test_missing_<10-digit pid>` fits.
+    fn missing_group_name() -> String {
+        format!("hole_test_missing_{}", std::process::id())
+    }
+
+    /// `getgrnam("wheel")` must return a record on every macOS install
+    /// (uid 0's primary group). Locale-independent — runs in CI under any user.
+    #[skuld::test]
+    fn group_exists_finds_wheel() {
+        assert!(crate::group::group_exists("wheel"));
+    }
+
+    /// `getgrnam` must return NULL (→ false) for a clearly-nonexistent name.
+    #[skuld::test]
+    fn group_exists_returns_false_for_missing() {
+        assert!(!crate::group::group_exists(&missing_group_name()));
+    }
+
+    /// A name with an embedded NUL is not a valid POSIX group name and
+    /// returns `false` rather than panicking.
+    #[skuld::test]
+    fn group_exists_returns_false_for_name_with_nul() {
+        assert!(!crate::group::group_exists("foo\0bar"));
+    }
+}
+
 // Cross-platform tests ================================================================================================
 
 #[skuld::test]

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -660,14 +660,16 @@ pub fn installer_user_sid_path() -> std::path::PathBuf {
 /// # Testing
 ///
 /// This function is not covered by a unit test. Its idempotence is a
-/// property of the primitives it composes: `group::create_group` and
-/// `group::add_user_to_group` are documented as idempotent on
-/// "already exists" errors (see their implementations in `group.rs`),
-/// and `std::fs::write` on the SID file path unconditionally overwrites.
-/// An end-to-end test would require elevation (to actually call
-/// `dseditgroup` / `net localgroup`), so we don't add one — elevation is
-/// a runtime dependency, not a test-harness dependency. Integration
-/// coverage is provided by the install-service Verification step.
+/// property of the primitives it composes: `group::create_group` is
+/// idempotent (macOS: verifies post-failure with `getgrnam(3)`;
+/// Windows: detects error code 1379) and `group::add_user_to_group`
+/// is idempotent (macOS: `dseditgroup -o edit -a` is naturally
+/// idempotent; Windows: detects error code 1378). `std::fs::write` on
+/// the SID file path unconditionally overwrites. An end-to-end test
+/// would require elevation (to actually call `dseditgroup` /
+/// `net localgroup`), so we don't add one — elevation is a runtime
+/// dependency, not a test-harness dependency. Integration coverage is
+/// provided by the install-service Verification step.
 pub fn prepare_ipc_access() -> std::io::Result<()> {
     crate::group::create_group()?;
     let user = crate::group::installing_username()?;
@@ -767,8 +769,11 @@ fn apply_socket_permissions(path: &Path) {
     // Look up the 'hole' group GID
     let group_name = CString::new(crate::group::GROUP_NAME).expect("GROUP_NAME verified at compile time");
     // SAFETY: `group_name` is a valid null-terminated CString kept alive for the
-    // call. getgrnam returns a pointer to static (thread-local) storage which we
-    // read immediately and do not cache.
+    // call. getgrnam returns a pointer into a libc-owned process-wide static
+    // buffer; per POSIX it is not thread-safe (see also `group::os::group_exists`).
+    // We read `gr_gid` below before any other libc call could overwrite that
+    // buffer, and the bridge's apply-socket-permissions path is single-threaded
+    // at this point.
     let grp = unsafe { libc::getgrnam(group_name.as_ptr()) };
 
     if grp.is_null() {


### PR DESCRIPTION
Closes #289.

## Summary
- `dseditgroup -o create hole` is non-idempotent on macOS — when the record exists it tries to interactively prompt and exits non-zero with `Operation cancelled because record could not be replaced`. The previous code treated only stderr containing `already exists` as benign, so `bridge grant-access` (and therefore the `scripts/dev.py` workflow) failed once the group existed.
- Switch the macOS branch to **EAFP via POSIX `getgrnam(3)`**: try the create; on failure, ask `getgrnam` whether the group exists. Locale-independent (no human-readable string parsing) and queries the same `opendirectoryd` backend `dseditgroup` writes to.
- Apply the same fix to `delete_group` (same class of bug — it stderr-matched `not found`, also locale-dependent) so `bridge uninstall` is also locale-safe.
- Fix a stale SAFETY comment in `ipc.rs:772` that incorrectly described `getgrnam`'s static buffer as "thread-local".

## Files changed
- `crates/bridge/src/group.rs` — new `pub(crate) fn group_exists` (libc::getgrnam wrapper, NUL-safe, no-deref so the static-buffer race is benign); `create_group` and `delete_group` rewritten as EAFP.
- `crates/bridge/src/group_tests.rs` — new `#[cfg(target_os = "macos")] mod macos` with three tests: existing group (`wheel`), missing group (per-pid suffix), name-with-NUL.
- `crates/bridge/src/ipc.rs` — refresh `prepare_ipc_access` `# Testing` doc to describe the new mechanism; fix the unrelated-but-adjacent SAFETY comment.

## Test plan
- [x] `cargo nextest run -p hole-bridge -E 'test(group_exists) | test(group_name)'` — 4 tests pass.
- [x] `cargo clippy -p hole-bridge --tests --no-deps` — no new warnings.
- [x] Manual macOS verification (root):
  - `sudo target/debug/hole bridge grant-access` with the `hole` group already present → exit 0, prints `prepared IPC access`.
  - `sudo dseditgroup -o delete hole && sudo target/debug/hole bridge grant-access` → exit 0 (creates).
  - Second `sudo target/debug/hole bridge grant-access` → exit 0 (idempotent).
  - `dseditgroup -o checkmember -m $(whoami) hole` → "yes Anna.Zhukova is a member of hole".
- [ ] CI (this PR) — `package(hole-bridge)` runs on `darwin/amd64` and `darwin/arm64` per `.github/workflows/ci.yaml`, exercising the new tests.