### PR TITLE
fix(garter): wire SIP003 server-mode chains correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "garter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "contracts",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "garter-bin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "garter",

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(v2ray_plugin_missing, allow(dead_code, unused_imports))]
 
-use garter::{BinaryPlugin, ChainRunner, PluginEnv};
+use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv};
 
 #[cfg(not(v2ray_plugin_missing))]
 const V2RAY_BYTES: &[u8] = include_bytes!(env!("V2RAY_PLUGIN_PATH"));
@@ -43,11 +43,12 @@ async fn main() -> anyhow::Result<()> {
 
     let verified = v2ray_binary.prepare()?;
 
-    let yamux_plugin = galoshes::yamux::YamuxPlugin::from_plugin_options(env.plugin_options.as_deref());
-
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    let yamux_plugin = galoshes::yamux::YamuxPlugin::new(mode == Mode::Server);
     let v2ray_plugin = BinaryPlugin::new(verified.exec_path(), env.plugin_options.as_deref());
 
     let runner = ChainRunner::new()
+        .mode(mode)
         .add(Box::new(yamux_plugin))
         .add(Box::new(v2ray_plugin));
 

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -436,11 +436,6 @@ impl YamuxPlugin {
             is_server,
         }
     }
-
-    pub fn from_plugin_options(options: Option<&str>) -> Self {
-        let is_server = options.map(|opts| opts.contains("server")).unwrap_or(false);
-        Self::new(is_server)
-    }
 }
 
 #[async_trait::async_trait]

--- a/crates/garter-bin/Cargo.toml
+++ b/crates/garter-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garter-bin"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false

--- a/crates/garter-bin/src/main.rs
+++ b/crates/garter-bin/src/main.rs
@@ -1,5 +1,5 @@
 use garter::sip003::parse_plugin_options;
-use garter::{BinaryPlugin, ChainRunner, PluginEnv};
+use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -26,7 +26,8 @@ async fn main() -> anyhow::Result<()> {
     let cfg = garter_bin::config::load_config(std::path::Path::new(&config_path))?;
     anyhow::ensure!(!cfg.chain.is_empty(), "chain config must have at least one plugin");
 
-    let mut runner = ChainRunner::new();
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    let mut runner = ChainRunner::new().mode(mode);
     for entry in cfg.chain {
         runner = runner.add(Box::new(BinaryPlugin::new(entry.plugin, entry.options.as_deref())));
     }

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garter"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license = "Apache-2.0"
 description = "Plugin-chain runner for SIP003u shadowsocks plugins."

--- a/crates/garter/README.md
+++ b/crates/garter/README.md
@@ -24,25 +24,43 @@ byte-level diagnostics.
   for any `tokio::io::AsyncRead + AsyncWrite` stream.
 - **`parse_plugin_options`** — parses the SIP003 `;`-separated options
   string into a typed `HashMap`.
+- **`Mode`** — selects chain direction (`Client` / `Server`); see below.
+
+### Modes
+
+`ChainRunner` supports two SIP003 chain directions selected via
+`.mode(...)`:
+
+- `Mode::Client` (default) — data flows from the SS client's listener
+  (`SS_LOCAL_*`) through the chain to the SS server's public endpoint
+  (`SS_REMOTE_*`).
+- `Mode::Server` — data flows from the public-facing endpoint
+  (`SS_REMOTE_*`) through the chain back to a local `ssserver`
+  (`SS_LOCAL_*`). The plugin add-order stays the same in both modes
+  (data-source-side first); garter inverts the address wiring and the
+  `on_ready` probe target accordingly.
+
+Use `Mode::from_plugin_options(env.plugin_options.as_deref())` to derive
+the mode automatically from the SIP003 `server` keyword in
+`SS_PLUGIN_OPTIONS`.
 
 ## Example
 
 ```rust,no_run
-use garter::{BinaryPlugin, ChainRunner, PluginEnv};
+use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv};
 
 #[tokio::main]
 async fn main() -> garter::Result<()> {
-    let env = PluginEnv {
-        remote_host: "203.0.113.1".into(),
-        remote_port: 8388,
-        local_host: "127.0.0.1".into(),
-        local_port: 0, // shadowsocks picks
-        options: String::new(),
-    };
+    let env = PluginEnv::from_env()?;
+    // Detect SIP003 chain mode from SS_PLUGIN_OPTIONS (`server` keyword
+    // = Server; default = Client). Same parse used by v2ray-plugin and
+    // other SIP003 plugins.
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
 
     let chain = ChainRunner::new()
-        .push(BinaryPlugin::new("v2ray-plugin", "host=example.com;tls"))
-        .push(BinaryPlugin::new("obfs-local", "obfs=tls"));
+        .mode(mode)
+        .add(Box::new(BinaryPlugin::new("v2ray-plugin", Some("host=example.com;tls"))))
+        .add(Box::new(BinaryPlugin::new("obfs-local", Some("obfs=tls"))));
 
     chain.run(env).await
 }

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -7,8 +7,24 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
+use crate::chain::Mode;
 use crate::plugin::ChainPlugin;
 use crate::shutdown;
+
+/// Resolved SIP003 environment-variable mapping for a `BinaryPlugin`'s
+/// child process. The plugin's `(local, remote)` from
+/// [`ChainPlugin::run`] is mapped here per the SIP003 spec: in client
+/// mode `local → SS_LOCAL_*` and `remote → SS_REMOTE_*`; in server mode
+/// the pair is swapped so the binary's own server-mode address swap
+/// (v2ray-plugin `parseEnv`, etc.) restores the chain's intended
+/// direction. See bindreams/hole#396 for the incident.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Sip003Env {
+    pub ss_local_host: String,
+    pub ss_local_port: u16,
+    pub ss_remote_host: String,
+    pub ss_remote_port: u16,
+}
 
 /// Callback invoked synchronously when a binary plugin process is spawned.
 /// Receives the child PID immediately after `Command::spawn()` returns,
@@ -41,6 +57,27 @@ impl BinaryPlugin {
         self.pid_sink = Some(sink);
         self
     }
+
+    /// Compute the SIP003 env-var mapping for `(local, remote)`. Public
+    /// to `crate` for testability; production callers use [`Self::run`]
+    /// which feeds this into `Command::env`. See [`Sip003Env`] for the
+    /// client/server semantics.
+    pub(crate) fn sip003_env(&self, local: SocketAddr, remote: SocketAddr) -> Sip003Env {
+        // In server mode the binary itself swaps SS_LOCAL/SS_REMOTE
+        // semantics (SS_REMOTE = inbound listener, SS_LOCAL = outbound
+        // dial). We swap here first so the binary's swap restores the
+        // direction we wanted.
+        let (ss_local, ss_remote) = match Mode::from_plugin_options(self.options.as_deref()) {
+            Mode::Client => (local, remote),
+            Mode::Server => (remote, local),
+        };
+        Sip003Env {
+            ss_local_host: ss_local.ip().to_string(),
+            ss_local_port: ss_local.port(),
+            ss_remote_host: ss_remote.ip().to_string(),
+            ss_remote_port: ss_remote.port(),
+        }
+    }
 }
 
 fn extract_name(path: &Path) -> String {
@@ -62,11 +99,12 @@ impl ChainPlugin for BinaryPlugin {
         remote: SocketAddr,
         shutdown: CancellationToken,
     ) -> crate::Result<()> {
+        let env = self.sip003_env(local, remote);
         let mut cmd = Command::new(&self.path);
-        cmd.env("SS_LOCAL_HOST", local.ip().to_string());
-        cmd.env("SS_LOCAL_PORT", local.port().to_string());
-        cmd.env("SS_REMOTE_HOST", remote.ip().to_string());
-        cmd.env("SS_REMOTE_PORT", remote.port().to_string());
+        cmd.env("SS_LOCAL_HOST", env.ss_local_host);
+        cmd.env("SS_LOCAL_PORT", env.ss_local_port.to_string());
+        cmd.env("SS_REMOTE_HOST", env.ss_remote_host);
+        cmd.env("SS_REMOTE_PORT", env.ss_remote_port.to_string());
         if let Some(ref opts) = self.options {
             cmd.env("SS_PLUGIN_OPTIONS", opts);
         }

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use crate::binary::BinaryPlugin;
 use crate::plugin::ChainPlugin;
 
@@ -18,4 +20,57 @@ fn binary_plugin_name_from_windows_path() {
 fn binary_plugin_with_options() {
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("tls;host=example.com"));
     assert_eq!(plugin.name(), "v2ray-plugin");
+}
+
+// SIP003 env-var direction tests ======================================================================================
+
+/// In Client mode (no `server` key in options) `BinaryPlugin` maps
+/// `local → SS_LOCAL_*` and `remote → SS_REMOTE_*`. This matches v2ray-plugin's
+/// client-mode interpretation: bind on SS_LOCAL, dial SS_REMOTE.
+#[skuld::test]
+fn sip003_env_client_mode_straight_through() {
+    let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+    let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
+    let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("tls;host=example.com"));
+    let env = plugin.sip003_env(listen, dial);
+    assert_eq!(env.ss_local_host, "127.0.0.1");
+    assert_eq!(env.ss_local_port, 9001);
+    assert_eq!(env.ss_remote_host, "203.0.113.1");
+    assert_eq!(env.ss_remote_port, 8388);
+}
+
+/// In Server mode (bare `server` key in options) `BinaryPlugin` must SWAP
+/// the env vars: `local → SS_REMOTE_*` and `remote → SS_LOCAL_*`. Reason:
+/// v2ray-plugin's server-mode `parseEnv` swaps SS_LOCAL/SS_REMOTE
+/// semantics again (SS_REMOTE = inbound listener, SS_LOCAL = outbound
+/// dial), so a double-swap restores the chain's intended direction.
+/// Without this swap the binary listens on `remote` and forwards to
+/// `local`, colliding with the previous chain link. See bindreams/hole#396.
+#[skuld::test]
+fn sip003_env_server_mode_swaps_addresses() {
+    let listen: SocketAddr = "[::]:80".parse().unwrap();
+    let dial: SocketAddr = "127.0.0.1:45589".parse().unwrap();
+    let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("server;host=example.com"));
+    let env = plugin.sip003_env(listen, dial);
+    // Swap: BinaryPlugin's `local` (where the chain wants the binary to
+    // bind, [::]:80) must reach v2ray-plugin as SS_REMOTE so its
+    // server-mode swap interprets it as the listen address.
+    assert_eq!(env.ss_remote_host, "::");
+    assert_eq!(env.ss_remote_port, 80);
+    assert_eq!(env.ss_local_host, "127.0.0.1");
+    assert_eq!(env.ss_local_port, 45589);
+}
+
+/// `server` keyword is detected by SIP003 key parser, not substring match.
+/// `servername=...` is NOT server mode.
+#[skuld::test]
+fn sip003_env_client_mode_when_options_only_have_servername() {
+    let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+    let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
+    let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("servername=cdn.example.com"));
+    let env = plugin.sip003_env(listen, dial);
+    assert_eq!(env.ss_local_host, "127.0.0.1");
+    assert_eq!(env.ss_local_port, 9001);
+    assert_eq!(env.ss_remote_host, "203.0.113.1");
+    assert_eq!(env.ss_remote_port, 8388);
 }

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -11,6 +11,48 @@ use crate::shutdown;
 
 const MAX_PORT_RETRIES: usize = 3;
 
+/// Direction of the SIP003 chain.
+///
+/// In `Client` mode, the chain forwards data from `SS_LOCAL_*` (the SS
+/// client's listener) to `SS_REMOTE_*` (the SS server's public endpoint).
+/// Plugin position 0 listens on `SS_LOCAL`, position N-1 forwards to
+/// `SS_REMOTE`. This is what the SIP003 spec calls "client mode."
+///
+/// In `Server` mode, the chain forwards data from `SS_REMOTE_*` (the
+/// public-facing endpoint that external clients connect to) to
+/// `SS_LOCAL_*` (the local `ssserver` instance). The plugin chain is
+/// supplied in the SAME order in both modes (data-source-side first),
+/// but garter inverts the address walk and the `on_ready` probe target
+/// so position 0 forwards to `SS_LOCAL` and position N-1 listens on
+/// `SS_REMOTE`. This is what the SIP003 spec calls "server mode" and
+/// what `ssserver --plugin <chain-runner>` requires.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Mode {
+    #[default]
+    Client,
+    Server,
+}
+
+impl Mode {
+    /// Derive the SIP003 chain mode from the `SS_PLUGIN_OPTIONS` string.
+    /// Returns [`Mode::Server`] if a `server` key is present in the
+    /// options (with or without a value), [`Mode::Client`] otherwise.
+    /// Uses the spec-correct key parser ([`crate::parse_plugin_options`]),
+    /// so options like `servername=cdn.example.com` correctly resolve to
+    /// client mode.
+    pub fn from_plugin_options(opts: Option<&str>) -> Self {
+        let Some(opts) = opts else { return Mode::Client };
+        if crate::sip003::parse_plugin_options(opts)
+            .iter()
+            .any(|(k, _)| k == "server")
+        {
+            Mode::Server
+        } else {
+            Mode::Client
+        }
+    }
+}
+
 /// Allocate `count` unique ephemeral ports on localhost.
 pub fn allocate_ports(count: usize) -> crate::Result<Vec<SocketAddr>> {
     let mut ports = Vec::with_capacity(count);
@@ -82,6 +124,7 @@ pub struct ChainRunner {
     drain_timeout: Duration,
     ready_tx: Option<oneshot::Sender<SocketAddr>>,
     external_cancel: Option<CancellationToken>,
+    mode: Mode,
 }
 
 impl Default for ChainRunner {
@@ -97,6 +140,7 @@ impl ChainRunner {
             drain_timeout: Duration::from_secs(5),
             ready_tx: None,
             external_cancel: None,
+            mode: Mode::default(),
         }
     }
 
@@ -149,6 +193,14 @@ impl ChainRunner {
         self
     }
 
+    /// Set the chain direction. See [`Mode`] for semantics.
+    ///
+    /// Default: [`Mode::Client`].
+    pub fn mode(mut self, mode: Mode) -> Self {
+        self.mode = mode;
+        self
+    }
+
     /// Run the full chain. Blocks until all plugins exit or shutdown is requested.
     #[debug_requires(!self.plugins.is_empty(), "chain must have at least one plugin")]
     pub async fn run(self, env: crate::sip003::PluginEnv) -> crate::Result<()> {
@@ -184,27 +236,44 @@ impl ChainRunner {
             });
         }
 
-        // Spawn all plugins
+        // Capture `Copy` field before the partial move below.
+        let mode = self.mode;
+
+        // Spawn all plugins. In Client mode, plugin i listens on addrs[i] and
+        // forwards to addrs[i+1]. In Server mode, the direction is inverted:
+        // plugin i listens on addrs[i+1] and forwards to addrs[i]. See `Mode`.
         let mut set = tokio::task::JoinSet::new();
         for (i, plugin) in self.plugins.into_iter().enumerate() {
-            let local = addrs[i];
-            let remote = addrs[i + 1];
+            let (local, remote) = match mode {
+                Mode::Client => (addrs[i], addrs[i + 1]),
+                Mode::Server => (addrs[i + 1], addrs[i]),
+            };
             let token = shutdown.child_token();
             let plugin_name = plugin.name().to_string();
 
-            let span = tracing::info_span!("plugin", name = %plugin_name, position = i);
+            let span = tracing::info_span!(
+                "plugin",
+                name = %plugin_name,
+                position = i,
+                chain_mode = ?mode,
+            );
             set.spawn(async move {
                 let result = plugin.run(local, remote, token).instrument(span).await;
                 (plugin_name, result)
             });
         }
 
-        // Readiness polling: probe the outermost local address until it accepts.
+        // Readiness polling: probe the public-facing local address. In Client
+        // mode that is the position-0 plugin (addrs[0] = SS_LOCAL); in Server
+        // mode it is the position-(N-1) plugin (addrs[n] = SS_REMOTE).
         if let Some(ready_tx) = self.ready_tx {
-            let local_addr = addrs[0];
+            let probe_addr = match mode {
+                Mode::Client => addrs[0],
+                Mode::Server => addrs[n],
+            };
             let shutdown = shutdown.clone();
             tokio::spawn(async move {
-                if let Some(addr) = poll_ready(local_addr, shutdown).await {
+                if let Some(addr) = poll_ready(probe_addr, shutdown).await {
                     let _ = ready_tx.send(addr);
                 }
                 // If poll_ready returns None (shutdown before ready), ready_tx

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
@@ -331,6 +332,262 @@ async fn cancel_token_triggers_graceful_shutdown() {
     // hangs and the test framework's timeout surfaces it.
     let result = handle.await.unwrap();
     assert!(result.is_ok(), "chain should exit Ok on external cancellation");
+}
+
+// Mode tests ==========================================================================================================
+
+/// Plugin that records its `(local, remote)` args and exits cleanly. Used
+/// to assert address wiring without doing real I/O. Backing storage is
+/// `Mutex<Option<(SocketAddr, SocketAddr)>>` initialized to `None` so a
+/// plugin that was never invoked is distinguishable from one whose
+/// recorded value happens to equal a sentinel; the assertion sites
+/// `.expect("...")` the `Option` before asserting the values.
+struct RecordingPlugin {
+    name: String,
+    record: Arc<Mutex<Option<(SocketAddr, SocketAddr)>>>,
+}
+
+#[async_trait::async_trait]
+impl ChainPlugin for RecordingPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        remote: SocketAddr,
+        _shutdown: CancellationToken,
+    ) -> crate::Result<()> {
+        *self.record.lock().unwrap() = Some((local, remote));
+        Ok(())
+    }
+}
+
+#[skuld::test]
+async fn mode_default_is_client() {
+    // Pin behavioral default. If someone removes the `#[default]` on
+    // `Mode::Client`, this fails before any wiring-dependent test does.
+    assert_eq!(crate::chain::Mode::default(), crate::chain::Mode::Client);
+}
+
+#[skuld::test]
+async fn chain_runner_server_mode_inverts_address_wiring() {
+    let ss_local: SocketAddr = "127.0.0.1:11111".parse().unwrap();
+    let ss_remote_port = allocate_ports(1).unwrap().pop().unwrap().port();
+    let ss_remote: SocketAddr = format!("127.0.0.1:{ss_remote_port}").parse().unwrap();
+
+    let rec0 = Arc::new(Mutex::new(None));
+    let rec1 = Arc::new(Mutex::new(None));
+
+    let runner = ChainRunner::new()
+        .mode(crate::chain::Mode::Server)
+        .add(Box::new(RecordingPlugin {
+            name: "inner".into(),
+            record: rec0.clone(),
+        }))
+        .add(Box::new(RecordingPlugin {
+            name: "outer".into(),
+            record: rec1.clone(),
+        }));
+
+    let env = crate::sip003::PluginEnv {
+        local_host: ss_local.ip(),
+        local_port: ss_local.port(),
+        remote_host: "127.0.0.1".into(),
+        remote_port: ss_remote_port,
+        plugin_options: None,
+    };
+
+    runner.run(env).await.unwrap();
+
+    let (l0, r0) = rec0.lock().unwrap().expect("inner plugin must have been invoked");
+    let (l1, r1) = rec1.lock().unwrap().expect("outer plugin must have been invoked");
+
+    // Inner plugin (position 0) faces the ssserver side: forwards to SS_LOCAL.
+    assert_eq!(r0, ss_local, "inner plugin must forward to SS_LOCAL in Server mode");
+    // Outer plugin (position N-1) faces the public side: listens on SS_REMOTE.
+    assert_eq!(l1, ss_remote, "outer plugin must listen on SS_REMOTE in Server mode");
+    // Inner listens on the intermediate; outer forwards to the same intermediate.
+    assert_eq!(
+        l0, r1,
+        "shared intermediate must match between inner.local and outer.remote"
+    );
+    // Concretely: the intermediate is neither SS_LOCAL nor SS_REMOTE.
+    assert_ne!(l0, ss_local);
+    assert_ne!(l0, ss_remote);
+}
+
+#[skuld::test]
+async fn chain_runner_server_mode_inverts_on_ready_probe_target() {
+    let (tx, rx) = oneshot::channel();
+    let listen_addr = allocate_ports(1).unwrap()[0];
+
+    // `ListeningPlugin` binds whatever `local` it is given. In Server mode
+    // the OUTER (position 1) plugin gets `local = SS_REMOTE`, so on_ready
+    // must probe THAT address. The probe's TCP-connect either succeeds
+    // (correct probe target) or never fires (wrong probe target — the
+    // test then hangs and skuld's runtime drop bounds it).
+    let runner = ChainRunner::new()
+        .mode(crate::chain::Mode::Server)
+        .add(Box::new(ListeningPlugin {
+            name: "inner-listener".into(),
+        }))
+        .add(Box::new(ListeningPlugin {
+            name: "outer-listener".into(),
+        }))
+        .on_ready(tx);
+
+    let ss_local_port = allocate_ports(1).unwrap()[0].port();
+    let env = crate::sip003::PluginEnv {
+        local_host: "127.0.0.1".parse().unwrap(),
+        local_port: ss_local_port,
+        remote_host: "127.0.0.1".into(),
+        remote_port: listen_addr.port(),
+        plugin_options: None,
+    };
+
+    let handle = tokio::spawn(runner.run(env));
+    let ready_addr = rx.await.expect("ready_tx dropped");
+    assert_eq!(
+        ready_addr.port(),
+        listen_addr.port(),
+        "on_ready in Server mode must probe SS_REMOTE (outer's local), not SS_LOCAL (inner's remote)"
+    );
+    handle.abort();
+}
+
+#[skuld::test]
+async fn chain_runner_default_matches_explicit_client_mode() {
+    let ss_local: SocketAddr = "127.0.0.1:22222".parse().unwrap();
+    let ss_remote_port = allocate_ports(1).unwrap().pop().unwrap().port();
+    let ss_remote: SocketAddr = format!("127.0.0.1:{ss_remote_port}").parse().unwrap();
+
+    let rec_default = Arc::new(Mutex::new(None));
+    let rec_explicit = Arc::new(Mutex::new(None));
+
+    // Default: no .mode() call
+    let runner = ChainRunner::new().add(Box::new(RecordingPlugin {
+        name: "p".into(),
+        record: rec_default.clone(),
+    }));
+    let env = crate::sip003::PluginEnv {
+        local_host: ss_local.ip(),
+        local_port: ss_local.port(),
+        remote_host: "127.0.0.1".into(),
+        remote_port: ss_remote_port,
+        plugin_options: None,
+    };
+    runner.run(env).await.unwrap();
+
+    // Explicit Client
+    let runner = ChainRunner::new()
+        .mode(crate::chain::Mode::Client)
+        .add(Box::new(RecordingPlugin {
+            name: "p".into(),
+            record: rec_explicit.clone(),
+        }));
+    let env = crate::sip003::PluginEnv {
+        local_host: ss_local.ip(),
+        local_port: ss_local.port(),
+        remote_host: "127.0.0.1".into(),
+        remote_port: ss_remote_port,
+        plugin_options: None,
+    };
+    runner.run(env).await.unwrap();
+
+    let default_rec = rec_default
+        .lock()
+        .unwrap()
+        .expect("default plugin must have been invoked");
+    let explicit_rec = rec_explicit
+        .lock()
+        .unwrap()
+        .expect("explicit-Client plugin must have been invoked");
+
+    assert_eq!(
+        default_rec, explicit_rec,
+        "no .mode() call must behave identically to .mode(Mode::Client)"
+    );
+    // Pin the actual wiring values too, so a future bug where both modes
+    // accidentally got the same (inverted) wiring would be caught.
+    assert_eq!(
+        default_rec,
+        (ss_local, ss_remote),
+        "Client mode (default): position-0 plugin must listen on SS_LOCAL, forward to SS_REMOTE"
+    );
+}
+
+// Mode::from_plugin_options tests -------------------------------------------------------------------------------------
+
+#[skuld::test]
+async fn mode_from_plugin_options_detects_bare_server_keyword() {
+    use crate::chain::Mode;
+    assert_eq!(Mode::from_plugin_options(Some("server")), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("server;path=/")), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("path=/;server;host=h")), Mode::Server);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_false_when_server_only_appears_as_substring() {
+    use crate::chain::Mode;
+    assert_eq!(
+        Mode::from_plugin_options(Some("servername=cdn.example.com")),
+        Mode::Client
+    );
+    assert_eq!(Mode::from_plugin_options(Some("path=/serverlist")), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("path=/server")), Mode::Client);
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/serverlist;servername=foo")),
+        Mode::Client
+    );
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_false_when_options_missing() {
+    use crate::chain::Mode;
+    assert_eq!(Mode::from_plugin_options(None), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("")), Mode::Client);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_handles_mixed_options() {
+    use crate::chain::Mode;
+    // Realistic postern server-side `plugin_opts`:
+    // `server;fast-open;path=/t/<token>;host=<fqdn>`. See voyager2's
+    // postern/portal/src/postern/ss_config.py.
+    let opts = "server;fast-open;path=/t/abc123;host=hole-stgn.binarydreams.me";
+    assert_eq!(Mode::from_plugin_options(Some(opts)), Mode::Server);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_false_for_capitalized_keyword() {
+    use crate::chain::Mode;
+    // SIP003 keys are lowercase per v2ray-plugin convention; pin the
+    // case-sensitive behavior so a future "be lenient about case" patch
+    // is a conscious decision rather than drift.
+    assert_eq!(Mode::from_plugin_options(Some("Server")), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("SERVER;path=/")), Mode::Client);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_true_when_key_has_value() {
+    use crate::chain::Mode;
+    // SIP003 convention treats `server` as a bare key, but v2ray-plugin's
+    // own parser uses `opts.Get("server")` which matches `server=value`
+    // (value ignored). Mirror that semantics: presence of the key triggers
+    // server mode regardless of value.
+    assert_eq!(Mode::from_plugin_options(Some("server=1;path=/")), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("server=true")), Mode::Server);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_false_for_escaped_server() {
+    use crate::chain::Mode;
+    // `\s` is not a SIP003-recognized escape (only \;, \\, \= per
+    // parse_plugin_options). So `\server` parses as the literal
+    // string `\server` -- which is NOT the bare key `server`.
+    assert_eq!(Mode::from_plugin_options(Some(r"\server")), Mode::Client);
 }
 
 // Drain-timeout semantics tests =======================================================================================

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -13,7 +13,7 @@ pub mod test_utils;
 pub mod tracing_test;
 
 pub use binary::{BinaryPlugin, PidSink};
-pub use chain::ChainRunner;
+pub use chain::{ChainRunner, Mode};
 pub use counting::{CountingStream, StreamCounters};
 pub use error::{Error, Result};
 pub use plugin::ChainPlugin;

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -172,6 +172,81 @@ async fn pid_sink_fires_once_per_binary_plugin() {
     let _ = handle.await;
 }
 
+/// Server-mode counterpart to `two_plugin_chain_relays_data`. In server
+/// mode, the chain runs in reverse: an external client connects to the
+/// "public" port (SS_REMOTE), data flows through the chain in the
+/// opposite direction to the "ssserver-stand-in" echo at SS_LOCAL.
+/// Uses the existing `mock-plugin` binary because it is direction-symmetric
+/// — bind `local`, connect to `remote` — and works for both modes once
+/// `ChainRunner` wires the addresses correctly.
+#[skuld::test]
+async fn two_plugin_chain_server_mode_relays_data() {
+    let mock_path = mock_plugin_path();
+
+    // Echo plays the ssserver role -- runs at SS_LOCAL.
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    let echo_task = tokio::spawn(async move {
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut r, mut w) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut r, &mut w).await;
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    // Public-facing port (SS_REMOTE): in server mode the chain LISTENS here.
+    let public_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let public_addr = public_listener.local_addr().unwrap();
+    drop(public_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let runner = ChainRunner::new()
+        .mode(garter::Mode::Server)
+        .add(Box::new(BinaryPlugin::new(&mock_path, None)))
+        .add(Box::new(BinaryPlugin::new(&mock_path, None)))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: echo_addr.ip(), // SS_LOCAL = ssserver-stand-in
+        local_port: echo_addr.port(),
+        remote_host: public_addr.ip().to_string(), // SS_REMOTE = public port
+        remote_port: public_addr.port(),
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    // on_ready fires when the OUTER plugin has bound the public port.
+    let ready_addr = ready_rx.await.expect("chain never signaled ready");
+    assert_eq!(
+        ready_addr.port(),
+        public_addr.port(),
+        "on_ready in Server mode must report SS_REMOTE (the public port)"
+    );
+
+    // External client connects to the public port; data round-trips
+    // through the chain to the echo and back.
+    let mut client = TcpStream::connect(public_addr).await.expect("connect to public");
+    client.write_all(b"hello server-mode chain").await.unwrap();
+
+    let mut buf = [0u8; 1024];
+    let n = client.read(&mut buf).await.expect("read failed");
+    assert_eq!(&buf[..n], b"hello server-mode chain");
+
+    drop(client);
+    echo_task.abort();
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
 // Install the workspace test subscriber + panic hook. See
 // `crates/test-observability/` and bindreams/hole#301.
 hole_test_observability::register!();


### PR DESCRIPTION
Fixes #396. Unblocks end-to-end verification for #395.

## Summary

`garter::ChainRunner` hardcoded a client-mode address walk: plugin `i` listens on `addrs[i]` and forwards to `addrs[i+1]`, where `addrs = [SS_LOCAL, intermediate..., SS_REMOTE]`. SIP003 server-mode chains need this inverted, otherwise the position-0 plugin tries to listen on `SS_LOCAL` (`ssserver`'s own loopback) and the chain restart-loops with "bind yamux server on [::1]:42995".

This PR:

- Adds `garter::Mode { Client, Server }` (default `Client`, non-breaking additive API) with a `Mode::from_plugin_options` helper that parses the SIP003 `server` keyword via the existing `parse_plugin_options`.
- `ChainRunner::mode(Mode)` inverts the address walk and the `on_ready` probe target in Server mode; plugin add-order stays the same in both modes (data-source-side first).
- `BinaryPlugin` swaps `SS_LOCAL`/`SS_REMOTE` env vars when its `plugin_options` contain `server`, compensating for the binary's own SIP003 server-mode swap. Without this, the chain wires the SocketAddrs correctly but the subprocess interprets them backwards.
- `galoshes` and `garter-bin` both derive mode from `SS_PLUGIN_OPTIONS` via `Mode::from_plugin_options` and pass it to `ChainRunner::mode()` — both binaries now work in server mode out of the box.
- Removes `galoshes::yamux::YamuxPlugin::from_plugin_options` (broken substring match — false-positives on `servername=cdn.example.com`); canonical keyword parsing now lives in garter.
- Bumps garter + garter-bin to `0.2.0` (additive minor, pre-1.0). README example fixed (`.push` → `.add`, `options: String::new()` → `plugin_options: Option<String>`) and now demonstrates `Mode::from_plugin_options`.

## Test coverage

New tests in `crates/garter/`:

- `chain_tests.rs`: `mode_default_is_client`, `chain_runner_server_mode_inverts_address_wiring`, `chain_runner_server_mode_inverts_on_ready_probe_target`, `chain_runner_default_matches_explicit_client_mode`, plus seven `mode_from_plugin_options_*` cases pinning correct vs spurious keyword detection (bare key, mixed options, escapes, capitalization, `server=value`, substring false-positives like `servername=`).
- `binary_tests.rs`: `sip003_env_client_mode_straight_through`, `sip003_env_server_mode_swaps_addresses`, `sip003_env_client_mode_when_options_only_have_servername` covering the env-var swap.
- `chain_integration.rs`: `two_plugin_chain_server_mode_relays_data` — real 2-mock-plugin server-mode chain with TCP round-trip through to an echo "ssserver" stand-in.

All new tests pass locally (`cargo test -p garter --no-default-features`: 67 unit + 3 integration). `cargo test -p galoshes -p garter-bin --no-default-features`: 4 pass, no regression.

## End-to-end verification

Verified against the postern `test-galoshes` connection on voyager2 via a transient `docker run` with the fixed galoshes binary:

```
INFO galoshes::yamux: yamux server listening local=127.0.0.1:43421 [chain_mode=Server]
WARN garter::binary: V2Ray 5.49.0 (V2Fly...) started
```

yamux-server correctly binds the intermediate port (no longer collides with ssserver's `[::1]:<ephemeral>`), v2ray-plugin starts cleanly and listens on `[::]:80`. Process stays alive for the full 60s observation window. Postern's existing `v2ray-plugin`-only connection (`ss-f2bf8d7310d3c535d82bb829`) is unchanged.

**Note on full container-managed verification**: the postern-managed container still restart-loops, but for a separate pre-existing bug now tracked at **#401**: galoshes can't exec its embedded v2ray-plugin from a `noexec` tmpfs `/tmp` (postern mounts `/tmp` as tmpfs which Docker defaults to noexec). This bug was masked by the wiring bug — galoshes never got past the yamux bind failure to attempt the v2ray-plugin spawn. The transient repro above bypasses the noexec tmpfs and confirms the chain wiring fix works end-to-end.

## Test plan

- [x] `cargo test -p garter --no-default-features` passes (67 unit + 3 integration; new tests included)
- [x] `cargo test -p galoshes -p garter-bin --no-default-features` passes
- [x] `cargo xtask version --check --group garter` passes (one-bump-ahead from `releases/garter/v0.1.0`)
- [x] `cargo xtask run hole-tests` — green except for 2 environmental Wintun failures (`e2e_none_full_tunnel_roundtrip`, `e2e_socks5_udp_associate_roundtrip`) that require admin elevation; both predate this PR and are independent of garter
- [x] Workspace audit: `rg 'ChainRunner::new\(\)' crates/` returns 5 hits, each accounted for — `garter/tests`, `garter/src/chain_tests`, `garter-bin/src/main` (derives via `Mode::from_plugin_options`), `galoshes/src/main` (same), `bridge/src/proxy/plugin.rs:268` (default `Client`, preserved — Hole the GUI is always a SIP003 client)
- [x] Voyager2 transient repro: yamux + v2ray-plugin start cleanly under server mode, no bind errors, runs >60s
- [x] Postern's `ss-f2bf...` (v2ray-plugin-only) container restart count unchanged
- [ ] Postern's `ss-635a...` (galoshes) container stays Up — **blocked by #401**, see above
- [ ] Hole GUI proxy toggle for `test-galoshes` — **blocked by #401** (galoshes embed can't exec on the postern-deployed image)
- [ ] CI green