### PR TITLE
chore(renovate): split major updates into individual PRs and rename groups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,44 +23,50 @@
       "enabled": false
     },
     {
-      "description": "Group GitHub Actions updates",
+      "description": "Group non-major GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "groupName": "github-actions",
-      "automerge": true,
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "GitHub Actions",
+      "automerge": true
     },
     {
-      "description": "Group Cargo updates",
+      "description": "Group non-major Rust crate updates",
       "matchManagers": ["cargo"],
-      "groupName": "cargo",
-      "automerge": true,
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Rust crates",
+      "automerge": true
     },
     {
-      "description": "Group Go module updates",
+      "description": "Group non-major Go module updates",
       "matchManagers": ["gomod"],
-      "groupName": "gomod",
-      "automerge": true,
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Go modules",
+      "automerge": true
     },
     {
-      "description": "Group Python (PEP 621) updates",
+      "description": "Group non-major Python (PEP 621) updates",
       "matchManagers": ["pep621"],
-      "groupName": "python",
-      "automerge": true,
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Python packages",
+      "automerge": true
     },
     {
-      "description": "Group npm updates",
+      "description": "Group non-major npm updates; weekly lockfile maintenance runs out-of-band",
       "matchManagers": ["npm"],
-      "groupName": "npm",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "npm packages",
       "automerge": true,
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "lockFileMaintenance": {
         "enabled": true,
         "automerge": true,
         "schedule": ["before 9am on monday"]
       }
+    },
+    {
+      "description": "Major updates: one PR per package (API breaks reviewed individually). groupName: null overrides any inherited monorepo group from config:recommended's group:monorepos / group:recommended presets. Applies to customManagers (WiX) as well — by design; the customManagers block has no groupName, so this just reasserts the default.",
+      "matchUpdateTypes": ["major"],
+      "groupName": null,
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Strip `"major"` from each per-ecosystem grouping rule's `matchUpdateTypes` so majors no longer coalesce.
- Add a final catch-all `matchUpdateTypes: ["major"]` rule with `groupName: null` to override any inherited monorepo grouping from `config:recommended` (which transitively extends `group:monorepos` + `group:recommended`).
- Rename ecosystem groups (`cargo` → `Rust crates`, `gomod` → `Go modules`, `pep621` → `Python packages`, `npm` → `npm packages`, `github-actions` → `GitHub Actions`) so grouped-PR titles read naturally and don't collapse to confusing forms like #352's "update cargo to v1".

Closes #374.

## Behavior change

- Majors: one PR per package, automerged on CI-green. Renovate will close #352 on its next pass (the grouping rule no longer matches) and reopen the two bumps as separate PRs — e.g. `chore(deps): update rust crate ctor to v1` and `chore(deps): update rust crate schemars to v1`.
- Non-majors: still grouped per ecosystem, but under the renamed `groupName`.
- `lockFileMaintenance` left nested in the npm rule. Per Renovate docs `matchUpdateTypes` does not filter it, so the weekly Monday schedule is unaffected.
- `customManagers` (WiX toolchain) majors are caught by the catch-all by design. The block sets no `groupName`, so the catch-all `groupName: null` just reasserts the default.

## Test plan

- [x] `python -m json.tool .github/renovate.json` — syntax-valid JSON.
- [x] `npx --yes --package renovate -- renovate-config-validator .github/renovate.json` — Renovate's own semantic validator reports `Config validated successfully`.
- [ ] Semantic-pr CI gate passes (`chore(renovate):` is a recognized Conventional Commit prefix).
- [ ] After merge, watch Renovate's next run: PR #352 should auto-close, two new per-crate major PRs should appear, and any pending non-major Cargo group should now read `update rust crates` instead of `update cargo`.