### PR TITLE
fix(installer): ad-hoc sign macOS .app bundle so DMG installs aren't rejected as 'damaged' (#364)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,6 +345,41 @@ jobs:
           $path = [Environment]::GetEnvironmentVariable("Path", "Machine")
           if ($path -match [regex]::Escape($binDir)) { throw "$binDir still in PATH" }
 
+  # Darwin-only counterpart to `test-installer`: build the DMG and run the
+  # signature-consistency tests in `dmg-installer/`. Catches issue #364 —
+  # an unsigned .app bundle that launches "damaged" under Gatekeeper
+  # quarantine. Always runs (no path filter) so this stays a stable
+  # required check on every PR.
+  test-dmg-signing:
+    name: Test DMG signing (${{ matrix.os }}/${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: darwin, arch: amd64, runner: macos-15-intel }
+          - { os: darwin, arch: arm64, runner: macos-latest }
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: ./.github/actions/setup-build
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Build DMG
+        run: cargo xtask build hole-dmg
+
+      - name: Test DMG signing
+        run: cargo xtask run hole-dmg-tests
+
   # Renovate npm safety gate: builds the Vite bundle (via `cargo xtask build
   # frontend-build`) and type-checks (via `cargo xtask run frontend-check`,
   # which does its own `npm ci` + `npm run check` — tsc reads source directly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,9 @@ external/                 → Third-party source (git-subrepos via ingydotnet/gi
                             release-group version lives at
                             external/v2ray-plugin/version.toml.
 msi-installer/            → WiX MSI installer (Python project: thin wrapper around xtask + WiX)
+dmg-installer/            → macOS DMG signature checks (Python project: pytest harness
+                            asserting `Hole.app`'s codesign seal is internally consistent
+                            so quarantined downloads don't launch "damaged" — see #364)
 scripts/                  → Utility scripts (dev.py, network-reset.py, sign-release.py, ...)
 ui/                       → Frontend HTML/CSS/TypeScript (Vite)
 ```
@@ -478,6 +481,13 @@ the 7 assertion-target tests (`proxy_manager_tests`,
 
 ```sh
 cd msi-installer && uv run --group dev pytest -v   # WiX source + MSI build validation
+```
+
+### macOS installer
+
+```sh
+cargo xtask build hole-dmg            # build the .dmg (npx tauri build under the hood)
+cargo xtask run hole-dmg-tests        # mount + assert .app code signature is intact
 ```
 
 ## Releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,8 @@ At runtime, Tauri embeds the OS's native webview (Edge WebView2 on Windows, WebK
 | `xtask/`         | workspace task runner (`cargo xtask <build\|run\|list\|stage\|...>`) — see `build.yaml` |
 | `xtask-lib/`     | shared helper crate used by xtask AND `crates/hole/build.rs`                            |
 | `external/`      | Third-party source (git subrepos)                                                       |
+| `msi-installer/` | Windows MSI installer (Python project: thin wrapper around xtask + WiX)                 |
+| `dmg-installer/` | macOS DMG signature checks (Python project: pytest harness over the built `Hole.app`)   |
 | `ui/`            | Frontend HTML/CSS/TypeScript (Vite)                                                     |
 
 ### Logging

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Single-binary design — `hole` serves as both the Tauri GUI and the privileged 
 
 Communication happens over IPC (Unix socket on macOS, named pipe on Windows) using HTTP/1.1 REST (JSON).
 
+## Install
+
+**macOS first launch:** Hole is ad-hoc-signed but not yet notarized by Apple.
+On first launch after installing from the DMG, macOS will say "Hole cannot be
+opened because the developer cannot be verified." Right-click the app →
+**Open** → **Open** in the confirmation dialog. This is a one-time step per
+machine; subsequent launches work normally. Tracked for removal once Developer
+ID + notarization is in place (#365).
+
 ## Build
 
 Prerequisites: Rust toolchain, Go toolchain, Node.js (for Tauri CLI and E2E tests).

--- a/build.yaml
+++ b/build.yaml
@@ -100,6 +100,14 @@ targets:
     platforms: [darwin/amd64, darwin/arm64]
     build: npx tauri build
 
+  hole-dmg-tests:
+    # Pytest harness that asserts the produced .app's code signature is
+    # internally consistent (sealed resources, no linker-signed-only Mach-Os,
+    # sidecar identifier rewritten). Guards against issue #364 regressing.
+    depends: hole-dmg
+    platforms: [darwin/amd64, darwin/arm64]
+    run: uv run --directory dmg-installer pytest -v
+
   frontend-build:
     # Vite bundle of ui/ → ui/dist/. Pure JS/TS toolchain, platform-independent
     # output, so we run on the cheapest CI host (linux/amd64) only. The

--- a/crates/hole/tauri.conf.json
+++ b/crates/hole/tauri.conf.json
@@ -24,6 +24,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "externalBin": [
       ".cache/v2ray-plugin/v2ray-plugin"
     ],

--- a/dmg-installer/pyproject.toml
+++ b/dmg-installer/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "dmg-installer"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/dmg_installer"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[dependency-groups]
+dev = ["pytest"]

--- a/dmg-installer/src/dmg_installer/__init__.py
+++ b/dmg-installer/src/dmg_installer/__init__.py
@@ -1,0 +1,42 @@
+"""Test harness for the Hole macOS DMG.
+
+Locates the DMG produced by `cargo xtask build hole-dmg`, mounts it, and
+exposes the installed `Hole.app` to pytest fixtures so we can assert that
+its code signature is internally consistent (the symptom that produces
+"Hole.app is damaged and can't be opened" on Gatekeeper-quarantined
+installs — see issue #364).
+
+Usage: `uv run --directory dmg-installer pytest -v`
+"""
+
+from pathlib import Path
+
+_PKG_DIR = Path(__file__).resolve().parent
+
+
+class DmgTestError(Exception):
+    """Raised when DMG test setup fails."""
+
+
+def _find_repo_root() -> Path:
+    p = _PKG_DIR
+    while p != p.parent:
+        if (p / ".git").exists():
+            return p
+        p = p.parent
+    raise DmgTestError("could not find repo root (no .git/ directory found)")
+
+
+def find_built_dmg(repo_root: Path) -> Path:
+    bundle_dir = repo_root / "target" / "release" / "bundle" / "dmg"
+    matches = sorted(bundle_dir.glob("*.dmg"))
+    if not matches:
+        raise DmgTestError(
+            f"no .dmg found in {bundle_dir}; run `cargo xtask build hole-dmg` first"
+        )
+    if len(matches) > 1:
+        raise DmgTestError(
+            f"multiple .dmg files in {bundle_dir}: {[p.name for p in matches]}; "
+            "remove stale ones before running tests"
+        )
+    return matches[0]

--- a/dmg-installer/src/dmg_installer/__init__.py
+++ b/dmg-installer/src/dmg_installer/__init__.py
@@ -31,9 +31,7 @@ def find_built_dmg(repo_root: Path) -> Path:
     bundle_dir = repo_root / "target" / "release" / "bundle" / "dmg"
     matches = sorted(bundle_dir.glob("*.dmg"))
     if not matches:
-        raise DmgTestError(
-            f"no .dmg found in {bundle_dir}; run `cargo xtask build hole-dmg` first"
-        )
+        raise DmgTestError(f"no .dmg found in {bundle_dir}; run `cargo xtask build hole-dmg` first")
     if len(matches) > 1:
         raise DmgTestError(
             f"multiple .dmg files in {bundle_dir}: {[p.name for p in matches]}; "

--- a/dmg-installer/tests/conftest.py
+++ b/dmg-installer/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Shared fixtures for DMG installer tests."""
+
+import shutil
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import dmg_installer
+
+REPO_ROOT = dmg_installer._find_repo_root()
+
+# The xattr value Brave writes when downloading a .dmg. Recorded verbatim
+# from a real installed bundle on 2026-05-18: the third semicolon-separated
+# field is the source app, the fourth is a per-download UUID; the leading
+# `0381` is the quarantine flags field (uncleared + user-approved bit).
+# Mirroring the exact shape ensures Gatekeeper treats the test bundle the
+# same way it treats a real user install.
+QUARANTINE_VALUE = "0381;6a0b6446;Brave;FAKE0000-0000-0000-0000-000000000000"
+
+
+@pytest.fixture(scope="module")
+def installed_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Mount the built DMG, copy Hole.app to a tmp dir, mark it quarantined.
+
+    The copy is what we test — copying out of the read-only mount mirrors
+    what Finder does on `cp -R` and what the OS does when the user drags
+    Hole.app into /Applications. Quarantine is applied so Gatekeeper's
+    assessment runs in the same code path it would for a real download.
+
+    Flags align with `crates/hole/src/update/install.rs::hdiutil_attach_args`
+    (-nobrowse, -quiet, -mountpoint) and add -readonly + -noverify which
+    only make sense for read-only test mounts.
+    """
+    dmg = dmg_installer.find_built_dmg(REPO_ROOT)
+
+    mount_dir = tmp_path_factory.mktemp("mount")
+    install_dir = tmp_path_factory.mktemp("install")
+
+    subprocess.run(
+        [
+            "hdiutil", "attach",
+            "-nobrowse", "-readonly", "-noverify", "-quiet",
+            "-mountpoint", str(mount_dir),
+            str(dmg),
+        ],
+        check=True,
+    )
+    try:
+        src_app = mount_dir / "Hole.app"
+        if not src_app.is_dir():
+            raise dmg_installer.DmgTestError(
+                f"Hole.app not found in DMG (looked in {mount_dir})"
+            )
+
+        dst_app = install_dir / "Hole.app"
+        shutil.copytree(src_app, dst_app, symlinks=True)
+
+        subprocess.run(
+            ["xattr", "-w", "com.apple.quarantine", QUARANTINE_VALUE, str(dst_app)],
+            check=True,
+        )
+
+        yield dst_app
+    finally:
+        subprocess.run(
+            ["hdiutil", "detach", "-quiet", str(mount_dir)],
+            check=False,
+        )

--- a/dmg-installer/tests/conftest.py
+++ b/dmg-installer/tests/conftest.py
@@ -40,9 +40,14 @@ def installed_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
 
     subprocess.run(
         [
-            "hdiutil", "attach",
-            "-nobrowse", "-readonly", "-noverify", "-quiet",
-            "-mountpoint", str(mount_dir),
+            "hdiutil",
+            "attach",
+            "-nobrowse",
+            "-readonly",
+            "-noverify",
+            "-quiet",
+            "-mountpoint",
+            str(mount_dir),
             str(dmg),
         ],
         check=True,
@@ -50,15 +55,14 @@ def installed_app(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
     try:
         src_app = mount_dir / "Hole.app"
         if not src_app.is_dir():
-            raise dmg_installer.DmgTestError(
-                f"Hole.app not found in DMG (looked in {mount_dir})"
-            )
+            raise dmg_installer.DmgTestError(f"Hole.app not found in DMG (looked in {mount_dir})")
 
         dst_app = install_dir / "Hole.app"
         shutil.copytree(src_app, dst_app, symlinks=True)
 
         subprocess.run(
-            ["xattr", "-w", "com.apple.quarantine", QUARANTINE_VALUE, str(dst_app)],
+            ["xattr", "-w", "com.apple.quarantine", QUARANTINE_VALUE,
+             str(dst_app)],
             check=True,
         )
 

--- a/dmg-installer/tests/test_config.py
+++ b/dmg-installer/tests/test_config.py
@@ -1,0 +1,29 @@
+"""Static config-drift guard.
+
+A future Tauri config refactor must not silently drop the `bundle.macOS`
+block. This test fails fast in CI (no DMG build needed) if `signingIdentity`
+is missing or set to anything other than ad-hoc.
+"""
+
+import json
+
+import dmg_installer
+
+REPO_ROOT = dmg_installer._find_repo_root()
+
+
+def test_tauri_conf_macos_signing_identity_is_ad_hoc() -> None:
+    conf_path = REPO_ROOT / "crates" / "hole" / "tauri.conf.json"
+    with open(conf_path) as f:
+        conf = json.load(f)
+
+    bundle = conf["bundle"]
+    assert "macOS" in bundle, (
+        f"{conf_path} has no `bundle.macOS` block — Tauri will skip codesign "
+        "and produce a 'damaged' .app under Gatekeeper quarantine (issue #364)."
+    )
+    assert bundle["macOS"].get("signingIdentity") == "-", (
+        f"{conf_path} `bundle.macOS.signingIdentity` must be `-` (ad-hoc) "
+        f"until Developer ID signing lands (issue #365), got "
+        f"{bundle['macOS'].get('signingIdentity')!r}"
+    )

--- a/dmg-installer/tests/test_dmg_signing.py
+++ b/dmg-installer/tests/test_dmg_signing.py
@@ -1,0 +1,74 @@
+"""Signature consistency checks for the built Hole.app.
+
+These tests catch the failure mode behind issue #364: a Tauri-built .app
+that ships with only the linker's ad-hoc Mach-O signature and no
+`_CodeSignature/CodeResources` seal. Such a bundle launches "damaged"
+under Gatekeeper quarantine because the Mach-O claims sealed resources
+that don't exist.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def _codesign_dv(target: Path) -> str:
+    """Return `codesign -dv --verbose=4` stderr (where codesign prints)."""
+    result = subprocess.run(
+        ["codesign", "-dv", "--verbose=4", str(target)],
+        capture_output=True,
+        text=True,
+    )
+    return result.stderr
+
+
+def test_code_signature_directory_exists(installed_app: Path) -> None:
+    assert (installed_app / "Contents" / "_CodeSignature" / "CodeResources").is_file()
+
+
+def test_codesign_verify_strict_passes(installed_app: Path) -> None:
+    result = subprocess.run(
+        ["codesign", "--verify", "--strict", "--verbose=4", str(installed_app)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"codesign --verify --strict failed:\n{result.stderr}"
+
+
+def test_codesign_verify_deep_strict_passes(installed_app: Path) -> None:
+    result = subprocess.run(
+        ["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(installed_app)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"codesign --verify --deep --strict failed:\n{result.stderr}"
+    )
+
+
+def test_bundle_has_sealed_resources(installed_app: Path) -> None:
+    output = _codesign_dv(installed_app)
+    assert "Sealed Resources=none" not in output, (
+        f"bundle has no sealed resource envelope:\n{output}"
+    )
+    assert "Sealed Resources version=" in output, (
+        f"bundle is missing Sealed Resources block:\n{output}"
+    )
+
+
+def test_main_binary_is_not_linker_signed(installed_app: Path) -> None:
+    output = _codesign_dv(installed_app / "Contents" / "MacOS" / "hole")
+    assert "linker-signed" not in output, (
+        f"main binary still carries the linker-applied ad-hoc signature "
+        f"(0x20000 flag bit) — Tauri's codesign step did not re-sign it:\n{output}"
+    )
+
+
+def test_sidecar_has_real_signature(installed_app: Path) -> None:
+    output = _codesign_dv(installed_app / "Contents" / "MacOS" / "v2ray-plugin")
+    assert "Identifier=a.out" not in output, (
+        f"v2ray-plugin sidecar still has the Go-linker default identifier 'a.out' "
+        f"— Tauri's codesign step did not re-sign it:\n{output}"
+    )
+    assert "linker-signed" not in output, (
+        f"v2ray-plugin sidecar still carries the linker-applied ad-hoc signature:\n{output}"
+    )

--- a/dmg-installer/tests/test_dmg_signing.py
+++ b/dmg-installer/tests/test_dmg_signing.py
@@ -27,7 +27,8 @@ def test_code_signature_directory_exists(installed_app: Path) -> None:
 
 def test_codesign_verify_strict_passes(installed_app: Path) -> None:
     result = subprocess.run(
-        ["codesign", "--verify", "--strict", "--verbose=4", str(installed_app)],
+        ["codesign", "--verify", "--strict", "--verbose=4",
+         str(installed_app)],
         capture_output=True,
         text=True,
     )
@@ -36,23 +37,18 @@ def test_codesign_verify_strict_passes(installed_app: Path) -> None:
 
 def test_codesign_verify_deep_strict_passes(installed_app: Path) -> None:
     result = subprocess.run(
-        ["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(installed_app)],
+        ["codesign", "--verify", "--deep", "--strict", "--verbose=4",
+         str(installed_app)],
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"codesign --verify --deep --strict failed:\n{result.stderr}"
-    )
+    assert result.returncode == 0, (f"codesign --verify --deep --strict failed:\n{result.stderr}")
 
 
 def test_bundle_has_sealed_resources(installed_app: Path) -> None:
     output = _codesign_dv(installed_app)
-    assert "Sealed Resources=none" not in output, (
-        f"bundle has no sealed resource envelope:\n{output}"
-    )
-    assert "Sealed Resources version=" in output, (
-        f"bundle is missing Sealed Resources block:\n{output}"
-    )
+    assert "Sealed Resources=none" not in output, (f"bundle has no sealed resource envelope:\n{output}")
+    assert "Sealed Resources version=" in output, (f"bundle is missing Sealed Resources block:\n{output}")
 
 
 def test_main_binary_is_not_linker_signed(installed_app: Path) -> None:

--- a/dmg-installer/uv.lock
+++ b/dmg-installer/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dmg-installer"
+version = "0.0.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]


### PR DESCRIPTION
## Summary
- Tauri was skipping codesign entirely on macOS because `crates/hole/tauri.conf.json` had no `bundle.macOS` block. The shipped `.app` was left with only linker-applied ad-hoc Mach-O signatures that referenced a `_CodeSignature/CodeResources` seal that didn't exist — Gatekeeper rejects this state as "damaged" once a quarantine xattr is present (i.e. on any DMG-from-browser install).
- Fix: set `bundle.macOS.signingIdentity = "-"` so Tauri ad-hoc-signs the bundle inside-out (sidecar v2ray-plugin first, then the main `hole` binary, then the outer `.app`), producing a proper resource seal and bundle-derived identifiers.
- Adds a new `dmg-installer/` pytest package mirroring `msi-installer/` and a darwin-only `test-dmg-signing` job in `ci.yaml` so this can't regress.
- Adds a README note about the one-time "right-click → Open" first-launch step (still needed under ad-hoc signing — full Developer ID + notarization tracked in #365).

Closes #364. Follow-up: #365.

## Test plan
- [x] Local: `cargo xtask build hole-dmg && uv run --directory dmg-installer pytest -v` — 7/7 pass on the freshly built bundle.
- [x] Local: same assertions confirmed to catch the existing broken `/Applications/Hole.app` (red proof).
- [x] Local: `spctl --assess --type execute` on a quarantined copy of the new bundle now rejects with verdict=false but no "damaged" / missing-seal message — the structural inconsistency is gone; users see the normal "unidentified developer" prompt instead.
- [ ] CI `test-dmg-signing` job passes on both `macos-latest` (arm64) and `macos-15-intel` (amd64).
- [ ] After merge, cut a new patch release and confirm the published DMG installs cleanly (with the one-time right-click → Open).