### PR TITLE
v2ray-plugin: lineage versioning + 6-platform release matrix

### DIFF
--- a/.github/workflows/draft-release-v2ray-plugin.yaml
+++ b/.github/workflows/draft-release-v2ray-plugin.yaml
@@ -32,7 +32,9 @@ jobs:
           V="${{ inputs.version }}"
           V="${V#v}"
           V="${V#releases/v2ray-plugin/v}"
-          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
+          # Accept X.Y.Z (bare) or X.Y.Z-hole.N (positive integer). See
+          # xtask-lib/src/v2ray_plugin_version.rs for the rule and rationale.
+          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-hole\.[1-9][0-9]*)?$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
           echo "version=$V" >> "$GITHUB_OUTPUT"
 
       - name: Create local tag for build
@@ -41,12 +43,14 @@ jobs:
       - name: Validate version.toml matches version
         run: cargo xtask version --check --exact --group v2ray-plugin
 
-  # Native-runner matrix. The set is intersected with shadowsocks/v2ray-plugin's
-  # upstream release platform list — anything upstream ships AND that we have
-  # a native runner for. Upstream historically ships darwin amd64/arm64, linux
-  # amd64/arm64 (and 386/arm/mips, which we don't cover), and windows amd64
-  # (no arm64). Updating this list when upstream changes platforms is a
-  # workflow-file edit. The publish workflow does not re-validate.
+  # Native-runner matrix. Upstream shadowsocks/v2ray-plugin's latest release
+  # ships darwin amd64/arm64, linux amd64/arm64 (and 386/arm/mips, which we
+  # don't cover), and windows amd64 — no windows-arm64. We add windows-arm64
+  # ourselves because galoshes (which embeds v2ray-plugin) builds and tests
+  # on all 6 platforms including windows-arm64, so the windows-arm64
+  # v2ray-plugin binary is already produced and transitively exercised; we
+  # just ship the same artifact here. Updating this list when upstream
+  # changes platforms is a workflow-file edit.
   build:
     name: Build (${{ matrix.os }}/${{ matrix.arch }})
     needs: validate
@@ -56,6 +60,7 @@ jobs:
       matrix:
         include:
           - { os: windows, arch: amd64, runner: windows-latest    }
+          - { os: windows, arch: arm64, runner: windows-11-arm    }
           - { os: darwin,  arch: amd64, runner: macos-15-intel    }
           - { os: darwin,  arch: arm64, runner: macos-latest      }
           - { os: linux,   arch: amd64, runner: ubuntu-latest     }
@@ -135,8 +140,8 @@ jobs:
           rm *.sha256line
 
           lines=$(wc -l < SHA256SUMS)
-          if [ "$lines" -ne 5 ]; then
-            echo "::error::Expected 5 entries in SHA256SUMS (5-platform upstream-parity matrix), got $lines"
+          if [ "$lines" -ne 6 ]; then
+            echo "::error::Expected 6 entries in SHA256SUMS (5 upstream-parity platforms + windows-arm64), got $lines"
             exit 1
           fi
 

--- a/.github/workflows/publish-release-v2ray-plugin.yaml
+++ b/.github/workflows/publish-release-v2ray-plugin.yaml
@@ -27,7 +27,8 @@ jobs:
           V="${{ inputs.version }}"
           V="${V#v}"
           V="${V#releases/v2ray-plugin/v}"
-          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
+          # Accept X.Y.Z (bare) or X.Y.Z-hole.N. See draft workflow + xtask-lib/src/v2ray_plugin_version.rs.
+          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-hole\.[1-9][0-9]*)?$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
           echo "tag=releases/v2ray-plugin/v${V}" >> "$GITHUB_OUTPUT"
 
       - name: Verify draft release exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,12 +384,12 @@ Version per group is declared in each crate's
 `xtask-lib::version` (publishable-but-ungrouped crates are rejected;
 within-group versions must match).
 
-| Product        | Group members                                                                                      | Artifacts                                                                | Signed         | crates.io     |
-| -------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------- | ------------- |
-| `hole`         | `hole, hole-common, hole-bridge, tun-engine, tun-engine-macros, dump, dump-macros, handle-holders` | MSI + DMG (amd64+arm64) + `SHA256SUMS`                                   | Yes (minisign) | No            |
-| `galoshes`     | `galoshes`                                                                                         | 6-platform server binaries + `SHA256SUMS`                                | No             | No            |
-| `garter`       | `garter, garter-bin`                                                                               | crates.io `garter` lib + 6-platform `garter` CLI binaries + `SHA256SUMS` | No             | `garter` only |
-| `v2ray-plugin` | (not a Rust crate — version in `external/v2ray-plugin/version.toml`)                               | Upstream-parity tar.gz set + `SHA256SUMS`                                | No             | n/a           |
+| Product        | Group members                                                                                       | Artifacts                                                                | Signed         | crates.io     |
+| -------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------- | ------------- |
+| `hole`         | `hole, hole-common, hole-bridge, tun-engine, tun-engine-macros, dump, dump-macros, handle-holders`  | MSI + DMG (amd64+arm64) + `SHA256SUMS`                                   | Yes (minisign) | No            |
+| `galoshes`     | `galoshes`                                                                                          | 6-platform server binaries + `SHA256SUMS`                                | No             | No            |
+| `garter`       | `garter, garter-bin`                                                                                | crates.io `garter` lib + 6-platform `garter` CLI binaries + `SHA256SUMS` | No             | `garter` only |
+| `v2ray-plugin` | (not a Rust crate — version in `external/v2ray-plugin/version.toml`, lineage form `X.Y.Z[-hole.N]`) | 6-platform tar.gz set (upstream parity + windows-arm64) + `SHA256SUMS`   | No             | n/a           |
 
 Asset naming:
 
@@ -418,9 +418,25 @@ step.
 ### Per-product release workflows
 
 - **hole**: `draft-release-hole.yaml` → `scripts/sign-release.py <version>` → `publish-release-hole.yaml`. Tag created at publish.
+
 - **galoshes**: `draft-release-galoshes.yaml` → `publish-release-galoshes.yaml`. No signing.
+
 - **garter**: `draft-release-garter.yaml` (also runs `cargo publish --dry-run -p garter` for early failure) → `publish-release-garter.yaml`. Publish workflow is idempotent: it queries crates.io's API to see whether the version already exists (200) and skips the `cargo publish` step if so, so a re-run after a partial-failure resumes cleanly. A `dry_run: true` input runs `cargo publish --dry-run` and exits without touching crates.io or the tag.
-- **v2ray-plugin**: `draft-release-v2ray-plugin.yaml` → `publish-release-v2ray-plugin.yaml`. The matrix matches shadowsocks/v2ray-plugin upstream's release platform list — currently darwin amd64/arm64, linux amd64/arm64, windows amd64 (5 platforms). When upstream changes its set, edit the matrix and the SHA256SUMS line count in the draft workflow. Hole-local v2ray-plugin patches land via `git subrepo pull external/v2ray-plugin` followed by ordinary commits.
+
+- **v2ray-plugin**: `draft-release-v2ray-plugin.yaml` → `publish-release-v2ray-plugin.yaml`. The matrix is upstream's release platform set — darwin amd64/arm64, linux amd64/arm64, windows amd64 — **plus windows-arm64**, which upstream doesn't ship but we already build and transitively test via galoshes-on-windows-arm64 (galoshes embeds v2ray-plugin). 6 platforms total. When upstream changes its set, edit the matrix and the SHA256SUMS line count in the draft workflow. Hole-local v2ray-plugin patches land via `git subrepo pull external/v2ray-plugin` followed by ordinary commits.
+
+  **Lineage versioning.** v2ray-plugin's version (`external/v2ray-plugin/version.toml`) follows the convention `X.Y.Z` (we vendor upstream's `vX.Y.Z` release exactly) or `X.Y.Z-hole.N` (we vendor upstream-master between two upstream tags, with `N` counting our successive Hole-side release iterations against the same `X.Y.Z` base). Per semver, `X.Y.Z-hole.N` orders strictly above `X.Y.Z-1`'s artifacts and strictly below upstream's eventual `vX.Y.Z` — capturing exactly the "between releases" semantic. Precedent: Go modules' pseudo-versions use the same `X.Y.(Z+1)-pre` shape.
+
+  Worked example: our current vendored commit `e9af1cd` is 5 upstream-master commits past `v1.3.2` (including a v2ray-core v4→v5 migration). Bump base = `1.3.3` (next patch after upstream's last tag), iteration = `1` (first Hole release of this base) → `version = "1.3.3-hole.1"`.
+
+  **Maintainer rules** (xtask-lib/src/v2ray_plugin_version.rs enforces shape + sequence; bases are your call):
+
+  - When pulling upstream-master between two upstream tags: set `X.Y.Z` to upstream's next-patch-after-last-tag and `N` to 1 (or increment if you've cut a prior Hole release against the same base).
+  - When pulling at an upstream tag exactly: set version to that tag's bare `X.Y.Z` (no `-hole.N` suffix).
+  - On each successive Hole release with the same `X.Y.Z` base, increment `N` by exactly 1 (no gaps). The validator rejects skips.
+  - The validator does NOT cross-check against upstream's tag history (we don't have upstream's git data locally); the maintainer is responsible for picking the right `X.Y.Z` base.
+
+  **Display-version note.** Dev builds downstream of `releases/v2ray-plugin/v1.3.3-hole.1` produce `1.3.3-hole.1-snapshot+git.<hash>`. This is valid semver — the `-snapshot` extends the pre-release identifier — and intentional. Two dashes before `+git.` is not a bug.
 
 ### Version model (`cargo xtask version`)
 

--- a/external/v2ray-plugin/version.toml
+++ b/external/v2ray-plugin/version.toml
@@ -1,1 +1,1 @@
-version = "0.1.0"
+version = "1.3.3-hole.1"

--- a/xtask-lib/src/lib.rs
+++ b/xtask-lib/src/lib.rs
@@ -8,11 +8,19 @@
 //! `msi-installer/src/msi_installer/__init__.py::get_version`, and
 //! `scripts/check-version.py`. This crate is the single source of truth.
 
+pub mod v2ray_plugin_version;
 pub mod version;
+
+#[cfg(test)]
+mod test_support;
 
 #[cfg(test)]
 #[path = "version_tests.rs"]
 mod version_tests;
+
+#[cfg(test)]
+#[path = "v2ray_plugin_version_tests.rs"]
+mod v2ray_plugin_version_tests;
 
 #[cfg(test)]
 fn main() {

--- a/xtask-lib/src/test_support.rs
+++ b/xtask-lib/src/test_support.rs
@@ -1,0 +1,41 @@
+//! Test-only helpers shared across `version_tests.rs` and
+//! `v2ray_plugin_version_tests.rs`. Compiled only under `#[cfg(test)]`.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Initialize a minimal git repo in `root` and commit any files present.
+///
+/// Used by tests that exercise tag-based behavior under a tempdir. Mirrors
+/// the same configuration used elsewhere in the workspace test suite.
+pub(crate) fn init_git_repo(root: &Path) {
+    fn git(root: &Path, args: &[&str]) {
+        let s = Command::new("git").args(args).current_dir(root).status().unwrap();
+        assert!(s.success(), "git {} failed in {}", args.join(" "), root.display());
+    }
+    git(root, &["init", "--quiet"]);
+    git(root, &["config", "user.email", "test@example.invalid"]);
+    git(root, &["config", "user.name", "Test"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "--quiet", "-m", "init"]);
+}
+
+/// Create an annotated tag at HEAD in the repo at `root`.
+pub(crate) fn create_tag(root: &Path, tag: &str) {
+    let s = Command::new("git")
+        .args(["tag", tag])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    assert!(s.success(), "git tag {tag} failed in {}", root.display());
+}
+
+/// Make an empty commit so subsequent tags point to distinct commits when needed.
+pub(crate) fn empty_commit(root: &Path, msg: &str) {
+    let s = Command::new("git")
+        .args(["commit", "--allow-empty", "--quiet", "-m", msg])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    assert!(s.success(), "git empty commit failed in {}", root.display());
+}

--- a/xtask-lib/src/v2ray_plugin_version.rs
+++ b/xtask-lib/src/v2ray_plugin_version.rs
@@ -1,0 +1,166 @@
+//! Lineage-aware version validator for the `v2ray-plugin` release group.
+//!
+//! Unlike the workspace-member groups (hole/garter/galoshes) which use
+//! strict-semver Cargo.toml versions locked within a group, v2ray-plugin
+//! vendors an upstream project (shadowsocks/v2ray-plugin) via git-subrepo
+//! and tracks its version separately in `external/v2ray-plugin/version.toml`.
+//!
+//! The version string captures Hole's relationship to upstream's release
+//! lineage:
+//!
+//! - **`X.Y.Z`** (bare semver) — we vendor upstream's `vX.Y.Z` release
+//!   commit exactly.
+//! - **`X.Y.Z-hole.N`** (pre-release) — we vendor upstream-master between
+//!   upstream's last tag and an unknown future `vX.Y.Z`, with `N` Hole
+//!   release iterations cut against this base. Per semver precedence,
+//!   `X.Y.Z-hole.N` orders strictly above all prior `X.Y.Z` and strictly
+//!   below upstream's eventual `vX.Y.Z` (or any later tag), so the
+//!   pre-release semantics align with what we mean by "between upstream's
+//!   last release and their next."
+//!
+//! Validator enforces two rules:
+//!
+//! 1. **Shape** — pre-release, when present, must be exactly `hole.N` for
+//!    a positive integer N. Build metadata is rejected.
+//! 2. **Sequence-no-gap** — for `X.Y.Z-hole.N`, N must equal
+//!    `max_existing(same_base) + 1` where `max_existing` is 0 when no
+//!    same-base `hole.K` tags exist. This catches both "started above 1"
+//!    (bootstrap reject) and "skipped a number" (mid-sequence reject).
+//!
+//! What this validator does NOT enforce:
+//!
+//! - Whether `X.Y.Z` matches a real upstream release tag, or is one
+//!   patch past upstream's last tag. We don't have upstream's git data
+//!   locally; the maintainer is trusted to pick the right base when
+//!   bumping `version.toml`.
+//! - `is_valid_next`-style "one bump ahead" transitions between bases.
+//!   Upstream itself can major/minor/patch-bump arbitrarily, so we don't
+//!   impose constraints on the base portion.
+
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use semver::Version;
+
+use crate::version::{ancestor_tags, nearest_tag_version, Group};
+
+/// Validate a v2ray-plugin version string's shape.
+///
+/// Accepts `X.Y.Z` or `X.Y.Z-hole.N` where N is a positive integer.
+/// Rejects build metadata in all cases. Rejects any pre-release form
+/// other than `hole.N`.
+pub fn parse_version_string(s: &str) -> Result<Version> {
+    let v = Version::parse(s).with_context(|| format!("v2ray-plugin version '{s}' is not valid semver"))?;
+    if !v.build.is_empty() {
+        bail!("v2ray-plugin version must not have build metadata: '{s}'");
+    }
+    if !v.pre.is_empty() {
+        let pre = v.pre.as_str();
+        let Some(n_str) = pre.strip_prefix("hole.") else {
+            bail!(
+                "v2ray-plugin pre-release identifier must be exactly `hole.N` for a positive integer N; \
+                 got '{pre}' in '{s}'"
+            );
+        };
+        let n: u64 = n_str
+            .parse()
+            .map_err(|_| anyhow!("v2ray-plugin hole.N suffix must be a positive integer; got '{pre}' in '{s}'"))?;
+        if n < 1 {
+            bail!("v2ray-plugin hole.N suffix N must be >= 1; got '{pre}' in '{s}'");
+        }
+    }
+    Ok(v)
+}
+
+/// Read and shape-validate `external/v2ray-plugin/version.toml`.
+pub fn read_version(repo_root: &Path) -> Result<Version> {
+    let version_path = repo_root.join("external").join("v2ray-plugin").join("version.toml");
+    let text =
+        std::fs::read_to_string(&version_path).with_context(|| format!("failed to read {}", version_path.display()))?;
+    let doc: toml::Table =
+        toml::from_str(&text).with_context(|| format!("failed to parse {}", version_path.display()))?;
+    let v_str = doc
+        .get("version")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("no `version` key in {}", version_path.display()))?;
+    parse_version_string(v_str).with_context(|| format!("in {}", version_path.display()))
+}
+
+/// Extract the hole iteration number `N` from a `Version` whose
+/// pre-release is `hole.N`, otherwise `None`.
+pub(crate) fn hole_iteration(v: &Version) -> Option<u64> {
+    if v.pre.is_empty() {
+        return None;
+    }
+    let n_str = v.pre.as_str().strip_prefix("hole.")?;
+    let n: u64 = n_str.parse().ok()?;
+    if n < 1 {
+        return None;
+    }
+    Some(n)
+}
+
+/// V2rayPlugin-specific version validator. See module-level docs for the rules.
+///
+/// `exact = true` (used by CI's release workflow): version.toml must equal
+/// the nearest ancestor `releases/v2ray-plugin/v...` tag exactly. A missing
+/// tag is itself an error.
+///
+/// `exact = false` (used by prek's local check): version.toml's shape is
+/// already validated by `read_version`. If the version is `X.Y.Z-hole.N`,
+/// apply the sequence-no-gap rule against ancestor tags. If bare `X.Y.Z`,
+/// no sequence constraint.
+pub fn validate_against_tag(repo_root: &Path, exact: bool) -> Result<Version> {
+    let current = read_version(repo_root)?;
+
+    if exact {
+        let Some(tag_ver) = nearest_tag_version(repo_root, Group::V2rayPlugin)? else {
+            bail!(
+                "group 'v2ray-plugin' has no `releases/v2ray-plugin/v...` tag yet but `--exact` was requested; \
+                 the release workflow must run on a commit with the matching tag"
+            );
+        };
+        if current != tag_ver {
+            bail!("group 'v2ray-plugin' version.toml ({current}) != tag version ({tag_ver})");
+        }
+        return Ok(current);
+    }
+
+    // Non-exact: shape is already validated. If bare X.Y.Z, no sequence
+    // constraint applies (the maintainer is signalling "we vendor an
+    // upstream tag exactly," and the validator trusts that claim).
+    let Some(n) = hole_iteration(&current) else {
+        return Ok(current);
+    };
+
+    // Sequence-no-gap rule. Find the highest existing hole.K tag that
+    // shares the same X.Y.Z base. The bootstrap pivot — `max_existing`
+    // defaults to 0 when no same-base hole.K tags exist — is what makes
+    // a single equality (`n == max_existing + 1`) handle both the
+    // bootstrap-reject case (N >= 2 when no tags exist) and the
+    // mid-sequence-skip-reject case (existing hole.K, current N != K+1).
+    // Do NOT simplify to "no tags → no constraint" — that breaks the
+    // bootstrap-reject path.
+    let all_tags = ancestor_tags(repo_root, Group::V2rayPlugin)?;
+    let max_existing = all_tags
+        .iter()
+        .filter(|(v, _)| v.major == current.major && v.minor == current.minor && v.patch == current.patch)
+        .filter_map(|(v, _)| hole_iteration(v))
+        .max()
+        .unwrap_or(0);
+
+    let expected = max_existing + 1;
+    if n != expected {
+        bail!(
+            "v2ray-plugin sequence violation: version.toml is `{current}` (hole.{n}), \
+             but the next valid hole iteration for base {}.{}.{} is hole.{expected} \
+             (max existing hole.K with this base = {max_existing}). \
+             Tags must increment by 1 with no gaps.",
+            current.major,
+            current.minor,
+            current.patch
+        );
+    }
+
+    Ok(current)
+}

--- a/xtask-lib/src/v2ray_plugin_version_tests.rs
+++ b/xtask-lib/src/v2ray_plugin_version_tests.rs
@@ -1,0 +1,349 @@
+use crate::test_support::{create_tag, empty_commit, init_git_repo};
+use crate::v2ray_plugin_version::*;
+use crate::version::{ancestor_tags, Group};
+use semver::Version;
+use std::path::Path;
+
+// Helpers =============================================================================================================
+
+fn write(path: impl AsRef<Path>, content: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn write_version_toml(root: &Path, version: &str) {
+    write(
+        root.join("external").join("v2ray-plugin").join("version.toml"),
+        &format!("version = \"{version}\"\n"),
+    );
+}
+
+// parse_version_string: shape =========================================================================================
+
+#[skuld::test]
+fn shape_accepts_strict_semver() {
+    let v = parse_version_string("1.3.2").unwrap();
+    assert_eq!(v, Version::new(1, 3, 2));
+    assert!(v.pre.is_empty());
+}
+
+#[skuld::test]
+fn shape_accepts_hole_n_pre_release() {
+    let v = parse_version_string("1.3.3-hole.1").unwrap();
+    assert_eq!(v.major, 1);
+    assert_eq!(v.minor, 3);
+    assert_eq!(v.patch, 3);
+    assert_eq!(v.pre.as_str(), "hole.1");
+}
+
+#[skuld::test]
+fn shape_accepts_zero_version() {
+    parse_version_string("0.0.1").unwrap();
+}
+
+#[skuld::test]
+fn shape_accepts_large_hole_iteration() {
+    let v = parse_version_string("99.99.99-hole.999").unwrap();
+    assert_eq!(v.pre.as_str(), "hole.999");
+}
+
+#[skuld::test]
+fn shape_rejects_alpha_pre_release() {
+    let err = parse_version_string("1.3.2-alpha").unwrap_err();
+    assert!(format!("{err:#}").contains("hole.N"));
+}
+
+#[skuld::test]
+fn shape_rejects_rc_pre_release() {
+    let err = parse_version_string("1.3.2-rc.1").unwrap_err();
+    assert!(format!("{err:#}").contains("hole.N"));
+}
+
+#[skuld::test]
+fn shape_rejects_bare_hole_no_number() {
+    let err = parse_version_string("1.3.2-hole").unwrap_err();
+    assert!(format!("{err:#}").contains("hole.N"));
+}
+
+#[skuld::test]
+fn shape_rejects_hole_zero() {
+    let err = parse_version_string("1.3.2-hole.0").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains(">= 1"), "msg was: {msg}");
+}
+
+#[skuld::test]
+fn shape_rejects_hole_non_numeric_suffix() {
+    let err = parse_version_string("1.3.2-hole.abc").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("positive integer"), "msg was: {msg}");
+}
+
+#[skuld::test]
+fn shape_rejects_hole_multi_segment_suffix() {
+    // semver parses "hole.1.2" as a three-identifier pre-release. Strip
+    // "hole." leaves "1.2", which fails u64 parse.
+    let err = parse_version_string("1.3.2-hole.1.2").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("positive integer"), "msg was: {msg}");
+}
+
+#[skuld::test]
+fn shape_rejects_build_metadata() {
+    let err = parse_version_string("1.3.2+build").unwrap_err();
+    assert!(format!("{err:#}").contains("build metadata"));
+}
+
+#[skuld::test]
+fn shape_rejects_hole_plus_build_metadata() {
+    let err = parse_version_string("1.3.2-hole.1+build").unwrap_err();
+    assert!(format!("{err:#}").contains("build metadata"));
+}
+
+#[skuld::test]
+fn shape_rejects_short_version() {
+    let err = parse_version_string("1.3").unwrap_err();
+    assert!(format!("{err:#}").contains("not valid semver"));
+}
+
+#[skuld::test]
+fn shape_rejects_garbage() {
+    let err = parse_version_string("garbage").unwrap_err();
+    assert!(format!("{err:#}").contains("not valid semver"));
+}
+
+// read_version ========================================================================================================
+
+#[skuld::test]
+fn read_version_strict_semver_from_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "5.3.0");
+    assert_eq!(read_version(root).unwrap(), Version::new(5, 3, 0));
+}
+
+#[skuld::test]
+fn read_version_hole_pre_release_from_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "5.3.0-hole.2");
+    let v = read_version(root).unwrap();
+    assert_eq!(v.major, 5);
+    assert_eq!(v.pre.as_str(), "hole.2");
+}
+
+#[skuld::test]
+fn read_version_rejects_rc1_pre_release() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "5.3.0-rc1");
+    let err = read_version(root).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("hole.N"), "msg was: {msg}");
+}
+
+#[skuld::test]
+fn read_version_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let err = read_version(root).unwrap_err();
+    assert!(format!("{err:#}").contains("failed to read"));
+}
+
+#[skuld::test]
+fn read_version_missing_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        root.join("external").join("v2ray-plugin").join("version.toml"),
+        "other = \"hi\"\n",
+    );
+    let err = read_version(root).unwrap_err();
+    assert!(format!("{err:#}").contains("no `version` key"));
+}
+
+// validate_against_tag: sequence rule =================================================================================
+
+#[skuld::test]
+fn sequence_first_hole_release_accepted() {
+    // Bootstrap: no tags exist, current is X.Y.Z-hole.1 → accept.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.1");
+    init_git_repo(root);
+
+    let v = validate_against_tag(root, false).unwrap();
+    assert_eq!(v.pre.as_str(), "hole.1");
+}
+
+#[skuld::test]
+fn sequence_bare_release_accepted_no_constraint() {
+    // Bare X.Y.Z: shape-only, no sequence check.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.2");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.2");
+
+    validate_against_tag(root, false).unwrap();
+}
+
+#[skuld::test]
+fn sequence_increment_within_base_accepted() {
+    // Prior hole.1 exists, current hole.2 → accept.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.2");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let v = validate_against_tag(root, false).unwrap();
+    assert_eq!(v.pre.as_str(), "hole.2");
+}
+
+#[skuld::test]
+fn sequence_new_base_after_hole_iterations_accepted() {
+    // Prior 1.3.3-hole.2, current 1.3.4-hole.1 → accept (new base, no
+    // same-base hole.K → max_existing = 0 → expected N = 1).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.4-hole.1");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.2");
+
+    validate_against_tag(root, false).unwrap();
+}
+
+#[skuld::test]
+fn sequence_skip_in_sequence_rejected() {
+    // Prior hole.1, current hole.3 → reject (skipped hole.2).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.3");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let err = validate_against_tag(root, false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("sequence violation"), "msg was: {msg}");
+    assert!(msg.contains("hole.2"), "expected hole.2 (max+1) in: {msg}");
+}
+
+#[skuld::test]
+fn sequence_start_above_one_rejected() {
+    // No prior tags, current hole.5 → reject (max_existing = 0, expected 1, got 5).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.5");
+    init_git_repo(root);
+
+    let err = validate_against_tag(root, false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("sequence violation"), "msg was: {msg}");
+    assert!(msg.contains("hole.1"), "expected hole.1 in: {msg}");
+}
+
+#[skuld::test]
+fn sequence_regression_rejected() {
+    // Prior hole.2, current hole.1 → reject (regression, max+1 = 3 ≠ 1).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.1");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+    empty_commit(root, "next");
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.2");
+
+    let err = validate_against_tag(root, false).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("sequence violation"), "msg was: {msg}");
+}
+
+// validate_against_tag: --exact path ==================================================================================
+
+#[skuld::test]
+fn exact_passes_when_tag_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.1");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let v = validate_against_tag(root, true).unwrap();
+    assert_eq!(v.pre.as_str(), "hole.1");
+}
+
+#[skuld::test]
+fn exact_errors_without_tag() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.1");
+    init_git_repo(root);
+
+    let err = validate_against_tag(root, true).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("no `releases/v2ray-plugin/v...` tag yet"),
+        "msg was: {msg}"
+    );
+}
+
+#[skuld::test]
+fn exact_errors_on_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.2");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let err = validate_against_tag(root, true).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("!= tag version"), "msg was: {msg}");
+}
+
+// Tag-glob round-trip =================================================================================================
+//
+// Protects against future regressions in Group::tag_glob's interaction
+// with fnmatch on -hole.N suffixed tags. The tag-glob is `releases/
+// v2ray-plugin/v[0-9]*.[0-9]*.[0-9]*` (shell glob); we rely on the
+// trailing `*` absorbing the `-hole.N` portion. If git's fnmatch ever
+// changes this behavior, this test fires.
+
+#[skuld::test]
+fn tag_glob_round_trip_includes_hole_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.1");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let tags = ancestor_tags(root, Group::V2rayPlugin).unwrap();
+    assert_eq!(tags.len(), 1, "expected 1 tag, got {:?}", tags);
+    assert_eq!(tags[0].1, "releases/v2ray-plugin/v1.3.3-hole.1");
+    assert_eq!(tags[0].0.pre.as_str(), "hole.1");
+}
+
+#[skuld::test]
+fn tag_glob_round_trip_includes_bare_and_hole() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.2");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.2");
+    empty_commit(root, "next");
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let tags = ancestor_tags(root, Group::V2rayPlugin).unwrap();
+    let names: Vec<&str> = tags.iter().map(|(_, n)| n.as_str()).collect();
+    assert!(
+        names.contains(&"releases/v2ray-plugin/v1.3.2"),
+        "missing v1.3.2 in {names:?}"
+    );
+    assert!(
+        names.contains(&"releases/v2ray-plugin/v1.3.3-hole.1"),
+        "missing v1.3.3-hole.1 in {names:?}"
+    );
+}

--- a/xtask-lib/src/version.rs
+++ b/xtask-lib/src/version.rs
@@ -16,8 +16,12 @@
 //! - **Tag version**: the nearest ancestor tag matching the group's tag
 //!   glob (`releases/<group>/v<X.Y.Z>`), parsed back into strict semver.
 //!
-//! The non-Rust `v2ray-plugin` group reads its version from
-//! `external/v2ray-plugin/version.toml`.
+//! The non-Rust `v2ray-plugin` group is handled by a separate module
+//! [`crate::v2ray_plugin_version`] which implements its own shape rules
+//! (lineage-aware, allowing `X.Y.Z-hole.N` pre-release) and sequence
+//! enforcement. The dispatcher entry points in this module
+//! ([`cargo_toml_version_for_group`], [`validate_against_tag`]) branch on
+//! `Group::V2rayPlugin` and delegate to that module.
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -160,33 +164,14 @@ pub fn read_workspace_versions(repo_root: &Path) -> Result<WorkspaceVersions> {
         by_group.insert(group, entries.into_iter().next().unwrap().1);
     }
 
-    // v2ray-plugin: read external/v2ray-plugin/version.toml if it exists.
-    let v2ray_path = repo_root.join("external").join("v2ray-plugin").join("version.toml");
-    if v2ray_path.exists() {
-        by_group.insert(Group::V2rayPlugin, read_v2ray_version(&v2ray_path)?);
-    }
+    // V2rayPlugin is NOT populated here — it's served by
+    // `crate::v2ray_plugin_version` via the per-group dispatcher in
+    // `cargo_toml_version_for_group`. Keeping it out of this map avoids
+    // baking the strict-semver shape rules of the workspace-member groups
+    // into a code path that has to accommodate v2ray-plugin's looser
+    // `hole.N` pre-release form.
 
     Ok(WorkspaceVersions { by_group })
-}
-
-fn read_v2ray_version(version_path: &Path) -> Result<Version> {
-    let text =
-        std::fs::read_to_string(version_path).with_context(|| format!("failed to read {}", version_path.display()))?;
-    let doc: toml::Table =
-        toml::from_str(&text).with_context(|| format!("failed to parse {}", version_path.display()))?;
-    let v_str = doc
-        .get("version")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("no `version` key in {}", version_path.display()))?;
-    let v = Version::parse(v_str)
-        .with_context(|| format!("{} version '{v_str}' is not valid semver", version_path.display()))?;
-    if !v.pre.is_empty() || !v.build.is_empty() {
-        bail!(
-            "{} version must be strict MAJOR.MINOR.PATCH (no pre-release/build): {v}",
-            version_path.display()
-        );
-    }
-    Ok(v)
 }
 
 fn workspace_members(root_doc: &toml::Table, root_toml: &Path) -> Result<Vec<String>> {
@@ -227,8 +212,16 @@ fn parse_strict_version(package: &toml::Table, cargo_path: &Path) -> Result<Vers
     Ok(v)
 }
 
-/// Convenience: read all groups and return the version for `group`.
+/// Convenience: return the version for `group`.
+///
+/// For Cargo.toml-based groups (Hole, Garter, Galoshes), reads workspace
+/// members via `read_workspace_versions`. For `Group::V2rayPlugin`,
+/// delegates to [`crate::v2ray_plugin_version::read_version`] which has
+/// its own shape rules (allows `X.Y.Z-hole.N` pre-release).
 pub fn cargo_toml_version_for_group(repo_root: &Path, group: Group) -> Result<Version> {
+    if group == Group::V2rayPlugin {
+        return crate::v2ray_plugin_version::read_version(repo_root);
+    }
     let ws = read_workspace_versions(repo_root)?;
     ws.by_group
         .get(&group)
@@ -254,6 +247,20 @@ pub fn nearest_tag_version(repo_root: &Path, group: Group) -> Result<Option<Vers
 /// the full tag name (`releases/<group>/v<X.Y.Z>`). Used by
 /// `display_version_inner` for distance/dirty computation.
 fn nearest_ancestor_tag(repo_root: &Path, group: Group) -> Result<Option<(Version, String)>> {
+    let mut candidates = ancestor_tags(repo_root, group)?;
+    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    Ok(candidates.into_iter().next())
+}
+
+/// Enumerate every `releases/<group>/v...` tag that is an ancestor of HEAD,
+/// parsed to its semver and paired with its full tag name. Returned order
+/// is unsorted — callers that only need the highest can call
+/// `nearest_ancestor_tag` instead; callers that need the full set (e.g.
+/// the v2ray-plugin sequence-no-gap check) call this directly.
+///
+/// Malformed tags matching the glob are silently skipped — a hand-created
+/// `releases/hole/v1.0.0-rc1` does not poison the lookup.
+pub fn ancestor_tags(repo_root: &Path, group: Group) -> Result<Vec<(Version, String)>> {
     let glob = group.tag_glob();
     let listed = run_git(repo_root, &["tag", "--list", &glob])?;
 
@@ -264,18 +271,13 @@ fn nearest_ancestor_tag(repo_root: &Path, group: Group) -> Result<Option<(Versio
             continue;
         }
         let Ok(v) = parse_tag_to_version(tag, group) else {
-            // Malformed tag matching the glob — ignore. Lenient by design:
-            // a hand-created `releases/hole/v1.0.0-rc1` should not poison
-            // the rest of the lookup.
             continue;
         };
         if is_ancestor_of_head(repo_root, tag)? {
             candidates.push((v, tag.to_string()));
         }
     }
-
-    candidates.sort_by(|a, b| b.0.cmp(&a.0));
-    Ok(candidates.into_iter().next())
+    Ok(candidates)
 }
 
 fn is_ancestor_of_head(repo_root: &Path, tag: &str) -> Result<bool> {
@@ -300,23 +302,40 @@ fn parse_tag_to_version(tag: &str, group: Group) -> Result<Version> {
     let semver_str = tag
         .strip_prefix(&prefix)
         .ok_or_else(|| anyhow!("tag '{tag}' does not start with '{prefix}'"))?;
-    let parsed = Version::parse(semver_str).with_context(|| format!("tag '{tag}' is not valid semver after prefix"))?;
-    if !parsed.pre.is_empty() || !parsed.build.is_empty() {
-        bail!("tag '{tag}' must be strict releases/<group>/vMAJOR.MINOR.PATCH");
+    match group {
+        Group::V2rayPlugin => {
+            // V2rayPlugin tags allow `X.Y.Z-hole.N` pre-release (and bare
+            // `X.Y.Z`); the shape rules live in v2ray_plugin_version.
+            crate::v2ray_plugin_version::parse_version_string(semver_str)
+                .with_context(|| format!("tag '{tag}' does not match v2ray-plugin shape"))
+        }
+        Group::Hole | Group::Garter | Group::Galoshes => {
+            let parsed =
+                Version::parse(semver_str).with_context(|| format!("tag '{tag}' is not valid semver after prefix"))?;
+            if !parsed.pre.is_empty() || !parsed.build.is_empty() {
+                bail!("tag '{tag}' must be strict releases/<group>/vMAJOR.MINOR.PATCH");
+            }
+            Ok(parsed)
+        }
     }
-    Ok(parsed)
 }
 
-/// Validate the group's Cargo.toml version against its nearest tag.
+/// Validate the group's declared version against the relevant tag(s).
 ///
-/// When `exact`, requires the Cargo.toml version to match the tag exactly.
-/// Otherwise, accepts equality or a single patch/minor/major bump ahead.
+/// For Cargo.toml-based groups (Hole, Garter, Galoshes):
+/// - With `exact`: Cargo.toml version must equal the nearest ancestor tag.
+/// - Without `exact`: equality or one-patch/minor/major-bump ahead per
+///   [`is_valid_next`]. Bootstrap state (no tag yet) is permissive.
 ///
-/// When no tag exists yet for the group (bootstrap state), accepts the
-/// Cargo.toml version unconditionally. The first release establishes the
-/// baseline. With `exact`, a missing tag is still an error — CI/release
-/// workflows always have a tag to match against.
+/// For [`Group::V2rayPlugin`]: delegates to
+/// [`crate::v2ray_plugin_version::validate_against_tag`] which enforces
+/// shape (`X.Y.Z` or `X.Y.Z-hole.N`) and sequence-no-gap rules. The
+/// `is_valid_next` "one-bump-ahead" rule does NOT apply to v2ray-plugin.
 pub fn validate_against_tag(repo_root: &Path, group: Group, exact: bool) -> Result<Version> {
+    if group == Group::V2rayPlugin {
+        return crate::v2ray_plugin_version::validate_against_tag(repo_root, exact);
+    }
+
     let cargo_ver = cargo_toml_version_for_group(repo_root, group)?;
     let Some(tag_ver) = nearest_tag_version(repo_root, group)? else {
         if exact {

--- a/xtask-lib/src/version_tests.rs
+++ b/xtask-lib/src/version_tests.rs
@@ -1,3 +1,4 @@
+use crate::test_support::init_git_repo;
 use crate::version::*;
 use semver::Version;
 use std::path::Path;
@@ -249,51 +250,11 @@ members = ["a", "b"]
     assert!(format!("{err:#}").contains("inconsistent"));
 }
 
-#[skuld::test]
-fn workspace_versions_v2ray_plugin_from_external_file() {
-    let dir = tempfile::tempdir().unwrap();
-    let root = dir.path();
-    write(
-        root.join("Cargo.toml"),
-        r#"[workspace]
-members = ["a"]
-"#,
-    );
-    write(
-        root.join("a").join("Cargo.toml"),
-        &cargo_with_group("a", "1.2.3", "hole"),
-    );
-    write(
-        root.join("external").join("v2ray-plugin").join("version.toml"),
-        "version = \"5.3.0\"\n",
-    );
-
-    let ws = read_workspace_versions(root).unwrap();
-    assert_eq!(ws.by_group.get(&Group::V2rayPlugin), Some(&v(5, 3, 0)));
-}
-
-#[skuld::test]
-fn workspace_versions_v2ray_plugin_rejects_pre_release() {
-    let dir = tempfile::tempdir().unwrap();
-    let root = dir.path();
-    write(
-        root.join("Cargo.toml"),
-        r#"[workspace]
-members = ["a"]
-"#,
-    );
-    write(
-        root.join("a").join("Cargo.toml"),
-        &cargo_with_group("a", "1.2.3", "hole"),
-    );
-    write(
-        root.join("external").join("v2ray-plugin").join("version.toml"),
-        "version = \"5.3.0-rc1\"\n",
-    );
-
-    let err = read_workspace_versions(root).unwrap_err();
-    assert!(format!("{err:#}").contains("strict MAJOR.MINOR.PATCH"));
-}
+// The two v2ray-plugin-specific tests that used to live here
+// (workspace_versions_v2ray_plugin_from_external_file,
+// workspace_versions_v2ray_plugin_rejects_pre_release) moved to
+// v2ray_plugin_version_tests.rs alongside the dedicated module, since
+// read_workspace_versions no longer populates Group::V2rayPlugin.
 
 #[skuld::test]
 fn workspace_versions_unknown_group_rejected() {
@@ -512,19 +473,6 @@ members = ["a"]
     let err = validate_against_tag(root, Group::Hole, true).unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("no `releases/hole/v...` tag yet"), "msg was: {msg}");
-}
-
-fn init_git_repo(root: &Path) {
-    use std::process::Command;
-    fn git(root: &Path, args: &[&str]) {
-        let s = Command::new("git").args(args).current_dir(root).status().unwrap();
-        assert!(s.success(), "git {} failed in {}", args.join(" "), root.display());
-    }
-    git(root, &["init", "--quiet"]);
-    git(root, &["config", "user.email", "test@example.invalid"]);
-    git(root, &["config", "user.name", "Test"]);
-    git(root, &["add", "."]);
-    git(root, &["commit", "--quiet", "-m", "init"]);
 }
 
 // display_version =====================================================================================================


### PR DESCRIPTION
Refs #291.

Two follow-ups to the four-product release split (PRs #292, #293) for the v2ray-plugin track:

## 1. Lineage-aware version validator

`0.1.0` for v2ray-plugin was wrong — we vendor a 5-year-old upstream project that's already past `v1.3.2` by 5 commits including a v2ray-core v4→v5 migration. New convention:

- **`X.Y.Z`** when we vendor upstream's `vX.Y.Z` tag exactly
- **`X.Y.Z-hole.N`** when we vendor upstream-master between two tags, with N counting Hole-side iterations against the same base

Per semver precedence, `1.3.3-hole.1` orders strictly above `1.3.2` and strictly below upstream's eventual `1.3.3` — captures the "between releases" semantic cleanly. Precedent: Go modules' pseudo-versions use the same `X.Y.(Z+1)-pre` shape.

Validator (new module `xtask-lib/src/v2ray_plugin_version.rs`) enforces:

- **Shape**: pre-release, when present, must be exactly `hole.N` (positive integer); build metadata always rejected
- **Sequence-no-gap**: `N` starts at 1 for each new `X.Y.Z` base and increments by exactly 1 against ancestor tags. The bootstrap pivot (`max_existing` defaults to 0 when no same-base `hole.K` tags exist) makes a single equality (`n == max_existing + 1`) handle both "started above 1" and "skipped a number"

Out of scope (per the agreed plan): upstream-tag verification, `is_valid_next`-style one-bump-ahead rule for `X.Y.Z` base transitions, Hole-local commits-ahead check.

`external/v2ray-plugin/version.toml` bumped from `0.1.0` to `1.3.3-hole.1`.

## 2. windows-arm64 added to the v2ray-plugin release matrix

Galoshes already builds and tests v2ray-plugin on windows-arm64 via the embedded plugin path (transitively via `Test galoshes (windows/arm64)`). The standalone v2ray-plugin release was 5-platform out of asymmetry. Now 6-platform.

## Test plan

- [x] `cargo test -p xtask-lib --tests` — 64 tests pass (was 35, added 29 for shape/sequence/exact/tag-glob)
- [x] `cargo run -p xtask --quiet -- version` prints `v2ray-plugin\t1.3.3-hole.1-dev+git.<hash>...`
- [x] `cargo run -p xtask --quiet -- version --check --group v2ray-plugin` passes (bootstrap)
- [x] `cargo run -p xtask --quiet -- version --check --exact --group v2ray-plugin` errors loudly (no tag yet)
- [x] `prek run --all-files` all hooks pass, including the four group-version-check hooks
- [ ] CI green on this PR
- [ ] Post-merge: cleanup stale `releases/v2ray-plugin/v0.1.0` draft (if any), re-dispatch `draft-release-v2ray-plugin.yaml` at `1.3.3-hole.1`, verify 6 tarballs + SHA256SUMS

## Notes

- Tag-glob `releases/v2ray-plugin/v[0-9]*.[0-9]*.[0-9]*` matches `v1.3.3-hole.1` (fnmatch `*` absorbs the `-hole.1` tail); covered by a regression test.
- `display_version` for dev builds downstream of `releases/v2ray-plugin/v1.3.3-hole.1` produces `1.3.3-hole.1-snapshot+git.<hash>` — valid semver, intentional. Documented in CLAUDE.md.
- Both v2ray-plugin workflow regexes loosened to accept `X.Y.Z-hole.N` (rejected outright otherwise, before the cargo-xtask check ever runs).