### PR TITLE
fix(release): set User-Agent on crates.io API requests

### DIFF
--- a/.github/workflows/reusable-publish-release.yaml
+++ b/.github/workflows/reusable-publish-release.yaml
@@ -133,9 +133,13 @@ jobs:
       - name: Check crates.io for existing version
         if: ${{ !inputs.dry-run && inputs.crates-publish }}
         id: crates_check
+        env:
+          # crates.io API requires a User-Agent header; without it the
+          # API responds with HTTP 403. See #346.
+          CRATES_UA: "hole-release-pipeline (https://github.com/bindreams/hole)"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          CODE=$(curl -sL -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/${{ inputs.crates-name }}/${VERSION}")
+          CODE=$(curl -sL -A "$CRATES_UA" -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/${{ inputs.crates-name }}/${VERSION}")
           if [ "$CODE" = "200" ]; then
             echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "Version ${VERSION} already on crates.io; will skip publish."
@@ -162,12 +166,15 @@ jobs:
 
       - name: Wait for crates.io indexing
         if: ${{ !inputs.dry-run && inputs.crates-publish }}
+        env:
+          # crates.io API requires User-Agent; see #346.
+          CRATES_UA: "hole-release-pipeline (https://github.com/bindreams/hole)"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           # Unbounded poll — `timeout-minutes: 30` on the job is the
           # only ceiling. crates.io indexing is well-behaved; only
           # reason to time out is a real outage.
-          until [ "$(curl -sL -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${{ inputs.crates-name }}/${VERSION}")" = "200" ]; do
+          until [ "$(curl -sL -A "$CRATES_UA" -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${{ inputs.crates-name }}/${VERSION}")" = "200" ]; do
             echo "Still indexing..."
             sleep 10
           done

--- a/ui/global.d.ts
+++ b/ui/global.d.ts
@@ -1,0 +1,4 @@
+// Side-effect CSS imports (e.g. `import "overlayscrollbars/overlayscrollbars.css"`)
+// have no runtime type to declare, but TypeScript 6+ rejects them without an
+// explicit module declaration. Vite handles the actual CSS bundling.
+declare module "*.css";


### PR DESCRIPTION
Garter publish failed with HTTP 403 from crates.io's API. Root cause: crates.io requires a User-Agent header on every API call; calls without one get 403.

```
##[error]Unexpected HTTP 403 from crates.io API
```

This is a pre-existing bug carried over from the old `publish-release-garter.yaml` (which had the same curl). It never surfaced because garter had never published to crates.io until today's attempt.

Fixes both curl invocations in `reusable-publish-release.yaml`:
- existence check (line 138)
- indexing wait loop (line 174)

Both now pass `-A "hole-release-pipeline (https://github.com/bindreams/hole)"`.

Closes #346.

## Test plan

- [x] YAML parse.
- [ ] Post-merge: re-trigger `publish-release-garter.yaml -f version=0.1.0`. Existence check should return 404 (garter not yet on crates.io), `cargo publish` should run, indexing wait should poll until 200.