### PR TITLE
ci(release): use sha256sum (cross-platform) instead of shasum

### DIFF
--- a/.github/workflows/draft-release-galoshes.yaml
+++ b/.github/workflows/draft-release-galoshes.yaml
@@ -78,7 +78,7 @@ jobs:
           ASSET="galoshes-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
 
           mv "target/release/galoshes${EXT}" "$ASSET"
-          shasum -a 256 "$ASSET" > "${ASSET}.sha256line"
+          sha256sum "$ASSET" > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
           cat "${ASSET}.sha256line"
 

--- a/.github/workflows/draft-release-garter.yaml
+++ b/.github/workflows/draft-release-garter.yaml
@@ -86,7 +86,7 @@ jobs:
           ASSET="garter-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
 
           mv "target/release/garter${EXT}" "$ASSET"
-          shasum -a 256 "$ASSET" > "${ASSET}.sha256line"
+          sha256sum "$ASSET" > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
           cat "${ASSET}.sha256line"
 

--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -96,7 +96,7 @@ jobs:
             mv target/release/bundle/dmg/*.dmg "$ASSET"
           fi
 
-          shasum -a 256 "$ASSET" > "${ASSET}.sha256line"
+          sha256sum "$ASSET" > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
           cat "${ASSET}.sha256line"
 

--- a/.github/workflows/draft-release-v2ray-plugin.yaml
+++ b/.github/workflows/draft-release-v2ray-plugin.yaml
@@ -108,7 +108,7 @@ jobs:
           tar -czf "$ARCHIVE" -C "$STAGE_DIR" "$INNER"
           rm -r "$STAGE_DIR"
 
-          shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256line"
+          sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256line"
           echo "Artifact: $ARCHIVE"
           cat "${ARCHIVE}.sha256line"
 


### PR DESCRIPTION
Refs #291.

`shasum -a 256` (Perl) is not present on Git For Windows on the GHA windows-latest / windows-11-arm runners; the v2ray-plugin draft workflow's first real-world dispatch failed at the hash step with exit code 127 ([run 25929556801](https://github.com/bindreams/hole/actions/runs/25929556801/job/76219774040)).

`sha256sum` (coreutils) is in Git For Windows and produces identical output format on all three OSes. One-line swap in all four draft-release workflows.

## Test plan

- [ ] CI green on the PR
- [ ] After merge: re-dispatch `draft-release-v2ray-plugin.yaml` at `0.1.0` and confirm the Windows build no longer fails on the hash step