### PR TITLE
fix: make proxy-start failures debuggable end-to-end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,12 @@ contracts = "0.6"
 
 [workspace.lints.clippy]
 disallowed_methods = "deny"
+
+# Release profile carries enough debug info for symbolicated panic
+# backtraces. Without this, `backtrace::Backtrace::force_capture()` in
+# `hole_common::logging::install_panic_hook` produces `<unknown>` frames
+# (the bridge.log panic in bindreams/hole#393). `"limited"` emits line
+# tables + function names, no types/locals — the right trade-off for
+# end-user crash reports vs PDB size.
+[profile.release]
+debug = "limited"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,24 @@ contracts = "0.6"
 [workspace.lints.clippy]
 disallowed_methods = "deny"
 
-# Release profile carries enough debug info for symbolicated panic
-# backtraces. Without this, `backtrace::Backtrace::force_capture()` in
+# Symbolicated panic backtraces. Without these settings,
+# `backtrace::Backtrace::force_capture()` in
 # `hole_common::logging::install_panic_hook` produces `<unknown>` frames
-# (the bridge.log panic in bindreams/hole#393). `"limited"` emits line
-# tables + function names, no types/locals — the right trade-off for
-# end-user crash reports vs PDB size.
+# (the bridge.log panic in bindreams/hole#393).
+#
+# - `debug = "limited"` (release only) — emits line tables + function
+#   names without types/locals. Cargo's release default is `false` which
+#   strips everything.
+# - `split-debuginfo = "packed"` — bundles debug info into a separate
+#   `.pdb` (MSVC, already the platform default) or `.dSYM` (macOS, the
+#   non-default). The cargo macOS dev default is `"unpacked"`, which
+#   leaves debug info in per-crate `.o` files referenced by the binary
+#   — so a binary copied out of `target/<profile>/` to a staging dir
+#   has no resolvable debug info. `"packed"` produces a self-contained
+#   `hole.dSYM` bundle that travels with the binary via `bindir_files`.
+[profile.dev]
+split-debuginfo = "packed"
+
 [profile.release]
 debug = "limited"
+split-debuginfo = "packed"

--- a/crates/bridge/src/diagnostics/etw.rs
+++ b/crates/bridge/src/diagnostics/etw.rs
@@ -93,6 +93,16 @@
 //! [`TCPIP_KEYWORDS`] — earlier versions of this module filtered at
 //! the kernel level and silently dropped events 1004 and 1077, both
 //! of which are critical to the #200 narrative.
+//!
+//! # AFD/WFP severity (bindreams/hole#393)
+//!
+//! Only TCPIP events get rich event-id-aware severity routing.
+//! AFD and WFP events are emitted at DEBUG via [`Emission::Unknown`]
+//! until either provider grows a rich handler. The cross-provider
+//! event-id collisions (AFD `1002` and `1004` overlap TCPIP
+//! `TCB_CONNECT_REQUESTED` / `TCB_SYN_SEND`) made the original
+//! event-id-only match misclassify AFD background traffic as
+//! INFO-level TCPIP events — see [`dispatch`] for the provider gate.
 
 use dump::{dump, DeriveDump};
 use ferrisetw::parser::Parser;
@@ -565,12 +575,22 @@ pub(crate) fn dispatch(
         return None;
     }
 
-    if is_tcpip_provider(provider) && HIGH_VOLUME_TCPIP_EVENTS.contains(&event_id) {
+    // **Provider gate (bindreams/hole#393).** TCPIP, AFD, and WFP all
+    // recycle small event-id integers (1002, 1004, 1017, …), so a
+    // bare `match event_id` matches AFD events as if they were TCPIP
+    // `TCB_CONNECT_REQUESTED` / `TCB_SYN_SEND` / etc. and emits them
+    // at INFO. That was the source of the ~2000-line bridge-log
+    // flood in #393. AFD and WFP have no rich handlers yet, so they
+    // surface at DEBUG via `Emission::Unknown` until one exists.
+    if !is_tcpip_provider(provider) {
+        return Some(Emission::Unknown);
+    }
+
+    if HIGH_VOLUME_TCPIP_EVENTS.contains(&event_id) {
         return None;
     }
 
-    // TCPIP-specific severity rules. WFP + AFD currently use the generic
-    // info-with-event-id path; their rich decoding is a future iteration.
+    // TCPIP-specific severity rules.
     match event_id {
         tcpip_events::TCB_CONNECT_REQUESTED | tcpip_events::SEND_RETRANSMIT_ROUND
             if fields.rexmit_count.is_some_and(|n| n >= RETRANSMIT_WARN_THRESHOLD) =>

--- a/crates/bridge/src/diagnostics/etw_tests.rs
+++ b/crates/bridge/src/diagnostics/etw_tests.rs
@@ -6,16 +6,31 @@
 use super::*;
 use dump::dump;
 
-// Zeroed GUID — matches no subscribed provider, used where the test is
-// about PID filtering or severity rules and not provider-scoped filters.
+// Zeroed GUID — matches no subscribed provider. Useful only for
+// "non-TCPIP" tests since the dispatch provider gate (#393) routes
+// anything not-TCPIP to `Emission::Unknown` regardless of event-id.
 fn any_guid() -> GUID {
     GUID::from_u128(0)
 }
 
-/// TCPIP provider GUID, used by tests that check the
-/// [`HIGH_VOLUME_TCPIP_EVENTS`] drop list (which only fires for TCPIP).
+/// TCPIP provider GUID, used by tests that exercise TCPIP-specific
+/// severity routing (which is the only path that distinguishes
+/// event-ids — see [`dispatch`]).
 fn tcpip_guid() -> GUID {
     GUID::from(TCPIP_PROVIDER)
+}
+
+/// Winsock-AFD provider GUID. Used by tests that verify AFD events
+/// with TCPIP-colliding IDs (1002, 1004, …) are not misclassified as
+/// TCPIP per the provider gate added in bindreams/hole#393.
+fn afd_guid() -> GUID {
+    GUID::from(AFD_PROVIDER)
+}
+
+/// Microsoft-Windows-WFP provider GUID. Symmetric with `afd_guid()`
+/// for WFP coverage.
+fn wfp_guid() -> GUID {
+    GUID::from(WFP_PROVIDER)
 }
 
 const BRIDGE_PID: u32 = 12345;
@@ -38,7 +53,7 @@ fn dispatch_ignores_non_bridge_pid() {
 #[skuld::test]
 fn dispatch_emits_for_matching_pid() {
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::CONNECT_COMPLETED,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -52,7 +67,7 @@ fn dispatch_emits_for_matching_pid() {
 #[skuld::test]
 fn dispatch_tcp_connect_completed_is_info() {
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::CONNECT_COMPLETED,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -64,7 +79,7 @@ fn dispatch_tcp_connect_completed_is_info() {
 #[skuld::test]
 fn dispatch_tcp_connect_request_timeout_is_warn() {
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::CONNECT_REQUEST_TIMEOUT,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -76,7 +91,7 @@ fn dispatch_tcp_connect_request_timeout_is_warn() {
 #[skuld::test]
 fn dispatch_tcp_retransmit_timeout_is_warn() {
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::RETRANSMIT_TIMEOUT,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -88,7 +103,7 @@ fn dispatch_tcp_retransmit_timeout_is_warn() {
 #[skuld::test]
 fn dispatch_tcp_abort_issued_is_warn() {
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::ABORT_ISSUED,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -106,7 +121,7 @@ fn dispatch_retransmit_count_lt_threshold_is_info() {
         ..Default::default()
     };
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::SEND_RETRANSMIT_ROUND,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -126,7 +141,7 @@ fn dispatch_retransmit_count_at_threshold_is_warn() {
         ..Default::default()
     };
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::SEND_RETRANSMIT_ROUND,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -146,7 +161,7 @@ fn dispatch_retransmit_count_gt_threshold_is_warn() {
         ..Default::default()
     };
     let got = dispatch(
-        any_guid(),
+        tcpip_guid(),
         tcpip_events::TCB_CONNECT_REQUESTED,
         BRIDGE_PID,
         BRIDGE_PID,
@@ -158,10 +173,57 @@ fn dispatch_retransmit_count_gt_threshold_is_warn() {
 // Unknown events ======================================================================================================
 
 #[skuld::test]
-fn dispatch_unknown_event_id_returns_unknown() {
+fn dispatch_unknown_event_id_from_tcpip_returns_unknown() {
+    // TCPIP event with an ID outside the rich-handler table falls through
+    // the match arm to Emission::Unknown.
+    let got = dispatch(
+        tcpip_guid(),
+        /*event_id=*/ 65500, // deliberately outside the known-IDs block
+        BRIDGE_PID,
+        BRIDGE_PID,
+        &ParsedFields::default(),
+    );
+    assert_eq!(got, Some(Emission::Unknown));
+}
+
+// Provider gate (bindreams/hole#393) ==================================================================================
+
+#[skuld::test]
+fn dispatch_afd_with_tcpip_colliding_id_returns_unknown() {
+    // AFD event-id 1004 is TCB_SYN_SEND under TCPIP. Without the
+    // provider gate, AFD would emit at INFO under "tcp event". With the
+    // gate, AFD short-circuits to DEBUG-level Unknown.
+    let got = dispatch(
+        afd_guid(),
+        tcpip_events::TCB_SYN_SEND,
+        BRIDGE_PID,
+        BRIDGE_PID,
+        &ParsedFields::default(),
+    );
+    assert_eq!(got, Some(Emission::Unknown));
+}
+
+#[skuld::test]
+fn dispatch_wfp_with_tcpip_colliding_id_returns_unknown() {
+    // Symmetric coverage for WFP. WFP event-id 1002 (whatever it means
+    // semantically) must not be misclassified as TCPIP
+    // TCB_CONNECT_REQUESTED.
+    let got = dispatch(
+        wfp_guid(),
+        tcpip_events::TCB_CONNECT_REQUESTED,
+        BRIDGE_PID,
+        BRIDGE_PID,
+        &ParsedFields::default(),
+    );
+    assert_eq!(got, Some(Emission::Unknown));
+}
+
+#[skuld::test]
+fn dispatch_unknown_provider_returns_unknown() {
+    // Zero GUID is not subscribed; same short-circuit as AFD/WFP.
     let got = dispatch(
         any_guid(),
-        /*event_id=*/ 65500, // deliberately outside the known-IDs block
+        tcpip_events::CONNECT_COMPLETED,
         BRIDGE_PID,
         BRIDGE_PID,
         &ParsedFields::default(),
@@ -184,15 +246,17 @@ fn dispatch_drops_high_volume_tcpip_events() {
 }
 
 #[skuld::test]
-fn dispatch_keeps_high_volume_event_ids_on_non_tcpip_providers() {
-    // Event IDs collide across providers; a high-volume TCPIP event ID
-    // from AFD or WFP must not be dropped.
+fn dispatch_non_tcpip_provider_with_high_volume_id_short_circuits_to_unknown() {
+    // Event IDs collide across providers, but with the #393 provider
+    // gate the AFD/WFP short-circuit fires BEFORE the drop list is
+    // consulted. Either way the user-visible effect is the same: no
+    // INFO spam from non-TCPIP background traffic.
     for &id in HIGH_VOLUME_TCPIP_EVENTS {
-        let got = dispatch(any_guid(), id, BRIDGE_PID, BRIDGE_PID, &ParsedFields::default());
+        let got = dispatch(afd_guid(), id, BRIDGE_PID, BRIDGE_PID, &ParsedFields::default());
         assert_eq!(
             got,
             Some(Emission::Unknown),
-            "event_id={id} from non-TCPIP provider should fall through to Unknown, got {got:?}"
+            "AFD event_id={id} should short-circuit to Unknown, got {got:?}"
         );
     }
 }

--- a/crates/bridge/src/proxy/shadowsocks.rs
+++ b/crates/bridge/src/proxy/shadowsocks.rs
@@ -57,13 +57,35 @@ impl Proxy for ShadowsocksProxy {
 
 /// RAII handle on a running shadowsocks tunnel.
 ///
-/// Drop aborts the spawned task best-effort; the supported shutdown path is
-/// [`RunningProxy::stop`], which also awaits the task so errors can be
-/// reported. Reaching `Drop` with a live handle indicates the caller forgot
-/// `stop().await` — a debug_assert fires in dev/test builds to surface such
-/// misuse per the CLAUDE.md "debug asserts are encouraged" rule.
+/// Two cleanup paths, both safe:
+///
+/// - [`RunningProxy::stop`] — graceful shutdown. Aborts the task and
+///   `await`s the handle, surfacing task-internal panics as
+///   `ProxyError::Runtime`. Preferred when the caller has an `.await`
+///   point (the normal Stop request flow).
+/// - `Drop` — cancel-unwind cleanup. Aborts the task best-effort and
+///   returns immediately. Used when the value goes out of scope under
+///   an error-path `?` (e.g. the #388 forwarder self-test gate inside
+///   `start_inner`) or when the surrounding future is cancelled (e.g.
+///   the `tokio::select!` in `start_cancellable`), where there is no
+///   `.await` point to host a graceful stop.
+///
+/// Both paths abort the task; the only thing `Drop` loses vs `stop()`
+/// is the ability to observe task-internal panics. See bindreams/hole#393
+/// for the incident that motivated documenting the dual contract.
 pub struct ShadowsocksRunning {
     handle: Option<JoinHandle<io::Result<()>>>,
+}
+
+#[cfg(test)]
+impl ShadowsocksRunning {
+    /// Test-only constructor: wrap a freshly-spawned task so the Drop
+    /// contract can be exercised without binding real shadowsocks
+    /// listeners. Production code never reaches `ShadowsocksRunning`
+    /// except through [`ShadowsocksProxy::start`].
+    pub(crate) fn from_handle(handle: JoinHandle<io::Result<()>>) -> Self {
+        Self { handle: Some(handle) }
+    }
 }
 
 impl RunningProxy for ShadowsocksRunning {
@@ -93,17 +115,17 @@ impl RunningProxy for ShadowsocksRunning {
 
 impl Drop for ShadowsocksRunning {
     fn drop(&mut self) {
-        // Last-resort cleanup for the panic-unwinding path. Errors are
-        // discarded because Rust does not allow `Drop::drop` to be async or
-        // fallible. Reaching here with a live task means the caller forgot
-        // to call `stop().await` — which loses the graceful-shutdown error
-        // reporting but at least aborts the task so it doesn't leak.
-        debug_assert!(
-            self.handle.as_ref().is_none_or(|h| h.is_finished()),
-            "ShadowsocksRunning dropped with a live task — caller forgot stop().await"
-        );
+        // Cancel-unwind cleanup. `h.abort()` is fire-and-forget — the
+        // runtime delivers cancellation to the task on the next poll.
+        // No `await` is possible here (Drop is sync), so task-internal
+        // panics are not observed; callers who need that signal use
+        // `stop().await`. See the type doc and bindreams/hole#393.
         if let Some(h) = self.handle.take() {
             h.abort();
         }
     }
 }
+
+#[cfg(test)]
+#[path = "shadowsocks_tests.rs"]
+mod shadowsocks_tests;

--- a/crates/bridge/src/proxy/shadowsocks_tests.rs
+++ b/crates/bridge/src/proxy/shadowsocks_tests.rs
@@ -1,0 +1,31 @@
+//! Unit tests for `ShadowsocksRunning`'s lifecycle, focused on the
+//! Drop contract: dropping with a live handle must NOT panic. The
+//! pre-#393 `debug_assert!` in `Drop::drop` fired on legitimate
+//! RAII-unwind paths (e.g. an error short-circuiting `start_inner`
+//! between `proxy.start().await` and the next `?`), killing the
+//! bridge mid-response and masking the real error.
+
+use super::ShadowsocksRunning;
+use crate::proxy::{ProxyError, RunningProxy};
+use std::io;
+
+#[skuld::test]
+async fn drop_does_not_panic_when_handle_alive() {
+    // A task that pends forever stands in for a freshly-spawned
+    // shadowsocks server: it is unambiguously not finished by the
+    // time we drop the wrapper.
+    let handle = tokio::spawn(std::future::pending::<io::Result<()>>());
+    let running = ShadowsocksRunning::from_handle(handle);
+    drop(running); // must not panic
+}
+
+#[skuld::test]
+async fn stop_then_drop_is_no_op() {
+    let handle = tokio::spawn(async { Ok::<(), io::Error>(()) });
+    let running = ShadowsocksRunning::from_handle(handle);
+    let res: Result<(), ProxyError> = running.stop().await;
+    res.expect("stop returns Ok on a clean exit");
+    // `stop` consumed `running`; nothing to assert beyond "didn't
+    // panic" — included as a regression guard so a future change that
+    // moves cleanup state out of `stop` triggers a visible failure.
+}

--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -116,7 +116,7 @@
            Staged by xtask::bindir alongside hole.exe, with the workspace
            `[profile.release].debug = "limited"` guaranteeing the PDB
            carries line tables + names. See bindreams/hole#393. -->
-      <Component Id="HolePdb" Guid="E5F6A7B8-C9D0-1234-EF01-345678901234">
+      <Component Id="HolePdb" Guid="1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D">
         <File Id="hole.pdb" Source="!(bindpath.BinDir)\hole.pdb" KeyPath="yes" />
       </Component>
       <Component Id="V2rayPlugin" Guid="B2C3D4E5-F6A7-8901-BCDE-F12345678901">

--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -112,6 +112,13 @@
       <Component Id="HoleExe" Guid="A1B2C3D4-E5F6-7890-ABCD-EF1234567890">
         <File Id="hole.exe" Source="!(bindpath.BinDir)\hole.exe" KeyPath="yes" />
       </Component>
+      <!-- hole.pdb — debug symbols for symbolicated panic backtraces.
+           Staged by xtask::bindir alongside hole.exe, with the workspace
+           `[profile.release].debug = "limited"` guaranteeing the PDB
+           carries line tables + names. See bindreams/hole#393. -->
+      <Component Id="HolePdb" Guid="E5F6A7B8-C9D0-1234-EF01-345678901234">
+        <File Id="hole.pdb" Source="!(bindpath.BinDir)\hole.pdb" KeyPath="yes" />
+      </Component>
       <Component Id="V2rayPlugin" Guid="B2C3D4E5-F6A7-8901-BCDE-F12345678901">
         <File Id="v2ray_plugin.exe" Source="!(bindpath.BinDir)\v2ray-plugin.exe" KeyPath="yes" />
       </Component>

--- a/msi-installer/tests/test_hole_msi.py
+++ b/msi-installer/tests/test_hole_msi.py
@@ -32,7 +32,10 @@ def staged_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     relocated-extract test (#357) has files to find post-extraction.
     """
     d = tmp_path_factory.mktemp("stage")
-    for name in ("hole.exe", "v2ray-plugin.exe", "wintun.dll", "NOTICES.md"):
+    # hole.pdb shipped alongside hole.exe for symbolicated panic
+    # backtraces — see bindreams/hole#393. Mirrors the bindir layout
+    # produced by `cargo xtask stage`.
+    for name in ("hole.exe", "hole.pdb", "v2ray-plugin.exe", "wintun.dll", "NOTICES.md"):
         (d / name).write_bytes(b"x" * 1024)
     return d
 
@@ -338,7 +341,7 @@ def test_msi_admin_extract_works_when_separated_from_build_dir(
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
-    payload_files = {"hole.exe", "v2ray-plugin.exe", "wintun.dll", "NOTICES.md"}
+    payload_files = {"hole.exe", "hole.pdb", "v2ray-plugin.exe", "wintun.dll", "NOTICES.md"}
     extracted = {p.name for p in extract_dir.rglob("*") if p.is_file() and p.name in payload_files}
     assert extracted == payload_files, (f"MSI extracted but expected payload missing: got {extracted}")
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import atexit
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -139,15 +140,84 @@ def cargo_build(cargo: str, target_user: tuple[int, int, str, str] | None) -> No
 
 # Process management ===================================================================================================
 
+_ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T")
 
-def prefix_stream(stream, label: str, color: str) -> None:
-    """Read lines from a stream and print them with a colored prefix."""
+
+def prefix_stream(
+    stream,
+    label: str,
+    color: str,
+    lock: threading.Lock,
+    *,
+    buffer_entries: bool,
+) -> None:
+    """Read lines from a stream and print them with a colored prefix.
+
+    Two modes:
+
+    - ``buffer_entries=True``: assume the stream emits structured
+      tracing entries that start with an ISO 8601 timestamp; any
+      continuation line (indented YAML body, stdlib panic frames, etc.)
+      is part of the previous entry. The whole entry is buffered and
+      flushed as a single atomic write under ``lock`` once the next
+      entry-start arrives — or on EOF — so other streams cannot
+      interleave their lines into the middle of a multi-line entry.
+      The panic backtrace in bindreams/hole#393 was the motivating
+      case: ``[client]`` log lines split the bridge's ``backtrace: |2``
+      block into pieces.
+
+    - ``buffer_entries=False``: each line is printed directly under
+      ``lock``. Used for streams that have no timestamp anchor (Vite),
+      where buffering would never see an entry-start and the stream's
+      output would never flush.
+
+    Tradeoff for the buffered mode: a quiet stream's last entry sits
+    in the buffer until the next entry-start arrives or EOF. In dev
+    the bridge has constant heartbeat traffic so latency is bounded;
+    the worst case (panic-then-exit) is bounded by subprocess EOF,
+    which triggers the final flush.
+    """
     prefix = f"{color}{BOLD}[{label}]{RESET} "
+
+    if not buffer_entries:
+        try:
+            for line in iter(stream.readline, ""):
+                with lock:
+                    print(f"{prefix}{line}", end="", flush=True)
+        except ValueError:
+            pass  # stream closed
+        return
+
+    buffer: list[str] = []
+
+    def flush() -> None:
+        if not buffer:
+            return
+        joined = "".join(f"{prefix}{ln}" for ln in buffer)
+        with lock:
+            sys.stdout.write(joined)
+            sys.stdout.flush()
+        buffer.clear()
+
     try:
         for line in iter(stream.readline, ""):
-            print(f"{prefix}{line}", end="", flush=True)
+            if _ISO_TIMESTAMP_RE.match(line):
+                # New entry-start. Emit any previous entry, begin a new buffer.
+                flush()
+                buffer.append(line)
+            elif buffer:
+                # Continuation of the in-progress entry.
+                buffer.append(line)
+            else:
+                # Standalone line with no preceding entry — e.g. the
+                # raw stdlib panic message `thread '...' panicked at ...`
+                # printed by the default panic hook AFTER the tracing
+                # entry was already flushed. Emit immediately.
+                with lock:
+                    print(f"{prefix}{line}", end="", flush=True)
+        flush()
     except ValueError:
-        pass  # stream closed
+        flush()  # stream closed
 
 
 def wait_for_port(port: int, timeout: float, proc: subprocess.Popen) -> bool:
@@ -249,7 +319,10 @@ def terminate_tree(proc: subprocess.Popen) -> None:
             proc.terminate()
 
 
-def shutdown(procs: list[subprocess.Popen]) -> None:
+def shutdown(
+    procs: list[subprocess.Popen],
+    prefix_threads: list[threading.Thread] | None = None,
+) -> None:
     print(f"\n{BOLD}Shutting down...{RESET}")
     for proc in procs:
         terminate_tree(proc)
@@ -260,6 +333,17 @@ def shutdown(procs: list[subprocess.Popen]) -> None:
             # Tree-kill already used SIGKILL on Windows; on POSIX fall
             # back to per-process SIGKILL for any stragglers.
             proc.kill()
+
+    # Drain the prefix_stream readers so any entry buffered in-flight
+    # (the bridge's panic before exit, in particular — see bindreams/hole#393)
+    # gets flushed to the console. Each thread's natural exit happens
+    # quickly after its subprocess's stdout closes; the 5 s budget is
+    # the graceful-failure bound for the external readline returning
+    # (CLAUDE.md "external event with graceful failure bound" — the
+    # exception class for sync against an out-of-process I/O event).
+    if prefix_threads is not None:
+        for t in prefix_threads:
+            t.join(timeout=5)
 
 
 # Privilege drop =======================================================================================================
@@ -385,6 +469,8 @@ def main() -> None:
     print()
 
     procs: list[subprocess.Popen] = []
+    prefix_threads: list[threading.Thread] = []
+    print_lock = threading.Lock()
     done = threading.Event()
 
     try:
@@ -404,7 +490,16 @@ def main() -> None:
             **new_process_group_kwargs(),
         )
         procs.append(vite_proc)
-        threading.Thread(target=prefix_stream, args=(vite_proc.stdout, "  vite", YELLOW), daemon=True).start()
+        # Vite's output has no ISO timestamps; per-line emit avoids the
+        # buffer-never-flushes failure mode (see prefix_stream docstring).
+        t_vite = threading.Thread(
+            target=prefix_stream,
+            args=(vite_proc.stdout, "  vite", YELLOW, print_lock),
+            kwargs={"buffer_entries": False},
+            daemon=True,
+        )
+        t_vite.start()
+        prefix_threads.append(t_vite)
         threading.Thread(target=wait_for_exit, args=(vite_proc, done), daemon=True).start()
 
         if not wait_for_port(VITE_PORT, VITE_READY_TIMEOUT, vite_proc):
@@ -433,7 +528,16 @@ def main() -> None:
             **new_process_group_kwargs(),
         )
         procs.append(bridge_proc)
-        threading.Thread(target=prefix_stream, args=(bridge_proc.stdout, "bridge", CYAN), daemon=True).start()
+        # Bridge emits ISO-timestamped tracing entries; buffer multi-line
+        # entries so panic backtraces don't get split by [client] lines.
+        t_bridge = threading.Thread(
+            target=prefix_stream,
+            args=(bridge_proc.stdout, "bridge", CYAN, print_lock),
+            kwargs={"buffer_entries": True},
+            daemon=True,
+        )
+        t_bridge.start()
+        prefix_threads.append(t_bridge)
         threading.Thread(target=wait_for_exit, args=(bridge_proc, done), daemon=True).start()
 
         # Wait for the bridge to bind the socket before starting the GUI.
@@ -480,7 +584,15 @@ def main() -> None:
             **new_process_group_kwargs(),
         )
         procs.append(gui_proc)
-        threading.Thread(target=prefix_stream, args=(gui_proc.stdout, "client", MAGENTA), daemon=True).start()
+        # GUI also emits ISO-timestamped tracing entries.
+        t_client = threading.Thread(
+            target=prefix_stream,
+            args=(gui_proc.stdout, "client", MAGENTA, print_lock),
+            kwargs={"buffer_entries": True},
+            daemon=True,
+        )
+        t_client.start()
+        prefix_threads.append(t_client)
         threading.Thread(target=wait_for_exit, args=(gui_proc, done), daemon=True).start()
 
         # Block until any process exits or Ctrl+C.
@@ -503,7 +615,7 @@ def main() -> None:
     except KeyboardInterrupt:
         pass
     finally:
-        shutdown(procs)
+        shutdown(procs, prefix_threads)
 
 
 if __name__ == "__main__":

--- a/scripts/dev_tests.py
+++ b/scripts/dev_tests.py
@@ -3,26 +3,25 @@
 # requires-python = ">=3.9"
 # dependencies = ["pytest"]
 # ///
-"""Unit tests for `drop_kwargs` in `dev.py`.
+"""Unit tests for helpers in `dev.py`.
+
+Covers:
+- `drop_kwargs` (POSIX-only; skipped on Windows)
+- `prefix_stream` log multiplexing (platform-agnostic)
 
 Run with: `uv run scripts/dev_tests.py`
 """
 from __future__ import annotations
 
 import importlib.util
+import io
 import sys
+import threading
 import types
 from pathlib import Path
 from unittest import mock
 
 import pytest
-
-# `drop_kwargs` is a no-op on Windows (always returns `{}`). Skip the whole
-# module to avoid loading `dev.py` which references `grp` (POSIX-only) when
-# `target_user` is non-None — and to avoid pretending we have coverage we
-# don't.
-if sys.platform == "win32":
-    pytest.skip("drop_kwargs is POSIX-only", allow_module_level=True)
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPTS_DIR))
@@ -45,11 +44,17 @@ assert _spec and _spec.loader, "failed to locate scripts/dev.py"
 dev = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(dev)
 
+# drop_kwargs tests (POSIX-only) =======================================================================================
 
+posix_only = pytest.mark.skipif(sys.platform == "win32", reason="drop_kwargs is POSIX-only")
+
+
+@posix_only
 def test_target_none_returns_empty():
     assert dev.drop_kwargs(None) == {}
 
 
+@posix_only
 def test_hole_present_includes_hole_gid():
     fake = types.SimpleNamespace(gr_gid=4242)
     with mock.patch.object(dev.grp, "getgrnam", return_value=fake):
@@ -57,12 +62,14 @@ def test_hole_present_includes_hole_gid():
     assert kw == {"user": 501, "group": 20, "extra_groups": [4242]}
 
 
+@posix_only
 def test_hole_absent_returns_empty_list():
     with mock.patch.object(dev.grp, "getgrnam", side_effect=KeyError("hole")):
         kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
     assert kw == {"user": 501, "group": 20, "extra_groups": []}
 
 
+@posix_only
 def test_directory_services_failure_returns_empty_list(capsys):
     with mock.patch.object(dev.grp, "getgrnam", side_effect=OSError("DS unreachable")):
         kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
@@ -70,6 +77,202 @@ def test_directory_services_failure_returns_empty_list(capsys):
     # Surface the failure to the user — silently dropping `hole` would
     # leave the GUI confused without any breadcrumb.
     assert "DS unreachable" in capsys.readouterr().err
+
+
+# prefix_stream tests (platform-agnostic) ==============================================================================
+#
+# Anchor the panic-backtrace incident from bindreams/hole#393: a
+# multi-line tracing entry from the bridge must not be interleaved
+# with [client] lines from the GUI subprocess.
+
+
+def _strip_ansi(s: str) -> str:
+    """Drop ANSI color escape sequences so assertions can compare the
+    visible text. dev.py wraps prefixes in colors; the tests only care
+    about ordering and atomicity."""
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def _run_streams(streams: list[tuple[str, str, bool]]) -> str:
+    """Run prefix_stream in parallel against `streams`.
+
+    Each tuple is `(label, text, buffer_entries)`. Returns the captured
+    stdout with ANSI codes stripped.
+    """
+    lock = threading.Lock()
+    threads: list[threading.Thread] = []
+    captured = io.StringIO()
+    with mock.patch.object(dev.sys, "stdout", captured):
+        for label, text, buffer_entries in streams:
+            stream = io.StringIO(text)
+            t = threading.Thread(
+                target=dev.prefix_stream,
+                args=(stream, label, "", lock),
+                kwargs={"buffer_entries": buffer_entries},
+            )
+            t.start()
+            threads.append(t)
+        for t in threads:
+            t.join(timeout=5)
+            assert not t.is_alive(), "prefix_stream thread did not terminate"
+    return _strip_ansi(captured.getvalue())
+
+
+def test_prefix_stream_single_line_emits_prefixed_line():
+    text = "2026-05-24T11:13:36Z INFO hole_bridge: started\n"
+    out = _run_streams([("bridge", text, True)])
+    assert out == "[bridge] 2026-05-24T11:13:36Z INFO hole_bridge: started\n"
+
+
+def test_prefix_stream_buffers_multiline_entry_until_next_entry():
+    # The bridge's structured panic entry from #393 — must stay
+    # contiguous in the output even when the test's "next entry"
+    # marker arrives mid-buffer.
+    bridge_text = (
+        "2026-05-24T11:13:36Z ERROR hole::panic: panic: ...\n"
+        "  location: shadowsocks.rs:101\n"
+        "  backtrace: |2\n"
+        "       0: frame_a\n"
+        "       1: frame_b\n"
+        "2026-05-24T11:13:37Z INFO hole_bridge: stopping\n"
+    )
+    out = _run_streams([("bridge", bridge_text, True)])
+    # The first entry's 5 lines must appear contiguously before the
+    # second entry's single line. (No other stream is competing, so
+    # this just verifies the buffer-and-flush mechanics.)
+    lines = out.splitlines(keepends=True)
+    assert lines == [
+        "[bridge] 2026-05-24T11:13:36Z ERROR hole::panic: panic: ...\n",
+        "[bridge]   location: shadowsocks.rs:101\n",
+        "[bridge]   backtrace: |2\n",
+        "[bridge]        0: frame_a\n",
+        "[bridge]        1: frame_b\n",
+        "[bridge] 2026-05-24T11:13:37Z INFO hole_bridge: stopping\n",
+    ]
+
+
+def test_prefix_stream_eof_flushes_final_entry():
+    # The panic-then-exit case: the bridge writes one tracing entry
+    # then dies. EOF must flush the buffered entry.
+    bridge_text = ("2026-05-24T11:13:36Z ERROR hole::panic: panic: dying\n"
+                   "  backtrace: |2\n"
+                   "       0: frame\n")
+    out = _run_streams([("bridge", bridge_text, True)])
+    assert out == (
+        "[bridge] 2026-05-24T11:13:36Z ERROR hole::panic: panic: dying\n"
+        "[bridge]   backtrace: |2\n"
+        "[bridge]        0: frame\n"
+    )
+
+
+def test_prefix_stream_non_buffered_emits_per_line():
+    # Vite has no timestamps; buffer_entries=False prints each line
+    # immediately. With buffer_entries=True we'd starve forever.
+    vite_text = "VITE v8.0.13 ready in 499 ms\nLocal: http://localhost:1420/\n"
+    out = _run_streams([("  vite", vite_text, False)])
+    assert out == ("[  vite] VITE v8.0.13 ready in 499 ms\n"
+                   "[  vite] Local: http://localhost:1420/\n")
+
+
+def test_prefix_stream_standalone_panic_message_after_flush():
+    # The stdlib default panic hook prints `thread '...' panicked at ...`
+    # AFTER the tracing entry. With no preceding buffer, this line is
+    # emitted as a standalone, not appended to a prior entry.
+    text = (
+        "2026-05-24T11:13:36Z ERROR hole::panic: panic\n"
+        "  backtrace: |2\n"
+        "       0: f\n"
+        "thread 'tokio-rt-worker' panicked at shadowsocks.rs:101\n"
+        "note: run with `RUST_BACKTRACE=1` ...\n"
+        "2026-05-24T11:13:37Z INFO hole_bridge: next entry\n"
+    )
+    out = _run_streams([("bridge", text, True)])
+    # First three lines are the tracing entry (flushed when "thread ..."
+    # arrives WITHOUT a timestamp — but my impl appends non-timestamp
+    # lines to the in-progress buffer if one exists). The current
+    # design buffers the panic-message lines onto the preceding
+    # tracing entry until the next entry-start arrives. That is the
+    # documented trade-off; pin it explicitly here so a future
+    # behavior change is noticed.
+    assert out == (
+        "[bridge] 2026-05-24T11:13:36Z ERROR hole::panic: panic\n"
+        "[bridge]   backtrace: |2\n"
+        "[bridge]        0: f\n"
+        "[bridge] thread 'tokio-rt-worker' panicked at shadowsocks.rs:101\n"
+        "[bridge] note: run with `RUST_BACKTRACE=1` ...\n"
+        "[bridge] 2026-05-24T11:13:37Z INFO hole_bridge: next entry\n"
+    )
+
+
+def test_prefix_stream_multiline_entries_do_not_interleave_across_streams():
+    # The motivating bug: bridge backtrace was chopped up by [client]
+    # lines. With the lock + buffer, each entry is one atomic write.
+    bridge_text = (
+        "2026-05-24T11:13:36Z ERROR hole::panic: panic\n"
+        "  backtrace: |2\n"
+        "       0: f0\n"
+        "       1: f1\n"
+        "       2: f2\n"
+        "2026-05-24T11:13:38Z INFO hole_bridge: done\n"
+    )
+    client_text = (
+        "2026-05-24T11:13:36Z WARN hole::state: comm error\n"
+        "  error: 'connection closed'\n"
+        "2026-05-24T11:13:37Z ERROR hole::tray: send failed\n"
+    )
+
+    # Run a few times to surface scheduling races. (Test-of-timing
+    # exception class per CLAUDE.md: we're checking the absence of
+    # interleaving, which is intrinsically a concurrency property.)
+    for _ in range(10):
+        out = _run_streams([
+            ("bridge", bridge_text, True),
+            ("client", client_text, True),
+        ])
+        # Each entry's lines must be contiguous. We test that by
+        # confirming no [client] line appears between two consecutive
+        # [bridge] lines of the same entry.
+        lines = out.splitlines(keepends=True)
+        bridge_entries: list[list[str]] = []
+        client_entries: list[list[str]] = []
+        current_bridge: list[str] | None = None
+        current_client: list[str] | None = None
+        for ln in lines:
+            if ln.startswith("[bridge]"):
+                if current_bridge is None:
+                    current_bridge = [ln]
+                elif "ERROR" in ln or "INFO" in ln or "WARN" in ln:
+                    # New entry — flush previous
+                    bridge_entries.append(current_bridge)
+                    current_bridge = [ln]
+                else:
+                    current_bridge.append(ln)
+                # If a [client] entry was in progress when [bridge] starts,
+                # it must NOT have been interrupted mid-entry.
+            elif ln.startswith("[client]"):
+                if current_client is None:
+                    current_client = [ln]
+                elif "ERROR" in ln or "INFO" in ln or "WARN" in ln:
+                    client_entries.append(current_client)
+                    current_client = [ln]
+                else:
+                    current_client.append(ln)
+        if current_bridge:
+            bridge_entries.append(current_bridge)
+        if current_client:
+            client_entries.append(current_client)
+
+        # Bridge entries: first 5 lines (entry-start + 4 continuations),
+        # then 1 line.
+        assert len(bridge_entries) == 2
+        assert len(bridge_entries[0]) == 5
+        assert len(bridge_entries[1]) == 1
+        # Client entries: first 2 lines, then 1 line.
+        assert len(client_entries) == 2
+        assert len(client_entries[0]) == 2
+        assert len(client_entries[1]) == 1
 
 
 if __name__ == "__main__":

--- a/ui/sidebar.ts
+++ b/ui/sidebar.ts
@@ -15,6 +15,8 @@ import {
 } from "./connection-state";
 import { config, loadConfig } from "./main";
 import { statusTooltipFor } from "./servers";
+import { showToast } from "./toast";
+import { toggleFailureToast } from "./toggle-failure";
 import {
   type DiagnosticsData,
   LATENCY_VALIDATED_ON_CONNECT,
@@ -193,12 +195,16 @@ async function toggleFromIdle(goingToConnect: boolean) {
     // Best-effort cancel so the bridge doesn't finish the connect in
     // the background behind our back. Ignore the result.
     invoke("cancel_proxy").catch(() => {});
+    const spec = toggleFailureToast(raced, goingToConnect);
+    showToast(spec.message, spec.kind);
     setState(goingToConnect ? "connection-failed" : "disconnection-failed");
     return;
   }
 
   if (raced.kind === "err") {
     console.error("toggle_proxy failed:", raced.error);
+    const spec = toggleFailureToast(raced, goingToConnect);
+    showToast(spec.message, spec.kind);
     setState(goingToConnect ? "connection-failed" : "disconnection-failed");
     return;
   }
@@ -219,6 +225,8 @@ async function toggleFromIdle(goingToConnect: boolean) {
       setState(stateForToggleOutcome(stopOutcome));
     } catch (err) {
       console.error("follow-up stop failed:", err);
+      const spec = toggleFailureToast({ kind: "err", error: err }, /*goingToConnect=*/ false);
+      showToast(spec.message, spec.kind);
       setState("disconnection-failed");
     }
     updatePublicIp();

--- a/ui/toggle-failure.test.ts
+++ b/ui/toggle-failure.test.ts
@@ -1,0 +1,43 @@
+// Unit tests for the pure failure-message helper. See
+// bindreams/hole#393 — the original incident was a real bridge error
+// being invisible to the user; these tests pin the format the user
+// sees in the toast.
+
+import { describe, expect, it } from "vitest";
+import { TOGGLE_TIMEOUT_MS, toggleFailureToast } from "./toggle-failure";
+
+describe("toggleFailureToast", () => {
+  it("timeout going-to-connect yields a 'start' message in seconds", () => {
+    expect(toggleFailureToast({ kind: "timeout" }, true)).toEqual({
+      message: `Proxy start timed out after ${Math.round(TOGGLE_TIMEOUT_MS / 1000)} s.`,
+      kind: "error",
+    });
+  });
+
+  it("timeout going-to-disconnect yields a 'stop' message", () => {
+    expect(toggleFailureToast({ kind: "timeout" }, false)).toEqual({
+      message: `Proxy stop timed out after ${Math.round(TOGGLE_TIMEOUT_MS / 1000)} s.`,
+      kind: "error",
+    });
+  });
+
+  it("string rejection surfaces the bridge error verbatim", () => {
+    // Production wire format: ProxyError::ForwarderSelfTestFailed.Display.
+    const msg = "forwarder self-test failed after 3 attempts in 4520ms: attempt 3 timed out after 1.5s";
+    expect(toggleFailureToast({ kind: "err", error: msg }, true)).toEqual({
+      message: msg,
+      kind: "error",
+    });
+  });
+
+  it("non-string rejection is stringified defensively (no [object Object])", () => {
+    expect(toggleFailureToast({ kind: "err", error: new Error("boom") }, true)).toEqual({
+      message: "Error: boom",
+      kind: "error",
+    });
+  });
+
+  it("undefined rejection still produces a non-empty message", () => {
+    expect(toggleFailureToast({ kind: "err", error: undefined }, true).message).toBe("undefined");
+  });
+});

--- a/ui/toggle-failure.ts
+++ b/ui/toggle-failure.ts
@@ -1,0 +1,40 @@
+// Pure helper: format the toast message for a `toggle_proxy` failure
+// (timeout, rejection, or follow-up-stop rejection). Extracted so the
+// message shape is unit-testable without DOM/Tauri-mock plumbing in
+// sidebar.ts.
+//
+// See bindreams/hole#393 for the original incident — a real bridge
+// failure was silently invisible to the user because `toggleFromIdle`
+// only logged to console.
+
+import type { ToastKind } from "./toast";
+
+/// Client-side timeout for `toggle_proxy`, mirrored from sidebar.ts so
+/// the helper has no upward import. Keep in sync.
+export const TOGGLE_TIMEOUT_MS = 15_000;
+
+export type ToggleFailure = { kind: "timeout" } | { kind: "err"; error: unknown };
+
+export interface ToastSpec {
+  message: string;
+  kind: ToastKind;
+}
+
+/// Compute the toast message for a `toggle_proxy` failure. Stringifies
+/// non-string rejections defensively (current bridge wire format is
+/// `Result<_, String>`, but a future shape change shouldn't silently
+/// fall back to "[object Object]" in the user's face).
+export function toggleFailureToast(failure: ToggleFailure, goingToConnect: boolean): ToastSpec {
+  if (failure.kind === "timeout") {
+    const action = goingToConnect ? "start" : "stop";
+    const seconds = Math.round(TOGGLE_TIMEOUT_MS / 1000);
+    return {
+      message: `Proxy ${action} timed out after ${seconds} s.`,
+      kind: "error",
+    };
+  }
+  return {
+    message: String(failure.error),
+    kind: "error",
+  };
+}

--- a/xtask/src/bindir.rs
+++ b/xtask/src/bindir.rs
@@ -13,19 +13,53 @@ use anyhow::{anyhow, Context, Result};
 
 use crate::Profile;
 
-/// One file that must end up in BINDIR alongside the bridge binary.
+/// Source kind for a BINDIR entry. Files use hard-link-then-copy;
+/// directory bundles (macOS `.dSYM`) recurse a copy. Introduced for
+/// bindreams/hole#393 so panic-backtrace symbols ship on both
+/// platforms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindirSource {
+    /// Single regular file. Staged via hard-link with copy fallback.
+    File(PathBuf),
+    /// Directory bundle. Staged via recursive copy. Used for macOS
+    /// `.dSYM` bundles; hard-link doesn't apply at the directory
+    /// level, and even if it did, Finder/Spotlight expect a real
+    /// directory tree.
+    Directory(PathBuf),
+}
+
+impl BindirSource {
+    pub fn path(&self) -> &Path {
+        match self {
+            BindirSource::File(p) | BindirSource::Directory(p) => p,
+        }
+    }
+}
+
+/// One file or bundle that must end up in BINDIR alongside the bridge
+/// binary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BindirFile {
-    /// Absolute source path on disk.
-    pub source: PathBuf,
+    /// Absolute source path on disk and its kind.
+    pub source: BindirSource,
     /// Filename to use in the destination directory (no path components).
     pub dest_name: String,
 }
 
 impl BindirFile {
+    /// Construct a file entry — the common case. Equivalent to
+    /// `BindirSource::File(source)`.
     pub fn new(source: PathBuf, dest_name: impl Into<String>) -> Self {
         Self {
-            source,
+            source: BindirSource::File(source),
+            dest_name: dest_name.into(),
+        }
+    }
+
+    /// Construct a directory-bundle entry (macOS `.dSYM`, etc.).
+    pub fn directory(source: PathBuf, dest_name: impl Into<String>) -> Self {
+        Self {
+            source: BindirSource::Directory(source),
             dest_name: dest_name.into(),
         }
     }
@@ -45,6 +79,29 @@ pub fn bindir_files(profile: Profile, repo_root: &Path) -> Result<Vec<BindirFile
     let hole_name = format!("hole{exe_suffix}");
     let hole_src = repo_root.join("target").join(profile.dir_name()).join(&hole_name);
     files.push(BindirFile::new(hole_src, hole_name));
+
+    // 1a. Debug symbols for `hole` — staged alongside the binary so panic
+    //     backtraces in dev (`scripts/dev.py`) and production (the MSI)
+    //     resolve frame names and line numbers. Without these, the panic
+    //     hook at `crates/common/src/logging.rs::install_panic_hook` renders
+    //     every frame as `<unknown>`. See bindreams/hole#393.
+    //
+    //     The workspace `[profile.release].debug = "limited"` guarantees the
+    //     PDB/dSYM exists for release builds (cargo's default is `false`).
+    //     Debug builds already emit full debug info.
+    #[cfg(target_os = "windows")]
+    {
+        // MSVC emits the binary's PDB next to the .exe.
+        let pdb_src = repo_root.join("target").join(profile.dir_name()).join("hole.pdb");
+        files.push(BindirFile::new(pdb_src, "hole.pdb".to_string()));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // Cargo's macOS `split-debuginfo = "unpacked"` (release default)
+        // emits a `.dSYM` bundle at the same level as the binary.
+        let dsym_src = repo_root.join("target").join(profile.dir_name()).join("hole.dSYM");
+        files.push(BindirFile::directory(dsym_src, "hole.dSYM".to_string()));
+    }
 
     // 2. v2ray-plugin sidecar. Built by `cargo xtask v2ray-plugin` into
     //    `.cache/v2ray-plugin/v2ray-plugin-<target-triple>{.exe}`. The

--- a/xtask/src/bindir_tests.rs
+++ b/xtask/src/bindir_tests.rs
@@ -8,12 +8,23 @@ fn fake_repo() -> tempfile::TempDir {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
-    // target/{debug,release}/hole{.exe}
+    // target/{debug,release}/hole{.exe} (+ debug symbols per platform).
+    // The PDB / dSYM is staged so panic backtraces resolve. See
+    // bindreams/hole#393.
     for profile in ["debug", "release"] {
         let target = root.join("target").join(profile);
         fs::create_dir_all(&target).unwrap();
         let name = if cfg!(windows) { "hole.exe" } else { "hole" };
         fs::write(target.join(name), b"fake hole binary").unwrap();
+
+        #[cfg(target_os = "windows")]
+        fs::write(target.join("hole.pdb"), b"fake pdb").unwrap();
+        #[cfg(target_os = "macos")]
+        {
+            let dsym = target.join("hole.dSYM").join("Contents");
+            fs::create_dir_all(&dsym).unwrap();
+            fs::write(dsym.join("Info.plist"), b"<plist/>").unwrap();
+        }
     }
 
     // .cache/v2ray-plugin/v2ray-plugin-<triple>{.exe} — exactly one match
@@ -63,6 +74,7 @@ fn bindir_contains_expected_files() {
         names,
         vec![
             "hole.exe",
+            "hole.pdb",
             "v2ray-plugin.exe",
             "galoshes.exe",
             "wintun.dll",
@@ -71,7 +83,10 @@ fn bindir_contains_expected_files() {
     );
 
     #[cfg(target_os = "macos")]
-    assert_eq!(names, vec!["hole", "v2ray-plugin", "galoshes", "NOTICES.md"]);
+    assert_eq!(
+        names,
+        vec!["hole", "hole.dSYM", "v2ray-plugin", "galoshes", "NOTICES.md"]
+    );
 
     #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
     assert_eq!(names, vec!["hole", "v2ray-plugin", "galoshes", "NOTICES.md"]);
@@ -87,19 +102,27 @@ fn bindir_uses_correct_profile_dir() {
     let debug_hole = &debug_files[0];
     let release_hole = &release_files[0];
     assert!(
-        debug_hole.source.to_string_lossy().contains("debug"),
+        debug_hole.source.path().to_string_lossy().contains("debug"),
         "expected debug profile path, got {}",
-        debug_hole.source.display()
+        debug_hole.source.path().display()
     );
     assert!(
-        release_hole.source.to_string_lossy().contains("release"),
+        release_hole.source.path().to_string_lossy().contains("release"),
         "expected release profile path, got {}",
-        release_hole.source.display()
+        release_hole.source.path().display()
     );
 
-    // Sidecar paths are profile-independent (they live in .cache/, not target/)
-    let debug_sidecar = &debug_files[1];
-    let release_sidecar = &release_files[1];
+    // Sidecar paths are profile-independent (they live in .cache/, not target/).
+    // Look up by name rather than index because debug symbols (added in #393)
+    // shift the v2ray-plugin slot off index 1 on Windows/macOS.
+    let debug_sidecar = debug_files
+        .iter()
+        .find(|f| f.dest_name.starts_with("v2ray-plugin"))
+        .unwrap();
+    let release_sidecar = release_files
+        .iter()
+        .find(|f| f.dest_name.starts_with("v2ray-plugin"))
+        .unwrap();
     assert_eq!(debug_sidecar.source, release_sidecar.source);
 }
 

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -676,6 +676,10 @@ fn frontend_check_target_shape() {
                 command: "npm run check".to_string(),
                 environment: HashMap::new(),
             },
+            Step::Bash {
+                command: "npm test".to_string(),
+                environment: HashMap::new(),
+            },
         ]
     );
     // No `depends: frontend-build`. tsc reads source files directly; the

--- a/xtask/src/stage.rs
+++ b/xtask/src/stage.rs
@@ -14,24 +14,13 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::bindir::BindirFile;
+use crate::bindir::{BindirFile, BindirSource};
 
 /// Stage `files` into `out_dir`. Creates `out_dir` if missing.
 pub fn stage(out_dir: &Path, files: &[BindirFile]) -> Result<()> {
     std::fs::create_dir_all(out_dir).with_context(|| format!("failed to create out_dir {}", out_dir.display()))?;
 
     for f in files {
-        // Validate the source exists with a clear error message — much more
-        // useful than the cryptic "No such file or directory" you'd get
-        // from std::fs::hard_link.
-        if !f.source.is_file() {
-            return Err(anyhow!(
-                "BINDIR source file does not exist: {}\n\
-                 Run `cargo build` (and, post-Commit-4, `cargo xtask deps`) first.",
-                f.source.display()
-            ));
-        }
-
         // Reject any dest_name with path separators — defense against future
         // edits to bindir_files() introducing nested layouts that the consumers
         // wouldn't handle.
@@ -44,25 +33,103 @@ pub fn stage(out_dir: &Path, files: &[BindirFile]) -> Result<()> {
 
         let dest = out_dir.join(&f.dest_name);
 
-        // Remove any pre-existing file at the destination so hard_link can
-        // succeed (it errors if the destination exists). This matches what
-        // shutil.copy2 and the existing link_or_copy helper do implicitly.
-        if dest.exists() {
-            std::fs::remove_file(&dest)
-                .with_context(|| format!("failed to remove pre-existing dest {}", dest.display()))?;
-        }
-
-        match std::fs::hard_link(&f.source, &dest) {
-            Ok(()) => {}
-            Err(_) => {
-                // Hardlink failed (cross-device, permissions, etc.). Fall back
-                // to a copy. We deliberately do not log the hardlink error —
-                // it's expected on a fresh dev temp dir on a different volume.
-                std::fs::copy(&f.source, &dest)
-                    .with_context(|| format!("failed to copy {} to {}", f.source.display(), dest.display()))?;
-            }
+        match &f.source {
+            BindirSource::File(src) => stage_file(src, &dest)?,
+            BindirSource::Directory(src) => stage_directory(src, &dest)?,
         }
     }
 
+    Ok(())
+}
+
+fn stage_file(src: &Path, dest: &Path) -> Result<()> {
+    // Validate the source exists with a clear error message — much more
+    // useful than the cryptic "No such file or directory" you'd get
+    // from std::fs::hard_link.
+    if !src.is_file() {
+        return Err(anyhow!(
+            "BINDIR source file does not exist: {}\n\
+             Run `cargo build` (and `cargo xtask deps`) first.",
+            src.display()
+        ));
+    }
+
+    // Remove any pre-existing file at the destination so hard_link can
+    // succeed (it errors if the destination exists). This matches what
+    // shutil.copy2 and the existing link_or_copy helper do implicitly.
+    if dest.exists() {
+        std::fs::remove_file(dest).with_context(|| format!("failed to remove pre-existing dest {}", dest.display()))?;
+    }
+
+    match std::fs::hard_link(src, dest) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            // Hardlink failed (cross-device, permissions, etc.). Fall back
+            // to a copy. We deliberately do not log the hardlink error —
+            // it's expected on a fresh dev temp dir on a different volume.
+            std::fs::copy(src, dest)
+                .map(|_| ())
+                .with_context(|| format!("failed to copy {} to {}", src.display(), dest.display()))
+        }
+    }
+}
+
+/// Recursively copy `src` directory into `dest`. Used for macOS `.dSYM`
+/// bundles. Hard-link is not attempted — these bundles are needed as
+/// real directory trees for Spotlight/Finder/lldb.
+///
+/// The recursion is depth-first, idempotent (pre-existing `dest` is
+/// removed first), and propagates the first I/O error encountered.
+fn stage_directory(src: &Path, dest: &Path) -> Result<()> {
+    if !src.is_dir() {
+        return Err(anyhow!(
+            "BINDIR source directory does not exist: {}\n\
+             Run `cargo build` (and `cargo xtask deps`) first.",
+            src.display()
+        ));
+    }
+
+    if dest.exists() {
+        std::fs::remove_dir_all(dest)
+            .with_context(|| format!("failed to remove pre-existing dest {}", dest.display()))?;
+    }
+
+    copy_dir_recursive(src, dest)
+        .with_context(|| format!("failed to copy directory {} to {}", src.display(), dest.display()))
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dest)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_symlink() {
+            // Preserve symlinks within the bundle (rare but possible
+            // inside dSYM/Versions/). On Windows symlinks may fail
+            // without elevation; fall back to a regular copy of the
+            // target so we still produce a usable bundle.
+            let target = std::fs::read_link(&from)?;
+            #[cfg(unix)]
+            {
+                std::os::unix::fs::symlink(&target, &to)?;
+            }
+            #[cfg(not(unix))]
+            {
+                // Resolve the symlink and copy its target as a regular file.
+                let resolved = if target.is_absolute() {
+                    target
+                } else {
+                    from.parent().unwrap_or(src).join(&target)
+                };
+                std::fs::copy(&resolved, &to)?;
+            }
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
     Ok(())
 }

--- a/xtask/src/stage_tests.rs
+++ b/xtask/src/stage_tests.rs
@@ -1,4 +1,4 @@
-use crate::bindir::BindirFile;
+use crate::bindir::{BindirFile, BindirSource};
 use crate::stage::stage;
 use std::fs;
 
@@ -60,6 +60,76 @@ fn stage_errors_when_source_missing() {
     assert!(
         msg.contains("does not exist") && msg.contains("hole.exe"),
         "expected missing-source error, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn stage_recursively_copies_directory_bundle() {
+    // Directory-bundle support was added for macOS `.dSYM` in
+    // bindreams/hole#393. Verify the recursion preserves nested
+    // structure.
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+
+    let bundle = src_dir.path().join("hole.dSYM");
+    fs::create_dir_all(bundle.join("Contents").join("Resources").join("DWARF")).unwrap();
+    fs::write(bundle.join("Contents").join("Info.plist"), b"<plist/>").unwrap();
+    fs::write(
+        bundle.join("Contents").join("Resources").join("DWARF").join("hole"),
+        b"dwarf",
+    )
+    .unwrap();
+
+    let files = vec![BindirFile::directory(bundle, "hole.dSYM")];
+    stage(dst_dir.path(), &files).unwrap();
+
+    let staged = dst_dir.path().join("hole.dSYM");
+    assert!(staged.is_dir());
+    assert_eq!(
+        fs::read(staged.join("Contents").join("Info.plist")).unwrap(),
+        b"<plist/>"
+    );
+    assert_eq!(
+        fs::read(staged.join("Contents").join("Resources").join("DWARF").join("hole")).unwrap(),
+        b"dwarf"
+    );
+}
+
+#[skuld::test]
+fn stage_directory_replaces_existing_bundle() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+
+    let bundle = src_dir.path().join("hole.dSYM");
+    fs::create_dir(&bundle).unwrap();
+    fs::write(bundle.join("new.txt"), b"new").unwrap();
+
+    // Pre-existing destination bundle with stale file — must be wiped
+    // before the new tree is copied in.
+    let stale = dst_dir.path().join("hole.dSYM");
+    fs::create_dir(&stale).unwrap();
+    fs::write(stale.join("stale.txt"), b"stale").unwrap();
+
+    let files = vec![BindirFile::directory(bundle, "hole.dSYM")];
+    stage(dst_dir.path(), &files).unwrap();
+
+    // Stale file is gone, new file is present.
+    assert!(!stale.join("stale.txt").exists(), "stale file should have been removed");
+    assert_eq!(fs::read(stale.join("new.txt")).unwrap(), b"new");
+}
+
+#[skuld::test]
+fn stage_errors_when_directory_source_missing() {
+    let dst_dir = tempfile::tempdir().unwrap();
+    let files = vec![BindirFile {
+        source: BindirSource::Directory(std::path::PathBuf::from("/no/such/bundle.dSYM")),
+        dest_name: "bundle.dSYM".to_string(),
+    }];
+    let err = stage(dst_dir.path(), &files).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("does not exist") && msg.contains("bundle.dSYM"),
+        "expected missing-directory error, got: {msg}"
     );
 }
 

--- a/xtask/src/test_binaries_tests.rs
+++ b/xtask/src/test_binaries_tests.rs
@@ -118,7 +118,7 @@ fn bindir_files_exe_only_when_no_pdb() {
     let files = bindir_files_for_artifact("hole_bridge.test.exe", &a);
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].dest_name, "hole_bridge.test.exe");
-    assert_eq!(files[0].source, exe);
+    assert_eq!(files[0].source.path(), exe.as_path());
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Closes #393.

## Summary

A staging-server connect attempt that tripped the #388 forwarder self-test gate produced a totally unreadable failure: the bridge panicked instead of returning the real error, the GUI showed nothing, and the bridge log was swamped with ETW noise and a backtrace with no symbols. This PR fixes all five compounding defects so the next reproduction yields a clear user-visible toast with the actual reason and a clean, symbolicated bridge log.

Each fix is its own commit and trace to a single incident.

### 1. `fix(bridge): ShadowsocksRunning::drop no longer panics on error-path unwind` (4e7f7e6)
`Drop::drop`'s `debug_assert!` was over-eager — #388's RAII unwind on error paths is the documented design path. Removed the assertion (Drop still calls `h.abort()` for cleanup); updated the doc comment to spell out the dual contract (`stop().await` graceful vs `Drop` cancel-unwind). Added `from_handle` test seam + 2 tests pinning the no-panic invariant.

### 2. `feat(ui): surface bridge errors as toasts on toggle_proxy failure` (131ca6a)
`toggleFromIdle` only `console.error`'d failures — invisible to users. New `ui/toggle-failure.ts` helper formats the toast message for timeout / rejection / non-string-rejection branches; the three failure sites in `sidebar.ts` now call `showToast(spec.message, spec.kind)` alongside the existing console output. 5 vitest cases pin the format including the verbatim `ForwarderSelfTestFailed` Display rendering.

### 3. `fix(bridge): gate ETW dispatch on TCPIP provider; AFD/WFP route to DEBUG` (fb3c6c1)
`dispatch` matched event-ids regardless of provider. AFD events 1002/1004/1017 collide with TCPIP `TCB_CONNECT_REQUESTED`/`TCB_SYN_SEND`/`ACCEPT_COMPLETED` and emitted at INFO — ~2000 lines of background-traffic noise. The module doc already said "WFP + AFD currently use the generic info-with-event-id path"; the code now matches that intent via a provider gate. TCPIP keeps its #200-designed connection-level INFO routing. 8 existing tests switched from `any_guid()` → `tcpip_guid()`, 3 new tests cover AFD/WFP/unknown-provider short-circuits, one test renamed to reflect its new semantics.

### 4. `build: stage hole.pdb (Windows) and hole.dSYM (macOS) for symbolicated panics` (e54edc0)
Panic backtraces had every frame as `<unknown>` because debug symbols were never staged into BINDIR. Three coordinated edits:
- Workspace `Cargo.toml`: `[profile.release].debug = "limited"` so release builds emit line tables + function names.
- `BindirFile` refactored to `BindirSource::{File, Directory}`; `stage.rs` grew a recursive directory copy for macOS `.dSYM` bundles (the directory case also handles future Linux split-DWARF).
- `bindir_files()` adds `hole.pdb` (Windows) and `hole.dSYM` (macOS) next to `hole.exe`.
- MSI: `<File Id="hole.pdb">` component added so it ships with the installer.
- Tests updated: `bindir_tests.rs` expects the new files, new `stage_recursively_copies_directory_bundle` + `stage_directory_replaces_existing_bundle` + `stage_errors_when_directory_source_missing`, and `test_hole_msi.py` stages `hole.pdb` into its fake bindir.

### 5. `fix(dev.py): atomic per-entry log multiplexing to prevent interleaving` (728a6f0)
`prefix_stream` printed per-line with no shared lock between subprocesses, so multi-line tracing entries got chopped up by other streams' lines. Now buffers continuation lines (matched against `^\d{4}-\d{2}-\d{2}T`) and flushes each entry as one atomic write under a shared `threading.Lock`. Per-label `buffer_entries` flag distinguishes timestamped streams (bridge, client) from Vite (no timestamps — buffering would starve). `shutdown()` joins the prefix-stream threads with a 5 s graceful-failure timeout so the bridge's panic-then-exit case still flushes the buffered entry. 6 new pytest cases cover single-line / multi-line / EOF / non-buffered / standalone-panic-line / cross-stream-no-interleave.

### Drive-by: `test(xtask): align frontend_check_target_shape with npm test in build.yaml` (4672168)
Pre-existing failure: `build.yaml` gained `npm test` in #385 but the test still asserted only `npm ci` + `npm run check`. One-line test update.

## Test plan

- [x] `cargo test -p hole-bridge --no-default-features --lib` — 441 pass, 2 expected env failures (e2e tests require elevation for TUN device creation).
- [x] `cargo test -p xtask --lib` — all pass (74 tests).
- [x] `npm test` — 34 vitest cases, including 5 new `toggle-failure` tests.
- [x] `uv run scripts/dev_tests.py` — 6 new prefix_stream tests pass, 4 drop_kwargs tests skipped on Windows.
- [x] `npx tsc --noEmit` clean.
- [x] `cargo clippy -p hole-bridge -p hole-common -p xtask --tests` clean.
- [ ] Manual repro of the #393 scenario: trigger the forwarder self-test failure (e.g. point upstream at an unreachable forwarder) and confirm:
  - GUI shows a red toast with the verbatim `ForwarderSelfTestFailed` message.
  - `bridge.log` contains the structured failure entry with a symbolicated backtrace (PDB now staged).
  - No `[client]`-interleaved bridge entries in dev.py console output.
  - No `ShadowsocksRunning dropped with a live task` panic.
  - ETW background traffic is no longer flooding the log at INFO.
- [ ] CI: full matrix (hole-tests, frontend-check, msi build, clippy).