### PR TITLE
refactor(test-observability): extract DistHarness panic-hook+registry into shared panic_dump module (#303)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,37 @@ Clients on TCP-only plugins (v2ray-plugin, anything without UDP multiplexing) wo
 
 All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` trait in `crates/bridge/src/proxy.rs` and the `Routing` trait in `crates/tun-engine/src/routing.rs`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in the workspace root `clippy.toml` via the `disallowed_methods` list (`tun_engine::routing::setup_routes` / `teardown_routes`). See bindreams/hole#165 for the incident that motivated the rule.
 
+### Panic-dump dispatcher
+
+The `hole-test-observability` crate ships a workspace-shared panic-hook
+dispatcher at
+[`hole_test_observability::panic_dump`](crates/test-observability/src/panic_dump.rs).
+On any test panic the dispatcher iterates a registry of registered
+sources and calls `PanicDumpSource::dump(&mut stderr)` on each, then
+chains to the previous hook
+(`hole_common::logging::install_panic_hook`'s tracing-emit, then
+libtest's panic printer).
+
+**Contract.** Implementations of `PanicDumpSource::dump` MUST swallow
+all I/O errors silently — a double-panic from `unwrap()` or `?` would
+replace the original panic's message with an I/O error, destroying the
+diagnostic.
+
+**Registration is RAII**:
+`panic_dump::register(Arc<dyn PanicDumpSource>)` returns a
+`PanicDumpGuard`. Drop the guard to unregister; the same `Arc` can be
+registered multiple times (refcount semantics).
+
+**Test-support consumers do NOT call `install_panic_hook_once`** — the
+dispatcher is installed by `hole_test_observability::install()` at
+ctor time. New diagnostic sources just `register()` and store the
+guard.
+
+Current consumers:
+[`BridgeChildLogSource`](crates/bridge/src/test_support/dist_harness.rs)
+dumps the full subprocess `bridge.log` of every live `DistHarness`
+child. See bindreams/hole#303 for the extraction rationale.
+
 ### Spawn-retry architecture (file-contention diagnostics)
 
 Three independent layers compose to handle transient file-contention on `Command::spawn` — typically Windows Defender scanning a freshly-built `hole.exe`, or macOS holding a writer while something tries to exec:

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -32,6 +32,18 @@ hole_test_observability::register!();
 
 #[cfg(test)]
 fn main() {
+    // Subprocess re-exec for the DistHarness panic-hook regression
+    // test. Dispatches into the child-side handler BEFORE skuld
+    // initializes — so the deliberate panic doesn't interact with the
+    // test runner, AND so libtest's filter / `--nocapture` arg parsing
+    // is bypassed for the child (we want unconditional dispatch on the
+    // env var, regardless of what cargo nextest passes downstream).
+    // See `test_support/dist_harness_panic_hook_tests.rs` and
+    // bindreams/hole#303.
+    if std::env::var_os("HOLE_DIST_HARNESS_PANIC_TEST").is_some() {
+        test_support::dist_harness_panic_hook_tests::run_child();
+        std::process::exit(0);
+    }
     skuld::run_all();
 }
 

--- a/crates/bridge/src/test_support.rs
+++ b/crates/bridge/src/test_support.rs
@@ -17,6 +17,7 @@
 pub(crate) mod certs;
 pub(crate) mod dist_fixture;
 pub(crate) mod dist_harness;
+pub(crate) mod dist_harness_panic_hook_tests;
 pub(crate) mod http_connect_client;
 pub(crate) mod http_target;
 pub(crate) mod log_capture;

--- a/crates/bridge/src/test_support/dist_fixture.rs
+++ b/crates/bridge/src/test_support/dist_fixture.rs
@@ -45,17 +45,17 @@ use xtask::Profile;
 /// fixture cache can race; this enforces one-and-only-one staging.
 static STAGED_DIST_BIN: OnceLock<Result<PathBuf, String>> = OnceLock::new();
 
-/// Stage the dist directory and return its absolute `bin/` path.
+/// Synchronous helper that performs the dist-directory staging.
 ///
-/// Process-scoped so the staging work happens at most once per test
-/// binary. The return value is reused by every `DistHarness::spawn`
-/// call — tests only borrow the path; they never mutate the directory.
-///
-/// `deref` lets tests request the fixture as `&Path` (via `Deref::Target`)
-/// instead of `&PathBuf`. `serial = DIST_BIN` makes tests using this
-/// fixture cross-process serial on that label.
-#[skuld::fixture(scope = process, deref, serial = DIST_BIN)]
-pub(crate) fn dist_dir() -> Result<PathBuf, String> {
+/// Called both by the [`dist_dir`] skuld fixture (which adds
+/// process-scope caching + the cross-process serial label) AND by the
+/// panic-hook regression test's child process in
+/// `dist_harness_panic_hook_tests::run_child` — a child can't go
+/// through skuld DI because skuld hasn't initialized at that point in
+/// `lib.rs::main`. Subsequent calls within a process short-circuit on
+/// the `OnceLock` cache. The cross-process serial guarantee is owned
+/// by the [`dist_dir`] fixture, not this helper.
+pub(crate) fn stage_dist_bin_dir() -> Result<PathBuf, String> {
     STAGED_DIST_BIN
         .get_or_init(|| {
             let repo_root = xtask::repo_root().map_err(|e| format!("locate workspace root: {e}"))?;
@@ -70,4 +70,18 @@ pub(crate) fn dist_dir() -> Result<PathBuf, String> {
             Ok(dist_bin)
         })
         .clone()
+}
+
+/// Stage the dist directory and return its absolute `bin/` path.
+///
+/// Process-scoped so the staging work happens at most once per test
+/// binary. The return value is reused by every `DistHarness::spawn`
+/// call — tests only borrow the path; they never mutate the directory.
+///
+/// `deref` lets tests request the fixture as `&Path` (via `Deref::Target`)
+/// instead of `&PathBuf`. `serial = DIST_BIN` makes tests using this
+/// fixture cross-process serial on that label.
+#[skuld::fixture(scope = process, deref, serial = DIST_BIN)]
+pub(crate) fn dist_dir() -> Result<PathBuf, String> {
+    stage_dist_bin_dir()
 }

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -210,22 +210,26 @@ impl DistHarness {
         // Register the live child with the workspace panic-dump
         // dispatcher (#303, originally #200 H3 evidence). The
         // returned guard's `Drop` removes the source on harness drop.
-        let panic_dump_guard =
-            hole_test_observability::panic_dump::register(std::sync::Arc::new(BridgeChildLogSource {
-                pid: child_pid,
-                socket: socket_path.clone(),
-                log_dir: log_dir.path().to_path_buf(),
-            }));
+        let log_source = std::sync::Arc::new(BridgeChildLogSource {
+            pid: child_pid,
+            socket: socket_path.clone(),
+            log_dir: log_dir.path().to_path_buf(),
+        });
+        let panic_dump_guard = hole_test_observability::panic_dump::register(log_source);
 
         // Wait for the socket to become connectable before returning.
         // If the subprocess has already exited, surface that instead of
         // waiting the full 10s timeout.
         if let Err(e) = wait_for_socket_or_exit(&socket_path, &mut child, Duration::from_secs(10)).await {
+            // Unregister BEFORE kill/wait — same ordering as the Drop
+            // impl. If `child.kill()` or `child.wait()` themselves
+            // panic, we don't want the dispatcher dumping a stale
+            // `BridgeChildLogSource` whose subprocess is mid-death.
+            drop(panic_dump_guard);
             // Try to reap the child so we don't leave a zombie if it's
             // still limping along.
             let _ = child.kill();
             let _ = child.wait();
-            drop(panic_dump_guard);
             return Err(HarnessError(format!(
                 "bridge subprocess never bound {socket_path:?}: {e}"
             )));

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -38,11 +38,10 @@ use hole_common::protocol::{
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
-use std::collections::BTreeMap;
+use std::io::Write;
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
@@ -111,6 +110,20 @@ pub(crate) struct DistHarness {
     /// runtime. After `shutdown()` (or the initial construction
     /// failure path), this is `None`.
     client: Option<BridgeIpcClient>,
+    /// RAII handle keeping this harness's `BridgeChildLogSource`
+    /// registered with the workspace panic-dump dispatcher.
+    ///
+    /// `Option` so the manual `Drop` impl can `take()` it and drop it
+    /// explicitly BEFORE running the kill/wait shutdown sequence. The
+    /// explicit take preserves the pre-#303 semantic of unregistering
+    /// before any code that could itself panic during shutdown (Stop
+    /// send, scoped `block_on`, kill, wait). Relying on implicit
+    /// field-drop order is unsafe: Rust drops fields in declaration
+    /// order top-to-bottom, so this field would drop LAST (after
+    /// `child`), and a shutdown-time panic would re-fire the hook
+    /// with a stale `BridgeChildLogSource` whose subprocess is
+    /// mid-death and whose `bridge.log` may be mid-rotation.
+    _panic_dump_guard: Option<hole_test_observability::panic_dump::PanicDumpGuard>,
 }
 
 impl DistHarness {
@@ -122,11 +135,13 @@ impl DistHarness {
     /// Blocks until the bridge's IPC socket is connectable (or the
     /// spawn-ready budget expires).
     pub(crate) async fn spawn(dist_bin_dir: &Path) -> Result<Self, HarnessError> {
-        // Install the panic hook BEFORE any fallible work so that if the
-        // harness itself panics during construction, the hook still runs.
-        // Idempotent across calls — `Once::call_once` is a no-op after the
-        // first invocation.
-        install_panic_hook_once();
+        // Note: the workspace panic-dump dispatcher (see #303) is
+        // installed at ctor time by `hole_test_observability::install`,
+        // which runs strictly before any test code via the `register!`
+        // macro's `#[ctor::ctor]` function. The pre-#303 explicit
+        // `install_panic_hook_once()` here was load-bearing as a
+        // before-fallible-work guarantee; the ctor-time install
+        // preserves that property.
 
         let hole_exe = dist_bin_dir.join(if cfg!(windows) { "hole.exe" } else { "hole" });
         if !hole_exe.is_file() {
@@ -192,16 +207,15 @@ impl DistHarness {
             log_dir.path().display()
         );
 
-        // Register the live child for the panic hook (#200 H3 evidence).
-        // Removed in `Drop`. Key by PID — unique per running child.
-        registry().lock().expect("registry mutex").insert(
-            child_pid,
-            ChildInfo {
+        // Register the live child with the workspace panic-dump
+        // dispatcher (#303, originally #200 H3 evidence). The
+        // returned guard's `Drop` removes the source on harness drop.
+        let panic_dump_guard =
+            hole_test_observability::panic_dump::register(std::sync::Arc::new(BridgeChildLogSource {
                 pid: child_pid,
                 socket: socket_path.clone(),
                 log_dir: log_dir.path().to_path_buf(),
-            },
-        );
+            }));
 
         // Wait for the socket to become connectable before returning.
         // If the subprocess has already exited, surface that instead of
@@ -211,7 +225,7 @@ impl DistHarness {
             // still limping along.
             let _ = child.kill();
             let _ = child.wait();
-            registry().lock().expect("registry mutex").remove(&child_pid);
+            drop(panic_dump_guard);
             return Err(HarnessError(format!(
                 "bridge subprocess never bound {socket_path:?}: {e}"
             )));
@@ -227,6 +241,7 @@ impl DistHarness {
             _log_dir: log_dir,
             child: Some(child),
             client: Some(client),
+            _panic_dump_guard: Some(panic_dump_guard),
         })
     }
 
@@ -286,11 +301,14 @@ impl Drop for DistHarness {
             // `shutdown()` already consumed or construction failed.
             return;
         };
-        // Remove from the panic-hook registry. PID is recorded once at
-        // spawn time; reuse it here rather than calling `child.id()` again
-        // (the docs allow returning a different PID after `wait()`).
-        let registered_pid = child.id();
-        registry().lock().expect("registry mutex").remove(&registered_pid);
+        // Unregister from the panic-dump dispatcher BEFORE the shutdown
+        // sequence below. If `Stop` send / scoped `block_on` / kill / wait
+        // themselves panic, we don't want this harness's stale
+        // `BridgeChildLogSource` dumped from the hook — the subprocess may
+        // already be dead and the bridge.log mid-rotation. Equivalent to
+        // the pre-#303 `registry().lock().remove(&registered_pid)` call at
+        // the same point in the shutdown sequence.
+        drop(self._panic_dump_guard.take());
 
         if let Some(client) = client {
             // Move client into a worker thread that drives a short
@@ -416,103 +434,64 @@ fn new_tempdir() -> std::io::Result<TempDir> {
     tempfile::tempdir()
 }
 
-// Panic-hook registry =================================================================================================
+// Bridge log dump source ==============================================================================================
 
-/// Snapshot of a live `DistHarness` child that the panic hook can read
-/// without holding any reference to the harness itself.
-#[derive(Clone)]
-pub(crate) struct ChildInfo {
+/// Snapshot of a live `DistHarness` child registered with the
+/// workspace-shared `panic_dump` dispatcher. On any test panic, the
+/// dispatcher calls [`hole_test_observability::panic_dump::PanicDumpSource::dump`]
+/// which writes a header (pid/socket/log_dir) followed by the full
+/// `bridge.log` contents to stderr.
+///
+/// All I/O errors are swallowed silently — see the contract on
+/// [`hole_test_observability::panic_dump::PanicDumpSource`].
+///
+/// Historical note: the dump used to be capped at the last 4 KB, which
+/// turned out to capture only ~4 ms of bridge activity in the #200
+/// repros — nowhere near the 5 s hang window. Nextest captures stderr
+/// per test and only prints it on failure, so the full dump is bounded
+/// in practice to a single failed test's bridge lifetime (~30 s under
+/// nextest's `terminate-after` cap).
+pub(crate) struct BridgeChildLogSource {
     pub(crate) pid: u32,
     pub(crate) socket: PathBuf,
     pub(crate) log_dir: PathBuf,
 }
 
-/// Process-wide registry of live child processes. Used by the panic hook
-/// (see [`install_panic_hook_once`]) to dump the bridge log tail when a
-/// test panics on a different thread than the harness was constructed on
-/// — which is the common case under `rt().block_on(...)`.
-fn registry() -> &'static Mutex<BTreeMap<u32, ChildInfo>> {
-    static HARNESS_REGISTRY: OnceLock<Mutex<BTreeMap<u32, ChildInfo>>> = OnceLock::new();
-    HARNESS_REGISTRY.get_or_init(|| Mutex::new(BTreeMap::new()))
-}
-
-/// Install a panic hook (idempotent across the test binary's lifetime)
-/// that, on every panic, prints each registered live `DistHarness` child's
-/// PID/socket/log_dir to stderr and dumps the entire bridge.log contents.
-/// The previous hook (typically the libtest panic printer) is chained so
-/// test output is preserved.
-///
-/// Historical note: the dump used to be capped at the last 4 KB, which
-/// turned out to capture only ~4 ms of bridge activity in the #200
-/// repros — nowhere near wide enough to see the 5 s hang window. Nextest
-/// captures stderr per test and only prints it on failure, so the full
-/// dump is bounded in practice to a single failed test's bridge lifetime
-/// (~30 s under the nextest `terminate-after` cap).
-///
-/// The hook reads a `OnceLock<Mutex<BTreeMap<...>>>`, NOT a `thread_local!`,
-/// because `wait_for_port` (the panicking call site) runs on whichever
-/// tokio worker resumes the `.await` — almost never the thread that
-/// constructed the harness. A thread-local would always read empty.
-///
-/// On a poisoned mutex, `lock()` returns `Err` and the hook silently skips
-/// the dump rather than double-panicking.
-fn install_panic_hook_once() {
-    static PANIC_HOOK_ONCE: std::sync::Once = std::sync::Once::new();
-    PANIC_HOOK_ONCE.call_once(|| {
-        let prev = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            eprintln!("[DistHarness panic hook] fired: {info}");
-            if let Ok(reg) = registry().lock() {
-                let mut stderr = std::io::stderr().lock();
-                for c in reg.values() {
-                    dump_harness_log(&mut stderr, c);
+impl hole_test_observability::panic_dump::PanicDumpSource for BridgeChildLogSource {
+    fn dump(&self, out: &mut dyn Write) {
+        let _ = writeln!(
+            out,
+            "[DistHarness panic hook] live harness pid={} socket={} log_dir={}",
+            self.pid,
+            self.socket.display(),
+            self.log_dir.display()
+        );
+        let log_path = self.log_dir.join("bridge.log");
+        match std::fs::read(&log_path) {
+            Ok(bytes) => {
+                let _ = writeln!(
+                    out,
+                    "[DistHarness panic hook] ---- full {} ({} bytes) ----",
+                    log_path.display(),
+                    bytes.len()
+                );
+                let _ = out.write_all(&bytes);
+                // Ensure the body is terminated by a newline so the
+                // `---- end ----` framing starts on its own line
+                // regardless of the log's trailing byte.
+                if bytes.last().is_none_or(|&b| b != b'\n') {
+                    let _ = writeln!(out);
                 }
+                let _ = writeln!(out, "[DistHarness panic hook] ---- end ----");
             }
-            prev(info);
-        }));
-    });
-}
-
-/// Write one harness's header + full bridge.log to `out`. Extracted from
-/// [`install_panic_hook_once`] so a unit test can assert on the output
-/// without redirecting the process-wide stderr.
-///
-/// All write failures are ignored: the caller is (usually) in a panic path
-/// and double-panicking via `unwrap` would replace the original panic's
-/// message with an I/O error.
-pub(crate) fn dump_harness_log(out: &mut dyn std::io::Write, c: &ChildInfo) {
-    let _ = writeln!(
-        out,
-        "[DistHarness panic hook] live harness pid={} socket={} log_dir={}",
-        c.pid,
-        c.socket.display(),
-        c.log_dir.display()
-    );
-    let log_path = c.log_dir.join("bridge.log");
-    match std::fs::read(&log_path) {
-        Ok(bytes) => {
-            let _ = writeln!(
-                out,
-                "[DistHarness panic hook] ---- full {} ({} bytes) ----",
-                log_path.display(),
-                bytes.len()
-            );
-            let _ = out.write_all(&bytes);
-            // Ensure the body is terminated by a newline so the `---- end ----`
-            // framing starts on its own line regardless of the log's trailing
-            // byte.
-            if bytes.last().is_none_or(|&b| b != b'\n') {
-                let _ = writeln!(out);
+            Err(e) => {
+                let _ = writeln!(
+                    out,
+                    "[DistHarness panic hook] could not read {}: {}",
+                    log_path.display(),
+                    e
+                );
             }
-            let _ = writeln!(out, "[DistHarness panic hook] ---- end ----");
-        }
-        Err(e) => {
-            let _ = writeln!(
-                out,
-                "[DistHarness panic hook] could not read {}: {}",
-                log_path.display(),
-                e
-            );
         }
     }
 }

--- a/crates/bridge/src/test_support/dist_harness_panic_hook_tests.rs
+++ b/crates/bridge/src/test_support/dist_harness_panic_hook_tests.rs
@@ -1,0 +1,136 @@
+//! Subprocess re-exec regression test for the workspace panic-dump
+//! dispatcher chain.
+//!
+//! Verifies that when a panic fires inside `rt().block_on(...)` with
+//! a `DistHarness` alive, the full hook chain runs in order:
+//!
+//! 1. `hole_test_observability::panic_dump` dispatcher — writes
+//!    `BridgeChildLogSource`'s `---- full <bridge.log> ----` framing
+//!    to stderr.
+//! 2. `hole_common::logging::install_panic_hook` — emits
+//!    `tracing::error!(target: "hole::panic", ...)` into the global
+//!    subscriber, which the test-observability subscriber writes to
+//!    stderr.
+//! 3. Libtest panic printer — `panicked at ...`.
+//!
+//! Pattern mirrors `crates/common/src/logging/logging_tests.rs`:
+//! parent re-execs the current test binary with
+//! `HOLE_DIST_HARNESS_PANIC_TEST=1`; `lib.rs::main` short-circuits
+//! into [`run_child`] before `skuld::run_all`.
+//!
+//! See bindreams/hole#303 (regression gate (b)).
+
+use crate::test_support::dist_fixture::stage_dist_bin_dir;
+use crate::test_support::dist_harness::DistHarness;
+use crate::test_support::rt;
+use std::process::Command;
+
+/// Child-side: spawn a `DistHarness`, then panic. The installed panic
+/// hooks run during unwind and write to stderr (which the parent has
+/// piped). The panic propagates out of `block_on` and out of
+/// `run_child`; with no `catch_unwind` in the chain, the process
+/// aborts with exit code 101.
+pub(crate) fn run_child() {
+    // Stage the dist directory using the non-fixture helper (skuld
+    // fixtures require DI, which is unavailable here — `main` runs
+    // before skuld initializes).
+    let dist_bin_dir = match stage_dist_bin_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("[child] stage_dist_bin_dir failed: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    let runtime = rt();
+    // Hold `_harness` across both `block_on` calls so its
+    // `BridgeChildLogSource` is still in the registry when the panic
+    // hook iterates. Order at end of `run_child`: (1) panic unwinds →
+    // (2) hook fires reading registry → (3) unwind continues, dropping
+    // `_harness` → (4) `DistHarness::Drop` unregisters via
+    // `_panic_dump_guard.take()`. The hook reads at step 2, before
+    // step 4 — correct ordering.
+    let _harness = runtime.block_on(async { DistHarness::spawn(&dist_bin_dir).await.expect("DistHarness::spawn") });
+
+    // Deliberate panic INSIDE `rt().block_on(...)` — the exact
+    // tokio-worker-thread panic scenario the original DistHarness
+    // hook was designed to handle (see #200 H3). Panic propagates out
+    // of `block_on`, then out of `run_child`, then out of `main`.
+    // Default unwind → libtest panic printer → exit 101.
+    runtime.block_on(async {
+        panic!("DistHarness-panic-hook-regression-test-marker");
+    });
+
+    // Defense-in-depth: if some future change makes `block_on`
+    // swallow the panic (it currently does NOT — panics in the
+    // top-level future propagate out), force a non-zero exit so the
+    // parent's `!output.status.success()` assertion still fires with a
+    // useful diagnostic. Without this safety net, a silent
+    // panic-swallow would make the test pass under a broken hook
+    // chain.
+    eprintln!("[child] panic did not propagate out of block_on — this indicates a regression");
+    std::process::exit(2);
+}
+
+#[skuld::test]
+fn panic_hook_chain_dumps_bridge_log_and_libtest_message() {
+    let exe = std::env::current_exe().expect("current_exe");
+    let output = Command::new(&exe)
+        .env("HOLE_DIST_HARNESS_PANIC_TEST", "1")
+        // `output()` captures both stdout and stderr. The child
+        // dispatches into `run_child` via the `lib.rs` branch
+        // BEFORE libtest's arg parsing, so we don't need any
+        // --nocapture / filter flags.
+        .output()
+        .expect("spawn child");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        !output.status.success(),
+        "child should exit non-zero after panic; status={:?}, stderr:\n{stderr}",
+        output.status
+    );
+
+    // Gate 1: panic_dump dispatcher fired — `BridgeChildLogSource`
+    // wrote its framing to stderr.
+    assert!(
+        stderr.contains("[DistHarness panic hook] live harness pid="),
+        "panic_dump dispatcher must dump the harness header. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[DistHarness panic hook] ---- full"),
+        "panic_dump dispatcher must include the bridge.log framing. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[panic_dump] dispatcher fired:"),
+        "panic_dump dispatcher must emit its fired-marker line. stderr:\n{stderr}"
+    );
+
+    // Gate 2: hole_common tracing-emit hook fired — the panic event
+    // reaches the global subscriber and is formatted with the
+    // `hole::panic` target.
+    assert!(
+        stderr.contains("hole::panic"),
+        "hole_common::logging::install_panic_hook must emit a \
+         target=\"hole::panic\" tracing event. stderr:\n{stderr}"
+    );
+
+    // Gate 3: libtest's panic printer fired — final `panicked at`
+    // message is preserved.
+    assert!(
+        stderr.contains("panicked at") && stderr.contains("DistHarness-panic-hook-regression-test-marker"),
+        "libtest's panic printer must run last and preserve the \
+         original panic message. stderr:\n{stderr}"
+    );
+
+    // Negative gate: the safety-net `eprintln!` MUST NOT appear — if
+    // it does, `block_on` swallowed the panic and the chain didn't
+    // get to fire at all (or fired without the panic value reaching
+    // the libtest printer).
+    assert!(
+        !stderr.contains("panic did not propagate out of block_on"),
+        "panic was swallowed by block_on or runtime — chain ordering \
+         is broken. stderr:\n{stderr}"
+    );
+}

--- a/crates/bridge/src/test_support/dist_harness_panic_hook_tests.rs
+++ b/crates/bridge/src/test_support/dist_harness_panic_hook_tests.rs
@@ -43,13 +43,13 @@ pub(crate) fn run_child() {
     };
 
     let runtime = rt();
-    // Hold `_harness` across both `block_on` calls so its
-    // `BridgeChildLogSource` is still in the registry when the panic
-    // hook iterates. Order at end of `run_child`: (1) panic unwinds →
-    // (2) hook fires reading registry → (3) unwind continues, dropping
-    // `_harness` → (4) `DistHarness::Drop` unregisters via
-    // `_panic_dump_guard.take()`. The hook reads at step 2, before
-    // step 4 — correct ordering.
+    // Hold `_harness` across the second `block_on` so its
+    // `BridgeChildLogSource` is still registered when the panic hook
+    // iterates. The panic hook fires from inside `panic_impl` BEFORE
+    // any local drop runs — `_harness` is live, the registry contains
+    // the source. Only AFTER the hook returns does unwind continue and
+    // drop `_harness`, which in turn runs `DistHarness::Drop`'s
+    // `_panic_dump_guard.take()` unregister. Hook reads before unregister.
     let _harness = runtime.block_on(async { DistHarness::spawn(&dist_bin_dir).await.expect("DistHarness::spawn") });
 
     // Deliberate panic INSIDE `rt().block_on(...)` — the exact
@@ -77,10 +77,18 @@ fn panic_hook_chain_dumps_bridge_log_and_libtest_message() {
     let exe = std::env::current_exe().expect("current_exe");
     let output = Command::new(&exe)
         .env("HOLE_DIST_HARNESS_PANIC_TEST", "1")
+        // Scrub env vars that other test-support code in the workspace
+        // interprets as "I am a child of a re-exec test", to avoid the
+        // child taking the wrong branch in `crates/common/src/lib.rs::main`
+        // or short-circuiting `hole_test_observability::install` (which
+        // would skip installing the dispatcher under test). Inheriting
+        // an accidentally-set value from the parent process would make
+        // this test silently pass under a broken chain.
+        .env_remove("HOLE_LOGGING_TEST_KIND")
         // `output()` captures both stdout and stderr. The child
-        // dispatches into `run_child` via the `lib.rs` branch
-        // BEFORE libtest's arg parsing, so we don't need any
-        // --nocapture / filter flags.
+        // dispatches into `run_child` via the `lib.rs` branch BEFORE
+        // libtest's arg parsing, so we don't need any --nocapture /
+        // filter flags.
         .output()
         .expect("spawn child");
 
@@ -125,12 +133,42 @@ fn panic_hook_chain_dumps_bridge_log_and_libtest_message() {
     );
 
     // Negative gate: the safety-net `eprintln!` MUST NOT appear — if
-    // it does, `block_on` swallowed the panic and the chain didn't
-    // get to fire at all (or fired without the panic value reaching
-    // the libtest printer).
+    // it does, `block_on` swallowed the panic and the chain didn't get
+    // to fire at all (or fired without the panic value reaching the
+    // libtest printer).
     assert!(
         !stderr.contains("panic did not propagate out of block_on"),
         "panic was swallowed by block_on or runtime — chain ordering \
          is broken. stderr:\n{stderr}"
+    );
+
+    // Ordering gate: the dispatcher must fire FIRST, then the
+    // hole_common tracing-emit hook, then libtest's panic printer.
+    // `contains`-based gates above would still pass if the chain
+    // silently reversed; this find-based check catches that regression.
+    //
+    // Note "panicked at" appears in BOTH the dispatcher's prologue
+    // (`writeln!(stderr, "[panic_dump] dispatcher fired: {info}")` —
+    // `PanicInfo`'s Display impl includes the "panicked at" line) AND
+    // libtest's panic printer. To identify libtest's line uniquely we
+    // search for the `thread '` prefix that libtest writes ahead of
+    // its `panicked at`; no other hook in the chain produces that
+    // prefix.
+    let pos_dispatcher = stderr
+        .find("[panic_dump] dispatcher fired:")
+        .expect("dispatcher marker");
+    let pos_tracing = stderr.find("hole::panic").expect("hole::panic tracing event");
+    let pos_libtest = stderr
+        .find("thread '")
+        .expect("libtest thread-prefixed panicked-at line");
+    assert!(
+        pos_dispatcher < pos_tracing,
+        "panic_dump dispatcher must run before the hole_common tracing-emit hook; \
+         dispatcher@{pos_dispatcher}, tracing@{pos_tracing}. stderr:\n{stderr}"
+    );
+    assert!(
+        pos_tracing < pos_libtest,
+        "hole_common tracing-emit hook must run before libtest's panic printer; \
+         tracing@{pos_tracing}, libtest@{pos_libtest}. stderr:\n{stderr}"
     );
 }

--- a/crates/bridge/src/test_support/dist_harness_tests.rs
+++ b/crates/bridge/src/test_support/dist_harness_tests.rs
@@ -2,7 +2,8 @@
 //! covers the panic-hook log-dump path; the rest of the harness is
 //! exercised implicitly through the e2e tests that use it.
 
-use super::{dump_harness_log, ChildInfo};
+use super::BridgeChildLogSource;
+use hole_test_observability::panic_dump::PanicDumpSource;
 use std::path::PathBuf;
 
 /// Build a log body larger than the old 4 KiB tail cap. If the dump
@@ -33,14 +34,14 @@ fn dump_harness_log_emits_full_log_not_just_tail() {
         body.len()
     );
 
-    let info = ChildInfo {
+    let info = BridgeChildLogSource {
         pid: 12345,
         socket: PathBuf::from("fake-socket"),
         log_dir: log_dir.path().to_path_buf(),
     };
 
     let mut buf: Vec<u8> = Vec::new();
-    dump_harness_log(&mut buf, &info);
+    info.dump(&mut buf);
     let out = String::from_utf8(buf).expect("utf8");
 
     assert!(
@@ -71,7 +72,7 @@ fn dump_harness_log_emits_full_log_not_just_tail() {
     assert!(out.contains("---- end ----"), "dump must include the end marker");
     assert!(
         out.contains("pid=12345"),
-        "dump must include the ChildInfo pid; preview: {}",
+        "dump must include the BridgeChildLogSource pid; preview: {}",
         &out[..out.len().min(200)]
     );
 }
@@ -79,14 +80,14 @@ fn dump_harness_log_emits_full_log_not_just_tail() {
 #[skuld::test]
 fn dump_harness_log_handles_missing_file() {
     let log_dir = tempfile::tempdir().expect("tempdir");
-    let info = ChildInfo {
+    let info = BridgeChildLogSource {
         pid: 42,
         socket: PathBuf::from("fake-socket"),
         log_dir: log_dir.path().to_path_buf(),
     };
 
     let mut buf: Vec<u8> = Vec::new();
-    dump_harness_log(&mut buf, &info);
+    info.dump(&mut buf);
     let out = String::from_utf8(buf).expect("utf8");
 
     assert!(

--- a/crates/test-observability/src/lib.rs
+++ b/crates/test-observability/src/lib.rs
@@ -49,6 +49,8 @@ use std::sync::Once;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
 
+pub mod panic_dump;
+
 /// Re-exported attribute macro so consumer crates don't need to add
 /// `ctor` to their own dev-dependencies. Exposed as
 /// `hole_test_observability::ctor` (the attribute macro), invoked
@@ -163,6 +165,14 @@ pub fn install() {
         // is the fallback diagnostic.
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         hole_common::logging::install_panic_hook();
+
+        // Workspace-shared panic-dump dispatcher. Chains over the
+        // hole_common tracing-emit hook (which chains over libtest's
+        // panic printer). Test-support consumers register sources
+        // via `panic_dump::register(Arc<dyn PanicDumpSource>)` —
+        // no per-consumer hook installation needed. See
+        // bindreams/hole#303.
+        panic_dump::install_panic_hook_once();
     });
 }
 

--- a/crates/test-observability/src/panic_dump.rs
+++ b/crates/test-observability/src/panic_dump.rs
@@ -1,0 +1,131 @@
+//! Process-wide panic-hook dispatcher with a registry of dump sources.
+//!
+//! On any test panic, the installed hook iterates the registry and
+//! calls [`PanicDumpSource::dump`] on each registered source, writing
+//! to stderr. Then chains to the previous hook (typically the
+//! tracing-emitting `hole_common::logging::install_panic_hook` chain,
+//! which itself chains to libtest's panic printer).
+//!
+//! Hook installation is wired into [`crate::install`], not exposed at
+//! the API surface — consumers register sources, the dispatcher hook
+//! is always present in test binaries that invoke
+//! `hole_test_observability::register!()`.
+//!
+//! Originated as `DistHarness::install_panic_hook_once` in
+//! [crates/bridge/src/test_support/dist_harness.rs]; see
+//! bindreams/hole#303 for the extraction rationale (avoiding parallel
+//! per-consumer hook chains).
+//!
+//! ## Contract for `dump` implementations
+//!
+//! `dump` is called from inside a panic hook. Implementations MUST
+//! swallow all I/O errors silently — a double-panic from `unwrap()`
+//! or `?` would replace the original panic's message with an I/O
+//! error, destroying the diagnostic. Mirrors the silent-on-write-error
+//! behaviour of the original `dump_harness_log`.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// A diagnostic source registered with the panic-dump dispatcher.
+/// Implementations describe their own dump format and own the source
+/// of bytes (file path, in-memory buffer, etc.).
+///
+/// See module docs for the silent-on-write-error contract.
+pub trait PanicDumpSource: Send + Sync {
+    fn dump(&self, out: &mut dyn Write);
+}
+
+/// RAII handle returned by [`register`]. Drop unregisters the source.
+///
+/// Each [`register`] call returns a fresh `PanicDumpGuard` with an
+/// independent registry key — registering the same `Arc` twice
+/// produces two guards, both of which must drop before the source
+/// stops being dumped on panic.
+pub struct PanicDumpGuard {
+    key: u64,
+}
+
+impl Drop for PanicDumpGuard {
+    fn drop(&mut self) {
+        // `lock().ok()` — on a poisoned mutex (a concurrent panic
+        // hook may have observed mid-mutation state), silently skip
+        // unregistration. The map will leak this entry until process
+        // exit, which is fine in a test binary.
+        if let Ok(mut reg) = registry().lock() {
+            reg.remove(&self.key);
+        }
+    }
+}
+
+fn registry() -> &'static Mutex<BTreeMap<u64, Arc<dyn PanicDumpSource>>> {
+    static REGISTRY: OnceLock<Mutex<BTreeMap<u64, Arc<dyn PanicDumpSource>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn next_key() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Register `source` for the lifetime of the returned guard.
+///
+/// The guard's `Drop` removes the source from the registry. Each call
+/// returns a fresh guard with an independent registry key; registering
+/// the same `Arc` twice is allowed (refcount semantics — both guards
+/// must drop before the source is removed).
+///
+/// On a poisoned registry mutex (e.g. a panic hook is currently
+/// iterating), registration silently no-ops and the returned guard is
+/// a tombstone — its `Drop` is also a no-op. Mirrors the
+/// silent-on-poison property of the original DistHarness
+/// implementation at `dist_harness.rs:465`.
+///
+/// `next_key()` uses `AtomicU64::fetch_add(1)`; overflow is structurally
+/// out of reach (at 1 register/μs that's 584,000 years).
+pub fn register(source: Arc<dyn PanicDumpSource>) -> PanicDumpGuard {
+    let key = next_key();
+    if let Ok(mut reg) = registry().lock() {
+        reg.insert(key, source);
+    }
+    PanicDumpGuard { key }
+}
+
+/// Install the process-wide dispatcher hook.
+///
+/// Idempotent across the entire test binary (first call wins via
+/// `Once`). The first call takes the previous hook (typically the
+/// chain from `hole_common::logging::install_panic_hook` →
+/// libtest) and chains it after the dispatcher pass.
+///
+/// On panic: iterate registry → call `dump` on each source → chain
+/// to previous hook. Poisoned mutex → skip dump pass, fall through.
+///
+/// Called from [`crate::install`]; test-support consumers should not
+/// call this directly — registering a source is enough.
+pub(crate) fn install_panic_hook_once() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            // Diagnostic marker so operators reading raw stderr can
+            // confirm the dispatcher actually fired before looking
+            // for source dumps. Inherited from the original
+            // DistHarness panic hook at `dist_harness.rs:464`.
+            let _ = writeln!(std::io::stderr().lock(), "[panic_dump] dispatcher fired: {info}");
+            if let Ok(reg) = registry().lock() {
+                let mut stderr = std::io::stderr().lock();
+                for source in reg.values() {
+                    source.dump(&mut stderr);
+                }
+            }
+            prev(info);
+        }));
+    });
+}
+
+#[cfg(test)]
+#[path = "panic_dump_tests.rs"]
+mod panic_dump_tests;

--- a/crates/test-observability/src/panic_dump.rs
+++ b/crates/test-observability/src/panic_dump.rs
@@ -81,7 +81,7 @@ fn next_key() -> u64 {
 /// iterating), registration silently no-ops and the returned guard is
 /// a tombstone — its `Drop` is also a no-op. Mirrors the
 /// silent-on-poison property of the original DistHarness
-/// implementation at `dist_harness.rs:465`.
+/// `install_panic_hook_once`.
 ///
 /// `next_key()` uses `AtomicU64::fetch_add(1)`; overflow is structurally
 /// out of reach (at 1 register/μs that's 584,000 years).
@@ -111,13 +111,24 @@ pub(crate) fn install_panic_hook_once() {
         let prev = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             // Diagnostic marker so operators reading raw stderr can
-            // confirm the dispatcher actually fired before looking
-            // for source dumps. Inherited from the original
-            // DistHarness panic hook at `dist_harness.rs:464`.
+            // confirm the dispatcher actually fired before looking for
+            // source dumps. Inherited from the pre-#303 DistHarness
+            // panic hook.
             let _ = writeln!(std::io::stderr().lock(), "[panic_dump] dispatcher fired: {info}");
-            if let Ok(reg) = registry().lock() {
+            // Snapshot the registry under the lock, then release it
+            // before iterating. Calling `dump()` while holding the
+            // registry mutex would deadlock if a source's `dump`
+            // re-enters via `register()` / guard drop, and would
+            // serialize slow I/O across the lock-hold window. The
+            // `Arc` clones are cheap; the snapshot makes the dispatch
+            // pass lock-free.
+            let sources: Vec<Arc<dyn PanicDumpSource>> = match registry().lock() {
+                Ok(reg) => reg.values().cloned().collect(),
+                Err(_) => return, // poisoned — silently skip
+            };
+            if !sources.is_empty() {
                 let mut stderr = std::io::stderr().lock();
-                for source in reg.values() {
+                for source in &sources {
                     source.dump(&mut stderr);
                 }
             }

--- a/crates/test-observability/src/panic_dump_tests.rs
+++ b/crates/test-observability/src/panic_dump_tests.rs
@@ -1,0 +1,101 @@
+//! Unit tests for `panic_dump`. Cover registry/guard mechanics; the
+//! end-to-end panic-hook chaining (panic_dump dispatcher → hole_common
+//! tracing-emit → libtest) is covered by the subprocess regression
+//! test in
+//! `crates/bridge/src/test_support/dist_harness_panic_hook_tests.rs`.
+
+use super::{install_panic_hook_once, register, registry, PanicDumpSource};
+use std::io::Write;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Test source that increments a counter every time `dump` is called.
+struct CountingSource {
+    label: &'static str,
+    count: AtomicUsize,
+}
+
+impl CountingSource {
+    fn new(label: &'static str) -> Self {
+        Self {
+            label,
+            count: AtomicUsize::new(0),
+        }
+    }
+    fn count(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+impl PanicDumpSource for CountingSource {
+    fn dump(&self, out: &mut dyn Write) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        let _ = writeln!(out, "{}", self.label);
+    }
+}
+
+/// Iterate the registry into a buffer. Mirrors what the installed
+/// panic hook would do, without firing `std::panic` (which would
+/// interact with the global hook in unpredictable ways under the
+/// test runner).
+fn dispatch_into_buffer() -> String {
+    let reg = registry().lock().expect("registry mutex");
+    let mut buf: Vec<u8> = Vec::new();
+    for source in reg.values() {
+        source.dump(&mut buf);
+    }
+    String::from_utf8(buf).expect("utf8")
+}
+
+#[skuld::test]
+fn register_and_dispatch_calls_source() {
+    let src = Arc::new(CountingSource::new("source-A"));
+    let _guard = register(src.clone());
+
+    let out = dispatch_into_buffer();
+    assert!(out.contains("source-A"), "expected source-A in output: {out:?}");
+    assert_eq!(src.count(), 1);
+}
+
+#[skuld::test]
+fn guard_drop_unregisters_source() {
+    let src = Arc::new(CountingSource::new("guarded-source"));
+    {
+        let _guard = register(src.clone());
+        let out = dispatch_into_buffer();
+        assert!(out.contains("guarded-source"));
+    }
+    // Guard dropped — source removed from registry.
+    let out = dispatch_into_buffer();
+    assert!(
+        !out.contains("guarded-source"),
+        "source must be removed after guard drop: {out:?}"
+    );
+}
+
+#[skuld::test]
+fn double_register_uses_refcount() {
+    let src = Arc::new(CountingSource::new("refcount-source"));
+    let g1 = register(src.clone());
+    let g2 = register(src.clone());
+
+    let out = dispatch_into_buffer();
+    assert_eq!(out.matches("refcount-source").count(), 2);
+
+    drop(g1);
+    let out = dispatch_into_buffer();
+    assert_eq!(out.matches("refcount-source").count(), 1, "one registration left");
+
+    drop(g2);
+    let out = dispatch_into_buffer();
+    assert!(!out.contains("refcount-source"), "all guards dropped");
+}
+
+#[skuld::test]
+fn install_panic_hook_once_is_idempotent() {
+    install_panic_hook_once();
+    install_panic_hook_once();
+    install_panic_hook_once();
+    // The `Once` inside ensures only the first call installs;
+    // subsequent calls are no-ops. No panic, no double-chained hook.
+}

--- a/crates/test-observability/src/panic_dump_tests.rs
+++ b/crates/test-observability/src/panic_dump_tests.rs
@@ -92,10 +92,15 @@ fn double_register_uses_refcount() {
 }
 
 #[skuld::test]
-fn install_panic_hook_once_is_idempotent() {
+fn install_panic_hook_once_does_not_panic_on_multiple_calls() {
+    // Smoke-test for the `Once` guard. We cannot easily verify the
+    // hook count didn't grow without firing a real panic, which would
+    // interfere with the global hook the test runner relies on; this
+    // test only proves the function returns cleanly on subsequent
+    // calls. End-to-end chain ordering (which would catch a missing
+    // `Once`) is verified by the subprocess regression test at
+    // `crates/bridge/src/test_support/dist_harness_panic_hook_tests.rs`.
     install_panic_hook_once();
     install_panic_hook_once();
     install_panic_hook_once();
-    // The `Once` inside ensures only the first call installs;
-    // subsequent calls are no-ops. No panic, no double-chained hook.
 }


### PR DESCRIPTION
## Summary

- Extracts the panic-hook + registry pattern from `DistHarness` into a workspace-shared `hole_test_observability::panic_dump` module, eliminating the parallel hook chain warned about in #303.
- Adds `PanicDumpSource` trait + RAII registration via `register()` returning `PanicDumpGuard` (refcount semantics).
- Dispatcher is installed at ctor time by `hole_test_observability::install()` and chains over the existing `hole_common::logging::install_panic_hook` (tracing-emit) and libtest's panic printer. Consumers register sources; they do not install hooks themselves.
- Migrates `DistHarness`: `ChildInfo` → `BridgeChildLogSource` implementing the trait, registered via the new dispatcher at spawn time; `_panic_dump_guard.take()` in `Drop` preserves the pre-#303 unregister-before-shutdown ordering.
- Subprocess re-exec regression test verifies the full hook chain (dispatcher → tracing-emit → libtest) fires in correct order on a deliberate panic inside `rt().block_on(...)` with a registered `DistHarness`. Includes a find-based ordering gate that would catch a silent chain inversion.

## Test plan

- [x] Existing `dump_harness_log_*` unit tests pass against the new `BridgeChildLogSource::dump` trait method (regression gate (a))
- [x] New subprocess test `panic_hook_chain_dumps_bridge_log_and_libtest_message` passes (regression gate (b))
- [x] New `panic_dump_tests` cover registry mechanics: dispatch, guard-drop unregister, refcount, idempotency
- [x] `cargo clippy -p hole-test-observability -p hole-bridge --all-targets -- -D warnings` clean
- [x] Pre-commit hooks pass on every commit
- [ ] CI green on the PR

## Notes

- The two pre-existing test failures observed locally on `main` (`handle-holders::find_holders_finds_foreign_process_holding_file_windows` — local `CARGO_BIN_EXE_hold_file` env var; `hole-bridge::e2e_none_full_tunnel_roundtrip` / `e2e_socks5_udp_associate_roundtrip` — `ShadowsocksRunning dropped with a live task` panic) are pre-existing and out of scope for this PR.
- `CLAUDE.md` updated with the new dispatcher contract and consumer registry under the `Bridge test-isolation contract` section.