### PR TITLE
fix(release): pin --latest at draft creation across all four tracks

### DIFF
--- a/.github/workflows/draft-release-galoshes.yaml
+++ b/.github/workflows/draft-release-galoshes.yaml
@@ -133,6 +133,10 @@ jobs:
           cat release-notes.md
           echo "--- end ---"
 
+      # --latest=false at draft-create time pins GitHub's make_latest so
+      # the eventual publish doesn't promote this release to
+      # /releases/latest via the legacy semver+date heuristic. Hole is
+      # the only track that claims /latest. See #308.
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -142,6 +146,7 @@ jobs:
           TAG="releases/galoshes/v${VERSION}"
           gh release create "$TAG" \
             --draft \
+            --latest=false \
             --notes-file release-notes.md \
             --title "galoshes v${VERSION}" \
             --target "${{ github.sha }}" \

--- a/.github/workflows/draft-release-garter.yaml
+++ b/.github/workflows/draft-release-garter.yaml
@@ -141,6 +141,10 @@ jobs:
           cat release-notes.md
           echo "--- end ---"
 
+      # --latest=false at draft-create time pins GitHub's make_latest so
+      # the eventual publish doesn't promote this release to
+      # /releases/latest via the legacy semver+date heuristic. Hole is
+      # the only track that claims /latest. See #308.
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -150,6 +154,7 @@ jobs:
           TAG="releases/garter/v${VERSION}"
           gh release create "$TAG" \
             --draft \
+            --latest=false \
             --notes-file release-notes.md \
             --title "garter v${VERSION}" \
             --target "${{ github.sha }}" \

--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -152,6 +152,11 @@ jobs:
           cat release-notes.md
           echo "--- end ---"
 
+      # Hole is the user-facing product and is the canonical holder of
+      # /releases/latest. Pinning --latest=true at draft-create time
+      # means make_latest is set through the draft→publish lifecycle
+      # and doesn't depend on GitHub's legacy semver+date heuristic.
+      # The other three tracks pass --latest=false. See #308.
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -161,6 +166,7 @@ jobs:
           TAG="releases/hole/v${VERSION}"
           gh release create "$TAG" \
             --draft \
+            --latest=true \
             --notes-file release-notes.md \
             --title "hole v${VERSION}" \
             --target "${{ github.sha }}" \

--- a/.github/workflows/draft-release-v2ray-plugin.yaml
+++ b/.github/workflows/draft-release-v2ray-plugin.yaml
@@ -168,6 +168,10 @@ jobs:
           cat release-notes.md
           echo "--- end ---"
 
+      # --latest=false at draft-create time pins GitHub's make_latest so
+      # the eventual publish doesn't promote this release to
+      # /releases/latest via the legacy semver+date heuristic. Hole is
+      # the only track that claims /latest. See #308.
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -177,6 +181,7 @@ jobs:
           TAG="releases/v2ray-plugin/v${VERSION}"
           gh release create "$TAG" \
             --draft \
+            --latest=false \
             --notes-file release-notes.md \
             --title "v2ray-plugin v${VERSION}" \
             --target "${{ github.sha }}" \

--- a/.github/workflows/publish-release-galoshes.yaml
+++ b/.github/workflows/publish-release-galoshes.yaml
@@ -43,5 +43,8 @@ jobs:
       - name: Publish release
         run: |
           TAG="${{ steps.version.outputs.tag }}"
+          # Belt-and-suspenders: --latest=false was pinned at draft
+          # creation; re-assert here so the published state matches even
+          # if the draft was edited externally. See #308.
           gh release edit "$TAG" --draft=false --latest=false
           echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/publish-release-garter.yaml
+++ b/.github/workflows/publish-release-garter.yaml
@@ -112,5 +112,8 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
+          # Belt-and-suspenders: --latest=false was pinned at draft
+          # creation; re-assert here so the published state matches even
+          # if the draft was edited externally. See #308.
           gh release edit "$TAG" --draft=false --latest=false
           echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/publish-release-hole.yaml
+++ b/.github/workflows/publish-release-hole.yaml
@@ -62,5 +62,8 @@ jobs:
       - name: Publish release
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          gh release edit "$TAG" --draft=false
+          # Belt-and-suspenders: --latest=true was set at draft creation,
+          # re-assert here so the published state matches even if the
+          # draft was edited externally. See #308.
+          gh release edit "$TAG" --draft=false --latest=true
           echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/publish-release-v2ray-plugin.yaml
+++ b/.github/workflows/publish-release-v2ray-plugin.yaml
@@ -43,5 +43,8 @@ jobs:
       - name: Publish release
         run: |
           TAG="${{ steps.version.outputs.tag }}"
+          # Belt-and-suspenders: --latest=false was pinned at draft
+          # creation; re-assert here so the published state matches even
+          # if the draft was edited externally. See #308.
           gh release edit "$TAG" --draft=false --latest=false
           echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,6 +489,22 @@ public actions (tag creation, `cargo publish` for garter, latest-flip)
 sanity-check gate before irreversible work, not just for hole's signing
 step.
 
+### `/releases/latest` pinning policy
+
+Each draft workflow pins `--latest` at `gh release create` time:
+`hole=true`, `galoshes`/`garter`/`v2ray-plugin`=`false`. Each publish
+workflow re-asserts the same value on `gh release edit` as
+belt-and-suspenders. Without the create-time pin, GitHub re-evaluates
+`make_latest` via the legacy semver+date heuristic on first publish and
+can promote the wrong track to `/releases/latest` — this is what
+happened to `releases/v2ray-plugin/v1.3.3-hole.1` before #308.
+
+Pre-release semver versions (e.g. v2ray-plugin's `X.Y.Z-hole.N`) are
+NOT marked with `--prerelease=true`. The GitHub UI's "pre-release"
+label means "beta/RC quality" to users, which is wrong for vendor
+patches that are production-ready. `--latest=false` alone is
+sufficient to keep them out of `/releases/latest`.
+
 ### Per-product release workflows
 
 - **hole**: `draft-release-hole.yaml` → `scripts/sign-release.py <version>` → `publish-release-hole.yaml`. Tag created at publish.


### PR DESCRIPTION
## Summary

- The v2ray-plugin release took `/releases/latest` despite `publish-release-v2ray-plugin.yaml` passing `--latest=false` to `gh release edit`. Likely cause: GitHub re-evaluates `make_latest` using the legacy semver+date heuristic during draft→publish transition when no `make_latest` was set at create time. The publish-edit-time flag is a non-authoritative preference if no competing release exists.
- All four draft workflows now pass `--latest=<bool>` to `gh release create` (gh CLI ≥2.39 supports it; runner has 2.87+):
  - `draft-release-hole.yaml` → `--latest=true` (hole is the canonical /latest holder).
  - `draft-release-galoshes.yaml` / `draft-release-garter.yaml` / `draft-release-v2ray-plugin.yaml` → `--latest=false`.
- `publish-release-hole.yaml` re-asserts `--latest=true` at the publish-edit step as belt-and-suspenders.
- **No `--prerelease` flag involvement.** `1.3.3-hole.1` IS a semver pre-release identifier, but the GH UI's "pre-release" label means "beta/RC quality" to users, which doesn't apply to a vendor patch. Using `--latest` exclusively avoids that misleading signal.

Closes #308.

## Test plan

- [x] Manual probe before PR: `gh release edit releases/v2ray-plugin/v1.3.3-hole.1 --latest=false` had no effect (confirms the publish-edit alone is insufficient). The existing v2ray-plugin release will be displaced from `/releases/latest` when the first hole release publishes.
- [x] YAML parse: `python -c "import yaml; yaml.safe_load(open(f))"` on all 5 modified workflows.
- [x] Grep verification: 3 non-hole draft workflows contain `--latest=false`; both hole files contain `--latest=true`.
- [ ] Post-merge: cut the next galoshes / garter / v2ray-plugin release through the updated workflow. Verify `gh release view <tag> --json isDraft` is created without taking `/releases/latest` away from hole (once hole publishes).
- [ ] Post-merge: cut the first hole release. Verify `gh api repos/bindreams/hole/releases/latest --jq .tag_name` returns the hole tag.