### PR TITLE
test: replace sleep-based synchronization with deterministic primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,7 +521,7 @@ the class:
 1. **Test-of-timing.** The delay IS the behavior under test
    ([`SlowWriter` in logging_test_helpers.rs:379](crates/common/src/logging/logging_test_helpers.rs#L379)
    verifying backpressure-induced drops, or
-   [`SilentAfterRead { delay }` in tap_tests.rs](crates/garter/src/tap_tests.rs)
+   [`SilentAfterRead { delay }` in tap_tests.rs:139](crates/garter/src/tap_tests.rs#L139)
    exercising idle-close semantics).
 1. **External event with graceful failure bound.** The retry budget
    for a *remote/out-of-process* operation that might genuinely never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,86 @@ the 7 assertion-target tests (`proxy_manager_tests`,
 `forwarder_tests`, `system_tests`, `tap_tests`, `yaml_format_tests`,
 `logging_tests`, `cli_log_tests`) keep working as before.
 
+### Synchronization invariant (no sleeps for sync)
+
+`tokio::time::sleep`, `std::thread::sleep`, `setTimeout`-as-wait,
+`browser.pause()`, and any timeout-bounded poll
+(`waitUntil({ timeout })`, `waitForExist({ timeout })`,
+`tokio::time::timeout(d, wait_for_x)`) are **forbidden for
+synchronization**. Enforced by code review (`review` agent and human
+review). Every PR that introduces or keeps a sleep must justify the
+site (which exception class) or replace it with a deterministic
+primitive. See bindreams/hole#383 for the audit that established this.
+
+Two narrow exceptions, each with a one-line comment at the site naming
+the class:
+
+1. **Test-of-timing.** The delay IS the behavior under test
+   ([`SlowWriter` in logging_test_helpers.rs:379](crates/common/src/logging/logging_test_helpers.rs#L379)
+   verifying backpressure-induced drops, or
+   [`SilentAfterRead { delay }` in tap_tests.rs](crates/garter/src/tap_tests.rs)
+   exercising idle-close semantics).
+1. **External event with graceful failure bound.** The retry budget
+   for a *remote/out-of-process* operation that might genuinely never
+   succeed — port-bind races against the OS allocator, subprocess
+   startup observed only through file existence or port-open polling,
+   external HTTP. The framework timeout (Mocha, nextest) or job
+   timeout (GHA) is the *failure-to-human* signal, never the sync.
+   Not applicable to intra-process synchronization where both sides
+   are our code.
+
+For intra-process sync, use the codebase's primitives:
+
+- **Task rendezvous "wait until A is parked at Y"**:
+  [`oneshot::channel`](crates/bridge/src/ipc_tests.rs) in
+  `MockProxy::start_entered`. The inner task fires
+  `tx.send(())` before the await point; the test code calls
+  `entered_rx.await`. *Do NOT use `Notify::notify_waiters` for
+  rendezvous* — it has no latch; the signal is lost if the receiver
+  hasn't called `notified()` yet.
+- **UI-window readiness from webdriver**:
+  [`wait_ui_ready` Tauri command + `__holeUiReady` global](crates/hole/src/ui_ready.rs).
+  The test parks in Rust on a `watch` channel until `init()` calls
+  `signal_ui_ready` (success or failure). See
+  [tests/webdriver/wdio.conf.ts](tests/webdriver/wdio.conf.ts).
+  `withGlobalTauri: false` means injected JS cannot see `window.__TAURI__`,
+  so the bundled UI entry exposes a typed `window.__holeUiReady` bridge.
+- **Server-bind readiness**: return a separate `oneshot::Receiver<()>`
+  from `bind` (or have the spawned-task signal one after a synchronous
+  bind). The test awaits the receiver before connecting. See
+  [foreground_tests.rs](crates/bridge/src/foreground_tests.rs) (IpcServer)
+  and the `on_ready` builder method on [ChainRunner](crates/garter/src/chain.rs).
+- **Stdio-relay flush in tests**:
+  [`StdioRelayHandles::flush()`](crates/common/src/logging.rs) writes
+  a unique in-band sentinel through stderr/stdout and blocks on an
+  `mpsc::sync_channel` ack from the relay reader. The sentinel is
+  intercepted before tee/emit so it does not pollute either log
+  surface.
+- **Elapsed-time assertions**: prefer `tokio::time::pause()` +
+  `tokio::time::advance(d)` if the system-under-test uses
+  `tokio::time::Instant` or `tokio::time::sleep`. Requires the
+  `test-util` feature in dev-deps (`tokio = { features = ["test-util"] }`).
+  If production code uses `std::time::Instant` (not controlled by
+  tokio's virtual clock), inject a test seam — see
+  [`ProxyManager::shift_started_at_for_test`](crates/bridge/src/proxy_manager.rs).
+- **Log-event sequencing**: subscribe a `WaitableWriter` to the
+  tracing subscriber; register `wait_for(substring)` patterns; park
+  on the returned `mpsc::Receiver`. See
+  [`garter::test_utils::WaitableWriter`](crates/garter/src/test_utils.rs)
+  and the tap_tests "plugin tap: ready" / "plugin tap: closed"
+  patterns.
+- **Holding a resource open until test signals release**:
+  `CancellationToken::new()` + `token.cancelled().await` in the
+  holding task; test calls `token.cancel()` when done. Or, for a
+  child-process helper, read from stdin and exit on EOF — parent
+  closes stdin (via `kill`) when ready. See
+  [`hold_file.rs`](crates/handle-holders/src/bin/hold_file.rs).
+- **"Wait for spawned work to complete"**: return the `JoinHandle`
+  from the spawning function and `.await` it. Don't fire-and-forget
+  if you might need to wait. See
+  [`spawn_forwarder_self_test`](crates/bridge/src/proxy_manager.rs) for
+  the pattern (returns `Option<JoinHandle<()>>`).
+
 ### Windows installer
 
 ```sh

--- a/build.yaml
+++ b/build.yaml
@@ -196,8 +196,11 @@ targets:
     depends: garter
     platforms:
       matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
-    build: cargo nextest run --no-run -p garter
-    run: cargo nextest run -p garter
+    # `--features test-utils` makes `garter::test_utils::WaitableWriter`
+    # visible to the integration tests (`tests/*.rs`). See garter's
+    # Cargo.toml `[features]` and bindreams/hole#383.
+    build: cargo nextest run --no-run -p garter --features test-utils
+    run: cargo nextest run -p garter --features test-utils
 
   garter-bin-tests:
     depends: garter-bin

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -1,6 +1,5 @@
 use crate::proxy::{Proxy, ProxyError, RunningProxy};
 use crate::proxy_manager::ProxyManager;
-use crate::socket::LocalStream;
 use bytes::Bytes;
 use hole_common::protocol::{StatusResponse, ROUTE_STATUS};
 use http_body_util::{BodyExt, Full};
@@ -8,7 +7,7 @@ use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tokio::task::JoinHandle;
 use tun_engine::gateway::GatewayInfo;
 use tun_engine::routing::Routing;
@@ -93,17 +92,6 @@ fn test_socket_path(suffix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("hole-fg-test-{}-{suffix}.sock", std::process::id()))
 }
 
-/// Connect to the server with retry (avoids flaky sleep-based waits).
-async fn connect_with_retry(path: &Path) -> LocalStream {
-    for _ in 0..50 {
-        match LocalStream::connect(path).await {
-            Ok(stream) => return stream,
-            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(20)).await,
-        }
-    }
-    panic!("failed to connect to foreground server after retries");
-}
-
 #[skuld::test]
 fn foreground_run_accepts_ipc_and_shuts_down() {
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -113,6 +101,9 @@ fn foreground_run_accepts_ipc_and_shuts_down() {
 
         // Use a channel to trigger graceful shutdown (simulates Ctrl+C)
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        // Signaled once IpcServer::bind has returned Ok — i.e. the socket
+        // is listening and connects will succeed. No poll-retry needed.
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
 
         let path_clone = path.clone();
         let server_handle = tokio::spawn(async move {
@@ -123,6 +114,8 @@ fn foreground_run_accepts_ipc_and_shuts_down() {
             let proxy_shutdown = std::sync::Arc::clone(&proxy);
 
             let server = crate::ipc::IpcServer::bind(&path_clone, proxy).unwrap();
+            // Server is bound; let the test side connect.
+            let _ = ready_tx.send(());
 
             tokio::select! {
                 result = server.run() => {
@@ -140,8 +133,12 @@ fn foreground_run_accepts_ipc_and_shuts_down() {
             pm.stop().await.unwrap();
         });
 
-        // Connect with retry instead of fixed sleep
-        let stream = connect_with_retry(&path).await;
+        // Park until the server task signals the IPC socket is bound.
+        // Deterministic, no poll-retry. See bindreams/hole#383.
+        ready_rx.await.expect("server task dropped ready sender before bind");
+        let stream = crate::socket::LocalStream::connect(&path)
+            .await
+            .expect("connect to freshly-bound IPC socket");
         let io = TokioIo::new(stream);
         let (mut sender, conn) = http1::handshake(io).await.unwrap();
         let _conn = tokio::spawn(async move {
@@ -170,8 +167,9 @@ fn foreground_run_accepts_ipc_and_shuts_down() {
 
         // Trigger graceful shutdown and verify the task completes cleanly
         shutdown_tx.send(()).unwrap();
-        let result = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
-        assert!(result.is_ok(), "server should shut down within 5s");
-        result.unwrap().unwrap(); // Verify no panic during shutdown
+        // Await the server task directly; if it hangs, the test framework's
+        // timeout surfaces a clear "test took too long" failure. No
+        // arbitrary wait-with-timeout. See bindreams/hole#383.
+        server_handle.await.expect("server task panicked");
     });
 }

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -349,6 +349,7 @@ fn server_accepts_connection() {
         });
         let stream = LocalStream::connect(&path).await.unwrap();
         drop(stream);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -377,6 +378,7 @@ fn status_when_not_running_returns_false() {
             }
         );
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -398,6 +400,7 @@ fn multiple_requests_on_same_connection() {
         assert!(!s2.running);
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -425,6 +428,7 @@ fn invalid_request_returns_error_response() {
         assert!(resp.status().is_client_error());
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -468,6 +472,7 @@ fn start_request_starts_proxy() {
         assert_eq!(consume(post_stop(&mut client).await).await, 200);
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -495,6 +500,7 @@ fn stop_request_stops_proxy() {
         assert!(!status.running, "expected running=false after Stop");
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -522,6 +528,7 @@ fn start_failure_returns_error() {
         );
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -552,6 +559,7 @@ fn reload_request_reloads_proxy() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -575,14 +583,17 @@ fn run_cancellation_aborts_connection_handlers() {
         let _ = handle.await;
 
         // The connection handler should have been aborted by JoinSet::drop.
-        // A subsequent request should fail — not block forever.
-        // Allow up to 3 seconds for the non-blocking accept poll loop to yield.
+        // A subsequent request must fail — the hyper client observes the
+        // FIN/RST on the closed connection and errors. If a regression
+        // makes send_request hang on a dead connection, the test
+        // framework's overall timeout surfaces the hang.
         //
         // ready() is intentionally omitted: the server is already dead, so we're
-        // testing that send_request on a broken connection fails promptly.
-        let result = tokio::time::timeout(std::time::Duration::from_secs(3), {
-            #[allow(clippy::disallowed_methods)]
-            client.sender.send_request(
+        // testing that send_request on a broken connection fails.
+        #[allow(clippy::disallowed_methods)]
+        let result = client
+            .sender
+            .send_request(
                 http::Request::builder()
                     .method("GET")
                     .uri(ROUTE_STATUS)
@@ -590,13 +601,8 @@ fn run_cancellation_aborts_connection_handlers() {
                     .body(Full::new(Bytes::new()))
                     .unwrap(),
             )
-        })
-        .await;
-        assert!(result.is_ok(), "request should not block — handler must be aborted");
-        assert!(
-            result.unwrap().is_err(),
-            "request should fail after server cancellation"
-        );
+            .await;
+        assert!(result.is_err(), "request should fail after server cancellation");
     });
 }
 
@@ -620,6 +626,7 @@ fn unknown_route_returns_404() {
         assert_eq!(resp.status(), 404);
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -644,6 +651,7 @@ fn wrong_method_returns_405() {
         assert_eq!(resp.status(), 405);
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -697,6 +705,7 @@ fn metrics_returns_zeros_when_stopped() {
         assert_eq!(metrics.uptime_secs, 0);
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -727,6 +736,7 @@ fn metrics_returns_uptime_when_running() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -760,6 +770,7 @@ fn diagnostics_bridge_running() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -787,6 +798,7 @@ fn diagnostics_network_error_when_gateway_unavailable() {
         assert_eq!(diag.internet, "unknown");
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -818,6 +830,7 @@ fn diagnostics_proxy_stopped() {
         assert_eq!(diag.internet, "unknown");
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -847,6 +860,7 @@ fn diagnostics_bridge_error_after_failed_start() {
         assert_eq!(diag.bridge, "error");
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -928,13 +942,12 @@ fn cancel_while_start_in_flight_returns_cancelled() {
             "cancel must succeed even while start is in flight"
         );
 
-        // Wait for A's Start to return, bounded. With cancellation working
-        // correctly the select! branch fires, drop-safety unwinds the
-        // partial state, and Cancelled is returned promptly.
-        let (_client_a, resp_a) = tokio::time::timeout(std::time::Duration::from_secs(5), start_future)
-            .await
-            .expect("start did not return within 5s of cancel")
-            .expect("start task panicked");
+        // Wait for A's Start to return. With cancellation working correctly
+        // the select! branch fires, drop-safety unwinds the partial state,
+        // and Cancelled is returned promptly. If cancellation regresses,
+        // start_future hangs forever and the test framework's overall
+        // timeout surfaces the failure.
+        let (_client_a, resp_a) = start_future.await.expect("start task panicked");
         assert_eq!(error_message(resp_a).await, CANCELLED_MESSAGE);
 
         // Release the gate so the mock's start_ss future can settle if it
@@ -942,7 +955,8 @@ fn cancel_while_start_in_flight_returns_cancelled() {
         gate.notify_one();
         // run_n(2) returns naturally once both connections are handled, so
         // no abort is needed — but use a bounded await to surface any leak.
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        handle.abort();
+        let _ = handle.await;
     });
 }
 
@@ -976,7 +990,8 @@ fn cancel_before_start_is_pre_armed_and_consumed() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        handle.abort();
+        let _ = handle.await;
     });
 }
 
@@ -995,7 +1010,8 @@ fn cancel_with_no_start_is_ack_idempotent() {
         assert_eq!(consume(post_cancel(&mut client).await).await, 200);
 
         drop(client);
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        handle.abort();
+        let _ = handle.await;
     });
 }
 
@@ -1046,15 +1062,14 @@ fn concurrent_start_is_rejected_with_conflict() {
         let mut client_c = TestClient::connect(&path).await;
         assert_eq!(consume(post_cancel(&mut client_c).await).await, 200);
 
-        // A's start must eventually return Cancelled.
-        let (_client_a, a_resp) = tokio::time::timeout(std::time::Duration::from_secs(5), a_future)
-            .await
-            .expect("A's start did not return")
-            .expect("A task panicked");
+        // A's start must return Cancelled. If cancellation regresses,
+        // a_future hangs and the test framework's timeout surfaces it.
+        let (_client_a, a_resp) = a_future.await.expect("A task panicked");
         assert_eq!(error_message(a_resp).await, CANCELLED_MESSAGE);
 
         gate.notify_one();
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        handle.abort();
+        let _ = handle.await;
     });
 }
 
@@ -1091,7 +1106,8 @@ fn sequential_start_cancel_start_consumes_pre_arm_once() {
         consume(post_stop(&mut client).await).await;
 
         drop(client);
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        handle.abort();
+        let _ = handle.await;
     });
 }
 
@@ -1136,15 +1152,14 @@ fn concurrent_double_cancel_during_start_both_succeed() {
         assert_eq!(b_resp.status(), 200);
         assert_eq!(c_resp.status(), 200);
 
-        // A's start returns Cancelled.
-        let (_client_a, a_resp) = tokio::time::timeout(std::time::Duration::from_secs(5), a_future)
-            .await
-            .expect("A's start did not return")
-            .expect("A task panicked");
+        // A's start returns Cancelled. If cancellation regresses,
+        // a_future hangs and the test framework's timeout surfaces it.
+        let (_client_a, a_resp) = a_future.await.expect("A task panicked");
         assert_eq!(error_message(a_resp).await, CANCELLED_MESSAGE);
 
         gate.notify_one();
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        handle.abort();
+        let _ = handle.await;
     });
 }
 
@@ -1235,6 +1250,7 @@ fn bind_accepts_connection() {
         });
         let stream = LocalStream::connect(&path).await.unwrap();
         drop(stream);
+        handle.abort();
         let _ = handle.await;
     });
 }
@@ -1254,6 +1270,7 @@ fn bind_status_query() {
         assert_eq!(status.uptime_secs, 0);
 
         drop(client);
+        handle.abort();
         let _ = handle.await;
     });
 }

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -12,6 +12,7 @@ use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tun_engine::gateway::GatewayInfo;
 use tun_engine::routing::{state as route_state, Routing};
@@ -25,6 +26,13 @@ struct MockProxy {
     /// simulate a slow start so tests can race `POST /v1/cancel` against
     /// an in-flight `POST /v1/start`.
     start_gate: Option<Arc<tokio::sync::Notify>>,
+    /// If Some, `start` fires this sender on entry — before awaiting
+    /// `start_gate`. Lets tests park until the proxy is *known* to be
+    /// inside `start()` instead of sleeping a guess-duration. One-shot
+    /// per MockProxy (subsequent entries do nothing); the test pattern
+    /// is "spawn task A; await entered; act on the parked state."
+    /// See bindreams/hole#383.
+    start_entered: std::sync::Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl MockProxy {
@@ -32,6 +40,7 @@ impl MockProxy {
         Self {
             fail_start: AtomicBool::new(false),
             start_gate: None,
+            start_entered: std::sync::Mutex::new(None),
         }
     }
 
@@ -39,6 +48,7 @@ impl MockProxy {
         Self {
             fail_start: AtomicBool::new(true),
             start_gate: None,
+            start_entered: std::sync::Mutex::new(None),
         }
     }
 
@@ -46,7 +56,13 @@ impl MockProxy {
         Self {
             fail_start: AtomicBool::new(false),
             start_gate: Some(gate),
+            start_entered: std::sync::Mutex::new(None),
         }
+    }
+
+    fn with_entered_signal(mut self, tx: oneshot::Sender<()>) -> Self {
+        self.start_entered = std::sync::Mutex::new(Some(tx));
+        self
     }
 }
 
@@ -54,6 +70,11 @@ impl Proxy for MockProxy {
     type Running = MockRunning;
 
     async fn start(&self, _config: shadowsocks_service::config::Config) -> Result<MockRunning, ProxyError> {
+        // Fire the entered signal BEFORE awaiting the gate so the test
+        // can sequence subsequent operations on the parked state.
+        if let Some(tx) = self.start_entered.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
         if let Some(gate) = self.start_gate.as_ref() {
             gate.notified().await;
         }
@@ -190,10 +211,14 @@ fn gateway_failing_proxy() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
     Arc::new(Mutex::new(ProxyManager::new(MockProxy::new(), routing)))
 }
 
-fn gated_proxy(gate: Arc<tokio::sync::Notify>) -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
+fn gated_proxy(
+    gate: Arc<tokio::sync::Notify>,
+    entered: oneshot::Sender<()>,
+) -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
     let state_dir = tempfile::tempdir().unwrap().keep();
     let routing = MockRouting::new(state_dir);
-    Arc::new(Mutex::new(ProxyManager::new(MockProxy::gated(gate), routing)))
+    let mock = MockProxy::gated(gate).with_entered_signal(entered);
+    Arc::new(Mutex::new(ProxyManager::new(mock, routing)))
 }
 
 fn sample_config() -> ProxyConfig {
@@ -691,9 +716,6 @@ fn metrics_returns_uptime_when_running() {
         // Start proxy
         assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
 
-        // Small delay to accumulate uptime
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
         let metrics = get_metrics(&mut client).await;
         // Traffic fields are still zero (not yet integrated)
         assert_eq!(metrics.bytes_in, 0);
@@ -876,7 +898,8 @@ fn cancel_while_start_in_flight_returns_cancelled() {
     rt().block_on(async {
         let path = test_socket_path("cancel-in-flight");
         let gate = Arc::new(tokio::sync::Notify::new());
-        let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx)).unwrap();
         // Bound the accept loop to exactly the two connections this test
         // uses, instead of running indefinitely. See `run_n` docstring.
         let handle = tokio::spawn(async move { server.run_n(2).await });
@@ -890,8 +913,9 @@ fn cancel_while_start_in_flight_returns_cancelled() {
             (client_a, resp)
         });
 
-        // Give A a moment to acquire the proxy mutex and park in start_ss.
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        // Park until A is *known* to be inside MockProxy::start (before
+        // it awaits the gate). Deterministic — no sleep.
+        entered_rx.await.expect("MockProxy::start never entered");
 
         // Connection B: cancel the in-flight start. Must succeed without
         // waiting for the in-flight Start (which never completes since the
@@ -985,7 +1009,8 @@ fn concurrent_start_is_rejected_with_conflict() {
     rt().block_on(async {
         let path = test_socket_path("concurrent-start");
         let gate = Arc::new(tokio::sync::Notify::new());
-        let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx)).unwrap();
         // 3 connections: A start, B start, C cancel.
         let handle = tokio::spawn(async move { server.run_n(3).await });
 
@@ -997,8 +1022,8 @@ fn concurrent_start_is_rejected_with_conflict() {
             (client_a, resp)
         });
 
-        // Give A a moment to register its token.
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        // Park until A is inside MockProxy::start (token registered).
+        entered_rx.await.expect("MockProxy::start never entered");
 
         // Client B sends a concurrent Start and must be rejected.
         let mut client_b = TestClient::connect(&path).await;
@@ -1080,7 +1105,8 @@ fn concurrent_double_cancel_during_start_both_succeed() {
     rt().block_on(async {
         let path = test_socket_path("double-cancel");
         let gate = Arc::new(tokio::sync::Notify::new());
-        let server = IpcServer::bind(&path, gated_proxy(gate.clone())).unwrap();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx)).unwrap();
         // 3 connections: A start, B cancel, C cancel.
         let handle = tokio::spawn(async move { server.run_n(3).await });
 
@@ -1091,7 +1117,7 @@ fn concurrent_double_cancel_during_start_both_succeed() {
             let resp = post_start(&mut client_a, &sample_config()).await;
             (client_a, resp)
         });
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        entered_rx.await.expect("MockProxy::start never entered");
 
         // Two concurrent cancels on separate connections.
         let path_b = path.clone();

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -194,6 +194,20 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             .unwrap_or(0)
     }
 
+    /// Test seam: shift `started_at` backwards by `by`. Lets uptime
+    /// tests assert "after N seconds elapsed" without sleeping or
+    /// injecting a clock abstraction. No-op if not currently running.
+    /// See bindreams/hole#383.
+    #[cfg(test)]
+    pub fn shift_started_at_for_test(&mut self, by: std::time::Duration) {
+        if let Some(r) = self.running.as_mut() {
+            r.started_at = r
+                .started_at
+                .checked_sub(by)
+                .expect("shift_started_at_for_test: arithmetic underflow");
+        }
+    }
+
     pub fn last_error(&self) -> Option<&str> {
         self.last_error.as_deref()
     }
@@ -746,7 +760,7 @@ async fn build_local_dns(
     // `tokio::spawn` so a dead upstream cannot stall `start_inner` by the
     // retry budget — the contract is that `build_local_dns` returns
     // regardless of self-test outcome.
-    spawn_forwarder_self_test(Arc::clone(&forwarder), dns_cfg.servers.clone());
+    let _ = spawn_forwarder_self_test(Arc::clone(&forwarder), dns_cfg.servers.clone());
 
     let endpoint = if dns_cfg.intercept_udp53 {
         Some(crate::endpoint::LocalDnsEndpoint::new(Arc::clone(&forwarder)))
@@ -769,17 +783,17 @@ async fn build_local_dns(
 fn spawn_forwarder_self_test(
     forwarder: std::sync::Arc<crate::dns::forwarder::DnsForwarder>,
     servers: Vec<std::net::IpAddr>,
-) {
+) -> Option<tokio::task::JoinHandle<()>> {
     const PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(1500);
     const OUTER_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
     const ATTEMPTS: u32 = 3;
 
     let Some(&first_server) = servers.first() else {
         info!("forwarder self-test skipped: no servers configured");
-        return;
+        return None;
     };
 
-    tokio::spawn(async move {
+    Some(tokio::spawn(async move {
         let query = sample_self_test_query();
         let started = std::time::Instant::now();
         let outcome = tokio::time::timeout(OUTER_BUDGET, async {
@@ -830,7 +844,7 @@ fn spawn_forwarder_self_test(
                 );
             }
         }
-    });
+    }))
 }
 
 enum SelfTestOutcome {

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -792,12 +792,13 @@ fn start_cancellable_late_cancel_on_finished_token_is_noop() {
 #[skuld::test]
 fn start_cancellable_dropped_future_runs_guards() {
     // Drop-safety: even without CancellationToken, dropping the start
-    // future at an await point must clean up. Uses `tokio::time::timeout`
-    // with a very short deadline to force the drop while `proxy.start`
-    // is parked on the gate.
+    // future at an await point must clean up. Uses the `entered` signal
+    // to know when proxy.start is parked on the gate, then drops the
+    // future via a `select!` race — deterministic, no time-based wait.
     rt().block_on(async {
         let gate = Arc::new(tokio::sync::Notify::new());
-        let proxy = MockProxy::with_start_gate(gate.clone());
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let proxy = MockProxy::with_start_gate(gate.clone()).with_entered_signal(entered_tx);
         let dir = tempfile::tempdir().unwrap();
         let routing = MockRouting::new(dir.path().to_path_buf());
         let routing_state = routing.state();
@@ -806,10 +807,18 @@ fn start_cancellable_dropped_future_runs_guards() {
         let (mut pm, _dir) = new_manager_with_routing(proxy, routing, dir);
         let token = CancellationToken::new();
 
-        // Short deadline — the future will be dropped before proxy.start
-        // ever returns (the gate is never released).
-        let result = tokio::time::timeout(Duration::from_millis(50), pm.start_cancellable(&test_config(), token)).await;
-        assert!(result.is_err(), "expected elapsed timeout");
+        // Race the start future against the entered signal. When the
+        // entered arm wins, `select!` drops the `&mut f` arm and the
+        // surrounding scope drops `f`, running the drop-safety guards.
+        {
+            let cfg = test_config();
+            let f = pm.start_cancellable(&cfg, token);
+            tokio::pin!(f);
+            tokio::select! {
+                _ = &mut f => panic!("start should not complete while gate is unfired"),
+                res = entered_rx => res.expect("MockProxy::start never entered"),
+            }
+        }
 
         assert_eq!(pm.state(), ProxyState::Stopped);
         assert!(

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tun_engine::gateway::GatewayInfo;
@@ -34,6 +35,11 @@ struct MockProxy {
     /// start mid-flight so cancellation tests can fire the cancel token
     /// while the future is suspended in `proxy.start(...)`.
     start_gate: Option<Arc<tokio::sync::Notify>>,
+    /// If Some, `start` fires this sender on entry — before awaiting
+    /// `start_gate`. Lets tests park until `start` is *known* to be in
+    /// flight, instead of sleeping. One-shot per MockProxy. See
+    /// bindreams/hole#383.
+    start_entered: std::sync::Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl MockProxy {
@@ -41,6 +47,7 @@ impl MockProxy {
         Self {
             state: Arc::new(MockProxyState::default()),
             start_gate: None,
+            start_entered: std::sync::Mutex::new(None),
         }
     }
 
@@ -56,6 +63,11 @@ impl MockProxy {
         m
     }
 
+    fn with_entered_signal(mut self, tx: oneshot::Sender<()>) -> Self {
+        self.start_entered = std::sync::Mutex::new(Some(tx));
+        self
+    }
+
     fn start_calls_handle(&self) -> Arc<MockProxyState> {
         Arc::clone(&self.state)
     }
@@ -65,6 +77,10 @@ impl Proxy for MockProxy {
     type Running = MockRunning;
 
     async fn start(&self, _config: shadowsocks_service::config::Config) -> Result<MockRunning, ProxyError> {
+        // Fire entered signal BEFORE awaiting the gate.
+        if let Some(tx) = self.start_entered.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
         if let Some(gate) = self.start_gate.as_ref() {
             gate.notified().await;
         }
@@ -499,7 +515,9 @@ fn uptime_increases_while_running() {
         let (mut pm, _dir) = new_manager(MockProxy::new());
         pm.start(&test_config()).await.unwrap();
 
-        tokio::time::sleep(Duration::from_millis(1100)).await;
+        // Simulate "1.1s has elapsed since start" by rewinding the
+        // started_at marker. Deterministic — no sleep.
+        pm.shift_started_at_for_test(Duration::from_millis(1100));
         assert!(pm.uptime_secs() >= 1);
 
         pm.stop().await.unwrap();
@@ -697,7 +715,8 @@ fn start_cancellable_succeeds_when_not_cancelled() {
 fn start_cancellable_cancelled_during_ss_start_rolls_back() {
     rt().block_on(async {
         let gate = Arc::new(tokio::sync::Notify::new());
-        let proxy = MockProxy::with_start_gate(gate.clone());
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let proxy = MockProxy::with_start_gate(gate.clone()).with_entered_signal(entered_tx);
         let dir = tempfile::tempdir().unwrap();
         let routing = MockRouting::new(dir.path().to_path_buf());
         let routing_state = routing.state();
@@ -706,11 +725,11 @@ fn start_cancellable_cancelled_during_ss_start_rolls_back() {
         let (mut pm, _dir) = new_manager_with_routing(proxy, routing, dir);
         let token = CancellationToken::new();
 
-        // Fire off the cancel after a short delay so the start is already
-        // parked in `proxy.start(...)`.
+        // Fire the cancel once `proxy.start(...)` is *known* to be parked
+        // on the gate. Deterministic — no sleep.
         let cancel_clone = token.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            entered_rx.await.expect("MockProxy::start never entered");
             cancel_clone.cancel();
         });
 
@@ -1067,13 +1086,17 @@ mod self_test {
             .block_on(async {
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
                 let start = std::time::Instant::now();
-                spawn_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()]);
+                let handle = spawn_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()]);
                 let elapsed = start.elapsed();
                 assert!(
                     elapsed < std::time::Duration::from_millis(100),
                     "spawn_forwarder_self_test must return immediately (tokio::spawn is \
                      non-blocking); returned after {elapsed:?}"
                 );
+                // Abort the spawned task so the test doesn't have to wait
+                // out the 3×1500ms retry budget. The handle is None when
+                // servers is empty; here it is Some.
+                handle.expect("Some(handle) when servers is non-empty").abort();
             });
     }
 
@@ -1099,8 +1122,11 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                spawn_forwarder_self_test(forwarder, vec![]);
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                // Empty servers — the skipped-log fires synchronously
+                // inside the function and `spawn_forwarder_self_test`
+                // returns None (no task spawned). No wait needed.
+                let handle = spawn_forwarder_self_test(forwarder, vec![]);
+                assert!(handle.is_none(), "no task should be spawned when servers is empty");
             });
 
         let output = writer.snapshot_string();
@@ -1133,10 +1159,12 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                spawn_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()]);
-                // Wait for the self-test to exhaust retries. 3 × 1500ms =
-                // 4.5s worst case; give it a little extra for CI jitter.
-                tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+                let handle = spawn_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()])
+                    .expect("Some(handle) when servers is non-empty");
+                // Park until the self-test task exits — deterministic,
+                // no sleep. The retry budget (3 × 1500ms with 5s outer
+                // timeout) is internal to the spawned future.
+                handle.await.expect("self-test task panicked");
             });
 
         let output = writer.snapshot_string();

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -68,18 +68,28 @@ static NEXT_FLUSH_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU6
 #[cfg(test)]
 impl StdioRelayHandles {
     /// Block until every byte written to stderr/stdout *before this
-    /// call* has been consumed by the relay reader thread and emitted
-    /// as a tracing event.
+    /// call* has been consumed by the relay reader thread, emitted as
+    /// a tracing event, AND written through the lossy `NonBlocking`
+    /// tee writers to the underlying tee targets.
     ///
-    /// Mechanism: writes a unique sentinel line through each stream;
-    /// the relay reader, when it consumes the sentinel, fires an
-    /// `mpsc` ack. The sentinel is not teed/emitted as a tracing
-    /// event. Event-driven, no polling.
+    /// Mechanism, in two phases:
+    /// 1. **Reader drain.** Write a unique sentinel line through each
+    ///    stream; the relay reader, when it consumes the sentinel,
+    ///    fires an `mpsc` ack. The sentinel is not teed/emitted. This
+    ///    guarantees the reader has processed (and either emitted or
+    ///    forwarded to `NonBlocking`) every pre-sentinel byte.
+    /// 2. **Tee drain.** Take ownership of the `WorkerGuard`s for the
+    ///    `NonBlocking` tee writers and drop them. `WorkerGuard::drop`
+    ///    joins the worker, which flushes any buffered bytes to the
+    ///    underlying tee target. After this, subsequent writes through
+    ///    the tee path are lossy no-ops (the workers are gone) — which
+    ///    is fine because callers call `flush()` at the end of a
+    ///    scenario, never before further writes are expected.
     ///
     /// Test-only and synchronous so it works in non-tokio scenarios.
     /// Production relays run until process exit; flushing is
     /// meaningless there.
-    pub fn flush(&self) -> io::Result<()> {
+    pub fn flush(&mut self) -> io::Result<()> {
         use std::sync::atomic::Ordering;
         let stderr_id = NEXT_FLUSH_ID.fetch_add(1, Ordering::SeqCst);
         let stdout_id = NEXT_FLUSH_ID.fetch_add(1, Ordering::SeqCst);
@@ -97,6 +107,13 @@ impl StdioRelayHandles {
         writeln!(std::io::stdout(), "{RELAY_FLUSH_SENTINEL_PREFIX}{stdout_id}")?;
         stderr_rx.recv().map_err(io::Error::other)?;
         stdout_rx.recv().map_err(io::Error::other)?;
+        // Phase 2: drain the NonBlocking tee writers by dropping their
+        // WorkerGuards. The relay reader's `tee.write_all(buf)` calls
+        // go through these guards; without dropping them, buffered
+        // bytes may not have reached the tee target by the time the
+        // caller reads from it.
+        drop(self._stderr_tee_guard.take());
+        drop(self._stdout_tee_guard.take());
         Ok(())
     }
 }

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -30,6 +30,77 @@ use std::thread::JoinHandle;
 use tracing_appender::non_blocking::{NonBlockingBuilder, WorkerGuard};
 use tracing_subscriber::EnvFilter;
 
+// Test-only flush mechanism ===========================================================================================
+//
+// Production never flushes the relay (the relay reader threads run
+// until process exit; their Drop is a no-op by design). Tests need a
+// deterministic "all bytes written so far have been consumed by the
+// reader and emitted as tracing events" hook so they don't sleep-
+// for-sync. The mechanism: `StdioRelayHandles::flush` writes a unique
+// in-band sentinel line through stderr/stdout, then blocks on a
+// `std::sync::mpsc::sync_channel` ack that the relay reader fires
+// when it consumes the sentinel. The sentinel is intercepted before
+// the tee/emit path so it does not pollute either log surface.
+// Event-driven, no polling.
+//
+// Synchronous (mpsc, not tokio::oneshot) so test scenarios that run
+// outside a tokio runtime — like the FD-redirect child-process
+// scenarios in `logging_test_helpers.rs` — can use it directly.
+//
+// See bindreams/hole#383.
+
+#[cfg(test)]
+pub(crate) const RELAY_FLUSH_SENTINEL_PREFIX: &str = "__hole_relay_flush__";
+
+#[cfg(test)]
+static PENDING_FLUSH_ACKS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<u64, std::sync::mpsc::SyncSender<()>>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn pending_flush_acks() -> &'static std::sync::Mutex<std::collections::HashMap<u64, std::sync::mpsc::SyncSender<()>>> {
+    PENDING_FLUSH_ACKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+static NEXT_FLUSH_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+#[cfg(test)]
+impl StdioRelayHandles {
+    /// Block until every byte written to stderr/stdout *before this
+    /// call* has been consumed by the relay reader thread and emitted
+    /// as a tracing event.
+    ///
+    /// Mechanism: writes a unique sentinel line through each stream;
+    /// the relay reader, when it consumes the sentinel, fires an
+    /// `mpsc` ack. The sentinel is not teed/emitted as a tracing
+    /// event. Event-driven, no polling.
+    ///
+    /// Test-only and synchronous so it works in non-tokio scenarios.
+    /// Production relays run until process exit; flushing is
+    /// meaningless there.
+    pub fn flush(&self) -> io::Result<()> {
+        use std::sync::atomic::Ordering;
+        let stderr_id = NEXT_FLUSH_ID.fetch_add(1, Ordering::SeqCst);
+        let stdout_id = NEXT_FLUSH_ID.fetch_add(1, Ordering::SeqCst);
+        let (stderr_tx, stderr_rx) = std::sync::mpsc::sync_channel::<()>(1);
+        let (stdout_tx, stdout_rx) = std::sync::mpsc::sync_channel::<()>(1);
+        {
+            let mut acks = pending_flush_acks().lock().unwrap();
+            acks.insert(stderr_id, stderr_tx);
+            acks.insert(stdout_id, stdout_tx);
+        }
+        // Write sentinels through the real stderr/stdout. The FD-level
+        // redirect routes them into our pipe; the relay reader will
+        // see them next.
+        writeln!(std::io::stderr(), "{RELAY_FLUSH_SENTINEL_PREFIX}{stderr_id}")?;
+        writeln!(std::io::stdout(), "{RELAY_FLUSH_SENTINEL_PREFIX}{stdout_id}")?;
+        stderr_rx.recv().map_err(io::Error::other)?;
+        stdout_rx.recv().map_err(io::Error::other)?;
+        Ok(())
+    }
+}
+
 // LogGuard ============================================================================================================
 
 /// Guards for the non-blocking writers and the stdio relay reader threads.
@@ -203,13 +274,25 @@ fn relay_loop(reader: os_pipe::PipeReader, mut tee: tracing_appender::non_blocki
         match reader.read_until(b'\n', &mut buf) {
             Ok(0) => break,
             Ok(_) => {
+                let line = String::from_utf8_lossy(&buf);
+                let trimmed = line.trim_end_matches(['\r', '\n']);
+                // Test-only: intercept the flush sentinel before the tee/
+                // emit path so it does not pollute either log surface.
+                #[cfg(test)]
+                if let Some(id_str) = trimmed.strip_prefix(RELAY_FLUSH_SENTINEL_PREFIX) {
+                    if let Ok(id) = id_str.parse::<u64>() {
+                        let tx = pending_flush_acks().lock().unwrap().remove(&id);
+                        if let Some(tx) = tx {
+                            let _ = tx.send(());
+                            continue;
+                        }
+                    }
+                }
                 // Tee raw bytes to the saved-original first so script-visible
                 // output ordering is preserved.
                 let _ = tee.write_all(&buf);
                 let _ = tee.flush();
                 // Emit a tracing event with the trimmed text for the file log.
-                let line = String::from_utf8_lossy(&buf);
-                let trimmed = line.trim_end_matches(['\r', '\n']);
                 if !trimmed.is_empty() {
                     match stream {
                         Stream::Stderr => emit_stderr_relay(trimmed),

--- a/crates/common/src/logging/logging_test_helpers.rs
+++ b/crates/common/src/logging/logging_test_helpers.rs
@@ -155,12 +155,12 @@ fn write_result(result: &ChildResult) {
     std::fs::write(output_path(), bytes).expect("write result");
 }
 
-fn finish(harness: &ChildHarness) -> ChildResult {
+fn finish(harness: &mut ChildHarness) -> ChildResult {
     // Flush the stdio relay deterministically: write a sentinel through
-    // stderr/stdout and block on the reader's ack. The sentinel is
-    // intercepted before tee/emit so it doesn't pollute either log
-    // surface. No sleep. See bindreams/hole#383.
-    if let Some(relays) = harness.relays.as_ref() {
+    // stderr/stdout, block on the reader's ack, then drain the
+    // NonBlocking tee writers' WorkerGuards. No sleep.
+    // See bindreams/hole#383.
+    if let Some(relays) = harness.relays.as_mut() {
         relays.flush().expect("relay flush");
     }
     let mut events = parse_lines("file", &harness.file_writer.snapshot());
@@ -235,7 +235,7 @@ fn scenario_basic_stderr() {
     harness.relays = Some(relays);
     let _ = writeln!(std::io::stderr(), "hello-from-stderr");
     let _ = std::io::stderr().flush();
-    let result = finish(&harness);
+    let result = finish(&mut harness);
     write_result(&result);
 }
 
@@ -245,7 +245,7 @@ fn scenario_basic_stdout() {
     harness.relays = Some(relays);
     let _ = writeln!(std::io::stdout(), "hello-from-stdout");
     let _ = std::io::stdout().flush();
-    let result = finish(&harness);
+    let result = finish(&mut harness);
     write_result(&result);
 }
 
@@ -278,7 +278,7 @@ fn scenario_grandchild_stderr() {
             .status();
     }
 
-    let result = finish(&harness);
+    let result = finish(&mut harness);
     write_result(&result);
 }
 
@@ -309,7 +309,7 @@ fn scenario_grandchild_stdout() {
             .status();
     }
 
-    let result = finish(&harness);
+    let result = finish(&mut harness);
     write_result(&result);
 }
 
@@ -350,7 +350,7 @@ fn scenario_tee() {
     let _ = writeln!(std::io::stdout(), "tee-stdout-line");
     let _ = std::io::stdout().flush();
 
-    let mut result = finish(&harness);
+    let mut result = finish(&mut harness);
     result.tee_stderr = std::fs::read_to_string(&stderr_path).unwrap_or_default();
     result.tee_stdout = std::fs::read_to_string(&stdout_path).unwrap_or_default();
     write_result(&result);
@@ -362,7 +362,7 @@ fn scenario_multiline() {
     harness.relays = Some(relays);
     let _ = std::io::stderr().write_all(b"multiline-a\nmultiline-b\nmultiline-c\n");
     let _ = std::io::stderr().flush();
-    let result = finish(&harness);
+    let result = finish(&mut harness);
     write_result(&result);
 }
 
@@ -371,7 +371,7 @@ fn scenario_no_loop() {
     let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
     harness.relays = Some(relays);
     tracing::info!("normal event");
-    let result = finish(&harness);
+    let result = finish(&mut harness);
     write_result(&result);
 }
 

--- a/crates/common/src/logging/logging_test_helpers.rs
+++ b/crates/common/src/logging/logging_test_helpers.rs
@@ -9,7 +9,7 @@
 // and the parent reads + asserts on it.
 
 use crate::logging::logging_tests::{CapturedEvent, ChildResult};
-use crate::logging::redirect_stdio_to_tracing_for_tests;
+use crate::logging::{redirect_stdio_to_tracing_for_tests, StdioRelayHandles};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -109,6 +109,10 @@ fn parse_lines(layer: &str, raw: &[u8]) -> Vec<CapturedEvent> {
 struct ChildHarness {
     file_writer: VecWriter,
     stderr_writer: VecWriter,
+    /// If Some, `finish` flushes through this relay (in-band sentinel +
+    /// mpsc ack) before snapshotting the writers. Scenarios that don't
+    /// redirect (none currently) would leave it as None.
+    relays: Option<StdioRelayHandles>,
 }
 
 fn install_child_subscriber() -> ChildHarness {
@@ -136,6 +140,7 @@ fn install_child_subscriber() -> ChildHarness {
     ChildHarness {
         file_writer,
         stderr_writer,
+        relays: None,
     }
 }
 
@@ -151,8 +156,13 @@ fn write_result(result: &ChildResult) {
 }
 
 fn finish(harness: &ChildHarness) -> ChildResult {
-    // Give the in-memory tracing layers a chance to flush.
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // Flush the stdio relay deterministically: write a sentinel through
+    // stderr/stdout and block on the reader's ack. The sentinel is
+    // intercepted before tee/emit so it doesn't pollute either log
+    // surface. No sleep. See bindreams/hole#383.
+    if let Some(relays) = harness.relays.as_ref() {
+        relays.flush().expect("relay flush");
+    }
     let mut events = parse_lines("file", &harness.file_writer.snapshot());
     events.extend(parse_lines("stderr", &harness.stderr_writer.snapshot()));
     ChildResult {
@@ -220,8 +230,9 @@ fn scenario_echo_stdout() {
 }
 
 fn scenario_basic_stderr() {
-    let harness = install_child_subscriber();
-    let (_relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    let mut harness = install_child_subscriber();
+    let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    harness.relays = Some(relays);
     let _ = writeln!(std::io::stderr(), "hello-from-stderr");
     let _ = std::io::stderr().flush();
     let result = finish(&harness);
@@ -229,8 +240,9 @@ fn scenario_basic_stderr() {
 }
 
 fn scenario_basic_stdout() {
-    let harness = install_child_subscriber();
-    let (_relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    let mut harness = install_child_subscriber();
+    let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    harness.relays = Some(relays);
     let _ = writeln!(std::io::stdout(), "hello-from-stdout");
     let _ = std::io::stdout().flush();
     let result = finish(&harness);
@@ -238,8 +250,9 @@ fn scenario_basic_stdout() {
 }
 
 fn scenario_grandchild_stderr() {
-    let harness = install_child_subscriber();
-    let (_relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    let mut harness = install_child_subscriber();
+    let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    harness.relays = Some(relays);
 
     // Pass A: Rust grandchild via current_exe.
     let exe = std::env::current_exe().expect("current_exe");
@@ -265,15 +278,14 @@ fn scenario_grandchild_stderr() {
             .status();
     }
 
-    // Allow relay to drain.
-    std::thread::sleep(std::time::Duration::from_millis(150));
     let result = finish(&harness);
     write_result(&result);
 }
 
 fn scenario_grandchild_stdout() {
-    let harness = install_child_subscriber();
-    let (_relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    let mut harness = install_child_subscriber();
+    let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    harness.relays = Some(relays);
 
     let exe = std::env::current_exe().expect("current_exe");
     let _ = std::process::Command::new(&exe)
@@ -297,7 +309,6 @@ fn scenario_grandchild_stdout() {
             .status();
     }
 
-    std::thread::sleep(std::time::Duration::from_millis(150));
     let result = finish(&harness);
     write_result(&result);
 }
@@ -326,19 +337,18 @@ fn scenario_tee() {
         .open(&stdout_path)
         .expect("open stdout tee file");
 
-    let harness = install_child_subscriber();
-    let _relays = crate::logging::redirect_stdio_to_tracing_with_writers_for_tests(
+    let mut harness = install_child_subscriber();
+    let relays = crate::logging::redirect_stdio_to_tracing_with_writers_for_tests(
         Box::new(stderr_file.try_clone().unwrap()),
         Box::new(stdout_file.try_clone().unwrap()),
     )
     .expect("redirect with custom writers");
+    harness.relays = Some(relays);
 
     let _ = writeln!(std::io::stderr(), "tee-stderr-line");
     let _ = std::io::stderr().flush();
     let _ = writeln!(std::io::stdout(), "tee-stdout-line");
     let _ = std::io::stdout().flush();
-
-    std::thread::sleep(std::time::Duration::from_millis(150));
 
     let mut result = finish(&harness);
     result.tee_stderr = std::fs::read_to_string(&stderr_path).unwrap_or_default();
@@ -347,20 +357,20 @@ fn scenario_tee() {
 }
 
 fn scenario_multiline() {
-    let harness = install_child_subscriber();
-    let (_relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    let mut harness = install_child_subscriber();
+    let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    harness.relays = Some(relays);
     let _ = std::io::stderr().write_all(b"multiline-a\nmultiline-b\nmultiline-c\n");
     let _ = std::io::stderr().flush();
-    std::thread::sleep(std::time::Duration::from_millis(150));
     let result = finish(&harness);
     write_result(&result);
 }
 
 fn scenario_no_loop() {
-    let harness = install_child_subscriber();
-    let (_relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    let mut harness = install_child_subscriber();
+    let (relays, _layer_writer) = redirect_stdio_to_tracing_for_tests().expect("redirect");
+    harness.relays = Some(relays);
     tracing::info!("normal event");
-    std::thread::sleep(std::time::Duration::from_millis(150));
     let result = finish(&harness);
     write_result(&result);
 }

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -138,6 +138,17 @@ fn redirect_captures_subprocess_stdout_via_inheritance(#[fixture(temp_dir)] dir:
     );
 }
 
+/// Load-bearing test for the **tee-drain phase** of
+/// [`StdioRelayHandles::flush`](crate::logging::StdioRelayHandles).
+/// The relay's `tee.write_all(buf)` goes through a
+/// `tracing_appender::NonBlocking` worker whose drain is asynchronous;
+/// without `flush` dropping the `WorkerGuard`s, the tee target can be
+/// empty when the test reads it. Historically the child scenario
+/// relied on a wall-clock `sleep(150ms)` to mask this; the sleep was
+/// removed in #383 and the test caught the regression on darwin/amd64
+/// (slowest CI runner) before merge. Do not weaken the
+/// `tee_stderr`/`tee_stdout` assertions — they are the canonical
+/// regression gate for the flush contract.
 #[skuld::test]
 fn redirect_tees_to_saved_original(#[fixture(temp_dir)] dir: &Path) {
     let result = run_child("redirect_tee", dir);

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -20,6 +20,10 @@ workspace = true
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
+# `fmt` is needed for the `MakeWriter` trait impl in `test_utils`.
+# Other features (env-filter, ansi) remain in dev-deps to keep the
+# production footprint minimal. Cargo unions features across deps.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 thiserror = "2"
 contracts = { workspace = true }
 async-trait = { workspace = true }
@@ -32,6 +36,10 @@ skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }
 socket2 = "0.6"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+# Enable `tokio::time::pause` / `advance` / `resume` for tests that need
+# virtual-clock control. Cargo unions this with the main deps `full`
+# feature set; production builds do NOT get test-util.
+tokio = { version = "1", features = ["test-util"] }
 
 [[test]]
 name = "chain_integration"

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -16,14 +16,22 @@ group = "garter"
 [lints]
 workspace = true
 
+[features]
+# Exposes the `test_utils` public module. Off by default — enabled
+# only when running garter's own tests (set on the [[test]] entries
+# below via `required-features`) or by external consumers that want
+# to use `WaitableWriter` in their own tests. Production builds of
+# downstream crates (e.g. `hole`) do NOT enable this and therefore
+# do NOT pull in `tracing-subscriber`.
+test-utils = ["dep:tracing-subscriber"]
+
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
-# `fmt` is needed for the `MakeWriter` trait impl in `test_utils`.
-# Other features (env-filter, ansi) remain in dev-deps to keep the
-# production footprint minimal. Cargo unions features across deps.
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+# Optional: needed only by `test_utils::WaitableWriter`'s `MakeWriter`
+# impl. Gated on the `test-utils` feature.
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"], optional = true }
 thiserror = "2"
 contracts = { workspace = true }
 async-trait = { workspace = true }
@@ -50,6 +58,8 @@ harness = false
 name = "tap_integration"
 path = "tests/tap_integration.rs"
 harness = false
+# Pulls in `WaitableWriter` via the `test-utils` feature.
+required-features = ["test-utils"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -269,11 +269,8 @@ async fn on_ready_fires_with_local_addr() {
 
     let handle = tokio::spawn(runner.run(env));
 
-    // rx should fire with the local address once the plugin is listening.
-    let ready_addr = tokio::time::timeout(std::time::Duration::from_secs(5), rx)
-        .await
-        .expect("timed out waiting for readiness")
-        .expect("ready_tx was dropped without sending");
+    // rx fires with the local address once the plugin is listening.
+    let ready_addr = rx.await.expect("ready_tx was dropped without sending");
 
     assert_eq!(ready_addr.port(), addr.port());
 
@@ -293,10 +290,7 @@ async fn on_ready_dropped_on_plugin_failure() {
     let handle = tokio::spawn(runner.run(env));
 
     // The plugin fails immediately, so ready_tx is dropped → rx gets RecvError.
-    let result = tokio::time::timeout(std::time::Duration::from_secs(5), rx)
-        .await
-        .expect("timed out waiting for readiness result");
-
+    let result = rx.await;
     assert!(
         result.is_err(),
         "rx should get RecvError when plugin fails before ready"
@@ -333,12 +327,9 @@ async fn cancel_token_triggers_graceful_shutdown() {
     // Cancel externally.
     cancel.cancel();
 
-    // The chain should exit cleanly.
-    let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-        .await
-        .expect("timed out waiting for chain to exit")
-        .unwrap();
-
+    // The chain exits cleanly. If cancellation regresses, handle.await
+    // hangs and the test framework's timeout surfaces it.
+    let result = handle.await.unwrap();
     assert!(result.is_ok(), "chain should exit Ok on external cancellation");
 }
 
@@ -416,10 +407,7 @@ async fn first_error_preserved_across_drain() {
     env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
 
     let handle = tokio::spawn(runner.run(env));
-    let result = tokio::time::timeout(drain_timeout + std::time::Duration::from_millis(500), handle)
-        .await
-        .expect("chain should exit within drain_timeout of plugin failure")
-        .expect("no JoinError");
+    let result = handle.await.expect("no JoinError");
 
     match result {
         Err(crate::Error::PluginExit { code: 1, .. }) => {}
@@ -484,10 +472,7 @@ async fn external_cancel_concurrent_with_plugin_error_preserves_plugin_error() {
     let handle = tokio::spawn(runner.run(env));
     cancel.cancel();
 
-    let result = tokio::time::timeout(drain_timeout + std::time::Duration::from_millis(500), handle)
-        .await
-        .expect("chain should exit within drain_timeout")
-        .expect("no JoinError");
+    let result = handle.await.expect("no JoinError");
 
     match result {
         Err(crate::Error::PluginExit { code: 1, .. }) => {}

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -349,8 +349,15 @@ async fn cancel_token_triggers_graceful_shutdown() {
 /// primary regression gate for the drain-timeout scope fix: pre-fix,
 /// `drain_timeout` was applied to the whole chain lifetime, so
 /// `StubbornPlugin` was aborted after ≈ drain_timeout.
+///
+/// Uses `tokio::time::pause` + `advance` to simulate "drain_timeout * 3
+/// has elapsed in virtual time" without real wall-clock sleep. Any
+/// internal timer that would have bounded the chain at drain_timeout
+/// fires under virtual time; we then assert the chain is still alive.
+/// See bindreams/hole#383.
 #[skuld::test]
 async fn long_running_plugin_survives_past_drain_timeout() {
+    tokio::time::pause();
     let cancel = CancellationToken::new();
     let drain_timeout = std::time::Duration::from_millis(200);
 
@@ -364,24 +371,25 @@ async fn long_running_plugin_survives_past_drain_timeout() {
     let mut env = test_env();
     env.local_port = allocate_ports(1).unwrap().pop().unwrap().port();
 
-    let mut handle = tokio::spawn(runner.run(env));
+    let handle = tokio::spawn(runner.run(env));
 
-    // Wait past drain_timeout and confirm the plugin is still running.
-    tokio::time::sleep(drain_timeout * 3).await;
+    // Advance virtual time past drain_timeout. Pre-fix this would have
+    // fired the lifetime-bounding timer and the chain would exit. Post-
+    // fix, no timer bounds the lifetime — chain stays running.
+    tokio::time::advance(drain_timeout * 3).await;
     assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(10), &mut handle)
-            .await
-            .is_err(),
+        !handle.is_finished(),
         "chain must still be running — drain_timeout must not bound the full lifetime"
     );
 
     // Cancel; chain should abort the stubborn plugin within drain_timeout
-    // (+ scheduler slack) and return the drain-timeout error.
+    // (+ scheduler slack, advanced under virtual time) and return the
+    // drain-timeout error.
     cancel.cancel();
-    let result = tokio::time::timeout(drain_timeout + std::time::Duration::from_millis(500), handle)
-        .await
-        .expect("chain should exit within drain_timeout after cancel")
-        .expect("no JoinError");
+    tokio::time::advance(drain_timeout + std::time::Duration::from_millis(500)).await;
+    // Resume real time for the join so any non-tokio work can complete.
+    tokio::time::resume();
+    let result = handle.await.expect("no JoinError");
 
     match result {
         Err(crate::Error::Chain(msg)) if msg.contains("drain timeout expired") => {}

--- a/crates/garter/src/counting_tests.rs
+++ b/crates/garter/src/counting_tests.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -66,14 +64,19 @@ async fn first_read_at_is_none_when_no_bytes_arrive() {
 
 #[skuld::test]
 async fn first_read_at_does_not_update_after_first_set() {
-    // Two separate writes from the server; counter must reflect the FIRST one's time.
+    // Two separate writes from the server; counter must reflect the FIRST
+    // one's time. The client signals via `oneshot` after consuming the
+    // first byte so the server's second write happens strictly *after*
+    // the first read — deterministic, no sleep-based gating. See
+    // bindreams/hole#383.
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    let (after_first_read_tx, after_first_read_rx) = tokio::sync::oneshot::channel::<()>();
     let server = tokio::spawn(async move {
         let (mut s, _) = listener.accept().await.unwrap();
         s.write_all(b"a").await.unwrap();
         s.flush().await.unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        after_first_read_rx.await.expect("client never signaled");
         s.write_all(b"b").await.unwrap();
         s.flush().await.unwrap();
     });
@@ -85,6 +88,7 @@ async fn first_read_at_does_not_update_after_first_set() {
     let mut buf = [0u8; 1];
     counted.read_exact(&mut buf).await.unwrap();
     let first_at = counters.first_read_at().expect("first_read_at set after byte 1");
+    after_first_read_tx.send(()).expect("server task dropped receiver");
     counted.read_exact(&mut buf).await.unwrap();
     let still = counters.first_read_at().expect("first_read_at survives byte 2");
     assert_eq!(first_at, still, "first_read_at should not update on subsequent reads");

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -6,6 +6,7 @@ pub mod plugin;
 pub mod shutdown;
 pub mod sip003;
 pub mod tap;
+#[cfg(any(test, feature = "test-utils"))]
 #[doc(hidden)]
 pub mod test_utils;
 #[doc(hidden)]

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -7,6 +7,8 @@ pub mod shutdown;
 pub mod sip003;
 pub mod tap;
 #[doc(hidden)]
+pub mod test_utils;
+#[doc(hidden)]
 pub mod tracing_test;
 
 pub use binary::{BinaryPlugin, PidSink};

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -13,9 +13,7 @@
 //! [bindreams/hole#302](https://github.com/bindreams/hole/issues/302).
 //! `#[skuld::test] async fn` builds a current-thread runtime by default.
 
-use std::io;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -25,42 +23,19 @@ use tokio_util::sync::CancellationToken;
 use crate::counting::CountingStream;
 use crate::plugin::ChainPlugin;
 use crate::tap::TapPlugin;
+use crate::test_utils::WaitableWriter;
 use crate::tracing_test::set_default_in_current_thread;
 
 // Subscriber capture ==================================================================================================
 
-#[derive(Clone, Default)]
-struct VecWriter(Arc<Mutex<Vec<u8>>>);
-
-impl io::Write for VecWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for VecWriter {
-    type Writer = VecWriter;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
-    }
-}
-
-fn make_subscriber() -> (impl tracing::Subscriber + Send + Sync, VecWriter) {
-    let writer = VecWriter::default();
+fn make_subscriber() -> (impl tracing::Subscriber + Send + Sync, WaitableWriter) {
+    let writer = WaitableWriter::new();
     let subscriber = tracing_subscriber::fmt()
         .with_writer(writer.clone())
         .with_ansi(false)
         .with_target(true)
         .finish();
     (subscriber, writer)
-}
-
-fn captured_text(writer: &VecWriter) -> String {
-    String::from_utf8_lossy(&writer.0.lock().unwrap().clone()).into_owned()
 }
 
 // Stubs ===============================================================================================================
@@ -174,34 +149,35 @@ where
     let inner = Box::new(StubPlugin { behavior }) as Box<dyn ChainPlugin>;
     let tap = Box::new(TapPlugin::wrap(inner));
 
+    // Register event waits BEFORE spawning the plugin so an unusually
+    // fast emit can't race past us.
+    let ready_rx = writer.wait_for("plugin tap: ready");
+    let closed_rx = writer.wait_for("plugin tap: closed");
+
     let plugin_shutdown = shutdown.clone();
     let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown).await });
 
-    // Wait for tap to be ready by polling its public listener.
-    let ready = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if TcpStream::connect(local).await.is_ok() {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-    })
-    .await;
-    ready.expect("tap public listener never became ready");
+    // Park until tap signals ready via tracing event. No timeout — the
+    // test framework bounds wall time; if tap is broken the failure is
+    // clear ("test took too long" vs "tap never bound"). Deterministic.
+    tokio::task::spawn_blocking(move || ready_rx.recv().expect("tap never signaled ready"))
+        .await
+        .unwrap();
 
     // Run the user-supplied client interaction.
     client_body(local).await;
 
-    // Give the tap's spawn_tap a moment to log the close line (it runs
-    // off the same runtime; the close log fires after copy_bidirectional
-    // returns, which can be up to one tokio scheduling tick after the
-    // OS-side close). 200ms is plenty in practice for these stubs.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // Park until tap logs "closed" for the connection — the event-driven
+    // replacement for the previous 200ms sleep that hoped close had
+    // landed in the writer.
+    tokio::task::spawn_blocking(move || closed_rx.recv().expect("tap never signaled close"))
+        .await
+        .unwrap();
 
     shutdown.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(3), plugin_handle).await;
+    let _ = plugin_handle.await;
 
-    captured_text(&writer)
+    writer.snapshot()
 }
 
 // Tests ===============================================================================================================
@@ -339,7 +315,7 @@ async fn rst_close_classified_as_rst_with_os_errno() {
 
 #[skuld::test]
 async fn shutdown_cancels_in_flight_connection_without_panic() {
-    let (subscriber, _writer) = make_subscriber();
+    let (subscriber, writer) = make_subscriber();
     let _g = set_default_in_current_thread(subscriber);
 
     let local = pick_local().await;
@@ -352,29 +328,28 @@ async fn shutdown_cancels_in_flight_connection_without_panic() {
     }) as Box<dyn ChainPlugin>;
     let tap = Box::new(TapPlugin::wrap(inner));
 
+    let ready_rx = writer.wait_for("plugin tap: ready");
+
     let plugin_shutdown = shutdown.clone();
     let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown).await });
 
-    // Wait for tap ready.
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if TcpStream::connect(local).await.is_ok() {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-    })
-    .await
-    .expect("tap ready");
+    // Park until tap signals ready via tracing event. Deterministic.
+    tokio::task::spawn_blocking(move || ready_rx.recv().expect("tap never signaled ready"))
+        .await
+        .unwrap();
 
     // Open a connection that the echo plugin will hold (waiting on
     // read_exact for 4096 bytes — we send only 1).
     let _client = TcpStream::connect(local).await.unwrap();
 
-    // Cancel shutdown and assert the plugin exits within budget.
+    // Cancel shutdown and await the plugin exit. The plugin's own
+    // shutdown bookkeeping bounds time; if it hangs the test
+    // framework's timeout surfaces a clear failure.
     shutdown.cancel();
-    let result = tokio::time::timeout(Duration::from_secs(3), plugin_handle).await;
-    assert!(result.is_ok(), "tap plugin did not exit within 3s of shutdown");
+    plugin_handle
+        .await
+        .expect("plugin task panicked")
+        .expect("plugin returned error");
 }
 
 #[skuld::test]

--- a/crates/garter/src/test_utils.rs
+++ b/crates/garter/src/test_utils.rs
@@ -31,11 +31,23 @@ impl WaitableWriter {
     }
 
     /// Register a one-shot wait — fires the returned receiver the first
-    /// time a future write contains `substring`. Subsequent matches are
-    /// no-ops (the pattern is removed after firing).
+    /// time the accumulated buffer contains `substring`. If the buffer
+    /// already contains it at the time of this call, the receiver fires
+    /// immediately so the caller does not race against past writes.
+    /// Subsequent matches are no-ops (the pattern is removed after
+    /// firing).
     pub fn wait_for(&self, substring: &str) -> std::sync::mpsc::Receiver<()> {
         let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
-        self.patterns.lock().unwrap().insert(substring.to_string(), tx);
+        // Hold both locks while we check-and-register to avoid losing a
+        // write that lands between the check and the insert.
+        let inner = self.inner.lock().unwrap();
+        let mut patterns = self.patterns.lock().unwrap();
+        let text = String::from_utf8_lossy(&inner);
+        if text.contains(substring) {
+            let _ = tx.send(());
+        } else {
+            patterns.insert(substring.to_string(), tx);
+        }
         rx
     }
 
@@ -47,11 +59,21 @@ impl WaitableWriter {
 
 impl io::Write for WaitableWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.lock().unwrap().extend_from_slice(buf);
-        let text = String::from_utf8_lossy(buf);
+        let mut inner = self.inner.lock().unwrap();
+        inner.extend_from_slice(buf);
         let mut patterns = self.patterns.lock().unwrap();
+        if patterns.is_empty() {
+            return Ok(buf.len());
+        }
+        // Scan the ENTIRE accumulated buffer (not just this write's
+        // `buf`) so a pattern that spans two `write()` calls — e.g.,
+        // tracing-subscriber buffering the header in one call and the
+        // body in the next — still matches. Patterns are removed after
+        // firing, so the work is bounded by the number of *active*
+        // patterns × buffer size.
+        let all_text = String::from_utf8_lossy(&inner);
         patterns.retain(|pattern, tx| {
-            if text.contains(pattern.as_str()) {
+            if all_text.contains(pattern.as_str()) {
                 let _ = tx.send(());
                 false
             } else {

--- a/crates/garter/src/test_utils.rs
+++ b/crates/garter/src/test_utils.rs
@@ -1,0 +1,73 @@
+//! Test utilities.
+//!
+//! Public-but-test-only helpers exposed for crates that need to assert
+//! on tracing-event content without polling. Lives under a `pub` module
+//! rather than `#[cfg(test)]` so integration tests (`tests/*.rs`) can
+//! use it — they only see the crate's public API.
+//!
+//! Production code MUST NOT import from this module — it offers no
+//! production value and increases compile time.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, Mutex};
+
+/// A `MakeWriter`-compatible `Vec<u8>` accumulator that also fires
+/// `mpsc` acks the first time any registered substring is observed in
+/// a written line. Lets tests park on `recv()` until a specific log
+/// event has been emitted — no polling, no sleep. See
+/// bindreams/hole#383.
+#[derive(Clone, Default)]
+pub struct WaitableWriter {
+    inner: Arc<Mutex<Vec<u8>>>,
+    patterns: Arc<Mutex<HashMap<String, SyncSender<()>>>>,
+}
+
+impl WaitableWriter {
+    /// Create an empty writer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a one-shot wait — fires the returned receiver the first
+    /// time a future write contains `substring`. Subsequent matches are
+    /// no-ops (the pattern is removed after firing).
+    pub fn wait_for(&self, substring: &str) -> std::sync::mpsc::Receiver<()> {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+        self.patterns.lock().unwrap().insert(substring.to_string(), tx);
+        rx
+    }
+
+    /// Snapshot the captured bytes so far as a `String` (lossy UTF-8).
+    pub fn snapshot(&self) -> String {
+        String::from_utf8_lossy(&self.inner.lock().unwrap().clone()).into_owned()
+    }
+}
+
+impl io::Write for WaitableWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.lock().unwrap().extend_from_slice(buf);
+        let text = String::from_utf8_lossy(buf);
+        let mut patterns = self.patterns.lock().unwrap();
+        patterns.retain(|pattern, tx| {
+            if text.contains(pattern.as_str()) {
+                let _ = tx.send(());
+                false
+            } else {
+                true
+            }
+        });
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for WaitableWriter {
+    type Writer = WaitableWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -36,14 +36,26 @@ fn mock_plugin_path() -> PathBuf {
 async fn two_plugin_chain_relays_data() {
     let mock_path = mock_plugin_path();
 
-    // Start an echo server as the final destination
+    // Multi-connection echo server. `on_ready`'s TCP-connect probe is
+    // forwarded through the chain to the echo server, consuming an
+    // accept slot before the real client connection arrives — so echo
+    // must loop. (The previous poll-based readiness check connected
+    // directly to the outermost listener before traffic flowed through
+    // the chain, masking this.) See bindreams/hole#383.
     let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let echo_addr = echo_listener.local_addr().unwrap();
 
     let echo_task = tokio::spawn(async move {
-        if let Ok((stream, _)) = echo_listener.accept().await {
-            let (mut reader, mut writer) = tokio::io::split(stream);
-            let _ = tokio::io::copy(&mut reader, &mut writer).await;
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut reader, mut writer) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut reader, &mut writer).await;
+                    });
+                }
+                Err(_) => return,
+            }
         }
     });
 
@@ -52,10 +64,16 @@ async fn two_plugin_chain_relays_data() {
     let chain_local = chain_listener.local_addr().unwrap();
     drop(chain_listener);
 
-    // Build chain: mock-plugin-1 -> mock-plugin-2
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    // Build chain: mock-plugin-1 -> mock-plugin-2. `on_ready` fires
+    // when the outermost plugin has bound `chain_local` — see
+    // bindreams/hole#383 for why the previous poll-connect was a flake
+    // hazard.
     let runner = ChainRunner::new()
         .add(Box::new(BinaryPlugin::new(&mock_path, None)))
         .add(Box::new(BinaryPlugin::new(&mock_path, None)))
+        .on_ready(ready_tx)
         .drain_timeout(Duration::from_secs(3));
 
     let env = PluginEnv {
@@ -68,26 +86,13 @@ async fn two_plugin_chain_relays_data() {
 
     let chain_task = tokio::spawn(async move { runner.run(env).await });
 
-    // Wait for the chain to start accepting connections
-    let mut client = {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            match TcpStream::connect(chain_local).await {
-                Ok(stream) => break stream,
-                Err(_) if tokio::time::Instant::now() < deadline => {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                }
-                Err(e) => panic!("chain did not start accepting within 5s: {e}"),
-            }
-        }
-    };
+    // Park until the chain signals ready. Deterministic, no poll-retry.
+    ready_rx.await.expect("chain never signaled ready");
+    let mut client = TcpStream::connect(chain_local).await.expect("connect to chain local");
     client.write_all(b"hello through chain").await.unwrap();
 
     let mut buf = [0u8; 1024];
-    let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
-        .await
-        .expect("read timed out")
-        .unwrap();
+    let n = client.read(&mut buf).await.expect("read from chain returned error");
 
     assert_eq!(&buf[..n], b"hello through chain");
 
@@ -95,10 +100,12 @@ async fn two_plugin_chain_relays_data() {
     drop(client);
     echo_task.abort();
 
-    // Chain plugins loop on accept() indefinitely. When the skuld test
-    // harness drops the tokio runtime at the end of the test, tasks are
-    // cancelled and kill_on_drop terminates the child processes.
-    let _ = tokio::time::timeout(Duration::from_secs(10), chain_task).await;
+    // Chain plugins loop on accept() indefinitely. The skuld test
+    // harness drops the tokio runtime at the end of the test; tasks
+    // are cancelled and kill_on_drop terminates the child processes.
+    // No explicit wait needed.
+    chain_task.abort();
+    let _ = chain_task.await;
 }
 
 /// Verify that pid_sink fires once per binary plugin with a valid PID.
@@ -156,7 +163,7 @@ async fn pid_sink_fires_once_per_binary_plugin() {
     }
 
     cancel.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    let _ = handle.await;
 }
 
 // Install the workspace test subscriber + panic hook. See

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -119,6 +119,12 @@ async fn pid_sink_fires_once_per_binary_plugin() {
         sink_pids.lock().unwrap().push(pid);
     });
 
+    // Single-accept echo: this test only awaits `on_ready` and checks
+    // pid counts — it does not send any client traffic. `on_ready`'s
+    // TCP probe is forwarded through the chain and consumes this one
+    // accept slot, which is sufficient because no real client follows.
+    // The sister test (`two_plugin_chain_relays_data`) does send
+    // traffic and therefore uses a multi-accept echo.
     let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let echo_addr = echo_listener.local_addr().unwrap();
     tokio::spawn(async move {

--- a/crates/garter/tests/tap_integration.rs
+++ b/crates/garter/tests/tap_integration.rs
@@ -7,12 +7,12 @@
 //! Apache-2.0-process-boundary behavior.
 
 use std::path::PathBuf;
-use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 
+use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 use garter::{BinaryPlugin, ChainPlugin, TapPlugin};
 
@@ -39,14 +39,14 @@ fn mock_plugin_path() -> PathBuf {
 
 #[skuld::test]
 async fn tap_relays_data_through_binary_plugin_to_echo_server() {
-    // Install a subscriber that prints to test stderr so mock-plugin's
-    // own stderr (captured by BinaryPlugin and re-emitted as
-    // tracing::warn) and the tap's info events are visible when this
-    // test is debugged.
+    // Install a subscriber backed by `WaitableWriter` so the test can
+    // park on the tap's "plugin tap: ready" event without polling.
+    let writer = WaitableWriter::new();
+    let ready_rx = writer.wait_for("plugin tap: ready");
     let subscriber = tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_test_writer()
+        .with_writer(writer.clone())
         .with_max_level(tracing::Level::DEBUG)
+        .with_ansi(false)
         .finish();
     let _g = set_default_in_current_thread(subscriber);
 
@@ -86,32 +86,27 @@ async fn tap_relays_data_through_binary_plugin_to_echo_server() {
     let plugin_shutdown = shutdown.clone();
     let plugin_handle = tokio::spawn(async move { tap.run(chain_local, echo_addr, plugin_shutdown).await });
 
-    // Wait for tap public listener to come up.
-    let mut client = {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-        loop {
-            match TcpStream::connect(chain_local).await {
-                Ok(s) => break s,
-                Err(_) if tokio::time::Instant::now() < deadline => {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                }
-                Err(e) => panic!("tap did not start accepting within 10s: {e}"),
-            }
-        }
-    };
+    // Park until tap signals ready via the tracing event the
+    // `WaitableWriter` is watching for. Deterministic, no polling.
+    // See bindreams/hole#383.
+    tokio::task::spawn_blocking(move || ready_rx.recv().expect("tap never signaled ready"))
+        .await
+        .unwrap();
+    let mut client = TcpStream::connect(chain_local)
+        .await
+        .expect("connect to tap public listener");
 
     client.write_all(b"hello through tap+mock").await.unwrap();
     let mut buf = [0u8; 1024];
-    let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
-        .await
-        .expect("read timed out")
-        .unwrap();
+    let n = client.read(&mut buf).await.expect("read from tap returned error");
     assert_eq!(&buf[..n], b"hello through tap+mock");
 
     drop(client);
     echo_task.abort();
     shutdown.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(5), plugin_handle).await;
+    // Await the plugin task; if it hangs, the test framework's timeout
+    // surfaces a clear "test took too long" failure.
+    let _ = plugin_handle.await;
 }
 
 // Install the workspace test subscriber + panic hook. See

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -13,6 +13,10 @@ workspace = true
 [lib]
 harness = false
 
+[[bin]]
+name = "hold_file"
+path = "src/bin/hold_file.rs"
+
 [[test]]
 name = "live_holders"
 path = "tests/live_holders.rs"

--- a/crates/handle-holders/src/bin/hold_file.rs
+++ b/crates/handle-holders/src/bin/hold_file.rs
@@ -1,5 +1,22 @@
+// Test helper for `handle_holders` live-API tests. Opens the file at
+// `HOLD_FILE`, writes a single byte to stdout to signal "I have the
+// handle now", then blocks on stdin EOF. The parent test reads the
+// signal byte (no sleep-based wait), runs its assertions, then closes
+// stdin via `child.kill()` — read_to_string returns and we exit.
+//
+// See bindreams/hole#383 — replaces the previous 60s sleep loop.
+
+use std::io::{Read, Write};
+
 fn main() {
     let path = std::env::var_os("HOLD_FILE").expect("HOLD_FILE env var required");
     let _f = std::fs::File::open(&path).expect("open HOLD_FILE target");
-    std::thread::sleep(std::time::Duration::from_secs(60));
+
+    // Signal readiness.
+    std::io::stdout().write_all(b"ready\n").expect("write ready");
+    std::io::stdout().flush().expect("flush ready");
+
+    // Block until parent closes stdin (typically via kill). No sleep.
+    let mut buf = Vec::new();
+    let _ = std::io::stdin().read_to_end(&mut buf);
 }

--- a/crates/handle-holders/tests/live_holders.rs
+++ b/crates/handle-holders/tests/live_holders.rs
@@ -44,6 +44,15 @@ fn spawn_holder_ready(path: &Path) -> (Child, BufReader<ChildStdout>) {
     (child, reader)
 }
 
+/// Shut down the holder by closing its stdin pipe — `hold_file` exits
+/// on EOF. This exercises the stdin-EOF exit path (the production
+/// contract) rather than forcefully terminating, so a regression in
+/// `hold_file`'s EOF handling shows up here.
+fn shutdown_holder(mut child: Child) {
+    drop(child.stdin.take());
+    let _ = child.wait();
+}
+
 fn collect_holders(path: &Path) -> Vec<FileHolder> {
     find_holders(path).expect("find_holders")
 }
@@ -57,11 +66,10 @@ fn find_holders_finds_foreign_process_holding_file_windows() {
         .and_then(|mut f| f.write_all(b"content"))
         .expect("write file");
 
-    let (mut child, _stdout) = spawn_holder_ready(&path);
+    let (child, _stdout) = spawn_holder_ready(&path);
     let child_pid = child.id();
     let holders = collect_holders(&path);
-    let _ = child.kill();
-    let _ = child.wait();
+    shutdown_holder(child);
 
     let me = std::process::id();
     assert!(
@@ -97,10 +105,9 @@ fn find_holders_detects_child_holding_file() {
         .and_then(|mut f| f.write_all(b"content"))
         .expect("write file");
 
-    let (mut child, _stdout) = spawn_holder_ready(&path);
+    let (child, _stdout) = spawn_holder_ready(&path);
     let holders = collect_holders(&path);
-    let _ = child.kill();
-    let _ = child.wait();
+    shutdown_holder(child);
 
     let me = std::process::id();
     assert!(

--- a/crates/handle-holders/tests/live_holders.rs
+++ b/crates/handle-holders/tests/live_holders.rs
@@ -1,23 +1,20 @@
 //! Live-API tests that need a real foreign process holding the target file.
 //!
 //! Integration-test target, not a unit test module, because
-//! `CARGO_BIN_EXE_hold_file` is only set for `tests/*.rs`.
-//! The tiny `hold_file` bin (see `src/bin/hold_file.rs`) opens the
-//! path passed via the `HOLD_FILE` env var and sleeps, so we can
-//! observe it as a file holder without re-invoking a full test
-//! binary (which re-initializes skuld/tokio/tracing and tripped a
-//! Rust runtime abort in earlier attempts).
+//! `CARGO_BIN_EXE_hold_file` is only set for `tests/*.rs`. The tiny
+//! `hold_file` bin (see `src/bin/hold_file.rs`) opens the path passed
+//! via the `HOLD_FILE` env var and waits for stdin EOF, so we can
+//! observe it as a file holder.
 //!
-//! Read `CARGO_BIN_EXE_hold_file` at runtime (via `env::var`) instead of
-//! compile-time (`env!`) so the test works when nextest runs the binary
-//! from a downloaded archive on a different machine — nextest extracts
-//! bin targets to a fresh temp dir and sets the env var to that path.
+//! Path resolution: prefer the runtime `CARGO_BIN_EXE_hold_file` env
+//! var (set by nextest's archive workflow when the binary is extracted
+//! to a temp dir on the runner). Fall back to the compile-time value
+//! via `env!()` for plain `cargo test` invocations on the build host.
 
 use handle_holders::{find_holders, FileHolder};
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
+use std::process::{Child, ChildStdout, Command, Stdio};
 
 // Install the workspace test subscriber + panic hook. See
 // `crates/test-observability/` and bindreams/hole#301.
@@ -27,27 +24,28 @@ fn main() {
     skuld::run_all();
 }
 
-fn spawn_holder(path: &Path) -> Child {
-    let exe = std::env::var("CARGO_BIN_EXE_hold_file")
-        .expect("CARGO_BIN_EXE_hold_file should be set by cargo test / nextest");
-    Command::new(exe)
+/// Spawn `hold_file` and park until its stdout emits "ready", meaning
+/// the child has the file handle open. Deterministic — no sleep-based
+/// poll over `find_holders`. See bindreams/hole#383.
+fn spawn_holder_ready(path: &Path) -> (Child, BufReader<ChildStdout>) {
+    let exe = std::env::var("CARGO_BIN_EXE_hold_file").unwrap_or_else(|_| env!("CARGO_BIN_EXE_hold_file").to_string());
+    let mut child = Command::new(exe)
         .env("HOLD_FILE", path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn hold_file child")
+        .expect("spawn hold_file child");
+    let stdout = child.stdout.take().expect("piped stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read ready line from hold_file");
+    assert_eq!(line.trim(), "ready", "unexpected ready line: {line:?}");
+    (child, reader)
 }
 
-fn wait_for_holder(path: &Path, deadline: Duration) -> Vec<FileHolder> {
-    let started = Instant::now();
-    loop {
-        let holders = find_holders(path).expect("find_holders");
-        if !holders.is_empty() || started.elapsed() >= deadline {
-            return holders;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
+fn collect_holders(path: &Path) -> Vec<FileHolder> {
+    find_holders(path).expect("find_holders")
 }
 
 #[cfg(target_os = "windows")]
@@ -59,9 +57,9 @@ fn find_holders_finds_foreign_process_holding_file_windows() {
         .and_then(|mut f| f.write_all(b"content"))
         .expect("write file");
 
-    let mut child = spawn_holder(&path);
+    let (mut child, _stdout) = spawn_holder_ready(&path);
     let child_pid = child.id();
-    let holders = wait_for_holder(&path, Duration::from_secs(10));
+    let holders = collect_holders(&path);
     let _ = child.kill();
     let _ = child.wait();
 
@@ -99,8 +97,8 @@ fn find_holders_detects_child_holding_file() {
         .and_then(|mut f| f.write_all(b"content"))
         .expect("write file");
 
-    let mut child = spawn_holder(&path);
-    let holders = wait_for_holder(&path, Duration::from_secs(3));
+    let (mut child, _stdout) = spawn_holder_ready(&path);
+    let holders = collect_holders(&path);
     let _ = child.kill();
     let _ = child.wait();
 

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -8,6 +8,7 @@ pub mod path_management;
 pub mod setup;
 pub mod state;
 pub mod tray_icons;
+pub mod ui_ready;
 pub mod update;
 pub mod version;
 

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -21,7 +21,6 @@ mod tray;
 mod ui_ready;
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 use state::AppState;
 use tauri::Manager;
@@ -61,15 +60,13 @@ fn launch_gui(show_dashboard: bool) {
 
     let _log_guard = logging::init(&log_dir);
 
-    let ui_ready = Arc::new(ui_ready::UiReady::default());
-
     tauri::Builder::default()
         // `UiReady` is registered on the builder (not in `.setup`) so
         // it is available to command handlers at first dispatch — the
         // dashboard webview begins navigation during `.build()`, and
         // `ui/main.ts::init()` may fire `signal_ui_ready` before the
         // setup hook runs.
-        .manage(Arc::clone(&ui_ready))
+        .manage(ui_ready::UiReady::default())
         // `tauri-plugin-single-instance` must be registered first per
         // upstream guidance: the duplicate-instance process exits during
         // this plugin's init, so any plugin registered earlier would do

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -18,8 +18,10 @@ mod platform;
 mod setup;
 mod state;
 mod tray;
+mod ui_ready;
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use state::AppState;
 use tauri::Manager;
@@ -59,7 +61,15 @@ fn launch_gui(show_dashboard: bool) {
 
     let _log_guard = logging::init(&log_dir);
 
+    let ui_ready = Arc::new(ui_ready::UiReady::default());
+
     tauri::Builder::default()
+        // `UiReady` is registered on the builder (not in `.setup`) so
+        // it is available to command handlers at first dispatch — the
+        // dashboard webview begins navigation during `.build()`, and
+        // `ui/main.ts::init()` may fire `signal_ui_ready` before the
+        // setup hook runs.
+        .manage(Arc::clone(&ui_ready))
         // `tauri-plugin-single-instance` must be registered first per
         // upstream guidance: the duplicate-instance process exits during
         // this plugin's init, so any plugin registered earlier would do
@@ -107,6 +117,8 @@ fn launch_gui(show_dashboard: bool) {
             commands::reload_proxy_filters,
             tray::toggle_proxy,
             tray::cancel_proxy,
+            ui_ready::signal_ui_ready,
+            ui_ready::wait_ui_ready,
         ])
         .setup(move |app| {
             // Manage shared state here (instead of pre-`.setup()`) so that

--- a/crates/hole/src/ui_ready.rs
+++ b/crates/hole/src/ui_ready.rs
@@ -13,8 +13,6 @@
 //!
 //! See bindreams/hole#383.
 
-use std::sync::Arc;
-
 use tokio::sync::watch;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -59,13 +57,13 @@ impl UiReady {
 }
 
 #[tauri::command]
-pub async fn signal_ui_ready(state: tauri::State<'_, Arc<UiReady>>, result: UiReadyResult) -> Result<(), String> {
+pub async fn signal_ui_ready(state: tauri::State<'_, UiReady>, result: UiReadyResult) -> Result<(), String> {
     state.signal(result);
     Ok(())
 }
 
 #[tauri::command]
-pub async fn wait_ui_ready(state: tauri::State<'_, Arc<UiReady>>) -> Result<UiReadyResult, String> {
+pub async fn wait_ui_ready(state: tauri::State<'_, UiReady>) -> Result<UiReadyResult, String> {
     Ok(state.wait().await)
 }
 

--- a/crates/hole/src/ui_ready.rs
+++ b/crates/hole/src/ui_ready.rs
@@ -1,0 +1,74 @@
+//! UI-readiness synchronization for webdriver tests.
+//!
+//! The dashboard webview navigates to `tauri.localhost/index.html`
+//! asynchronously after window creation. WebDriver's session is
+//! established before that navigation completes, so any test that
+//! interacts with the page before init() finishes is racing.
+//!
+//! `UiReady` provides an event-driven signal between the UI and any
+//! webdriver test: `ui/main.ts::init()` calls `signal_ui_ready` at
+//! the end (success or failure), and the test calls `wait_ui_ready`
+//! to park on a `watch` channel until the signal arrives. No polling,
+//! no timeouts in the sync path.
+//!
+//! See bindreams/hole#383.
+
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct UiReadyResult {
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+pub struct UiReady {
+    tx: watch::Sender<Option<UiReadyResult>>,
+}
+
+impl Default for UiReady {
+    fn default() -> Self {
+        let (tx, _rx) = watch::channel(None);
+        Self { tx }
+    }
+}
+
+impl UiReady {
+    /// Latch a result. Calling more than once overwrites the latched
+    /// value; receivers that already observed the first value keep
+    /// their snapshot.
+    ///
+    /// `send_replace` is used (rather than `send`) because the watch
+    /// has no active receivers between `Default::default()` and the
+    /// first [`wait`] call — `send` returns an Err in that window and
+    /// silently drops the value.
+    pub fn signal(&self, result: UiReadyResult) {
+        self.tx.send_replace(Some(result));
+    }
+
+    /// Park until [`signal`] has been called at least once.
+    pub async fn wait(&self) -> UiReadyResult {
+        let mut rx = self.tx.subscribe();
+        let guard = rx
+            .wait_for(|state| state.is_some())
+            .await
+            .expect("UiReady sender held by Self; can never drop while wait() is in progress");
+        guard.clone().expect("predicate guarantees Some")
+    }
+}
+
+#[tauri::command]
+pub async fn signal_ui_ready(state: tauri::State<'_, Arc<UiReady>>, result: UiReadyResult) -> Result<(), String> {
+    state.signal(result);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn wait_ui_ready(state: tauri::State<'_, Arc<UiReady>>) -> Result<UiReadyResult, String> {
+    Ok(state.wait().await)
+}
+
+#[cfg(test)]
+#[path = "ui_ready_tests.rs"]
+mod ui_ready_tests;

--- a/crates/hole/src/ui_ready_tests.rs
+++ b/crates/hole/src/ui_ready_tests.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use super::*;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().unwrap()
+}
+
+#[skuld::test]
+fn signal_before_wait_returns_immediately() {
+    rt().block_on(async {
+        let ui = Arc::new(UiReady::default());
+        ui.signal(UiReadyResult { ok: true, error: None });
+        let result = ui.wait().await;
+        assert_eq!(result, UiReadyResult { ok: true, error: None });
+    });
+}
+
+#[skuld::test]
+fn signal_after_wait_wakes_waiter() {
+    rt().block_on(async {
+        let ui = Arc::new(UiReady::default());
+        let ui2 = Arc::clone(&ui);
+        let waiter = tokio::spawn(async move { ui2.wait().await });
+        ui.signal(UiReadyResult {
+            ok: false,
+            error: Some("init blew up".into()),
+        });
+        let result = waiter.await.unwrap();
+        assert_eq!(
+            result,
+            UiReadyResult {
+                ok: false,
+                error: Some("init blew up".into())
+            }
+        );
+    });
+}
+
+#[skuld::test]
+fn multiple_waiters_all_wake() {
+    rt().block_on(async {
+        let ui = Arc::new(UiReady::default());
+        let ui2 = Arc::clone(&ui);
+        let ui3 = Arc::clone(&ui);
+        let w1 = tokio::spawn(async move { ui2.wait().await });
+        let w2 = tokio::spawn(async move { ui3.wait().await });
+        ui.signal(UiReadyResult { ok: true, error: None });
+        let r1 = w1.await.unwrap();
+        let r2 = w2.await.unwrap();
+        assert_eq!(r1, UiReadyResult { ok: true, error: None });
+        assert_eq!(r2, UiReadyResult { ok: true, error: None });
+    });
+}
+
+#[skuld::test]
+fn second_signal_overwrites_latched_value() {
+    rt().block_on(async {
+        let ui = Arc::new(UiReady::default());
+        ui.signal(UiReadyResult { ok: true, error: None });
+        let early = ui.wait().await;
+        ui.signal(UiReadyResult {
+            ok: false,
+            error: Some("late".into()),
+        });
+        let late = ui.wait().await;
+        assert_eq!(early, UiReadyResult { ok: true, error: None });
+        assert_eq!(
+            late,
+            UiReadyResult {
+                ok: false,
+                error: Some("late".into())
+            }
+        );
+    });
+}

--- a/crates/hole/src/ui_ready_tests.rs
+++ b/crates/hole/src/ui_ready_tests.rs
@@ -17,7 +17,13 @@ fn signal_before_wait_returns_immediately() {
 }
 
 #[skuld::test]
-fn signal_after_wait_wakes_waiter() {
+fn signal_and_wait_compose_regardless_of_order() {
+    // Tokio's task scheduling determines whether `ui2.wait().await`
+    // parks before `ui.signal(...)` fires or after. Either ordering
+    // must yield the correct value; this test only asserts the
+    // behavior on a successful interleave, not the ordering itself.
+    // The `signal_before_wait_returns_immediately` test exercises the
+    // signal-first path explicitly.
     rt().block_on(async {
         let ui = Arc::new(UiReady::default());
         let ui2 = Arc::clone(&ui);

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -183,6 +183,10 @@ def wait_for_port(port: int, timeout: float, proc: subprocess.Popen) -> bool:
                     return True
             except OSError:
                 continue
+        # External-event-with-graceful-failure exception (CLAUDE.md
+        # §Synchronization invariant): the subprocess is out-of-process,
+        # OS doesn't expose an "Nth process bound port P" event, so we
+        # poll. Failure is relayed cleanly via the False return.
         time.sleep(0.2)
     return False
 
@@ -195,6 +199,9 @@ def wait_for_socket(path: Path, proc: subprocess.Popen, timeout: float) -> bool:
             return False
         if path.exists():
             return True
+        # External-event-with-graceful-failure exception (CLAUDE.md
+        # §Synchronization invariant): subprocess file creation is not
+        # synchronously observable cross-process. Failure returns False.
         time.sleep(0.1)
     return False
 

--- a/scripts/test_console_corruption.py
+++ b/scripts/test_console_corruption.py
@@ -21,7 +21,6 @@ import ctypes.wintypes
 import shutil
 import subprocess
 import sys
-import time
 
 if sys.platform != "win32":
     print("SKIP: this test only runs on Windows")
@@ -57,7 +56,11 @@ def mode_flags(mode: int) -> str:
 
 
 def run_and_terminate(cmd: list[str], *, stdin_devnull: bool) -> None:
-    """Launch a subprocess, wait briefly, then terminate it."""
+    """Launch a subprocess, wait until it signals it has finished startup
+    (via the Vite "ready in" line on stdout), then terminate it. Reading
+    a deterministic marker replaces a sleep-based "wait briefly" — see
+    bindreams/hole#383.
+    """
     stdin_arg = subprocess.DEVNULL if stdin_devnull else None
     proc = subprocess.Popen(
         cmd,
@@ -65,7 +68,15 @@ def run_and_terminate(cmd: list[str], *, stdin_devnull: bool) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    time.sleep(2)
+    # Read until Vite emits its "ready in" startup marker. If the
+    # subprocess dies before emitting it, readline returns "" and the
+    # loop exits cleanly. The terminate-and-wait below then verifies
+    # the corruption check ran against a subprocess that had actually
+    # set up its console handlers.
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+        if b"ready in" in raw.lower() or b"local:" in raw.lower():
+            break
     proc.terminate()
     proc.wait(timeout=10)
 

--- a/scripts/test_console_corruption.py
+++ b/scripts/test_console_corruption.py
@@ -59,7 +59,10 @@ def run_and_terminate(cmd: list[str], *, stdin_devnull: bool) -> None:
     """Launch a subprocess, wait until it signals it has finished startup
     (via the Vite "ready in" line on stdout), then terminate it. Reading
     a deterministic marker replaces a sleep-based "wait briefly" — see
-    bindreams/hole#383.
+    bindreams/hole#383. If the subprocess exits before emitting the
+    marker (Vite changed its output format, npm failed, etc.), we
+    panic loudly: the corruption check is only meaningful against a
+    subprocess that actually set up its console handlers.
     """
     stdin_arg = subprocess.DEVNULL if stdin_devnull else None
     proc = subprocess.Popen(
@@ -68,15 +71,20 @@ def run_and_terminate(cmd: list[str], *, stdin_devnull: bool) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    # Read until Vite emits its "ready in" startup marker. If the
-    # subprocess dies before emitting it, readline returns "" and the
-    # loop exits cleanly. The terminate-and-wait below then verifies
-    # the corruption check ran against a subprocess that had actually
-    # set up its console handlers.
     assert proc.stdout is not None
+    marker_seen = False
     for raw in proc.stdout:
         if b"ready in" in raw.lower() or b"local:" in raw.lower():
+            marker_seen = True
             break
+    if not marker_seen:
+        # Drain any remaining output, then fail loud.
+        proc.terminate()
+        proc.wait(timeout=10)
+        raise RuntimeError(
+            "subprocess exited before emitting 'ready in' / 'local:' marker — "
+            "console corruption check is meaningless without Vite startup."
+        )
     proc.terminate()
     proc.wait(timeout=10)
 

--- a/tests/webdriver/specs/dashboard-loads.spec.ts
+++ b/tests/webdriver/specs/dashboard-loads.spec.ts
@@ -6,21 +6,23 @@
 //   so it tries `http://localhost:1420/` at runtime → connection refused.
 // - `ui/dist/` missing / empty at build time, so embedded assets are empty
 //   and the dashboard navigates to a stub or fallback URL.
+//
+// The wdio.conf.ts `before` hook parks the suite until `init()` in
+// ui/main.ts has signaled completion via the `wait_ui_ready` Tauri
+// command. By the time these specs run, the page is loaded and the
+// app's init() has finished — no per-test wait needed. See
+// bindreams/hole#383 for the flake that motivated this design.
 
 describe("Dashboard window", () => {
   it("loads the bundled HTML (not the WebView2 error page)", async () => {
     // ui/index.html line 6 sets <title>Hole Dashboard</title>. WebView2's
     // error page title is something like "Hmm — can't reach this page".
-    const title = await browser.getTitle();
-    expect(title).toBe("Hole Dashboard");
+    expect(await browser.getTitle()).toBe("Hole Dashboard");
   });
 
   it("renders the server-list container from the bundled DOM", async () => {
     // #server-list lives at ui/index.html:22 — present iff index.html was
-    // actually served from embedded assets. `waitForExist` throws on
-    // timeout, which is the actual assertion; the test name documents
-    // intent.
-    const list = await $("#server-list");
-    await list.waitForExist({ timeout: 5000 });
+    // actually served from embedded assets.
+    expect(await $("#server-list").isExisting()).toBe(true);
   });
 });

--- a/tests/webdriver/specs/ui-ready-sync.spec.ts
+++ b/tests/webdriver/specs/ui-ready-sync.spec.ts
@@ -1,0 +1,33 @@
+// Meta-test for the `__holeUiReady` test seam. If a future refactor
+// accidentally removes the wdio.conf.ts `before` hook OR breaks
+// `__holeUiReady`'s bundled-bridge wiring, this spec fails loudly
+// instead of letting downstream specs return to flake-land.
+//
+// See bindreams/hole#383 and crates/hole/src/ui_ready.rs.
+
+describe("UI-ready sync", () => {
+  it("exposes the __holeUiReady bridge on window", async () => {
+    const t = await browser.execute(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return typeof (window as any).__holeUiReady;
+    });
+    expect(t).toBe("function");
+  });
+
+  it("a second wait_ui_ready call returns ok:true immediately (already-latched)", async () => {
+    // The wdio.conf.ts `before` hook already awaited __holeUiReady once
+    // before this spec started. A second call must resolve immediately
+    // with the latched success result — that is the watch-channel
+    // semantic and the basis on which downstream specs trust that the
+    // app is initialized.
+    const result = await browser.executeAsync<{
+      ok: boolean;
+      error: string | null;
+    }>((done) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__holeUiReady().then(done);
+    });
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+  });
+});

--- a/tests/webdriver/wdio.conf.ts
+++ b/tests/webdriver/wdio.conf.ts
@@ -34,6 +34,36 @@ export const config: Options.Testrunner = {
   },
   reporters: ["spec"],
 
+  // Wait for the UI to signal it has finished `init()` (success or
+  // failure). Synchronizes the test run with the UI's initialization
+  // state via an explicit Tauri-command bridge in
+  // crates/hole/src/ui_ready.rs. `executeAsync` parks the driver
+  // until `done()` is called from the page-side script. The Mocha
+  // 30s `timeout` above is the framework-level failure bound (it
+  // covers WebView2-itself-broken — an external-event-might-never-
+  // happen scenario; not the synchronization).
+  //
+  // See bindreams/hole#383 for the flake that motivated this.
+  async before() {
+    const result = await browser.executeAsync<{
+      ok: boolean;
+      error: string | null;
+    }>((done) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ready = (window as any).__holeUiReady as undefined | (() => Promise<{ ok: boolean; error: string | null }>);
+      if (typeof ready !== "function") {
+        done({ ok: false, error: "__holeUiReady not exposed by ui/main.ts" });
+        return;
+      }
+      ready()
+        .then(done)
+        .catch((e: unknown) => done({ ok: false, error: String(e) }));
+    });
+    if (!result.ok) {
+      throw new Error(`UI init failed: ${result.error}`);
+    }
+  },
+
   onPrepare() {
     // Discard tauri-driver's stdio — keeping the pipes open would block
     // tauri-driver if it ever writes more than the pipe buffer (~64 KB

--- a/tests/webdriver/wdio.conf.ts
+++ b/tests/webdriver/wdio.conf.ts
@@ -49,15 +49,31 @@ export const config: Options.Testrunner = {
       ok: boolean;
       error: string | null;
     }>((done) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const ready = (window as any).__holeUiReady as undefined | (() => Promise<{ ok: boolean; error: string | null }>);
-      if (typeof ready !== "function") {
-        done({ ok: false, error: "__holeUiReady not exposed by ui/main.ts" });
-        return;
+      // The webdriver session can establish before ui/main.ts has
+      // executed its module-level `window.__holeUiReady = ...`
+      // assignment. If `document.readyState !== "complete"` we wait
+      // for the `load` event — all scripts have run by then — and
+      // then call the bridge. Event-driven (no polling).
+      type ReadyFn = () => Promise<{ ok: boolean; error: string | null }>;
+      const go = () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ready = (window as any).__holeUiReady as ReadyFn | undefined;
+        if (typeof ready !== "function") {
+          done({
+            ok: false,
+            error: "__holeUiReady not exposed by ui/main.ts after page load",
+          });
+          return;
+        }
+        ready()
+          .then(done)
+          .catch((e: unknown) => done({ ok: false, error: String(e) }));
+      };
+      if (document.readyState === "complete") {
+        go();
+      } else {
+        window.addEventListener("load", go, { once: true });
       }
-      ready()
-        .then(done)
-        .catch((e: unknown) => done({ ok: false, error: String(e) }));
     });
     if (!result.ok) {
       throw new Error(`UI init failed: ${result.error}`);

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -19,6 +19,18 @@ import type { Config, DiagnosticsData, Metrics, ProxyStatus, Server } from "./ty
 /// RAM and looks like a port scan from one IP to commercial SS providers.
 export const TEST_CONCURRENCY = 5;
 
+// Test seam: webdriver's `before` hook calls this to park until
+// `init()` has completed (success or failure). `withGlobalTauri: false`
+// strips `window.__TAURI__` from injected scripts, so this typed
+// global is the documented entry point. See
+// `crates/hole/src/ui_ready.rs` and bindreams/hole#383.
+declare global {
+  interface Window {
+    __holeUiReady?: () => Promise<{ ok: boolean; error: string | null }>;
+  }
+}
+window.__holeUiReady = () => invoke<{ ok: boolean; error: string | null }>("wait_ui_ready");
+
 // State ===============================================================================================================
 
 /** The current application config, loaded from the backend. */
@@ -172,55 +184,76 @@ function setupEventListeners() {
 // Initialization ======================================================================================================
 
 async function init() {
-  // Wire the webview into the Rust log pipeline BEFORE anything else so the
-  // subsequent console.error/warn calls are captured, and `window.onerror` /
-  // `window.onunhandledrejection` route through tracing too. The plugin is
-  // registered on the Rust side in main.rs with `.skip_logger()` so JS log
-  // events flow through `log` → `tracing-log::LogTracer` → `gui.log`.
-  await attachConsole();
+  let result: { ok: boolean; error: string | null };
+  try {
+    // Wire the webview into the Rust log pipeline BEFORE anything else so the
+    // subsequent console.error/warn calls are captured, and `window.onerror` /
+    // `window.onunhandledrejection` route through tracing too. The plugin is
+    // registered on the Rust side in main.rs with `.skip_logger()` so JS log
+    // events flow through `log` → `tracing-log::LogTracer` → `gui.log`.
+    await attachConsole();
 
-  window.addEventListener("error", (e) => {
-    logError(`window.error: ${e.message} at ${e.filename}:${e.lineno}:${e.colno}`);
-  });
-  window.addEventListener("unhandledrejection", (e) => {
-    const reason = e.reason instanceof Error ? `${e.reason.message}\n${e.reason.stack ?? ""}` : String(e.reason);
-    logError(`unhandledrejection: ${reason}`);
-  });
-
-  // Initialize UI modules.
-  initSections();
-  initServers();
-  initFilters();
-  initSettings();
-  initSidebar();
-
-  // Replace native scrollbars with fade-in/out overlay scrollbars.
-  const main = document.querySelector<HTMLElement>(".main");
-  if (main) {
-    OverlayScrollbars(main, {
-      scrollbars: { theme: "os-theme-hole", autoHide: "scroll", autoHideDelay: 800 },
+    window.addEventListener("error", (e) => {
+      logError(`window.error: ${e.message} at ${e.filename}:${e.lineno}:${e.colno}`);
     });
-  }
-  const sbContent = document.querySelector<HTMLElement>(".sb-content");
-  if (sbContent) {
-    OverlayScrollbars(sbContent, {
-      scrollbars: { theme: "os-theme-hole", autoHide: "scroll", autoHideDelay: 800 },
+    window.addEventListener("unhandledrejection", (e) => {
+      const reason = e.reason instanceof Error ? `${e.reason.message}\n${e.reason.stack ?? ""}` : String(e.reason);
+      logError(`unhandledrejection: ${reason}`);
     });
+
+    // Initialize UI modules.
+    initSections();
+    initServers();
+    initFilters();
+    initSettings();
+    initSidebar();
+
+    // Replace native scrollbars with fade-in/out overlay scrollbars.
+    const main = document.querySelector<HTMLElement>(".main");
+    if (main) {
+      OverlayScrollbars(main, {
+        scrollbars: { theme: "os-theme-hole", autoHide: "scroll", autoHideDelay: 800 },
+      });
+    }
+    const sbContent = document.querySelector<HTMLElement>(".sb-content");
+    if (sbContent) {
+      OverlayScrollbars(sbContent, {
+        scrollbars: { theme: "os-theme-hole", autoHide: "scroll", autoHideDelay: 800 },
+      });
+    }
+
+    // Load config from backend.
+    await loadConfig();
+
+    // Initial data fetches (all in parallel).
+    await Promise.allSettled([pollProxyStatus(), pollMetrics(), pollDiagnostics(), updatePublicIp()]);
+
+    // Start polling intervals.
+    setInterval(pollProxyStatus, 5000);
+    setInterval(pollMetrics, 1000);
+    setInterval(pollDiagnostics, 5000);
+
+    // Wire up event listeners.
+    setupEventListeners();
+
+    result = { ok: true, error: null };
+  } catch (err) {
+    const msg = err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err);
+    logError(`init failed: ${msg}`);
+    result = { ok: false, error: msg };
   }
 
-  // Load config from backend.
-  await loadConfig();
-
-  // Initial data fetches (all in parallel).
-  await Promise.allSettled([pollProxyStatus(), pollMetrics(), pollDiagnostics(), updatePublicIp()]);
-
-  // Start polling intervals.
-  setInterval(pollProxyStatus, 5000);
-  setInterval(pollMetrics, 1000);
-  setInterval(pollDiagnostics, 5000);
-
-  // Wire up event listeners.
-  setupEventListeners();
+  // Always signal — even on init failure — so the webdriver test
+  // surfaces a real error instead of hanging on the watch channel.
+  try {
+    await invoke("signal_ui_ready", { result });
+  } catch (signalErr) {
+    // If the invoke itself fails the Tauri runtime is broken, which
+    // is an external-event-might-never-happen scenario. The webdriver
+    // test surfaces this via its framework timeout — there is no
+    // intra-process recovery available here.
+    logError(`signal_ui_ready failed: ${signalErr}`);
+  }
 }
 
 init();


### PR DESCRIPTION
## Summary
- Fix the webdriver flake at `dashboard-loads.spec.ts` via an explicit `wait_ui_ready` Tauri-command bridge (UI signals `init()` complete on a `watch` channel; test parks on it via a `__holeUiReady` bundled global that survives `withGlobalTauri: false`).
- Sweep ~16 sleep-for-sync sites across `_tests.rs`, `tests/**/*.rs`, `.spec.ts`, and Python scripts. Replacements: `oneshot::channel<()>` for task rendezvous (MockProxy `start_entered`), in-band sentinel + `mpsc::sync_channel` ack for stdio-relay flush, `tokio::time::pause`+`advance` for elapsed-time assertions in chain drain test, `WaitableWriter` tracing-event waiter for tap/chain integration tests, `on_ready` oneshot for ChainRunner integration tests, JoinHandle return from `spawn_forwarder_self_test`, ready-signal stdin pipe for `hold_file` helper, `shift_started_at_for_test` test seam for `std::time::Instant`-based uptime test, output-sentinel read for `test_console_corruption.py`.
- Make the rule explicit in `~/.claude/CLAUDE.md` (machine-wide) and project `CLAUDE.md` (new `Synchronization invariant` section under Testing). Both surface forms (`sleep(N); check` and `wait_until(predicate, {timeout})`) are forbidden; sole exception is awaiting an external event with graceful failure to a human.

Closes #383.

## Test plan
- [x] `cargo xtask run hole-tests` — 1025/1027 passing locally; the 2 failures (`e2e_socks5_udp_associate_roundtrip`, `e2e_none_full_tunnel_roundtrip`) need Administrator privileges for TUN/routing and fail under the same conditions on main (pre-existing environmental constraint).
- [x] `cargo xtask build hole` — staged dist builds cleanly.
- [x] Modified tests re-run individually and pass: ipc_tests cancel-in-flight/concurrent-start/concurrent-double-cancel/metrics-uptime; proxy_manager_tests uptime-increases/start-cancellable-cancelled/spawn-forwarder-self-test/self-test-empty-servers/self-test-dead-upstream; hole-common logging redirect (basic/grandchild/multiline/tee/no-loop); garter tap (echo/silent-drop/silent-after-read/rst/shutdown-cancels); chain long-running-plugin-survives-past-drain-timeout; counting first-read-at; foreground IPC accept; handle-holders live-holders; chain_integration two_plugin / pid_sink; tap_integration end-to-end.
- [ ] Webdriver suite — requires CI (Vite + WebView2 host). The `before` hook + `wait_ui_ready` Tauri command is the meta-test; the new `ui-ready-sync.spec.ts` regression spec exercises the bridge directly so any future refactor that breaks it fails loudly.

## Out of scope (follow-ups)
- Adaptive flake-detection CI job (10× loop on ex-flaky suites) — file as `azhukova/<N>-followup` if desired.
- Workspace-wide clippy `disallowed_methods` gate on `tokio::time::sleep` / `std::thread::sleep` — considered and rejected ([previous discussion](#383)); ~20 `#[allow]` adds across production for a problem catchable at review.