### PR TITLE
feat(release): per-track release-notes config + Conventional Commits policy

### DIFF
--- a/.github/release-galoshes.yaml
+++ b/.github/release-galoshes.yaml
@@ -1,0 +1,37 @@
+# Per-track release notes config for the `galoshes` release group.
+# Consumed by scripts/generate-release-notes.py at release time.
+#
+# See CONTRIBUTING.md "Commit messages — Conventional Commits".
+
+initial_release: |
+  Initial release of the standalone `galoshes` SIP003u plugin for
+  shadowsocks server operators. See #291 for the four-track release
+  decoupling rationale.
+
+include_paths:
+  - crates/galoshes/**
+  - crates/garter/**
+  - external/v2ray-plugin/**
+  - .github/workflows/draft-release-galoshes.yaml
+  - .github/workflows/publish-release-galoshes.yaml
+  - .github/release-galoshes.yaml
+
+categories:
+  - title: "🚀 Features"
+    types: [feat]
+  - title: "🐛 Bug Fixes"
+    types: [fix]
+  - title: "⚡ Performance"
+    types: [perf]
+  - title: "♻️ Refactors"
+    types: [refactor]
+  - title: "📚 Documentation"
+    types: [docs]
+  - title: "🔧 Build & CI"
+    types: [build, ci]
+  - title: "🧪 Tests"
+    types: [test]
+  - title: "🧹 Chores"
+    types: [chore, style, revert]
+  - title: "Other"
+    types: []

--- a/.github/release-garter.yaml
+++ b/.github/release-garter.yaml
@@ -1,0 +1,38 @@
+# Per-track release notes config for the `garter` release group.
+# Consumed by scripts/generate-release-notes.py at release time.
+#
+# See CONTRIBUTING.md "Commit messages — Conventional Commits".
+
+initial_release: |
+  Initial release of `garter`, the SIP003u plugin-chain runner library
+  + `garter` CLI binary for plugin developers. Library is published to
+  crates.io; CLI ships as a 6-platform binary via GitHub release. See
+  #291 for the four-track release decoupling rationale.
+
+include_paths:
+  - crates/garter/**
+  - crates/garter-bin/**
+  - crates/mock-plugin/**
+  - .github/workflows/draft-release-garter.yaml
+  - .github/workflows/publish-release-garter.yaml
+  - .github/release-garter.yaml
+
+categories:
+  - title: "🚀 Features"
+    types: [feat]
+  - title: "🐛 Bug Fixes"
+    types: [fix]
+  - title: "⚡ Performance"
+    types: [perf]
+  - title: "♻️ Refactors"
+    types: [refactor]
+  - title: "📚 Documentation"
+    types: [docs]
+  - title: "🔧 Build & CI"
+    types: [build, ci]
+  - title: "🧪 Tests"
+    types: [test]
+  - title: "🧹 Chores"
+    types: [chore, style, revert]
+  - title: "Other"
+    types: []

--- a/.github/release-hole.yaml
+++ b/.github/release-hole.yaml
@@ -1,0 +1,64 @@
+# Per-track release notes config for the `hole` release group.
+# Consumed by scripts/generate-release-notes.py at release time.
+#
+# See CONTRIBUTING.md "Commit messages — Conventional Commits" for the
+# PR-title convention this config relies on.
+
+# Initial-release stub. Used when no prior `releases/hole/v...` tag
+# exists on the branch. The script emits this verbatim instead of the
+# usual since-last-tag listing.
+initial_release: |
+  Initial release of the `hole` track. See #291 for the four-track
+  release decoupling rationale and CLAUDE.md "Releases" for the
+  versioning scheme.
+
+# A commit is included in this track's notes if it modified any file
+# matching one of these globs. Globs use fnmatch semantics
+# (`**` recursive, `*` non-slash wildcard).
+include_paths:
+  - crates/hole/**
+  - crates/common/**
+  - crates/bridge/**
+  - crates/tun-engine/**
+  - crates/tun-engine-macros/**
+  - crates/dump/**
+  - crates/dump-macros/**
+  - crates/handle-holders/**
+  - xtask/**
+  - xtask-lib/**
+  - msi-installer/**
+  - ui/**
+  - scripts/**
+  - .github/workflows/draft-release-hole.yaml
+  - .github/workflows/publish-release-hole.yaml
+  - .github/release-hole.yaml
+  - CLAUDE.md
+  - CONTRIBUTING.md
+  - README.md
+  - Cargo.toml
+  - Cargo.lock
+  - build.yaml
+  - prek.toml
+
+# Each commit is placed under the first category whose `types` list
+# contains the commit's Conventional Commit type. Commits without a
+# recognizable type prefix go under `Other` (last).
+categories:
+  - title: "🚀 Features"
+    types: [feat]
+  - title: "🐛 Bug Fixes"
+    types: [fix]
+  - title: "⚡ Performance"
+    types: [perf]
+  - title: "♻️ Refactors"
+    types: [refactor]
+  - title: "📚 Documentation"
+    types: [docs]
+  - title: "🔧 Build & CI"
+    types: [build, ci]
+  - title: "🧪 Tests"
+    types: [test]
+  - title: "🧹 Chores"
+    types: [chore, style, revert]
+  - title: "Other"
+    types: []

--- a/.github/release-v2ray-plugin.yaml
+++ b/.github/release-v2ray-plugin.yaml
@@ -1,0 +1,43 @@
+# Per-track release notes config for the `v2ray-plugin` release group.
+# Consumed by scripts/generate-release-notes.py at release time.
+#
+# See CONTRIBUTING.md "Commit messages — Conventional Commits".
+
+initial_release: |
+  Initial release of `v2ray-plugin` as a standalone Hole-published
+  track. See #291 for the four-track release decoupling rationale and
+  CLAUDE.md "Releases > Per-product release workflows > v2ray-plugin"
+  for the lineage versioning scheme (`X.Y.Z` for upstream-tagged
+  releases, `X.Y.Z-hole.N` for Hole iterations between upstream tags).
+
+# Notes: a v2ray-plugin release commonly contains zero Hole-authored
+# changes (it ships upstream's master as of the last `git subrepo pull`,
+# with no Hole-local commits in `external/v2ray-plugin/` in between). In
+# that case the script emits a body that explicitly says "no commits in
+# this range touched the v2ray-plugin track; upstream-only changes since
+# <prev>" rather than misleading empty output.
+include_paths:
+  - external/v2ray-plugin/**
+  - .github/workflows/draft-release-v2ray-plugin.yaml
+  - .github/workflows/publish-release-v2ray-plugin.yaml
+  - .github/release-v2ray-plugin.yaml
+
+categories:
+  - title: "🚀 Features"
+    types: [feat]
+  - title: "🐛 Bug Fixes"
+    types: [fix]
+  - title: "⚡ Performance"
+    types: [perf]
+  - title: "♻️ Refactors"
+    types: [refactor]
+  - title: "📚 Documentation"
+    types: [docs]
+  - title: "🔧 Build & CI"
+    types: [build, ci]
+  - title: "🧪 Tests"
+    types: [test]
+  - title: "🧹 Chores"
+    types: [chore, style, revert]
+  - title: "Other"
+    types: []

--- a/.github/workflows/draft-release-galoshes.yaml
+++ b/.github/workflows/draft-release-galoshes.yaml
@@ -113,6 +113,26 @@ jobs:
           echo "SHA256SUMS:"
           cat SHA256SUMS
 
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: source
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Generate per-track release notes
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="releases/galoshes/v${VERSION}"
+          uv run source/scripts/generate-release-notes.py galoshes \
+            --new-tag "$TAG" \
+            --head "${{ github.sha }}" \
+            --repo-root source \
+            > release-notes.md
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+          echo "--- end ---"
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -122,7 +142,7 @@ jobs:
           TAG="releases/galoshes/v${VERSION}"
           gh release create "$TAG" \
             --draft \
-            --generate-notes \
+            --notes-file release-notes.md \
             --title "galoshes v${VERSION}" \
             --target "${{ github.sha }}" \
             galoshes-* SHA256SUMS

--- a/.github/workflows/draft-release-garter.yaml
+++ b/.github/workflows/draft-release-garter.yaml
@@ -121,6 +121,26 @@ jobs:
           echo "SHA256SUMS:"
           cat SHA256SUMS
 
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: source
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Generate per-track release notes
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="releases/garter/v${VERSION}"
+          uv run source/scripts/generate-release-notes.py garter \
+            --new-tag "$TAG" \
+            --head "${{ github.sha }}" \
+            --repo-root source \
+            > release-notes.md
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+          echo "--- end ---"
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -130,7 +150,7 @@ jobs:
           TAG="releases/garter/v${VERSION}"
           gh release create "$TAG" \
             --draft \
-            --generate-notes \
+            --notes-file release-notes.md \
             --title "garter v${VERSION}" \
             --target "${{ github.sha }}" \
             garter-* SHA256SUMS

--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -131,6 +131,27 @@ jobs:
           echo "SHA256SUMS:"
           cat SHA256SUMS
 
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # `path: source` so we don't clobber the downloaded artifacts in $GITHUB_WORKSPACE.
+          path: source
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Generate per-track release notes
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="releases/hole/v${VERSION}"
+          uv run source/scripts/generate-release-notes.py hole \
+            --new-tag "$TAG" \
+            --head "${{ github.sha }}" \
+            --repo-root source \
+            > release-notes.md
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+          echo "--- end ---"
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -140,7 +161,7 @@ jobs:
           TAG="releases/hole/v${VERSION}"
           gh release create "$TAG" \
             --draft \
-            --generate-notes \
+            --notes-file release-notes.md \
             --title "hole v${VERSION}" \
             --target "${{ github.sha }}" \
             hole-* SHA256SUMS

--- a/.github/workflows/draft-release-v2ray-plugin.yaml
+++ b/.github/workflows/draft-release-v2ray-plugin.yaml
@@ -148,6 +148,26 @@ jobs:
           echo "SHA256SUMS:"
           cat SHA256SUMS
 
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: source
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Generate per-track release notes
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="releases/v2ray-plugin/v${VERSION}"
+          uv run source/scripts/generate-release-notes.py v2ray-plugin \
+            --new-tag "$TAG" \
+            --head "${{ github.sha }}" \
+            --repo-root source \
+            > release-notes.md
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+          echo "--- end ---"
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -157,7 +177,7 @@ jobs:
           TAG="releases/v2ray-plugin/v${VERSION}"
           gh release create "$TAG" \
             --draft \
-            --generate-notes \
+            --notes-file release-notes.md \
             --title "v2ray-plugin v${VERSION}" \
             --target "${{ github.sha }}" \
             v2ray-plugin-* SHA256SUMS

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -7,8 +7,15 @@ name: Semantic PR Title
 #
 # See CONTRIBUTING.md "Commit messages — Conventional Commits".
 
+# `on: pull_request` (vs `pull_request_target`) runs the workflow from the
+# PR's branch using the default read-only GITHUB_TOKEN. We don't need
+# write access (the action only reads the PR title), and using
+# `pull_request` lets the workflow itself be validated by its own PR at
+# introduction time. From a security standpoint there's nothing
+# exploitable in this workflow: it doesn't check out PR code, doesn't run
+# untrusted scripts, doesn't expose secrets.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,42 @@
+name: Semantic PR Title
+
+# Enforces the Conventional Commits convention on PR titles. Since this
+# repo squash-merges every PR, the PR title becomes the commit subject on
+# main, and the type prefix drives per-track release-notes categorization
+# (see scripts/generate-release-notes.py).
+#
+# See CONTRIBUTING.md "Commit messages — Conventional Commits".
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types match the CONTRIBUTING.md list and
+          # .github/release-*.yaml categorization buckets. If you add a
+          # new type here, also add a category for it in every
+          # per-track release config (or let it fall into "Other").
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,42 @@ Any code that needs an ephemeral port and follows up with an OS bind (TCP listen
 
 **Scope.** `bind_with_retry` retries `is_bind_race` errors that surface through the closure as `io::Error`. Out-of-process binders (plugin subprocesses) report bind failures through other channels (oneshot timeout, exit code) — not retried by the wrapper. For those sites use `bind_with_retry` for structural consistency; the actual race-mitigation comes from `free_port`'s internal probe-side retries. The three current consumers — [`LocalDnsServer::bind`](crates/bridge/src/dns/server.rs), [`start_plugin_chain`](crates/bridge/src/proxy/plugin.rs), and [`test_support::ssserver::start_real_ss_server*`](crates/bridge/src/test_support/ssserver.rs) — all route through it.
 
+## Commit messages — Conventional Commits
+
+This repository squash-merges every PR, so the PR title becomes the
+commit subject on `main`. PR titles MUST follow the
+[Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>)?: <description>
+```
+
+`type` is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+`test`, `build`, `ci`, `chore`, `revert`. `scope` is optional and
+identifies an area or crate (`bridge`, `xtask`, `release`, etc.). A
+trailing `!` (e.g. `feat(api)!: …`) flags a breaking change.
+
+Examples that match this convention:
+
+- `feat(bridge): add HTTPS DoH support to DNS forwarder`
+- `fix(release): use sha256sum (cross-platform) instead of shasum`
+- `refactor(xtask-lib): per-product version groups`
+- `chore(deps): bump tokio from 1.52 to 1.53`
+
+Enforcement: a CI check on every PR validates the title against the
+allowed types and shape (see [.github/workflows/semantic-pr.yaml](.github/workflows/semantic-pr.yaml)).
+A non-conforming title fails the check; rename via `gh pr edit <N> --title "..."`
+or the web UI and the check re-runs automatically.
+
+Why it matters operationally: the type prefix drives per-track release
+notes categorization. `scripts/generate-release-notes.py` reads each
+track's `.github/release-<track>.yaml` config, filters squash-commits
+by file paths the PR touched, and groups them under their type's
+heading (Features / Bug fixes / etc.). A PR without a recognizable type
+prefix is grouped under "Other" rather than dropped — so the existing
+non-conforming history before this policy landed remains visible — but
+new PRs must conform via the CI gate.
+
 ## Prerequisites
 
 - Rust toolchain

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["PyYAML>=6"]
+# ///
+"""Generate per-track release notes for Hole's four release tracks.
+
+Reads a per-track config from `.github/release-<track>.yaml`, walks
+squash-commits in the range `<previous-track-tag>..<head>`, filters by
+the file globs the config declares, categorizes by Conventional Commit
+type, and writes markdown to stdout.
+
+Usage:
+    uv run scripts/generate-release-notes.py <track> --new-tag <tag>
+    uv run scripts/generate-release-notes.py <track> --new-tag <tag> --head <ref>
+
+`<track>` is one of `hole`, `galoshes`, `garter`, `v2ray-plugin`.
+
+The previous tag is auto-discovered as the highest-versioned tag
+matching `releases/<track>/v*` that's an ancestor of `<head>` (default
+HEAD). If none exists, the config's `initial_release:` body is emitted.
+
+Run from the repo root or pass `--repo-root`.
+"""
+
+import argparse
+import dataclasses
+import fnmatch
+import re
+import subprocess
+import sys
+import typing as t
+from pathlib import Path
+
+import yaml
+
+CONVENTIONAL_COMMIT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?!?:\s*(?P<desc>.+)$")
+PR_NUMBER_RE = re.compile(r"\(#(\d+)\)\s*$")
+TAG_VERSION_RE = re.compile(r"^releases/[^/]+/v(\d+)\.(\d+)\.(\d+)(?:-(.+))?$")
+
+
+@dataclasses.dataclass
+class TrackConfig:
+    initial_release: str
+    include_paths: list[str]
+    categories: list["Category"]
+
+
+@dataclasses.dataclass
+class Category:
+    title: str
+    types: list[str]
+
+
+@dataclasses.dataclass
+class Commit:
+    sha: str
+    subject: str
+    files: list[str]
+    pr_number: int | None
+    type: str | None
+    desc: str
+
+
+# Loading ==============================================================================================================
+
+
+def load_config(repo_root: Path, track: str) -> TrackConfig:
+    path = repo_root / ".github" / f"release-{track}.yaml"
+    with open(path, encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    return TrackConfig(
+        initial_release=raw.get("initial_release", "").strip(),
+        include_paths=list(raw.get("include_paths", [])),
+        categories=[Category(title=c["title"], types=list(c.get("types", []))) for c in raw.get("categories", [])],
+    )
+
+
+# Git plumbing =========================================================================================================
+
+
+def git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed (exit {result.returncode}): {result.stderr.strip()}")
+    return result.stdout
+
+
+def find_previous_tag(repo_root: Path, track: str, head: str) -> str | None:
+    """Highest-versioned `releases/<track>/v*` tag that's an ancestor of HEAD."""
+    listed = git(repo_root, "tag", "--list", f"releases/{track}/v*")
+    tags = [t.strip() for t in listed.splitlines() if t.strip()]
+
+    # Sort key: (major, minor, patch, bare-discriminator, pre-release).
+    # The bare-discriminator is 1 for `X.Y.Z` and 0 for `X.Y.Z-pre`; this
+    # encodes the semver rule that bare > pre-release at the same M.M.P.
+    candidates: list[tuple[tuple[int, int, int, int, str], str]] = []
+    for tag in tags:
+        m = TAG_VERSION_RE.match(tag)
+        if not m:
+            continue
+        # Verify ancestor-of-head via merge-base --is-ancestor (exit code).
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", tag, head],
+            cwd=repo_root,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            continue
+        major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        pre = m.group(4) or ""
+        # Sort key: (major, minor, patch, pre-or-empty). Bare X.Y.Z sorts
+        # ABOVE X.Y.Z-hole.N per semver precedence (no pre > with pre).
+        # We encode that as: bare → ("",), pre → (pre,). Tuple comparison
+        # treats "" as less than any non-empty string, so we invert:
+        # use a discriminator (1 for bare, 0 for pre-release).
+        sort_key = (major, minor, patch, 1 if not pre else 0, pre)
+        candidates.append((sort_key, tag))
+
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+def list_commits(repo_root: Path, range_spec: str) -> list[Commit]:
+    """Walk commits in `range_spec` (e.g. `tag..HEAD` or just `HEAD`).
+
+    Returns Commit list ordered newest-first.
+    """
+    if ".." not in range_spec:
+        log_args = ["log", "--no-merges", "--format=%H%x09%s", range_spec]
+    else:
+        log_args = ["log", "--no-merges", "--format=%H%x09%s", range_spec]
+    out = git(repo_root, *log_args)
+
+    commits: list[Commit] = []
+    for line in out.splitlines():
+        if not line:
+            continue
+        sha, _, subject = line.partition("\t")
+        files = git(repo_root, "show", "--no-renames", "--name-only", "--format=", sha).splitlines()
+        files = [f.strip() for f in files if f.strip()]
+
+        pr_match = PR_NUMBER_RE.search(subject)
+        pr_number = int(pr_match.group(1)) if pr_match else None
+
+        cc_match = CONVENTIONAL_COMMIT_RE.match(subject)
+        commit_type = cc_match.group("type") if cc_match else None
+        # Use the full subject (minus PR-number suffix) for display so the
+        # type/scope prefix is visible in the rendered bullet.
+        desc_display = PR_NUMBER_RE.sub("", subject).strip()
+
+        commits.append(
+            Commit(
+                sha=sha,
+                subject=subject,
+                files=files,
+                pr_number=pr_number,
+                type=commit_type,
+                desc=desc_display,
+            )
+        )
+    return commits
+
+
+# Filtering & categorization ===========================================================================================
+
+
+def matches_paths(commit_files: list[str], globs: list[str]) -> bool:
+    """True if any commit file matches any glob (fnmatch semantics).
+
+    Globs use `**` for recursive match. We expand `**/` and `/**` by
+    rewriting the pattern to fnmatch's equivalent.
+    """
+    for path in commit_files:
+        for g in globs:
+            if _fnmatch_recursive(path, g):
+                return True
+    return False
+
+
+def _fnmatch_recursive(path: str, glob: str) -> bool:
+    # fnmatch doesn't natively support `**`. We rewrite `**` to `*` and
+    # rely on fnmatch's `*` matching path separators in fnmatch (it
+    # doesn't actually distinguish `/` from other chars, unlike shell
+    # glob). So `crates/hole/**` matches `crates/hole/src/main.rs`
+    # because the trailing `*` from `**` matches the whole `src/main.rs`.
+    # Edge: a glob ending in `/**` should also match the directory
+    # itself. We approximate by also matching the trimmed form.
+    if glob.endswith("/**"):
+        prefix = glob[:-len("/**")]
+        return fnmatch.fnmatchcase(path, prefix) or fnmatch.fnmatchcase(path, prefix + "/*") or fnmatch.fnmatchcase(
+            path, glob.replace("**", "*")
+        )
+    normalized = glob.replace("**", "*")
+    return fnmatch.fnmatchcase(path, normalized)
+
+
+def categorize(commits: list[Commit], categories: list[Category]) -> dict[str, list[Commit]]:
+    """Place each commit under the first category whose `types` list
+    contains the commit's type. Commits with no type, or whose type
+    matches no listed category, fall into the catch-all category
+    (whose `types` is `[]`) if one exists; otherwise they're dropped.
+
+    Returns dict keyed by category title preserving the config's order.
+    """
+    out: dict[str, list[Commit]] = {c.title: [] for c in categories}
+    catchall_title = next((c.title for c in categories if not c.types), None)
+
+    for commit in commits:
+        placed = False
+        for cat in categories:
+            if commit.type and commit.type in cat.types:
+                out[cat.title].append(commit)
+                placed = True
+                break
+        if not placed and catchall_title is not None:
+            out[catchall_title].append(commit)
+
+    return out
+
+
+# Rendering ============================================================================================================
+
+
+def render_bullet(commit: Commit) -> str:
+    """Render a single commit as a bullet line."""
+    line = commit.desc
+    if commit.pr_number is not None:
+        line += f" (#{commit.pr_number})"
+    return f"- {line}"
+
+
+def render_notes(
+    grouped: dict[str, list[Commit]],
+    new_tag: str,
+    previous_tag: str | None,
+    repo_url: str,
+) -> str:
+    parts: list[str] = []
+
+    if previous_tag is None:
+        # Caller should have already emitted initial_release stub; this
+        # branch is defensive.
+        return f"Initial release {new_tag}.\n"
+
+    # Non-empty category list rendered as `## <title>` followed by bullets.
+    has_any = any(commits for commits in grouped.values())
+    if not has_any:
+        parts.append(
+            f"_No commits in this range touched files in this track. "
+            f"(Range: `{previous_tag}` → `{new_tag}`.)_"
+        )
+    else:
+        for title, commits in grouped.items():
+            if not commits:
+                continue
+            parts.append(f"## {title}")
+            for commit in commits:
+                parts.append(render_bullet(commit))
+            parts.append("")  # blank line between sections
+
+    parts.append(f"**Full Changelog**: {repo_url}/compare/{previous_tag}...{new_tag}")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# Entry point ==========================================================================================================
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("track", choices=["hole", "galoshes", "garter", "v2ray-plugin"])
+    parser.add_argument("--new-tag", required=True, help="Tag being released (e.g. releases/hole/v0.2.0)")
+    parser.add_argument("--head", default="HEAD", help="Git ref representing the new release commit (default: HEAD)")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Path to repo root (default: discovered via `git rev-parse --show-toplevel`)",
+    )
+    parser.add_argument(
+        "--repo-url",
+        default="https://github.com/bindreams/hole",
+        help="Repository URL for `Full Changelog` link",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo_root
+    if repo_root is None:
+        repo_root = Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        )
+
+    config = load_config(repo_root, args.track)
+    previous_tag = find_previous_tag(repo_root, args.track, args.head)
+
+    if previous_tag is None:
+        # First-of-track release: emit the configured stub instead of
+        # walking history. Avoids the "every PR ever merged" problem.
+        body = config.initial_release or f"Initial release of the `{args.track}` track."
+        sys.stdout.write(body.rstrip() + "\n")
+        return 0
+
+    range_spec = f"{previous_tag}..{args.head}"
+    commits = list_commits(repo_root, range_spec)
+    filtered = [c for c in commits if matches_paths(c.files, config.include_paths)]
+    grouped = categorize(filtered, config.categories)
+    body = render_notes(grouped, new_tag=args.new_tag, previous_tag=previous_tag, repo_url=args.repo_url)
+    sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# Tests (pytest) =======================================================================================================
+
+
+def test_conventional_commit_re_matches_type() -> None:
+    m = CONVENTIONAL_COMMIT_RE.match("feat(bridge): add DoH support")
+    assert m is not None
+    assert m.group("type") == "feat"
+    assert m.group("scope") == "bridge"
+    assert m.group("desc") == "add DoH support"
+
+
+def test_conventional_commit_re_matches_no_scope() -> None:
+    m = CONVENTIONAL_COMMIT_RE.match("fix: protocol-aware port allocation")
+    assert m is not None
+    assert m.group("type") == "fix"
+    assert m.group("scope") is None
+
+
+def test_conventional_commit_re_rejects_non_conventional() -> None:
+    assert CONVENTIONAL_COMMIT_RE.match("Just some description") is None
+
+
+def test_conventional_commit_re_accepts_breaking_marker() -> None:
+    m = CONVENTIONAL_COMMIT_RE.match("feat(api)!: rename endpoint")
+    assert m is not None
+    assert m.group("type") == "feat"
+
+
+def test_pr_number_extraction():
+    # PR_NUMBER_RE is anchored at end-of-string (`(#\d+)\s*$`), so only the
+    # last parenthesized PR ref is captured even when multiple appear.
+    m = PR_NUMBER_RE.search("foo bar (#123)")
+    assert m is not None
+    assert m.group(1) == "123"
+    assert PR_NUMBER_RE.search("no number here") is None
+    m = PR_NUMBER_RE.search("revert PR (#1) for cause (#2)")
+    assert m is not None
+    assert m.group(1) == "2"
+
+
+def test_tag_version_re():
+    m = TAG_VERSION_RE.match("releases/hole/v1.2.3")
+    assert m is not None
+    assert m.groups() == ("1", "2", "3", None)
+    m = TAG_VERSION_RE.match("releases/v2ray-plugin/v1.3.3-hole.1")
+    assert m is not None
+    assert m.groups() == ("1", "3", "3", "hole.1")
+
+
+def test_fnmatch_recursive_basic(tmp_path):
+    assert _fnmatch_recursive("crates/hole/src/main.rs", "crates/hole/**")
+    assert _fnmatch_recursive("crates/hole/Cargo.toml", "crates/hole/**")
+    assert not _fnmatch_recursive("crates/galoshes/src/main.rs", "crates/hole/**")
+    assert _fnmatch_recursive(".github/workflows/draft-release-hole.yaml", ".github/workflows/draft-release-hole.yaml")
+    assert _fnmatch_recursive("external/v2ray-plugin/main.go", "external/v2ray-plugin/**")
+
+
+def test_categorize_first_match_wins():
+    cats = [
+        Category("Features", ["feat"]),
+        Category("Fixes", ["fix"]),
+        Category("Other", []),
+    ]
+    commits = [
+        Commit(sha="a", subject="feat: x", files=[], pr_number=None, type="feat", desc="feat: x"),
+        Commit(sha="b", subject="fix: y", files=[], pr_number=None, type="fix", desc="fix: y"),
+        Commit(sha="c", subject="something", files=[], pr_number=None, type=None, desc="something"),
+    ]
+    grouped = categorize(commits, cats)
+    assert [c.sha for c in grouped["Features"]] == ["a"]
+    assert [c.sha for c in grouped["Fixes"]] == ["b"]
+    assert [c.sha for c in grouped["Other"]] == ["c"]
+
+
+def test_categorize_no_catchall_drops_uncategorized():
+    cats = [Category("Features", ["feat"])]
+    commits = [Commit(sha="a", subject="?", files=[], pr_number=None, type=None, desc="?")]
+    grouped = categorize(commits, cats)
+    assert grouped == {"Features": []}
+
+
+def test_matches_paths_globs():
+    assert matches_paths(["crates/hole/src/main.rs"], ["crates/hole/**"])
+    assert matches_paths(["a", "crates/hole/src/main.rs"], ["crates/hole/**"])
+    assert not matches_paths(["crates/galoshes/src/main.rs"], ["crates/hole/**"])
+    assert matches_paths(["external/v2ray-plugin/main.go"], ["external/v2ray-plugin/**"])

--- a/xtask-lib/src/v2ray_plugin_version.rs
+++ b/xtask-lib/src/v2ray_plugin_version.rs
@@ -134,13 +134,19 @@ pub fn validate_against_tag(repo_root: &Path, exact: bool) -> Result<Version> {
     };
 
     // Sequence-no-gap rule. Find the highest existing hole.K tag that
-    // shares the same X.Y.Z base. The bootstrap pivot — `max_existing`
-    // defaults to 0 when no same-base hole.K tags exist — is what makes
-    // a single equality (`n == max_existing + 1`) handle both the
-    // bootstrap-reject case (N >= 2 when no tags exist) and the
-    // mid-sequence-skip-reject case (existing hole.K, current N != K+1).
+    // shares the same X.Y.Z base. `max_existing` defaults to 0 when no
+    // same-base hole.K tags exist (bootstrap pivot). The current
+    // version is accepted when it equals `max_existing` (after-release
+    // stable state — same as the most recent tag, hasn't been bumped
+    // yet) or `max_existing + 1` (preparing the next release). Any
+    // other value is a gap (`N > max_existing + 1`) or a regression
+    // (`N < max_existing`).
+    //
     // Do NOT simplify to "no tags → no constraint" — that breaks the
-    // bootstrap-reject path.
+    // bootstrap-reject path. In bootstrap state (max_existing = 0),
+    // current N == 0 is impossible (hole_iteration requires N >= 1), so
+    // the only accepted N is 1. Same single equality, same correct
+    // semantics for both bootstrap and mid-sequence states.
     let all_tags = ancestor_tags(repo_root, Group::V2rayPlugin)?;
     let max_existing = all_tags
         .iter()
@@ -149,16 +155,15 @@ pub fn validate_against_tag(repo_root: &Path, exact: bool) -> Result<Version> {
         .max()
         .unwrap_or(0);
 
-    let expected = max_existing + 1;
-    if n != expected {
+    if n != max_existing && n != max_existing + 1 {
         bail!(
             "v2ray-plugin sequence violation: version.toml is `{current}` (hole.{n}), \
-             but the next valid hole iteration for base {}.{}.{} is hole.{expected} \
-             (max existing hole.K with this base = {max_existing}). \
-             Tags must increment by 1 with no gaps.",
+             but valid hole iterations for base {}.{}.{} are hole.{max_existing} \
+             (current latest) or hole.{} (next). Tags must increment by 1 with no gaps.",
             current.major,
             current.minor,
-            current.patch
+            current.patch,
+            max_existing + 1
         );
     }
 

--- a/xtask-lib/src/v2ray_plugin_version_tests.rs
+++ b/xtask-lib/src/v2ray_plugin_version_tests.rs
@@ -205,6 +205,22 @@ fn sequence_increment_within_base_accepted() {
 }
 
 #[skuld::test]
+fn sequence_equal_to_latest_accepted() {
+    // After-release stable state: version.toml equals the most recent
+    // same-base hole.N tag. This is valid until the next bump (the
+    // maintainer hasn't decided what comes next yet). Mirrors the
+    // hole/garter/galoshes validator's "Cargo.toml == nearest tag" path.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_version_toml(root, "1.3.3-hole.1");
+    init_git_repo(root);
+    create_tag(root, "releases/v2ray-plugin/v1.3.3-hole.1");
+
+    let v = validate_against_tag(root, false).unwrap();
+    assert_eq!(v.pre.as_str(), "hole.1");
+}
+
+#[skuld::test]
 fn sequence_new_base_after_hole_iterations_accepted() {
     // Prior 1.3.3-hole.2, current 1.3.4-hole.1 → accept (new base, no
     // same-base hole.K → max_existing = 0 → expected N = 1).


### PR DESCRIPTION
Closes #295. Follow-up to #292/#293/#294.

## Summary

- **`.github/release-{hole,galoshes,garter,v2ray-plugin}.yaml`** — per-track config files declaring path globs (track scoping) + Conventional Commit `type` → section title mapping. Initial-release stubs configurable per track.
- **`scripts/generate-release-notes.py`** (uv, ~430 LOC) — reads the per-track config, finds the prior `releases/<track>/v*` ancestor tag, walks commits in the range, filters by paths, categorizes by Conventional Commit type. 10 pytest tests pass.
- **Conventional Commits policy** in `CONTRIBUTING.md` with `amannn/action-semantic-pull-request@v5` enforcing PR-title shape on every PR (we squash-merge, so PR title === commit subject on main).
- **All 4 draft-release workflows** updated: replaced `gh release create ... --generate-notes` with `uv run scripts/generate-release-notes.py <track> > release-notes.md` then `gh release create ... --notes-file release-notes.md`. Includes a checkout step to make the script + repo history available to the release job.
- **Validator fix**: `xtask-lib/src/v2ray_plugin_version.rs::validate_against_tag` non-exact path now accepts `current == max_existing` (after-release stable state where the maintainer hasn't bumped yet) in addition to `current == max_existing + 1` (preparing next release). This mirrors the hole/garter/galoshes validator's "Cargo.toml == nearest tag is OK" semantics and unblocks prek after each release. Added `sequence_equal_to_latest_accepted` test.

## Why a script vs pure \`.github/release.yml\`

GitHub's `.github/release.yml` schema only supports OR-matching of labels per category, with no AND across categories. We can't express \"include only PRs labeled \`track:X\` AND categorize by \`type:Y\`\" in pure config. The script reads the per-track YAML config (one file per track, declarative) and does the path+type filtering. Per-track config files remain readable and reviewable.

## \`.yaml\` vs \`.yml\`

We bypass GitHub's default lookup (\`.github/release.yml\`) entirely — the script reads the per-track YAML directly. So we use the more canonical \`.yaml\` extension, free of the default-lookup ambiguity that may or may not accept both extensions.

## Test plan

- [x] \`cargo test -p xtask-lib --tests\` — 66 tests pass (was 65, added 1 for equality-accepted)
- [x] \`uv run --with pytest pytest scripts/generate-release-notes.py\` — 10 tests pass
- [x] Live dry-run on \`v2ray-plugin\` (track with an existing tag) produces correct \"no commits in this range touched files in this track\" message
- [x] Live dry-run on \`hole\` and \`galoshes\` (first-of-track) produces the configured initial-release stub
- [x] \`prek run --all-files\` — all hooks pass (including the four group-version-check hooks)
- [ ] CI green on this PR
- [ ] (Post-merge, optional) verify the v2ray-plugin release-notes path end-to-end via a test dispatch

## Out of scope (deferred)

- A path-based PR labeler (e.g. \`actions/labeler@v5\`). The script already does path-filtering directly from commit-touched files, so a labeler is redundant for release-notes purposes. If we later want filterable PR lists in the UI, a labeler can be added independently.
- Retroactive re-titling of older PRs to match Conventional Commits. The policy is from-this-point-on; older non-conforming commits fall into the "Other" section of generated notes.