### PR TITLE
chore(release): bump hole-group crates to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dump"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "dump-macros",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "dump-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "dump",
  "hole-test-observability",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "handle-holders"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "hole-test-observability",
  "skuld",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "hole"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "hole-bridge"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "hole-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.11.1",
  "dirs 6.0.0",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "hole-test-observability"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ctor 1.0.6",
  "hole-common",
@@ -7675,7 +7675,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7702,7 +7702,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "hole-test-observability",
  "proc-macro2",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-bridge"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-common"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump-macros"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the dump crate (provides #[derive(Dump)])."

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 description = "YAML-shaped representation for logging, analogous to Python's dump() alongside str()/repr()."

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handle-holders"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-test-observability"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 license = "GPL-3.0-or-later"
 publish = false

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine-macros"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the tun-engine crate (provides #[freeze])."

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 description = "Cross-platform TUN device, OS routing, gateway discovery, and a smoltcp-backed packet-loop engine for building split-tunnel VPN/proxy daemons."


### PR DESCRIPTION
Bumps the 9 hole-group crates (`hole`, `hole-common`, `hole-bridge`, `hole-test-observability`, `tun-engine`, `tun-engine-macros`, `dump`, `dump-macros`, `handle-holders`) from 0.1.1 -> **0.2.0** in lockstep, ahead of cutting `releases/hole/v0.2.0`.

Closes #381.

## Why minor

11 commits since [`releases/hole/v0.1.1`](https://github.com/bindreams/hole/releases/tag/releases%2Fhole%2Fv0.1.1):

- **1 `feat`** — #367 install-dir picker + shortcut checkboxes in the MSI UI (user-facing UI addition)
- 6 `fix` (single-instance lock #362, elevated-install log #369, MSI frontend #373, ARP icon #361, DMG signing #366, embedded cabinets #357 — already in v0.1.1, doesn't count)
- 4 `chore` (renovate config + dep bumps)

SemVer + Conventional Commits: a single `feat` -> minor bump.

## Validation

- `cargo xtask version --check --group hole` -> `0.2.0` (one-bump-ahead of v0.1.1, accepted by `is_valid_next`)
- `cargo update --workspace --offline` refreshed `Cargo.lock` for the 9 internal version edges only

The `--exact` form will pass once the draft-release workflow creates the local v0.2.0 tag.

## Test plan

- [ ] CI green
- [ ] After merge: trigger `Draft Release (hole)` workflow with `version=0.2.0`
- [ ] Sign via `uv run scripts/sign-release.py 0.2.0`
- [ ] Trigger `Publish Release (hole)` workflow