### PR TITLE
refactor(release): migrate garter draft+publish to reusable workflows

### DIFF
--- a/.github/workflows/draft-release-garter.yaml
+++ b/.github/workflows/draft-release-garter.yaml
@@ -1,5 +1,9 @@
 name: Draft Release (garter)
 
+# Thin caller for the shared draft-release reusable, plus a garter-only
+# `cargo publish --dry-run` pre-check that runs before the reusable.
+# See .github/workflows/reusable-draft-release.yaml and #326.
+
 on:
   workflow_dispatch:
     inputs: &inputs
@@ -10,153 +14,41 @@ on:
   workflow_call:
     inputs: *inputs
 
-permissions:
-  contents: write
-
 jobs:
-  validate:
-    name: Validate version + cargo publish --dry-run
+  # Garter-specific pre-check: surface crates.io publish blockers
+  # (missing metadata, syntax, path-deps that won't resolve) BEFORE the
+  # reusable kicks off the 6-platform build matrix.
+  validate-cargo-publish:
+    name: cargo publish --dry-run for garter library
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --dry-run -p garter
 
-      - name: Normalize and validate version
-        id: version
-        run: |
-          V="${{ inputs.version }}"
-          V="${V#v}"
-          V="${V#releases/garter/v}"
-          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
-          echo "version=$V" >> "$GITHUB_OUTPUT"
-
-      - name: Create local tag for build
-        run: git tag "releases/garter/v${{ steps.version.outputs.version }}"
-
-      - name: Validate Cargo.toml matches version
-        run: cargo xtask version --check --exact --group garter
-
-      # Surface any crates.io publish blockers (missing metadata, syntax,
-      # path-dep that won't resolve) BEFORE we build artifacts.
-      - name: cargo publish --dry-run for garter library
-        run: cargo publish --dry-run -p garter
-
-  build:
-    name: Build garter-bin (${{ matrix.os }}/${{ matrix.arch }})
-    needs: validate
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - { os: windows, arch: amd64, runner: windows-latest    }
-          - { os: windows, arch: arm64, runner: windows-11-arm    }
-          - { os: darwin,  arch: amd64, runner: macos-15-intel    }
-          - { os: darwin,  arch: arm64, runner: macos-latest      }
-          - { os: linux,   arch: amd64, runner: ubuntu-latest     }
-          - { os: linux,   arch: arm64, runner: ubuntu-24.04-arm  }
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Create local tag for build
-        run: git tag "releases/garter/v${{ needs.validate.outputs.version }}"
-
-      - uses: ./.github/actions/setup-build
-
-      - name: Build garter-bin (release)
-        shell: bash
-        run: cargo xtask build garter-bin
-
-      # garter-bin's binary is named `garter` (per CLAUDE.md / Cargo.toml
-      # `[[bin]] name = "garter"`). The release-asset name carries the
-      # crate's release-group as the user-visible prefix.
-      - name: Rename artifact and compute SHA-256
-        shell: bash
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          EXT=""
-          if [ "${{ matrix.os }}" = "windows" ]; then EXT=".exe"; fi
-          ASSET="garter-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}${EXT}"
-
-          mv "target/release/garter${EXT}" "$ASSET"
-          sha256sum "$ASSET" > "${ASSET}.sha256line"
-          echo "Artifact: $ASSET"
-          cat "${ASSET}.sha256line"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: garter-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            garter-*
-            garter-*.sha256line
-
-  release:
-    name: Create draft release
-    needs: [validate, build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: garter-*
-          merge-multiple: true
-
-      - name: Assemble SHA256SUMS
-        run: |
-          cat *.sha256line > SHA256SUMS
-          rm *.sha256line
-
-          lines=$(wc -l < SHA256SUMS)
-          if [ "$lines" -ne 6 ]; then
-            echo "::error::Expected 6 entries in SHA256SUMS (6-platform matrix), got $lines"
-            exit 1
-          fi
-
-          echo "SHA256SUMS:"
-          cat SHA256SUMS
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          path: source
-
-      - uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Generate per-track release notes
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          TAG="releases/garter/v${VERSION}"
-          uv run source/scripts/generate-release-notes.py garter \
-            --new-tag "$TAG" \
-            --head "${{ github.sha }}" \
-            --repo-root source \
-            > release-notes.md
-          echo "--- release-notes.md ---"
-          cat release-notes.md
-          echo "--- end ---"
-
-      # --latest=false at draft-create time pins GitHub's make_latest so
-      # the eventual publish doesn't promote this release to
-      # /releases/latest via the legacy semver+date heuristic. Hole is
-      # the only track that claims /latest. See #308.
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          VERSION="${{ needs.validate.outputs.version }}"
-          TAG="releases/garter/v${VERSION}"
-          gh release create "$TAG" \
-            --draft \
-            --latest=false \
-            --notes-file release-notes.md \
-            --title "garter v${VERSION}" \
-            --target "${{ github.sha }}" \
-            garter-* SHA256SUMS
-          echo "Draft release created: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+  draft:
+    needs: validate-cargo-publish
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable-draft-release.yaml
+    with:
+      track: garter
+      crate: garter
+      version: ${{ inputs.version }}
+      version-regex: '^[0-9]+\.[0-9]+\.[0-9]+$'
+      cargo-version-group: garter
+      matrix: |
+        [
+          { "os": "windows", "arch": "amd64", "runner": "windows-latest" },
+          { "os": "windows", "arch": "arm64", "runner": "windows-11-arm" },
+          { "os": "darwin",  "arch": "amd64", "runner": "macos-15-intel" },
+          { "os": "darwin",  "arch": "arm64", "runner": "macos-latest" },
+          { "os": "linux",   "arch": "amd64", "runner": "ubuntu-latest" },
+          { "os": "linux",   "arch": "arm64", "runner": "ubuntu-24.04-arm" }
+        ]
+      build-target: garter-bin
+      expected-sha256sums-count: 6
+      release-title: garter v${{ inputs.version }}
+      latest: false

--- a/.github/workflows/publish-release-garter.yaml
+++ b/.github/workflows/publish-release-garter.yaml
@@ -1,119 +1,35 @@
 name: Publish Release (garter)
 
+# Thin caller for the shared publish-release reusable workflow.
+# See .github/workflows/reusable-publish-release.yaml and #326.
+
 on:
   workflow_dispatch:
-    inputs:
+    inputs: &inputs
       version:
         description: "garter release version (e.g. 0.1.0)"
         required: true
         type: string
       dry_run:
-        description: "Run `cargo publish --dry-run` and exit before tag work"
+        description: "Run `cargo publish --dry-run` only; do not touch crates.io or the tag"
         required: false
         type: boolean
         default: false
-
-permissions:
-  contents: write
+  workflow_call:
+    inputs: *inputs
 
 jobs:
   publish:
-    name: Verify, publish to crates.io, tag
-    runs-on: ubuntu-latest
-    # 30 minutes is generous for the cargo-publish + crates.io indexing
-    # wait (typically completes in seconds-to-minutes). If indexing takes
-    # longer, that's a crates.io outage; the timeout surfaces it instead
-    # of letting the runner hang for 6 hours.
-    timeout-minutes: 30
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GH_REPO: ${{ github.repository }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Normalize and validate version
-        id: version
-        run: |
-          V="${{ inputs.version }}"
-          V="${V#v}"
-          V="${V#releases/garter/v}"
-          [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::Invalid version: '${{ inputs.version }}'"; exit 1; }
-          echo "version=$V" >> "$GITHUB_OUTPUT"
-          echo "tag=releases/garter/v${V}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify draft release exists
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          IS_DRAFT=$(gh release view "$TAG" --json isDraft -q .isDraft)
-          if [ "$IS_DRAFT" != "true" ]; then
-            echo "::error::Release $TAG is not a draft"
-            exit 1
-          fi
-
-      - name: Dry-run path
-        if: ${{ inputs.dry_run }}
-        run: |
-          cargo publish --dry-run -p garter
-          echo "dry_run=true; not publishing or tagging"
-
-      # Check if this version is already on crates.io. The HTTP API returns
-      # 200 for an existing version and 404 for a missing one. Anything else
-      # is treated as a transient failure and fails the workflow loudly.
-      - name: Check if garter version already on crates.io
-        id: crates_io
-        if: ${{ !inputs.dry_run }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          URL="https://crates.io/api/v1/crates/garter/${VERSION}"
-          CODE=$(curl -sf -o /dev/null -w '%{http_code}' -X GET "$URL" || true)
-          echo "HTTP status: $CODE"
-          case "$CODE" in
-            200) echo "already_published=true"  >> "$GITHUB_OUTPUT" ;;
-            404) echo "already_published=false" >> "$GITHUB_OUTPUT" ;;
-            *)   echo "::error::Unexpected HTTP status $CODE from crates.io for garter ${VERSION}"; exit 1 ;;
-          esac
-
-      - name: cargo publish (only when not already on crates.io)
-        if: ${{ !inputs.dry_run && steps.crates_io.outputs.already_published == 'false' }}
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p garter
-
-      # crates.io accepts `cargo publish` and indexes asynchronously
-      # (seconds to minutes). If we flip the GitHub release to published
-      # immediately, downstream users may see the release announcement
-      # before `cargo install garter` works. Wait until the API confirms
-      # the version is indexed before continuing.
-      #
-      # No artificial loop cap: the workflow's job-level timeout below
-      # is the hard ceiling. crates.io indexing is well-behaved; the only
-      # reason this would time out is a real outage, in which case the
-      # tag-creation step below should not run either.
-      - name: Wait for crates.io to index the new version
-        if: ${{ !inputs.dry_run }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          URL="https://crates.io/api/v1/crates/garter/${VERSION}"
-          while true; do
-            CODE=$(curl -sf -o /dev/null -w '%{http_code}' -X GET "$URL" || true)
-            if [ "$CODE" = "200" ]; then
-              echo "garter ${VERSION} is indexed on crates.io"
-              break
-            fi
-            echo "Still indexing... (HTTP $CODE)"
-            sleep 10
-          done
-
-      - name: Publish GitHub release (and create tag)
-        if: ${{ !inputs.dry_run }}
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          # Belt-and-suspenders: --latest=false was pinned at draft
-          # creation; re-assert here so the published state matches even
-          # if the draft was edited externally. See #308.
-          gh release edit "$TAG" --draft=false --latest=false
-          echo "Release published: https://github.com/${{ github.repository }}/releases/tag/$TAG"
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable-publish-release.yaml
+    with:
+      track: garter
+      version: ${{ inputs.version }}
+      version-regex: '^[0-9]+\.[0-9]+\.[0-9]+$'
+      latest: false
+      crates-publish: true
+      crates-name: garter
+      dry-run: ${{ inputs.dry_run }}
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

Part 3 of 3 in the reusable-workflow consolidation. Migrates the garter track to the reusables introduced in PR #322 and exercised by PR #330.

**Scope decision (per PR #322 review):** This PR migrates only garter. Hole (MSI/DMG + Node/uv) and v2ray-plugin (Go + tar.gz) don't fit the galoshes-shape reusable and would each require either expanding the reusable's input surface significantly OR introducing additional track-specific reusables. Both options risk net-zero or net-negative LOC reduction. Keeping hole and v2ray-plugin bespoke is the pragmatic call:

- 2/4 tracks (galoshes, garter) use the consolidated reusable: clean uniformity for the "Rust binary per platform" shape.
- 2/4 tracks (hole, v2ray-plugin) remain bespoke: their per-track specials are too divergent to consolidate cheaply.

LOC change for garter: 247 lines → 89 lines (-158). Combined with galoshes from PR #330 (-153), the reusable has now displaced ~310 lines across 2 tracks. The reusable itself is 376 lines. Net workspace LOC roughly even, but uniformity and single-source-of-truth for the common path is the real win.

Garter-specific shape inside the caller:
- **Draft**: a `validate-cargo-publish` job runs `cargo publish --dry-run -p garter` BEFORE the reusable kicks off the 6-platform build matrix. Workflow-call `needs:` semantics chain it correctly.
- **Publish**: thin caller passes `crates-publish: true`, `crates-name: garter`, `dry-run: ${{ inputs.dry_run }}`, plus `secrets: CARGO_REGISTRY_TOKEN`.

Closes #326.

## Test plan

- [x] YAML parse on both caller files.
- [ ] Post-merge: cut a test garter release; verify `cargo publish --dry-run` pre-check runs first; verify reusable's 6-platform build + draft creation works; verify crates.io publish + indexing flow on the publish step.
- [ ] Verify the `dry_run` input on publish-release-garter still works (run with `-f dry_run=true` and confirm no GitHub release flip + no crates.io publish).