### PR TITLE
docs(release): rollback runbook + key rotation + dry-run TOCTOU

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,3 +260,7 @@ When Windows CI fails with a timeout in `server_test_tests` or loopback connects
 - Add `--test-threads=1` to the Windows CI invocation
 - Serialize tests via bare `#[skuld::test(serial)]` except for structural invariant checks. Resource-contention serialization belongs on the fixture that models the resource (`#[skuld::fixture(serial = LABEL)]`) or on the test carrying the resource's label: `#[skuld::test(labels = [LABEL], serial = LABEL)]`. Labels live in `crates/bridge/src/test_support/skuld_fixtures.rs` (`DIST_BIN`, `PORT_ALLOC`, `TUN`, `IPV6`). Label names are cross-crate reserved via skuld's SQLite coordinator — adding the same label name in another crate will unintentionally serialize tests across crates.
 - Add a per-test timeout. Job-level timeouts in `.github/workflows/ci.yaml` — `build` 30m, `test-hole` 20m, `test-garter`/`test-galoshes` 10m — are the sole global test timeouts. Developers wanting local per-test hang protection can set `NEXTEST_SLOW_TIMEOUT` in their shell.
+
+## Release operations
+
+See [docs/RELEASE-OPS.md](docs/RELEASE-OPS.md) for the rollback procedure, minisign key rotation, and the crates.io dry-run TOCTOU note.

--- a/docs/RELEASE-OPS.md
+++ b/docs/RELEASE-OPS.md
@@ -1,0 +1,81 @@
+# Release operations runbook
+
+Per-product release procedure: see [CLAUDE.md § Releases](../CLAUDE.md#releases). This file is the runbook for the off-happy-path operations: rollback, minisign key rotation, and the crates.io dry-run TOCTOU gap.
+
+## Rollback procedure
+
+Use when a release is published but later determined to be defective (broken binary, regression, security issue).
+
+### All tracks
+
+1. Delete the GitHub release. This detaches uploaded assets and removes the release object; the tag remains.
+
+   ```bash
+   gh release delete releases/<track>/v<X.Y.Z> --yes
+   ```
+
+1. Delete the tag locally and on the remote.
+
+   ```bash
+   git tag -d releases/<track>/v<X.Y.Z>
+   git push --delete origin releases/<track>/v<X.Y.Z>
+   ```
+
+### `garter` track only — yank from crates.io
+
+`garter` is the only crate published to crates.io. After the GitHub release/tag are removed, yank the crates.io version:
+
+```bash
+cargo yank --version <X.Y.Z> garter
+```
+
+Yank does NOT delete the crate from crates.io. It prevents new `Cargo.toml` entries from resolving to the yanked version, but existing `Cargo.lock` files continue to work. To re-allow the version, run `cargo yank --version <X.Y.Z> --undo garter`.
+
+### `hole` track only — auto-updater consideration
+
+`hole` releases are auto-pulled by the upgrade flow (`hole upgrade`). If users have already been updated to a defective release, deleting the GitHub release does NOT roll back their installed version. Procedure:
+
+1. Issue a hotfix release with an incremented patch version.
+1. Users on the defective version auto-update to the hotfix on the next upgrade check.
+1. Do NOT publish a release with a lower version number than the defective one — the auto-updater treats higher versions as canonical and would not roll back.
+
+## Minisign key rotation (hole only)
+
+Hole's release `SHA256SUMS` is signed with a long-lived minisign key. The public key is committed at [`.github/workflows/publish-release-hole.yaml`](../.github/workflows/publish-release-hole.yaml). The private key is held by the maintainer offline.
+
+Rotation steps (key compromise, lost key, scheduled rotation):
+
+1. Generate a new key pair on the trusted local machine.
+
+   ```bash
+   minisign -G -p new-minisign.pub -s new-minisign.key
+   ```
+
+1. Update `publish-release-hole.yaml`'s `minisign -Vm SHA256SUMS -P '<NEW-PUBKEY>' ...` line with the new public key.
+
+1. Update [`scripts/sign-release.py`](../scripts/sign-release.py) if it embeds the key path (currently it does not — it uses minisign's default key search).
+
+1. Commit and merge the workflow change.
+
+1. Verify the new key works end-to-end. Cut a test release on a private branch using the new key, run the publish workflow against it, confirm minisign verification passes.
+
+1. **Do NOT delete the old key.** Archive it so historical releases continue to verify against their original signature. The release artifacts on GitHub are immutable; their signature remains tied to the old key.
+
+## Crates.io dry-run TOCTOU
+
+The `garter` draft workflow runs `cargo publish --dry-run -p garter` at validate time to fail-fast on broken metadata (missing fields, license issues, unresolvable deps). The actual `cargo publish` runs later in the publish workflow.
+
+Gap: between draft creation and publish, a transitive dependency could be yanked, an upstream registry change could land, or `Cargo.lock` could drift. Probability is low but non-zero.
+
+On publish failure:
+
+1. Check the failed `cargo publish` output for the yanked or unavailable dep.
+
+1. Two paths:
+
+   - Pin around the issue in `Cargo.toml` (e.g. `dep = "=X.Y.Z-1"` if the latest was yanked), bump garter's version per the group rules, cut a new draft.
+   - Wait for upstream resolution and re-run `publish-release-garter.yaml`.
+
+1. The publish workflow is idempotent: it queries crates.io's API and skips `cargo publish` if the version is already there. A re-run after a partial failure resumes cleanly without double-publishing.
+
+The draft GitHub release remains for re-attempt; no rollback is needed unless the draft itself is invalid.

--- a/docs/RELEASE-OPS.md
+++ b/docs/RELEASE-OPS.md
@@ -1,47 +1,64 @@
 # Release operations runbook
 
-Per-product release procedure: see [CLAUDE.md § Releases](../CLAUDE.md#releases). This file is the runbook for the off-happy-path operations: rollback, minisign key rotation, and the crates.io dry-run TOCTOU gap.
+Per-product release procedure: see [CLAUDE.md § Releases](../CLAUDE.md#releases). This file is the runbook for the off-happy-path operations: rollback, minisign key rotation, and the crates.io dry-run staleness gap.
 
 ## Rollback procedure
 
-Use when a release is published but later determined to be defective (broken binary, regression, security issue).
+Rollback is a **forward-only mitigation**, not undo. A yanked crates.io version cannot be republished; a deleted-and-recreated GitHub release with the same tag has a different commit history. Plan accordingly.
 
-### All tracks
+Use when a release is published but later determined defective (broken binary, regression, security issue).
 
-1. Delete the GitHub release. This detaches uploaded assets and removes the release object; the tag remains.
+### All tracks (prerequisite for the per-track sections below)
+
+1. Delete the GitHub release. This removes the release object and all uploaded assets. The underlying git tag is preserved by default; use `--cleanup-tag` to drop both in one shot.
 
    ```bash
-   gh release delete releases/<track>/v<X.Y.Z> --yes
+   gh release delete releases/<track>/v<X.Y.Z> --yes --cleanup-tag
    ```
 
-1. Delete the tag locally and on the remote.
+1. If `--cleanup-tag` wasn't used (or the tag still exists locally), delete the tag explicitly.
 
    ```bash
    git tag -d releases/<track>/v<X.Y.Z>
    git push --delete origin releases/<track>/v<X.Y.Z>
    ```
 
+For a **draft** release (e.g. a failed `garter` publish), `gh release delete` destroys the release AND the tag together (drafts hold tags in release metadata, not as real git refs). The `git tag -d` step will fail with "tag not found" — expected.
+
 ### `garter` track only — yank from crates.io
 
-`garter` is the only crate published to crates.io. After the GitHub release/tag are removed, yank the crates.io version:
+`garter` is the only crate published to crates.io. After completing the all-tracks steps above, yank the crates.io version:
 
 ```bash
 cargo yank --version <X.Y.Z> garter
 ```
 
-Yank does NOT delete the crate from crates.io. It prevents new `Cargo.toml` entries from resolving to the yanked version, but existing `Cargo.lock` files continue to work. To re-allow the version, run `cargo yank --version <X.Y.Z> --undo garter`.
+What yank does and doesn't do:
+
+- Prevents new `Cargo.toml` entries from resolving to the yanked version.
+- Does NOT delete the version. Existing `Cargo.lock` files still resolve it via sparse registry / `cargo fetch`.
+- **Permanently consumes the version number.** A subsequent `cargo publish` of the same `X.Y.Z` is rejected by crates.io; the hotfix MUST use a strictly greater version.
+- `cargo yank --version <X.Y.Z> --undo garter` un-yanks. Avoid using this after a hotfix is published — it leaves two versions installable and confuses downstream resolution.
 
 ### `hole` track only — auto-updater consideration
 
-`hole` releases are auto-pulled by the upgrade flow (`hole upgrade`). If users have already been updated to a defective release, deleting the GitHub release does NOT roll back their installed version. Procedure:
+`hole` releases are auto-pulled by the upgrade flow (`hole upgrade`, periodic check via `start_update_checker`). The auto-updater is **forward-only**: [`candidate_tags`](../crates/hole/src/update/check.rs) keeps only tags with `ver > current` (strict greater-than for non-snapshot installs).
 
-1. Issue a hotfix release with an incremented patch version.
-1. Users on the defective version auto-update to the hotfix on the next upgrade check.
-1. Do NOT publish a release with a lower version number than the defective one — the auto-updater treats higher versions as canonical and would not roll back.
+What this means for rollback:
+
+1. Deleting the defective GitHub release causes `fetch_release_for_tag` to return None for that tag, so new `hole upgrade` invocations skip it and find the previous-good release. New users are immediately safe.
+1. Users already on the defective version are stuck. The client never downgrades. The only fix is a **hotfix release with a strictly greater version**.
+1. Time-to-rollback equals time-to-cut-hotfix. There is no kill switch. For severe bugs, notify users out-of-band (GitHub release announcement, README banner) while the hotfix is in flight.
+1. Do not publish a hotfix with a lower version number than the defective one. The version-comparison check would skip it.
 
 ## Minisign key rotation (hole only)
 
-Hole's release `SHA256SUMS` is signed with a long-lived minisign key. The public key is committed at [`.github/workflows/publish-release-hole.yaml`](../.github/workflows/publish-release-hole.yaml). The private key is held by the maintainer offline.
+Hole's release `SHA256SUMS` is signed with a long-lived minisign key. **Two embedded copies of the public key must stay in sync**:
+
+- Server-side (release verification): embedded in the `Verify signature` step of [`.github/workflows/publish-release-hole.yaml`](../.github/workflows/publish-release-hole.yaml) as the `-P '...'` argument to `minisign -Vm`.
+- Client-side (auto-update verification): `MINISIGN_PUBLIC_KEY` constant in [`crates/hole/src/update/verify.rs`](../crates/hole/src/update/verify.rs).
+
+The private key lives on the maintainer's machine at minisign's default location (`~/.minisign/minisign.key`). [`scripts/sign-release.py`](../scripts/sign-release.py) calls `minisign -Sm` without `-s`, so the default path is what gets used unless `--secret-key` is passed.
 
 Rotation steps (key compromise, lost key, scheduled rotation):
 
@@ -51,31 +68,46 @@ Rotation steps (key compromise, lost key, scheduled rotation):
    minisign -G -p new-minisign.pub -s new-minisign.key
    ```
 
-1. Update `publish-release-hole.yaml`'s `minisign -Vm SHA256SUMS -P '<NEW-PUBKEY>' ...` line with the new public key.
+1. **Archive** the current `~/.minisign/minisign.key` (do NOT delete — see step 7) and replace it with `new-minisign.key`.
 
-1. Update [`scripts/sign-release.py`](../scripts/sign-release.py) if it embeds the key path (currently it does not — it uses minisign's default key search).
+1. Update the public key in `.github/workflows/publish-release-hole.yaml` (the `-P '<NEW-PUBKEY>'` argument to `minisign -Vm`).
 
-1. Commit and merge the workflow change.
+1. Update the public key in `crates/hole/src/update/verify.rs` (`MINISIGN_PUBLIC_KEY` constant). **Missing this step silently breaks `hole upgrade` for all already-installed clients** — they verify against the old key and reject the new-key-signed release.
 
-1. Verify the new key works end-to-end. Cut a test release on a private branch using the new key, run the publish workflow against it, confirm minisign verification passes.
+1. Commit and merge the workflow + client changes together.
 
-1. **Do NOT delete the old key.** Archive it so historical releases continue to verify against their original signature. The release artifacts on GitHub are immutable; their signature remains tied to the old key.
+1. Verify end-to-end. Cut a release on a temporary branch using the new key against a **personal fork** (not the production repo — a production publish workflow flips `/releases/latest`, which would clobber the live release). Run the fork's publish workflow, confirm minisign verification passes, confirm `hole upgrade` against the fork accepts the new signature.
 
-## Crates.io dry-run TOCTOU
+1. **Do NOT delete the old key.** Archive it so historical releases continue to verify against their original signature. The release artifacts on GitHub are immutable; their signature remains tied to the old key. If a user runs `hole upgrade` from a very old version and the auto-updater walks intermediate releases, those intermediate signatures still need the old public key on the client — which is why the client-side key in `verify.rs` MUST be updated for new releases but old clients MUST retain the old key (handled today by clients only verifying the release they're upgrading to, never historical ones).
 
-The `garter` draft workflow runs `cargo publish --dry-run -p garter` at validate time to fail-fast on broken metadata (missing fields, license issues, unresolvable deps). The actual `cargo publish` runs later in the publish workflow.
+**Compromised key vs. lost key.** A compromised key requires a public revocation (announce in repo README + GitHub release notes) in addition to rotation. A lost key requires the same rotation procedure but is recoverable only because the maintainer can sign a new client release with the new key — the next `hole upgrade` cycle propagates the trust transition.
 
-Gap: between draft creation and publish, a transitive dependency could be yanked, an upstream registry change could land, or `Cargo.lock` could drift. Probability is low but non-zero.
+## Crates.io dry-run staleness
+
+(Originally framed as "TOCTOU" — strictly it's stale validation, not a check-then-act race.)
+
+The `garter` draft workflow runs `cargo publish --dry-run -p garter` at validate time to fail-fast on broken metadata (missing fields, license issues, unresolvable deps). The actual `cargo publish` runs later in the publish workflow. Between those two moments, a transitive dep could be yanked, an upstream registry change could land, or `Cargo.lock` could drift.
 
 On publish failure:
 
-1. Check the failed `cargo publish` output for the yanked or unavailable dep.
+1. Read the failed `cargo publish` output to identify the yanked or unavailable dep.
 
-1. Two paths:
+1. Pick a recovery path based on the failure mode:
 
-   - Pin around the issue in `Cargo.toml` (e.g. `dep = "=X.Y.Z-1"` if the latest was yanked), bump garter's version per the group rules, cut a new draft.
-   - Wait for upstream resolution and re-run `publish-release-garter.yaml`.
+   - **Transient upstream issue** (e.g. registry hiccup): wait, then re-run the publish workflow. Idempotent — if the version already reached crates.io, `cargo publish` is skipped and the GitHub release is just flipped from draft to published.
+   - **Persistent issue** (yanked dep, breaking registry change): the draft is salvageable only after the underlying `Cargo.toml` is patched. Pin around the issue (e.g. `tokio = "=1.41.0"` to lock to the previous-good version), bump garter's version per the group rules, abandon the existing draft (`gh release delete` per the rollback procedure above), and cut a new draft against the patched commit.
 
-1. The publish workflow is idempotent: it queries crates.io's API and skips `cargo publish` if the version is already there. A re-run after a partial failure resumes cleanly without double-publishing.
+The publish workflow's idempotency check (`already_published` query) protects against **double-publishing** the same version, NOT against repeated-failure publishes — a yanked-dep failure will reproduce on every re-run until the upstream resolution lands.
 
-The draft GitHub release remains for re-attempt; no rollback is needed unless the draft itself is invalid.
+## Track interactions
+
+### Bundled-galoshes consideration
+
+CLAUDE.md notes galoshes is "shipped alongside hole.exe AND released standalone." A defective galoshes shipped inside a hole release requires:
+
+1. Roll back the **standalone** galoshes release using the procedure above (so server operators don't deploy it fresh).
+1. Roll back the **bundled** copy by cutting a new hole release with a fixed galoshes. The bundled bytes are baked into the MSI/DMG — patching galoshes alone does not retroactively fix already-installed hole.
+
+### v2ray-plugin lineage rollback
+
+The v2ray-plugin track uses `X.Y.Z-hole.N` lineage versioning (per CLAUDE.md). The "no-gaps" sequence validator in [`xtask-lib/src/v2ray_plugin_version.rs`](../xtask-lib/src/v2ray_plugin_version.rs) rejects skipped N values. After rolling back `1.3.3-hole.1`, the next attempt must be `1.3.3-hole.2` (the rollback removed the tag; the validator looks at tag history not release history, so the gap is invisible to it).


### PR DESCRIPTION
## Summary

Adds `docs/RELEASE-OPS.md` with three release-engineering runbook sections:

- **Rollback procedure** (L1): all-tracks GitHub release + tag deletion, `cargo yank` for garter, auto-updater consideration for hole (delete-and-replace, never roll back to lower version).
- **Minisign key rotation** (L2): hole-only, 6-step procedure including "do NOT delete the old key" note (historical releases must remain verifiable).
- **Crates.io dry-run TOCTOU** (L4): explains the gap between `cargo publish --dry-run` at draft time and real publish later; recovery procedure leveraging the workflow's idempotency.

`CONTRIBUTING.md` gains a "Release operations" pointer to the new runbook.

Closes #319.

## Test plan

- [x] mdformat hook reformatted ordered-list numbers to CommonMark `1.` style on commit.
- [x] All cross-links resolve (`../CLAUDE.md#releases`, `../.github/workflows/publish-release-hole.yaml`, `../scripts/sign-release.py`).
- [ ] Render in GitHub UI for final visual check.