### PR TITLE
fix(installer): embed cabinets in MSI to ship a self-contained installer

### DIFF
--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -119,9 +119,14 @@ jobs:
       - name: Sanity-check artifact sizes
         run: |
           set -euo pipefail
+          shopt -s nullglob
+          files=( hole-*.msi hole-*.dmg )
+          if (( ${#files[@]} != 3 )); then
+            echo "::error::expected 3 release artifacts (1 MSI + 2 DMGs), found ${#files[@]}: ${files[*]}"
+            exit 1
+          fi
           fail=0
-          for f in hole-*.msi hole-*.dmg; do
-            [ -f "$f" ] || continue
+          for f in "${files[@]}"; do
             size=$(stat -c%s "$f")
             if [ "$size" -lt 5000000 ]; then
               echo "::error::$f is only $size bytes (expected >= 5 MB) -- likely external-cab MSI or truncated artifact (#357)"

--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -111,32 +111,6 @@ jobs:
           pattern: release-*
           merge-multiple: true
 
-      # Sanity-check artifact sizes before signing/publishing. v0.1.0 shipped
-      # a 36 KB Windows MSI (external-cab, binaries omitted) and broke every
-      # user. A self-contained Hole installer is always 10+ MB. 5 MB floor
-      # is a defensive lower bound; raise if Hole's payload ever shrinks
-      # below it. See #357.
-      - name: Sanity-check artifact sizes
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          files=( hole-*.msi hole-*.dmg )
-          if (( ${#files[@]} != 3 )); then
-            echo "::error::expected 3 release artifacts (1 MSI + 2 DMGs), found ${#files[@]}: ${files[*]}"
-            exit 1
-          fi
-          fail=0
-          for f in "${files[@]}"; do
-            size=$(stat -c%s "$f")
-            if [ "$size" -lt 5000000 ]; then
-              echo "::error::$f is only $size bytes (expected >= 5 MB) -- likely external-cab MSI or truncated artifact (#357)"
-              fail=1
-            else
-              echo "OK: $f is $size bytes"
-            fi
-          done
-          exit $fail
-
       # Hash on ubuntu (single platform) so SHA256SUMS is uniformly
       # text-mode regardless of which per-matrix runner built each
       # artifact. Git-Bash sha256sum on Windows defaults to binary mode

--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -111,6 +111,27 @@ jobs:
           pattern: release-*
           merge-multiple: true
 
+      # Sanity-check artifact sizes before signing/publishing. v0.1.0 shipped
+      # a 36 KB Windows MSI (external-cab, binaries omitted) and broke every
+      # user. A self-contained Hole installer is always 10+ MB. 5 MB floor
+      # is a defensive lower bound; raise if Hole's payload ever shrinks
+      # below it. See #357.
+      - name: Sanity-check artifact sizes
+        run: |
+          set -euo pipefail
+          fail=0
+          for f in hole-*.msi hole-*.dmg; do
+            [ -f "$f" ] || continue
+            size=$(stat -c%s "$f")
+            if [ "$size" -lt 5000000 ]; then
+              echo "::error::$f is only $size bytes (expected >= 5 MB) -- likely external-cab MSI or truncated artifact (#357)"
+              fail=1
+            else
+              echo "OK: $f is $size bytes"
+            fi
+          done
+          exit $fail
+
       # Hash on ubuntu (single platform) so SHA256SUMS is uniformly
       # text-mode regardless of which per-matrix runner built each
       # artifact. Git-Bash sha256sum on Windows defaults to binary mode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dump"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "dump-macros",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "dump-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dump",
  "hole-test-observability",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "handle-holders"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hole-test-observability",
  "skuld",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "hole"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "hole-bridge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "hole-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitflags 2.11.1",
  "dirs 6.0.0",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "hole-test-observability"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ctor 0.13.1",
  "hole-common",
@@ -7485,7 +7485,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7512,7 +7512,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hole-test-observability",
  "proc-macro2",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-bridge"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-common"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the dump crate (provides #[derive(Dump)])."

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 description = "YAML-shaped representation for logging, analogous to Python's dump() alongside str()/repr()."

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handle-holders"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-test-observability"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license = "GPL-3.0-or-later"
 publish = false

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the tun-engine crate (provides #[freeze])."

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 description = "Cross-platform TUN device, OS routing, gateway discovery, and a smoltcp-backed packet-loop engine for building split-tunnel VPN/proxy daemons."

--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -21,6 +21,11 @@
       AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of Hole is already installed." />
 
+    <!-- Embed cabinets inside the .msi so the installer is one self-contained
+         file. WiX v4+ defaults to EmbedCab="no" (external cabs) when this
+         element is omitted; that made v0.1.0 unusable (#357). -->
+    <MediaTemplate EmbedCab="yes" />
+
     <!-- Installation directory structure -->
     <StandardDirectory Id="ProgramFiles64Folder">
       <Directory Id="INSTALLFOLDER" Name="hole">

--- a/msi-installer/tests/test_hole_msi.py
+++ b/msi-installer/tests/test_hole_msi.py
@@ -5,6 +5,7 @@ table inspection. Windows-only, requires WiX toolchain.
 """
 
 import platform
+import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -23,10 +24,14 @@ pytestmark = [
 
 @pytest.fixture(scope="session")
 def staged_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create a staging directory with dummy (empty) binaries."""
+    """Create a staging directory with non-zero dummy binaries.
+
+    Non-zero so the embedded cabinet actually contains data and the
+    relocated-extract test (#357) has files to find post-extraction.
+    """
     d = tmp_path_factory.mktemp("stage")
     for name in ("hole.exe", "v2ray-plugin.exe", "wintun.dll"):
-        (d / name).write_bytes(b"")
+        (d / name).write_bytes(b"x" * 1024)
     return d
 
 
@@ -173,3 +178,78 @@ def test_components_are_64bit(decompiled_tree: ET.ElementTree) -> None:
             f"Component '{comp_id}' has Bitness='always32' (32-bit). "
             "Pass '-arch x64' to 'wix build' to build a 64-bit MSI."
         )
+
+
+# Cabinet embedding tests ==============================================================================================
+
+
+def test_decompiled_msi_cab_is_embedded(decompiled_tree: ET.ElementTree) -> None:
+    """The built MSI's Media table must declare embedded cabinets.
+
+    `wix msi decompile` translates the on-disk Cabinet='#name.cab' embedded
+    marker back to source form: it strips the '#' and emits EmbedCab='yes'
+    on each <Media>. Absence of EmbedCab='yes' on the decompiled XML means
+    the MSI ships external cabs and breaks for end users (#357 — v0.1.0).
+    """
+    pkg = decompiled_tree.getroot().find("wix:Package", NS)
+    assert pkg is not None
+    media_elements = list(pkg.iter(f"{{{NS['wix']}}}Media"))
+    assert media_elements, "Decompiled MSI has no <Media> element"
+    for media in media_elements:
+        embed = media.get("EmbedCab", "")
+        assert embed == "yes", (
+            f"<Media Id='{media.get('Id')}' Cabinet='{media.get('Cabinet')}' "
+            f"EmbedCab='{embed}'> declares an EXTERNAL cabinet. "
+            "Set <MediaTemplate EmbedCab='yes'> in hole.wxs."
+        )
+
+
+def test_built_msi_has_no_external_cab(built_msi: Path) -> None:
+    """No .cab file should sit next to the built .msi.
+
+    External cabs land in the same directory as the .msi with a name like
+    'cab1.cab'. End users who download only the .msi then get 'Source file
+    not found: cab1.cab' at install time (#357 — v0.1.0).
+    """
+    siblings = list(built_msi.parent.glob("*.cab"))
+    assert not siblings, (
+        f"Found external cabinet(s) next to the built MSI: {siblings}. "
+        "The MSI must be self-contained (<MediaTemplate EmbedCab='yes'>)."
+    )
+
+
+def test_msi_admin_extract_works_when_separated_from_build_dir(
+    built_msi: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Simulate the end-user 'download MSI alone and run it' flow.
+
+    Copy the .msi alone to a fresh directory (no cab siblings) and run
+    `msiexec /a` — administrative install, read-only extract, no admin
+    rights, no system mutation. External-cab MSIs fail here with the same
+    'cab1.cab not found' error that broke v0.1.0 (#357).
+    """
+    relocated_dir = tmp_path_factory.mktemp("relocated")
+    relocated = Path(shutil.copy(built_msi, relocated_dir / "hole.msi"))
+    extract_dir = tmp_path_factory.mktemp("extract")
+    abs_target = str(extract_dir.resolve())
+
+    # Trailing backslash on TARGETDIR is required by msiexec.
+    result = subprocess.run(
+        ["msiexec", "/a", str(relocated.resolve()), f"TARGETDIR={abs_target}\\", "/qn"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"msiexec /a failed (exit {result.returncode}) on a relocated MSI — "
+        f"the same code path that failed for v0.1.0 end users.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    extracted = {
+        p.name
+        for p in extract_dir.rglob("*") if p.is_file() and p.name in {"hole.exe", "v2ray-plugin.exe", "wintun.dll"}
+    }
+    assert extracted == {"hole.exe", "v2ray-plugin.exe",
+                         "wintun.dll"}, (f"MSI extracted but expected payload missing: got {extracted}")

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -263,6 +263,24 @@ def test_major_upgrade_allows_same_version(package: ET.Element) -> None:
     )
 
 
+def test_media_template_embeds_cab(package: ET.Element) -> None:
+    """<Package> must declare <MediaTemplate EmbedCab='yes'>.
+
+    Without it, WiX v4+ defaults to external cabinets, which makes the
+    .msi unusable when downloaded alone (#357 — v0.1.0).
+    """
+    template = package.find("wix:MediaTemplate", NS)
+    assert template is not None, (
+        "<Package> must declare <MediaTemplate EmbedCab='yes'>. Without it "
+        "WiX defaults to external cabs and the MSI fails to install when "
+        "downloaded alone."
+    )
+    assert template.get("EmbedCab") == "yes", (
+        f"<MediaTemplate> must set EmbedCab='yes', got "
+        f"EmbedCab='{template.get('EmbedCab')}'."
+    )
+
+
 # Custom action attribute tests ========================================================================================
 
 


### PR DESCRIPTION
Fixes #357. Bumps the hole release group to v0.1.1.

## Summary

- Add `<MediaTemplate EmbedCab="yes" />` to [`msi-installer/src/msi_installer/hole.wxs`](msi-installer/src/msi_installer/hole.wxs). WiX v4+ defaults to `EmbedCab="no"` (external cabinets) when this element is omitted; that made v0.1.0's MSI unusable (36 KB shell referencing a `cab1.cab` the release workflow correctly did not upload).
- Add four regression tests across three layers so the bug cannot recur:
  - [`test_hole_wxs.py::test_media_template_embeds_cab`](msi-installer/tests/test_hole_wxs.py) — source-level XPath assertion on `<MediaTemplate EmbedCab="yes">`.
  - [`test_hole_msi.py::test_decompiled_msi_cab_is_embedded`](msi-installer/tests/test_hole_msi.py) — after `wix msi decompile`, every `<Media>` must declare `EmbedCab="yes"` (the decompiler translates the on-disk `Cabinet='#name.cab'` marker back to the `EmbedCab` attribute).
  - `test_built_msi_has_no_external_cab` — no `*.cab` siblings next to the built MSI.
  - `test_msi_admin_extract_works_when_separated_from_build_dir` — the load-bearing one: copy the .msi alone to a fresh temp dir, run `msiexec /a` (read-only admin extract), confirm the three payload files land in the target tree. This is the exact code path that failed for v0.1.0 end users.
- Bump `staged_dir` fixture to write 1 KB stubs (was zero-byte) so the embedded cab actually contains data for the relocated-extract test to find post-extraction.
- Bump the 9-crate `hole` release group from 0.1.0 to 0.1.1.

## Why the existing test suite missed v0.1.0

The MSI test suite already built, ICE-validated, and decompiled the .msi — but none of those caught external cabinets:

1. ICE validation passes for external-cab MSIs (legitimate multi-disc config).
2. Tests never invoked `msiexec` against the built artifact.
3. Tests never relocated the .msi away from its build dir, so even hypothetical msiexec runs would find the sibling .cab.
4. The decompiled-XML assertions only walked `InstallExecuteSequence` / `Component` / `Shortcut`, never `Media`.
5. The fixture wrote zero-byte stubs, so even a size sanity check was inert.

Every layer treated the .msi as a structurally valid artifact, and an external-cab MSI **is** structurally valid; it only breaks when separated from its build siblings.

## Test plan

- [x] `uv run --group dev pytest -v` from `msi-installer/` — 31 passed (4 new + 27 existing).
- [x] Verified the 4 new tests fail when `<MediaTemplate>` is reverted (manual `git stash` of the WXS).
- [x] `cargo xtask build hole-msi` produced `target/release/hole.msi` at 12.5 MB with no sibling `.cab`.
- [x] `cargo xtask version --check --group hole` accepts the 0.1.1 bump.
- [ ] After merge: cut v0.1.1 via draft → sign → publish; verify the published MSI is ~12 MB and installs successfully when downloaded from the release page.

## v0.1.0 disposition

Existing v0.1.0 release notes already carry a "DO NOT INSTALL — broken, use v0.1.1" banner. The v0.1.1 publish workflow already pins `--latest=true`, so v0.1.0 falls off `/releases/latest` automatically once v0.1.1 ships.
