### PR TITLE
fix(galoshes): #401 require exec-capable XDG runtime dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,25 @@ executable at compile time:
    triples in the CI matrix (Hole's Windows/macOS set plus ex-Galoshes
    Linux x64/arm64 and Windows-arm64).
 
+**Runtime extraction directory.** At startup galoshes writes the
+embedded v2ray-plugin to a per-user runtime dir resolved by
+[`embedded::runtime_dir`](crates/galoshes/src/embedded.rs):
+`$XDG_RUNTIME_DIR/galoshes` if set (honored cross-platform), else the
+platform default — `$HOME/.cache/galoshes` on Linux,
+`$HOME/Library/Caches/galoshes` on macOS, `%LOCALAPPDATA%/galoshes` on
+Windows. If neither env var is set, startup bails with a message naming
+both. The Linux `/tmp` fallback was removed because tmpfs mounts are
+commonly `noexec` (Docker `--tmpfs`, systemd `PrivateTmp=yes`, hardened
+distros) and silently became unable to exec the embedded plugin.
+
+After resolving the dir, galoshes statvfs's it (Linux `ST_NOEXEC`) /
+statfs's it (macOS `MNT_NOEXEC`) and bails with a clear remediation
+hint if the mount is noexec. Windows has no noexec filesystem flag
+and skips the probe — Windows-side execution failures (AppLocker,
+Defender) surface from the eventual spawn with anyhow context. See
+bindreams/hole#401 for the postern-container incident that motivated
+the strict resolution + probe.
+
 Build orchestration is owned by `xtask/`. The canonical list of files that
 go into the runnable BINDIR (next to `hole.exe`) lives in
 [xtask/src/bindir.rs](xtask/src/bindir.rs); both `scripts/dev.py` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,7 @@ dependencies = [
  "futures",
  "garter",
  "hole-test-observability",
+ "libc",
  "sha2 0.11.0",
  "skuld",
  "tempfile",

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -28,6 +28,9 @@ yamux = "0.13"
 sha2 = "0.11"
 tempfile = "3"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }

--- a/crates/galoshes/src/embedded.rs
+++ b/crates/galoshes/src/embedded.rs
@@ -44,6 +44,8 @@ impl EmbeddedBinary {
         #[cfg(unix)]
         set_dir_permissions(dir)?;
 
+        check_dir_executable(dir)?;
+
         let target = dir.join(self.name);
 
         // Warm start: try to verify the existing file first.
@@ -135,36 +137,70 @@ fn hex(bytes: &[u8; 32]) -> String {
 
 // Platform: runtime_dir ===============================================================================================
 
-#[cfg(target_os = "linux")]
 fn runtime_dir() -> Result<PathBuf> {
-    if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
-        Ok(PathBuf::from(dir).join("galoshes"))
-    } else {
-        Ok(std::env::temp_dir().join("galoshes"))
-    }
+    let xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+    let default_root = platform_default_env().ok();
+    resolve(xdg.as_deref(), default_root.as_deref())
 }
 
-#[cfg(target_os = "macos")]
-fn runtime_dir() -> Result<PathBuf> {
-    if let Ok(home) = std::env::var("HOME") {
-        Ok(PathBuf::from(home).join("Library").join("Caches").join("galoshes"))
-    } else {
-        Ok(std::env::temp_dir().join("galoshes"))
-    }
+#[cfg(unix)]
+fn platform_default_env() -> Result<String, std::env::VarError> {
+    std::env::var("HOME")
 }
 
 #[cfg(target_os = "windows")]
-fn runtime_dir() -> Result<PathBuf> {
-    if let Ok(dir) = std::env::var("LOCALAPPDATA") {
-        Ok(PathBuf::from(dir).join("galoshes"))
-    } else {
-        Ok(std::env::temp_dir().join("galoshes"))
+fn platform_default_env() -> Result<String, std::env::VarError> {
+    std::env::var("LOCALAPPDATA")
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn resolve(xdg: Option<&str>, default_root: Option<&str>) -> Result<PathBuf> {
+    if let Some(dir) = xdg {
+        return Ok(PathBuf::from(dir).join("galoshes"));
     }
+    if let Some(home) = default_root {
+        return Ok(PathBuf::from(home).join(".cache").join("galoshes"));
+    }
+    bail!(
+        "cannot resolve galoshes runtime directory: neither XDG_RUNTIME_DIR nor HOME is set. \
+         Set XDG_RUNTIME_DIR to a directory on an exec-capable mount."
+    );
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn resolve(xdg: Option<&str>, default_root: Option<&str>) -> Result<PathBuf> {
+    if let Some(dir) = xdg {
+        return Ok(PathBuf::from(dir).join("galoshes"));
+    }
+    if let Some(home) = default_root {
+        return Ok(PathBuf::from(home).join("Library").join("Caches").join("galoshes"));
+    }
+    bail!(
+        "cannot resolve galoshes runtime directory: neither XDG_RUNTIME_DIR nor HOME is set. \
+         Set XDG_RUNTIME_DIR to a directory on an exec-capable mount."
+    );
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn resolve(xdg: Option<&str>, default_root: Option<&str>) -> Result<PathBuf> {
+    if let Some(dir) = xdg {
+        return Ok(PathBuf::from(dir).join("galoshes"));
+    }
+    if let Some(local) = default_root {
+        return Ok(PathBuf::from(local).join("galoshes"));
+    }
+    bail!(
+        "cannot resolve galoshes runtime directory: neither XDG_RUNTIME_DIR nor LOCALAPPDATA is set. \
+         Set XDG_RUNTIME_DIR to a directory on an exec-capable mount."
+    );
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-fn runtime_dir() -> Result<PathBuf> {
-    Ok(std::env::temp_dir().join("galoshes"))
+pub(crate) fn resolve(xdg: Option<&str>, _default_root: Option<&str>) -> Result<PathBuf> {
+    if let Some(dir) = xdg {
+        return Ok(PathBuf::from(dir).join("galoshes"));
+    }
+    bail!("cannot resolve galoshes runtime directory: XDG_RUNTIME_DIR is not set");
 }
 
 // Platform: permissions ===============================================================================================
@@ -181,6 +217,69 @@ fn set_file_permissions(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     fs::set_permissions(path, fs::Permissions::from_mode(0o500))
         .with_context(|| format!("failed to set permissions on {}", path.display()))
+}
+
+// Platform: check_dir_executable ======================================================================================
+
+fn check_dir_executable(dir: &Path) -> Result<()> {
+    if is_noexec_mount(dir)? {
+        bail!(
+            "runtime directory {} is mounted noexec; galoshes cannot exec the embedded \
+             v2ray-plugin from this location. Set XDG_RUNTIME_DIR to a directory on an \
+             exec-capable mount, or remount this filesystem with the exec option.",
+            dir.display(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn is_noexec_mount(dir: &Path) -> Result<bool> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(dir.as_os_str().as_bytes())
+        .with_context(|| format!("path {} contains a NUL byte", dir.display()))?;
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(anyhow::Error::from(err)).with_context(|| format!("statvfs({}) failed", dir.display()));
+    }
+    Ok(check_noexec_linux(stat.f_flag))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn check_noexec_linux(flag: libc::c_ulong) -> bool {
+    flag & libc::ST_NOEXEC == libc::ST_NOEXEC
+}
+
+#[cfg(target_os = "macos")]
+fn is_noexec_mount(dir: &Path) -> Result<bool> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(dir.as_os_str().as_bytes())
+        .with_context(|| format!("path {} contains a NUL byte", dir.display()))?;
+    let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::statfs(c_path.as_ptr(), &mut stat) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(anyhow::Error::from(err)).with_context(|| format!("statfs({}) failed", dir.display()));
+    }
+    Ok(check_noexec_macos(stat.f_flags))
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn check_noexec_macos(flags: u32) -> bool {
+    let mask = libc::MNT_NOEXEC as u32;
+    flags & mask == mask
+}
+
+// Windows has no noexec filesystem flag. Read-only attributes, AppLocker, and
+// Defender quarantine fail at runtime — those paths surface through anyhow
+// context on the existing fs / persist / spawn calls. Other Unixes (FreeBSD,
+// OpenBSD, …) fall through to the same noop; their MNT_NOEXEC semantics differ
+// per kernel and galoshes is not currently shipped there.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn is_noexec_mount(_dir: &Path) -> Result<bool> {
+    Ok(false)
 }
 
 // Platform: open_verified =============================================================================================

--- a/crates/galoshes/src/embedded_tests.rs
+++ b/crates/galoshes/src/embedded_tests.rs
@@ -70,3 +70,144 @@ fn wrong_embedded_hash_fails() {
     let result = binary.prepare_in(dir.path());
     assert!(result.is_err());
 }
+
+// Resolution ==========================================================================================================
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn resolve_linux_prefers_xdg_runtime_dir() {
+    use crate::embedded::resolve;
+    let path = resolve(Some("/run/user/1000"), Some("/home/x")).unwrap();
+    assert_eq!(path, std::path::PathBuf::from("/run/user/1000/galoshes"));
+}
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn resolve_linux_falls_back_to_home_cache() {
+    use crate::embedded::resolve;
+    let path = resolve(None, Some("/home/x")).unwrap();
+    assert_eq!(path, std::path::PathBuf::from("/home/x/.cache/galoshes"));
+}
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn resolve_linux_bails_when_nothing_resolves() {
+    use crate::embedded::resolve;
+    let err = resolve(None, None).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("XDG_RUNTIME_DIR"),
+        "error should name XDG_RUNTIME_DIR: {msg}"
+    );
+    assert!(msg.contains("HOME"), "error should name HOME: {msg}");
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn resolve_macos_prefers_xdg_runtime_dir() {
+    use crate::embedded::resolve;
+    let path = resolve(Some("/some/runtime"), Some("/Users/x")).unwrap();
+    assert_eq!(path, std::path::PathBuf::from("/some/runtime/galoshes"));
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn resolve_macos_falls_back_to_library_caches() {
+    use crate::embedded::resolve;
+    let path = resolve(None, Some("/Users/x")).unwrap();
+    assert_eq!(path, std::path::PathBuf::from("/Users/x/Library/Caches/galoshes"));
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn resolve_macos_bails_when_nothing_resolves() {
+    use crate::embedded::resolve;
+    let err = resolve(None, None).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("XDG_RUNTIME_DIR"),
+        "error should name XDG_RUNTIME_DIR: {msg}"
+    );
+    assert!(msg.contains("HOME"), "error should name HOME: {msg}");
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn resolve_windows_prefers_xdg_runtime_dir() {
+    use crate::embedded::resolve;
+    let path = resolve(Some(r"C:\run"), Some(r"C:\Users\x\AppData\Local")).unwrap();
+    assert_eq!(path, std::path::PathBuf::from(r"C:\run\galoshes"));
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn resolve_windows_falls_back_to_localappdata() {
+    use crate::embedded::resolve;
+    let path = resolve(None, Some(r"C:\Users\x\AppData\Local")).unwrap();
+    assert_eq!(path, std::path::PathBuf::from(r"C:\Users\x\AppData\Local\galoshes"));
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn resolve_windows_bails_when_nothing_resolves() {
+    use crate::embedded::resolve;
+    let err = resolve(None, None).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("XDG_RUNTIME_DIR"),
+        "error should name XDG_RUNTIME_DIR: {msg}"
+    );
+    assert!(msg.contains("LOCALAPPDATA"), "error should name LOCALAPPDATA: {msg}");
+}
+
+// Noexec predicate ====================================================================================================
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn check_noexec_linux_passes_on_zero_flag() {
+    assert!(!crate::embedded::check_noexec_linux(0));
+}
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn check_noexec_linux_detects_st_noexec() {
+    assert!(crate::embedded::check_noexec_linux(libc::ST_NOEXEC));
+}
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn check_noexec_linux_ignores_st_rdonly() {
+    // ST_RDONLY set, ST_NOEXEC clear → not noexec
+    assert!(!crate::embedded::check_noexec_linux(libc::ST_RDONLY));
+}
+
+#[cfg(target_os = "linux")]
+#[skuld::test]
+fn check_noexec_linux_detects_st_noexec_combined_with_other_flags() {
+    assert!(crate::embedded::check_noexec_linux(libc::ST_NOEXEC | libc::ST_RDONLY));
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn check_noexec_macos_passes_on_zero_flag() {
+    assert!(!crate::embedded::check_noexec_macos(0));
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn check_noexec_macos_detects_mnt_noexec() {
+    assert!(crate::embedded::check_noexec_macos(libc::MNT_NOEXEC as u32));
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn check_noexec_macos_ignores_mnt_rdonly() {
+    assert!(!crate::embedded::check_noexec_macos(libc::MNT_RDONLY as u32));
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn check_noexec_macos_detects_mnt_noexec_combined_with_other_flags() {
+    let combined = (libc::MNT_NOEXEC as u32) | (libc::MNT_RDONLY as u32);
+    assert!(crate::embedded::check_noexec_macos(combined));
+}


### PR DESCRIPTION
## Summary

Fixes #401. galoshes embeds v2ray-plugin and extracts it to a runtime
directory before `exec`'ing via `/proc/self/fd/N`. The prior Linux
resolution fell back to `std::env::temp_dir()` (`/tmp`) when
`XDG_RUNTIME_DIR` was unset — and Docker `--tmpfs /tmp` (postern's
default), systemd `PrivateTmp=yes`, and hardened distros all mount
`/tmp` `noexec`. The kernel then rejected the execve with `EACCES`,
surfaced as the unhelpful `failed to spawn '/proc/self/fd/9': Permission denied (os error 13)`.

Pre-#396 the chain aborted earlier so this never surfaced; #396's
wiring fix exposed it.

This PR makes resolution strict and adds a proactive noexec probe:

- **Resolution (cross-platform).** Honor `XDG_RUNTIME_DIR` if set;
  otherwise fall back to a platform-specific cache dir
  (`$HOME/.cache/galoshes` on Linux, `$HOME/Library/Caches/galoshes`
  on macOS, `%LOCALAPPDATA%/galoshes` on Windows). If neither resolves,
  startup bails with a clear error naming both env vars. The Linux
  `/tmp` fallback is removed.
- **Noexec probe.** Linux uses `statvfs` + `ST_NOEXEC`; macOS uses
  `statfs` + `MNT_NOEXEC`; Windows is a noop (no noexec filesystem
  flag — read-only / AppLocker / Defender surface from existing fs
  error paths with anyhow context). On detection, bails with:
  `runtime directory <dir> is mounted noexec; galoshes cannot exec the embedded v2ray-plugin from this location. Set XDG_RUNTIME_DIR to a directory on an exec-capable mount, or remount this filesystem with the exec option.`

The Linux resolution fix alone resolves the postern container case —
`$HOME=/root` is on the container's writable layer and is
exec-capable, so the new fallback (`/root/.cache/galoshes`) just
works. The noexec probe is defense-in-depth + clear-error layer for
the case where an operator explicitly sets `XDG_RUNTIME_DIR` to a
noexec mount, or where `$HOME` itself lives on one.

### Behavior change

Linux galoshes no longer falls back to `/tmp` when both
`XDG_RUNTIME_DIR` and `HOME` are unset — it errors out at startup.
This affects only degenerate container environments missing both
env vars, which were already broken by the `/tmp`-noexec case.

### Files

- [crates/galoshes/src/embedded.rs](crates/galoshes/src/embedded.rs):
  consolidate per-OS \`runtime_dir\` into a single entry point + per-OS
  pure \`resolve\` functions; add \`check_dir_executable\` and per-OS
  predicates.
- [crates/galoshes/src/embedded_tests.rs](crates/galoshes/src/embedded_tests.rs):
  per-OS cfg-gated tests for resolution + noexec predicates (15 new
  tests across Linux/macOS/Windows).
- [crates/galoshes/Cargo.toml](crates/galoshes/Cargo.toml): add
  \`libc = "0.2"\` under \`[target.'cfg(unix)'.dependencies]\`.
- [CLAUDE.md](CLAUDE.md): extend "v2ray-plugin embedding" section
  with the runtime-dir contract.

## Test plan

- [x] \`cargo xtask run galoshes-tests\` (Windows host): 12/12 passed.
- [x] \`cargo check -p galoshes --target x86_64-unknown-linux-gnu\`: clean.
- [x] \`cargo check -p galoshes --target aarch64-apple-darwin\`: clean.
- [x] \`cargo clippy -p galoshes --tests\`: clean.
- [x] CI: galoshes-tests on Linux + macOS + Windows (six target triples).
- [ ] Manual repro on a Linux host with Docker, after CI is green:
  \`\`\`sh
  docker run --rm --init --tmpfs /tmp --network none \
    -e SS_CONFIG="\$SS_B64" -e XDG_RUNTIME_DIR=/tmp \
    local/shadowsocks-server:latest
  \`\`\`
  Expected: galoshes exits non-zero with the new noexec error message,
  before the chain reaches \`BinaryPlugin\` spawn.
- [ ] Sanity: same \`docker run\` with \`--tmpfs /tmp:exec\` succeeds.