### PR TITLE
chore(deps): migrate ctor 0.13 / rand 0.10 / rcgen 0.14

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,30 +56,6 @@
         "automerge": true,
         "schedule": ["before 9am on monday"]
       }
-    },
-    {
-      "description": "Pin ctor < 0.3 pending hole-test-observability migration to ctor 0.13 (see #336).",
-      "matchPackageNames": ["ctor"],
-      "matchManagers": ["cargo"],
-      "allowedVersions": "<0.3"
-    },
-    {
-      "description": "Pin schemars < 0.9 pending crates/common/build.rs migration to schemars 0.9 (see #336).",
-      "matchPackageNames": ["schemars"],
-      "matchManagers": ["cargo"],
-      "allowedVersions": "<0.9"
-    },
-    {
-      "description": "Pin rand < 0.10 pending hole-bridge test_support migration to rand 0.10 (see #336).",
-      "matchPackageNames": ["rand"],
-      "matchManagers": ["cargo"],
-      "allowedVersions": "<0.10"
-    },
-    {
-      "description": "Pin rcgen < 0.14 pending hole-bridge test_support migration to rcgen 0.14 (see #336).",
-      "matchPackageNames": ["rcgen"],
-      "matchManagers": ["cargo"],
-      "allowedVersions": "<0.14"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,8 +416,8 @@ as a dev-dependency and invokes
 either at the top level of `src/lib.rs` (lib tests) or at the top of
 each `tests/*.rs` (integration tests). The macro expands (under
 `#[cfg(test)]`) to a `mod _hole_test_observability_init` containing
-a `#[ctor::ctor]` function. The ctor runs pre-main on every test
-binary and installs:
+a `ctor::declarative::ctor!` block. The ctor runs pre-main on every
+test binary and installs:
 
 - A process-global `tracing_subscriber` writing to stderr. Skuld's
   FD-level capture (under bare `cargo test`) and nextest's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,7 +392,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -361,6 +400,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1093,16 +1141,6 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
@@ -1110,6 +1148,12 @@ dependencies = [
  "ctor-proc-macro",
  "dtor",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3429e8f8e3ce0ffe475c411850f70468c70d7a87d2ac3d15dd44703fb885aede"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -1249,6 +1293,20 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1615,7 +1673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2704,7 +2762,7 @@ dependencies = [
  "ipnet",
  "libc",
  "lru",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rcgen",
  "regex",
  "rustls",
@@ -2770,7 +2828,7 @@ dependencies = [
 name = "hole-test-observability"
 version = "0.1.0"
 dependencies = [
- "ctor 0.2.9",
+ "ctor 0.13.1",
  "hole-common",
  "log",
  "skuld",
@@ -2912,7 +2970,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4279,6 +4337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,7 +4380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5094,14 +5161,15 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -5441,7 +5509,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6831,7 +6899,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8119,7 +8187,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8965,6 +9033,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9032,10 +9118,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,16 @@ edition = "2021"
 skuld = { version = "0.2", features = ["tokio"] }
 # Pre-main init for the test-observability subscriber install. See
 # crates/test-observability and bindreams/hole#301.
-ctor = "0.2"
+#
+# `default-features = false` disables the `proc_macro` default feature
+# (the `#[ctor]` attribute macro). Re-exporting wrappers must use the
+# declarative `ctor::declarative::ctor!` form instead — the proc-macro
+# emits absolute `::ctor::…` paths in consumer crates, which fails
+# because consumers (galoshes, hole, garter-bin, …) don't depend on
+# ctor directly. Upstream docs: "It is recommended that crates
+# re-exporting the `ctor` macro disable this feature and only use the
+# declarative form."
+ctor = { version = "0.13", default-features = false }
 insta = { version = "1", features = ["yaml"] }
 trybuild = "1"
 # DNS forwarder deps — direct so a future shadowsocks-service bump cannot

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -97,8 +97,8 @@ tokio = { version = "1", features = ["test-util"] }
 # lines (layer=..., caused_by=...) added for #248.
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 shadowsocks-service = { version = "1", features = ["server"] }
-rcgen = "0.13"
-rand = "0.9"
+rcgen = "0.14"
+rand = "0.10"
 base64 = "0.22"
 # Used by `test_support::net_discovery` for primary IPv4 detection in TUN tests.
 default-net = "0.22"

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -138,9 +138,9 @@ impl DistHarness {
         // Note: the workspace panic-dump dispatcher (see #303) is
         // installed at ctor time by `hole_test_observability::install`,
         // which runs strictly before any test code via the `register!`
-        // macro's `#[ctor::ctor]` function. The pre-#303 explicit
-        // `install_panic_hook_once()` here was load-bearing as a
-        // before-fallible-work guarantee; the ctor-time install
+        // macro's `ctor::declarative::ctor!` block. The pre-#303
+        // explicit `install_panic_hook_once()` here was load-bearing
+        // as a before-fallible-work guarantee; the ctor-time install
         // preserves that property.
 
         let hole_exe = dist_bin_dir.join(if cfg!(windows) { "hole.exe" } else { "hole" });
@@ -385,7 +385,7 @@ impl Drop for DistHarness {
 
 /// Generate a short random suffix for the socket path.
 fn rand_suffix() -> String {
-    use rand::Rng;
+    use rand::RngExt;
     let n: u32 = rand::rng().random();
     format!("{n:08x}")
 }

--- a/crates/bridge/src/test_support/ssserver.rs
+++ b/crates/bridge/src/test_support/ssserver.rs
@@ -32,7 +32,7 @@ pub(crate) const TEST_PASSWORD: &str = "test-password-1234";
 /// - For all other ciphers (stream, AEAD v1), the password is just an
 ///   arbitrary string and we hex-encode the random bytes for legibility.
 pub(crate) fn random_password_for(method: CipherKind) -> String {
-    use rand::RngCore;
+    use rand::Rng;
     let key_len = method.key_len();
     let mut bytes = vec![0u8; key_len];
     rand::rng().fill_bytes(&mut bytes);

--- a/crates/handle-holders/src/lib_tests.rs
+++ b/crates/handle-holders/src/lib_tests.rs
@@ -17,10 +17,11 @@ fn find_holders_missing_file_returns_empty() {
 /// Cross-platform ctor-linkage regression test for #301.
 ///
 /// The `hole_test_observability::register!()` invocation at the top
-/// of `lib.rs` expands to a `#[ctor::ctor]` static in THIS crate's
-/// object file. If a future MSVC link.exe / lld / ld / ld64 change
-/// (or a workspace refactor) DCE'd the static, our test subscriber
-/// would silently disappear from this binary.
+/// of `lib.rs` expands to a `ctor::declarative::ctor!` block emitting
+/// a `#[used]` static in THIS crate's object file. If a future MSVC
+/// link.exe / lld / ld / ld64 change (or a workspace refactor) DCE'd
+/// the static, our test subscriber would silently disappear from
+/// this binary.
 ///
 /// We detect this by asserting that AFTER our ctor has run, calling
 /// `set_global_default` again fails — proving a global default is

--- a/crates/test-observability/src/lib.rs
+++ b/crates/test-observability/src/lib.rs
@@ -1,9 +1,9 @@
 //! Process-global test observability for the Hole workspace.
 //!
 //! Each test-bearing crate invokes [`register!`] from its `lib.rs`. The
-//! macro expands to a `#[cfg(test)]` `#[ctor::ctor]` block in the
-//! **consumer** crate (not this rlib) that calls [`install`] before
-//! `main` runs. [`install`] is idempotent.
+//! macro expands to a `#[cfg(test)]` `ctor::declarative::ctor!` block
+//! in the **consumer** crate (not this rlib) that calls [`install`]
+//! before `main` runs. [`install`] is idempotent.
 //!
 //! What gets installed:
 //!
@@ -51,12 +51,15 @@ use tracing_subscriber::EnvFilter;
 
 pub mod panic_dump;
 
-/// Re-exported attribute macro so consumer crates don't need to add
-/// `ctor` to their own dev-dependencies. Exposed as
-/// `hole_test_observability::ctor` (the attribute macro), invoked
-/// from the [`register!`] expansion as `#[$crate::ctor]`.
+/// Re-exported `ctor` crate so consumer crates don't need to add
+/// `ctor` to their own dev-dependencies. The [`register!`] macro
+/// invokes `ctor::declarative::ctor!` against this re-export — the
+/// declarative form is required because `default-features = false`
+/// in the workspace turns off the proc-macro `#[ctor]` attribute
+/// (which would otherwise emit absolute `::ctor::…` paths in
+/// consumer crates that don't depend on `ctor` directly).
 #[doc(hidden)]
-pub use ::ctor::ctor;
+pub use ::ctor;
 
 /// Default `EnvFilter` directives. Catch-all `info`; every Hole-side
 /// crate is pinned to `debug` for diagnostic depth. Third-party
@@ -82,7 +85,7 @@ const DEFAULT_FILTER: &str = "info,\
 /// Install the global subscriber, panic hook, and backtrace env var.
 ///
 /// Idempotent: subsequent calls are no-ops. Safe to invoke from any
-/// `#[ctor::ctor]` site or from a regular `fn`.
+/// `ctor::declarative::ctor!` site or from a regular `fn`.
 ///
 /// Short-circuits and does nothing when `HOLE_LOGGING_TEST_KIND` is
 /// set — the FD-redirect child-process branch in
@@ -100,7 +103,7 @@ pub fn install() {
     ONCE.call_once(|| {
         // SAFETY: ctor runs pre-main, single-threaded. The workspace
         // has no other ctor that reads env vars (grep-verified for
-        // `#[ctor]` / `ctor::ctor`).
+        // `ctor::declarative::ctor!` / `ctor::ctor`).
         if std::env::var_os("RUST_BACKTRACE").is_none() {
             unsafe { std::env::set_var("RUST_BACKTRACE", "full") };
         }
@@ -184,10 +187,10 @@ pub fn install() {
 /// ```
 ///
 /// Expands to a `#[cfg(test)]` private module containing a
-/// `#[ctor::ctor]` function that calls [`install`]. The ctor's
-/// `#[used]` static is emitted in the **consumer** crate's object
-/// file — sidestepping rlib dead-code-elimination across linker
-/// variants (MSVC link.exe / lld / ld / ld64).
+/// `ctor::declarative::ctor!` block that calls [`install`]. The
+/// declarative form emits its `#[used]` static in the **consumer**
+/// crate's object file — sidestepping rlib dead-code-elimination
+/// across linker variants (MSVC link.exe / lld / ld / ld64).
 ///
 /// One invocation per crate root (including each `tests/foo.rs`
 /// integration-test target). The expanded module name is fixed, so
@@ -199,9 +202,11 @@ macro_rules! register {
         #[cfg(test)]
         #[doc(hidden)]
         mod _hole_test_observability_init {
-            #[$crate::ctor]
-            fn init() {
-                $crate::install();
+            $crate::ctor::declarative::ctor! {
+                #[ctor(unsafe)]
+                fn init() {
+                    $crate::install();
+                }
             }
         }
     };


### PR DESCRIPTION
## Summary

Addresses #336 (ctor / rand / rcgen sub-tasks; schemars deferred pending typify).

Bumps three of the four crate majors that PR #318 pinned as a
workaround, and removes the Renovate `allowedVersions` rules from #341.

- **ctor 0.2 → 0.13** — switch `hole_test_observability::register!()` to the upstream-recommended declarative form (`ctor::declarative::ctor!`). `default-features = false` disables the proc-macro so its absolute `::ctor::…` path emission can't break consumer crates that don't directly depend on `ctor`.
- **rand 0.9 → 0.10** — imports only: `RngCore` → `Rng` (now provided by `rand_core`, re-exported as `rand::Rng`) and `Rng` → `RngExt`. No call-site changes.
- **rcgen 0.13 → 0.14** — bump-only. `CertificateParams` fields stay public, `KeyPair: SigningKey` so `self_signed(&key_pair)` still type-checks, `pem` remains a default feature.

All four `allowedVersions` Renovate pins are removed (`ctor`, `schemars`, `rand`, `rcgen`). The cargo group Renovate PR #318 will keep proposing schemars 0.9 and failing CI until typify ships schemars-0.9 support — acceptable per planning round.

## Schemars deferred

`crates/common/build.rs` calls `typify::TypeSpace::add_ref_types`, which takes a `schemars 0.8 Schema`. typify 0.6.2 (the only released version) [transitively pins `schemars = "0.8.22"`](https://github.com/oxidecomputer/typify/blob/bbfad31316045497948f7f01fc46d65e4979b9c1/Cargo.toml) in its workspace. Bumping schemars to 0.9 makes `add_ref_types` un-callable due to Schema-type drift. Until typify ships schemars-0.9 support, the schemars sub-task of #336 stays open. **Do not use `closes #336`** — the schemars checkbox would silently lose its tracking.

## Test plan

- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI green (Windows + macOS + Linux)
- [ ] #301 regression test [`crates/handle-holders/src/lib_tests.rs`](crates/handle-holders/src/lib_tests.rs) passes on all CI platforms — verifies the declarative-form `#[used]` static survives DCE on link.exe / ld / ld64
- [ ] hole-bridge e2e tests pass on CI (local environment lacks Admin elevation; pre-existing on origin/main)