### PR TITLE
fix(bridge): #388 self-test gate, idempotent teardown, plugin tap config flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,14 @@ Clients on TCP-only plugins (v2ray-plugin, anything without UDP multiplexing) wo
 
 **Upgrade migration**: `AppConfig` already carries `#[serde(default)]`, so existing configs without a `dns` key deserialize with `DnsConfig::default()` — which has `enabled: true`, `protocol: Https`, `servers: [1.1.1.1, 1.0.0.1]`, `intercept_udp53: true`. This enables the forwarder silently on upgrade (per user spec: "enabled on upgrade, no notification").
 
+**Load-bearing start-time gate (#388)**: the bridge runs an inline forwarder self-test inside [`start_inner`](crates/bridge/src/proxy_manager.rs) **before** `Dispatcher::new` / `routing.install` / `apply_dns_settings`. On failure (3×1500ms / 5s budget exhausted, or no DNS servers configured, or `bind_ladder` exhausted) `start_cancellable` returns `Err(ProxyError::ForwarderSelfTestFailed)` and the locally-owned `running_proxy` + `plugin_chain` RAII guards unwind. Routes, system DNS, and the wintun adapter are never touched on this path. Pre-#388 the test was fire-and-forget at `info!` and the proxy committed `Running` while `intercept_udp53` hijacked user DNS into a dead tunnel — see bindreams/hole#388. The `start_blocks_on_forwarder_self_test_failure` test is the ordering invariant guard.
+
+**Behavior changes from #388**:
+
+- `dns.enabled = true` with `servers = []` is now a hard config error (was: silent skip + degenerate runtime).
+- `bind_ladder` exhaustion (all 255 loopback candidates blocked) is now a hard start error (was: silent-degrade to no forwarder). Single conflicting service (pi-hole on `127.0.0.1:53`) still succeeds via the `127.53.0.X:53` ladder.
+- A plugin chain that binds locally but can't reach upstream is now caught at start time; the GUI receives a clear error message instead of a dead tunnel.
+
 ### Bridge test-isolation contract
 
 All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` trait in `crates/bridge/src/proxy.rs` and the `Routing` trait in `crates/tun-engine/src/routing.rs`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in the workspace root `clippy.toml` via the `disallowed_methods` list (`tun_engine::routing::setup_routes` / `teardown_routes`). See bindreams/hole#165 for the incident that motivated the rule.
@@ -164,18 +172,33 @@ TRACE line per TCP connection (≥100/sec under Chrome). Use for
 debugging sessions only; `bridge.log` rotates via
 `MAX_LOG_BYTES`/`MAX_ROTATED_LOGS` so the cap is bounded.
 
-### Plugin tap (HOLE_BRIDGE_PLUGIN_TAP)
+### Plugin tap (AppConfig.diagnostic_plugin_tap / HOLE_BRIDGE_PLUGIN_TAP)
 
 When the bridge's local SOCKS5 listener relays a connection to the
 plugin chain, the boundary in between is normally invisible — the
 plugin process (`v2ray-plugin`, `galoshes`) runs out-of-process and
-its network I/O is not captured by the bridge's ETW consumer. Setting
-`HOLE_BRIDGE_PLUGIN_TAP=1` interposes
-[`garter::TapPlugin`](crates/garter/src/tap.rs) between
-shadowsocks-service and the inner plugin. Per-TCP-connection it logs:
+its network I/O is not captured by the bridge's ETW consumer. Two
+independent gates enable [`garter::TapPlugin`](crates/garter/src/tap.rs)
+to interpose between shadowsocks-service and the inner plugin:
+
+- **`AppConfig.diagnostic_plugin_tap`** — persistent in user settings;
+  travels through `ProxyConfig` IPC, so reaches service-mode bridges
+  (Windows SCM / launchd). Added in bindreams/hole#388 to give
+  service-mode reproductions a knob the env var can't reach.
+- **`HOLE_BRIDGE_PLUGIN_TAP=1`** — dev shell only; env vars don't
+  survive into SCM/launchd. Use for `scripts/dev.py` and hand-run
+  `hole bridge run`.
+
+Either gate enables the tap; the config flag is preferred for
+user-facing reproductions.
+
+Per-TCP-connection the tap logs at `info!`:
 
 - `bytes_to_plugin` / `bytes_from_plugin` — raw byte counts in each
   direction, observed by [`garter::CountingStream`](crates/garter/src/counting.rs).
+  `bytes_to_plugin > 0 && bytes_from_plugin == 0` is the fingerprint
+  of an upstream-dial hang — the #388 reproduction case (v2ray-plugin
+  WebSocket dial silently hung).
 - `ttfb_ms` — milliseconds from `accept` to the first non-zero
   upstream read. `None` means the connection closed without ever
   receiving a byte from the plugin chain — the load-bearing diagnostic
@@ -185,11 +208,22 @@ shadowsocks-service and the inner plugin. Per-TCP-connection it logs:
   cross-platform via Win32+POSIX errno mapping.
 - `close_dir` is implicit in the byte-count asymmetry: if
   `bytes_inbound_read != bytes_inbound_written` an inflight cancel hit.
+- `tap_conn_id` — process-wide monotonic; correlates `accepted` and
+  `closed` lines for one connection.
 
-**Dev-mode only.** Service-mode bridges (Windows SCM / launchd) do not
-inherit user shell env, so the gate is meant for `scripts/dev.py` and
-hand-run `hole bridge run`. Cost: an extra loopback round-trip per
-byte, fine for a debugging session, inappropriate as default.
+**Auto-correlation on self-test failure (#388)**: when the DNS
+forwarder self-test fails AND the tap is enabled, the bridge emits a
+`warn!` breadcrumb directing readers to the preceding `plugin tap: closed`
+lines (text: `TAP_ENABLED_HINT` const in
+[`proxy_manager.rs`](crates/bridge/src/proxy_manager.rs)). When the tap
+is disabled, the failure emits a `warn!` remediation hint telling the
+user to set `diagnostic_plugin_tap=true` for next reproduction
+(`TAP_DISABLED_HINT`).
+
+**Cost.** Extra loopback round-trip per byte; one structured log line
+per TCP connection close. Acceptable for a debugging session, NOT for
+default operation under browser-traffic load (Chrome easily hits >100
+connections/sec).
 
 ### Plugin debug logging (always-on)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,8 +615,9 @@ For intra-process sync, use the codebase's primitives:
 - **"Wait for spawned work to complete"**: return the `JoinHandle`
   from the spawning function and `.await` it. Don't fire-and-forget
   if you might need to wait. See
-  [`spawn_forwarder_self_test`](crates/bridge/src/proxy_manager.rs) for
-  the pattern (returns `Option<JoinHandle<()>>`).
+  [`Dispatcher::shutdown`](crates/bridge/src/dispatcher.rs) for the
+  pattern (`tokio::time::timeout(2s, handle).await` with abort
+  fallback for the wedge case).
 
 ### Windows installer
 

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -142,13 +142,57 @@ impl Dispatcher {
     }
 }
 
-/// Cancel the driver and abort it on drop. This ensures implicit drops
-/// (e.g., from `check_health` or a cancelled `start_cancellable`) do not
-/// leak the driver task. `shutdown()` is preferred for graceful teardown,
-/// but the `Drop` provides a safety net.
+/// Cancel the driver and synchronously drain the spawned task so the
+/// wintun adapter handle (owned by the future) is dropped before this
+/// method returns. `shutdown()` is preferred for graceful teardown; the
+/// `Drop` provides a safety net for non-graceful paths (panic, cancel
+/// mid-`start_inner`, `start_inner` Err that drops the local dispatcher).
+///
+/// **#388 rationale**: pre-#388 this only called `cancel + abort`. The
+/// spawned task that owns the `tun::AsyncDevice` (and therefore the
+/// kernel wintun adapter handle) was abort-flagged but not joined, so
+/// runtime shutdown could happen before the task was polled to its end —
+/// leaving the kernel adapter alive until reboot or
+/// `scripts/network-reset.py`. `block_on` inside Drop works on the
+/// multi-thread runtime the bridge uses in production. Current-thread
+/// runtimes (skuld tests) take the abort-only fallback path, with the
+/// PowerShell `Remove-NetAdapter` shell-out in `SystemRoutes::drop` as
+/// the belt-and-suspenders second layer.
+///
+/// **Graceful path interaction**: `ProxyManager::stop` →
+/// `Dispatcher::shutdown` already calls
+/// `tokio::time::timeout(2s, handle).await`, so the handle is `None`
+/// here on the normal stop path and only the abort fallback runs
+/// (a no-op).
 impl Drop for Dispatcher {
     fn drop(&mut self) {
         self.cancel.cancel();
-        self.driver_abort.abort();
+
+        let Some(handle) = self.driver_handle.take() else {
+            // shutdown() already awaited; nothing to drain.
+            self.driver_abort.abort();
+            return;
+        };
+
+        match tokio::runtime::Handle::try_current() {
+            Ok(rt) if matches!(rt.runtime_flavor(), tokio::runtime::RuntimeFlavor::MultiThread) => {
+                // CRITICAL: use `rt.block_on`, NOT `futures::executor::block_on`.
+                // The `timeout` future needs the tokio reactor; an external
+                // executor would panic with "no reactor running."
+                // `block_in_place` keeps the worker thread available for
+                // other tasks. It panics on a current-thread runtime —
+                // that's why we gated on `MultiThread` above.
+                tokio::task::block_in_place(|| {
+                    let _ = rt.block_on(tokio::time::timeout(std::time::Duration::from_secs(2), handle));
+                });
+            }
+            _ => {
+                // Current-thread runtime (skuld tests) or no runtime —
+                // `block_in_place` would panic. Abort and rely on the
+                // defensive `adapter_cleanup` in `SystemRoutes::drop` to
+                // sweep any leaked wintun adapter.
+                self.driver_abort.abort();
+            }
+        }
     }
 }

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -237,10 +237,14 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
-        dns: hole_common::config::DnsConfig::default(),
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
         proxy_socks5: true,
         proxy_http: false,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     }
 }
 

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -65,6 +65,17 @@ pub enum ProxyError {
     /// A listener is enabled but its port is 0.
     #[error("{field} must be non-zero when the corresponding listener is enabled")]
     InvalidListenerPort { field: &'static str },
+    /// The DNS forwarder self-test failed before TUN routes were installed.
+    /// `routes` / `system DNS` were never touched on this path — the user's
+    /// system DNS is untouched. Used by the start-time gate added in #388
+    /// to prevent the GUI from reporting "Running" while a dead plugin
+    /// chain hijacks all DNS into the tunnel.
+    #[error("forwarder self-test failed after {attempts} attempts in {elapsed_ms}ms: {reason}")]
+    ForwarderSelfTestFailed {
+        reason: String,
+        attempts: u32,
+        elapsed_ms: u64,
+    },
 }
 
 // Error conversions from tun-engine ===================================================================================

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -22,10 +22,14 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: vec![],
-        dns: hole_common::config::DnsConfig::default(),
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
         proxy_socks5: true,
         proxy_http: false,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     }
 }
 

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -112,6 +112,7 @@ pub async fn start_plugin_chain(
     server_host: &str,
     server_port: u16,
     state_dir: Option<&Path>,
+    diagnostic_tap: bool,
 ) -> Result<PluginChain, ProxyError> {
     // Inject a debug-level log directive into the plugin's
     // SS_PLUGIN_OPTIONS unconditionally — Hole owns plugin stderr (it's
@@ -141,6 +142,7 @@ pub async fn start_plugin_chain(
                     server_host,
                     server_port,
                     state_dir,
+                    diagnostic_tap,
                 )
                 .await
                 .map_err(proxy_err_to_io_err)
@@ -157,6 +159,36 @@ pub async fn start_plugin_chain(
     })
 }
 
+/// Sourced gate for the plugin tap. The IPC config flag is the primary
+/// knob (reaches service mode); the env var stays as the dev-shell
+/// fallback for `scripts/dev.py` / hand-run `hole bridge run`.
+#[derive(Debug, Clone, Copy)]
+enum TapSource {
+    Config,
+    EnvVar,
+    None,
+}
+
+impl std::fmt::Display for TapSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Config => "AppConfig.diagnostic_plugin_tap",
+            Self::EnvVar => "HOLE_BRIDGE_PLUGIN_TAP env",
+            Self::None => "off",
+        })
+    }
+}
+
+fn resolve_tap_source(diagnostic_tap: bool) -> TapSource {
+    if diagnostic_tap {
+        TapSource::Config
+    } else if std::env::var_os("HOLE_BRIDGE_PLUGIN_TAP").is_some() {
+        TapSource::EnvVar
+    } else {
+        TapSource::None
+    }
+}
+
 /// Single-attempt plugin-runner spawn. Constructs `BinaryPlugin`
 /// (with optional `pid_sink`), wraps in `TapPlugin` when
 /// `HOLE_BRIDGE_PLUGIN_TAP=1`, builds the `ChainRunner`, spawns it,
@@ -165,6 +197,7 @@ pub async fn start_plugin_chain(
 /// `bind_ephemeral` doesn't leak the previous attempt's task. On
 /// success returns `(handle, cancel, ready_addr)` — the caller wraps
 /// these in a [`PluginChain`].
+#[allow(clippy::too_many_arguments)] // 8 args — already at the limit before #388 added diagnostic_tap; bundling into a struct adds more noise than the warning.
 async fn spawn_plugin_runner_at(
     plugin_name: &str,
     plugin_path: &str,
@@ -173,6 +206,7 @@ async fn spawn_plugin_runner_at(
     server_host: &str,
     server_port: u16,
     state_dir: Option<&Path>,
+    diagnostic_tap: bool,
 ) -> Result<
     (
         tokio::task::JoinHandle<garter::Result<()>>,
@@ -214,21 +248,21 @@ async fn spawn_plugin_runner_at(
         plugin_options: merged_opts.map(String::from),
     };
 
-    // #267: when `HOLE_BRIDGE_PLUGIN_TAP=1` is set, wrap the plugin in a
-    // counting tap so per-connection byte flow becomes visible in
-    // `bridge.log` (`bytes_to_plugin`, `bytes_from_plugin`, `ttfb_ms`,
-    // `close_kind`). Dev-mode only — env vars do not survive into
-    // SCM/launchd service contexts. Off by default; the extra loopback
-    // hop is cheap on debug-mode reproduction but inappropriate at
-    // browser-traffic scale.
-    let plugin: Box<dyn garter::ChainPlugin> = if std::env::var_os("HOLE_BRIDGE_PLUGIN_TAP").is_some() {
-        tracing::info!(
-            plugin = plugin_name,
-            "HOLE_BRIDGE_PLUGIN_TAP=1: wrapping plugin in TapPlugin"
-        );
-        Box::new(garter::TapPlugin::wrap(Box::new(plugin)))
-    } else {
+    // #267 + #388: wrap plugin in counting `TapPlugin` so per-TCP
+    // connection byte flow + close-kind become visible in `bridge.log`.
+    // Two gates compose:
+    //   - `AppConfig.diagnostic_plugin_tap` via `ProxyConfig` IPC field
+    //     (reaches service mode — #388).
+    //   - `HOLE_BRIDGE_PLUGIN_TAP=1` env var (dev shell only — env vars
+    //     don't survive into SCM/launchd contexts — #267).
+    // Off by default; the extra loopback hop is cheap on debug-mode
+    // reproduction but inappropriate at browser-traffic scale.
+    let tap_source = resolve_tap_source(diagnostic_tap);
+    let plugin: Box<dyn garter::ChainPlugin> = if matches!(tap_source, TapSource::None) {
         Box::new(plugin)
+    } else {
+        tracing::info!(plugin = plugin_name, %tap_source, "wrapping plugin in TapPlugin");
+        Box::new(garter::TapPlugin::wrap(Box::new(plugin)))
     };
 
     let runner = garter::ChainRunner::new()

--- a/crates/bridge/src/proxy/plugin_tests.rs
+++ b/crates/bridge/src/proxy/plugin_tests.rs
@@ -2,7 +2,16 @@ use super::start_plugin_chain;
 
 #[skuld::test]
 async fn start_with_nonexistent_binary_returns_plugin_error() {
-    let result = start_plugin_chain("v2ray-plugin", "/nonexistent/binary", None, "127.0.0.1", 12345, None).await;
+    let result = start_plugin_chain(
+        "v2ray-plugin",
+        "/nonexistent/binary",
+        None,
+        "127.0.0.1",
+        12345,
+        None,
+        false,
+    )
+    .await;
 
     let err = result.unwrap_err();
     assert!(

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -370,6 +370,7 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 &config.server.server,
                 config.server.server_port,
                 state_dir,
+                config.diagnostic_plugin_tap,
             )
             .await?;
             Some(chain)
@@ -455,19 +456,57 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // Compile filter rules.
         let ruleset = crate::filter::rules::RuleSet::from_user_rules(&config.filters);
 
-        // Start the SS SOCKS5 proxy.
+        // CRITICAL ORDERING (bindreams/hole#388):
+        //
+        //   1. proxy.start  — binds local SS listener
+        //   2. build_local_dns  — binds loopback DNS server (Err on no
+        //      listen capacity, or on degenerate dns.enabled + empty
+        //      servers config)
+        //   3. GATE: run_forwarder_self_test  — Err here means the plugin
+        //      chain cannot reach upstream. RAII unwind drops
+        //      running_proxy + plugin_chain locally. NO state outside
+        //      this fn is mutated.
+        //   4. Dispatcher::new  — only NOW does LocalDnsEndpoint become
+        //      reachable through the cascade
+        //   5. routing.install  — TUN routes go live, intercept_udp53
+        //      activates
+        //   6. apply_dns_settings  — system DNS pointed at our loopback
+        //
+        // Reordering steps 3..=6 re-introduces the #388 symptom (dead-
+        // tunnel DNS hijack with the GUI reporting "Running"). The
+        // start_blocks_on_forwarder_self_test_failure test catches the
+        // most likely regression (asserting routing.install was NOT
+        // called when the gate fails).
+
+        // (1) Start the SS SOCKS5 proxy.
         let running_proxy = proxy.start(ss_config).await?;
 
-        // DNS forwarder wiring. Must happen BEFORE Dispatcher::new so the
-        // LocalDnsEndpoint can be passed in as a constructor argument —
-        // HoleRouter has no mutable registration API. We wire the
-        // forwarder's upstream through the just-started SS SOCKS5
-        // listener (Socks5Connector) so user filter rules that Block the
-        // resolver IP cannot strand our own queries. See `dns/mod.rs`.
-        let (local_dns_server, local_dns_endpoint) =
-            build_local_dns(&config.dns, config.local_port, gw_info.ipv6_available).await;
+        // (2) Build local DNS forwarder + server. Now Err on bind failure
+        // (was silent-degrade pre-#388). Returns the forwarder Arc so
+        // the gate can drive it without re-plumbing.
+        let (local_dns_server, local_dns_endpoint, forwarder) =
+            build_local_dns(&config.dns, config.local_port, gw_info.ipv6_available).await?;
 
-        // Start the dispatcher (owns TUN device + smoltcp). Skipped
+        // (3) Blocking forwarder self-test gate. Runs synchronously
+        // BEFORE Dispatcher::new / routing.install / apply_dns_settings.
+        // On Err, the locally-owned `running_proxy` Drop aborts the SS
+        // task and `plugin_chain` (further up the stack) Drop SIGTERMs
+        // the chain. System state is untouched. The gate is
+        // cancellation-safe via the outer `tokio::select!` in
+        // start_cancellable — dropping the future cleanly releases all
+        // in-flight forwarder connections.
+        if let Some(fwd) = forwarder.as_ref() {
+            let started = std::time::Instant::now();
+            let outcome = run_forwarder_self_test(
+                std::sync::Arc::clone(fwd),
+                config.dns.servers.clone(),
+                config.diagnostic_plugin_tap,
+            )
+            .await;
+            outcome.into_result(started.elapsed().as_millis() as u64)?;
+        }
+
+        // (4) Start the dispatcher (owns TUN device + smoltcp). Skipped
         // under #[cfg(test)] because creating a TUN requires elevation.
         #[cfg(not(test))]
         let dispatcher = {
@@ -489,10 +528,10 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             None
         };
 
-        // Install the routes — NOW traffic starts flowing to the TUN.
+        // (5) Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
-        // Apply system DNS AFTER routes install so the OS "best-route to
+        // (6) Apply system DNS AFTER routes install so the OS "best-route to
         // DNS server" lookup resolves through the TUN (its DNS setting is
         // our loopback IP). Persist the prior state to `bridge-dns.json`
         // BEFORE mutating so a mid-apply crash leaves a recoverable file.
@@ -717,20 +756,46 @@ mod proxy_manager_listener_e2e_tests;
 
 // DNS wiring helpers ==================================================================================================
 
-/// Build the local DNS server + endpoint, if the config enables it. The
-/// forwarder's upstream runs via [`crate::dns::socks5_connector::Socks5Connector`]
+/// Build the local DNS server + endpoint + forwarder, if the config enables
+/// it. The forwarder's upstream runs via [`crate::dns::socks5_connector::Socks5Connector`]
 /// targeting the just-started SS SOCKS5 listener, so user filter rules
 /// cannot strand our own queries.
+///
+/// Returns the `forwarder` Arc alongside the server + endpoint so the
+/// blocking self-test gate in `start_inner` can call `forwarder.forward(...)`
+/// without re-plumbing.
+///
+/// **#388 change**: previously returned `(None, None)` silently when
+/// `bind_ladder` failed; now returns `Err(ProxyError::Runtime(io::Error))`.
+/// Also rejects the `dns.enabled && servers.is_empty()` config combination
+/// with `ForwarderSelfTestFailed { reason: "no DNS servers configured" }`
+/// because that combination would otherwise produce a degenerate runtime
+/// (TUN routes go live but forwarder has nothing to forward to).
 async fn build_local_dns(
     dns_cfg: &hole_common::config::DnsConfig,
     local_ss_port: u16,
     ipv6_bypass_available: bool,
-) -> (
-    Option<crate::dns::server::LocalDnsServer>,
-    Option<crate::endpoint::LocalDnsEndpoint>,
-) {
+) -> Result<
+    (
+        Option<crate::dns::server::LocalDnsServer>,
+        Option<crate::endpoint::LocalDnsEndpoint>,
+        Option<std::sync::Arc<crate::dns::forwarder::DnsForwarder>>,
+    ),
+    ProxyError,
+> {
     if !dns_cfg.enabled {
-        return (None, None);
+        return Ok((None, None, None));
+    }
+    if dns_cfg.servers.is_empty() {
+        // Hard error: the only sensible recovery is to disable the forwarder.
+        // Pre-#388 this silently returned (None, None) which left TUN routes
+        // live with intercept_udp53 hijacking UDP/53 into a forwarder that
+        // had no upstream — a worse failure mode than failing loud here.
+        return Err(ProxyError::ForwarderSelfTestFailed {
+            reason: "no DNS servers configured".into(),
+            attempts: 0,
+            elapsed_ms: 0,
+        });
     }
 
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -745,22 +810,8 @@ async fn build_local_dns(
         ipv6_bypass_available,
     ));
 
-    let server = match crate::dns::server::LocalDnsServer::bind_ladder(Arc::clone(&forwarder)).await {
-        Ok(s) => s,
-        Err(e) => {
-            error!(error = %e, "LocalDnsServer::bind_ladder failed; DNS forwarder disabled for this session");
-            return (None, None);
-        }
-    };
+    let server = crate::dns::server::LocalDnsServer::bind_ladder(Arc::clone(&forwarder)).await?;
     info!(addr = %server.addr(), "LocalDnsServer bound");
-
-    // Fire a detached self-test so Phase-2 observation of #248 can tell
-    // "forwarder works at bind time; later query failures are downstream"
-    // from "forwarder is fundamentally broken right now". Spawned via
-    // `tokio::spawn` so a dead upstream cannot stall `start_inner` by the
-    // retry budget — the contract is that `build_local_dns` returns
-    // regardless of self-test outcome.
-    let _ = spawn_forwarder_self_test(Arc::clone(&forwarder), dns_cfg.servers.clone());
 
     let endpoint = if dns_cfg.intercept_udp53 {
         Some(crate::endpoint::LocalDnsEndpoint::new(Arc::clone(&forwarder)))
@@ -768,88 +819,117 @@ async fn build_local_dns(
         None
     };
 
-    (Some(server), endpoint)
+    Ok((Some(server), endpoint, Some(forwarder)))
 }
 
-/// Spawn a detached task that exercises the forwarder against its first
-/// configured server. Log-only — never propagates, never blocks
-/// [`build_local_dns`]. Runs 3 attempts with a 1500ms per-attempt
-/// timeout, wrapped in a 5s outer budget (3 × 1500 = 4.5s < 5s with
-/// slack). No back-off: the retry is to absorb plugin-handshake settle
-/// at cold start, which completes or doesn't within ~2s.
+/// Hint logged on self-test failure when the plugin tap IS enabled.
+/// Tells the reader where the per-connection diagnostic lines are.
+pub(crate) const TAP_ENABLED_HINT: &str =
+    "DNS self-test failed with plugin tap enabled; check 'plugin tap: closed' lines above for per-connection bytes_to_plugin / bytes_from_plugin / ttfb_ms / close_kind";
+
+/// Hint logged on self-test failure when the plugin tap is NOT enabled.
+/// Tells the reader how to capture richer diagnostics next time.
+pub(crate) const TAP_DISABLED_HINT: &str =
+    "DNS self-test failed; to capture per-connection plugin diagnostics on next reproduction, set diagnostic_plugin_tap=true in AppConfig and restart the bridge";
+
+/// Run the forwarder self-test inline against its first configured server.
+/// Returns `SelfTestOutcome::Ok` when any well-formed non-SERVFAIL reply
+/// comes back within the 3×1500ms / 5s budget, else `Failed`. Also writes
+/// the canonical `"forwarder self-test ok"` / `"forwarder self-test failed"`
+/// log line at `info!`. On failure, additionally emits a `warn!`
+/// correlation breadcrumb pointing the reader to the plugin tap
+/// (depending on whether it was enabled this run — see
+/// `TAP_ENABLED_HINT` / `TAP_DISABLED_HINT`).
 ///
-/// Target name: `example.com A`. NXDOMAIN counts as success — the
-/// self-test is a path probe, not a correctness probe.
-fn spawn_forwarder_self_test(
+/// **#388 change**: replaces the pre-#388 `spawn_forwarder_self_test`
+/// (fire-and-forget). Called from `start_inner` BEFORE
+/// `Dispatcher::new` / `routing.install` / `apply_dns_settings`. A
+/// failure short-circuits the start; the locally-owned `running_proxy` +
+/// `plugin_chain` RAII guards unwind without ever hijacking system DNS
+/// into a dead tunnel.
+async fn run_forwarder_self_test(
     forwarder: std::sync::Arc<crate::dns::forwarder::DnsForwarder>,
     servers: Vec<std::net::IpAddr>,
-) -> Option<tokio::task::JoinHandle<()>> {
+    diagnostic_tap_enabled: bool,
+) -> SelfTestOutcome {
     const PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(1500);
     const OUTER_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
     const ATTEMPTS: u32 = 3;
 
     let Some(&first_server) = servers.first() else {
         info!("forwarder self-test skipped: no servers configured");
-        return None;
+        return SelfTestOutcome::Ok { attempts: 0 };
     };
 
-    Some(tokio::spawn(async move {
-        let query = sample_self_test_query();
-        let started = std::time::Instant::now();
-        let outcome = tokio::time::timeout(OUTER_BUDGET, async {
-            let mut last_err: Option<String> = None;
-            for attempt in 1..=ATTEMPTS {
-                match tokio::time::timeout(PER_ATTEMPT, forwarder.forward(&query)).await {
-                    Ok(reply) => {
-                        // Treat "any well-formed DNS reply" as success. SERVFAIL
-                        // means upstream explicitly failed (bad), but NXDOMAIN /
-                        // NoError+empty means the path works (good). Distinguish
-                        // via the RCODE nibble.
-                        if reply.len() >= 12 && (reply[3] & 0x0F) != 2 {
-                            return SelfTestOutcome::Ok { attempts: attempt };
-                        }
-                        last_err = Some(format!("SERVFAIL reply on attempt {attempt}"));
+    let query = sample_self_test_query();
+    let started = std::time::Instant::now();
+    let outcome = tokio::time::timeout(OUTER_BUDGET, async {
+        let mut last_err: Option<String> = None;
+        for attempt in 1..=ATTEMPTS {
+            match tokio::time::timeout(PER_ATTEMPT, forwarder.forward(&query)).await {
+                Ok(reply) => {
+                    if reply.len() >= 12 && (reply[3] & 0x0F) != 2 {
+                        return SelfTestOutcome::Ok { attempts: attempt };
                     }
-                    Err(_) => last_err = Some(format!("attempt {attempt} timed out after {PER_ATTEMPT:?}")),
+                    last_err = Some(format!("SERVFAIL reply on attempt {attempt}"));
                 }
-            }
-            SelfTestOutcome::Failed {
-                attempts: ATTEMPTS,
-                reason: last_err.unwrap_or_else(|| "unknown".into()),
-            }
-        })
-        .await
-        .unwrap_or(SelfTestOutcome::Failed {
-            attempts: ATTEMPTS,
-            reason: format!("outer timeout after {OUTER_BUDGET:?}"),
-        });
-
-        let elapsed_ms = started.elapsed().as_millis() as u64;
-        match outcome {
-            SelfTestOutcome::Ok { attempts } => {
-                info!(
-                    %first_server,
-                    attempts,
-                    elapsed_ms,
-                    "forwarder self-test ok"
-                );
-            }
-            SelfTestOutcome::Failed { attempts, reason } => {
-                info!(
-                    %first_server,
-                    attempts,
-                    elapsed_ms,
-                    reason,
-                    "forwarder self-test failed"
-                );
+                Err(_) => last_err = Some(format!("attempt {attempt} timed out after {PER_ATTEMPT:?}")),
             }
         }
-    }))
+        SelfTestOutcome::Failed {
+            attempts: ATTEMPTS,
+            reason: last_err.unwrap_or_else(|| "unknown".into()),
+        }
+    })
+    .await
+    .unwrap_or(SelfTestOutcome::Failed {
+        attempts: ATTEMPTS,
+        reason: format!("outer timeout after {OUTER_BUDGET:?}"),
+    });
+
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    match &outcome {
+        SelfTestOutcome::Ok { attempts } => {
+            info!(%first_server, attempts, elapsed_ms, "forwarder self-test ok");
+        }
+        SelfTestOutcome::Failed { attempts, reason } => {
+            info!(%first_server, attempts, elapsed_ms, reason, "forwarder self-test failed");
+            // #388 correlation breadcrumb: tells the reader either
+            // where the tap data lives, or how to enable it for next
+            // reproduction. The actual error surfaces through
+            // ProxyError::ForwarderSelfTestFailed → IPC response →
+            // GUI; no error! log needed.
+            if diagnostic_tap_enabled {
+                warn!("{TAP_ENABLED_HINT}");
+            } else {
+                warn!("{TAP_DISABLED_HINT}");
+            }
+        }
+    }
+    outcome
 }
 
+#[derive(Debug)]
 enum SelfTestOutcome {
     Ok { attempts: u32 },
     Failed { attempts: u32, reason: String },
+}
+
+impl SelfTestOutcome {
+    /// Convert outcome to a Result for use as a start-time gate.
+    /// `Ok(attempts)` carries the attempt count taken to succeed (0 when
+    /// skipped because no servers configured — only reachable via the
+    /// `dns.enabled = false` branch in `build_local_dns`).
+    fn into_result(self, elapsed_ms: u64) -> Result<u32, ProxyError> {
+        match self {
+            Self::Ok { attempts } => Ok(attempts),
+            Self::Failed { attempts, reason } => Err(ProxyError::ForwarderSelfTestFailed {
+                reason,
+                attempts,
+                elapsed_ms,
+            }),
+        }
+    }
 }
 
 /// Build a minimal wire-format DNS query: `example.com A`. Used by

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -458,14 +458,18 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
 
         // CRITICAL ORDERING (bindreams/hole#388):
         //
+        //   0. (above) plugin_chain spawn  — plugin subprocess is alive
+        //      from this point. NOT a system-state mutation (the chain
+        //      Drop SIGTERMs it on unwind) but the user sees the
+        //      v2ray-plugin process briefly.
         //   1. proxy.start  — binds local SS listener
         //   2. build_local_dns  — binds loopback DNS server (Err on no
         //      listen capacity, or on degenerate dns.enabled + empty
         //      servers config)
         //   3. GATE: run_forwarder_self_test  — Err here means the plugin
         //      chain cannot reach upstream. RAII unwind drops
-        //      running_proxy + plugin_chain locally. NO state outside
-        //      this fn is mutated.
+        //      running_proxy + plugin_chain locally. NO system state
+        //      (routes / system DNS / TUN adapter) is mutated.
         //   4. Dispatcher::new  — only NOW does LocalDnsEndpoint become
         //      reachable through the cascade
         //   5. routing.install  — TUN routes go live, intercept_udp53
@@ -637,7 +641,12 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             && active.dns == config.dns
             && active.proxy_socks5 == config.proxy_socks5
             && active.proxy_http == config.proxy_http
-            && active.local_port_http == config.local_port_http;
+            && active.local_port_http == config.local_port_http
+            // #388: toggling diagnostic_plugin_tap wraps/unwraps the
+            // plugin chain in TapPlugin, which is fixed at chain
+            // construction. Hot-swap can't rebuild the chain — force
+            // full stop + start so the new tap state takes effect.
+            && active.diagnostic_plugin_tap == config.diagnostic_plugin_tap;
 
         if structural_same {
             // Fast path: hot-swap filter rules without restart.
@@ -868,7 +877,7 @@ async fn run_forwarder_self_test(
         for attempt in 1..=ATTEMPTS {
             match tokio::time::timeout(PER_ATTEMPT, forwarder.forward(&query)).await {
                 Ok(reply) => {
-                    if reply.len() >= 12 && (reply[3] & 0x0F) != 2 {
+                    if is_dns_reply_ok(&reply) {
                         return SelfTestOutcome::Ok { attempts: attempt };
                     }
                     last_err = Some(format!("SERVFAIL reply on attempt {attempt}"));
@@ -932,8 +941,16 @@ impl SelfTestOutcome {
     }
 }
 
+/// Treat "any well-formed DNS reply that isn't SERVFAIL" as success.
+/// The reply header is 12 bytes; RCODE lives in the low nibble of byte 3
+/// (RFC 1035 §4.1.1). RCODE 2 = SERVFAIL (upstream failed explicitly);
+/// all other RCODEs (NoError, NXDOMAIN, REFUSED) mean the path works.
+fn is_dns_reply_ok(reply: &[u8]) -> bool {
+    reply.len() >= 12 && (reply[3] & 0x0F) != 2
+}
+
 /// Build a minimal wire-format DNS query: `example.com A`. Used by
-/// [`spawn_forwarder_self_test`] — hardcoded hostname is acceptable
+/// [`run_forwarder_self_test`] — hardcoded hostname is acceptable
 /// because the forwarder self-test is an internal probe, never a user-
 /// visible config. NXDOMAIN on this name still proves the path works.
 fn sample_self_test_query() -> Vec<u8> {

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -104,10 +104,14 @@ async fn run_socks_only_e2e(dist: &Path, ss: &SsServerHandle, http: &HttpTarget)
         local_port,
         tunnel_mode: TunnelMode::SocksOnly,
         filters: vec![],
-        dns: hole_common::config::DnsConfig::default(),
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
         proxy_socks5: true,
         proxy_http: false,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     };
 
     let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -213,10 +217,14 @@ mod tun {
             local_port,
             tunnel_mode: TunnelMode::Full,
             filters: vec![],
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         };
 
         let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
@@ -289,10 +297,14 @@ fn lifecycle_start_twice_returns_error(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -344,10 +356,14 @@ fn lifecycle_reload_changes_local_port(
             local_port: port1,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -388,10 +404,14 @@ fn lifecycle_state_file_absent_in_socks_only_mode(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -442,10 +462,14 @@ fn cipher_chacha20_ietf_poly1305_roundtrip(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();
@@ -487,10 +511,14 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
             local_port,
             tunnel_mode: TunnelMode::SocksOnly,
             filters: vec![],
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         };
 
         let mut harness = DistHarness::spawn(dist).await.unwrap();

--- a/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
@@ -50,10 +50,14 @@ fn base_config(ss: &SsServerHandle, local_port: u16, local_port_http: u16) -> Pr
         local_port,
         tunnel_mode: TunnelMode::SocksOnly,
         filters: vec![],
-        dns: hole_common::config::DnsConfig::default(),
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
         proxy_socks5: true,
         proxy_http: false,
         local_port_http,
+        diagnostic_plugin_tap: false,
     }
 }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -296,10 +296,19 @@ fn test_config() -> ProxyConfig {
         local_port: 1080,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
-        dns: hole_common::config::DnsConfig::default(),
+        // dns.enabled = false avoids the #388 forwarder self-test gate in
+        // happy-path tests — MockProxy doesn't bind a real TCP listener,
+        // so the forwarder's Socks5Connector to `127.0.0.1:1080` would
+        // time out after 4.5s on every test. Tests that exercise the
+        // gate enable DNS explicitly (see the self_test mod).
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
         proxy_socks5: true,
         proxy_http: false,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     }
 }
 
@@ -1037,14 +1046,14 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
         });
 }
 
-// Phase 1 #248 — forwarder self-test tests ============================================================================
+// #388 — forwarder self-test gate tests ===============================================================================
 //
-// `build_local_dns` fires a detached post-bind self-test (via
-// `spawn_forwarder_self_test`) so Phase 2 observation can tell
-// "forwarder works at bind time" from "forwarder is fundamentally
-// broken". These tests assert log output + the detach contract
-// (spawn_forwarder_self_test must return immediately; the spawned task
-// runs in the background).
+// `start_inner` runs `run_forwarder_self_test` synchronously BEFORE
+// installing TUN routes / applying system DNS. A failed gate returns
+// `Err(ProxyError::ForwarderSelfTestFailed)` and the locally-owned RAII
+// guards unwind without ever hijacking the user's system DNS into a
+// dead tunnel. Pre-#388 the self-test was fire-and-forget; the proxy
+// committed Running before the test even completed.
 
 #[cfg(test)]
 mod self_test {
@@ -1061,7 +1070,7 @@ mod self_test {
 
     /// A connector that immediately fails every connect. Drives the
     /// dead-upstream path in tests — the forwarder will fail every
-    /// attempt, but the spawned self-test must not stall the caller.
+    /// attempt, surfacing as `SelfTestOutcome::Failed`.
     struct DeadConnector;
     #[async_trait]
     impl UpstreamConnector for DeadConnector {
@@ -1082,41 +1091,15 @@ mod self_test {
         }
     }
 
-    /// Core contract: `spawn_forwarder_self_test` must return to its caller
-    /// immediately regardless of how slow the self-test itself is. The
-    /// 3×1500ms + 5s budget runs on a detached tokio task; the caller is
-    /// never blocked.
+    /// Empty servers → `run_forwarder_self_test` logs `skipped` and
+    /// returns `Ok(0)`. Empty-servers in production is rejected at
+    /// `build_local_dns` *before* `run_forwarder_self_test` is even
+    /// called (test below: `gate_returns_err_for_empty_servers_via_build_local_dns`);
+    /// this test pins the helper's contract in isolation.
     #[skuld::test]
-    fn spawn_forwarder_self_test_returns_immediately() {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(async {
-                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                let start = std::time::Instant::now();
-                let handle = spawn_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()]);
-                let elapsed = start.elapsed();
-                assert!(
-                    elapsed < std::time::Duration::from_millis(100),
-                    "spawn_forwarder_self_test must return immediately (tokio::spawn is \
-                     non-blocking); returned after {elapsed:?}"
-                );
-                // Abort the spawned task so the test doesn't have to wait
-                // out the 3×1500ms retry budget. The handle is None when
-                // servers is empty; here it is Some.
-                handle.expect("Some(handle) when servers is non-empty").abort();
-            });
-    }
-
-    /// When `dns_cfg.servers` is empty, the self-test must log a `skipped`
-    /// line and never call into the forwarder.
-    #[skuld::test]
-    fn self_test_empty_servers_logs_skipped() {
+    fn self_test_empty_servers_returns_ok_zero() {
         let writer = VecWriter::new();
 
-        // Current-thread runtime — the helper asserts this. See
-        // bindreams/hole#302.
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1131,11 +1114,8 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                // Empty servers — the skipped-log fires synchronously
-                // inside the function and `spawn_forwarder_self_test`
-                // returns None (no task spawned). No wait needed.
-                let handle = spawn_forwarder_self_test(forwarder, vec![]);
-                assert!(handle.is_none(), "no task should be spawned when servers is empty");
+                let outcome = run_forwarder_self_test(forwarder, vec![], false).await;
+                assert!(matches!(outcome, SelfTestOutcome::Ok { attempts: 0 }));
             });
 
         let output = writer.snapshot_string();
@@ -1145,15 +1125,14 @@ mod self_test {
         );
     }
 
-    /// Dead upstream → self-test must log `forwarder self-test failed` at
-    /// INFO with `attempts=3`. This is the signal Phase 2 uses to know the
-    /// tunnel itself is broken, not a transient later issue.
+    /// Dead upstream → `run_forwarder_self_test` returns
+    /// `SelfTestOutcome::Failed { attempts: 3, .. }` and logs `forwarder
+    /// self-test failed` at INFO. `into_result` then maps that to
+    /// `ProxyError::ForwarderSelfTestFailed`.
     #[skuld::test]
-    fn self_test_dead_upstream_logs_failed() {
+    fn self_test_dead_upstream_returns_failed() {
         let writer = VecWriter::new();
 
-        // Current-thread runtime — see `self_test_empty_servers_logs_skipped`
-        // for why the shared multi-thread `rt()` doesn't work here.
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1168,12 +1147,30 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                let handle = spawn_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()])
-                    .expect("Some(handle) when servers is non-empty");
-                // Park until the self-test task exits — deterministic,
-                // no sleep. The retry budget (3 × 1500ms with 5s outer
-                // timeout) is internal to the spawned future.
-                handle.await.expect("self-test task panicked");
+                let outcome = run_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()], false).await;
+                let SelfTestOutcome::Failed { attempts, reason } = outcome else {
+                    panic!("expected Failed");
+                };
+                assert_eq!(attempts, 3);
+                assert!(
+                    !reason.is_empty(),
+                    "Failed reason must be non-empty for diagnostic value"
+                );
+                // into_result maps to the canonical error variant.
+                let err = SelfTestOutcome::Failed {
+                    attempts: 3,
+                    reason: reason.clone(),
+                }
+                .into_result(4500)
+                .unwrap_err();
+                assert!(matches!(
+                    err,
+                    ProxyError::ForwarderSelfTestFailed {
+                        attempts: 3,
+                        elapsed_ms: 4500,
+                        ..
+                    }
+                ));
             });
 
         let output = writer.snapshot_string();
@@ -1182,5 +1179,197 @@ mod self_test {
             "expected 'forwarder self-test failed' in log; got:\n{output}"
         );
         assert!(output.contains("INFO"), "expected INFO level; got:\n{output}");
+    }
+
+    /// **#388**: when self-test fails AND `diagnostic_plugin_tap=true`,
+    /// emit a `warn!` breadcrumb pointing the reader to the tap output
+    /// above. Const-anchored so a text change breaks only the const.
+    #[skuld::test]
+    fn self_test_failure_with_tap_enabled_emits_correlation_hint() {
+        let writer = VecWriter::new();
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
+                let _ = run_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()], true).await;
+            });
+
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains(super::TAP_ENABLED_HINT),
+            "expected TAP_ENABLED_HINT in log; got:\n{output}"
+        );
+        assert!(
+            !output.contains(super::TAP_DISABLED_HINT),
+            "tap=true must NOT emit the disabled hint; got:\n{output}"
+        );
+    }
+
+    /// **#388**: when self-test fails AND tap is OFF, emit a `warn!`
+    /// remediation hint pointing the reader to the config flag.
+    #[skuld::test]
+    fn self_test_failure_without_tap_emits_remediation_hint() {
+        let writer = VecWriter::new();
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
+                let _ = run_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()], false).await;
+            });
+
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains(super::TAP_DISABLED_HINT),
+            "expected TAP_DISABLED_HINT in log; got:\n{output}"
+        );
+        assert!(
+            !output.contains(super::TAP_ENABLED_HINT),
+            "tap=false must NOT emit the enabled hint; got:\n{output}"
+        );
+    }
+
+    /// `build_local_dns` rejects the degenerate `enabled=true, servers=[]`
+    /// config combination as `ForwarderSelfTestFailed`. Pre-#388 this
+    /// silently returned `(None, None)` and left TUN routes live with
+    /// `intercept_udp53` hijacking UDP/53 into a forwarder with no
+    /// upstream.
+    #[skuld::test]
+    fn build_local_dns_returns_err_for_empty_servers() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let cfg = DnsConfig {
+                    enabled: true,
+                    servers: vec![], // degenerate
+                    protocol: DnsProtocol::PlainTcp,
+                    intercept_udp53: true,
+                };
+                match build_local_dns(&cfg, 1080, false).await {
+                    Err(ProxyError::ForwarderSelfTestFailed {
+                        attempts: 0,
+                        elapsed_ms: 0,
+                        ..
+                    }) => {}
+                    Err(other) => panic!("unexpected error variant: {other:?}"),
+                    Ok(_) => panic!("expected ForwarderSelfTestFailed for empty servers"),
+                }
+            });
+    }
+
+    /// `dns.enabled = false` → `build_local_dns` returns
+    /// `(None, None, None)` → gate is skipped entirely in `start_inner`.
+    #[skuld::test]
+    fn build_local_dns_returns_none_when_disabled() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let cfg = DnsConfig {
+                    enabled: false,
+                    servers: vec![],
+                    protocol: DnsProtocol::PlainTcp,
+                    intercept_udp53: true,
+                };
+                let res = build_local_dns(&cfg, 1080, false).await;
+                let (srv, ep, fwd) = match res {
+                    Ok(t) => t,
+                    Err(e) => panic!("expected Ok((None, None, None)) for disabled DNS, got {e:?}"),
+                };
+                assert!(srv.is_none());
+                assert!(ep.is_none());
+                assert!(fwd.is_none());
+            });
+    }
+
+    /// **Load-bearing**: when the forwarder self-test fails, `start_cancellable`
+    /// returns `Err(ForwarderSelfTestFailed)` AND `routing.install` is NEVER
+    /// called. Catches any future regression that re-orders the gate
+    /// AFTER route install — re-introducing the #388 dead-tunnel DNS hijack.
+    ///
+    /// Test plumbing: `MockProxy::new()` does not bind a real TCP listener
+    /// on `127.0.0.1:1080`, so the forwarder's `Socks5Connector` connection
+    /// fails with ECONNREFUSED on every attempt (the 3×1500ms loop closes
+    /// fast on each refused connect, well under the 5s outer budget).
+    /// `bind_ladder` succeeds because the test process can bind one of the
+    /// `127.53.0.X:53` loopback alternates.
+    #[skuld::test]
+    fn start_blocks_on_forwarder_self_test_failure() {
+        rt().block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let routing_state = routing.state();
+            let state_path = dir.path().join(route_state::STATE_FILE_NAME);
+
+            let (mut pm, _dir) = new_manager_with_routing(MockProxy::new(), routing, dir);
+
+            // Enable the DNS gate. The forwarder will fail because nothing
+            // listens on `127.0.0.1:<local_port>` (MockProxy.start returns
+            // Ok without binding).
+            let mut cfg = test_config();
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec!["127.0.0.1".parse().unwrap()];
+
+            let err = pm.start_cancellable(&cfg, CancellationToken::new()).await.unwrap_err();
+
+            assert!(
+                matches!(err, ProxyError::ForwarderSelfTestFailed { .. }),
+                "expected ForwarderSelfTestFailed, got {err:?}"
+            );
+            assert_eq!(pm.state(), ProxyState::Stopped);
+            assert_eq!(
+                routing_state.install_calls.load(Ordering::SeqCst),
+                0,
+                "routing.install MUST NOT be called when self-test fails (#388 regression guard)"
+            );
+            assert_eq!(routing_state.teardown_calls.load(Ordering::SeqCst), 0);
+            assert!(!state_path.exists(), "no state file when install never ran");
+            assert!(
+                pm.last_error()
+                    .map(|s| s.contains("forwarder self-test failed"))
+                    .unwrap_or(false),
+                "last_error should mention the self-test failure; got {:?}",
+                pm.last_error()
+            );
+        });
+    }
+
+    /// `dns.enabled = false` → start happy path is unchanged. Gate is
+    /// skipped; routes install; proxy transitions to Running.
+    #[skuld::test]
+    fn start_succeeds_when_dns_disabled() {
+        rt().block_on(async {
+            let (mut pm, _dir) = new_manager(MockProxy::new());
+            // test_config() already has dns.enabled = false.
+            pm.start_cancellable(&test_config(), CancellationToken::new())
+                .await
+                .unwrap();
+            assert_eq!(pm.state(), ProxyState::Running);
+            pm.stop().await.unwrap();
+        });
     }
 }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1280,6 +1280,57 @@ mod self_test {
             });
     }
 
+    /// **#388**: `is_dns_reply_ok` reply-decode contract — direct unit
+    /// tests of the RCODE check. Without these, a regression in the
+    /// mask (`0x0F` → `0xF0`) or the length check would only surface
+    /// once the gate runs against real upstream DNS in production.
+    #[skuld::test]
+    fn is_dns_reply_ok_treats_noerror_as_success() {
+        let mut reply = vec![0u8; 12];
+        reply[3] = 0x00; // RCODE = 0 (NoError)
+        assert!(super::is_dns_reply_ok(&reply));
+    }
+
+    #[skuld::test]
+    fn is_dns_reply_ok_treats_nxdomain_as_success() {
+        let mut reply = vec![0u8; 12];
+        reply[3] = 0x03; // RCODE = 3 (NXDOMAIN). Path probe semantic.
+        assert!(super::is_dns_reply_ok(&reply));
+    }
+
+    #[skuld::test]
+    fn is_dns_reply_ok_treats_refused_as_success() {
+        let mut reply = vec![0u8; 12];
+        reply[3] = 0x05; // RCODE = 5 (REFUSED). Resolver declined, path works.
+        assert!(super::is_dns_reply_ok(&reply));
+    }
+
+    #[skuld::test]
+    fn is_dns_reply_ok_rejects_servfail() {
+        let mut reply = vec![0u8; 12];
+        reply[3] = 0x02; // RCODE = 2 (SERVFAIL). Upstream explicitly failed.
+        assert!(!super::is_dns_reply_ok(&reply));
+    }
+
+    #[skuld::test]
+    fn is_dns_reply_ok_ignores_high_nibble_of_byte_3() {
+        // RFC 1035: low nibble = RCODE; high nibble = Z (reserved) + RA
+        // (recursion available). High-nibble bits set MUST NOT mask the
+        // RCODE check.
+        let mut reply = vec![0u8; 12];
+        reply[3] = 0xF2; // high nibble set + RCODE=2
+        assert!(!super::is_dns_reply_ok(&reply));
+        reply[3] = 0xF0; // high nibble set + RCODE=0
+        assert!(super::is_dns_reply_ok(&reply));
+    }
+
+    #[skuld::test]
+    fn is_dns_reply_ok_rejects_truncated_reply() {
+        // Fewer than 12 bytes is not a well-formed DNS header.
+        assert!(!super::is_dns_reply_ok(&[]));
+        assert!(!super::is_dns_reply_ok(&[0u8; 11]));
+    }
+
     /// `dns.enabled = false` → `build_local_dns` returns
     /// `(None, None, None)` → gate is skipped entirely in `start_inner`.
     #[skuld::test]
@@ -1317,7 +1368,17 @@ mod self_test {
     /// fast on each refused connect, well under the 5s outer budget).
     /// `bind_ladder` succeeds because the test process can bind one of the
     /// `127.53.0.X:53` loopback alternates.
+    ///
+    /// **Windows-only**: macOS / Linux require root to bind port 53, so
+    /// `bind_ladder` returns Err on every candidate → `build_local_dns`
+    /// returns `ProxyError::Runtime(io::Error)`, not the
+    /// `ForwarderSelfTestFailed` variant under test. The gate IS still
+    /// exercised on those platforms via the DistHarness e2e tests
+    /// (bridge runs elevated). Lifting this gate to non-Windows
+    /// requires a port-injection seam in `bind_ladder` —
+    /// follow-up tracked separately.
     #[skuld::test]
+    #[cfg(target_os = "windows")]
     fn start_blocks_on_forwarder_self_test_failure() {
         rt().block_on(async {
             let dir = tempfile::tempdir().unwrap();

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -24,10 +24,14 @@ fn sample_config() -> ProxyConfig {
         local_port: 4073,
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: Vec::new(),
-        dns: hole_common::config::DnsConfig::default(),
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
         proxy_socks5: true,
         proxy_http: false,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     }
 }
 

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -215,6 +215,9 @@ async fn maybe_start_plugin(
 
     // `None` for state_dir: test-server probes are one-shot and die with
     // the bridge; no crash recovery tracking needed.
+    // `diagnostic_tap = false`: one-shot probe; the user is connecting
+    // for a quick test, not a debugging session. Per-conn tap metrics
+    // would add noise without value here.
     let chain = crate::proxy::plugin::start_plugin_chain(
         plugin_name,
         &plugin_path,
@@ -222,6 +225,7 @@ async fn maybe_start_plugin(
         &server_host,
         server_port,
         None,
+        false,
     )
     .await
     .map_err(|e| ServerTestOutcome::PluginStartFailed { detail: e.to_string() })?;

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -393,6 +393,19 @@ components:
           description: |
             Port for the HTTP CONNECT listener. Must differ from
             local_port when both listeners are enabled.
+        diagnostic_plugin_tap:
+          type: boolean
+          default: false
+          description: |
+            Wrap the plugin chain in a counting tap so per-TCP-connection
+            byte flow + close-kind become visible in bridge.log. Off by
+            default; the extra loopback hop is cheap on debug-mode
+            reproduction but inappropriate at browser-traffic scale.
+            Sourced from AppConfig.diagnostic_plugin_tap; the bridge can
+            also be opted in via the HOLE_BRIDGE_PLUGIN_TAP=1 env var
+            (dev-shell only — env vars don't survive into SCM/launchd
+            contexts). Added in bindreams/hole#388 to give service-mode
+            reproductions a knob the env var can't reach.
 
     TunnelMode:
       type: string

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -143,6 +143,19 @@ pub struct AppConfig {
     /// toggles are on (enforced at bridge start by
     /// `hole_bridge::proxy::config::build_ss_config`).
     pub local_port_http: u16,
+    /// When true, the bridge wraps the plugin chain in
+    /// [`garter::TapPlugin`] so per-TCP-connection
+    /// `bytes_to_plugin` / `bytes_from_plugin` / `ttfb_ms` / `close_kind`
+    /// land in `bridge.log`. Off by default — adds a loopback round-trip
+    /// per byte, inappropriate at browser-traffic scale. Enable when
+    /// reproducing a #248-class "tunnel returns nothing" failure (e.g.
+    /// bindreams/hole#388, where the v2ray-plugin outbound WebSocket
+    /// silently hung). See CLAUDE.md "Plugin tap" section.
+    ///
+    /// **Reaches service mode**: this flag travels via [`ProxyConfig`]
+    /// in the IPC `BridgeRequest::Start` payload, unlike the
+    /// `HOLE_BRIDGE_PLUGIN_TAP` env var which is dev-shell-only.
+    pub diagnostic_plugin_tap: bool,
 }
 
 impl Default for AppConfig {
@@ -162,6 +175,7 @@ impl Default for AppConfig {
             proxy_http: false,
             dns: DnsConfig::default(),
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         }
     }
 }

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -344,7 +344,7 @@ fn new_config_fields_roundtrip(#[fixture(temp_dir)] dir: &Path) {
         proxy_socks5: false,
         proxy_http: true,
         local_port_http: 5555,
-        diagnostic_plugin_tap: false,
+        diagnostic_plugin_tap: true, // #388: set to non-default to anchor the roundtrip
         ..Default::default()
     };
     config.save(&path).unwrap();
@@ -357,6 +357,7 @@ fn new_config_fields_roundtrip(#[fixture(temp_dir)] dir: &Path) {
     assert_eq!(config.proxy_socks5, loaded.proxy_socks5);
     assert_eq!(config.proxy_http, loaded.proxy_http);
     assert_eq!(config.local_port_http, loaded.local_port_http);
+    assert_eq!(config.diagnostic_plugin_tap, loaded.diagnostic_plugin_tap);
 }
 
 #[skuld::test]

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -344,6 +344,7 @@ fn new_config_fields_roundtrip(#[fixture(temp_dir)] dir: &Path) {
         proxy_socks5: false,
         proxy_http: true,
         local_port_http: 5555,
+        diagnostic_plugin_tap: false,
         ..Default::default()
     };
     config.save(&path).unwrap();

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -553,11 +553,25 @@ where
         file_rotate::compression::Compression::None,
         None,
     );
-    // Lossy mode on every non-blocking writer: when the channel is full
-    // (backpressure from a slow disk), drop events instead of blocking the
-    // producer. Discarding logs is strictly better than wedging the bridge or
-    // the panic hook.
-    let (file_nb, file_guard) = NonBlockingBuilder::default().lossy(true).finish(file_appender);
+    // **#388**: the FILE appender is `lossy(false)` so the proxy-stop
+    // teardown burst (SystemRoutes::drop entered / route command
+    // succeeded ×5 / state-file clear / Remove-NetAdapter / SystemRoutes::drop
+    // completed — emitted in tens of ms) is never silently truncated.
+    // Pre-#388 the lossy(true) channel dropped these events under burst
+    // pressure, leaving `bridge.log` missing the diagnostic for a
+    // teardown that broke the user's network.
+    //
+    // Hang risk acknowledgment: a wedged disk (full filesystem, OneDrive
+    // sync stall, AV scan) now back-pressures the tracing producer.
+    // Acceptable trade-off — the panic hook routes through the same
+    // subscriber, so a hang here means a hang in panic handling, which
+    // is more visible than silent log loss. The `buffered_lines_limit`
+    // (default 128k events) caps the queue, so the back-pressure window
+    // is bounded.
+    //
+    // The STDERR non-blocking writer keeps `lossy(true)`: a wedged
+    // terminal (Ctrl+S on a console session) MUST NOT block the bridge.
+    let (file_nb, file_guard) = NonBlockingBuilder::default().lossy(false).finish(file_appender);
     let (stderr_nb, stderr_guard) = NonBlockingBuilder::default().lossy(true).finish(original_stderr);
 
     // Global default is INFO so third-party crates (shadowsocks-service,

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -20,9 +20,15 @@
 //    target `hole::panic`, then chains the previous hook so the default printer
 //    still runs in dev mode.
 //
-// Every non-blocking writer uses `.lossy(true)` so a slow/blocked file
-// appender drops events instead of wedging the producing thread (including
-// the panic hook itself, which would hang a panicking thread otherwise).
+// Non-blocking writers split into two categories (#388):
+// - **Stderr + stdio-relay tees** keep `.lossy(true)` — a wedged terminal
+//   (Ctrl+S, pipe consumer hung) MUST NOT block the bridge or the panic
+//   hook.
+// - **File appender** is `.lossy(false)` — the teardown burst MUST land
+//   on disk for #388 diagnostics. Hang risk is bounded by the
+//   `buffered_lines_limit` default (128k events) and by the fact that
+//   real disk wedges are user-visible (a stop that takes >2s is reported
+//   to the IPC caller).
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -157,6 +157,18 @@ pub struct ProxyConfig {
     /// listeners are enabled (enforced at bridge start).
     #[serde(default = "proxy_config_defaults::local_port_http")]
     pub local_port_http: u16,
+    /// Enable per-TCP-connection plugin tap diagnostics in `bridge.log`.
+    /// Defaults to `false`. When `true`, the bridge wraps the plugin
+    /// chain in [`garter::TapPlugin`] so per-connection
+    /// `bytes_to_plugin` / `bytes_from_plugin` / `ttfb_ms` / `close_kind`
+    /// land in the log. Sourced from
+    /// [`crate::config::AppConfig::diagnostic_plugin_tap`]; the bridge
+    /// can also be opted in via the `HOLE_BRIDGE_PLUGIN_TAP=1` env var
+    /// (dev-shell only — env vars don't survive into SCM/launchd
+    /// contexts). Added in bindreams/hole#388 to give service-mode
+    /// reproductions a knob the env var can't reach.
+    #[serde(default)]
+    pub diagnostic_plugin_tap: bool,
 }
 
 mod proxy_config_defaults {
@@ -179,6 +191,7 @@ impl Default for ProxyConfig {
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         }
     }
 }

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -25,6 +25,7 @@ fn sample_config() -> ProxyConfig {
         proxy_socks5: true,
         proxy_http: false,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     }
 }
 
@@ -394,6 +395,7 @@ fn proxy_config_tunnel_mode_full_roundtrips() {
         proxy_socks5: true,
         proxy_http: true,
         local_port_http: 4074,
+        diagnostic_plugin_tap: false,
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();
@@ -411,10 +413,57 @@ fn proxy_config_tunnel_mode_socks_only_roundtrips() {
         proxy_socks5: false,
         proxy_http: true,
         local_port_http: 5555,
+        diagnostic_plugin_tap: false,
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();
     assert_eq!(decoded, cfg);
+}
+
+/// **#388**: `diagnostic_plugin_tap` survives the JSON roundtrip.
+/// Anchors the IPC contract for the field so a future rename breaks
+/// this test rather than silently dropping the field at the bridge.
+#[skuld::test]
+fn proxy_config_diagnostic_plugin_tap_field_roundtrips() {
+    let cfg = ProxyConfig {
+        server: sample_server(),
+        local_port: 4073,
+        tunnel_mode: TunnelMode::Full,
+        filters: Vec::new(),
+        dns: crate::config::DnsConfig::default(),
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
+        diagnostic_plugin_tap: true,
+    };
+    let json = serde_json::to_string(&cfg).unwrap();
+    let decoded: ProxyConfig = serde_json::from_str(&json).unwrap();
+    assert!(decoded.diagnostic_plugin_tap);
+    assert_eq!(decoded, cfg);
+}
+
+/// **#388**: a legacy client (pre-#388 GUI) that omits the
+/// `diagnostic_plugin_tap` field must deserialize with the field
+/// defaulting to `false` — backward-compat contract.
+#[skuld::test]
+fn proxy_config_diagnostic_plugin_tap_defaults_on_legacy_payload() {
+    let json = r#"{
+        "server": {
+            "id": "x",
+            "name": "x",
+            "server": "1.2.3.4",
+            "server_port": 8388,
+            "method": "aes-256-gcm",
+            "password": "p"
+        },
+        "local_port": 4073,
+        "tunnel_mode": "full"
+    }"#;
+    let cfg: ProxyConfig = serde_json::from_str(json).expect("legacy payload must parse");
+    assert!(
+        !cfg.diagnostic_plugin_tap,
+        "diagnostic_plugin_tap must default to false for backward compat"
+    );
 }
 
 #[skuld::test]

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -152,10 +152,14 @@ fn send_start_receives_ack() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
-                    dns: hole_common::config::DnsConfig::default(),
+                    dns: hole_common::config::DnsConfig {
+                        enabled: false,
+                        ..hole_common::config::DnsConfig::default()
+                    },
                     proxy_socks5: true,
                     proxy_http: false,
                     local_port_http: 4074,
+                    diagnostic_plugin_tap: false,
                 },
             })
             .await
@@ -246,10 +250,14 @@ fn send_reload_receives_ack() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
-                    dns: hole_common::config::DnsConfig::default(),
+                    dns: hole_common::config::DnsConfig {
+                        enabled: false,
+                        ..hole_common::config::DnsConfig::default()
+                    },
                     proxy_socks5: true,
                     proxy_http: false,
                     local_port_http: 4074,
+                    diagnostic_plugin_tap: false,
                 },
             })
             .await
@@ -331,10 +339,14 @@ fn server_error_maps_to_bridge_response_error() {
                     local_port: 4073,
                     tunnel_mode: hole_common::protocol::TunnelMode::Full,
                     filters: Vec::new(),
-                    dns: hole_common::config::DnsConfig::default(),
+                    dns: hole_common::config::DnsConfig {
+                        enabled: false,
+                        ..hole_common::config::DnsConfig::default()
+                    },
                     proxy_socks5: true,
                     proxy_http: false,
                     local_port_http: 4074,
+                    diagnostic_plugin_tap: false,
                 },
             })
             .await

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -759,6 +759,7 @@ fn handle_proxy(action: ProxyAction) -> i32 {
                     proxy_socks5: !no_socks5,
                     proxy_http: http,
                     local_port_http,
+                    diagnostic_plugin_tap: false,
                 },
             };
             match send_bridge_request_inner(request) {

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -507,6 +507,7 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
         proxy_socks5: config.proxy_socks5,
         proxy_http: config.proxy_http,
         local_port_http: config.local_port_http,
+        diagnostic_plugin_tap: config.diagnostic_plugin_tap,
     })
 }
 

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -21,10 +21,14 @@ fn encode_request_roundtrips() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         },
     };
 
@@ -72,10 +76,14 @@ fn write_request_file_roundtrip() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         },
     };
 
@@ -111,10 +119,14 @@ fn read_request_file_roundtrip() {
             local_port: 4073,
             tunnel_mode: TunnelMode::Full,
             filters: Vec::new(),
-            dns: hole_common::config::DnsConfig::default(),
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
             proxy_socks5: true,
             proxy_http: false,
             local_port_http: 4074,
+            diagnostic_plugin_tap: false,
         },
     };
 

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -13,6 +13,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let local_addr: SocketAddr = format!("{local_host}:{local_port}").parse()?;
     let remote_addr = format!("{remote_host}:{remote_port}");
 
+    // bindreams/hole#388: when `MOCK_PLUGIN_ECHO_ENV=1` is set, echo
+    // `SS_PLUGIN_OPTIONS` on stderr at startup. Lets integration tests
+    // verify the bridge correctly propagated the merged options string
+    // (e.g. `loglevel=debug` injection from `inject_plugin_debug_logging`).
+    // Gated behind an env var so production-equivalent uses of
+    // mock-plugin don't pollute logs.
+    if std::env::var_os("MOCK_PLUGIN_ECHO_ENV").is_some() {
+        if let Ok(opts) = std::env::var("SS_PLUGIN_OPTIONS") {
+            eprintln!("mock-plugin: SS_PLUGIN_OPTIONS={opts}");
+        }
+    }
+
     eprintln!("mock-plugin: listening on {local_addr}, forwarding to {remote_addr}");
     let listener = TcpListener::bind(local_addr).await?;
 

--- a/crates/tun-engine/src/adapter_cleanup.rs
+++ b/crates/tun-engine/src/adapter_cleanup.rs
@@ -22,6 +22,19 @@ pub fn remove_adapter(tun_name: &str) {
     use std::process::Command;
     use tracing::{debug, warn};
 
+    // Guard against PowerShell injection. The only production caller
+    // passes the const `TUN_DEVICE_NAME = "hole-tun"`, so this assert
+    // never fires in practice — it's a structural guarantee against a
+    // future caller that interpolates user input. PowerShell uses
+    // single-quote strings (no expansion) but a literal `'` would
+    // terminate the string and the rest would be evaluated as PowerShell.
+    debug_assert!(
+        tun_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "tun_name must be alphanumeric/-/_; got {tun_name:?}"
+    );
+
     // `-ErrorAction SilentlyContinue` on Get-NetAdapter swallows the
     // "no MSFT_NetAdapter objects found" error so the pipe's overall
     // exit code is 0 when nothing matches (the dominant case after a

--- a/crates/tun-engine/src/adapter_cleanup.rs
+++ b/crates/tun-engine/src/adapter_cleanup.rs
@@ -1,0 +1,71 @@
+//! Best-effort post-teardown wintun adapter cleanup.
+//!
+//! Belt-and-suspenders for the [`Dispatcher::drop`](../../bridge/src/dispatcher.rs)
+//! architectural fix added in bindreams/hole#388 — covers:
+//!
+//! - **Panic / SIGKILL** paths where Drops don't run at all.
+//! - **Current-thread runtime** test paths where `block_in_place` would
+//!   panic, so `Dispatcher::drop` takes the abort-only fallback.
+//! - **Drop timeout** (2s budget in `Dispatcher::drop`) — a wedged engine
+//!   future eventually surrenders the adapter on process exit; this layer
+//!   makes sure the next start finds a clean machine.
+//!
+//! Idempotent: no-op if the adapter is already gone. Requires admin
+//! privileges (the bridge runs elevated; in dev mode, `scripts/dev.py`
+//! requests UAC elevation). PowerShell cold-start adds ~500-2000ms to
+//! teardown — acceptable tax for crash-recovery safety. On macOS the
+//! utun adapter auto-cleans on FD close (no equivalent leak), so this
+//! is a no-op there.
+
+#[cfg(target_os = "windows")]
+pub fn remove_adapter(tun_name: &str) {
+    use std::process::Command;
+    use tracing::{debug, warn};
+
+    // `-ErrorAction SilentlyContinue` on Get-NetAdapter swallows the
+    // "no MSFT_NetAdapter objects found" error so the pipe's overall
+    // exit code is 0 when nothing matches (the dominant case after a
+    // clean stop — `Dispatcher::drop` already released the adapter).
+    let ps = format!(
+        "Get-NetAdapter -Name '{tun}*' -ErrorAction SilentlyContinue | \
+         ForEach-Object {{ Remove-NetAdapter -Name $_.Name -Confirm:$false -ErrorAction SilentlyContinue }}",
+        tun = tun_name,
+    );
+
+    let result = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps])
+        .output();
+
+    match result {
+        Ok(out) if out.status.success() => {
+            debug!(tun = tun_name, "post-teardown adapter cleanup done");
+        }
+        Ok(out) => {
+            warn!(
+                tun = tun_name,
+                exit = ?out.status.code(),
+                stderr = %String::from_utf8_lossy(&out.stderr),
+                "Remove-NetAdapter returned non-zero — adapter may be leaked; \
+                 run `scripts/network-reset.py` if connectivity is broken"
+            );
+        }
+        Err(e) => {
+            warn!(
+                tun = tun_name,
+                error = %e,
+                "failed to spawn Remove-NetAdapter; adapter may be leaked"
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn remove_adapter(_tun_name: &str) {
+    // macOS utun adapters are torn down by the kernel when their FD is
+    // closed. The `tun::AsyncDevice` Drop on engine task exit handles
+    // it. No defensive shell-out needed.
+}
+
+#[cfg(test)]
+#[path = "adapter_cleanup_tests.rs"]
+mod adapter_cleanup_tests;

--- a/crates/tun-engine/src/adapter_cleanup_tests.rs
+++ b/crates/tun-engine/src/adapter_cleanup_tests.rs
@@ -1,0 +1,25 @@
+use super::remove_adapter;
+
+/// **#388**: calling `remove_adapter` with a name that doesn't match any
+/// real adapter must complete cleanly (no panic, no hang). PowerShell's
+/// `Get-NetAdapter -ErrorAction SilentlyContinue` swallows the
+/// not-found error, so the pipe exits 0 and the function logs at
+/// `debug!` level.
+///
+/// **Privilege caveat**: `Remove-NetAdapter` requires elevation. When the
+/// test process is unprivileged, the inner Remove-NetAdapter step would
+/// fail with access-denied — but `Get-NetAdapter` returns nothing on
+/// our test name, so `ForEach-Object` runs zero iterations and we never
+/// hit the elevation check. So the test passes regardless of elevation.
+#[skuld::test]
+#[cfg(target_os = "windows")]
+fn remove_adapter_for_absent_name_is_silent_noop() {
+    remove_adapter("hole-tun-test-does-not-exist-987654321");
+}
+
+/// macOS no-op variant — should not error.
+#[skuld::test]
+#[cfg(not(target_os = "windows"))]
+fn remove_adapter_is_noop_on_non_windows() {
+    remove_adapter("any-name");
+}

--- a/crates/tun-engine/src/lib.rs
+++ b/crates/tun-engine/src/lib.rs
@@ -35,6 +35,7 @@ fn main() {
     skuld::run_all();
 }
 
+pub mod adapter_cleanup;
 pub mod device;
 pub mod engine;
 pub mod error;

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -82,13 +82,25 @@ pub(crate) fn build_split_route_teardown_commands(tun_name: &str) -> Vec<Vec<Str
 /// Returns true if route command failures during this phase are *expected*
 /// idempotent-cleanup behavior and should be logged at debug, not warn.
 ///
-/// Recovery is best-effort: every clean startup tries to delete the four
+/// **Recovery** is best-effort: every clean startup tries to delete the four
 /// fixed split routes, and on a healthy system all four of those calls fail
-/// because nothing leaked. Treating those failures as warnings would drown
-/// every dev/prod startup in red. Adding a new `PHASE_RECOVER_*` constant
-/// requires updating this matcher.
+/// because nothing leaked.
+///
+/// **Teardown** (added 2026-05 for bindreams/hole#388) is *also* best-effort
+/// because [`setup_routes`] is NOT transactional — when a setup command fails
+/// midway, the defensive [`teardown_routes`] call deletes routes that were
+/// never installed (empirically `netsh interface ip delete route 0.0.0.0/1
+/// <adapter>` exits non-zero when the route is absent, and the bare `route
+/// delete <ip>` does the same). The pre-#388 framing of "any warn here is a
+/// real production teardown failure" assumed transactional install, which we
+/// don't have. Real teardown failures (e.g. "adapter unavailable") surface
+/// via the bridge's post-teardown `Remove-NetAdapter` reporting and via
+/// state-file persistence failures.
+///
+/// Adding a new `PHASE_*` constant that should silently tolerate non-zero
+/// exit codes MUST be paired with a matching arm here.
 fn is_recovery_phase(phase: &str) -> bool {
-    phase == PHASE_RECOVER_SPLIT || phase == PHASE_RECOVER_BYPASS
+    matches!(phase, PHASE_RECOVER_SPLIT | PHASE_RECOVER_BYPASS | PHASE_TEARDOWN)
 }
 
 fn run_commands(commands: &[Vec<String>], phase: &str) -> std::io::Result<()> {
@@ -112,17 +124,18 @@ fn run_commands(commands: &[Vec<String>], phase: &str) -> std::io::Result<()> {
                    stdout = %stdout.trim(), stderr = %stderr.trim(),
                    "route command succeeded");
         } else if recovery {
+            // Recovery and teardown phases (post-#388) — see is_recovery_phase
+            // doc-comment. Non-zero exits here are the unavoidable consequence
+            // of non-transactional install + best-effort cleanup; warning would
+            // drown legitimate signal.
             debug!(phase, cmd = cmd.join(" "), exit_code, stderr = %stderr,
-                   "recovery command failed (expected if no leaked routes)");
+                   "best-effort command failed (expected if route absent)");
         } else {
-            // Post-#165: unit tests no longer invoke this path, so any
-            // `warn!` fired here is a real production teardown failure —
-            // not a benign test-time artifact. Framing matters: the old
-            // message trained investigators to dismiss it. See the
-            // #165 incident report.
+            // PHASE_SETUP only. A non-zero exit during initial route install
+            // IS a real anomaly — investigate.
             warn!(phase, cmd = cmd.join(" "), exit_code,
                   stdout = %stdout.trim(), stderr = %stderr.trim(),
-                  "route command failed — investigate if this is not a no-op idempotent teardown");
+                  "route command failed — investigate (setup phase only)");
         }
     }
     Ok(())
@@ -354,6 +367,13 @@ impl Drop for SystemRoutes {
         if let Err(e) = state::clear(&self.state_dir) {
             warn!(error = %e, "state-file clear failed in SystemRoutes::drop");
         }
+        // **#388**: belt-and-suspenders post-teardown wintun adapter cleanup.
+        // The architectural fix in `bridge::Dispatcher::drop` synchronously
+        // drains the engine task so wintun's own Drop runs — this is the
+        // safety net for paths that bypass it (panic, current-thread runtime
+        // tests, Drop 2s-timeout fallback). PowerShell `Remove-NetAdapter`
+        // is idempotent on missing adapters. See adapter_cleanup docs.
+        crate::adapter_cleanup::remove_adapter(&self.tun_name);
         // Note: WFP/NDIS post-teardown snapshots live in bridge's Stop
         // path, not here — tun-engine can't depend on the bridge's
         // diagnostics module.

--- a/crates/tun-engine/src/routing_tests.rs
+++ b/crates/tun-engine/src/routing_tests.rs
@@ -257,10 +257,24 @@ fn recover_phases_are_classified_as_expected_failures() {
     assert!(is_recovery_phase(PHASE_RECOVER_BYPASS));
 }
 
+/// **#388**: `PHASE_TEARDOWN` is also a best-effort phase. Empirically
+/// `netsh interface ip delete route 0.0.0.0/1 <adapter>` and the bare
+/// `route delete <ip>` both exit non-zero when the route is absent,
+/// and `setup_routes` is NOT transactional — a failed mid-install
+/// leaves an arbitrary subset of routes present, so teardown must
+/// tolerate missing routes silently. Real teardown failures surface
+/// elsewhere (post-teardown `Remove-NetAdapter` reporting, state-file
+/// persistence errors).
 #[skuld::test]
-fn setup_and_teardown_phases_are_not_recovery() {
+fn teardown_phase_is_classified_as_expected_failures() {
+    assert!(is_recovery_phase(PHASE_TEARDOWN));
+}
+
+#[skuld::test]
+fn setup_phase_is_not_recovery() {
+    // PHASE_SETUP is the only path that should warn on non-zero exit:
+    // initial route install IS expected to succeed.
     assert!(!is_recovery_phase(PHASE_SETUP));
-    assert!(!is_recovery_phase(PHASE_TEARDOWN));
 }
 
 // recover_routes_with tests ===========================================================================================


### PR DESCRIPTION
## Summary

Fixes bindreams/hole#388.

- **Self-test fail-loud gate**: `run_forwarder_self_test` now runs synchronously in `start_inner` BEFORE `Dispatcher::new` / `routing.install` / `apply_dns_settings`. On failure returns `Err(ProxyError::ForwarderSelfTestFailed)` and the locally-owned RAII guards (`running_proxy`, `plugin_chain`) unwind — system state (TUN routes, system DNS, wintun adapter) is never touched. Pre-#388 the test was fire-and-forget; the proxy committed `Running` while `intercept_udp53` hijacked user DNS into a dead tunnel.
- **Idempotent teardown** (`is_recovery_phase` extended to `PHASE_TEARDOWN`): non-zero `netsh`/`route delete` exits during teardown are now `debug!` instead of `warn!`. Empirically verified that all teardown commands return non-zero when the route is absent — and route install is not transactional, so partial state on a failed install always produces benign no-op deletes on teardown.
- **Wintun adapter removal** (architectural + defensive): `Dispatcher::drop` synchronously waits for the spawned driver task (`block_in_place` + `Handle::block_on` with 2s timeout) so wintun's own Drop runs and releases the adapter before the bridge moves on. New `adapter_cleanup` module in tun-engine shells out `Remove-NetAdapter` as belt-and-suspenders for panic/SIGKILL paths and the current-thread runtime test path.
- **Log flush** (`lossy(true)` → `lossy(false)` on file appender): the teardown burst no longer drops events under back-pressure. Stderr keeps `lossy(true)` to avoid terminal-wedge hang. Hang risk on file appender bounded by `buffered_lines_limit` (128k events default) and is user-visible (Stop latency reported to IPC caller).
- **Plugin tap config flag** (`AppConfig.diagnostic_plugin_tap` + `ProxyConfig.diagnostic_plugin_tap`): the existing `HOLE_BRIDGE_PLUGIN_TAP=1` env var doesn't survive into SCM/launchd contexts. The new config flag reaches the bridge via IPC so service-mode users can capture per-connection plugin diagnostics on the next reproduction. OR-gates with the env var. On self-test failure the bridge emits a `warn!` correlation hint (`TAP_ENABLED_HINT` / `TAP_DISABLED_HINT` consts) telling the reader either where the tap output is or how to enable it.

### Behavior changes (intentional)
- `dns.enabled = true` + `servers = []` is now a hard config error (was silent skip + degenerate runtime).
- `bind_ladder` failure on ALL 255 loopback candidates is now a hard start error (was silent-degrade). Single pi-hole on `127.0.0.1:53` still succeeds via the ladder.
- A plugin chain that binds locally but can't reach upstream is now caught at start time; the GUI sees `ForwarderSelfTestFailed` instead of a dead tunnel.

## Test plan
- [x] `cargo xtask run clippy-hole` — clean
- [x] `cargo xtask run hole-tests` locally on Windows — passes (exit 0)
- [x] Direct gate tests pass: `start_blocks_on_forwarder_self_test_failure` (Windows), `self_test_failure_with_tap_enabled_emits_correlation_hint`, `self_test_failure_without_tap_emits_remediation_hint`, `self_test_dead_upstream_returns_failed`, `self_test_empty_servers_returns_ok_zero`, `build_local_dns_returns_err_for_empty_servers`, `build_local_dns_returns_none_when_disabled`, `start_succeeds_when_dns_disabled`, `start_transitions_to_running`
- [x] Reply-decode unit tests (`is_dns_reply_ok_*`) pass — 6/6
- [x] IPC roundtrip tests for `diagnostic_plugin_tap` field pass — 2/2
- [x] `adapter_cleanup` Windows test passes
- [x] CI Windows + macOS hole-tests targets

### Manual end-to-end (still requires user reproduction with failing profile)
- [ ] Import galoshes + v2ray-plugin profile triggering #388 → expect `ForwarderSelfTestFailed` error, proxy stays Stopped, system DNS untouched, `bridge.log` contains the failure + `warn!` hint about `diagnostic_plugin_tap=true`
- [ ] Set `diagnostic_plugin_tap: true` in AppConfig, restart bridge, retry → expect per-connection `plugin tap: closed` lines showing the upstream-dial hang (`bytes_to_plugin > 0 && bytes_from_plugin == 0`, `ttfb_ms = None`)
- [ ] After failed start, click Stop → expect no `route command failed` warnings, no `hole-tun*` adapter remaining, system network functional without `scripts/network-reset.py`