### PR TITLE
chore(renovate): auto-merge majors and pin breaking deps from #336

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,40 +22,64 @@
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
     },
     {
       "description": "Group Cargo updates",
       "matchManagers": ["cargo"],
       "groupName": "cargo",
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
     },
     {
       "description": "Group Go module updates",
       "matchManagers": ["gomod"],
       "groupName": "gomod",
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
     },
     {
       "description": "Group Python (PEP 621) updates",
       "matchManagers": ["pep621"],
       "groupName": "python",
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
     },
     {
       "description": "Group npm updates",
       "matchManagers": ["npm"],
       "groupName": "npm",
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "lockFileMaintenance": {
         "enabled": true,
         "automerge": true,
         "schedule": ["before 9am on monday"]
       }
+    },
+    {
+      "description": "Pin ctor < 0.3 pending hole-test-observability migration to ctor 0.13 (see #336).",
+      "matchPackageNames": ["ctor"],
+      "matchManagers": ["cargo"],
+      "allowedVersions": "<0.3"
+    },
+    {
+      "description": "Pin schemars < 0.9 pending crates/common/build.rs migration to schemars 0.9 (see #336).",
+      "matchPackageNames": ["schemars"],
+      "matchManagers": ["cargo"],
+      "allowedVersions": "<0.9"
+    },
+    {
+      "description": "Pin rand < 0.10 pending hole-bridge test_support migration to rand 0.10 (see #336).",
+      "matchPackageNames": ["rand"],
+      "matchManagers": ["cargo"],
+      "allowedVersions": "<0.10"
+    },
+    {
+      "description": "Pin rcgen < 0.14 pending hole-bridge test_support migration to rcgen 0.14 (see #336).",
+      "matchPackageNames": ["rcgen"],
+      "matchManagers": ["cargo"],
+      "allowedVersions": "<0.14"
     }
   ]
 }


### PR DESCRIPTION
Closes #339.

## What changes

1. **Extend auto-merge to majors.** Each grouped package rule (github-actions / cargo / gomod / pep621 / npm) now matches `["major", "minor", "patch", "pin", "digest"]` instead of `["minor", "patch", "pin", "digest"]`. CI is the safety check: if every required check is green on a Renovate PR, GitHub's platform auto-merge fires it without a human gate.

2. **Pin four crates pending the migrations tracked in #336.** Renovate's cargo manager classifies `0.x → 0.y` bumps as minor, so without an explicit guard those four would keep landing in the cargo group PR each week and breaking it. Each pin uses `allowedVersions: "<X.Y"` against the next-known-broken version. Remove the pin in the same PR that lands the migration.

| Crate | Pin | Reason |
|---|---|---|
| `ctor` | `<0.3` | `hole-test-observability::register!()` expands `#[$crate::ctor]` into consumer crates without ctor in their deps; ctor 0.13's proc-macro requires that. |
| `schemars` | `<0.9` | `crates/common/build.rs` imports `schemars::schema::Schema`; schemars 0.9 made the module private. |
| `rand` | `<0.10` | `rand::RngCore` moved; `Rng::fill_bytes` removed; `Rng::random()` renamed. |
| `rcgen` | `<0.14` | Test-cert generation API changed in `test_support/certs.rs`. |

## Validation

The corresponding workspace pins land in #318 (this week's cargo Renovate batch). With the renovate-config rule in place, future Monday batches will skip these crates rather than re-proposing the broken bumps.