### PR TITLE
fix(release): hash SHA256SUMS on ubuntu aggregator

### DIFF
--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -83,8 +83,7 @@ jobs:
         shell: bash
         run: cargo xtask build "hole-${{ matrix.ext }}"
 
-      # Rename and hash
-      - name: Rename artifact and compute SHA-256
+      - name: Rename artifact
         shell: bash
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
@@ -95,20 +94,12 @@ jobs:
           else
             mv target/release/bundle/dmg/*.dmg "$ASSET"
           fi
-
-          # Git-Bash sha256sum defaults to binary mode (asterisk marker,
-          # single space); strip it so output matches the macOS text-mode
-          # format (two spaces). Hashing itself is still binary-correct.
-          sha256sum "$ASSET" | sed 's/ \*/  /' > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
-          cat "${ASSET}.sha256line"
 
       - uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            hole-*.${{ matrix.ext }}
-            hole-*.${{ matrix.ext }}.sha256line
+          path: hole-*.${{ matrix.ext }}
 
   release:
     name: Create draft release
@@ -120,10 +111,14 @@ jobs:
           pattern: release-*
           merge-multiple: true
 
-      - name: Assemble SHA256SUMS
+      # Hash on ubuntu (single platform) so SHA256SUMS is uniformly
+      # text-mode regardless of which per-matrix runner built each
+      # artifact. Git-Bash sha256sum on Windows defaults to binary mode
+      # (asterisk marker), macOS defaults to text mode; hashing here
+      # avoids that divergence entirely. See #355.
+      - name: Compute SHA256SUMS
         run: |
-          cat *.sha256line > SHA256SUMS
-          rm *.sha256line
+          sha256sum hole-* > SHA256SUMS
 
           lines=$(wc -l < SHA256SUMS)
           if [ "$lines" -ne 3 ]; then

--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -96,7 +96,10 @@ jobs:
             mv target/release/bundle/dmg/*.dmg "$ASSET"
           fi
 
-          sha256sum "$ASSET" > "${ASSET}.sha256line"
+          # Git-Bash sha256sum defaults to binary mode (asterisk marker,
+          # single space); strip it so output matches the macOS text-mode
+          # format (two spaces). Hashing itself is still binary-correct.
+          sha256sum "$ASSET" | sed 's/ \*/  /' > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
           cat "${ASSET}.sha256line"
 

--- a/.github/workflows/draft-release-v2ray-plugin.yaml
+++ b/.github/workflows/draft-release-v2ray-plugin.yaml
@@ -113,7 +113,10 @@ jobs:
           tar -czf "$ARCHIVE" -C "$STAGE_DIR" "$INNER"
           rm -r "$STAGE_DIR"
 
-          sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256line"
+          # Git-Bash sha256sum defaults to binary mode (asterisk marker,
+          # single space); strip it so output matches the macOS text-mode
+          # format (two spaces). Hashing itself is still binary-correct.
+          sha256sum "$ARCHIVE" | sed 's/ \*/  /' > "${ARCHIVE}.sha256line"
           echo "Artifact: $ARCHIVE"
           cat "${ARCHIVE}.sha256line"
 

--- a/.github/workflows/draft-release-v2ray-plugin.yaml
+++ b/.github/workflows/draft-release-v2ray-plugin.yaml
@@ -112,20 +112,12 @@ jobs:
           ARCHIVE="v2ray-plugin-${OS}-${ARCH}-v${VERSION}.tar.gz"
           tar -czf "$ARCHIVE" -C "$STAGE_DIR" "$INNER"
           rm -r "$STAGE_DIR"
-
-          # Git-Bash sha256sum defaults to binary mode (asterisk marker,
-          # single space); strip it so output matches the macOS text-mode
-          # format (two spaces). Hashing itself is still binary-correct.
-          sha256sum "$ARCHIVE" | sed 's/ \*/  /' > "${ARCHIVE}.sha256line"
           echo "Artifact: $ARCHIVE"
-          cat "${ARCHIVE}.sha256line"
 
       - uses: actions/upload-artifact@v7
         with:
           name: v2ray-plugin-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            v2ray-plugin-*.tar.gz
-            v2ray-plugin-*.tar.gz.sha256line
+          path: v2ray-plugin-*.tar.gz
 
   release:
     name: Create draft release
@@ -137,10 +129,14 @@ jobs:
           pattern: v2ray-plugin-*
           merge-multiple: true
 
-      - name: Assemble SHA256SUMS
+      # Hash on ubuntu (single platform) so SHA256SUMS is uniformly
+      # text-mode regardless of which per-matrix runner built each
+      # artifact. Git-Bash sha256sum on Windows defaults to binary mode
+      # (asterisk marker), macOS defaults to text mode; hashing here
+      # avoids that divergence entirely. See #355.
+      - name: Compute SHA256SUMS
         run: |
-          cat *.sha256line > SHA256SUMS
-          rm *.sha256line
+          sha256sum v2ray-plugin-*.tar.gz > SHA256SUMS
 
           lines=$(wc -l < SHA256SUMS)
           if [ "$lines" -ne 6 ]; then

--- a/.github/workflows/reusable-draft-release.yaml
+++ b/.github/workflows/reusable-draft-release.yaml
@@ -126,7 +126,10 @@ jobs:
           if [ "$OS" = "windows" ]; then EXT=".exe"; fi
           ASSET="${TRACK}-${VERSION}-${OS}-${ARCH}${EXT}"
           mv "target/release/${CRATE}${EXT}" "$ASSET"
-          sha256sum "$ASSET" > "${ASSET}.sha256line"
+          # Git-Bash sha256sum defaults to binary mode (asterisk marker,
+          # single space); strip it so output matches the macOS text-mode
+          # format (two spaces). Hashing itself is still binary-correct.
+          sha256sum "$ASSET" | sed 's/ \*/  /' > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
           cat "${ASSET}.sha256line"
 

--- a/.github/workflows/reusable-draft-release.yaml
+++ b/.github/workflows/reusable-draft-release.yaml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         run: cargo xtask build ${{ inputs.build-target }}
 
-      - name: Rename artifact and compute SHA-256
+      - name: Rename artifact
         shell: bash
         env:
           OS: ${{ matrix.os }}
@@ -126,19 +126,12 @@ jobs:
           if [ "$OS" = "windows" ]; then EXT=".exe"; fi
           ASSET="${TRACK}-${VERSION}-${OS}-${ARCH}${EXT}"
           mv "target/release/${CRATE}${EXT}" "$ASSET"
-          # Git-Bash sha256sum defaults to binary mode (asterisk marker,
-          # single space); strip it so output matches the macOS text-mode
-          # format (two spaces). Hashing itself is still binary-correct.
-          sha256sum "$ASSET" | sed 's/ \*/  /' > "${ASSET}.sha256line"
           echo "Artifact: $ASSET"
-          cat "${ASSET}.sha256line"
 
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.track }}-${{ matrix.os }}-${{ matrix.arch }}
-          path: |
-            ${{ inputs.track }}-*
-            ${{ inputs.track }}-*.sha256line
+          path: ${{ inputs.track }}-*
 
   release:
     name: Create draft release
@@ -150,10 +143,14 @@ jobs:
           pattern: ${{ inputs.track }}-*
           merge-multiple: true
 
-      - name: Assemble SHA256SUMS
+      # Hash on ubuntu (single platform) so SHA256SUMS is uniformly
+      # text-mode regardless of which per-matrix runner built each
+      # artifact. Git-Bash sha256sum on Windows defaults to binary mode
+      # (asterisk marker), macOS defaults to text mode; hashing here
+      # avoids that divergence entirely. See #355.
+      - name: Compute SHA256SUMS
         run: |
-          cat *.sha256line > SHA256SUMS
-          rm *.sha256line
+          sha256sum ${{ inputs.track }}-* > SHA256SUMS
 
           lines=$(wc -l < SHA256SUMS)
           if [ "$lines" -ne ${{ inputs.expected-sha256sums-count }} ]; then


### PR DESCRIPTION
Fixes #355.

The hole / garter / galoshes / v2ray-plugin draft workflows previously hashed each artifact on the matrix runner that built it, then concatenated the `.sha256line` snippets on the aggregator. That left `sha256sum`'s output-format choice (binary-mode `*` marker on Git-Bash/Windows vs. text-mode two-space on macOS/Linux) embedded in the resulting `SHA256SUMS`, producing:

```
ac6aa3...  hole-0.1.0-darwin-amd64.dmg
4af9af...  hole-0.1.0-darwin-arm64.dmg
6d7f4a... *hole-0.1.0-windows-amd64.msi   <-- Windows, binary mode
```

`scripts/sign-release.py`'s regex rejected the Windows line on the v0.1.0 draft.

## Fix

Hash on the ubuntu aggregator instead. The matrix jobs just rename and upload the artifact; the release job runs a single `sha256sum <glob> > SHA256SUMS` on Linux, which gives uniform text-mode output for every line regardless of which platform built each artifact. This eliminates the per-platform format divergence as a *class* of bug rather than papering over it with per-runner workarounds, and future workflows can't forget to apply the workaround.

The bytes being hashed are the artifact bytes as they ship to GitHub — same content the matrix runner produced (artifacts move through GitHub Actions' zip transport without mutation), so the hash semantics are unchanged.

Touches three workflows:

- `.github/workflows/draft-release-hole.yaml`
- `.github/workflows/draft-release-v2ray-plugin.yaml`
- `.github/workflows/reusable-draft-release.yaml` (covers galoshes + garter)

## Test plan

- [ ] After merge, re-run `Draft Release (hole)` for v0.1.0 and confirm `SHA256SUMS` is uniform.
- [ ] Confirm `uv run scripts/sign-release.py 0.1.0` succeeds against the new draft.