### PR TITLE
ci(renovate): drop top-level Monday schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["before 9am on monday"],
   "minimumReleaseAge": "7 days",
   "postUpdateOptions": ["gomodTidy", "npmDedupe"],
   "platformAutomerge": true,


### PR DESCRIPTION
## Summary
- Removes the top-level `"schedule": ["before 9am on monday"]` field from [.github/renovate.json](.github/renovate.json) so dependency-update PRs open as soon as Renovate detects them, rather than queuing for a single weekly window.
- `minimumReleaseAge: 7 days` is preserved (supply-chain delay floor) and `lockFileMaintenance.schedule` is left at weekly — lockfile-refresh is a different operation and weekly is the right cadence for transitive churn.

## Why
The repo onboarded Renovate but has never received a single update PR — all 14 detected update batches are parked under "Awaiting Schedule" on the [Dependency Dashboard](https://github.com/bindreams/hole/issues/275). Removing the weekly gate lets the dashboard drain.

Fixes #297.

## Test plan
- [ ] Merge and watch the Dependency Dashboard (#275) — within ~1h of merge, Renovate should run and convert the "Awaiting Schedule" batches into open PRs.
- [ ] Verify the `lockFileMaintenance` block still schedules its refresh weekly (it has its own `schedule` field).