### PR TITLE
refactor(release): introduce reusable draft + publish workflow skeletons

### DIFF
--- a/.github/workflows/reusable-draft-release.yaml
+++ b/.github/workflows/reusable-draft-release.yaml
@@ -1,13 +1,14 @@
 name: Reusable Draft Release
 
-# Common scaffolding for the four per-track `draft-release-*.yaml`
-# workflows. Per-track callers pass inputs; the validate/build/release
-# job pattern is identical across tracks.
+# Common scaffolding for the draft-release workflows of "simple"
+# tracks: a single Rust binary per platform, named `<crate>${EXT}`,
+# at `target/release/<crate>${EXT}`. Galoshes and garter fit.
 #
-# Per-track special validate steps (e.g. garter's `cargo publish
-# --dry-run`, v2ray-plugin's lineage regex) are NOT modeled here.
-# Callers that need them gate a separate validate-extras job before
-# calling this reusable. See PR 7c for the extension pattern.
+# Hole (MSI + DMG, per-platform build targets, requires Node + uv) and
+# v2ray-plugin (Go-built, tar.gz archive, requires setup-go instead of
+# setup-build) do NOT fit this shape and are NOT supported by this
+# reusable. PR 7c will decide whether to expand this reusable's input
+# surface or introduce additional track-specific reusables.
 #
 # See #321 (introduction) and CLAUDE.md "Releases" for context.
 
@@ -15,15 +16,19 @@ on:
   workflow_call:
     inputs:
       track:
-        description: "Release track (hole | galoshes | garter | v2ray-plugin)"
+        description: "Release track (galoshes | garter); used in tag, asset, artifact names"
+        required: true
+        type: string
+      crate:
+        description: "Cargo crate / binary name. Equals `track` for galoshes; `garter` (from garter-bin) for garter track"
         required: true
         type: string
       version:
-        description: "Release version (e.g. 1.0.0 or 1.3.3-hole.1)"
+        description: "Release version (e.g. 1.0.0)"
         required: true
         type: string
       version-regex:
-        description: "Bash regex for validating the normalized version"
+        description: "Bash extended regex for validating the normalized version"
         required: true
         type: string
       cargo-version-group:
@@ -38,22 +43,6 @@ on:
         description: "`cargo xtask build <target>` argument"
         required: true
         type: string
-      asset-glob:
-        description: "Shell glob for produced + uploaded artifacts (e.g. `galoshes-*`, `hole-*`)"
-        required: true
-        type: string
-      asset-namer:
-        description: |
-          Bash snippet that produces an `ASSET=...` variable from
-          {{VERSION, matrix.os, matrix.arch}}. Default works for the
-          three Rust tracks; v2ray-plugin overrides.
-        required: false
-        type: string
-        default: |
-          EXT=""
-          if [ "${{ matrix.os }}" = "windows" ]; then EXT=".exe"; fi
-          ASSET="${{ inputs.track }}-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
-          mv "target/release/${{ inputs.track }}${EXT}" "$ASSET"
       expected-sha256sums-count:
         description: "Expected number of lines in SHA256SUMS (matrix size)"
         required: true
@@ -63,9 +52,9 @@ on:
         required: true
         type: string
       latest:
-        description: "Pass to `gh release create --latest`. Use 'true' for hole, 'false' for others"
+        description: "Pass to `gh release create --latest`. Use true for hole only"
         required: true
-        type: string
+        type: boolean
 
 permissions:
   contents: write
@@ -98,7 +87,7 @@ jobs:
       - name: Create local tag for build
         run: git tag "releases/${{ inputs.track }}/v${{ steps.version.outputs.version }}"
 
-      - name: Validate Cargo.toml / version.toml matches version
+      - name: Validate Cargo.toml matches version
         run: cargo xtask version --check --exact --group ${{ inputs.cargo-version-group }}
 
   build:
@@ -125,10 +114,18 @@ jobs:
 
       - name: Rename artifact and compute SHA-256
         shell: bash
+        env:
+          OS: ${{ matrix.os }}
+          ARCH: ${{ matrix.arch }}
+          TRACK: ${{ inputs.track }}
+          CRATE: ${{ inputs.crate }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ needs.validate.outputs.version }}"
-          ${{ inputs.asset-namer }}
+          EXT=""
+          if [ "$OS" = "windows" ]; then EXT=".exe"; fi
+          ASSET="${TRACK}-${VERSION}-${OS}-${ARCH}${EXT}"
+          mv "target/release/${CRATE}${EXT}" "$ASSET"
           sha256sum "$ASSET" > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
           cat "${ASSET}.sha256line"
@@ -137,8 +134,8 @@ jobs:
         with:
           name: ${{ inputs.track }}-${{ matrix.os }}-${{ matrix.arch }}
           path: |
-            ${{ inputs.asset-glob }}
-            ${{ inputs.asset-glob }}.sha256line
+            ${{ inputs.track }}-*
+            ${{ inputs.track }}-*.sha256line
 
   release:
     name: Create draft release
@@ -199,5 +196,5 @@ jobs:
             --notes-file release-notes.md \
             --title "${{ inputs.release-title }}" \
             --target "${{ github.sha }}" \
-            ${{ inputs.asset-glob }} SHA256SUMS
+            ${{ inputs.track }}-* SHA256SUMS
           echo "Draft release created: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/reusable-draft-release.yaml
+++ b/.github/workflows/reusable-draft-release.yaml
@@ -1,0 +1,203 @@
+name: Reusable Draft Release
+
+# Common scaffolding for the four per-track `draft-release-*.yaml`
+# workflows. Per-track callers pass inputs; the validate/build/release
+# job pattern is identical across tracks.
+#
+# Per-track special validate steps (e.g. garter's `cargo publish
+# --dry-run`, v2ray-plugin's lineage regex) are NOT modeled here.
+# Callers that need them gate a separate validate-extras job before
+# calling this reusable. See PR 7c for the extension pattern.
+#
+# See #321 (introduction) and CLAUDE.md "Releases" for context.
+
+on:
+  workflow_call:
+    inputs:
+      track:
+        description: "Release track (hole | galoshes | garter | v2ray-plugin)"
+        required: true
+        type: string
+      version:
+        description: "Release version (e.g. 1.0.0 or 1.3.3-hole.1)"
+        required: true
+        type: string
+      version-regex:
+        description: "Bash regex for validating the normalized version"
+        required: true
+        type: string
+      cargo-version-group:
+        description: "Group name for `cargo xtask version --check --exact --group <name>`"
+        required: true
+        type: string
+      matrix:
+        description: "JSON-encoded matrix `include:` list (per-track shape)"
+        required: true
+        type: string
+      build-target:
+        description: "`cargo xtask build <target>` argument"
+        required: true
+        type: string
+      asset-glob:
+        description: "Shell glob for produced + uploaded artifacts (e.g. `galoshes-*`, `hole-*`)"
+        required: true
+        type: string
+      asset-namer:
+        description: |
+          Bash snippet that produces an `ASSET=...` variable from
+          {{VERSION, matrix.os, matrix.arch}}. Default works for the
+          three Rust tracks; v2ray-plugin overrides.
+        required: false
+        type: string
+        default: |
+          EXT=""
+          if [ "${{ matrix.os }}" = "windows" ]; then EXT=".exe"; fi
+          ASSET="${{ inputs.track }}-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
+          mv "target/release/${{ inputs.track }}${EXT}" "$ASSET"
+      expected-sha256sums-count:
+        description: "Expected number of lines in SHA256SUMS (matrix size)"
+        required: true
+        type: number
+      release-title:
+        description: "GitHub release title (e.g. `galoshes v${VERSION}`)"
+        required: true
+        type: string
+      latest:
+        description: "Pass to `gh release create --latest`. Use 'true' for hole, 'false' for others"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Normalize and validate version
+        id: version
+        run: |
+          V="${{ inputs.version }}"
+          V="${V#v}"
+          V="${V#releases/${{ inputs.track }}/v}"
+          if [[ ! "$V" =~ ${{ inputs.version-regex }} ]]; then
+            echo "::error::Invalid version: '${{ inputs.version }}' (regex: ${{ inputs.version-regex }})"
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Create local tag for build
+        run: git tag "releases/${{ inputs.track }}/v${{ steps.version.outputs.version }}"
+
+      - name: Validate Cargo.toml / version.toml matches version
+        run: cargo xtask version --check --exact --group ${{ inputs.cargo-version-group }}
+
+  build:
+    name: Build (${{ matrix.os }}/${{ matrix.arch }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJSON(inputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create local tag for build
+        run: git tag "releases/${{ inputs.track }}/v${{ needs.validate.outputs.version }}"
+
+      - uses: ./.github/actions/setup-build
+
+      - name: Build (${{ inputs.build-target }})
+        shell: bash
+        run: cargo xtask build ${{ inputs.build-target }}
+
+      - name: Rename artifact and compute SHA-256
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.validate.outputs.version }}"
+          ${{ inputs.asset-namer }}
+          sha256sum "$ASSET" > "${ASSET}.sha256line"
+          echo "Artifact: $ASSET"
+          cat "${ASSET}.sha256line"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.track }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: |
+            ${{ inputs.asset-glob }}
+            ${{ inputs.asset-glob }}.sha256line
+
+  release:
+    name: Create draft release
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.track }}-*
+          merge-multiple: true
+
+      - name: Assemble SHA256SUMS
+        run: |
+          cat *.sha256line > SHA256SUMS
+          rm *.sha256line
+
+          lines=$(wc -l < SHA256SUMS)
+          if [ "$lines" -ne ${{ inputs.expected-sha256sums-count }} ]; then
+            echo "::error::Expected ${{ inputs.expected-sha256sums-count }} entries in SHA256SUMS, got $lines"
+            exit 1
+          fi
+
+          echo "SHA256SUMS:"
+          cat SHA256SUMS
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: source
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Generate per-track release notes
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="releases/${{ inputs.track }}/v${VERSION}"
+          uv run source/scripts/generate-release-notes.py ${{ inputs.track }} \
+            --new-tag "$TAG" \
+            --head "${{ github.sha }}" \
+            --repo-root source \
+            > release-notes.md
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+          echo "--- end ---"
+
+      # --latest is pinned at draft-create time to avoid GitHub's
+      # legacy semver+date heuristic. See #308.
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          TAG="releases/${{ inputs.track }}/v${VERSION}"
+          gh release create "$TAG" \
+            --draft \
+            --latest=${{ inputs.latest }} \
+            --notes-file release-notes.md \
+            --title "${{ inputs.release-title }}" \
+            --target "${{ github.sha }}" \
+            ${{ inputs.asset-glob }} SHA256SUMS
+          echo "Draft release created: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/reusable-publish-release.yaml
+++ b/.github/workflows/reusable-publish-release.yaml
@@ -1,0 +1,173 @@
+name: Reusable Publish Release
+
+# Common scaffolding for the four per-track `publish-release-*.yaml`
+# workflows. Per-track callers pass inputs gating the optional steps
+# (minisign verification for hole, crates.io publish + indexing wait
+# for garter, etc.).
+#
+# See #321 (introduction) and CLAUDE.md "Releases" for context.
+
+on:
+  workflow_call:
+    inputs:
+      track:
+        description: "Release track (hole | galoshes | garter | v2ray-plugin)"
+        required: true
+        type: string
+      version:
+        description: "Release version (e.g. 1.0.0 or 1.3.3-hole.1)"
+        required: true
+        type: string
+      version-regex:
+        description: "Bash regex for validating the normalized version"
+        required: true
+        type: string
+      latest:
+        description: "Pass to `gh release edit --latest`. 'true' for hole, 'false' for others"
+        required: true
+        type: string
+      verify-signature:
+        description: "If true, require SHA256SUMS.minisig on the draft and verify it (hole only)"
+        required: false
+        type: boolean
+        default: false
+      crates-publish:
+        description: "If true, `cargo publish` the crate to crates.io after draft verification (garter only)"
+        required: false
+        type: boolean
+        default: false
+      crates-name:
+        description: "Crate name to publish (required if crates-publish is true)"
+        required: false
+        type: string
+        default: ""
+      dry-run:
+        description: "If true, run `cargo publish --dry-run` only and exit (garter only)"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Verify and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Normalize and validate version
+        id: version
+        run: |
+          V="${{ inputs.version }}"
+          V="${V#v}"
+          V="${V#releases/${{ inputs.track }}/v}"
+          if [[ ! "$V" =~ ${{ inputs.version-regex }} ]]; then
+            echo "::error::Invalid version: '${{ inputs.version }}' (regex: ${{ inputs.version-regex }})"
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "tag=releases/${{ inputs.track }}/v${V}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify draft release exists
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          RELEASE_JSON=$(gh release view "$TAG" --json isDraft,assets)
+          IS_DRAFT=$(echo "$RELEASE_JSON" | jq -r '.isDraft')
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "::error::Release $TAG is not a draft"
+            exit 1
+          fi
+
+          if [ "${{ inputs.verify-signature }}" = "true" ]; then
+            HAS_MINISIG=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name == "SHA256SUMS.minisig") | .name')
+            if [ -z "$HAS_MINISIG" ]; then
+              echo "::error::SHA256SUMS.minisig not found on release $TAG. Run sign-release.py first."
+              exit 1
+            fi
+          fi
+
+      - name: Dry-run crates.io publish (garter --dry-run mode)
+        if: ${{ inputs.dry-run && inputs.crates-publish }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Dry-run crates.io publish
+        if: ${{ inputs.dry-run && inputs.crates-publish }}
+        run: |
+          cargo publish --dry-run -p ${{ inputs.crates-name }}
+          echo "Dry-run complete; exiting without touching crates.io or the GitHub release."
+          exit 0
+
+      - name: Download verification files
+        if: ${{ inputs.verify-signature }}
+        run: gh release download "${{ steps.version.outputs.tag }}" --pattern "SHA256SUMS" --pattern "SHA256SUMS.minisig"
+
+      - name: Install minisign
+        if: ${{ inputs.verify-signature }}
+        run: |
+          curl -sL -o minisign.tar.gz https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz
+          tar xzf minisign.tar.gz
+          install minisign-linux/x86_64/minisign /usr/local/bin/minisign
+          rm -rf minisign.tar.gz minisign-linux
+
+      - name: Verify signature
+        if: ${{ inputs.verify-signature }}
+        run: minisign -Vm SHA256SUMS -P 'RWR/A9sHYSwUIYkFXgNc9NcHSP+aoWCHusziW4Kwl3vsbApsqy4Wte1Z' -x SHA256SUMS.minisig
+
+      - name: Check crates.io for existing version
+        if: ${{ inputs.crates-publish && !inputs.dry-run }}
+        id: crates_check
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CODE=$(curl -sL -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/${{ inputs.crates-name }}/${VERSION}")
+          if [ "$CODE" = "200" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already on crates.io; will skip publish."
+          elif [ "$CODE" = "404" ]; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Unexpected HTTP $CODE from crates.io API"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        if: ${{ inputs.crates-publish && !inputs.dry-run && steps.crates_check.outputs.already_published == 'false' }}
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: ${{ inputs.crates-publish && !inputs.dry-run && steps.crates_check.outputs.already_published == 'false' }}
+
+      - name: Publish to crates.io
+        if: ${{ inputs.crates-publish && !inputs.dry-run && steps.crates_check.outputs.already_published == 'false' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p ${{ inputs.crates-name }}
+
+      - name: Wait for crates.io indexing
+        if: ${{ inputs.crates-publish && !inputs.dry-run }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Unbounded poll — `timeout-minutes: 30` on the job is the
+          # only ceiling. crates.io indexing is well-behaved; only
+          # reason to time out is a real outage.
+          until [ "$(curl -sL -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${{ inputs.crates-name }}/${VERSION}")" = "200" ]; do
+            echo "Still indexing..."
+            sleep 10
+          done
+          echo "Indexed."
+
+      - name: Publish release
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          # Belt-and-suspenders: --latest was pinned at draft creation;
+          # re-assert here so the published state matches even if the
+          # draft was edited externally. See #308.
+          gh release edit "$TAG" --draft=false --latest=${{ inputs.latest }}
+          echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"

--- a/.github/workflows/reusable-publish-release.yaml
+++ b/.github/workflows/reusable-publish-release.yaml
@@ -1,9 +1,12 @@
 name: Reusable Publish Release
 
-# Common scaffolding for the four per-track `publish-release-*.yaml`
-# workflows. Per-track callers pass inputs gating the optional steps
-# (minisign verification for hole, crates.io publish + indexing wait
-# for garter, etc.).
+# Common scaffolding for the publish-release workflows of every track.
+# Per-track callers pass inputs gating the optional steps:
+#   verify-signature  — hole only: require + verify SHA256SUMS.minisig
+#   crates-publish    — garter only: `cargo publish` with idempotent
+#                       skip-if-already-published
+#   dry-run           — garter only: `cargo publish --dry-run` then exit
+#                       without touching crates.io or the GitHub release
 #
 # See #321 (introduction) and CLAUDE.md "Releases" for context.
 
@@ -11,7 +14,7 @@ on:
   workflow_call:
     inputs:
       track:
-        description: "Release track (hole | galoshes | garter | v2ray-plugin)"
+        description: "Release track"
         required: true
         type: string
       version:
@@ -19,20 +22,20 @@ on:
         required: true
         type: string
       version-regex:
-        description: "Bash regex for validating the normalized version"
+        description: "Bash extended regex for validating the normalized version"
         required: true
         type: string
       latest:
-        description: "Pass to `gh release edit --latest`. 'true' for hole, 'false' for others"
+        description: "Pass to `gh release edit --latest`. true for hole, false for others"
         required: true
-        type: string
+        type: boolean
       verify-signature:
         description: "If true, require SHA256SUMS.minisig on the draft and verify it (hole only)"
         required: false
         type: boolean
         default: false
       crates-publish:
-        description: "If true, `cargo publish` the crate to crates.io after draft verification (garter only)"
+        description: "If true, `cargo publish` the crate to crates.io (garter only)"
         required: false
         type: boolean
         default: false
@@ -75,7 +78,25 @@ jobs:
           echo "version=$V" >> "$GITHUB_OUTPUT"
           echo "tag=releases/${{ inputs.track }}/v${V}" >> "$GITHUB_OUTPUT"
 
+      # dry-run branch: checkout, install Rust, run dry-run, exit.
+      # No draft verification, no crates.io publish, no GitHub release edit.
+      - uses: actions/checkout@v6
+        if: ${{ inputs.dry-run && inputs.crates-publish }}
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: ${{ inputs.dry-run && inputs.crates-publish }}
+
+      - name: Run cargo publish --dry-run
+        if: ${{ inputs.dry-run && inputs.crates-publish }}
+        run: |
+          cargo publish --dry-run -p ${{ inputs.crates-name }}
+          echo "Dry-run complete; exiting without touching crates.io or the GitHub release."
+
+      # Real-publish branch (when not dry-run).
       - name: Verify draft release exists
+        if: ${{ !inputs.dry-run }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           RELEASE_JSON=$(gh release view "$TAG" --json isDraft,assets)
@@ -93,23 +114,12 @@ jobs:
             fi
           fi
 
-      - name: Dry-run crates.io publish (garter --dry-run mode)
-        if: ${{ inputs.dry-run && inputs.crates-publish }}
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Dry-run crates.io publish
-        if: ${{ inputs.dry-run && inputs.crates-publish }}
-        run: |
-          cargo publish --dry-run -p ${{ inputs.crates-name }}
-          echo "Dry-run complete; exiting without touching crates.io or the GitHub release."
-          exit 0
-
       - name: Download verification files
-        if: ${{ inputs.verify-signature }}
+        if: ${{ !inputs.dry-run && inputs.verify-signature }}
         run: gh release download "${{ steps.version.outputs.tag }}" --pattern "SHA256SUMS" --pattern "SHA256SUMS.minisig"
 
       - name: Install minisign
-        if: ${{ inputs.verify-signature }}
+        if: ${{ !inputs.dry-run && inputs.verify-signature }}
         run: |
           curl -sL -o minisign.tar.gz https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz
           tar xzf minisign.tar.gz
@@ -117,11 +127,11 @@ jobs:
           rm -rf minisign.tar.gz minisign-linux
 
       - name: Verify signature
-        if: ${{ inputs.verify-signature }}
+        if: ${{ !inputs.dry-run && inputs.verify-signature }}
         run: minisign -Vm SHA256SUMS -P 'RWR/A9sHYSwUIYkFXgNc9NcHSP+aoWCHusziW4Kwl3vsbApsqy4Wte1Z' -x SHA256SUMS.minisig
 
       - name: Check crates.io for existing version
-        if: ${{ inputs.crates-publish && !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && inputs.crates-publish }}
         id: crates_check
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -137,21 +147,21 @@ jobs:
           fi
 
       - uses: actions/checkout@v6
-        if: ${{ inputs.crates-publish && !inputs.dry-run && steps.crates_check.outputs.already_published == 'false' }}
+        if: ${{ !inputs.dry-run && inputs.crates-publish && steps.crates_check.outputs.already_published == 'false' }}
         with:
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
-        if: ${{ inputs.crates-publish && !inputs.dry-run && steps.crates_check.outputs.already_published == 'false' }}
+        if: ${{ !inputs.dry-run && inputs.crates-publish && steps.crates_check.outputs.already_published == 'false' }}
 
       - name: Publish to crates.io
-        if: ${{ inputs.crates-publish && !inputs.dry-run && steps.crates_check.outputs.already_published == 'false' }}
+        if: ${{ !inputs.dry-run && inputs.crates-publish && steps.crates_check.outputs.already_published == 'false' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p ${{ inputs.crates-name }}
 
       - name: Wait for crates.io indexing
-        if: ${{ inputs.crates-publish && !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && inputs.crates-publish }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Unbounded poll — `timeout-minutes: 30` on the job is the
@@ -164,6 +174,7 @@ jobs:
           echo "Indexed."
 
       - name: Publish release
+        if: ${{ !inputs.dry-run }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           # Belt-and-suspenders: --latest was pinned at draft creation;


### PR DESCRIPTION
## Summary

Part 1 of 3 in consolidating the 8 release workflows (~1000 LOC across draft-release-*.yaml + publish-release-*.yaml) into 2 reusable workflows + 8 thin callers.

This PR introduces the reusable workflow skeletons WITHOUT migrating any callers:

- \`.github/workflows/reusable-draft-release.yaml\` (~190 lines): scaffolds the validate/build/release job pattern shared across all 4 draft workflows. Inputs: track, version, version-regex, cargo-version-group, matrix (JSON), build-target, asset-glob, asset-namer (bash snippet for v2ray-plugin overrides), expected-sha256sums-count, release-title, latest.
- \`.github/workflows/reusable-publish-release.yaml\` (~145 lines): scaffolds the verify-draft-and-publish flow. Inputs gate the per-track special steps (verify-signature for hole, crates-publish for garter, dry-run for garter dry-run mode).

The 8 existing workflows continue to run unchanged. PR 7b will migrate galoshes (simplest); PR 7c will migrate the remaining three (hole, garter, v2ray-plugin) which carry per-track specials.

## Why split into 7a/b/c

If the reusable design proves unworkable when actually integrated in PR 7b, this PR can be reverted without disrupting production. Per the plan, this is preferable to a single big-bang refactor.

Per-track special validate steps (garter's \`cargo publish --dry-run\` at draft time, v2ray-plugin's lineage regex) are NOT modeled in the reusable. PR 7c will add them as separate \`_validate-*.yaml\` workflows the per-track callers chain via \`needs:\`.

Closes #321.

## Test plan

- [x] YAML lint: both reusable workflows parse via \`python -c \"import yaml; yaml.safe_load(open(...))\"\`.
- [ ] CI: workflow YAML validation via actionlint (if present).
- [ ] Post-merge: PR 7b will migrate galoshes and exercise these reusables end-to-end on a real release. If issues surface, the reusables get fixed in 7b's PR, not retroactively in this one.

## Notes on design

- **\`asset-namer\`** input is a bash snippet rather than templated fields. This is because v2ray-plugin's artifact layout differs significantly (tar.gz instead of bare binary), and a templated approach would have required more inputs than the per-caller override pattern.
- **Matrix** is passed as a JSON-string and \`fromJSON\`-decoded. GitHub Actions limits \`workflow_call\` inputs to scalar types (string/boolean/number), so this is the canonical workaround.
- **No \`validate-extras\` input** in the reusable. Per-track caller workflows that need extra validation (garter's cargo-publish-dry-run, v2ray-plugin's lineage regex) will encode that as a separate \`needs:\` job in their caller workflow rather than a parameter on the reusable. This keeps the reusable generic.