### PR TITLE
chore(renovate): ignore vendored upstream CI under external/*/.circleci/

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,11 @@
   ],
   "packageRules": [
     {
+      "description": "Don't update vendored upstream CI under external/*/.circleci/. We don't run it; subrepo pulls overwrite any edits.",
+      "matchFileNames": ["external/*/.circleci/**"],
+      "enabled": false
+    },
+    {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",


### PR DESCRIPTION
## Summary

Stops Renovate from churning PRs against vendored upstream CI files. Fixes #370.

- Adds one `packageRules` entry to `.github/renovate.json` matching `external/*/.circleci/**` with `"enabled": false`.
- We do not run upstream's CircleCI (Hole builds v2ray-plugin via `cargo xtask v2ray-plugin` and embeds it into `galoshes` at compile time), and any in-place edits get clobbered on the next `git subrepo pull external/v2ray-plugin`. PRs like #309 (merged) and #334 (open) are wasted churn.
- The `*` segment wildcard auto-handles future subrepos placed under `external/`. If a future subrepo nests its CI deeper (e.g. `external/<name>/<subdir>/.circleci/`), the pattern would need extending — noted for the future reader.

## What is NOT changed

- Renovate continues to update `external/v2ray-plugin/go.mod` / `go.sum` (real dependency updates; cf. merged #327). Only upstream-CI files are ignored.
- Top-level `ignorePaths` was considered and rejected: it has `mergeable: false` in the Renovate schema, so setting it would *replace* (not merge with) the defaults inherited from `config:recommended` → `:ignoreModulesAndTests` (`**/node_modules/**`, `**/vendor/**`, etc.). A `packageRules` entry is surgical and additive.

## Test plan

- [x] `npx --yes --package renovate -- renovate-config-validator` — passes, config schema is valid.
- [ ] CI green (`ci.yaml`, `semantic-pr.yaml`).
- [ ] Post-merge: Renovate auto-closes #334 on its next scan and stops listing `external/v2ray-plugin/.circleci/config.yml` on the [Mend dashboard](https://developer.mend.io/github/bindreams/hole).