### PR TITLE
refactor(release): migrate galoshes draft+publish to reusable workflows

### DIFF
--- a/.github/workflows/draft-release-galoshes.yaml
+++ b/.github/workflows/draft-release-galoshes.yaml
@@ -1,5 +1,8 @@
 name: Draft Release (galoshes)
 
+# Thin caller for the shared draft-release reusable workflow.
+# See .github/workflows/reusable-draft-release.yaml and #325.
+
 on:
   workflow_dispatch:
     inputs: &inputs
@@ -10,145 +13,27 @@ on:
   workflow_call:
     inputs: *inputs
 
-permissions:
-  contents: write
-
 jobs:
-  validate:
-    name: Validate version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Normalize and validate version
-        id: version
-        run: |
-          V="${{ inputs.version }}"
-          V="${V#v}"
-          V="${V#releases/galoshes/v}"
-          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
-          echo "version=$V" >> "$GITHUB_OUTPUT"
-
-      - name: Create local tag for build
-        run: git tag "releases/galoshes/v${{ steps.version.outputs.version }}"
-
-      - name: Validate Cargo.toml matches version
-        run: cargo xtask version --check --exact --group galoshes
-
-  build:
-    name: Build (${{ matrix.os }}/${{ matrix.arch }})
-    needs: validate
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - { os: windows, arch: amd64, runner: windows-latest    }
-          - { os: windows, arch: arm64, runner: windows-11-arm    }
-          - { os: darwin,  arch: amd64, runner: macos-15-intel    }
-          - { os: darwin,  arch: arm64, runner: macos-latest      }
-          - { os: linux,   arch: amd64, runner: ubuntu-latest     }
-          - { os: linux,   arch: arm64, runner: ubuntu-24.04-arm  }
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Create local tag for build
-        run: git tag "releases/galoshes/v${{ needs.validate.outputs.version }}"
-
-      - uses: ./.github/actions/setup-build
-
-      - name: Build galoshes (release)
-        shell: bash
-        run: cargo xtask build galoshes
-
-      - name: Rename artifact and compute SHA-256
-        shell: bash
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          EXT=""
-          if [ "${{ matrix.os }}" = "windows" ]; then EXT=".exe"; fi
-          ASSET="galoshes-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
-
-          mv "target/release/galoshes${EXT}" "$ASSET"
-          sha256sum "$ASSET" > "${ASSET}.sha256line"
-          echo "Artifact: $ASSET"
-          cat "${ASSET}.sha256line"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: galoshes-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            galoshes-*
-            galoshes-*.sha256line
-
-  release:
-    name: Create draft release
-    needs: [validate, build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: galoshes-*
-          merge-multiple: true
-
-      - name: Assemble SHA256SUMS
-        run: |
-          cat *.sha256line > SHA256SUMS
-          rm *.sha256line
-
-          lines=$(wc -l < SHA256SUMS)
-          if [ "$lines" -ne 6 ]; then
-            echo "::error::Expected 6 entries in SHA256SUMS (6-platform matrix), got $lines"
-            exit 1
-          fi
-
-          echo "SHA256SUMS:"
-          cat SHA256SUMS
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          path: source
-
-      - uses: astral-sh/setup-uv@v7
-
-      - name: Generate per-track release notes
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          TAG="releases/galoshes/v${VERSION}"
-          uv run source/scripts/generate-release-notes.py galoshes \
-            --new-tag "$TAG" \
-            --head "${{ github.sha }}" \
-            --repo-root source \
-            > release-notes.md
-          echo "--- release-notes.md ---"
-          cat release-notes.md
-          echo "--- end ---"
-
-      # --latest=false at draft-create time pins GitHub's make_latest so
-      # the eventual publish doesn't promote this release to
-      # /releases/latest via the legacy semver+date heuristic. Hole is
-      # the only track that claims /latest. See #308.
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          TAG="releases/galoshes/v${VERSION}"
-          gh release create "$TAG" \
-            --draft \
-            --latest=false \
-            --notes-file release-notes.md \
-            --title "galoshes v${VERSION}" \
-            --target "${{ github.sha }}" \
-            galoshes-* SHA256SUMS
-          echo "Draft release created: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+  draft:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable-draft-release.yaml
+    with:
+      track: galoshes
+      crate: galoshes
+      version: ${{ inputs.version }}
+      version-regex: '^[0-9]+\.[0-9]+\.[0-9]+$'
+      cargo-version-group: galoshes
+      matrix: |
+        [
+          { "os": "windows", "arch": "amd64", "runner": "windows-latest" },
+          { "os": "windows", "arch": "arm64", "runner": "windows-11-arm" },
+          { "os": "darwin",  "arch": "amd64", "runner": "macos-15-intel" },
+          { "os": "darwin",  "arch": "arm64", "runner": "macos-latest" },
+          { "os": "linux",   "arch": "amd64", "runner": "ubuntu-latest" },
+          { "os": "linux",   "arch": "arm64", "runner": "ubuntu-24.04-arm" }
+        ]
+      build-target: galoshes
+      expected-sha256sums-count: 6
+      release-title: galoshes v${{ inputs.version }}
+      latest: false

--- a/.github/workflows/publish-release-galoshes.yaml
+++ b/.github/workflows/publish-release-galoshes.yaml
@@ -1,5 +1,8 @@
 name: Publish Release (galoshes)
 
+# Thin caller for the shared publish-release reusable workflow.
+# See .github/workflows/reusable-publish-release.yaml and #325.
+
 on:
   workflow_dispatch:
     inputs: &inputs
@@ -10,41 +13,13 @@ on:
   workflow_call:
     inputs: *inputs
 
-permissions:
-  contents: write
-
 jobs:
   publish:
-    name: Verify and publish
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GH_REPO: ${{ github.repository }}
-    steps:
-      - name: Normalize and validate version
-        id: version
-        run: |
-          V="${{ inputs.version }}"
-          V="${V#v}"
-          V="${V#releases/galoshes/v}"
-          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
-          echo "tag=releases/galoshes/v${V}" >> "$GITHUB_OUTPUT"
-
-      # Confirm draft exists; galoshes is unsigned, so no minisig check.
-      - name: Verify draft release exists
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          IS_DRAFT=$(gh release view "$TAG" --json isDraft -q .isDraft)
-          if [ "$IS_DRAFT" != "true" ]; then
-            echo "::error::Release $TAG is not a draft"
-            exit 1
-          fi
-
-      - name: Publish release
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          # Belt-and-suspenders: --latest=false was pinned at draft
-          # creation; re-assert here so the published state matches even
-          # if the draft was edited externally. See #308.
-          gh release edit "$TAG" --draft=false --latest=false
-          echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable-publish-release.yaml
+    with:
+      track: galoshes
+      version: ${{ inputs.version }}
+      version-regex: '^[0-9]+\.[0-9]+\.[0-9]+$'
+      latest: false


### PR DESCRIPTION
## Summary

Part 2 of 3 in the reusable-workflow consolidation. Migrates the galoshes track (simplest — no signing, no crates.io publish, single-binary-per-platform Rust shape) to the reusables introduced in PR #322.

LOC change: 217 lines → 64 lines for the galoshes pair (-153). The 376-line reusable amortizes across additional tracks; PR 7c will need to choose between expanding the reusable (for garter) or keeping hole/v2ray-plugin bespoke (per PR #322 review which flagged those tracks can't fit the galoshes-shaped reusable).

Validates the reusable design end-to-end. Issues surfaced here should be fixed in this PR rather than retroactively in PR 7a.

Closes #325.

## Test plan

- [x] YAML parse on both caller files.
- [ ] Post-merge: cut a test galoshes release (e.g. via `gh workflow run draft-release-galoshes.yaml -f version=999.0.0`) and verify:
  - Draft is created with `--latest=false`.
  - All 6 platform artifacts uploaded.
  - SHA256SUMS has 6 entries.
  - Release notes generated.
  - Clean up the test release/tag afterward.
- [ ] Verify CI doesn't auto-trigger this draft workflow on push (it's workflow_dispatch / workflow_call only).