### PR TITLE
fix(setup): surface elevated-install log, defer prompt to connect, repair root-owned user dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2708,7 @@ dependencies = [
  "clap",
  "contracts",
  "dirs 6.0.0",
+ "filetime",
  "garter",
  "hole-bridge",
  "hole-common",
@@ -2728,6 +2739,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "walkdir",
  "windows 0.62.2",
  "winreg 0.56.0",
  "xtask-lib",

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -59,6 +59,13 @@ windows = { version = "0.62", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Used by `setup::repair` to walk the user data dir on a one-shot
+# ownership repair triggered by the elevated `bridge install`. macOS-only
+# because the bug it fixes (osascript-admin elevation creating user-home
+# files as root) doesn't occur on Windows (UAC same-user elevation).
+walkdir = "2"
+
 [dev-dependencies]
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }
@@ -66,6 +73,7 @@ axum = { version = "0.8", default-features = false, features = ["json"] }
 tower = { version = "0.5", features = ["util"] }
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 garter = { path = "../garter" }
+filetime = "0.2"
 
 [build-dependencies]
 tauri-build = "2"

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -126,7 +126,21 @@ pub(crate) enum BridgeAction {
         state_dir: Option<std::path::PathBuf>,
     },
     /// Install and start the bridge service
-    Install,
+    Install {
+        /// Override the log directory. The GUI's elevated-install path
+        /// passes a per-invocation temp dir here so it can read this CLI's
+        /// `gui-cli.log` back after the elevation completes (and surface it
+        /// in the failure dialog).
+        #[arg(long)]
+        log_dir: Option<std::path::PathBuf>,
+        /// Repair ownership of a user data directory tree that an earlier
+        /// elevated install left root-owned (macOS only — a no-op
+        /// elsewhere). The walk is bounded to this exact path; symlinks
+        /// are never followed; hard-linked files are skipped. Best-effort:
+        /// failures are logged but do not abort the install.
+        #[arg(long)]
+        repair_user_data_dir: Option<std::path::PathBuf>,
+    },
     /// Stop and remove the bridge service
     Uninstall,
     /// Print bridge install/running status
@@ -224,20 +238,38 @@ pub(crate) fn should_install_cli_log_guard(command: &Command) -> bool {
     )
 }
 
+/// Resolve the directory where `dispatch` should install the `gui-cli.log`
+/// guard for `command`. `None` means "don't install a guard" — see
+/// [`should_install_cli_log_guard`]. A `Some` result means "install in this
+/// directory".
+///
+/// `Bridge::Install { log_dir: Some(d), .. }` overrides the default — the
+/// GUI's elevated-install path uses this to redirect the subscriber into a
+/// per-invocation temp dir it can read back after the elevation completes
+/// (so the failure dialog can include the underlying error text).
+pub(crate) fn resolve_cli_log_dir(command: &Command) -> Option<std::path::PathBuf> {
+    if !should_install_cli_log_guard(command) {
+        return None;
+    }
+    match command {
+        Command::Bridge {
+            action: BridgeAction::Install { log_dir: Some(d), .. },
+        } => Some(d.clone()),
+        _ => Some(hole_common::logging::default_log_dir()),
+    }
+}
+
 /// Dispatch a parsed subcommand to its handler. Exits the process when done.
 ///
 /// For write-action subcommands (Upgrade, Bridge::{Install, Uninstall, Status,
 /// GrantAccess, IpcSend}, and Path), install a CLI log guard so that
 /// `cli_log!(...)` calls are recorded in `gui-cli.log` in addition to the
 /// user-facing terminal output. See [`should_install_cli_log_guard`] for
-/// the exemption list.
+/// the exemption list and [`resolve_cli_log_dir`] for how the directory is
+/// chosen.
 pub(crate) fn dispatch(command: Command) -> ! {
-    let _cli_log_guard = if should_install_cli_log_guard(&command) {
-        let log_dir = hole_common::logging::default_log_dir();
-        Some(hole_common::logging::init(&log_dir, "gui-cli.log", "hole=info"))
-    } else {
-        None
-    };
+    let _cli_log_guard =
+        resolve_cli_log_dir(&command).map(|d| hole_common::logging::init(&d, "gui-cli.log", "hole=info"));
     let code = match command {
         Command::Version => {
             println!("hole {}", hole::version::VERSION);
@@ -352,8 +384,20 @@ fn handle_bridge(action: BridgeAction) -> i32 {
             }
             0
         }
-        BridgeAction::Install => {
-            if let Err(e) = crate::setup::install_bridge() {
+        BridgeAction::Install {
+            log_dir: _, // consumed by `resolve_cli_log_dir` already
+            repair_user_data_dir,
+        } => {
+            // Header line — guarantees the gui-cli.log identifies the build
+            // and host even if the rest of the install fails immediately.
+            cli_log!(
+                info,
+                "hole bridge install: hole={}, os={}, target={}",
+                hole::version::VERSION,
+                std::env::consts::OS,
+                std::env::consts::ARCH,
+            );
+            if let Err(e) = crate::setup::install_bridge(repair_user_data_dir.as_deref()) {
                 cli_log!(error, "bridge install failed: {e}");
                 return 1;
             }

--- a/crates/hole/src/cli_tests.rs
+++ b/crates/hole/src/cli_tests.rs
@@ -94,7 +94,10 @@ fn dispatch_exempts_bridge_log_from_cli_log_guard() {
 fn dispatch_installs_cli_log_guard_for_write_actions() {
     assert!(should_install_cli_log_guard(&Command::Upgrade));
     assert!(should_install_cli_log_guard(&Command::Bridge {
-        action: BridgeAction::Install,
+        action: BridgeAction::Install {
+            log_dir: None,
+            repair_user_data_dir: None,
+        },
     }));
     assert!(should_install_cli_log_guard(&Command::Bridge {
         action: BridgeAction::Uninstall,
@@ -316,4 +319,127 @@ fn read_server_entry_file_rejects_malformed_json(#[fixture(temp_dir)] dir: &Path
         err.contains("failed to parse"),
         "error should mention parse failure: {err}"
     );
+}
+
+// `bridge install` flag parsing =======================================================================================
+//
+// The GUI's elevated-install path passes `--log-dir` to redirect the CLI's
+// gui-cli.log into a per-invocation temp directory and
+// `--repair-user-data-dir` to reclaim a root-owned user data tree (macOS).
+
+#[skuld::test]
+fn bridge_install_parses_with_no_flags() {
+    let cli = Cli::try_parse_from(["hole", "bridge", "install"]).expect("parse bridge install");
+    let Some(Command::Bridge {
+        action: BridgeAction::Install {
+            log_dir,
+            repair_user_data_dir,
+        },
+    }) = cli.command
+    else {
+        panic!("expected Command::Bridge::Install");
+    };
+    assert!(log_dir.is_none(), "default log_dir is None");
+    assert!(repair_user_data_dir.is_none(), "default repair_user_data_dir is None");
+}
+
+#[skuld::test]
+fn bridge_install_parses_log_dir_flag() {
+    let cli = Cli::try_parse_from(["hole", "bridge", "install", "--log-dir", "/tmp/hole-install-XXXX"])
+        .expect("parse bridge install --log-dir");
+    let Some(Command::Bridge {
+        action: BridgeAction::Install { log_dir, .. },
+    }) = cli.command
+    else {
+        panic!("expected Command::Bridge::Install");
+    };
+    assert_eq!(log_dir, Some(std::path::PathBuf::from("/tmp/hole-install-XXXX")));
+}
+
+#[skuld::test]
+fn bridge_install_parses_repair_user_data_dir_flag() {
+    let cli = Cli::try_parse_from([
+        "hole",
+        "bridge",
+        "install",
+        "--repair-user-data-dir",
+        "/Users/test/Library/Application Support/hole",
+    ])
+    .expect("parse bridge install --repair-user-data-dir");
+    let Some(Command::Bridge {
+        action: BridgeAction::Install {
+            repair_user_data_dir, ..
+        },
+    }) = cli.command
+    else {
+        panic!("expected Command::Bridge::Install");
+    };
+    assert_eq!(
+        repair_user_data_dir,
+        Some(std::path::PathBuf::from("/Users/test/Library/Application Support/hole"))
+    );
+}
+
+#[skuld::test]
+fn bridge_install_parses_both_flags() {
+    let cli = Cli::try_parse_from([
+        "hole",
+        "bridge",
+        "install",
+        "--log-dir",
+        "/tmp/L",
+        "--repair-user-data-dir",
+        "/tmp/R",
+    ])
+    .expect("parse bridge install with both flags");
+    let Some(Command::Bridge {
+        action: BridgeAction::Install {
+            log_dir,
+            repair_user_data_dir,
+        },
+    }) = cli.command
+    else {
+        panic!("expected Command::Bridge::Install");
+    };
+    assert_eq!(log_dir, Some(std::path::PathBuf::from("/tmp/L")));
+    assert_eq!(repair_user_data_dir, Some(std::path::PathBuf::from("/tmp/R")));
+}
+
+#[skuld::test]
+fn resolve_cli_log_dir_honors_install_log_dir_override() {
+    let custom = std::path::PathBuf::from("/tmp/hole-install-XYZ");
+    let cmd = Command::Bridge {
+        action: BridgeAction::Install {
+            log_dir: Some(custom.clone()),
+            repair_user_data_dir: None,
+        },
+    };
+    let resolved = resolve_cli_log_dir(&cmd);
+    assert_eq!(resolved, Some(custom));
+}
+
+#[skuld::test]
+fn resolve_cli_log_dir_falls_back_to_default_without_override() {
+    let cmd = Command::Bridge {
+        action: BridgeAction::Install {
+            log_dir: None,
+            repair_user_data_dir: None,
+        },
+    };
+    let resolved = resolve_cli_log_dir(&cmd);
+    assert_eq!(resolved, Some(hole_common::logging::default_log_dir()));
+}
+
+#[skuld::test]
+fn resolve_cli_log_dir_returns_none_for_exempt_commands() {
+    assert!(resolve_cli_log_dir(&Command::Version).is_none());
+    assert!(resolve_cli_log_dir(&Command::Bridge {
+        action: BridgeAction::Run {
+            socket_path: None,
+            service: false,
+            log_dir: None,
+            state_dir: None,
+        },
+    })
+    .is_none());
 }

--- a/crates/hole/src/elevation.rs
+++ b/crates/hole/src/elevation.rs
@@ -136,7 +136,7 @@ async fn run_grant_access_elevated(app: &AppHandle, request: &BridgeRequest) -> 
     .await;
 
     match result {
-        Ok(Ok(status)) if status.success() => {
+        Ok(Ok(())) => {
             info!("grant-access succeeded");
             true
         }
@@ -144,19 +144,10 @@ async fn run_grant_access_elevated(app: &AppHandle, request: &BridgeRequest) -> 
             info!("user cancelled elevation prompt");
             false
         }
-        Ok(Ok(status)) => {
-            let code = status.code().unwrap_or(-1);
-            error!("grant-access exited with code {code}");
-            app.dialog()
-                .message(format!("Failed to grant access (exit code {code})."))
-                .title("Elevation Error")
-                .blocking_show();
-            false
-        }
         Ok(Err(e)) => {
-            error!("elevation failed: {e}");
+            error!("grant-access elevation failed: {e}");
             app.dialog()
-                .message(format!("Elevation failed: {e}"))
+                .message(format!("Failed to grant access.\n\n{e}"))
                 .title("Elevation Error")
                 .blocking_show();
             false
@@ -194,7 +185,7 @@ async fn run_ipc_send_elevated(_app: &AppHandle, request: &BridgeRequest) -> boo
     .await;
 
     match result {
-        Ok(Ok(status)) if status.success() => {
+        Ok(Ok(())) => {
             info!("ipc-send succeeded");
             true
         }
@@ -202,13 +193,8 @@ async fn run_ipc_send_elevated(_app: &AppHandle, request: &BridgeRequest) -> boo
             info!("user cancelled elevation prompt");
             false
         }
-        Ok(Ok(status)) => {
-            let code = status.code().unwrap_or(-1);
-            error!("ipc-send exited with code {code}");
-            false
-        }
         Ok(Err(e)) => {
-            error!("elevation failed: {e}");
+            error!("ipc-send elevation failed: {e}");
             false
         }
         Err(e) => {

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -12,6 +12,7 @@ mod commands;
 mod elevation;
 mod log_collector;
 mod logging;
+mod orphan_sweep;
 mod path_management;
 mod platform;
 mod setup;
@@ -98,7 +99,12 @@ fn launch_gui(show_dashboard: bool) {
             if show_dashboard {
                 tray::open_settings_window(app.handle());
             }
-            setup::check_bridge_on_launch(app.handle().clone());
+            // Best-effort sweep of `hole-install-*` temp directories left
+            // behind by failed elevated installs (`run_elevated` detaches
+            // its TempDir on failure so the user can attach the log to
+            // support; this cleans those up after a few days). Non-
+            // blocking; failures are logged at `warn` only.
+            orphan_sweep::spawn_default();
             hole::update::start_update_checker(app.handle().clone(), |app, info| {
                 // Rebuild tray menu to include the "Install Update" item.
                 if let Some(tray_icon) = app.tray_by_id("main") {

--- a/crates/hole/src/orphan_sweep.rs
+++ b/crates/hole/src/orphan_sweep.rs
@@ -1,0 +1,98 @@
+// Best-effort sweep of `hole-install-*` temp directories left over from
+// failed elevated installs.
+//
+// `crate::setup::run_elevated` allocates a per-invocation `TempDir` and,
+// when the elevation fails, detaches it from auto-cleanup so the user can
+// attach the contained `gui-cli.log` to a support email. macOS's `/tmp`
+// is cleaned on reboot, but Windows `%TEMP%` is not — without an explicit
+// sweep, repeated failed installs leak forever.
+//
+// This module enumerates `std::env::temp_dir()` at GUI startup, looks for
+// entries named `hole-install-*`, and deletes any whose mtime is older
+// than [`MAX_AGE`]. Bounded to [`MAX_DELETE_PER_SWEEP`] entries per call
+// so a misbehaving filesystem can't stall startup.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+const PREFIX: &str = "hole-install-";
+const MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60); // 7 days
+const MAX_DELETE_PER_SWEEP: usize = 100;
+
+/// Spawn the default sweep against `std::env::temp_dir()` on a background
+/// std thread. Non-blocking; failures are logged at `warn`.
+pub(crate) fn spawn_default() {
+    std::thread::Builder::new()
+        .name("hole-orphan-sweep".into())
+        .spawn(|| {
+            sweep(&std::env::temp_dir(), MAX_AGE, MAX_DELETE_PER_SWEEP);
+        })
+        .map(|_| ())
+        .unwrap_or_else(|e| {
+            tracing::warn!("could not spawn orphan-sweep thread: {e}");
+        });
+}
+
+/// Walk `dir` and delete child entries that:
+///   1. have a file name beginning with [`PREFIX`], AND
+///   2. have an mtime older than `max_age` ago.
+///
+/// Deletes at most `max_delete` entries before returning (so a directory
+/// with thousands of stale entries doesn't stall startup; the next launch
+/// continues the sweep).
+///
+/// Returns the number of entries actually deleted. Errors are swallowed
+/// (this is best-effort), but a `read_dir` failure is logged at `warn`.
+pub(crate) fn sweep(dir: &Path, max_age: Duration, max_delete: usize) -> usize {
+    let now = SystemTime::now();
+    let cutoff = now.checked_sub(max_age).unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!("orphan_sweep: read_dir({}) failed: {e}", dir.display());
+            return 0;
+        }
+    };
+
+    let mut deleted = 0usize;
+    for entry in entries.flatten() {
+        if deleted >= max_delete {
+            break;
+        }
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else { continue };
+        if !name_str.starts_with(PREFIX) {
+            continue;
+        }
+        // symlink_metadata so a symlink whose target is fresh doesn't
+        // shield an old link (and so we never follow into the wider FS).
+        let meta = match entry.path().symlink_metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let mtime = match meta.modified() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if mtime >= cutoff {
+            continue;
+        }
+        let path = entry.path();
+        let result = if meta.file_type().is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        if let Err(e) = result {
+            tracing::warn!("orphan_sweep: failed to remove {}: {e}", path.display());
+            continue;
+        }
+        deleted += 1;
+    }
+    deleted
+}
+
+#[cfg(test)]
+#[path = "orphan_sweep_tests.rs"]
+mod orphan_sweep_tests;

--- a/crates/hole/src/orphan_sweep_tests.rs
+++ b/crates/hole/src/orphan_sweep_tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+use std::fs;
+use std::time::Duration;
+
+/// Set `mtime` and `atime` on `path` to roughly `now - age` so the sweep
+/// considers the entry old enough to delete.
+fn backdate(path: &Path, age: Duration) {
+    let target = std::time::SystemTime::now()
+        .checked_sub(age)
+        .expect("system clock is reasonable");
+    let ft = filetime::FileTime::from_system_time(target);
+    filetime::set_file_mtime(path, ft).expect("backdate mtime");
+}
+
+#[skuld::test]
+fn sweep_deletes_old_hole_install_dirs() {
+    let tmp = tempfile::TempDir::with_prefix("orphan-sweep-test-").unwrap();
+    let old_dir = tmp.path().join("hole-install-aaaa");
+    let young_dir = tmp.path().join("hole-install-bbbb");
+    let unrelated = tmp.path().join("other-thing-zzzz");
+    fs::create_dir_all(&old_dir).unwrap();
+    fs::create_dir_all(&young_dir).unwrap();
+    fs::create_dir_all(&unrelated).unwrap();
+    // Drop a file inside the old dir to make sure remove_dir_all is wired up.
+    fs::write(old_dir.join("gui-cli.log"), b"some log content").unwrap();
+    backdate(&old_dir, Duration::from_secs(30 * 24 * 60 * 60));
+    // Unrelated also backdated so we'd notice if the prefix filter were missing.
+    backdate(&unrelated, Duration::from_secs(30 * 24 * 60 * 60));
+
+    let deleted = sweep(tmp.path(), Duration::from_secs(7 * 24 * 60 * 60), 100);
+
+    assert_eq!(deleted, 1, "exactly the old hole-install dir should be deleted");
+    assert!(!old_dir.exists(), "old hole-install-aaaa should be deleted");
+    assert!(young_dir.exists(), "young hole-install-bbbb should survive");
+    assert!(unrelated.exists(), "non-prefix dirs should never be touched");
+}
+
+#[skuld::test]
+fn sweep_respects_max_delete_cap() {
+    let tmp = tempfile::TempDir::with_prefix("orphan-sweep-test-").unwrap();
+    // Create 5 old hole-install dirs.
+    for i in 0..5 {
+        let d = tmp.path().join(format!("hole-install-old{i}"));
+        fs::create_dir_all(&d).unwrap();
+        backdate(&d, Duration::from_secs(30 * 24 * 60 * 60));
+    }
+
+    let deleted = sweep(tmp.path(), Duration::from_secs(7 * 24 * 60 * 60), 2);
+
+    assert_eq!(deleted, 2, "cap honored");
+    let remaining: usize = fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with(PREFIX))
+        .count();
+    assert_eq!(remaining, 3, "remaining old dirs survive for next sweep");
+}
+
+#[skuld::test]
+fn sweep_returns_zero_when_dir_missing() {
+    let nonexistent = std::path::Path::new("/this/path/does/not/exist/orphan-sweep");
+    let deleted = sweep(nonexistent, Duration::from_secs(60), 100);
+    assert_eq!(deleted, 0);
+}
+
+#[skuld::test]
+fn sweep_skips_recent_hole_install_dirs() {
+    let tmp = tempfile::TempDir::with_prefix("orphan-sweep-test-").unwrap();
+    let fresh = tmp.path().join("hole-install-fresh");
+    fs::create_dir_all(&fresh).unwrap();
+
+    let deleted = sweep(tmp.path(), Duration::from_secs(7 * 24 * 60 * 60), 100);
+    assert_eq!(deleted, 0);
+    assert!(fresh.exists());
+}

--- a/crates/hole/src/setup.rs
+++ b/crates/hole/src/setup.rs
@@ -1,7 +1,6 @@
 // Bridge installation status detection and privilege elevation.
 
 use std::path::{Path, PathBuf};
-use std::process::ExitStatus;
 use thiserror::Error;
 
 // Status detection ====================================================================================================
@@ -35,14 +34,70 @@ pub fn bridge_install_status() -> BridgeInstallStatus {
 pub enum SetupError {
     #[error("user cancelled the elevation prompt")]
     Cancelled,
-    #[error("elevated process failed with exit code {0}")]
-    #[allow(dead_code)] // Used on macOS
-    ExitCode(i32),
+    #[error("{}", format_exit_code_error(*code, output, log_path.as_deref()))]
+    ExitCode {
+        code: i32,
+        output: String,
+        log_path: Option<PathBuf>,
+    },
     #[error("{0}")]
     Io(#[from] std::io::Error),
     #[cfg(target_os = "windows")]
     #[error("windows error: {0}")]
     Windows(#[from] windows::core::Error),
+}
+
+fn format_exit_code_error(code: i32, output: &str, log_path: Option<&Path>) -> String {
+    let mut s = format!("elevated process exited with code {code}");
+    if !output.is_empty() {
+        s.push_str("\n\n");
+        s.push_str(output);
+    }
+    if let Some(p) = log_path {
+        if output.is_empty() {
+            s.push_str("\n\n");
+        } else if !s.ends_with('\n') {
+            s.push('\n');
+        }
+        s.push_str("Full log: ");
+        s.push_str(&p.display().to_string());
+    }
+    s
+}
+
+/// Maximum number of bytes from the elevated child's log to embed in a
+/// `SetupError::ExitCode` dialog. The full file is still detached on disk
+/// (its path goes into the dialog as `Full log: <path>`), so support can
+/// pull the rest if needed.
+const DIALOG_OUTPUT_BUDGET: usize = 3 * 1024;
+const ELLIPSIS_PREFIX: &str = "...\n";
+
+/// Trim `s` to roughly `DIALOG_OUTPUT_BUDGET` bytes for inclusion in a
+/// message dialog. Cuts on a line boundary when possible (so the truncated
+/// view doesn't start mid-line), falls back to a char-boundary byte cut
+/// when no newline is available within the budget, and prefixes `...\n` on
+/// any truncation. Returns the input unchanged when already within budget.
+pub(crate) fn truncate_for_dialog(s: &str) -> String {
+    if s.len() <= DIALOG_OUTPUT_BUDGET {
+        return s.to_string();
+    }
+    // Take last DIALOG_OUTPUT_BUDGET bytes, then advance to next char
+    // boundary so we never split a UTF-8 sequence.
+    let mut start = s.len() - DIALOG_OUTPUT_BUDGET;
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    let tail = &s[start..];
+    // Skip the (likely partial) first line if a newline exists in the
+    // tail — gives the user complete lines only.
+    let body = match tail.find('\n') {
+        Some(nl) => &tail[nl + 1..],
+        None => tail,
+    };
+    let mut out = String::with_capacity(ELLIPSIS_PREFIX.len() + body.len());
+    out.push_str(ELLIPSIS_PREFIX);
+    out.push_str(body);
+    out
 }
 
 /// Resolve the path to the bridge binary (which is ourselves).
@@ -54,11 +109,20 @@ pub fn bridge_binary_path() -> std::io::Result<PathBuf> {
 
 /// Run a command with elevated privileges.
 ///
+/// On non-success, returns `Err(SetupError::ExitCode { code, output, log_path })`.
+/// `output` carries whatever diagnostic stdio the platform allows
+/// capturing without a co-operating child (osascript stderr on macOS;
+/// empty on Windows because UAC strips inheritable stdio handles). The
+/// elevated-install path layered above this in
+/// [`prompt_bridge_install`] augments the result with the temp-log it
+/// passes via `--log-dir`.
+///
 /// On Windows, uses `ShellExecuteExW` with the "runas" verb (UAC prompt).
 /// On macOS, uses `osascript` with `with administrator privileges`.
 #[cfg(target_os = "windows")]
-pub fn run_elevated(program: &Path, args: &[&str]) -> Result<ExitStatus, SetupError> {
+pub fn run_elevated(program: &Path, args: &[&str]) -> Result<(), SetupError> {
     use std::os::windows::process::ExitStatusExt;
+    use std::process::ExitStatus;
     use windows::core::{HSTRING, PCWSTR};
     use windows::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
     use windows::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject, INFINITE};
@@ -105,7 +169,7 @@ pub fn run_elevated(program: &Path, args: &[&str]) -> Result<ExitStatus, SetupEr
     // process handle. WaitForSingleObject blocks until the process exits.
     // GetExitCodeProcess reads the exit code into a stack-local u32.
     // CloseHandle is called exactly once on all paths, releasing the handle.
-    unsafe {
+    let exit_status: ExitStatus = unsafe {
         let wait_result = WaitForSingleObject(handle, INFINITE);
         if wait_result != WAIT_OBJECT_0 {
             let _ = CloseHandle(handle);
@@ -116,8 +180,23 @@ pub fn run_elevated(program: &Path, args: &[&str]) -> Result<ExitStatus, SetupEr
         GetExitCodeProcess(handle, &mut exit_code)?;
         let _ = CloseHandle(handle);
 
-        Ok(ExitStatus::from_raw(exit_code))
+        ExitStatus::from_raw(exit_code)
+    };
+
+    if exit_status.success() {
+        return Ok(());
     }
+
+    let code = exit_status.code().unwrap_or(1);
+    // ShellExecuteExW cannot redirect child stdio under UAC; no captured
+    // output available here. Callers that need diagnostics pass a path
+    // via a co-operating CLI flag (e.g. `bridge install --log-dir`) and
+    // read it back themselves — see `prompt_bridge_install`.
+    Err(SetupError::ExitCode {
+        code,
+        output: String::new(),
+        log_path: None,
+    })
 }
 
 /// Quote a single argument per the MSDN `CommandLineToArgvW` specification.
@@ -201,9 +280,13 @@ fn cmdline_roundtrips(cmdline: &str, expected: &[&str]) -> bool {
 
 /// Run a command with elevated privileges.
 ///
-/// On macOS, uses `osascript` with `with administrator privileges`.
+/// On macOS, uses `osascript` with `with administrator privileges`. On
+/// non-success, captures osascript's stderr (truncated for dialog
+/// display) — that's the only diagnostic channel guaranteed available
+/// without a co-operating child. For richer diagnostics
+/// see [`prompt_bridge_install`], which layers a temp-log capture on top.
 #[cfg(target_os = "macos")]
-pub fn run_elevated(program: &Path, args: &[&str]) -> Result<ExitStatus, SetupError> {
+pub fn run_elevated(program: &Path, args: &[&str]) -> Result<(), SetupError> {
     // Build the shell command with proper escaping
     let mut cmd_parts = vec![shell_escape(program.to_string_lossy().as_ref())];
     for arg in args {
@@ -218,15 +301,26 @@ pub fn run_elevated(program: &Path, args: &[&str]) -> Result<ExitStatus, SetupEr
 
     let output = std::process::Command::new("osascript").args(["-e", &script]).output()?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("User canceled") {
-            return Err(SetupError::Cancelled);
-        }
-        return Err(SetupError::ExitCode(output.status.code().unwrap_or(1)));
+    if output.status.success() {
+        return Ok(());
     }
 
-    Ok(output.status)
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("User canceled") {
+        return Err(SetupError::Cancelled);
+    }
+
+    let code = output.status.code().unwrap_or(1);
+    let captured = if stderr.trim().is_empty() {
+        String::new()
+    } else {
+        truncate_for_dialog(stderr.trim())
+    };
+    Err(SetupError::ExitCode {
+        code,
+        output: captured,
+        log_path: None,
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -238,8 +332,26 @@ fn shell_escape(s: &str) -> String {
 // Install/uninstall orchestration =====================================================================================
 
 /// Run `bridge install` — idempotent, handles upgrades.
-pub fn install_bridge() -> Result<(), Box<dyn std::error::Error>> {
+///
+/// `repair_user_data_dir` is the path to a (possibly root-owned-by-mistake)
+/// user data directory that the GUI wants the elevated install to reclaim
+/// for the invoking user before doing anything else. Best-effort on macOS;
+/// no-op everywhere else.
+pub fn install_bridge(repair_user_data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
     let binary_path = bridge_binary_path()?;
+
+    // Reclaim ownership of an existing user data dir if the GUI asked us to.
+    // Runs before everything else so the rest of the install can write into
+    // user-home subdirs as needed (and so that even a crash mid-install
+    // leaves the user with a healthy data dir for the next attempt).
+    if let Some(path) = repair_user_data_dir {
+        #[cfg(target_os = "macos")]
+        repair::run(path);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = path; // suppress unused on non-macOS
+        }
+    }
 
     // Create access group, add installing user, and (on Windows) write the
     // installer SID file so the bridge includes it in the socket DACL on
@@ -285,40 +397,12 @@ pub fn uninstall_bridge() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// GUI launch check ====================================================================================================
+// GUI install prompt ==================================================================================================
 
-/// Check bridge status at GUI launch and prompt for installation if needed.
-///
-/// This runs asynchronously to avoid blocking the Tauri event loop.
-pub fn check_bridge_on_launch(app: tauri::AppHandle) {
-    // In dev mode (HOLE_BRIDGE_SOCKET set), the bridge runs in foreground
-    // rather than as an installed service. Skip the install check.
-    if std::env::var("HOLE_BRIDGE_SOCKET").is_ok() {
-        tracing::info!("HOLE_BRIDGE_SOCKET set, skipping bridge install check");
-        return;
-    }
-
-    let status = bridge_install_status();
-
-    match status {
-        BridgeInstallStatus::Running => {
-            tracing::info!("bridge is running");
-        }
-        BridgeInstallStatus::Installed => {
-            tracing::warn!("bridge is installed but not running");
-            // The service has auto-start; it should start on its own.
-            // Just log and continue.
-        }
-        BridgeInstallStatus::NotInstalled => {
-            tracing::info!("bridge not installed, prompting user");
-            tauri::async_runtime::spawn(async move {
-                prompt_bridge_install(app).await;
-            });
-        }
-    }
-}
-
-async fn prompt_bridge_install(app: tauri::AppHandle) {
+/// Prompt the user to install the bridge, run the elevated install, and
+/// return whether the bridge is now reachable. Returns `false` on cancel,
+/// elevation failure, or post-install IPC unreachability.
+pub async fn prompt_bridge_install(app: tauri::AppHandle) -> bool {
     use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
     let confirmed = app
@@ -330,7 +414,7 @@ async fn prompt_bridge_install(app: tauri::AppHandle) {
 
     if !confirmed {
         tracing::info!("user declined bridge install");
-        return;
+        return false;
     }
 
     let exe = match bridge_binary_path() {
@@ -341,43 +425,103 @@ async fn prompt_bridge_install(app: tauri::AppHandle) {
                 .message(format!("Failed to determine binary path: {e}"))
                 .title("Setup Error")
                 .blocking_show();
-            return;
+            return false;
         }
     };
 
-    // Run elevated install on a blocking thread
-    let result = tokio::task::spawn_blocking(move || run_elevated(&exe, &["bridge", "install"])).await;
+    // `--repair-user-data-dir` lets the elevated install reclaim ownership
+    // of the unprivileged user data dir if a previous install ran as root
+    // via osascript and left it root-owned.
+    let user_data_dir_arg = dirs::config_dir().map(|d| d.join("hole").to_string_lossy().into_owned());
+
+    let result = tokio::task::spawn_blocking({
+        let exe = exe.clone();
+        let user_data_dir_arg = user_data_dir_arg.clone();
+        move || run_elevated_install(&exe, user_data_dir_arg.as_deref())
+    })
+    .await;
 
     match result {
-        Ok(Ok(status)) if status.success() => {
+        Ok(Ok(())) => {
             tracing::info!("bridge installed successfully via elevation");
             // Poll IPC to verify bridge is reachable
             let reachable = poll_bridge_ipc().await;
             if !reachable {
                 tracing::warn!("bridge installed but not yet reachable via IPC");
+                app.dialog()
+                    .message("The bridge installed, but is not yet reachable. Try again in a moment.")
+                    .title("Setup Error")
+                    .blocking_show();
+                return false;
             }
-        }
-        Ok(Ok(status)) => {
-            let code = status.code().unwrap_or(-1);
-            tracing::error!("bridge install exited with code {code}");
-            app.dialog()
-                .message(format!("Bridge installation failed (exit code {code})."))
-                .title("Setup Error")
-                .blocking_show();
+            true
         }
         Ok(Err(SetupError::Cancelled)) => {
             tracing::info!("user cancelled elevation prompt");
+            false
         }
         Ok(Err(e)) => {
             tracing::error!("elevation failed: {e}");
             app.dialog()
-                .message(format!("Failed to run installer: {e}"))
+                .message(format!("Failed to install the Hole bridge.\n\n{e}"))
                 .title("Setup Error")
                 .blocking_show();
+            false
         }
         Err(e) => {
             tracing::error!("spawn_blocking failed: {e}");
+            false
         }
+    }
+}
+
+/// Run an elevated `hole bridge install`, capturing the elevated child's
+/// `gui-cli.log` into a per-invocation temp directory so a failed install
+/// can surface the underlying cause (`dseditgroup` errors, missing
+/// permissions, etc.) instead of just an exit code.
+///
+/// On success: the temp dir is dropped (auto-deleted).
+/// On failure: the temp dir is detached from auto-cleanup and its path
+/// becomes the `log_path` of `SetupError::ExitCode`, so the user can
+/// attach the full file to support if the truncated copy in the dialog
+/// isn't sufficient.
+fn run_elevated_install(exe: &Path, repair_user_data_dir: Option<&str>) -> Result<(), SetupError> {
+    let tempdir = tempfile::TempDir::with_prefix("hole-install-")?;
+    let log_dir_arg = tempdir.path().to_string_lossy().into_owned();
+
+    let mut args: Vec<&str> = vec!["bridge", "install", "--log-dir", &log_dir_arg];
+    if let Some(d) = repair_user_data_dir {
+        args.push("--repair-user-data-dir");
+        args.push(d);
+    }
+
+    match run_elevated(exe, &args) {
+        Ok(()) => Ok(()),
+        Err(SetupError::ExitCode {
+            code,
+            output: native_output,
+            log_path: _,
+        }) => {
+            let log_path = tempdir.path().join("gui-cli.log");
+            let raw_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+            let display_output = if !raw_log.is_empty() {
+                truncate_for_dialog(&raw_log)
+            } else if !native_output.is_empty() {
+                // Elevated child exited before tracing init — fall back to
+                // whatever stderr the OS gave us at the elevation layer.
+                native_output
+            } else {
+                "(no further detail available — elevated process exited before logging began)".to_string()
+            };
+            // Detach the tempdir so the user can attach the full file.
+            let kept = tempdir.keep();
+            Err(SetupError::ExitCode {
+                code,
+                output: display_output,
+                log_path: Some(kept.join("gui-cli.log")),
+            })
+        }
+        Err(other) => Err(other),
     }
 }
 
@@ -397,6 +541,129 @@ async fn poll_bridge_ipc() -> bool {
         }
     }
     false
+}
+
+// Ownership repair (macOS) ============================================================================================
+
+/// Reclaim ownership of a directory tree that was created root-owned by an
+/// earlier elevated install (the osascript admin-privileges context
+/// preserves `HOME` from the unprivileged parent, so root-mode CLI helpers
+/// happily wrote `~/Library/Application Support/hole/` and friends as
+/// root). This module walks the tree and `lchown`s every entry back to the
+/// owner of the path's parent.
+///
+/// Safety-critical: runs as root, so any symlink confusion is a privilege
+/// escalation primitive. Constraints:
+///
+/// - `walkdir` with `.follow_links(false)` (the default; set explicitly).
+/// - `lchown` (not `chown`) on every entry, so symlink ENTRIES get
+///   re-owned, not their TARGETS.
+/// - Regular files with `nlink > 1` are skipped — a hard link planted in a
+///   writable subdir could otherwise re-own a file outside the tree.
+/// - The top-level `path` itself, if a symlink, is refused (warning
+///   logged, install continues).
+///
+/// Best-effort. Failures are logged at `warn` level (with a summary line)
+/// but do not abort the install.
+#[cfg(target_os = "macos")]
+mod repair {
+    use std::os::unix::fs::MetadataExt;
+    use std::path::Path;
+
+    pub(super) fn run(path: &Path) {
+        // Path may not exist (first install on a clean machine) — nothing to do.
+        let Ok(top_meta) = std::fs::symlink_metadata(path) else {
+            return;
+        };
+        if top_meta.file_type().is_symlink() {
+            cli_log!(warn, "refusing to repair ownership of symlink: {}", path.display());
+            return;
+        }
+
+        // Resolve parent owner — the user who owns ~/Library/Application Support
+        // by definition.
+        let parent = match path.parent() {
+            Some(p) => p,
+            None => {
+                cli_log!(warn, "cannot determine parent of {}", path.display());
+                return;
+            }
+        };
+        let parent_meta = match std::fs::metadata(parent) {
+            Ok(m) => m,
+            Err(e) => {
+                cli_log!(warn, "cannot stat parent {}: {e}", parent.display());
+                return;
+            }
+        };
+        let target_uid = parent_meta.uid();
+        let target_gid = parent_meta.gid();
+
+        // Skip the walk entirely when the tree is already healthy.
+        if top_meta.uid() == target_uid && top_meta.gid() == target_gid {
+            return;
+        }
+
+        let mut repaired = 0usize;
+        let mut skipped = 0usize;
+        let mut failed = 0usize;
+
+        for entry in walkdir::WalkDir::new(path).follow_links(false) {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    cli_log!(warn, "walkdir error under {}: {e}", path.display());
+                    failed += 1;
+                    continue;
+                }
+            };
+            let entry_path = entry.path();
+            let meta = match entry.metadata() {
+                Ok(m) => m,
+                Err(e) => {
+                    cli_log!(warn, "stat failed for {}: {e}", entry_path.display());
+                    failed += 1;
+                    continue;
+                }
+            };
+
+            // Already correctly owned — skip the chown call.
+            if meta.uid() == target_uid && meta.gid() == target_gid {
+                continue;
+            }
+
+            // Refuse to chown a regular file with extra hard links: an
+            // attacker with prior write access in the tree could plant a
+            // hard link to a file outside the tree, and changing the
+            // ownership of one hard link silently re-owns the other.
+            if meta.file_type().is_file() && meta.nlink() > 1 {
+                cli_log!(
+                    warn,
+                    "skipping {} (nlink={}): refusing to chown hard-linked file",
+                    entry_path.display(),
+                    meta.nlink(),
+                );
+                skipped += 1;
+                continue;
+            }
+
+            // lchown: do not follow symlinks (the entry returned by
+            // walkdir with follow_links(false) is the symlink itself; we
+            // re-own the link, never its target).
+            if let Err(e) = std::os::unix::fs::lchown(entry_path, Some(target_uid), Some(target_gid)) {
+                cli_log!(warn, "lchown failed for {}: {e}", entry_path.display());
+                failed += 1;
+                continue;
+            }
+            repaired += 1;
+        }
+
+        cli_log!(
+            info,
+            "repaired ownership: {repaired} entries chowned, {skipped} skipped, {failed} failed (path={})",
+            path.display(),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/hole/src/setup_tests.rs
+++ b/crates/hole/src/setup_tests.rs
@@ -115,3 +115,134 @@ fn bridge_binary_path_resolves() {
     let path = bridge_binary_path().expect("should resolve current exe");
     assert!(path.exists(), "resolved path should exist: {path:?}");
 }
+
+// truncate_for_dialog =================================================================================================
+
+#[skuld::test]
+fn truncate_for_dialog_empty_input() {
+    assert_eq!(truncate_for_dialog(""), "");
+}
+
+#[skuld::test]
+fn truncate_for_dialog_under_limit_passthrough() {
+    let s = "one\ntwo\nthree\n";
+    assert_eq!(truncate_for_dialog(s), s);
+}
+
+#[skuld::test]
+fn truncate_for_dialog_under_limit_no_trailing_newline() {
+    let s = "single line no newline";
+    assert_eq!(truncate_for_dialog(s), s);
+}
+
+#[skuld::test]
+fn truncate_for_dialog_over_limit_cuts_at_line_boundary() {
+    // Build a big repeating line, well over DIALOG_OUTPUT_BUDGET (3 KiB).
+    let line = "AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA AAAA";
+    let big = std::iter::repeat_n(line, 100).collect::<Vec<_>>().join("\n");
+    let truncated = truncate_for_dialog(&big);
+    assert!(truncated.starts_with("...\n"), "ellipsis prefix expected");
+    assert!(truncated.len() < big.len(), "should be shorter");
+    // The body after the ellipsis prefix should start at a line boundary
+    // (no leading partial line).
+    let body = truncated.strip_prefix("...\n").unwrap();
+    assert!(body.starts_with("AAAA"), "body should start at a clean line boundary");
+}
+
+#[skuld::test]
+fn truncate_for_dialog_over_limit_no_newline_falls_back_to_byte_cut() {
+    // Single line that exceeds the budget — there's no newline within the
+    // budget, so the function must fall back to a byte-aligned cut.
+    let big = "x".repeat(DIALOG_OUTPUT_BUDGET + 500);
+    let truncated = truncate_for_dialog(&big);
+    assert!(truncated.starts_with("...\n"));
+    let body = truncated.strip_prefix("...\n").unwrap();
+    assert!(body.chars().all(|c| c == 'x'));
+}
+
+#[skuld::test]
+fn truncate_for_dialog_never_splits_utf8() {
+    // Build a string with a multi-byte char placed exactly at the
+    // tentative byte-cut. Function must advance the cut to the next char
+    // boundary — checked indirectly by asserting the output is valid UTF-8
+    // and contains the cyrillic byte sequence intact.
+    let lead = "x".repeat(DIALOG_OUTPUT_BUDGET);
+    let trail = "Привет\n".repeat(10);
+    let big = format!("{lead}{trail}");
+    let truncated = truncate_for_dialog(&big);
+    // No assertion required beyond "doesn't panic" — slicing on a non-char
+    // boundary in `is_char_boundary`-loop code path is the bug we're
+    // guarding against. Additionally check the trailing chars are intact.
+    assert!(truncated.contains("Привет"));
+}
+
+// SetupError::ExitCode Display ========================================================================================
+
+#[skuld::test]
+fn exit_code_display_with_empty_output_no_log() {
+    let e = SetupError::ExitCode {
+        code: 1,
+        output: String::new(),
+        log_path: None,
+    };
+    let rendered = e.to_string();
+    assert_eq!(rendered, "elevated process exited with code 1");
+}
+
+#[skuld::test]
+fn exit_code_display_with_output_no_log() {
+    let e = SetupError::ExitCode {
+        code: 2,
+        output: "first line\nsecond line".into(),
+        log_path: None,
+    };
+    let rendered = e.to_string();
+    assert_eq!(
+        rendered,
+        "elevated process exited with code 2\n\nfirst line\nsecond line"
+    );
+}
+
+#[skuld::test]
+fn exit_code_display_with_log_no_output() {
+    let e = SetupError::ExitCode {
+        code: 3,
+        output: String::new(),
+        log_path: Some(PathBuf::from("/tmp/hole-install-XXXX/gui-cli.log")),
+    };
+    let rendered = e.to_string();
+    assert!(
+        rendered.contains("elevated process exited with code 3"),
+        "got: {rendered}"
+    );
+    assert!(
+        rendered.contains("Full log: /tmp/hole-install-XXXX/gui-cli.log"),
+        "got: {rendered}"
+    );
+}
+
+#[skuld::test]
+fn exit_code_display_with_output_and_log() {
+    let e = SetupError::ExitCode {
+        code: 4,
+        output: "some error".into(),
+        log_path: Some(PathBuf::from("/tmp/hole-install-XXXX/gui-cli.log")),
+    };
+    let rendered = e.to_string();
+    assert!(rendered.contains("some error"));
+    assert!(rendered.contains("Full log: /tmp/hole-install-XXXX/gui-cli.log"));
+    // Sanity: no stray double-blank-then-blank artifacts.
+    assert!(!rendered.contains("\n\n\n"));
+}
+
+#[skuld::test]
+fn exit_code_display_with_unicode_output() {
+    let e = SetupError::ExitCode {
+        code: 5,
+        output: "Привет\n世界".into(),
+        log_path: None,
+    };
+    let rendered = e.to_string();
+    assert!(rendered.contains("Привет"));
+    assert!(rendered.contains("世界"));
+}

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -213,6 +213,18 @@ fn revert_proxy_state(app: &AppHandle, enabled: bool) {
 pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<ToggleOutcome, String> {
     let state = app.state::<AppState>();
 
+    // Bridge install gate: if the user is trying to enable the proxy and
+    // the bridge isn't installed yet, prompt for installation BEFORE
+    // flipping any config state. Cancelling here leaves `config.enabled`
+    // untouched (no rollback needed). Replaces the prior launch-time
+    // install check at `setup::check_bridge_on_launch`.
+    if enabled
+        && crate::setup::bridge_install_status() == crate::setup::BridgeInstallStatus::NotInstalled
+        && !crate::setup::prompt_bridge_install(app.clone()).await
+    {
+        return Err("The Hole bridge must be installed to connect.".into());
+    }
+
     let proxy_config = {
         let mut config = state.config.lock().unwrap();
         if config.enabled == enabled {
@@ -480,7 +492,7 @@ async fn handle_uninstall_helper(app: AppHandle) {
     let result = tokio::task::spawn_blocking(move || crate::setup::run_elevated(&exe, &["bridge", "uninstall"])).await;
 
     match result {
-        Ok(Ok(status)) if status.success() => {
+        Ok(Ok(())) => {
             app.dialog()
                 .message("Bridge helper has been uninstalled.")
                 .title("Uninstall Helper")
@@ -495,10 +507,6 @@ async fn handle_uninstall_helper(app: AppHandle) {
                 .message(format!("Uninstall failed: {e}"))
                 .title("Error")
                 .blocking_show();
-        }
-        Ok(Ok(status)) => {
-            let code = status.code().unwrap_or(-1);
-            error!("uninstall exited with code {code}");
         }
         Err(e) => {
             error!("spawn_blocking failed: {e}");

--- a/crates/hole/src/update/install.rs
+++ b/crates/hole/src/update/install.rs
@@ -113,13 +113,11 @@ fn install_from_mount(mount_dir: &Path) -> Result<(), UpdateError> {
     let cp_path = Path::new("/bin/cp");
     let src_str = app_src.to_string_lossy().to_string();
     let cp_args = ["-R", &src_str, &app_dest];
-    let status = crate::setup::run_elevated(cp_path, &cp_args)
-        .map_err(|e| UpdateError::Io(std::io::Error::other(e.to_string())))?;
-    if !status.success() {
-        return Err(UpdateError::InstallerFailed(status.code().unwrap_or(-1)));
+    match crate::setup::run_elevated(cp_path, &cp_args) {
+        Ok(()) => Ok(()),
+        Err(crate::setup::SetupError::ExitCode { code, .. }) => Err(UpdateError::InstallerFailed(code)),
+        Err(e) => Err(UpdateError::Io(std::io::Error::other(e.to_string()))),
     }
-
-    Ok(())
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/hole/src/update/install.rs
+++ b/crates/hole/src/update/install.rs
@@ -13,10 +13,12 @@ pub fn run_installer(path: &Path, quiet: bool) -> Result<(), UpdateError> {
 
     if quiet {
         // Quiet mode skips UAC, so we must elevate explicitly.
-        let status = crate::setup::run_elevated(Path::new("msiexec"), &args_ref)
-            .map_err(|e| UpdateError::Io(std::io::Error::other(e.to_string())))?;
-        if !status.success() {
-            return Err(UpdateError::InstallerFailed(status.code().unwrap_or(-1)));
+        match crate::setup::run_elevated(Path::new("msiexec"), &args_ref) {
+            Ok(()) => {}
+            Err(crate::setup::SetupError::ExitCode { code, .. }) => {
+                return Err(UpdateError::InstallerFailed(code));
+            }
+            Err(e) => return Err(UpdateError::Io(std::io::Error::other(e.to_string()))),
         }
     } else {
         // Interactive mode: msiexec shows its own UAC prompt.


### PR DESCRIPTION
Fixes #368.

## Summary

The user just got `Failed to run installer: elevated process failed with exit code 1` on app launch on their Mac with no way to find out what actually went wrong. Three problems were stacked:

1. **The elevated child's output was captured then discarded.** `osascript`'s stdout+stderr were captured at [setup.rs:219](https://github.com/bindreams/hole/blob/main/crates/hole/src/setup.rs#L219) but only scanned for `"User canceled"`; any other failure became a bare `SetupError::ExitCode(code)`.
2. **The install prompt fired at GUI launch**, before any user-initiated action.
3. **Nothing on disk survived the failure.** The GUI's `gui.log` could not be written because `~/Library/Application Support/hole/` was root-owned by a prior elevated install (the osascript admin-privileges context preserves `HOME` from the unprivileged parent, so root-mode CLI helpers wrote into the user's home as root). The elevated CLI's `gui-cli.log` *did* contain a matching diagnostic but the GUI never read it.

This PR fixes all three.

## Changes

### Change 1 — surface the elevated child's log in the failure dialog

- New `--log-dir <DIR>` flag on `hole bridge install`. The GUI allocates a per-invocation `tempfile::TempDir` named `hole-install-*` and passes its path so the elevated CLI writes its `gui-cli.log` somewhere the unprivileged caller can read back.
- `cli::dispatch()` refactored: the `gui-cli.log` guard is installed via a new `resolve_cli_log_dir(&command)` helper that consults the per-subcommand override, instead of hard-coding `default_log_dir()` at top of dispatch. Per-subcommand override avoids any env-var-based plumbing (which would leak into `bridge run`'s log dir, `log_collector`, etc.).
- `SetupError::ExitCode` is now a struct variant `{ code, output, log_path }`. `Display` formats as `elevated process exited with code N` + the captured output (if any) + a `Full log: <path>` line (if any).
- `run_elevated` returns `Result<(), SetupError>` on both platforms (was `Result<ExitStatus, SetupError>` on Windows). Three callers updated (`elevation.rs::run_grant_access_elevated`, `elevation.rs::run_ipc_send_elevated`, `update::install::install_from_mount`, `tray.rs::handle_uninstall_helper`).
- `prompt_bridge_install` does the tempdir+log-read dance via the new private `run_elevated_install` wrapper. On failure the `TempDir` is detached (`TempDir::keep()`) so the user can attach the full file to support; on success it auto-cleans.
- macOS fallback for early failures: when the elevated child crashes before tracing init (so the temp `gui-cli.log` is empty), the dialog shows osascript's captured stderr instead. On Windows there's no equivalent — UAC strips inheritable stdio — so the dialog reports a clear "no further detail" message.
- Header line at the top of every elevated install run logs the build version, OS, and target so support can identify the build even if the run fails immediately.
- `truncate_for_dialog` helper caps the dialog body at ~3 KB, cuts on a line boundary when possible, falls back to a char-boundary byte cut, never splits UTF-8.
- New `orphan_sweep` module deletes `hole-install-*` directories older than 7 days at GUI startup (Windows `%TEMP%` is not cleaned on reboot). Bounded at 100 deletions per sweep.

### Change 2 — defer the install prompt to first connect

- Removed `setup::check_bridge_on_launch` (function deleted; main.rs no longer calls it).
- Install gate added in `tray::set_proxy_enabled`, **before** the `config.enabled = true` flip. Cancelling the install prompt now leaves `config.enabled` untouched (no rollback dance).
- `prompt_bridge_install` returns `bool` (was `()`); `true` means installed-and-IPC-reachable.

### Change 3 — repair root-owned user data dirs (macOS)

- New `--repair-user-data-dir <PATH>` flag on `hole bridge install`. The GUI passes `dirs::config_dir().join("hole")`.
- New `setup::repair` module (macOS-only). Walks the tree with `walkdir::WalkDir::new(path).follow_links(false)`; uses `std::os::unix::fs::lchown` (NOT `chown`) on each entry; refuses to chown regular files with `nlink > 1` (denies hard-link tricks); refuses to repair if the top-level path is itself a symlink; computes target uid/gid from the parent's `stat`.
- Best-effort: failures log a warning, never abort the install.
- Skips the walk entirely when the tree is already user-owned.

## Test plan

- [x] `cargo +stable nextest run -E 'package(hole)'` — 167/167 pass, including 11 new tests (truncate_for_dialog edge cases × 6; SetupError::ExitCode Display × 5; orphan_sweep × 4; bridge_install flag parsing × 6; resolve_cli_log_dir × 3).
- [x] `cargo +stable nextest run -E 'package(hole-common) + package(hole-bridge) + package(tun-engine)'` — 625/625 pass, 2 skipped (no regression in upstream callers).
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo +stable xtask run prek` — clean.
- [x] `cargo +stable xtask build hole` — debug build OK; `target/debug/hole bridge install --help` shows both new flags.
- [x] Real CLI smoke (this Mac, no sudo): `hole bridge install --log-dir /tmp/X` produces `/tmp/X/gui-cli.log` containing the `hole bridge install: hole=…, os=macos, target=aarch64` header and the actual `dseditgroup add user failed: Username and password must be provided.` diagnostic — i.e. exactly the kind of underlying error that used to be lost.
- [x] `--repair-user-data-dir` no-ops cleanly on a non-existent path.
- [ ] Full GUI flow (launch, click Connect, see new failure dialog text with the dseditgroup error) — needs human-driven elevation prompt with password; verified via the CLI test instead.

Note: a pre-existing `handle-holders::find_holders_detects_child_holding_file` test fails on `main` too on this Mac — not introduced by this PR.