### PR TITLE
fix(release-notes): include workspace-engineering paths in all tracks

### DIFF
--- a/.github/release-galoshes.yaml
+++ b/.github/release-galoshes.yaml
@@ -9,22 +9,23 @@ initial_release: |
   decoupling rationale.
 
 include_paths:
+  # Note: crates/garter/** was removed from this list in #312. Garter
+  # changes belong in garter release notes; galoshes consumers wanting
+  # garter-library detail can read the garter release notes directly.
   - crates/galoshes/**
   - external/v2ray-plugin/**
   - .github/workflows/draft-release-galoshes.yaml
   - .github/workflows/publish-release-galoshes.yaml
   - .github/release-galoshes.yaml
   # Workspace-engineering files affect every release track. See #312.
-  # (crates/garter/** removed: garter changes belong in garter release
-  # notes; galoshes consumers wanting embedded-garter detail can read
-  # the garter release notes directly.)
   - xtask/**
   - xtask-lib/**
   - scripts/generate-release-notes.py
-  - scripts/sign-release.py
   - Cargo.toml
   - Cargo.lock
   - build.yaml
+  - prek.toml
+  - clippy.toml
 
 categories:
   - title: "🚀 Features"

--- a/.github/release-galoshes.yaml
+++ b/.github/release-galoshes.yaml
@@ -10,11 +10,21 @@ initial_release: |
 
 include_paths:
   - crates/galoshes/**
-  - crates/garter/**
   - external/v2ray-plugin/**
   - .github/workflows/draft-release-galoshes.yaml
   - .github/workflows/publish-release-galoshes.yaml
   - .github/release-galoshes.yaml
+  # Workspace-engineering files affect every release track. See #312.
+  # (crates/garter/** removed: garter changes belong in garter release
+  # notes; galoshes consumers wanting embedded-garter detail can read
+  # the garter release notes directly.)
+  - xtask/**
+  - xtask-lib/**
+  - scripts/generate-release-notes.py
+  - scripts/sign-release.py
+  - Cargo.toml
+  - Cargo.lock
+  - build.yaml
 
 categories:
   - title: "🚀 Features"

--- a/.github/release-garter.yaml
+++ b/.github/release-garter.yaml
@@ -20,10 +20,11 @@ include_paths:
   - xtask/**
   - xtask-lib/**
   - scripts/generate-release-notes.py
-  - scripts/sign-release.py
   - Cargo.toml
   - Cargo.lock
   - build.yaml
+  - prek.toml
+  - clippy.toml
 
 categories:
   - title: "🚀 Features"

--- a/.github/release-garter.yaml
+++ b/.github/release-garter.yaml
@@ -16,6 +16,14 @@ include_paths:
   - .github/workflows/draft-release-garter.yaml
   - .github/workflows/publish-release-garter.yaml
   - .github/release-garter.yaml
+  # Workspace-engineering files affect every release track. See #312.
+  - xtask/**
+  - xtask-lib/**
+  - scripts/generate-release-notes.py
+  - scripts/sign-release.py
+  - Cargo.toml
+  - Cargo.lock
+  - build.yaml
 
 categories:
   - title: "🚀 Features"

--- a/.github/release-hole.yaml
+++ b/.github/release-hole.yaml
@@ -39,6 +39,7 @@ include_paths:
   - Cargo.lock
   - build.yaml
   - prek.toml
+  - clippy.toml
 
 # Each commit is placed under the first category whose `types` list
 # contains the commit's Conventional Commit type. Commits without a

--- a/.github/release-v2ray-plugin.yaml
+++ b/.github/release-v2ray-plugin.yaml
@@ -25,10 +25,11 @@ include_paths:
   - xtask/**
   - xtask-lib/**
   - scripts/generate-release-notes.py
-  - scripts/sign-release.py
   - Cargo.toml
   - Cargo.lock
   - build.yaml
+  - prek.toml
+  - clippy.toml
 
 categories:
   - title: "🚀 Features"

--- a/.github/release-v2ray-plugin.yaml
+++ b/.github/release-v2ray-plugin.yaml
@@ -21,6 +21,14 @@ include_paths:
   - .github/workflows/draft-release-v2ray-plugin.yaml
   - .github/workflows/publish-release-v2ray-plugin.yaml
   - .github/release-v2ray-plugin.yaml
+  # Workspace-engineering files affect every release track. See #312.
+  - xtask/**
+  - xtask-lib/**
+  - scripts/generate-release-notes.py
+  - scripts/sign-release.py
+  - Cargo.toml
+  - Cargo.lock
+  - build.yaml
 
 categories:
   - title: "🚀 Features"


### PR DESCRIPTION
## Summary

Two related cleanups to `.github/release-*.yaml`:

### H2 — Workspace-engineering paths now in all four tracks

Before this PR, only `release-hole.yaml` included `xtask/**`, `xtask-lib/**`, `scripts/{generate-release-notes,sign-release}.py`, `Cargo.toml`, `Cargo.lock`, `build.yaml`. A change to e.g. `xtask-lib/src/version.rs` (which gates *every* track's release validation) would only appear in hole release notes.

This PR adds those paths to `release-galoshes.yaml`, `release-garter.yaml`, `release-v2ray-plugin.yaml` so workspace-engineering changes appear in every track's release notes. S8 → option (a) per the implementation plan.

### M3 — `crates/garter/**` removed from galoshes config

`release-galoshes.yaml` included `crates/garter/**`, causing garter-only commits to appear in both garter AND galoshes release notes when both products released together. Now removed: galoshes consumers wanting embedded-garter detail can read garter's release notes directly.

Closes #312.

## Verification

```
$ uv run scripts/generate-release-notes.py v2ray-plugin --new-tag releases/v2ray-plugin/v999.0.0 --head HEAD
## 🚀 Features
- feat(release): per-track release-notes config + Conventional Commits policy (#296)

## 🧪 Tests
- test(observability): process-global tracing subscriber via hole-test-observability (#301) (#307)
- test: enforce set_default + current-thread tokio runtime invariant (#302) (#305)

**Full Changelog**: ...
```

All three are workspace-engineering changes (touching `scripts/generate-release-notes.py`, `Cargo.lock`, etc.) that don't touch `external/v2ray-plugin/` — they appear now because the new include_paths cover them. PRs that touch only `crates/common/` or `crates/bridge/` (like #285, #306) correctly do NOT appear in v2ray-plugin notes.

Galoshes/garter have no `releases/<track>/v*` tags yet, so the script emits the configured `initial_release` stub; no functional change to that path. The H2/M3 effects will surface on the next release of those tracks.

## Test plan

- [x] YAML lint passes on all 3 modified files.
- [x] Generator produces expected output (above) on `v2ray-plugin` track with the new include_paths.
- [x] Generator's `initial_release` stub still emitted correctly for tagless `galoshes`/`garter` tracks.
- [ ] Post-merge: next release on any non-hole track will surface workspace-engineering changes in its notes.