### PR TITLE
test(observability): process-global tracing subscriber via hole-test-observability (#301)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,12 @@ crates/dump-macros/       → dump-macros.  GPL-3.0, hole group, publish=false.
                             Proc-macro support for `dump` (#[derive(Dump)]).
 crates/handle-holders/    → handle-holders. GPL-3.0, hole group, publish=false.
                             File-handle introspection (Windows NtQuery / macOS lsof).
+crates/test-observability/ → hole-test-observability. GPL-3.0, hole group, publish=false.
+                            Dev-dep-only: pre-main ctor installs a process-global
+                            tracing subscriber + panic hook for every test binary.
+                            Wired into each test-bearing crate via
+                            `hole_test_observability::register!()` in lib.rs / tests/*.rs.
+                            See bindreams/hole#301.
 crates/garter/            → garter.       Apache-2.0, garter group, **published to crates.io**.
                             SIP003u plugin-chain runner library (ChainPlugin, ChainRunner).
 crates/garter-bin/        → garter-bin.   Apache-2.0, garter group, publish=false.
@@ -371,6 +377,52 @@ npx tauri build                  # produces .dmg in target/release/bundle/
 Uses [skuld](https://github.com/bindreams/skuld) framework (`#[skuld::test]`), not `#[test]`.
 Unit test files are siblings: `foo.rs` → `foo_tests.rs`.
 
+### Test observability invariant
+
+Every test-bearing workspace crate depends on `hole-test-observability`
+as a dev-dependency and invokes
+`hole_test_observability::register!()` once per test binary —
+either at the top level of `src/lib.rs` (lib tests) or at the top of
+each `tests/*.rs` (integration tests). The macro expands (under
+`#[cfg(test)]`) to a `mod _hole_test_observability_init` containing
+a `#[ctor::ctor]` function. The ctor runs pre-main on every test
+binary and installs:
+
+- A process-global `tracing_subscriber` writing to stderr. Skuld's
+  FD-level capture (under bare `cargo test`) and nextest's
+  per-subprocess capture (CI) both buffer it and dump on failure.
+- `RUST_BACKTRACE=full` (if unset) so the stdlib panic hook prints a
+  backtrace.
+- Hole's tracing-emitting panic hook from
+  [`hole_common::logging::install_panic_hook`](crates/common/src/logging.rs)
+  — chains before the stdlib hook, adds `target=hole::panic`
+  events with `force_capture` backtraces.
+
+Override the filter via `HOLE_TEST_LOG=hole_bridge=debug` (etc.).
+Default is catch-all `info` with every Hole-side crate pinned to
+`debug` — Hole's `debug!` lines are not high-volume; third-party
+`log::trace!` from `shadowsocks-service` / `tokio` / `mio` is
+level-rejected at `Dispatch::enabled()` before `tracing-log`
+allocates a tracing `Event` (the load-bearing safeguard against the
+#147 perf trap).
+
+**Do NOT** call `tracing_subscriber::fmt().init()` or any
+`SubscriberInitExt::try_init()` in test code — `clippy.toml`'s
+`disallowed-methods` denies it workspace-wide. The single
+production caller in
+[crates/common/src/logging.rs](crates/common/src/logging.rs) is
+`#[allow]`-suppressed.
+
+Special case: the FD-redirect child-process branch in
+[`crates/common/src/lib.rs::main`](crates/common/src/lib.rs)
+(`HOLE_LOGGING_TEST_KIND` set) installs its own
+`set_global_default` via `install_child_subscriber`. The ctor in
+`hole-test-observability::install` short-circuits when that env
+var is set so it doesn't preempt the child-side subscriber.
+
+See bindreams/hole#301 (motivation) and #147 (regression
+constraint).
+
 ### Tracing-subscriber test invariant
 
 Tests that install a per-test `tracing` subscriber as their assertion
@@ -384,6 +436,12 @@ the raw form. `#[skuld::test] async fn` builds a current-thread runtime
 via `skuld::__private::build_async_runtime` and satisfies the invariant
 automatically. See bindreams/hole#302 for the incident and the helper's
 documented silent-passthrough limitation when called outside `block_on`.
+
+Per-test thread-local subscribers via the helper shadow the
+test-observability global default on their thread without conflict —
+the 7 assertion-target tests (`proxy_manager_tests`,
+`forwarder_tests`, `system_tests`, `tap_tests`, `yaml_format_tests`,
+`logging_tests`, `cli_log_tests`) keep working as before.
 
 ### Windows installer
 
@@ -400,12 +458,12 @@ Version per group is declared in each crate's
 `xtask-lib::version` (publishable-but-ungrouped crates are rejected;
 within-group versions must match).
 
-| Product        | Group members                                                                                       | Artifacts                                                                | Signed         | crates.io     |
-| -------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------- | ------------- |
-| `hole`         | `hole, hole-common, hole-bridge, tun-engine, tun-engine-macros, dump, dump-macros, handle-holders`  | MSI + DMG (amd64+arm64) + `SHA256SUMS`                                   | Yes (minisign) | No            |
-| `galoshes`     | `galoshes`                                                                                          | 6-platform server binaries + `SHA256SUMS`                                | No             | No            |
-| `garter`       | `garter, garter-bin`                                                                                | crates.io `garter` lib + 6-platform `garter` CLI binaries + `SHA256SUMS` | No             | `garter` only |
-| `v2ray-plugin` | (not a Rust crate — version in `external/v2ray-plugin/version.toml`, lineage form `X.Y.Z[-hole.N]`) | 6-platform tar.gz set (upstream parity + windows-arm64) + `SHA256SUMS`   | No             | n/a           |
+| Product        | Group members                                                                                                               | Artifacts                                                                | Signed         | crates.io     |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------- | ------------- |
+| `hole`         | `hole, hole-common, hole-bridge, hole-test-observability, tun-engine, tun-engine-macros, dump, dump-macros, handle-holders` | MSI + DMG (amd64+arm64) + `SHA256SUMS`                                   | Yes (minisign) | No            |
+| `galoshes`     | `galoshes`                                                                                                                  | 6-platform server binaries + `SHA256SUMS`                                | No             | No            |
+| `garter`       | `garter, garter-bin`                                                                                                        | crates.io `garter` lib + 6-platform `garter` CLI binaries + `SHA256SUMS` | No             | `garter` only |
+| `v2ray-plugin` | (not a Rust crate — version in `external/v2ray-plugin/version.toml`, lineage form `X.Y.Z[-hole.N]`)                         | 6-platform tar.gz set (upstream parity + windows-arm64) + `SHA256SUMS`   | No             | n/a           |
 
 Asset naming:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,6 +1427,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "dump-macros",
+ "hole-test-observability",
  "serde",
  "skuld",
 ]
@@ -1436,6 +1437,7 @@ name = "dump-macros"
 version = "0.1.0"
 dependencies = [
  "dump",
+ "hole-test-observability",
  "proc-macro2",
  "quote",
  "skuld",
@@ -1923,6 +1925,7 @@ dependencies = [
  "contracts",
  "futures",
  "garter",
+ "hole-test-observability",
  "sha2 0.10.9",
  "skuld",
  "tempfile",
@@ -1940,6 +1943,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "contracts",
+ "hole-test-observability",
  "libc",
  "skuld",
  "socket2",
@@ -1957,6 +1961,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "garter",
+ "hole-test-observability",
  "serde",
  "skuld",
  "tokio",
@@ -2313,6 +2318,7 @@ dependencies = [
 name = "handle-holders"
 version = "0.1.0"
 dependencies = [
+ "hole-test-observability",
  "skuld",
  "tempfile",
  "tracing",
@@ -2502,6 +2508,7 @@ dependencies = [
  "garter",
  "hole-bridge",
  "hole-common",
+ "hole-test-observability",
  "http",
  "http-body-util",
  "hyper",
@@ -2553,6 +2560,7 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "hole-common",
+ "hole-test-observability",
  "http",
  "http-body-util",
  "hyper",
@@ -2599,6 +2607,7 @@ dependencies = [
  "dirs 6.0.0",
  "file-rotate",
  "garter",
+ "hole-test-observability",
  "libc",
  "log",
  "nu-ansi-term",
@@ -2620,6 +2629,19 @@ dependencies = [
  "uuid",
  "windows 0.62.2",
  "yaml_serde",
+]
+
+[[package]]
+name = "hole-test-observability"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "hole-common",
+ "log",
+ "skuld",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7098,6 +7120,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "default-net",
+ "hole-test-observability",
  "libc",
  "serde",
  "serde_json",
@@ -7120,6 +7143,7 @@ dependencies = [
 name = "tun-engine-macros"
 version = "0.1.0"
 dependencies = [
+ "hole-test-observability",
  "proc-macro2",
  "quote",
  "skuld",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,7 @@ dependencies = [
  "skuld",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
  "windows 0.62.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/common", "crates/bridge", "crates/dump", "crates/dump-macros", "crates/galoshes", "crates/garter", "crates/garter-bin", "crates/handle-holders", "crates/hole", "crates/mock-plugin", "crates/tun-engine", "crates/tun-engine-macros", "xtask", "xtask-lib"]
+members = ["crates/common", "crates/bridge", "crates/dump", "crates/dump-macros", "crates/galoshes", "crates/garter", "crates/garter-bin", "crates/handle-holders", "crates/hole", "crates/mock-plugin", "crates/test-observability", "crates/tun-engine", "crates/tun-engine-macros", "xtask", "xtask-lib"]
 resolver = "2"
 
 [workspace.package]
@@ -13,6 +13,9 @@ edition = "2021"
 
 [workspace.dependencies]
 skuld = { version = "0.2", features = ["tokio"] }
+# Pre-main init for the test-observability subscriber install. See
+# crates/test-observability and bindreams/hole#301.
+ctor = "0.2"
 insta = { version = "1", features = ["yaml"] }
 trybuild = "1"
 # DNS forwarder deps — direct so a future shadowsocks-service bump cannot

--- a/clippy.toml
+++ b/clippy.toml
@@ -58,6 +58,11 @@ reason = "Use `port_alloc::bind_ephemeral` instead — it folds the caller's bin
 # `#[allow(clippy::disallowed_methods)]` to call the real function;
 # `garter::tracing_test_tests::raw_set_default_on_multi_thread_loses_spawned_events`
 # uses it to deliberately demonstrate the bug the helper protects against.
+# `crates/test-observability/src/lib_tests.rs` also uses an inline
+# `#[allow]` for its own sync tests that exercise the global-default
+# dispatch — no tokio runtime is present so the helper's check is
+# vacuous, and the test-observability crate already sits beneath garter
+# in the workspace dep graph (cycle avoidance).
 
 [[disallowed-methods]]
 path = "tracing::subscriber::set_default"
@@ -70,3 +75,42 @@ reason = "Use `garter::tracing_test::set_default_in_current_thread` — it asser
 [[disallowed-methods]]
 path = "tracing::dispatcher::set_default"
 reason = "Use `garter::tracing_test::set_default_in_current_thread` — `tracing::subscriber::set_default` delegates to this lower-level function; disallowing the underlying form keeps the same thread-local-guard footgun out of reach for code that reaches under the abstraction. See bindreams/hole#302."
+
+# Test-time subscriber install — only hole-test-observability and the
+# production logging::init_multi site may install global tracing
+# subscribers via the `try_init` family. Direct callers in tests
+# trigger the #147 LogTracer perf regression that times out
+# `server_test_tests` on Windows CI. See bindreams/hole#301.
+#
+# Sanctioned suppressions:
+# 1. `crates/common/src/logging.rs::init_multi` — the production
+#    bridge logger; gated by a per-site `#[allow]` with a citation.
+# 2. `crates/test-observability/src/lib.rs` only ever uses the bare
+#    `tracing::subscriber::set_global_default` function, not
+#    `SubscriberInitExt::try_init`, so the rule does not bite it.
+# 3. `crates/galoshes/src/main.rs` and `crates/garter-bin/src/main.rs`
+#    are production binary mains that use `tracing_subscriber::fmt().init()`;
+#    sanctioned via per-site `#[allow]`.
+
+[[disallowed-methods]]
+path = "tracing_subscriber::util::SubscriberInitExt::init"
+reason = "Use hole_test_observability::register!() at lib.rs level for tests. Direct .init() calls trigger the #147 LogTracer perf trap (sets log::max_level=Trace and allocates a tracing Event for every log::*! from shadowsocks-service/tokio/mio). See bindreams/hole#301."
+
+[[disallowed-methods]]
+path = "tracing_subscriber::util::SubscriberInitExt::try_init"
+reason = "Use hole_test_observability::register!() at lib.rs level for tests; the production caller in crates/common/src/logging.rs is sanctioned via #[allow]. See bindreams/hole#301."
+
+# `fmt::SubscriberBuilder::{init,try_init}` are the `tracing_subscriber::fmt().init()`
+# entry points; they forward to `SubscriberInitExt::try_init` internally, so the
+# rules above do NOT catch them — clippy `disallowed_methods` matches the literal
+# called path, not the transitive forwarder. Ban explicitly. The two production
+# callers in `crates/galoshes/src/main.rs` and `crates/garter-bin/src/main.rs`
+# carry per-site `#[allow]` suppressions citing this rule.
+
+[[disallowed-methods]]
+path = "tracing_subscriber::fmt::SubscriberBuilder::init"
+reason = "Use hole_test_observability::register!() at lib.rs level for tests. Production main.rs callers in galoshes/garter-bin are sanctioned via #[allow]. See bindreams/hole#301."
+
+[[disallowed-methods]]
+path = "tracing_subscriber::fmt::SubscriberBuilder::try_init"
+reason = "Use hole_test_observability::register!() at lib.rs level for tests. See bindreams/hole#301."

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -90,6 +90,7 @@ ferrisetw = "1.2.0"
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 tokio = { version = "1", features = ["test-util"] }
 # In-process log capture in tests — verifies diagnostic spans /
 # `elapsed_ms` debug logs (#247) and the forwarder's typed-error log

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -831,22 +831,27 @@ fn diagnostics_bridge_error_after_failed_start() {
 
 // The bridge's error-log emission on IPC handler failure is a single
 // `error!(error = %e, "proxy start failed")` call in `handle_start` (and
-// the analogous calls in `handle_stop`/`handle_reload`). We deliberately
-// do NOT write a log-capture test for these, because installing a custom
-// tracing subscriber in a workspace test binary has process-wide side
-// effects — `tracing_subscriber::fmt().init()` calls `LogTracer::init()`
-// which mutates the global `log::max_level` state and makes every
-// `log::debug!`/`trace!` call in every dependency (shadowsocks-service,
-// tokio, mio, etc.) start flowing through the tracing → log bridge.
-// That added per-event overhead causes the parallel `server_test_tests`
-// (which do real localhost TCP handshakes with 5 s timeouts) to tip over
-// into timing out on GH Actions Windows runners — see the #147 CI
-// investigation.
+// the analogous calls in `handle_stop`/`handle_reload`). A dedicated
+// log-capture test for these is currently NOT in this file; the same
+// error path is exercised end-to-end by `start_failure_returns_error`
+// (line ~363), which verifies the HTTP 500 response and error message.
 //
-// Keeping the coverage elsewhere: `start_failure_returns_error` (line
-// ~363) exercises the exact same error path and verifies the HTTP 500
-// response and error message. The `error!` call is trivially verifiable
-// by reading the three-line match arm in `ipc.rs`.
+// Historical note: pre-#301, the comment here documented the #147
+// constraint — `tracing_subscriber::fmt().init()` calls
+// `LogTracer::init()`, which sets `log::max_level=Trace` and routes
+// every `log::*!` from `shadowsocks-service`/`tokio`/`mio` through
+// `tracing-log`, allocating per event. That overhead tipped
+// `server_test_tests` (real localhost TCP + 5 s timeouts) into CI
+// timeout on Windows runners.
+//
+// Since #301, the workspace ships `hole-test-observability` (a
+// dev-dep installed via `hole_test_observability::register!()` in
+// every test-bearing crate's `lib.rs`). It installs a global
+// subscriber via `set_global_default` (not `try_init`) with an
+// EnvFilter that level-rejects noisy third-party log events before
+// `tracing-log` allocates. Adding a thread-local
+// `set_default`-based capture for the IPC error paths would now be
+// safe; doing so is a follow-up, not in scope for #301.
 
 // public_ip handler test is intentionally omitted — it makes an external HTTP call
 // to ipinfo.io which is not available in CI and cannot be easily mocked without

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -24,6 +24,12 @@ pub mod socket;
 #[cfg(test)]
 mod test_support;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/bridge/src/test_support/port_alloc.rs
+++ b/crates/bridge/src/test_support/port_alloc.rs
@@ -61,10 +61,18 @@ pub(crate) async fn allocate_ephemeral_port(protocols: Protocols) -> u16 {
 /// attempts fit in a 10 s budget. The wrapper forces fast retries so the
 /// histogram reflects the actual attempt distribution.
 ///
-/// Diagnostics use `eprintln!` (not `tracing::*`) on purpose: installing a
-/// global tracing subscriber in the bridge test binary triggers the #147
-/// LogTracer regression that times out `server_test_tests` on Windows CI.
-/// See `crates/bridge/src/ipc_tests.rs:827-844`.
+/// Diagnostics use `eprintln!` on purpose. Pre-#301 the rationale was
+/// to avoid the #147 LogTracer regression — any global tracing
+/// subscriber install would set `log::max_level=Trace` and tip
+/// `server_test_tests` into Windows CI timeout. Since #301 the
+/// workspace ships `hole-test-observability` with an EnvFilter that
+/// level-rejects noisy log events before `tracing-log` allocates,
+/// so a `tracing::info!` here would actually be captured by
+/// Skuld/nextest on failure. `eprintln!` is retained because this
+/// diagnostic is intentionally always-on (not filterable) — it's a
+/// load-bearing histogram for understanding TCP-connect failure
+/// shapes on the runner, and we'd lose it if it went through the
+/// filter. See `crates/bridge/src/ipc_tests.rs` for the #301 follow-up.
 pub(crate) async fn wait_for_port(addr: SocketAddr, timeout: Duration) {
     let start = Instant::now();
     let mut attempts: u32 = 0;

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -50,6 +50,7 @@ yaml_serde = "0.10"
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 log = "0.4"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -8,6 +8,13 @@ pub mod protocol;
 pub mod retry;
 pub mod version;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds
+// (`dev-dependencies` are only available when building tests).
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     // FD-redirect tests in `logging_tests.rs` re-invoke the test binary as a

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -335,8 +335,14 @@ pub(crate) fn install_panic_hook_for_tests() {
     install_panic_hook_inner();
 }
 
-fn install_panic_hook() {
-    // Idempotent: only install once per process. See PANIC_HOOK_INSTALLED.
+/// Install the tracing-emitting panic hook (chains before stdlib default).
+/// Idempotent — subsequent calls in the same process are no-ops.
+///
+/// Called from production `init_multi` and from
+/// `hole-test-observability`'s ctor; safe to invoke from both because
+/// the `PANIC_HOOK_INSTALLED` AtomicBool ensures only one hook is
+/// chained per process. See bindreams/hole#301.
+pub fn install_panic_hook() {
     if PANIC_HOOK_INSTALLED.swap(true, std::sync::atomic::Ordering::SeqCst) {
         return;
     }
@@ -491,6 +497,11 @@ where
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
     use tracing_subscriber::Layer;
+    // Sanctioned by clippy.toml `disallowed_methods` (see #301).
+    // Production bridge logger — this is the ONE caller of
+    // `try_init` workspace-wide. Tests use
+    // `hole_test_observability::register!()` instead.
+    #[allow(clippy::disallowed_methods)]
     if let Err(e) = tracing_subscriber::registry()
         .with(env_filter)
         .with(file_layer)

--- a/crates/common/src/logging/logging_test_helpers.rs
+++ b/crates/common/src/logging/logging_test_helpers.rs
@@ -176,8 +176,32 @@ pub(crate) fn run_child(kind: &str) {
         "lossy_backpressure" => scenario_lossy_backpressure(),
         "echo_stderr" => scenario_echo_stderr(),
         "echo_stdout" => scenario_echo_stdout(),
+        "log_bridge_to_file" => scenario_log_bridge_to_file(),
         other => panic!("unknown HOLE_LOGGING_TEST_KIND: {other}"),
     }
+}
+
+/// Verifies that `log::info!` (from the `log` crate) is bridged into
+/// tracing's file-rotator layer by the production `init` path. The
+/// parent test spawns this scenario, then reads the log file the
+/// child wrote and asserts the marker is present.
+///
+/// Runs in a subprocess so that the production `init()`'s
+/// `set_global_default` succeeds — the parent test binary already
+/// has the `hole-test-observability` global subscriber installed.
+/// See bindreams/hole#301.
+fn scenario_log_bridge_to_file() {
+    let log_dir_str = std::env::var("HOLE_LOGGING_TEST_LOG_DIR").expect("HOLE_LOGGING_TEST_LOG_DIR var");
+    let log_dir = std::path::Path::new(&log_dir_str);
+    // The redirect would eat the libtest-mimic per-test result lines; we
+    // need its diagnostics if the child fails. Disabled the same way the
+    // pre-#301 in-process test did.
+    unsafe { std::env::set_var("HOLE_LOGGING_DISABLE_REDIRECT", "1") };
+    let _guard = super::init(log_dir, "test.log", "info");
+    log::info!("from-log-crate-bridge-test");
+    // Sleep so the non-blocking file rotator flushes before we exit.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    drop(_guard);
 }
 
 /// Helper used by the redirect_grandchild_* scenarios. Writes a marker line

--- a/crates/common/src/logging/logging_test_helpers.rs
+++ b/crates/common/src/logging/logging_test_helpers.rs
@@ -197,11 +197,13 @@ fn scenario_log_bridge_to_file() {
     // need its diagnostics if the child fails. Disabled the same way the
     // pre-#301 in-process test did.
     unsafe { std::env::set_var("HOLE_LOGGING_DISABLE_REDIRECT", "1") };
-    let _guard = super::init(log_dir, "test.log", "info");
+    let guard = super::init(log_dir, "test.log", "info");
     log::info!("from-log-crate-bridge-test");
-    // Sleep so the non-blocking file rotator flushes before we exit.
-    std::thread::sleep(std::time::Duration::from_millis(200));
-    drop(_guard);
+    // Drop the guard explicitly so the `tracing_appender::NonBlocking`
+    // worker thread flushes its in-flight events to disk before the
+    // child process exits. No sleep — the WorkerGuard's Drop joins
+    // the worker.
+    drop(guard);
 }
 
 /// Helper used by the redirect_grandchild_* scenarios. Writes a marker line

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -13,8 +13,6 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use super::*;
-
 // Test result format ==================================================================================================
 
 /// Captured-event record written by the child to its result file.
@@ -477,28 +475,29 @@ fn cleanup_legacy_daily_logs_tolerates_missing_directory(#[fixture(temp_dir)] di
 
 // Tests: log crate bridge =============================================================================================
 
-#[skuld::test(serial)]
+#[skuld::test]
 fn log_crate_macros_reach_file(#[fixture(temp_dir)] dir: &Path) {
-    // Disable the FD redirect inside init() so libtest-mimic's per-test
-    // result lines (printed to FD 1) aren't eaten. Clean up the env var on
-    // every exit path to avoid leaking the override into other tests.
-    struct EnvGuard;
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                std::env::remove_var("HOLE_LOGGING_DISABLE_REDIRECT");
-            }
-        }
-    }
-    unsafe {
-        std::env::set_var("HOLE_LOGGING_DISABLE_REDIRECT", "1");
-    }
-    let _env_guard = EnvGuard;
+    // Runs as a subprocess: post-#301 the parent has the
+    // `hole-test-observability` global subscriber installed, so the
+    // production `init()`'s `set_global_default` would fail in-process
+    // and the file layer would never receive events. The child has a
+    // clean global slot (the ctor short-circuits on
+    // `HOLE_LOGGING_TEST_KIND`).
     let log_dir = dir.join("log-bridge-test");
-    let _guard = init(&log_dir, "test.log", "info");
-
-    log::info!("from-log-crate-bridge-test");
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::fs::create_dir_all(&log_dir).expect("create log dir");
+    let exe = std::env::current_exe().expect("current_exe");
+    let status = Command::new(&exe)
+        .env("HOLE_LOGGING_TEST_KIND", "log_bridge_to_file")
+        .env("HOLE_LOGGING_TEST_LOG_DIR", &log_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("spawn child");
+    assert!(
+        status.success(),
+        "log_bridge_to_file child failed with status {status:?}"
+    );
 
     let entries: Vec<_> = std::fs::read_dir(&log_dir)
         .expect("read log dir")

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -24,6 +24,7 @@ proc-macro2 = "1"
 [dev-dependencies]
 dump = { path = "../dump" }
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 
 [[test]]
 name = "derive_tests"

--- a/crates/dump-macros/tests/derive_tests.rs
+++ b/crates/dump-macros/tests/derive_tests.rs
@@ -7,6 +7,10 @@
 use dump::{tag, Dump, DumpValue};
 use dump_macros::Dump as DeriveDump;
 
+// Install the workspace test subscriber + panic hook. See
+// `crates/test-observability/` and bindreams/hole#301.
+hole_test_observability::register!();
+
 fn main() {
     skuld::run_all();
 }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -60,6 +60,12 @@ macro_rules! dump {
     }};
 }
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -30,6 +30,7 @@ tempfile = "3"
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 
 [build-dependencies]
 sha2 = "0.10"

--- a/crates/galoshes/src/lib.rs
+++ b/crates/galoshes/src/lib.rs
@@ -8,6 +8,12 @@ mod embedded_tests;
 #[cfg(test)]
 mod yamux_tests;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -16,6 +16,9 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(not(v2ray_plugin_missing))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Sanctioned production caller of `fmt::SubscriberBuilder::init`;
+    // banned in tests via clippy.toml `disallowed_methods`. See #301.
+    #[allow(clippy::disallowed_methods)]
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();

--- a/crates/garter-bin/Cargo.toml
+++ b/crates/garter-bin/Cargo.toml
@@ -29,6 +29,7 @@ yaml_serde = "0.10"
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 
 [build-dependencies]
 xtask-lib = { path = "../../xtask-lib" }

--- a/crates/garter-bin/src/lib.rs
+++ b/crates/garter-bin/src/lib.rs
@@ -3,6 +3,12 @@ pub mod config;
 #[cfg(test)]
 mod config_tests;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/garter-bin/src/main.rs
+++ b/crates/garter-bin/src/main.rs
@@ -3,6 +3,9 @@ use garter::{BinaryPlugin, ChainRunner, PluginEnv};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Sanctioned production caller of `fmt::SubscriberBuilder::init`;
+    // banned in tests via clippy.toml `disallowed_methods`. See #301.
+    #[allow(clippy::disallowed_methods)]
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -29,6 +29,7 @@ harness = false
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 socket2 = "0.6"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -37,6 +37,12 @@ mod tap_tests;
 #[cfg(test)]
 mod tracing_test_tests;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -159,6 +159,10 @@ async fn pid_sink_fires_once_per_binary_plugin() {
     let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
 }
 
+// Install the workspace test subscriber + panic hook. See
+// `crates/test-observability/` and bindreams/hole#301.
+hole_test_observability::register!();
+
 fn main() {
     skuld::run_all();
 }

--- a/crates/garter/tests/tap_integration.rs
+++ b/crates/garter/tests/tap_integration.rs
@@ -114,6 +114,10 @@ async fn tap_relays_data_through_binary_plugin_to_echo_server() {
     let _ = tokio::time::timeout(Duration::from_secs(5), plugin_handle).await;
 }
 
+// Install the workspace test subscriber + panic hook. See
+// `crates/test-observability/` and bindreams/hole#301.
+hole_test_observability::register!();
+
 fn main() {
     skuld::run_all();
 }

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -35,3 +35,5 @@ windows = { version = "0.62", features = [
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }
 tempfile = "3"
+# Used by the ctor-linkage regression test for #301.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -33,4 +33,5 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 tempfile = "3"

--- a/crates/handle-holders/src/lib.rs
+++ b/crates/handle-holders/src/lib.rs
@@ -117,6 +117,12 @@ pub fn log_holders(path: &Path) {
 #[cfg(test)]
 mod lib_tests;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/handle-holders/src/lib_tests.rs
+++ b/crates/handle-holders/src/lib_tests.rs
@@ -13,3 +13,35 @@ fn find_holders_missing_file_returns_empty() {
         "expected no holders for nonexistent path, got {holders:?}"
     );
 }
+
+/// Cross-platform ctor-linkage regression test for #301.
+///
+/// The `hole_test_observability::register!()` invocation at the top
+/// of `lib.rs` expands to a `#[ctor::ctor]` static in THIS crate's
+/// object file. If a future MSVC link.exe / lld / ld / ld64 change
+/// (or a workspace refactor) DCE'd the static, our test subscriber
+/// would silently disappear from this binary.
+///
+/// We detect this by asserting that AFTER our ctor has run, calling
+/// `set_global_default` again fails — proving a global default is
+/// already installed. The failure mode of a DCE'd ctor would be
+/// `set_global_default` *succeeding* here (no prior install).
+///
+/// Lives in `handle-holders` rather than `test-observability`
+/// because the test must run inside a CONSUMER crate's test binary —
+/// the regression we're guarding against is "consumer's
+/// `#[cfg(test)] register!()` macro fired the ctor in the consumer's
+/// object file." Inside test-observability's own test binary, the
+/// ctor is in the crate itself; that doesn't exercise the same path.
+#[skuld::test]
+fn hole_test_observability_ctor_fired_in_this_binary() {
+    let subscriber = tracing_subscriber::registry();
+    let result = tracing::subscriber::set_global_default(subscriber);
+    assert!(
+        result.is_err(),
+        "set_global_default succeeded — the hole-test-observability ctor did NOT \
+         install a global subscriber in this binary. The register!() macro at \
+         crates/handle-holders/src/lib.rs may have been DCE'd by the linker. \
+         See bindreams/hole#301."
+    );
+}

--- a/crates/handle-holders/tests/live_holders.rs
+++ b/crates/handle-holders/tests/live_holders.rs
@@ -19,6 +19,10 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+// Install the workspace test subscriber + panic hook. See
+// `crates/test-observability/` and bindreams/hole#301.
+hole_test_observability::register!();
+
 fn main() {
     skuld::run_all();
 }

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -61,6 +61,7 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 axum = { version = "0.8", default-features = false, features = ["json"] }
 tower = { version = "0.5", features = ["util"] }
 tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -11,6 +11,12 @@ pub mod tray_icons;
 pub mod update;
 pub mod version;
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "hole-test-observability"
+version = "0.1.0"
+edition.workspace = true
+license = "GPL-3.0-or-later"
+publish = false
+description = "Process-global tracing subscriber + panic hook for Hole workspace test binaries. Dev-dep-only."
+repository = "https://github.com/bindreams/hole"
+
+[package.metadata.hole-release]
+group = "hole"
+
+[lints]
+workspace = true
+
+[lib]
+harness = false
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "registry"] }
+ctor = { workspace = true }
+# Direct dep on hole-common for `install_panic_hook` — Cargo allows
+# the cycle because hole-common only references this crate via
+# [dev-dependencies].
+hole-common = { path = "../common" }
+
+[dev-dependencies]
+skuld = { workspace = true }
+log = "0.4"
+tracing-log = "0.2"

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -20,9 +20,15 @@ harness = false
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "registry"] }
 ctor = { workspace = true }
+
 # Direct dep on hole-common for `install_panic_hook` — Cargo allows
 # the cycle because hole-common only references this crate via
-# [dev-dependencies].
+# [dev-dependencies]. Gated to the platforms hole-common supports
+# (hole-common itself uses `compile_error!` on non-macOS/Windows
+# targets, so we can't pull it in on Linux/etc. without breaking
+# downstream Linux clippy jobs that hit this crate transitively via
+# garter/garter-bin/galoshes dev-deps).
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 hole-common = { path = "../common" }
 
 [dev-dependencies]

--- a/crates/test-observability/src/lib.rs
+++ b/crates/test-observability/src/lib.rs
@@ -155,6 +155,13 @@ pub fn install() {
         // Hole's tracing-emitting panic hook. Chains before the
         // stdlib default. Idempotent via its own AtomicBool, so
         // safe alongside any production caller of `init_logging`.
+        // Gated to Mac/Windows because `hole-common` only compiles
+        // on those platforms (see this crate's Cargo.toml); on
+        // Linux/etc. (where ex-Galoshes crates get clippy-checked
+        // and transitively pull in this crate via dev-deps) the
+        // stdlib default panic hook + `RUST_BACKTRACE=full` above
+        // is the fallback diagnostic.
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
         hole_common::logging::install_panic_hook();
     });
 }

--- a/crates/test-observability/src/lib.rs
+++ b/crates/test-observability/src/lib.rs
@@ -1,0 +1,163 @@
+//! Process-global test observability for the Hole workspace.
+//!
+//! Each test-bearing crate invokes [`register!`] from its `lib.rs`. The
+//! macro expands to a `#[cfg(test)]` `#[ctor::ctor]` block in the
+//! **consumer** crate (not this rlib) that calls [`install`] before
+//! `main` runs. [`install`] is idempotent.
+//!
+//! What gets installed:
+//!
+//! * `RUST_BACKTRACE=full` (if unset) so the stdlib panic hook prints
+//!   a usable backtrace.
+//! * A global `tracing` subscriber writing to stderr. Skuld's
+//!   FD-level capture (under bare `cargo test`) and nextest's
+//!   per-subprocess capture (under CI) buffer and dump the events on
+//!   test failure. Filter defaults to a catch-all `info` with every
+//!   Hole-side crate pinned to `debug`; override with
+//!   `HOLE_TEST_LOG=...`.
+//! * Hole's tracing-emitting panic hook
+//!   ([`hole_common::logging::install_panic_hook`]) chained before the
+//!   stdlib default — adds `target=hole::panic` events with
+//!   `force_capture` backtraces.
+//!
+//! ## Why a separate crate (vs feature on hole-common)
+//!
+//! * `dev-dependencies` only — never linked into production binaries.
+//! * Single ownership for the `pub use ::ctor;` re-export and the
+//!   `register!` macro.
+//!
+//! ## Avoiding the #147 LogTracer perf trap
+//!
+//! `tracing_subscriber::fmt().init()` (and any `SubscriberInitExt::try_init`)
+//! calls `tracing_log::LogTracer::init()` as a side effect. That sets
+//! `log::max_level()` to `Trace` and routes every `log::debug!` /
+//! `log::trace!` from `shadowsocks-service`, `tokio`, `mio`, `hyper`
+//! through tracing — the per-event allocation in `tracing-log` tipped
+//! `server_test_tests` (real localhost TCP + 5 s timeouts) into CI
+//! timeout on GH Actions Windows runners. We install via the bare
+//! `tracing::subscriber::set_global_default` (not `try_init`), but the
+//! load-bearing safeguard is the EnvFilter default: the noisy
+//! third-party namespaces stay at `info` so their `log::trace!` /
+//! `log::debug!` events are level-rejected at `Dispatch::enabled()`
+//! before `tracing-log` allocates an `Event`.
+//!
+//! See bindreams/hole#301 (motivation), #300 (trigger flake), #147
+//! (regression constraint).
+
+use std::sync::Once;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::EnvFilter;
+
+/// Re-exported so consumer crates don't need to add `ctor` to their
+/// own dev-dependencies.
+pub use ctor;
+
+/// Default `EnvFilter` directives. Catch-all `info`; every Hole-side
+/// crate is pinned to `debug` for diagnostic depth. Third-party
+/// crates stay at `info` — enough to keep `log::trace!` from
+/// `shadowsocks-service` / `tokio` / `mio` level-rejected before
+/// `tracing-log` allocates an Event.
+///
+/// Override per-binary with `HOLE_TEST_LOG=...`.
+const DEFAULT_FILTER: &str = "info,\
+    hole=debug,\
+    hole_common=debug,\
+    hole_bridge=debug,\
+    hole_test_observability=debug,\
+    tun_engine=debug,\
+    tun_engine_macros=debug,\
+    garter=debug,\
+    garter_bin=debug,\
+    galoshes=debug,\
+    dump=debug,\
+    dump_macros=debug,\
+    handle_holders=debug";
+
+/// Install the global subscriber, panic hook, and backtrace env var.
+///
+/// Idempotent: subsequent calls are no-ops. Safe to invoke from any
+/// `#[ctor::ctor]` site or from a regular `fn`.
+///
+/// Short-circuits and does nothing when `HOLE_LOGGING_TEST_KIND` is
+/// set — the FD-redirect child-process branch in
+/// `crates/common/src/lib.rs::main` re-dispatches into
+/// `logging_test_helpers::run_child` which installs its OWN
+/// `set_global_default`. Pre-installing here would make that call
+/// panic on the "already set" error. The child branch short-circuits
+/// `skuld::run_all` before any test body runs, so the global
+/// subscriber serves no diagnostic purpose there anyway.
+pub fn install() {
+    if std::env::var_os("HOLE_LOGGING_TEST_KIND").is_some() {
+        return;
+    }
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: ctor runs pre-main, single-threaded. The workspace
+        // has no other ctor that reads env vars (grep-verified for
+        // `#[ctor]` / `ctor::ctor`).
+        if std::env::var_os("RUST_BACKTRACE").is_none() {
+            unsafe { std::env::set_var("RUST_BACKTRACE", "full") };
+        }
+
+        let env_filter = EnvFilter::try_from_env("HOLE_TEST_LOG").unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+
+        let subscriber = tracing_subscriber::registry().with(env_filter).with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_ansi(false)
+                .with_target(true)
+                .with_level(true),
+        );
+
+        // set_global_default — bare function, NOT
+        // SubscriberInitExt::try_init() — so we do not call
+        // LogTracer::init() ourselves. The EnvFilter handles noisy
+        // third-party log events whether or not LogTracer ends up
+        // installed by another code path. See #147.
+        let _ = tracing::subscriber::set_global_default(subscriber);
+
+        // Hole's tracing-emitting panic hook. Chains before the
+        // stdlib default. Idempotent via its own AtomicBool, so
+        // safe alongside any production caller of `init_logging`.
+        hole_common::logging::install_panic_hook();
+    });
+}
+
+/// Invoke from each test-bearing crate's `lib.rs` or integration
+/// test file's top level:
+///
+/// ```ignore
+/// hole_test_observability::register!();
+/// ```
+///
+/// Expands to a `#[cfg(test)]` private module containing a
+/// `#[ctor::ctor]` function that calls [`install`]. The ctor's
+/// `#[used]` static is emitted in the **consumer** crate's object
+/// file — sidestepping rlib dead-code-elimination across linker
+/// variants (MSVC link.exe / lld / ld / ld64).
+///
+/// One invocation per crate root (including each `tests/foo.rs`
+/// integration-test target). The expanded module name is fixed, so
+/// invoking twice in the same crate root would collide; that's
+/// intentional — one entry-point per test binary.
+#[macro_export]
+macro_rules! register {
+    () => {
+        #[cfg(test)]
+        #[doc(hidden)]
+        mod _hole_test_observability_init {
+            #[$crate::ctor::ctor]
+            fn init() {
+                $crate::install();
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod lib_tests;
+
+#[cfg(test)]
+fn main() {
+    skuld::run_all();
+}

--- a/crates/test-observability/src/lib.rs
+++ b/crates/test-observability/src/lib.rs
@@ -44,13 +44,17 @@
 //! See bindreams/hole#301 (motivation), #300 (trigger flake), #147
 //! (regression constraint).
 
+use std::io::Write;
 use std::sync::Once;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
 
-/// Re-exported so consumer crates don't need to add `ctor` to their
-/// own dev-dependencies.
-pub use ctor;
+/// Re-exported attribute macro so consumer crates don't need to add
+/// `ctor` to their own dev-dependencies. Exposed as
+/// `hole_test_observability::ctor` (the attribute macro), invoked
+/// from the [`register!`] expansion as `#[$crate::ctor]`.
+#[doc(hidden)]
+pub use ::ctor::ctor;
 
 /// Default `EnvFilter` directives. Catch-all `info`; every Hole-side
 /// crate is pinned to `debug` for diagnostic depth. Third-party
@@ -99,7 +103,28 @@ pub fn install() {
             unsafe { std::env::set_var("RUST_BACKTRACE", "full") };
         }
 
-        let env_filter = EnvFilter::try_from_env("HOLE_TEST_LOG").unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+        // Layer `HOLE_TEST_LOG` ON TOP of the default filter so users
+        // who pass e.g. `HOLE_TEST_LOG=hole_bridge=debug` get THAT
+        // directive in addition to the catch-all `info` and the
+        // per-crate `debug` pins — not in place of them.
+        let mut env_filter = EnvFilter::new(DEFAULT_FILTER);
+        if let Ok(extra) = std::env::var("HOLE_TEST_LOG") {
+            for directive in extra.split(',') {
+                let directive = directive.trim();
+                if directive.is_empty() {
+                    continue;
+                }
+                match directive.parse() {
+                    Ok(d) => env_filter = env_filter.add_directive(d),
+                    Err(e) => {
+                        let _ = writeln!(
+                            std::io::stderr(),
+                            "hole-test-observability: ignoring invalid HOLE_TEST_LOG directive {directive:?}: {e}"
+                        );
+                    }
+                }
+            }
+        }
 
         let subscriber = tracing_subscriber::registry().with(env_filter).with(
             tracing_subscriber::fmt::layer()
@@ -114,7 +139,18 @@ pub fn install() {
         // LogTracer::init() ourselves. The EnvFilter handles noisy
         // third-party log events whether or not LogTracer ends up
         // installed by another code path. See #147.
-        let _ = tracing::subscriber::set_global_default(subscriber);
+        //
+        // If a foreign global subscriber was installed before our ctor
+        // (linker-order race, unlikely but theoretically possible),
+        // fail loud to stderr rather than silently swallow — this
+        // crate's whole purpose is to NOT drop diagnostics silently.
+        if let Err(e) = tracing::subscriber::set_global_default(subscriber) {
+            let _ = writeln!(
+                std::io::stderr(),
+                "hole-test-observability: set_global_default failed; \
+                 a foreign subscriber pre-empted ours: {e}"
+            );
+        }
 
         // Hole's tracing-emitting panic hook. Chains before the
         // stdlib default. Idempotent via its own AtomicBool, so
@@ -146,7 +182,7 @@ macro_rules! register {
         #[cfg(test)]
         #[doc(hidden)]
         mod _hole_test_observability_init {
-            #[$crate::ctor::ctor]
+            #[$crate::ctor]
             fn init() {
                 $crate::install();
             }

--- a/crates/test-observability/src/lib_tests.rs
+++ b/crates/test-observability/src/lib_tests.rs
@@ -1,0 +1,106 @@
+//! Regression tests for `hole_test_observability::install`.
+//!
+//! Two structural gates:
+//!
+//! 1. [`install_subscriber_dispatches_info_events`] — confirms the
+//!    global subscriber is wired up: an `info!` event reaches a
+//!    sibling `set_default` capture buffer.
+//! 2. [`shadowsocks_service_trace_is_filter_rejected_cheaply`] — the
+//!    #147 perf-trap gate. Even with `LogTracer` installed,
+//!    `log::trace!` from a noisy third-party namespace must be
+//!    level-rejected at `Dispatch::enabled()` before `tracing-log`
+//!    allocates.
+
+use super::*;
+use std::io;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone)]
+struct Buf(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for Buf {
+    fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for Buf {
+    type Writer = Buf;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[skuld::test]
+fn install_subscriber_dispatches_info_events() {
+    install(); // idempotent
+
+    // Capture into a sibling thread-local subscriber. The global
+    // installed by `install()` writes to stderr; the local one here
+    // is what we assert against.
+    let buf = Buf(Arc::new(Mutex::new(Vec::new())));
+    let local = tracing_subscriber::fmt()
+        .with_writer(buf.clone())
+        .with_ansi(false)
+        .finish();
+    // Sync test, no tokio runtime — the #302
+    // `set_default_in_current_thread` helper's check would pass
+    // through. Sanctioned to use the raw form here (test-observability
+    // sits beneath garter in the dep graph, so we can't depend on the
+    // helper).
+    #[allow(clippy::disallowed_methods)]
+    let _g = tracing::subscriber::set_default(local);
+
+    tracing::info!(target: "ho_test_marker", value = 42, "regression-event");
+
+    let s = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+    assert!(s.contains("ho_test_marker"), "marker missing in captured output:\n{s}");
+    assert!(
+        s.contains("regression-event"),
+        "message missing in captured output:\n{s}"
+    );
+    assert!(s.contains("value=42"), "field missing in captured output:\n{s}");
+}
+
+#[skuld::test]
+fn shadowsocks_service_trace_is_filter_rejected_cheaply() {
+    install();
+    // Simulate any test path that installs LogTracer (the existing
+    // `subscriber.set_default()` method-form sites in bridge tests do
+    // this implicitly). Discard result — second-install is harmless.
+    let _ = tracing_log::LogTracer::init();
+
+    // Hot loop emitting a noisy third-party log event. EnvFilter
+    // pins `shadowsocks_service` to `info` via the catch-all (no
+    // explicit pin for `shadowsocks_service` in DEFAULT_FILTER, so
+    // it inherits the `info` catch-all). A `log::trace!` is below
+    // `info` and must be rejected before allocation.
+    let start = std::time::Instant::now();
+    for _ in 0..100_000 {
+        log::trace!(target: "shadowsocks_service::relay", "fake busy event");
+    }
+    let elapsed = start.elapsed();
+
+    // Expected wall-clock is < 10 ms. A regression (full formatting
+    // + write per event) would be tens of seconds. 500 ms threshold
+    // is generous.
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "shadowsocks_service log::trace! took {elapsed:?} for 100k events — \
+         EnvFilter level-rejection path may have regressed. See bindreams/hole#147."
+    );
+}
+
+#[skuld::test]
+fn install_is_idempotent() {
+    install();
+    install();
+    install();
+    // No panic, no double-set warning. The `Once` inside ensures
+    // only the first call observed.
+}

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -23,6 +23,7 @@ proc-macro2 = "1"
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }
 trybuild = "1"
 
 [[test]]

--- a/crates/tun-engine-macros/tests/freeze_tests.rs
+++ b/crates/tun-engine-macros/tests/freeze_tests.rs
@@ -8,6 +8,10 @@ use std::time::Duration;
 
 use tun_engine_macros::freeze;
 
+// Install the workspace test subscriber + panic hook. See
+// `crates/test-observability/` and bindreams/hole#301.
+hole_test_observability::register!();
+
 fn main() {
     skuld::run_all();
 }

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -59,3 +59,4 @@ wintun-bindings = "0.7"
 
 [dev-dependencies]
 skuld = { workspace = true }
+hole-test-observability = { path = "../test-observability" }

--- a/crates/tun-engine/src/lib.rs
+++ b/crates/tun-engine/src/lib.rs
@@ -24,6 +24,12 @@
 //! `teardown_routes` are lint-disallowed outside the crate's own internals
 //! (see workspace `clippy.toml`). See bindreams/hole#165.
 
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
+
 #[cfg(test)]
 fn main() {
     skuld::run_all();


### PR DESCRIPTION
Fixes #301.

## Summary

- New dev-dep-only crate `crates/test-observability/` (`hole-test-observability`) exposes `hole_test_observability::register!()`. Each of the 11 test-bearing workspace crates invokes the macro from its `lib.rs` (and from each integration `tests/*.rs`); it expands to a `#[ctor::ctor]` static IN the consumer crate so rlib DCE can't strip it across linker variants (MSVC link.exe / lld / ld / ld64).
- The ctor installs a process-global `tracing_subscriber` writing to stderr (no LogTracer side effect — uses bare `tracing::subscriber::set_global_default`, not `SubscriberInitExt::try_init`). EnvFilter defaults to catch-all `info` with every Hole-side crate pinned to `debug`. `RUST_BACKTRACE=full` is set if unset. Hole's `install_panic_hook` (now `pub`) is installed so panic events emit as `target=hole::panic` tracing events with `force_capture` backtrace.
- Skuld's FD-level capture (under bare `cargo test`) and nextest's per-subprocess capture (CI) both buffer the stderr stream and dump on failure — so the production code's `tracing::*!` diagnostic events (the trigger for #300's `port_alloc` flake) now surface in CI failure output.
- `clippy.toml` bans `SubscriberInitExt::{init,try_init}` AND `fmt::SubscriberBuilder::{init,try_init}` workspace-wide. Three sanctioned production callers (`common/logging::init_multi`, `galoshes/main`, `garter-bin/main`) carry per-site `#[allow]` with citations.
- One existing in-process test (`log_crate_macros_reach_file`) was refactored to spawn a subprocess (new `HOLE_LOGGING_TEST_KIND=log_bridge_to_file` variant) because it called production `init()` which races our global subscriber install. The ctor short-circuits when `HOLE_LOGGING_TEST_KIND` is set so the child gets a clean global slot.

## Why this design

- #147 is the dominant constraint: `tracing_subscriber::fmt().init()` calls `LogTracer::init()` as a side effect, sets `log::max_level=Trace`, and tipped `server_test_tests` into Windows CI timeout via per-event allocations in `tracing-log`. The load-bearing defense is the EnvFilter (noisy third-party crates stay at `info`, level-rejected at `Dispatch::enabled()` before allocation); the secondary defense is using the bare `set_global_default` function so we don't install LogTracer ourselves.
- No Skuld code change. Skuld's FD-level capture is already orthogonal to the subscriber install. A companion docs-only PR against bindreams/skuld documents the `set_global_default`-vs-`try_init` pattern for other Skuld users.

## Regression tests

- `crates/test-observability/src/lib_tests.rs`:
  - `install_subscriber_dispatches_info_events` — info event reaches a sibling capture buffer.
  - `shadowsocks_service_trace_is_filter_rejected_cheaply` — 100k `log::trace!` from a third-party namespace complete in < 500ms (regression gate for #147 perf trap).
  - `install_is_idempotent`.
- `crates/handle-holders/src/lib_tests.rs::hole_test_observability_ctor_fired_in_this_binary` — cross-platform regression gate that the consumer-crate `register!()` ctor is not DCE'd by future linker changes.

## Test plan

- [x] `cargo build --workspace --tests` clean.
- [x] `cargo clippy --workspace --tests --all-targets` clean (no new denies).
- [x] `cargo nextest run -p hole-test-observability` — 3/3 pass.
- [x] `cargo nextest run -p hole-common` — 188/188 pass (incl. refactored `log_crate_macros_reach_file`).
- [x] `cargo nextest run -p hole -p hole-test-observability -p hole-common` — 393/393 pass.
- [x] `cargo nextest run -p hole-bridge` — 420/422 pass. The 2 failures (`e2e_socks5_udp_associate_roundtrip`, `e2e_none_full_tunnel_roundtrip`) are pre-existing on `main` (verified on a baseline worktree).
- [x] `cargo nextest run -p dump -p dump-macros -p tun-engine -p tun-engine-macros -p garter -p galoshes -p hole-test-observability` — 229/229 pass.
- [x] All 9 assertion-target test sites (proxy_manager_tests ×4, forwarder_tests ×3, system_tests, apply_dns_settings, cli_log_tests, tap_integration, yaml_format, logging_tests) — pass unchanged.
- [x] Manual diagnostic probe in `port_alloc_tests::ensure_port_free_ok_on_free_port`: captured stderr contained the production `INFO free_port_retry`, `WARN free_port_exhausted`, and the structured `ERROR hole::panic` with backtrace. Reverted.
- [x] `cargo xtask version --check --group hole` accepts the new member.
- [ ] CI matrix (Linux/macOS/Windows nextest). Watch `server_test_tests` Windows wall-clock specifically for #147 regression.

## References

- #301 motivation, #300 trigger flake, #147 regression constraint.
- Companion docs PR against bindreams/skuld (filed separately): "capturing tracing/log output" — documents the `set_global_default` (not `try_init`) pattern for Skuld users.