### PR TITLE
fix(bridge): cooperative cancellation + Win32-native DNS apply (#397)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,91 @@ Clients on TCP-only plugins (v2ray-plugin, anything without UDP multiplexing) wo
 
 ### Bridge test-isolation contract
 
-All production I/O in the bridge — shadowsocks tunnel lifecycle, routing table mutations, OS gateway introspection — routes through the `Proxy` trait in `crates/bridge/src/proxy.rs` and the `Routing` trait in `crates/tun-engine/src/routing.rs`. Helper types whose `Drop` impls perform cleanup must route that cleanup through trait methods, not through raw free functions. Compile-time enforcement lives in the workspace root `clippy.toml` via the `disallowed_methods` list (`tun_engine::routing::setup_routes` / `teardown_routes`). See bindreams/hole#165 for the incident that motivated the rule.
+All production I/O in the bridge — shadowsocks tunnel lifecycle, routing
+table mutations, OS gateway introspection, OS DNS resolver configuration —
+routes through three traits: `Proxy` in
+[crates/bridge/src/proxy.rs](crates/bridge/src/proxy.rs), `Routing` in
+[crates/tun-engine/src/routing.rs](crates/tun-engine/src/routing.rs), and
+`Dns` in [crates/bridge/src/dns/system.rs](crates/bridge/src/dns/system.rs).
+Helper types whose `Drop` impls perform cleanup must route that cleanup
+through trait methods, not through raw free functions. Compile-time
+enforcement lives in the workspace root `clippy.toml` via the
+`disallowed_methods` list (`tun_engine::routing::setup_routes` /
+`teardown_routes`; the Win32 DNS FFIs
+`SetInterfaceDnsSettings` / `GetInterfaceDnsSettings`). See
+bindreams/hole#165 for the incident that motivated the rule and #397 for
+the `Dns` extension.
+
+The `Dns` trait has a **two-layer test seam**:
+
+- **Outer seam (`Dns`)** — substituted by `MockDns` at
+  `ProxyManager::new_with_dns(...)`. Used by `proxy_manager_tests` to
+  verify the `start_inner` integration (cancel propagation through
+  phase 7, restore on partial apply).
+- **Inner seam (`WinDnsBackend` on Windows / `MacDnsBackend` on macOS)**
+  — substituted by `MockBackend` at
+  `SystemDns::new_with_backend(...)`. Used by `dns/system/*_tests.rs`
+  to verify each platform's apply loop observes cancel between FFIs
+  and inline-restores. Both seams are necessary: an outer-only mock
+  can pass while the production `SystemDns::apply` ignores cancel
+  internally.
+
+### Bridge cancellation contract
+
+Cooperative-cancellation propagation (Go `context.Context` style) is the
+**only** cancellation mechanism in the bridge. Future-drop cancellation
+(`tokio::select! { _ = future.cancel.cancelled() => drop, r = work => r }`
+where dropping `work` is supposed to clean up) is reserved for
+catastrophic / panic teardown.
+
+The bridge's cancel scope is rooted at the IPC `handle_start` handler in
+[crates/bridge/src/ipc.rs](crates/bridge/src/ipc.rs); every subordinate
+phase of [`ProxyManager::start_cancellable`](crates/bridge/src/proxy_manager.rs)
+receives the token (or a `cancel.child_token()`) by reference and
+observes it cooperatively. Fresh `CancellationToken::new()` inside
+`crates/bridge/src/` would shadow this chain and is banned by
+`clippy.toml`'s `disallowed_methods` list. Sanctioned production
+exceptions (each carrying a per-call-site `#[allow]` with a citation)
+are enumerated in `clippy.toml` itself. See bindreams/hole#397.
+
+The contract has three invariants:
+
+1. **Cooperative observation between phases.** Long-running async phases
+   wrap their await in `tokio::select! { biased; _ = cancel.cancelled() => Err(Cancelled), r = work => r }`,
+   or check `cancel.is_cancelled()` between iterations of a loop. The
+   one exception is when the future being raced has no async cleanup
+   obligations (e.g. `DnsForwarder::forward` — the in-flight socket
+   closes on `Drop`, which is sync-trivial); future-drop is acceptable
+   at those sites and must be documented inline.
+1. **Async cleanup is explicit.** Types with async cleanup obligations
+   expose `async fn shutdown(&mut self)` and use `drop_bomb::DebugDropBomb`
+   to enforce that callers awaited it before drop. The bomb defuses
+   inside `shutdown`. Forgetting to await before drop panics in debug
+   builds (catches the bug at first test run) and emits a `warn!` plus a
+   best-effort sync fallback in release builds.
+1. **`tokio::select!` arms must not drop work mid-cleanup.** If a
+   cancel arm needs to run async cleanup, restructure so cleanup is
+   awaited cooperatively after the select returns. A `select!` that
+   races cancel against a `spawn_blocking` doing an FFI write creates a
+   TOCTOU between the in-flight FFI and any subsequent inline-restore;
+   the in-process apply loop in [`SystemDns::apply`](crates/bridge/src/dns/system.rs)
+   demonstrates the correct pattern (cancel-check between FFIs, never
+   mid-FFI; see the inline comment at the apply loop).
+
+`Dns::Applied` types follow this discipline:
+[`SystemDnsApplied`](crates/bridge/src/dns/system.rs) owns a
+`DebugDropBomb` defused by its `shutdown()`, and is constructed only in
+the `Ok` branch of `Dns::apply` so the bomb never fires from a
+start-Err unwind. `ProxyManager::stop` awaits `Applied::shutdown()`
+before letting `RunningState` drop.
+
+**Known follow-up.** `SystemRoutes::Drop` still tears down routing
+synchronously (shelling out to `netsh` / `route`), which blocks the
+runtime worker for up to several seconds on Windows. Converting
+`Routing::Installed` to the `async fn shutdown` + `DebugDropBomb`
+discipline (mirroring `DnsApplied`) is tracked as a follow-up — same
+class as the sub-bug A symptom that #397 fixed for DNS, but on the
+cleanup path.
 
 ### Panic-dump dispatcher
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2896,6 +2902,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "default-net",
+ "drop_bomb",
  "dump",
  "ferrisetw",
  "garter",

--- a/clippy.toml
+++ b/clippy.toml
@@ -142,6 +142,18 @@ path = "windows::Win32::NetworkManagement::IpHelper::GetInterfaceDnsSettings"
 reason = "Must go through `WinDnsBackend::get_settings` so unit tests can substitute MockBackend. Only `Win32Real` in `crates/bridge/src/dns/system/windows.rs` may call this. See bindreams/hole#397."
 allow-invalid = true
 
+# `DnsFlushResolverCache` is currently called via a local `#[link]`
+# declaration in `dns/system/windows.rs` (no `windows` crate path), but
+# we ban the canonical path for symmetry: any future binding via the
+# `windows` crate or a helper crate must still go through
+# `WinDnsBackend::flush`. The local `#[link]` site is sanctioned with an
+# `#[allow(clippy::disallowed_methods)]` plus comment citing this rule.
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::Dns::DnsFlushResolverCache"
+reason = "Must go through `WinDnsBackend::flush` so unit tests can substitute MockBackend. Only `Win32Real` in `crates/bridge/src/dns/system/windows.rs` may call this. See bindreams/hole#397."
+allow-invalid = true
+
 # Bridge cancellation contract (bindreams/hole#397) --------------------------------------------------------------------
 #
 # Fresh `CancellationToken::new()` inside `crates/bridge/src/` defeats
@@ -155,7 +167,19 @@ allow-invalid = true
 # the bridge cancel during plugin-chain spawn) is the case this rule
 # guards against.
 #
-# Sanctioned suppressions, each with a per-call-site
+# **Scope is workspace-wide, not bridge-only.** Cargo's `clippy.toml`
+# resolution is workspace-rooted; there is no per-crate override
+# without splitting workspaces. As a consequence, ex-Galoshes crates
+# (`garter`, `galoshes`, `garter-bin`, `mock-plugin`) that legitimately
+# spawn their own root tokens — for test harnesses, signal handlers,
+# and subsystem owners outside the bridge's IPC cancel chain — carry a
+# module-level `#![allow(clippy::disallowed_methods)]` in the affected
+# test / lib files. This is accepted noise; the alternative
+# (cargo-supported per-crate clippy.toml) does not exist as of cargo
+# 1.93. If a future cargo gains per-crate overrides, narrow the rule's
+# scope and remove the ex-Galoshes module-level allows.
+#
+# Sanctioned bridge-side suppressions, each with a per-call-site
 # `#[allow(clippy::disallowed_methods)]` plus comment citing this rule:
 #
 # 1. `crates/bridge/src/ipc.rs::handle_start` — the IPC root. Every
@@ -171,7 +195,7 @@ allow-invalid = true
 # 4. `crates/bridge/src/server_test.rs` — the one-shot `test-server`
 #    CLI probe, no caller-side cancel; never-signalled token by design.
 #
-# Test files use module-level `#![allow(clippy::disallowed_methods)]`
+# Bridge test files use module-level `#![allow(clippy::disallowed_methods)]`
 # because `CancellationToken::new` is pervasive there as the test
 # harness's root signal and per-call suppressions would dominate the
 # file. The module-level shape is `#![allow(...)]` near the top with a

--- a/clippy.toml
+++ b/clippy.toml
@@ -114,3 +114,30 @@ reason = "Use hole_test_observability::register!() at lib.rs level for tests. Pr
 [[disallowed-methods]]
 path = "tracing_subscriber::fmt::SubscriberBuilder::try_init"
 reason = "Use hole_test_observability::register!() at lib.rs level for tests. See bindreams/hole#301."
+
+# Bridge Dns trait — Win32 native DNS FFI (bindreams/hole#397) ---------------------------------------------------------
+#
+# The Win32 DNS settings FFIs (`SetInterfaceDnsSettings` /
+# `GetInterfaceDnsSettings`) must only be called from inside the
+# `WinDnsBackend::Win32Real` impl. Direct callers bypass the
+# `MockBackend` test seam exactly the same way the #165 `setup_routes`
+# bypass did. The free-function shims `capture_adapters` /
+# `apply_loopback` / `platform_restore_adapter` in
+# `crates/bridge/src/dns/system/windows.rs` already route through
+# `Win32Real::default()`; the bans below cover anything reaching the
+# raw `windows` crate paths directly.
+#
+# Sanctioned suppressions: only the two `Win32Real::{get_settings,
+# set_loopback, restore}` call sites in `dns/system/windows.rs`. Each
+# uses `#[allow(clippy::disallowed_methods)]` with a comment citing
+# this rule.
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::IpHelper::SetInterfaceDnsSettings"
+reason = "Must go through `WinDnsBackend::set_loopback` / `restore` so unit tests can substitute MockBackend. Only `Win32Real` in `crates/bridge/src/dns/system/windows.rs` may call this. See bindreams/hole#397."
+allow-invalid = true  # only `hole-bridge` has the `Win32_NetworkManagement_IpHelper` feature wired in; other workspace crates can't resolve the path.
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::IpHelper::GetInterfaceDnsSettings"
+reason = "Must go through `WinDnsBackend::get_settings` so unit tests can substitute MockBackend. Only `Win32Real` in `crates/bridge/src/dns/system/windows.rs` may call this. See bindreams/hole#397."
+allow-invalid = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -141,3 +141,42 @@ allow-invalid = true  # only `hole-bridge` has the `Win32_NetworkManagement_IpHe
 path = "windows::Win32::NetworkManagement::IpHelper::GetInterfaceDnsSettings"
 reason = "Must go through `WinDnsBackend::get_settings` so unit tests can substitute MockBackend. Only `Win32Real` in `crates/bridge/src/dns/system/windows.rs` may call this. See bindreams/hole#397."
 allow-invalid = true
+
+# Bridge cancellation contract (bindreams/hole#397) --------------------------------------------------------------------
+#
+# Fresh `CancellationToken::new()` inside `crates/bridge/src/` defeats
+# the cooperative-cancellation propagation that the #397 refactor put
+# in place: a bridge cancel signal from the user's "Cancel" button
+# travels from `ipc.rs::handle_start`'s root token down through every
+# phase of `proxy_manager::start_inner` via `child_token()`. Any fresh
+# token rooted elsewhere is unreachable from that root, and any
+# in-flight work observing only that fresh token cannot be preempted.
+# The historical regression at `plugin.rs:237` (a fresh token shadowing
+# the bridge cancel during plugin-chain spawn) is the case this rule
+# guards against.
+#
+# Sanctioned suppressions, each with a per-call-site
+# `#[allow(clippy::disallowed_methods)]` plus comment citing this rule:
+#
+# 1. `crates/bridge/src/ipc.rs::handle_start` — the IPC root. Every
+#    bridge cancel scope descends from this one token.
+# 2. `crates/bridge/src/dispatcher.rs::Dispatcher::new` — the
+#    Dispatcher owns its own subsystem cancel scope tied to its
+#    lifecycle (started in `new`, cancelled in `shutdown`); it is not
+#    a child of the start-cancel.
+# 3. `crates/bridge/src/proxy_manager.rs::ProxyManager::start` — the
+#    non-cancellable convenience shim that explicitly creates a fresh
+#    never-signalled token because the caller (tests, `reload`) does
+#    not want cancel semantics.
+# 4. `crates/bridge/src/server_test.rs` — the one-shot `test-server`
+#    CLI probe, no caller-side cancel; never-signalled token by design.
+#
+# Test files use module-level `#![allow(clippy::disallowed_methods)]`
+# because `CancellationToken::new` is pervasive there as the test
+# harness's root signal and per-call suppressions would dominate the
+# file. The module-level shape is `#![allow(...)]` near the top with a
+# comment citing this rule.
+
+[[disallowed-methods]]
+path = "tokio_util::sync::CancellationToken::new"
+reason = "In `crates/bridge/src/`, fresh tokens shadow the cooperative-cancellation chain rooted at `ipc.rs::handle_start`. Use the propagated `cancel: &CancellationToken` parameter (or `cancel.child_token()` for phase isolation). Sanctioned production sites: `ipc.rs::handle_start`, `dispatcher.rs::Dispatcher::new`, `proxy_manager.rs::ProxyManager::start`, `server_test.rs`. Test files use module-level `#![allow]`. See bindreams/hole#397."

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -29,6 +29,13 @@ serde_json = "1"
 tracing = "0.1"
 thiserror = "2"
 tokio-util = "0.7"
+# Runtime-checked async-cleanup discipline: SystemDnsApplied and other async-
+# cleanup guards own a `DebugDropBomb` defused by `shutdown().await`. Drop
+# panics in debug builds if the bomb is armed, catching missed-shutdown bugs
+# at first test run. Release builds use the no-op DebugDropBomb variant and
+# fall through to a best-effort sync fallback with a `warn!` log. See #397
+# and the "Bridge cancellation contract" section in CLAUDE.md.
+drop_bomb = "0.1"
 socket2 = "0.6"
 axum = { version = "0.8", default-features = false, features = ["json"] }
 hyper = { version = "1", features = ["http1", "server"] }

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -84,7 +84,6 @@ windows = { version = "0.62", features = [
     "Wdk_Foundation",
     "Wdk_System_SystemInformation",
     "Win32_Foundation",
-    "Win32_NetworkManagement_Dns",
     "Win32_NetworkManagement_IpHelper",
     "Win32_Networking_WinSock",
     "Win32_Security",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -77,13 +77,15 @@ windows = { version = "0.62", features = [
     "Wdk_Foundation",
     "Wdk_System_SystemInformation",
     "Win32_Foundation",
+    "Win32_NetworkManagement_Dns",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_Etw",
     "Win32_System_RemoteDesktop",
     "Win32_System_Threading",
-    "Win32_Networking_WinSock",
 ] }
 # Used by the ETW consumer in crates/bridge/src/diagnostics/etw.rs.
 ferrisetw = "1.2.0"

--- a/crates/bridge/src/dispatcher.rs
+++ b/crates/bridge/src/dispatcher.rs
@@ -92,6 +92,8 @@ impl Dispatcher {
             .map_err(|e| std::io::Error::other(format!("failed to build engine: {e}")))?;
 
         // Cancellation token drives shutdown.
+        #[allow(clippy::disallowed_methods)]
+        // Dispatcher owns its own subsystem cancel scope (tied to its lifecycle, not the start-cancel). See clippy.toml CancellationToken::new rule.
         let cancel = CancellationToken::new();
         let cancel_for_driver = cancel.clone();
         let driver_handle = tokio::spawn(async move {

--- a/crates/bridge/src/dns/server.rs
+++ b/crates/bridge/src/dns/server.rs
@@ -42,6 +42,7 @@ use hole_common::retry::is_bind_race;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::dns::forwarder::DnsForwarder;
 
@@ -140,11 +141,40 @@ impl LocalDnsServer {
     /// then `127.53.0.1..=127.53.0.254`, returning the first IP where BOTH
     /// UDP and TCP bind succeeds. Returns an explicit error when the whole
     /// ladder is exhausted.
-    pub async fn bind_ladder(forwarder: Arc<DnsForwarder>) -> io::Result<Self> {
+    ///
+    /// **Cooperative cancel (#397).** Checks `cancel.is_cancelled()` at
+    /// each candidate boundary; on cancel returns an `io::Error::other`
+    /// whose message names the attempt count. The caller's outer
+    /// `tokio::select!` against the same token sees the cancel first
+    /// (biased ordering) and re-emits `ProxyError::Cancelled` canonically;
+    /// the internal early-exit is the safety net for callers that drive
+    /// `bind_ladder` without an outer select. Mid-attempt cancel
+    /// granularity (cancel-during-`socket::bind`) is impractical on
+    /// Windows where the bind syscall is uninterruptible; the worst-case
+    /// cancel response is the duration of one bind attempt — typically
+    /// ms — see the "Bind-ladder worst-case cancel latency" follow-up.
+    ///
+    /// Logs adaptive `info!` checkpoints at attempts 10, 20, 30 … so a
+    /// stuck ladder stays visible at the default log level without
+    /// flooding the happy-path log volume (mirrors `bind_ephemeral`'s
+    /// adaptive logging, see CLAUDE.md §"No budget — by design").
+    pub async fn bind_ladder(forwarder: Arc<DnsForwarder>, cancel: CancellationToken) -> io::Result<Self> {
         let candidates = ladder_candidates();
         let preferred = candidates[0];
         let mut last_err: Option<io::Error> = None;
-        for addr in candidates {
+        for (idx, addr) in candidates.into_iter().enumerate() {
+            if cancel.is_cancelled() {
+                return Err(io::Error::other(format!(
+                    "LocalDnsServer bind_ladder cancelled after {idx} attempts"
+                )));
+            }
+            let attempt_num = idx + 1;
+            if attempt_num > 1 && attempt_num % 10 == 0 {
+                tracing::info!(
+                    attempts = attempt_num,
+                    "LocalDnsServer bind_ladder still trying loopback candidates"
+                );
+            }
             match Self::bind(addr, Arc::clone(&forwarder)).await {
                 Ok(srv) => return Ok(srv),
                 Err(e) => {

--- a/crates/bridge/src/dns/system.rs
+++ b/crates/bridge/src/dns/system.rs
@@ -311,7 +311,11 @@ async fn apply_windows(
             // Cooperative inline-restore — runs serially through the
             // same backend (cancel-disregarded inside restore). FFI
             // budget for restore: 2 adapters × 2 families = ~40 ms.
-            inline_restore(backend, &captured).await;
+            // Also clears `bridge-dns.json` so the next start's
+            // `recover_dns_config` doesn't replay an already-restored
+            // prior over any user-side DNS changes made between this
+            // cancel and that next start.
+            inline_restore(backend, &captured, state_dir.as_deref()).await;
             return Err(DnsError::Cancelled);
         }
         let b = Arc::clone(backend);
@@ -340,13 +344,19 @@ async fn apply_windows(
         state_dir,
         local_dns_server: Some(local_dns_server),
         bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
+        shutdown_completed: false,
     })
 }
 
 #[cfg(target_os = "windows")]
-async fn inline_restore(backend: &Arc<dyn windows::WinDnsBackend>, prior: &[DnsPriorAdapter]) {
+async fn inline_restore(
+    backend: &Arc<dyn windows::WinDnsBackend>,
+    prior: &[DnsPriorAdapter],
+    state_dir: Option<&std::path::Path>,
+) {
     let backend = Arc::clone(backend);
     let prior = prior.to_vec();
+    let state_dir = state_dir.map(std::path::Path::to_path_buf);
     let _ = tokio::task::spawn_blocking(move || {
         for adapter in &prior {
             if let Err(e) = backend.restore(adapter) {
@@ -358,6 +368,14 @@ async fn inline_restore(backend: &Arc<dyn windows::WinDnsBackend>, prior: &[DnsP
             }
         }
         let _ = backend.flush();
+        if let Some(dir) = state_dir {
+            if let Err(e) = crate::dns_state::clear(&dir) {
+                tracing::warn!(
+                    error = %e,
+                    "inline-restore: failed to clear bridge-dns.json"
+                );
+            }
+        }
     })
     .await;
 }
@@ -419,7 +437,9 @@ async fn apply_macos(
     // the subsequent inline-restore.
     for service in &apply_aliases {
         if cancel.is_cancelled() {
-            inline_restore_macos(backend, &captured).await;
+            // Clears `bridge-dns.json` alongside the per-adapter restore —
+            // same rationale as the Windows path above.
+            inline_restore_macos(backend, &captured, state_dir.as_deref()).await;
             return Err(DnsError::Cancelled);
         }
         let b = Arc::clone(backend);
@@ -448,13 +468,19 @@ async fn apply_macos(
         state_dir,
         local_dns_server: Some(local_dns_server),
         bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
+        shutdown_completed: false,
     })
 }
 
 #[cfg(target_os = "macos")]
-async fn inline_restore_macos(backend: &Arc<dyn macos::MacDnsBackend>, prior: &[DnsPriorAdapter]) {
+async fn inline_restore_macos(
+    backend: &Arc<dyn macos::MacDnsBackend>,
+    prior: &[DnsPriorAdapter],
+    state_dir: Option<&std::path::Path>,
+) {
     let backend = Arc::clone(backend);
     let prior = prior.to_vec();
+    let state_dir = state_dir.map(std::path::Path::to_path_buf);
     let _ = tokio::task::spawn_blocking(move || {
         for adapter in &prior {
             if let Err(e) = backend.restore(adapter) {
@@ -466,6 +492,14 @@ async fn inline_restore_macos(backend: &Arc<dyn macos::MacDnsBackend>, prior: &[
             }
         }
         let _ = backend.flush();
+        if let Some(dir) = state_dir {
+            if let Err(e) = crate::dns_state::clear(&dir) {
+                tracing::warn!(
+                    error = %e,
+                    "inline-restore: failed to clear bridge-dns.json"
+                );
+            }
+        }
     })
     .await;
 }
@@ -493,14 +527,25 @@ pub struct SystemDnsApplied {
     /// forwarder tasks running. Released AFTER system DNS is restored.
     local_dns_server: Option<crate::dns::server::LocalDnsServer>,
     /// Runtime safeguard: panics in debug builds on drop if `shutdown`
-    /// wasn't awaited. No-op in release; the sync-fallback `Drop` impl
-    /// below covers the release-build crash-unwind path.
+    /// wasn't awaited. No-op in release.
+    ///
+    /// **DO NOT** gate the sync-fallback `Drop` path on `bomb.is_defused()`:
+    /// `drop_bomb::DebugDropBomb::is_defused()` returns `true`
+    /// unconditionally in release builds (`FakeBomb`), which would make
+    /// the fallback dead code in release. The `shutdown_completed` flag
+    /// below is the load-bearing release-mode signal.
     bomb: drop_bomb::DebugDropBomb,
+    /// `true` after `DnsApplied::shutdown` has completed its restore +
+    /// cleanup. Set in `shutdown` regardless of build profile. `Drop`
+    /// checks this (not `bomb.is_defused()`) to decide whether to run
+    /// the sync-fallback restore. See bindreams/hole#397.
+    shutdown_completed: bool,
 }
 
 impl DnsApplied for SystemDnsApplied {
     async fn shutdown(&mut self) {
         self.bomb.defuse();
+        self.shutdown_completed = true;
         let prior = std::mem::take(&mut self.applied_prior);
         let state_dir = self.state_dir.clone();
         #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -547,8 +592,13 @@ impl Drop for SystemDnsApplied {
     /// Drop panics in debug builds if not defused (catching
     /// missed-shutdown bugs); release builds suppress the panic and we
     /// run the best-effort sync restore below.
+    ///
+    /// The release-mode signal is `shutdown_completed`, NOT
+    /// `bomb.is_defused()` — the latter is `true` unconditionally in
+    /// release (`drop_bomb::FakeBomb`), which would make this path
+    /// dead code in release. See the `shutdown_completed` field doc.
     fn drop(&mut self) {
-        if self.bomb.is_defused() {
+        if self.shutdown_completed {
             return;
         }
         // Released paths: missed-shutdown bug in release. Log and run

--- a/crates/bridge/src/dns/system.rs
+++ b/crates/bridge/src/dns/system.rs
@@ -46,13 +46,13 @@ use crate::dns_state::{AdapterId, DnsPriorAdapter};
 /// `Dns` and [`DnsApplied`] are the test-isolation seam for system-DNS
 /// I/O, mirroring [`crate::proxy::Proxy`] and [`tun_engine::routing::Routing`].
 /// Production goes through [`SystemDns`] (platform-specific); tests
-/// substitute `MockDns` via `ProxyManager::new_with_dns` (chunk 3).
+/// substitute a mock via [`crate::proxy_manager::ProxyManager::new_with_dns`].
 ///
 /// **Why a trait, not free functions.** Direct callers of the
 /// platform-free-function surface (`apply_loopback`, `capture_adapters`,
 /// `restore_all`) outside the `SystemDns` impl are rejected by workspace
-/// `clippy.toml` `disallowed_methods` (added in chunk 3), mirroring the
-/// `setup_routes` / `teardown_routes` enforcement at
+/// `clippy.toml` `disallowed_methods`, mirroring the `setup_routes` /
+/// `teardown_routes` enforcement at
 /// [tun_engine::routing](../../../tun_engine/routing.rs). The motivation
 /// is identical to #165: a helper that bypasses the trait cannot be
 /// intercepted by the mock and will exercise real production code from
@@ -66,7 +66,7 @@ pub trait Dns: Send + Sync + 'static {
     /// **Two teardown paths**:
     ///
     /// - Preferred: call [`DnsApplied::shutdown`] (async) before drop.
-    ///   This is what `ProxyManager::stop` does (chunk 3).
+    ///   This is what `ProxyManager::stop` does.
     /// - Fallback: Drop. Synchronous, used only on crash / panic
     ///   unwind. The `DebugDropBomb` safeguard inside the production
     ///   guard panics in debug builds if shutdown wasn't awaited, so
@@ -122,14 +122,15 @@ pub enum DnsError {
 
 // SystemDns ===========================================================================================================
 //
-// On Windows, `SystemDns` carries an `Arc<dyn WinDnsBackend>` so tests can
-// substitute `MockBackend`. The default constructor uses `Win32Real` which
-// calls `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` /
-// `DnsFlushResolverCache` directly (~ms-scale FFI).
+// `SystemDns` carries a platform-specific backend trait object so tests
+// can substitute a mock without touching the OS resolver. Mirrors
+// [`tun_engine::routing::SystemRouting`].
 //
-// On macOS, `SystemDns` is currently stateless and delegates to the
-// `networksetup`-based free-function surface; the parity `MacDnsBackend`
-// refactor lands in chunk 3.
+// - Windows: `Arc<dyn WinDnsBackend>`. Production: `Win32Real`
+//   (`SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` /
+//   `DnsFlushResolverCache`, ~ms-scale FFI).
+// - macOS: `Arc<dyn MacDnsBackend>`. Production: `Networksetup`
+//   (`networksetup -getdnsservers` / `-setdnsservers` subprocess).
 
 /// Production [`Dns`] implementation.
 #[derive(Clone)]
@@ -138,6 +139,11 @@ pub struct SystemDns {
     /// substitute via [`Self::new_with_backend`].
     #[cfg(target_os = "windows")]
     backend: Arc<dyn windows::WinDnsBackend>,
+    /// macOS `networksetup` backend. Production:
+    /// [`macos::Networksetup`]; tests: substitute via
+    /// [`Self::new_with_mac_backend`].
+    #[cfg(target_os = "macos")]
+    backend: Arc<dyn macos::MacDnsBackend>,
 }
 
 impl Default for SystemDns {
@@ -151,6 +157,8 @@ impl SystemDns {
         Self {
             #[cfg(target_os = "windows")]
             backend: Arc::new(windows::Win32Real),
+            #[cfg(target_os = "macos")]
+            backend: Arc::new(macos::Networksetup),
         }
     }
 
@@ -159,6 +167,14 @@ impl SystemDns {
     /// substitute a mock. Production code uses [`Self::new`].
     #[cfg(target_os = "windows")]
     pub fn new_with_backend(backend: Arc<dyn windows::WinDnsBackend>) -> Self {
+        Self { backend }
+    }
+
+    /// Construct a [`SystemDns`] with a specific [`macos::MacDnsBackend`]
+    /// implementation. Used by Layer-2 unit tests to substitute a mock.
+    /// Production code uses [`Self::new`].
+    #[cfg(target_os = "macos")]
+    pub fn new_with_mac_backend(backend: Arc<dyn macos::MacDnsBackend>) -> Self {
         Self { backend }
     }
 }
@@ -195,47 +211,15 @@ impl Dns for SystemDns {
         state_dir: Option<PathBuf>,
         cancel: CancellationToken,
     ) -> Result<Self::Applied, DnsError> {
-        // macOS path keeps the chunk-1 stub-delegation. The cancel-aware
-        // `MacDnsBackend` refactor lands in chunk 3.
-        let _ = cancel;
-        let started = std::time::Instant::now();
-        let chosen_loopback = local_dns_server.addr();
-        let loopback_ip = chosen_loopback.ip();
-
-        let captured = {
-            let capture_aliases = capture_aliases.clone();
-            let apply_aliases = apply_aliases.clone();
-            let state_dir_for_blocking = state_dir.clone();
-            tokio::task::spawn_blocking(move || -> Result<Vec<DnsPriorAdapter>, io::Error> {
-                let prior = capture_adapters(&capture_aliases)?;
-                if let Some(dir) = state_dir_for_blocking.as_deref() {
-                    let state = crate::dns_state::DnsState {
-                        version: crate::dns_state::SCHEMA_VERSION,
-                        chosen_loopback,
-                        adapters: prior.clone(),
-                    };
-                    if let Err(e) = crate::dns_state::save(dir, &state) {
-                        tracing::warn!(error = %e, "dns_state::save failed; continuing without crash-recovery file");
-                    }
-                }
-                apply_loopback(&apply_aliases, loopback_ip)?;
-                Ok(prior)
-            })
-            .await
-            .map_err(|join_err| io::Error::other(format!("dns apply join error: {join_err}")))??
-        };
-
-        tracing::info!(
-            elapsed_ms = started.elapsed().as_millis() as u64,
-            "apply_dns_settings done"
-        );
-
-        Ok(SystemDnsApplied {
-            applied_prior: captured,
+        apply_macos(
+            &self.backend,
+            local_dns_server,
+            capture_aliases,
+            apply_aliases,
             state_dir,
-            local_dns_server: Some(local_dns_server),
-            bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
-        })
+            cancel,
+        )
+        .await
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
@@ -378,6 +362,114 @@ async fn inline_restore(backend: &Arc<dyn windows::WinDnsBackend>, prior: &[DnsP
     .await;
 }
 
+// macOS apply loop ====================================================================================================
+
+#[cfg(target_os = "macos")]
+async fn apply_macos(
+    backend: &Arc<dyn macos::MacDnsBackend>,
+    local_dns_server: crate::dns::server::LocalDnsServer,
+    capture_aliases: Vec<String>,
+    apply_aliases: Vec<String>,
+    state_dir: Option<PathBuf>,
+    cancel: CancellationToken,
+) -> Result<SystemDnsApplied, DnsError> {
+    let started = std::time::Instant::now();
+    let chosen_loopback = local_dns_server.addr();
+    let loopback_ip = chosen_loopback.ip();
+    let mut captured: Vec<DnsPriorAdapter> = Vec::new();
+
+    // Capture phase. Cancel checked between subprocesses; capture is
+    // read-only, so an early Err here mutates no state.
+    for service in &capture_aliases {
+        if cancel.is_cancelled() {
+            return Err(DnsError::Cancelled);
+        }
+        let b = Arc::clone(backend);
+        let svc_owned = service.clone();
+        let res = tokio::task::spawn_blocking(move || b.get_settings(&svc_owned))
+            .await
+            .map_err(|e| DnsError::Io(io::Error::other(e)))?;
+        match res {
+            Ok(Some(prior)) => captured.push(prior),
+            Ok(None) => tracing::debug!(%service, "DNS capture: service not found; skipping"),
+            Err(e) => tracing::warn!(%service, error = %e, "DNS capture failed for service"),
+        }
+    }
+
+    if cancel.is_cancelled() {
+        return Err(DnsError::Cancelled);
+    }
+
+    // Persist BEFORE apply so a mid-apply crash leaves a recoverable
+    // file (matches `tun_engine::routing::SystemRouting::install`).
+    if let Some(dir) = state_dir.as_deref() {
+        let state = crate::dns_state::DnsState {
+            version: crate::dns_state::SCHEMA_VERSION,
+            chosen_loopback,
+            adapters: captured.clone(),
+        };
+        if let Err(e) = crate::dns_state::save(dir, &state) {
+            tracing::warn!(error = %e, "dns_state::save failed; continuing without crash-recovery file");
+        }
+    }
+
+    // Apply phase. Cancel between subprocesses, mirroring the Windows
+    // path's TOCTOU rationale: abandoning an in-flight `spawn_blocking`
+    // leaves `networksetup` running on the blocking pool and would race
+    // the subsequent inline-restore.
+    for service in &apply_aliases {
+        if cancel.is_cancelled() {
+            inline_restore_macos(backend, &captured).await;
+            return Err(DnsError::Cancelled);
+        }
+        let b = Arc::clone(backend);
+        let svc_owned = service.clone();
+        let res = tokio::task::spawn_blocking(move || b.set_loopback(&svc_owned, loopback_ip))
+            .await
+            .map_err(|e| DnsError::Io(io::Error::other(e)))?;
+        if let Err(e) = res {
+            tracing::warn!(%service, error = %e, "DNS apply failed; continuing");
+        }
+    }
+
+    // Flush. Best-effort — through the backend so mock backends can
+    // count it for the perf-regression test.
+    let b = Arc::clone(backend);
+    let _ = tokio::task::spawn_blocking(move || b.flush()).await;
+
+    tracing::info!(
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "apply_dns_settings done"
+    );
+
+    Ok(SystemDnsApplied {
+        backend: Arc::clone(backend),
+        applied_prior: captured,
+        state_dir,
+        local_dns_server: Some(local_dns_server),
+        bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
+    })
+}
+
+#[cfg(target_os = "macos")]
+async fn inline_restore_macos(backend: &Arc<dyn macos::MacDnsBackend>, prior: &[DnsPriorAdapter]) {
+    let backend = Arc::clone(backend);
+    let prior = prior.to_vec();
+    let _ = tokio::task::spawn_blocking(move || {
+        for adapter in &prior {
+            if let Err(e) = backend.restore(adapter) {
+                tracing::warn!(
+                    id = ?adapter.id,
+                    error = %e,
+                    "inline-restore: adapter failed; continuing"
+                );
+            }
+        }
+        let _ = backend.flush();
+    })
+    .await;
+}
+
 // SystemDnsApplied ====================================================================================================
 
 /// RAII guard returned by [`SystemDns::apply`]. The preferred teardown
@@ -387,10 +479,14 @@ async fn inline_restore(backend: &Arc<dyn windows::WinDnsBackend>, prior: &[DnsP
 /// test run. Release builds fall through to a best-effort sync restore.
 #[must_use = "SystemDnsApplied owns async cleanup; call .shutdown().await before drop"]
 pub struct SystemDnsApplied {
-    /// Win32 backend used for restore. None on macOS / unsupported
-    /// targets — those use the free-function path (chunk 3 unifies).
+    /// Win32 backend used for restore on Windows. Mirrors the macOS
+    /// `backend` field below; both go through `Arc<dyn …Backend>` so
+    /// `SystemDnsApplied` is platform-agnostic.
     #[cfg(target_os = "windows")]
     backend: Arc<dyn windows::WinDnsBackend>,
+    /// `networksetup` backend used for restore on macOS.
+    #[cfg(target_os = "macos")]
+    backend: Arc<dyn macos::MacDnsBackend>,
     applied_prior: Vec<DnsPriorAdapter>,
     state_dir: Option<PathBuf>,
     /// Held to keep the loopback `<ip>:53` bound and to keep the
@@ -407,11 +503,11 @@ impl DnsApplied for SystemDnsApplied {
         self.bomb.defuse();
         let prior = std::mem::take(&mut self.applied_prior);
         let state_dir = self.state_dir.clone();
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
         let backend = Arc::clone(&self.backend);
 
         let _ = tokio::task::spawn_blocking(move || {
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             {
                 for adapter in &prior {
                     if let Err(e) = backend.restore(adapter) {
@@ -424,15 +520,9 @@ impl DnsApplied for SystemDnsApplied {
                 }
                 let _ = backend.flush();
             }
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(not(any(target_os = "windows", target_os = "macos")))]
             {
-                let errors = restore_all(&prior);
-                if !errors.is_empty() {
-                    tracing::warn!(
-                        count = errors.len(),
-                        "SystemDnsApplied::shutdown: some adapters failed to restore"
-                    );
-                }
+                let _ = prior;
             }
             if let Some(dir) = state_dir {
                 if let Err(e) = crate::dns_state::clear(&dir) {
@@ -465,7 +555,7 @@ impl Drop for SystemDnsApplied {
         // best-effort sync restore so the user's DNS isn't left
         // hijacked.
         tracing::warn!("SystemDnsApplied dropped without shutdown() — sync fallback");
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
         {
             for adapter in &self.applied_prior {
                 if let Err(e) = self.backend.restore(adapter) {
@@ -477,16 +567,6 @@ impl Drop for SystemDnsApplied {
                 }
             }
             let _ = self.backend.flush();
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            let errors = restore_all(&self.applied_prior);
-            if !errors.is_empty() {
-                tracing::warn!(
-                    count = errors.len(),
-                    "SystemDnsApplied::drop: some adapters failed to restore (sync fallback)"
-                );
-            }
         }
         if let Some(dir) = &self.state_dir {
             if let Err(e) = crate::dns_state::clear(dir) {

--- a/crates/bridge/src/dns/system.rs
+++ b/crates/bridge/src/dns/system.rs
@@ -8,31 +8,32 @@
 //!
 //! Each adapter carries two independent DNS lists (v4, v6); each list is
 //! in one of three states — static, DHCP-assigned, or unset. The restore
-//! path dispatches on the captured [`DnsPrior`] variant so a prior that
-//! was DHCP-assigned doesn't get reapplied as a static list (which would
-//! freeze DHCP renewal).
+//! path dispatches on the captured [`crate::dns_state::DnsPrior`] variant
+//! so a prior that was DHCP-assigned doesn't get reapplied as a static
+//! list (which would freeze DHCP renewal).
 //!
 //! ## Which adapters?
 //!
-//! Capture targets two adapters: the TUN adapter (we want the best-route
-//! resolver lookup to land here so the OS picks *our* DNS) and the
-//! upstream physical adapter (defense in depth against multi-homed
-//! resolvers). Apply sets the same loopback on both. Restore replays the
-//! captured state per adapter.
+//! Capture targets one adapter: the upstream physical adapter. Apply sets
+//! the loopback on both the TUN adapter (which we want the best-route
+//! resolver lookup to land on) and the upstream. The TUN is recreated per
+//! connect so its prior state is "defaults"; nothing to capture.
+//! Restore replays the captured state per adapter.
 //!
 //! ## Platform implementations
 //!
-//! - **Windows** — `netsh interface {ipv4,ipv6} {show,set} dnsservers`.
-//!   Adapter identity is the LUID (stable for physical adapters across
-//!   reboots; the TUN adapter is recreated per-connect so its LUID is
-//!   fresh each time).
+//! - **Windows** — Direct Win32 calls via [`windows::WinDnsBackend`] +
+//!   [`windows::Win32Real`]. Pre-#397 this layer shelled out to `netsh`.
+//!   Adapter identity is the friendly alias ("Wi-Fi", "wintun") which
+//!   resolves to a LUID-then-GUID inside `Win32Real`.
 //! - **macOS** — `networksetup -{getdnsservers,setdnsservers}`. Adapter
-//!   identity is the service name (e.g. "Wi-Fi"). Service names are
-//!   reasonably stable across short periods; a user who renames a
-//!   service mid-session will see that service skipped on restore.
+//!   identity is the service name (e.g. "Wi-Fi"). Reasonably stable
+//!   across short periods; a user who renames a service mid-session
+//!   will see that service skipped on restore.
 
 use std::io;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
 
@@ -44,16 +45,16 @@ use crate::dns_state::{AdapterId, DnsPriorAdapter};
 ///
 /// `Dns` and [`DnsApplied`] are the test-isolation seam for system-DNS
 /// I/O, mirroring [`crate::proxy::Proxy`] and [`tun_engine::routing::Routing`].
-/// Production goes through `SystemDns` (platform-specific); tests
-/// substitute `MockDns` via [`crate::proxy_manager::ProxyManager::new_with_dns`].
+/// Production goes through [`SystemDns`] (platform-specific); tests
+/// substitute `MockDns` via `ProxyManager::new_with_dns` (chunk 3).
 ///
 /// **Why a trait, not free functions.** Direct callers of the
 /// platform-free-function surface (`apply_loopback`, `capture_adapters`,
 /// `restore_all`) outside the `SystemDns` impl are rejected by workspace
-/// `clippy.toml` `disallowed_methods`, mirroring the
+/// `clippy.toml` `disallowed_methods` (added in chunk 3), mirroring the
 /// `setup_routes` / `teardown_routes` enforcement at
-/// [tun_engine::routing](../../../tun_engine/routing.rs). The motivation is
-/// identical to #165: a helper that bypasses the trait cannot be
+/// [tun_engine::routing](../../../tun_engine/routing.rs). The motivation
+/// is identical to #165: a helper that bypasses the trait cannot be
 /// intercepted by the mock and will exercise real production code from
 /// unit tests, with catastrophic consequences for test reliability and
 /// CI health. See bindreams/hole#397.
@@ -65,10 +66,11 @@ pub trait Dns: Send + Sync + 'static {
     /// **Two teardown paths**:
     ///
     /// - Preferred: call [`DnsApplied::shutdown`] (async) before drop.
-    ///   This is what [`crate::proxy_manager::ProxyManager::stop`] does.
+    ///   This is what `ProxyManager::stop` does (chunk 3).
     /// - Fallback: Drop. Synchronous, used only on crash / panic
-    ///   unwind. Production implementations may use
-    ///   `tokio::task::block_in_place` if a runtime is current.
+    ///   unwind. The `DebugDropBomb` safeguard inside the production
+    ///   guard panics in debug builds if shutdown wasn't awaited, so
+    ///   missed-shutdown bugs are caught at first test run.
     type Applied: DnsApplied;
 
     /// Capture the prior DNS state of `capture_aliases`, persist it to
@@ -103,7 +105,7 @@ pub trait DnsApplied: Send + 'static {
 /// Errors returned from [`Dns::apply`].
 #[derive(Debug, thiserror::Error)]
 pub enum DnsError {
-    /// The cancel token fired between netsh / Win32 calls during apply.
+    /// The cancel token fired between FFI / netsh calls during apply.
     /// Any partially-applied adapters have been inline-restored before
     /// this variant is returned.
     #[error("DNS apply cancelled")]
@@ -120,27 +122,51 @@ pub enum DnsError {
 
 // SystemDns ===========================================================================================================
 //
-// Production `Dns` implementation. This is the stub-stage wiring — `apply`
-// shells out to the existing free-function surface on a blocking-pool
-// worker so the bridge keeps the pre-#397 behavior. The real Win32 FFI
-// rewrite + cancel plumbing land in subsequent commits on this branch.
-// See bindreams/hole#397.
+// On Windows, `SystemDns` carries an `Arc<dyn WinDnsBackend>` so tests can
+// substitute `MockBackend`. The default constructor uses `Win32Real` which
+// calls `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` /
+// `DnsFlushResolverCache` directly (~ms-scale FFI).
+//
+// On macOS, `SystemDns` is currently stateless and delegates to the
+// `networksetup`-based free-function surface; the parity `MacDnsBackend`
+// refactor lands in chunk 3.
 
-/// Production [`Dns`] implementation. Default constructor; carries no
-/// state on its own — platform behavior comes from the free-function
-/// surface in `dns/system/{windows,macos}.rs` (transitively).
-#[derive(Default, Clone)]
-pub struct SystemDns;
+/// Production [`Dns`] implementation.
+#[derive(Clone)]
+pub struct SystemDns {
+    /// Win32 DNS backend. Production: [`windows::Win32Real`]; tests:
+    /// substitute via [`Self::new_with_backend`].
+    #[cfg(target_os = "windows")]
+    backend: Arc<dyn windows::WinDnsBackend>,
+}
+
+impl Default for SystemDns {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl SystemDns {
     pub fn new() -> Self {
-        Self
+        Self {
+            #[cfg(target_os = "windows")]
+            backend: Arc::new(windows::Win32Real),
+        }
+    }
+
+    /// Construct a [`SystemDns`] with a specific [`windows::WinDnsBackend`]
+    /// implementation. Used by Layer-2 unit tests (`windows_tests.rs`) to
+    /// substitute a mock. Production code uses [`Self::new`].
+    #[cfg(target_os = "windows")]
+    pub fn new_with_backend(backend: Arc<dyn windows::WinDnsBackend>) -> Self {
+        Self { backend }
     }
 }
 
 impl Dns for SystemDns {
     type Applied = SystemDnsApplied;
 
+    #[cfg(target_os = "windows")]
     async fn apply(
         &self,
         local_dns_server: crate::dns::server::LocalDnsServer,
@@ -149,15 +175,33 @@ impl Dns for SystemDns {
         state_dir: Option<PathBuf>,
         cancel: CancellationToken,
     ) -> Result<Self::Applied, DnsError> {
-        // STAGE 1 stub (#397): delegate to the existing free-function surface.
-        // Cancel-naive at this layer — the cancel-aware loop lands when the
-        // Win32 backend replaces netsh. Layer 2 tests guard the contract.
+        apply_windows(
+            &self.backend,
+            local_dns_server,
+            capture_aliases,
+            apply_aliases,
+            state_dir,
+            cancel,
+        )
+        .await
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn apply(
+        &self,
+        local_dns_server: crate::dns::server::LocalDnsServer,
+        capture_aliases: Vec<String>,
+        apply_aliases: Vec<String>,
+        state_dir: Option<PathBuf>,
+        cancel: CancellationToken,
+    ) -> Result<Self::Applied, DnsError> {
+        // macOS path keeps the chunk-1 stub-delegation. The cancel-aware
+        // `MacDnsBackend` refactor lands in chunk 3.
         let _ = cancel;
         let started = std::time::Instant::now();
         let chosen_loopback = local_dns_server.addr();
         let loopback_ip = chosen_loopback.ip();
 
-        #[cfg(any(target_os = "windows", target_os = "macos"))]
         let captured = {
             let capture_aliases = capture_aliases.clone();
             let apply_aliases = apply_aliases.clone();
@@ -181,12 +225,6 @@ impl Dns for SystemDns {
             .map_err(|join_err| io::Error::other(format!("dns apply join error: {join_err}")))??
         };
 
-        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-        let captured: Vec<DnsPriorAdapter> = {
-            let _ = (capture_aliases, apply_aliases);
-            Vec::new()
-        };
-
         tracing::info!(
             elapsed_ms = started.elapsed().as_millis() as u64,
             "apply_dns_settings done"
@@ -196,41 +234,205 @@ impl Dns for SystemDns {
             applied_prior: captured,
             state_dir,
             local_dns_server: Some(local_dns_server),
-            shutdown_called: false,
+            bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
+        })
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    async fn apply(
+        &self,
+        local_dns_server: crate::dns::server::LocalDnsServer,
+        _capture_aliases: Vec<String>,
+        _apply_aliases: Vec<String>,
+        state_dir: Option<PathBuf>,
+        _cancel: CancellationToken,
+    ) -> Result<Self::Applied, DnsError> {
+        Ok(SystemDnsApplied {
+            applied_prior: Vec::new(),
+            state_dir,
+            local_dns_server: Some(local_dns_server),
+            bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
         })
     }
 }
 
-/// RAII guard returned by [`SystemDns::apply`]. Drop restores system DNS
-/// (sync fallback for crash / panic unwind) and releases the
-/// [`LocalDnsServer`]. The preferred teardown path is
-/// [`DnsApplied::shutdown`] (async), called by `ProxyManager::stop`.
+/// Message stored in the `DebugDropBomb`. The `#[should_panic(expected =
+/// ...)]` in [`crate::dns::system::windows::windows_tests`] matches this
+/// exact string.
+const BOMB_MSG: &str = "SystemDnsApplied dropped without awaiting shutdown()";
+
+// Windows apply loop ==================================================================================================
+
+#[cfg(target_os = "windows")]
+async fn apply_windows(
+    backend: &Arc<dyn windows::WinDnsBackend>,
+    local_dns_server: crate::dns::server::LocalDnsServer,
+    capture_aliases: Vec<String>,
+    apply_aliases: Vec<String>,
+    state_dir: Option<PathBuf>,
+    cancel: CancellationToken,
+) -> Result<SystemDnsApplied, DnsError> {
+    let started = std::time::Instant::now();
+    let chosen_loopback = local_dns_server.addr();
+    let loopback_ip = chosen_loopback.ip();
+    let mut captured: Vec<DnsPriorAdapter> = Vec::new();
+
+    // Capture phase. Cancel checked between FFIs; capture is read-only,
+    // so an early Err here mutates no state.
+    for alias in &capture_aliases {
+        if cancel.is_cancelled() {
+            return Err(DnsError::Cancelled);
+        }
+        let b = Arc::clone(backend);
+        let alias_owned = alias.clone();
+        let res = tokio::task::spawn_blocking(move || b.get_settings(&alias_owned))
+            .await
+            .map_err(|e| DnsError::Io(io::Error::other(e)))?;
+        match res {
+            Ok(Some(prior)) => captured.push(prior),
+            Ok(None) => tracing::debug!(%alias, "DNS capture: adapter not found; skipping"),
+            Err(e) => tracing::warn!(%alias, error = %e, "DNS capture failed for adapter"),
+        }
+    }
+
+    // Cancel-check after capture, before mutating side: capture is pure
+    // read, persist + apply mutate state. Skipping the check here would
+    // let a cancel arriving between the last capture and the first
+    // persist proceed to write `bridge-dns.json` and start mutating DNS.
+    if cancel.is_cancelled() {
+        return Err(DnsError::Cancelled);
+    }
+
+    // Persist BEFORE apply so a mid-apply crash leaves a recoverable
+    // file (matches `tun_engine::routing::SystemRouting::install`).
+    if let Some(dir) = state_dir.as_deref() {
+        let state = crate::dns_state::DnsState {
+            version: crate::dns_state::SCHEMA_VERSION,
+            chosen_loopback,
+            adapters: captured.clone(),
+        };
+        if let Err(e) = crate::dns_state::save(dir, &state) {
+            tracing::warn!(error = %e, "dns_state::save failed; continuing without crash-recovery file");
+        }
+    }
+
+    // Apply phase. Cancel between FFIs — we do NOT race cancel against
+    // an in-flight `spawn_blocking` because abandoning the join handle
+    // leaves the FFI running on the blocking pool and creates a TOCTOU
+    // race against the inline-restore that runs next (both could be
+    // mutating the same adapter from different threads). Each FFI is
+    // ~10 ms; the cancel-response delay is bounded by ≤1 FFI duration.
+    for alias in &apply_aliases {
+        if cancel.is_cancelled() {
+            // Cooperative inline-restore — runs serially through the
+            // same backend (cancel-disregarded inside restore). FFI
+            // budget for restore: 2 adapters × 2 families = ~40 ms.
+            inline_restore(backend, &captured).await;
+            return Err(DnsError::Cancelled);
+        }
+        let b = Arc::clone(backend);
+        let alias_owned = alias.clone();
+        let res = tokio::task::spawn_blocking(move || b.set_loopback(&alias_owned, loopback_ip))
+            .await
+            .map_err(|e| DnsError::Io(io::Error::other(e)))?;
+        if let Err(e) = res {
+            tracing::warn!(%alias, error = %e, "DNS apply failed; continuing");
+        }
+    }
+
+    // Flush. Best-effort — through the backend so MockBackend can count
+    // it for the perf-regression test.
+    let b = Arc::clone(backend);
+    let _ = tokio::task::spawn_blocking(move || b.flush()).await;
+
+    tracing::info!(
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "apply_dns_settings done"
+    );
+
+    Ok(SystemDnsApplied {
+        backend: Arc::clone(backend),
+        applied_prior: captured,
+        state_dir,
+        local_dns_server: Some(local_dns_server),
+        bomb: drop_bomb::DebugDropBomb::new(BOMB_MSG),
+    })
+}
+
+#[cfg(target_os = "windows")]
+async fn inline_restore(backend: &Arc<dyn windows::WinDnsBackend>, prior: &[DnsPriorAdapter]) {
+    let backend = Arc::clone(backend);
+    let prior = prior.to_vec();
+    let _ = tokio::task::spawn_blocking(move || {
+        for adapter in &prior {
+            if let Err(e) = backend.restore(adapter) {
+                tracing::warn!(
+                    id = ?adapter.id,
+                    error = %e,
+                    "inline-restore: adapter failed; continuing"
+                );
+            }
+        }
+        let _ = backend.flush();
+    })
+    .await;
+}
+
+// SystemDnsApplied ====================================================================================================
+
+/// RAII guard returned by [`SystemDns::apply`]. The preferred teardown
+/// path is [`DnsApplied::shutdown`] (async) called by
+/// `ProxyManager::stop`; the `DebugDropBomb` panics in debug builds if
+/// shutdown wasn't awaited, catching missed-shutdown bugs at the first
+/// test run. Release builds fall through to a best-effort sync restore.
+#[must_use = "SystemDnsApplied owns async cleanup; call .shutdown().await before drop"]
 pub struct SystemDnsApplied {
+    /// Win32 backend used for restore. None on macOS / unsupported
+    /// targets — those use the free-function path (chunk 3 unifies).
+    #[cfg(target_os = "windows")]
+    backend: Arc<dyn windows::WinDnsBackend>,
     applied_prior: Vec<DnsPriorAdapter>,
     state_dir: Option<PathBuf>,
     /// Held to keep the loopback `<ip>:53` bound and to keep the
     /// forwarder tasks running. Released AFTER system DNS is restored.
     local_dns_server: Option<crate::dns::server::LocalDnsServer>,
-    shutdown_called: bool,
+    /// Runtime safeguard: panics in debug builds on drop if `shutdown`
+    /// wasn't awaited. No-op in release; the sync-fallback `Drop` impl
+    /// below covers the release-build crash-unwind path.
+    bomb: drop_bomb::DebugDropBomb,
 }
 
 impl DnsApplied for SystemDnsApplied {
     async fn shutdown(&mut self) {
-        if self.shutdown_called {
-            return;
-        }
-        self.shutdown_called = true;
+        self.bomb.defuse();
         let prior = std::mem::take(&mut self.applied_prior);
         let state_dir = self.state_dir.clone();
-        // Run sync restore on the blocking pool so we never stall the
-        // runtime worker.
+        #[cfg(target_os = "windows")]
+        let backend = Arc::clone(&self.backend);
+
         let _ = tokio::task::spawn_blocking(move || {
-            let errors = restore_all(&prior);
-            if !errors.is_empty() {
-                tracing::warn!(
-                    count = errors.len(),
-                    "SystemDnsApplied::shutdown: some adapters failed to restore"
-                );
+            #[cfg(target_os = "windows")]
+            {
+                for adapter in &prior {
+                    if let Err(e) = backend.restore(adapter) {
+                        tracing::warn!(
+                            id = ?adapter.id,
+                            error = %e,
+                            "SystemDnsApplied::shutdown: restore failed for adapter"
+                        );
+                    }
+                }
+                let _ = backend.flush();
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let errors = restore_all(&prior);
+                if !errors.is_empty() {
+                    tracing::warn!(
+                        count = errors.len(),
+                        "SystemDnsApplied::shutdown: some adapters failed to restore"
+                    );
+                }
             }
             if let Some(dir) = state_dir {
                 if let Err(e) = crate::dns_state::clear(&dir) {
@@ -242,6 +444,7 @@ impl DnsApplied for SystemDnsApplied {
             }
         })
         .await;
+
         // Drop the LocalDnsServer AFTER restore so the OS still has the
         // loopback resolver bound during the window between restore
         // start and finish.
@@ -250,19 +453,40 @@ impl DnsApplied for SystemDnsApplied {
 }
 
 impl Drop for SystemDnsApplied {
-    /// Sync fallback for crash / panic unwind. The async `shutdown` path
-    /// is the preferred teardown; production code calls it explicitly
-    /// before drop.
+    /// Sync fallback for crash / panic unwind. `DebugDropBomb`'s own
+    /// Drop panics in debug builds if not defused (catching
+    /// missed-shutdown bugs); release builds suppress the panic and we
+    /// run the best-effort sync restore below.
     fn drop(&mut self) {
-        if self.shutdown_called {
+        if self.bomb.is_defused() {
             return;
         }
-        let errors = restore_all(&self.applied_prior);
-        if !errors.is_empty() {
-            tracing::warn!(
-                count = errors.len(),
-                "SystemDnsApplied::drop: some adapters failed to restore (sync fallback path)"
-            );
+        // Released paths: missed-shutdown bug in release. Log and run
+        // best-effort sync restore so the user's DNS isn't left
+        // hijacked.
+        tracing::warn!("SystemDnsApplied dropped without shutdown() — sync fallback");
+        #[cfg(target_os = "windows")]
+        {
+            for adapter in &self.applied_prior {
+                if let Err(e) = self.backend.restore(adapter) {
+                    tracing::warn!(
+                        id = ?adapter.id,
+                        error = %e,
+                        "SystemDnsApplied::drop: restore failed (sync fallback)"
+                    );
+                }
+            }
+            let _ = self.backend.flush();
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let errors = restore_all(&self.applied_prior);
+            if !errors.is_empty() {
+                tracing::warn!(
+                    count = errors.len(),
+                    "SystemDnsApplied::drop: some adapters failed to restore (sync fallback)"
+                );
+            }
         }
         if let Some(dir) = &self.state_dir {
             if let Err(e) = crate::dns_state::clear(dir) {
@@ -357,7 +581,7 @@ pub fn apply_loopback(_aliases: &[String], _loopback_ip: std::net::IpAddr) -> io
 }
 
 // Re-export DnsPrior helpers so callers don't need a separate import just
-// for the "construct from raw netsh lines" side.
+// for the "construct from raw lines" side.
 pub use crate::dns_state::DnsPrior as Prior;
 pub use crate::dns_state::DnsPriorAdapter as PriorAdapter;
 

--- a/crates/bridge/src/dns/system.rs
+++ b/crates/bridge/src/dns/system.rs
@@ -32,8 +32,249 @@
 //!   service mid-session will see that service skipped on restore.
 
 use std::io;
+use std::path::PathBuf;
+
+use tokio_util::sync::CancellationToken;
 
 use crate::dns_state::{AdapterId, DnsPriorAdapter};
+
+// Dns trait surface ===================================================================================================
+
+/// Bridge-side system-DNS facade.
+///
+/// `Dns` and [`DnsApplied`] are the test-isolation seam for system-DNS
+/// I/O, mirroring [`crate::proxy::Proxy`] and [`tun_engine::routing::Routing`].
+/// Production goes through `SystemDns` (platform-specific); tests
+/// substitute `MockDns` via [`crate::proxy_manager::ProxyManager::new_with_dns`].
+///
+/// **Why a trait, not free functions.** Direct callers of the
+/// platform-free-function surface (`apply_loopback`, `capture_adapters`,
+/// `restore_all`) outside the `SystemDns` impl are rejected by workspace
+/// `clippy.toml` `disallowed_methods`, mirroring the
+/// `setup_routes` / `teardown_routes` enforcement at
+/// [tun_engine::routing](../../../tun_engine/routing.rs). The motivation is
+/// identical to #165: a helper that bypasses the trait cannot be
+/// intercepted by the mock and will exercise real production code from
+/// unit tests, with catastrophic consequences for test reliability and
+/// CI health. See bindreams/hole#397.
+pub trait Dns: Send + Sync + 'static {
+    /// RAII guard returned by [`apply`](Self::apply). Owns the
+    /// `LocalDnsServer`, the captured `DnsPriorAdapter`s, and any
+    /// platform-specific state needed for restore.
+    ///
+    /// **Two teardown paths**:
+    ///
+    /// - Preferred: call [`DnsApplied::shutdown`] (async) before drop.
+    ///   This is what [`crate::proxy_manager::ProxyManager::stop`] does.
+    /// - Fallback: Drop. Synchronous, used only on crash / panic
+    ///   unwind. Production implementations may use
+    ///   `tokio::task::block_in_place` if a runtime is current.
+    type Applied: DnsApplied;
+
+    /// Capture the prior DNS state of `capture_aliases`, persist it to
+    /// `bridge-dns.json` (if `state_dir` is set), then point the OS at
+    /// `local_dns_server.addr().ip()` on each adapter in `apply_aliases`.
+    ///
+    /// **Cancellation.** The implementation MUST check `cancel.cancelled()`
+    /// between per-adapter I/O operations and inline-restore any
+    /// partially-applied adapters before returning
+    /// [`DnsError::Cancelled`]. Cancel-check granularity is between calls,
+    /// not mid-call — see the plan for #397 for rationale.
+    fn apply(
+        &self,
+        local_dns_server: crate::dns::server::LocalDnsServer,
+        capture_aliases: Vec<String>,
+        apply_aliases: Vec<String>,
+        state_dir: Option<PathBuf>,
+        cancel: CancellationToken,
+    ) -> impl std::future::Future<Output = Result<Self::Applied, DnsError>> + Send;
+}
+
+/// RAII guard returned by [`Dns::apply`]. See [`Dns::Applied`] for the
+/// shutdown contract.
+pub trait DnsApplied: Send + 'static {
+    /// Restore the captured prior DNS state and release the
+    /// `LocalDnsServer`. Async so the platform I/O can use
+    /// `tokio::task::spawn_blocking` and never stall the runtime worker.
+    /// Idempotent: calling twice is a no-op the second time.
+    fn shutdown(&mut self) -> impl std::future::Future<Output = ()> + Send + '_;
+}
+
+/// Errors returned from [`Dns::apply`].
+#[derive(Debug, thiserror::Error)]
+pub enum DnsError {
+    /// The cancel token fired between netsh / Win32 calls during apply.
+    /// Any partially-applied adapters have been inline-restored before
+    /// this variant is returned.
+    #[error("DNS apply cancelled")]
+    Cancelled,
+
+    /// Capture or apply failed at the platform level. The bridge logs a
+    /// warning and continues with a degraded `RunningState.dns = None`
+    /// (preserves the pre-#397 behavior: forwarder is up but OS
+    /// resolvers haven't been redirected). Non-cancel failures are NOT
+    /// fatal to proxy start.
+    #[error("DNS apply failed: {0}")]
+    Io(#[from] io::Error),
+}
+
+// SystemDns ===========================================================================================================
+//
+// Production `Dns` implementation. This is the stub-stage wiring — `apply`
+// shells out to the existing free-function surface on a blocking-pool
+// worker so the bridge keeps the pre-#397 behavior. The real Win32 FFI
+// rewrite + cancel plumbing land in subsequent commits on this branch.
+// See bindreams/hole#397.
+
+/// Production [`Dns`] implementation. Default constructor; carries no
+/// state on its own — platform behavior comes from the free-function
+/// surface in `dns/system/{windows,macos}.rs` (transitively).
+#[derive(Default, Clone)]
+pub struct SystemDns;
+
+impl SystemDns {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Dns for SystemDns {
+    type Applied = SystemDnsApplied;
+
+    async fn apply(
+        &self,
+        local_dns_server: crate::dns::server::LocalDnsServer,
+        capture_aliases: Vec<String>,
+        apply_aliases: Vec<String>,
+        state_dir: Option<PathBuf>,
+        cancel: CancellationToken,
+    ) -> Result<Self::Applied, DnsError> {
+        // STAGE 1 stub (#397): delegate to the existing free-function surface.
+        // Cancel-naive at this layer — the cancel-aware loop lands when the
+        // Win32 backend replaces netsh. Layer 2 tests guard the contract.
+        let _ = cancel;
+        let started = std::time::Instant::now();
+        let chosen_loopback = local_dns_server.addr();
+        let loopback_ip = chosen_loopback.ip();
+
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
+        let captured = {
+            let capture_aliases = capture_aliases.clone();
+            let apply_aliases = apply_aliases.clone();
+            let state_dir_for_blocking = state_dir.clone();
+            tokio::task::spawn_blocking(move || -> Result<Vec<DnsPriorAdapter>, io::Error> {
+                let prior = capture_adapters(&capture_aliases)?;
+                if let Some(dir) = state_dir_for_blocking.as_deref() {
+                    let state = crate::dns_state::DnsState {
+                        version: crate::dns_state::SCHEMA_VERSION,
+                        chosen_loopback,
+                        adapters: prior.clone(),
+                    };
+                    if let Err(e) = crate::dns_state::save(dir, &state) {
+                        tracing::warn!(error = %e, "dns_state::save failed; continuing without crash-recovery file");
+                    }
+                }
+                apply_loopback(&apply_aliases, loopback_ip)?;
+                Ok(prior)
+            })
+            .await
+            .map_err(|join_err| io::Error::other(format!("dns apply join error: {join_err}")))??
+        };
+
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        let captured: Vec<DnsPriorAdapter> = {
+            let _ = (capture_aliases, apply_aliases);
+            Vec::new()
+        };
+
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "apply_dns_settings done"
+        );
+
+        Ok(SystemDnsApplied {
+            applied_prior: captured,
+            state_dir,
+            local_dns_server: Some(local_dns_server),
+            shutdown_called: false,
+        })
+    }
+}
+
+/// RAII guard returned by [`SystemDns::apply`]. Drop restores system DNS
+/// (sync fallback for crash / panic unwind) and releases the
+/// [`LocalDnsServer`]. The preferred teardown path is
+/// [`DnsApplied::shutdown`] (async), called by `ProxyManager::stop`.
+pub struct SystemDnsApplied {
+    applied_prior: Vec<DnsPriorAdapter>,
+    state_dir: Option<PathBuf>,
+    /// Held to keep the loopback `<ip>:53` bound and to keep the
+    /// forwarder tasks running. Released AFTER system DNS is restored.
+    local_dns_server: Option<crate::dns::server::LocalDnsServer>,
+    shutdown_called: bool,
+}
+
+impl DnsApplied for SystemDnsApplied {
+    async fn shutdown(&mut self) {
+        if self.shutdown_called {
+            return;
+        }
+        self.shutdown_called = true;
+        let prior = std::mem::take(&mut self.applied_prior);
+        let state_dir = self.state_dir.clone();
+        // Run sync restore on the blocking pool so we never stall the
+        // runtime worker.
+        let _ = tokio::task::spawn_blocking(move || {
+            let errors = restore_all(&prior);
+            if !errors.is_empty() {
+                tracing::warn!(
+                    count = errors.len(),
+                    "SystemDnsApplied::shutdown: some adapters failed to restore"
+                );
+            }
+            if let Some(dir) = state_dir {
+                if let Err(e) = crate::dns_state::clear(&dir) {
+                    tracing::warn!(
+                        error = %e,
+                        "SystemDnsApplied::shutdown: failed to clear bridge-dns.json"
+                    );
+                }
+            }
+        })
+        .await;
+        // Drop the LocalDnsServer AFTER restore so the OS still has the
+        // loopback resolver bound during the window between restore
+        // start and finish.
+        let _ = self.local_dns_server.take();
+    }
+}
+
+impl Drop for SystemDnsApplied {
+    /// Sync fallback for crash / panic unwind. The async `shutdown` path
+    /// is the preferred teardown; production code calls it explicitly
+    /// before drop.
+    fn drop(&mut self) {
+        if self.shutdown_called {
+            return;
+        }
+        let errors = restore_all(&self.applied_prior);
+        if !errors.is_empty() {
+            tracing::warn!(
+                count = errors.len(),
+                "SystemDnsApplied::drop: some adapters failed to restore (sync fallback path)"
+            );
+        }
+        if let Some(dir) = &self.state_dir {
+            if let Err(e) = crate::dns_state::clear(dir) {
+                tracing::warn!(
+                    error = %e,
+                    "SystemDnsApplied::drop: failed to clear bridge-dns.json"
+                );
+            }
+        }
+        // LocalDnsServer drops via the field's own Drop on this struct's drop.
+    }
+}
 
 #[cfg(target_os = "windows")]
 pub mod windows;

--- a/crates/bridge/src/dns/system/macos.rs
+++ b/crates/bridge/src/dns/system/macos.rs
@@ -4,20 +4,149 @@
 //! `networksetup -listallnetworkservices`. This is what the set/get DNS
 //! subcommands accept directly, avoiding a separate name-to-GUID lookup
 //! via `scutil`.
+//!
+//! ## Two layers
+//!
+//! - [`MacDnsBackend`] — the **inner test seam**, mirroring
+//!   [`super::windows::WinDnsBackend`] and the `Routing` precedent from
+//!   [bindreams/hole#165](https://github.com/bindreams/hole/issues/165).
+//!   Production goes through [`Networksetup`]; unit tests substitute
+//!   `MockMacBackend` via [`crate::dns::system::SystemDns::new_with_mac_backend`].
+//!
+//! - The free-function shims [`capture_adapters`] / [`apply_loopback`] /
+//!   [`platform_restore_adapter`] / [`flush_dns_cache`] keep the
+//!   crash-recovery / non-Dns-trait call sites (see
+//!   [`crate::dns::recovery`]) intact. Each shim instantiates
+//!   [`Networksetup`] and delegates.
 
 use std::io;
 use std::net::IpAddr;
 use std::process::Command;
+use std::sync::Arc;
 
 use super::AppliedAdapter;
 use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
 
 const NETWORKSETUP: &str = "networksetup";
 
+// MacDnsBackend trait =================================================================================================
+
+/// The bridge-side macOS DNS backend.
+///
+/// Production [`Networksetup`] shells out to `networksetup`. Tests
+/// substitute `MockMacBackend` via
+/// [`crate::dns::system::SystemDns::new_with_mac_backend`].
+///
+/// **Send + Sync + 'static** so an `Arc<dyn MacDnsBackend>` can cross a
+/// `tokio::task::spawn_blocking(move || …)` closure unchanged.
+///
+/// All methods are sync; the async apply loop in
+/// [`crate::dns::system::SystemDns`] dispatches each call onto the
+/// blocking pool so the subprocess never stalls a runtime worker.
+pub trait MacDnsBackend: Send + Sync + 'static {
+    /// Capture the v4 + v6 DNS state of `service`. Returns `Ok(None)`
+    /// when the service does not exist; returns `Err` only on unexpected
+    /// `networksetup` failures.
+    fn get_settings(&self, service: &str) -> io::Result<Option<DnsPriorAdapter>>;
+
+    /// Point the DNS resolver on `service` at `loopback`. `networksetup`
+    /// accepts mixed v4/v6 lists in one call.
+    fn set_loopback(&self, service: &str, loopback: IpAddr) -> io::Result<()>;
+
+    /// Restore the captured prior DNS state for `adapter`. Replays both
+    /// v4 and v6 in a single `networksetup -setdnsservers` invocation.
+    fn restore(&self, adapter: &DnsPriorAdapter) -> io::Result<()>;
+
+    /// Flush the macOS DNS cache (`dscacheutil -flushcache` +
+    /// `killall -HUP mDNSResponder`). Best-effort; failures are logged
+    /// but not returned.
+    fn flush(&self) -> io::Result<()>;
+}
+
+// Networksetup ========================================================================================================
+
+/// Production [`MacDnsBackend`] implementation. Stateless; methods
+/// shell out to `networksetup`.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Networksetup;
+
+impl MacDnsBackend for Networksetup {
+    fn get_settings(&self, service: &str) -> io::Result<Option<DnsPriorAdapter>> {
+        let output = Command::new(NETWORKSETUP).args(["-getdnsservers", service]).output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("not a recognized network service") {
+                return Ok(None);
+            }
+            return Err(io::Error::other(format!(
+                "networksetup -getdnsservers failed: {} (stderr={})",
+                output.status, stderr
+            )));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let (v4, v6) = split_v4_v6(parse_networksetup_output(&stdout));
+        Ok(Some(DnsPriorAdapter {
+            id: AdapterId::MacosServiceName {
+                value: service.to_string(),
+            },
+            name_at_capture: service.to_string(),
+            v4,
+            v6,
+        }))
+    }
+
+    fn set_loopback(&self, service: &str, loopback: IpAddr) -> io::Result<()> {
+        set_dnsservers(service, &[loopback])
+    }
+
+    fn restore(&self, adapter: &DnsPriorAdapter) -> io::Result<()> {
+        let AdapterId::MacosServiceName { value: svc } = &adapter.id else {
+            return Err(io::Error::other(format!(
+                "Networksetup::restore: expected MacosServiceName, got {:?}",
+                adapter.id
+            )));
+        };
+        // macOS restores v4 and v6 via the same `setdnsservers`
+        // invocation — it takes a mixed list. The captured v4/v6 priors
+        // must be merged.
+        let mut combined: Vec<IpAddr> = Vec::new();
+        let mut saw_static = false;
+        for p in [&adapter.v4, &adapter.v6] {
+            if let DnsPrior::Static { servers } = p {
+                saw_static = true;
+                combined.extend_from_slice(servers);
+            }
+        }
+        if saw_static {
+            set_dnsservers(svc, &combined)
+        } else {
+            // Both v4 and v6 were DHCP or None — macOS collapses these
+            // to `Empty`, which means "clear all DNS for this service,
+            // rely on DHCP".
+            clear_dnsservers(svc)
+        }
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        // Fire-and-forget the cache flush. `dscacheutil` is fast; the
+        // SIGHUP to mDNSResponder is a courtesy notification.
+        let _ = Command::new("dscacheutil").arg("-flushcache").status();
+        let _ = Command::new("killall").args(["-HUP", "mDNSResponder"]).status();
+        Ok(())
+    }
+}
+
+// Free-function shims (crash-recovery + non-Dns-trait call sites) =====================================================
+//
+// `crate::dns::recovery` and `super::restore_all` call these shims; the
+// new `Dns`-trait path inside `SystemDns::apply` goes through
+// `Arc<dyn MacDnsBackend>` directly.
+
 pub fn capture_adapters(services: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
+    let backend = Networksetup;
     let mut out = Vec::with_capacity(services.len());
     for svc in services {
-        match capture_one(svc) {
+        match backend.get_settings(svc) {
             Ok(Some(p)) => out.push(p),
             Ok(None) => {
                 tracing::debug!(service = %svc, "DNS capture: service not found; skipping");
@@ -31,9 +160,10 @@ pub fn capture_adapters(services: &[String]) -> io::Result<Vec<DnsPriorAdapter>>
 }
 
 pub fn apply_loopback(services: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
+    let backend = Networksetup;
     let mut applied = Vec::with_capacity(services.len());
     for svc in services {
-        if let Err(e) = set_dnsservers(svc, &[loopback_ip]) {
+        if let Err(e) = backend.set_loopback(svc, loopback_ip) {
             tracing::warn!(service = %svc, error = %e, "DNS apply failed; continuing");
             continue;
         }
@@ -46,68 +176,20 @@ pub fn apply_loopback(services: &[String], loopback_ip: IpAddr) -> io::Result<Ve
     Ok(applied)
 }
 
-/// Flush the macOS DNS cache as a **fire-and-forget** background op
-/// (dscacheutil + mDNSResponder signal). Returns immediately.
+/// Flush the macOS DNS cache.
 ///
-/// Mirrors the Windows implementation — see [`super::windows::flush_dns_cache`]
-/// for the Phase-4 rationale (#247) and the symmetry argument for setup vs
-/// teardown.
+/// Pre-#397 this was a fire-and-forget detached thread because the
+/// `dscacheutil` subprocess was thought slow. The actual cost is
+/// ms-scale; inline-through-[`Networksetup::flush`] is correct.
 pub fn flush_dns_cache() {
-    std::thread::spawn(|| {
-        let _ = Command::new("dscacheutil").arg("-flushcache").status();
-        let _ = Command::new("killall").args(["-HUP", "mDNSResponder"]).status();
-    });
+    let _ = Networksetup.flush();
 }
 
 pub fn platform_restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
-    let AdapterId::MacosServiceName { value: svc } = &adapter.id else {
-        return Err(io::Error::other(format!(
-            "expected MacosServiceName in DnsPriorAdapter.id, got {:?}",
-            adapter.id
-        )));
-    };
-    // macOS restores v4 and v6 via the same `setdnsservers` invocation —
-    // it takes a mixed list. The captured v4/v6 priors must be merged
-    // into a single list.
-    let mut combined: Vec<IpAddr> = Vec::new();
-    let mut saw_static = false;
-    for p in [&adapter.v4, &adapter.v6] {
-        if let DnsPrior::Static { servers } = p {
-            saw_static = true;
-            combined.extend_from_slice(servers);
-        }
-    }
-    if saw_static {
-        set_dnsservers(svc, &combined)
-    } else {
-        // Both v4 and v6 were DHCP or None — macOS collapses these to
-        // `Empty`, which means "clear all DNS for this service, rely on
-        // DHCP".
-        clear_dnsservers(svc)
-    }
+    Networksetup.restore(adapter)
 }
 
-fn capture_one(svc: &str) -> io::Result<Option<DnsPriorAdapter>> {
-    let output = Command::new(NETWORKSETUP).args(["-getdnsservers", svc]).output()?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("not a recognized network service") {
-            return Ok(None);
-        }
-        return Err(io::Error::other(format!(
-            "networksetup -getdnsservers failed: {} (stderr={})",
-            output.status, stderr
-        )));
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let (v4, v6) = split_v4_v6(parse_networksetup_output(&stdout));
-    Ok(Some(DnsPriorAdapter {
-        id: AdapterId::MacosServiceName { value: svc.to_string() },
-        name_at_capture: svc.to_string(),
-        v4,
-        v6,
-    }))
-}
+// Helpers =============================================================================================================
 
 /// Parse the stdout of `networksetup -getdnsservers <svc>` into a
 /// [`DnsPrior`]. Shapes:
@@ -185,4 +267,9 @@ fn set_dnsservers(svc: &str, ips: &[IpAddr]) -> io::Result<()> {
 
 fn clear_dnsservers(svc: &str) -> io::Result<()> {
     set_dnsservers(svc, &[])
+}
+
+/// Wrap a backend in an `Arc<dyn MacDnsBackend>` for trait-object use.
+pub fn boxed<B: MacDnsBackend>(backend: B) -> Arc<dyn MacDnsBackend> {
+    Arc::new(backend)
 }

--- a/crates/bridge/src/dns/system/windows.rs
+++ b/crates/bridge/src/dns/system/windows.rs
@@ -1,39 +1,386 @@
-//! Windows `netsh`-based system DNS capture / apply / restore.
+//! Windows system DNS capture / apply / restore via the Win32 native API.
 //!
-//! Shelling out rather than calling `SetInterfaceDnsSettings` directly is
-//! deliberate: `netsh` output is forward-compatible and the equivalent
-//! Win32 API has a narrow Windows-version window. The existing routing
-//! layer also uses `netsh`, so we match that convention.
+//! Pre-#397 this layer shelled out to `netsh interface {ipv4,ipv6} ...`.
+//! Each `netsh` subprocess took ~5–7 s on Defender-active machines, and
+//! four sequential subprocess invocations per start was the 22.6 s
+//! `apply_dns_settings` stall the user reported. The current path calls
+//! `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` /
+//! `DnsFlushResolverCache` directly via the `windows = "0.62"` crate. Each
+//! FFI is ms-scale; total apply ≈ 50 ms.
 //!
-//! ## Command surface
+//! ## Two layers
 //!
-//! - **Capture**: `netsh interface {ipv4,ipv6} show dnsservers name="<alias>"`
-//!   parses into [`DnsPrior::Static`], [`DnsPrior::Dhcp`], or
-//!   [`DnsPrior::None`].
-//! - **Apply**: `netsh interface ipv4 set dnsservers name="<alias>" static
-//!   <ip> primary` (plus `ipconfig /flushdns` after).
-//! - **Restore**: dispatches on the captured variant.
+//! - [`WinDnsBackend`] — the **inner test seam** (per-platform, mirrors
+//!   the `Routing` precedent from
+//!   [bindreams/hole#165](https://github.com/bindreams/hole/issues/165)).
+//!   Production goes through [`Win32Real`]; unit tests substitute
+//!   `MockBackend` via [`crate::dns::system::SystemDns::new_with_backend`].
+//!   The trait surface intentionally uses bridge types only (no
+//!   `windows::*` types) so the mock can be constructed without depending
+//!   on the Win32 crate.
+//!
+//! - The free-function shims [`capture_adapters`] / [`apply_loopback`] /
+//!   [`platform_restore_adapter`] / [`flush_dns_cache`] keep the
+//!   pre-#397 call-site contract intact until chunk 3 rewires
+//!   [`crate::proxy_manager::apply_dns_settings`] to call into
+//!   `SystemDns::apply` directly. Each shim instantiates [`Win32Real`]
+//!   and delegates.
+//!
+//! ## Windows version floor
+//!
+//! `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` were added in
+//! Windows 10 build 19041 (version 2004, May 2020). Pre-19041 systems
+//! will fail to link at runtime. The MSI installer gate
+//! (`WIN10BUILD >= 19041` launch condition) lands in a later chunk.
+//!
+//! ## v4 vs v6
+//!
+//! The DNS configuration on a Windows adapter is split per address
+//! family. `SetInterfaceDnsSettings` configures one family per call —
+//! select v4 vs v6 via the `DNS_SETTING_IPV6` flag in
+//! [`DNS_INTERFACE_SETTINGS::Flags`]. To match pre-#397 netsh semantics
+//! the apply path **only configures v4** (loopback is always IPv4 from
+//! [`crate::dns::server::LocalDnsServer`]). v6 is left untouched on
+//! apply and replayed verbatim from the captured prior on restore.
 
 use std::io;
 use std::net::IpAddr;
-use std::process::Command;
+use std::sync::Arc;
 use std::time::Instant;
+
+use windows::core::{GUID, PCWSTR, PWSTR};
+use windows::Win32::Foundation::{ERROR_SUCCESS, WIN32_ERROR};
+use windows::Win32::NetworkManagement::IpHelper::{
+    ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToGuid, FreeInterfaceDnsSettings, GetInterfaceDnsSettings,
+    SetInterfaceDnsSettings, DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS_VERSION3, DNS_SETTING_IPV6,
+    DNS_SETTING_NAMESERVER,
+};
+use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+
+// `DnsFlushResolverCache` lives in `dnsapi.dll` but isn't exposed by
+// `windows-rs` 0.62. The signature is stable since Windows 2000: takes no
+// arguments, returns a nonzero `BOOL` on success. We declare the binding
+// inline rather than adding a separate FFI crate.
+#[link(name = "dnsapi")]
+unsafe extern "system" {
+    fn DnsFlushResolverCache() -> i32;
+}
 
 use super::AppliedAdapter;
 use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
 
-const NETSH: &str = "netsh";
+// WinDnsBackend trait =================================================================================================
 
-// Public API ==========================================================================================================
+/// The bridge-side Win32 DNS backend.
+///
+/// Production [`Win32Real`] calls the OS directly. Tests substitute
+/// `MockBackend` (in [`windows_tests`]) via
+/// [`crate::dns::system::SystemDns::new_with_backend`].
+///
+/// **Send + Sync + 'static** so an `Arc<dyn WinDnsBackend>` can cross a
+/// `tokio::task::spawn_blocking(move || …)` closure unchanged.
+///
+/// All methods are sync; the async apply loop in
+/// [`crate::dns::system::SystemDns`] dispatches each call onto the
+/// blocking pool so the FFI never stalls a runtime worker.
+pub trait WinDnsBackend: Send + Sync + 'static {
+    /// Capture the v4 + v6 DNS state of `alias`. Returns `Ok(None)` when
+    /// the adapter does not exist (e.g. the TUN alias hasn't been created
+    /// yet); returns `Err` only on unexpected Win32 failures.
+    fn get_settings(&self, alias: &str) -> io::Result<Option<DnsPriorAdapter>>;
+
+    /// Point the v4 DNS resolver on `alias` at `loopback`. v6 is left
+    /// untouched (matches pre-#397 netsh semantics — `loopback` is always
+    /// IPv4 from `LocalDnsServer`).
+    fn set_loopback(&self, alias: &str, loopback: IpAddr) -> io::Result<()>;
+
+    /// Restore the captured prior DNS state for `adapter`. Replays both
+    /// v4 and v6 from [`DnsPriorAdapter::v4`] / [`DnsPriorAdapter::v6`].
+    fn restore(&self, adapter: &DnsPriorAdapter) -> io::Result<()>;
+
+    /// Flush the OS resolver cache. Equivalent to `ipconfig /flushdns`.
+    fn flush(&self) -> io::Result<()>;
+}
+
+// Win32Real ===========================================================================================================
+
+/// Production [`WinDnsBackend`] implementation. Stateless; methods call
+/// `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` /
+/// `DnsFlushResolverCache` directly.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Win32Real;
+
+impl WinDnsBackend for Win32Real {
+    fn get_settings(&self, alias: &str) -> io::Result<Option<DnsPriorAdapter>> {
+        let started = Instant::now();
+        let guid = match alias_to_guid(alias)? {
+            Some(g) => g,
+            None => {
+                tracing::debug!(
+                    %alias,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "Win32Real::get_settings: adapter not found"
+                );
+                return Ok(None);
+            }
+        };
+        let v4 = get_one(guid, false)?;
+        let v6 = get_one(guid, true)?;
+        tracing::debug!(
+            %alias,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "Win32Real::get_settings"
+        );
+        Ok(Some(DnsPriorAdapter {
+            id: AdapterId::WindowsAlias {
+                value: alias.to_string(),
+            },
+            name_at_capture: alias.to_string(),
+            v4,
+            v6,
+        }))
+    }
+
+    fn set_loopback(&self, alias: &str, loopback: IpAddr) -> io::Result<()> {
+        let started = Instant::now();
+        let guid = match alias_to_guid(alias)? {
+            Some(g) => g,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Win32Real::set_loopback: adapter not found: {alias}"),
+                ));
+            }
+        };
+        // Loopback from LocalDnsServer is always IPv4; v6 is untouched.
+        set_one(
+            guid,
+            false,
+            &DnsPrior::Static {
+                servers: vec![loopback],
+            },
+        )?;
+        tracing::debug!(
+            %alias,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "Win32Real::set_loopback"
+        );
+        Ok(())
+    }
+
+    fn restore(&self, adapter: &DnsPriorAdapter) -> io::Result<()> {
+        let AdapterId::WindowsAlias { value: alias } = &adapter.id else {
+            return Err(io::Error::other(format!(
+                "Win32Real::restore: expected WindowsAlias, got {:?}",
+                adapter.id
+            )));
+        };
+        let started = Instant::now();
+        let guid = match alias_to_guid(alias)? {
+            Some(g) => g,
+            None => {
+                // Adapter vanished between capture and restore (e.g. user
+                // disconnected Wi-Fi). Match pre-#397 best-effort restore
+                // semantics: warn-and-skip, not Err.
+                tracing::warn!(%alias, "Win32Real::restore: adapter not found; skipping");
+                return Ok(());
+            }
+        };
+        set_one(guid, false, &adapter.v4)?;
+        set_one(guid, true, &adapter.v6)?;
+        tracing::debug!(
+            %alias,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "Win32Real::restore"
+        );
+        Ok(())
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        let started = Instant::now();
+        // SAFETY: `DnsFlushResolverCache` takes no arguments and has no
+        // pointer outputs. Always safe to call.
+        let rc: i32 = unsafe { DnsFlushResolverCache() };
+        tracing::debug!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            rc,
+            "Win32Real::flush"
+        );
+        // `DnsFlushResolverCache` returns BOOL — nonzero on success, zero
+        // on failure. A failed flush leaves the cache stale for up to one
+        // TTL window, which is the worst-case symptom and acceptable; we
+        // surface no error to the caller (matches the pre-#397
+        // fire-and-forget `ipconfig /flushdns` semantics).
+        Ok(())
+    }
+}
+
+// FFI helpers =========================================================================================================
+
+/// Resolve a Windows adapter friendly name (alias) like "Wi-Fi" or
+/// "wintun" to its GUID. Returns `Ok(None)` when the alias does not match
+/// any adapter — every other failure is `Err`.
+fn alias_to_guid(alias: &str) -> io::Result<Option<GUID>> {
+    let wide: Vec<u16> = alias.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut luid = NET_LUID_LH::default();
+    // SAFETY: `wide` is a NUL-terminated UTF-16 buffer; `luid` is an owned
+    // `NET_LUID_LH` whose address is valid for the call.
+    let rc: WIN32_ERROR = unsafe { ConvertInterfaceAliasToLuid(PCWSTR(wide.as_ptr()), &mut luid) };
+    if rc != ERROR_SUCCESS {
+        // ERROR_INVALID_PARAMETER (87) is what `ConvertInterfaceAliasToLuid`
+        // returns when the alias doesn't match an installed adapter — map
+        // that to `Ok(None)` to match pre-#397 "skip silently" semantics.
+        if rc.0 == 87 {
+            return Ok(None);
+        }
+        return Err(io::Error::from_raw_os_error(rc.0 as i32));
+    }
+    let mut guid = GUID::zeroed();
+    // SAFETY: `luid` and `guid` are owned values whose addresses are valid.
+    let rc: WIN32_ERROR = unsafe { ConvertInterfaceLuidToGuid(&luid, &mut guid) };
+    if rc != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(rc.0 as i32));
+    }
+    Ok(Some(guid))
+}
+
+/// Build an empty `DNS_INTERFACE_SETTINGS` with `Version` set and
+/// `Flags` populated to indicate "the `NameServer` field is meaningful".
+/// `ipv6` controls the `DNS_SETTING_IPV6` flag (selects v6 vs v4).
+fn empty_settings(ipv6: bool) -> DNS_INTERFACE_SETTINGS {
+    let mut flags: u64 = DNS_SETTING_NAMESERVER as u64;
+    if ipv6 {
+        flags |= DNS_SETTING_IPV6 as u64;
+    }
+    DNS_INTERFACE_SETTINGS {
+        Version: DNS_INTERFACE_SETTINGS_VERSION3,
+        Flags: flags,
+        Domain: PWSTR::null(),
+        NameServer: PWSTR::null(),
+        SearchList: PWSTR::null(),
+        RegistrationEnabled: 0,
+        RegisterAdapterName: 0,
+        EnableLLMNR: 0,
+        QueryAdapterName: 0,
+        ProfileNameServer: PWSTR::null(),
+    }
+}
+
+/// Query DNS settings for one family. Returns a [`DnsPrior`] reflecting
+/// whether the family is set statically, via DHCP, or unset.
+///
+/// Win32 does not distinguish "DHCP-assigned" from "no static override"
+/// at the `GetInterfaceDnsSettings` level — both surface as a blank
+/// `NameServer`. To preserve the existing `DnsPrior::{Static, Dhcp,
+/// None}` trichotomy, we treat a blank `NameServer` as
+/// [`DnsPrior::Dhcp`] for v4 (the historically common case) and
+/// [`DnsPrior::None`] for v6 (Windows rarely DHCP-assigns DNS v6 servers
+/// on consumer setups). This is best-effort — the pre-#397 netsh parser
+/// had the same lossy collapse on `"DNS servers configured through DHCP:
+/// None"`.
+fn get_one(guid: GUID, ipv6: bool) -> io::Result<DnsPrior> {
+    let mut settings = empty_settings(ipv6);
+    // SAFETY: `settings` is an owned `DNS_INTERFACE_SETTINGS` whose
+    // address is valid for the call. The OS writes a fresh `NameServer`
+    // string we must free via `FreeInterfaceDnsSettings`.
+    let rc: WIN32_ERROR = unsafe { GetInterfaceDnsSettings(guid, &mut settings) };
+    if rc != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(rc.0 as i32));
+    }
+    let result = match read_pwstr(settings.NameServer) {
+        Some(s) if !s.is_empty() => {
+            let servers = parse_servers(&s);
+            if servers.is_empty() {
+                DnsPrior::Dhcp
+            } else {
+                DnsPrior::Static { servers }
+            }
+        }
+        _ => {
+            if ipv6 {
+                DnsPrior::None
+            } else {
+                DnsPrior::Dhcp
+            }
+        }
+    };
+    // SAFETY: `settings` was filled by `GetInterfaceDnsSettings` above.
+    // `FreeInterfaceDnsSettings` is the documented counterpart that
+    // frees PWSTRs allocated by the get call.
+    unsafe { FreeInterfaceDnsSettings(&mut settings) };
+    Ok(result)
+}
+
+/// Apply `prior` to the one family selected by `ipv6`. Buffers the
+/// stringified server list as a UTF-16 NUL-terminated buffer, points
+/// `NameServer` at it, and calls `SetInterfaceDnsSettings`.
+///
+/// The wide-string buffer is held in this function's stack frame for the
+/// FFI's duration, so the call cannot outlive the buffer.
+fn set_one(guid: GUID, ipv6: bool, prior: &DnsPrior) -> io::Result<()> {
+    let mut settings = empty_settings(ipv6);
+    // `DnsPrior::Dhcp` and `DnsPrior::None` both surface to Windows as
+    // "blank NameServer": the OS reverts to DHCP-assigned DNS for that
+    // family. We can't represent "explicitly unset and don't DHCP" with
+    // a single `SetInterfaceDnsSettings` call; the trichotomy collapses
+    // in this direction.
+    let nameserver_string = match prior {
+        DnsPrior::None | DnsPrior::Dhcp => String::new(),
+        DnsPrior::Static { servers } => servers
+            .iter()
+            .filter(|ip| ip.is_ipv6() == ipv6)
+            .map(|ip| ip.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+    };
+    let mut wide: Vec<u16> = nameserver_string.encode_utf16().chain(std::iter::once(0)).collect();
+    settings.NameServer = PWSTR(wide.as_mut_ptr());
+    // SAFETY: `settings` and `wide` outlive the FFI call. The OS reads
+    // `Version` first to interpret the struct; we always pass
+    // `DNS_INTERFACE_SETTINGS_VERSION3`.
+    let rc: WIN32_ERROR = unsafe { SetInterfaceDnsSettings(guid, &settings) };
+    if rc != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(rc.0 as i32));
+    }
+    Ok(())
+}
+
+/// Read a Windows-allocated `PWSTR` into a `String`. Returns `None` for
+/// a null pointer.
+fn read_pwstr(pwstr: PWSTR) -> Option<String> {
+    if pwstr.is_null() {
+        return None;
+    }
+    // SAFETY: `pwstr` is a NUL-terminated UTF-16 string owned by the OS.
+    // `PWSTR::to_string` walks until the NUL, returning a fresh String.
+    Some(unsafe { pwstr.to_string() }.unwrap_or_default())
+}
+
+/// Parse a `NameServer` string into a vec of [`IpAddr`]. Windows accepts
+/// the list separator as comma, semicolon, or whitespace; we accept any.
+fn parse_servers(s: &str) -> Vec<IpAddr> {
+    s.split(|c: char| c == ',' || c == ';' || c.is_whitespace())
+        .filter(|tok| !tok.is_empty())
+        .filter_map(|tok| tok.parse::<IpAddr>().ok())
+        .collect()
+}
+
+// Free-function shims (pre-#397 call-site compat) =====================================================================
+//
+// `crate::proxy_manager::apply_dns_settings` and `super::restore_all`
+// still call these free functions; chunk 3 rewires them to call
+// `SystemDns::apply` directly. Until then, the shims delegate to
+// `Win32Real::default()` so the call sites get the Win32-native fast
+// path immediately without rewriting the call structure.
 
 /// Capture the v4+v6 DNS state of every adapter in `aliases`. Adapters
-/// that don't exist (e.g. the TUN alias hasn't been created yet) are
-/// silently skipped.
+/// that don't exist are silently skipped. See [`Win32Real::get_settings`].
 pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
     let started = Instant::now();
+    let backend = Win32Real;
     let mut out = Vec::with_capacity(aliases.len());
     for alias in aliases {
-        match capture_one(alias) {
+        match backend.get_settings(alias) {
             Ok(Some(p)) => out.push(p),
             Ok(None) => {
                 tracing::debug!(%alias, "DNS capture: adapter not found; skipping");
@@ -52,15 +399,15 @@ pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> 
     Ok(out)
 }
 
-/// Apply `loopback_ip` as the DNS server on each adapter in `aliases`.
+/// Apply `loopback_ip` as the v4 DNS server on each adapter in `aliases`.
 /// Returns one [`AppliedAdapter`] per adapter that was successfully set.
-/// Callers flush the DNS cache separately (via [`flush_dns_cache`]) once
-/// the full adapter list is applied.
+/// Callers flush the DNS cache separately via [`flush_dns_cache`].
 pub fn apply_loopback(aliases: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
     let started = Instant::now();
+    let backend = Win32Real;
     let mut applied = Vec::with_capacity(aliases.len());
     for alias in aliases {
-        if let Err(e) = set_dns_ipv4(alias, Some(loopback_ip)) {
+        if let Err(e) = backend.set_loopback(alias, loopback_ip) {
             tracing::warn!(%alias, error = %e, "DNS apply failed; continuing");
             continue;
         }
@@ -79,352 +426,27 @@ pub fn apply_loopback(aliases: &[String], loopback_ip: IpAddr) -> io::Result<Vec
     Ok(applied)
 }
 
-/// Run `ipconfig /flushdns` as a **fire-and-forget** background
-/// operation. Returns immediately; callers never block on the flush.
-///
-/// Why detached (Phase 4 #247): `ipconfig /flushdns` is notoriously slow
-/// on Windows — often 1-5 seconds, and was a significant chunk of the
-/// 11.3s apply stall observed in #247. Nothing downstream actually
-/// depends on the flush having completed: the preceding `netsh set
-/// dnsservers` has already invalidated the per-adapter cache for the
-/// aliases we just changed. The OS-wide DNS client cache staleness
-/// tradeoff is documented in the PR body.
-///
-/// Symmetry note: this is fire-and-forget on both setup (the
-/// `apply_loopback` call path) and teardown (`RunningDns::drop` →
-/// `super::restore_all`) sides. If one side blocked and the other
-/// didn't, start would be fast while stop would be slow — inconsistent
-/// from a UX perspective.
-///
-/// Uses `std::thread::spawn` rather than `tokio::task::spawn_blocking`
-/// so callers need no runtime handle — `RunningDns::drop` is sync and
-/// cannot reach a tokio runtime. The thread calls `Command::output()`,
-/// which reaps the spawned `Child` on its own `Drop`, so no process
-/// leak if the bridge exits before the flush returns.
-///
-/// The DEBUG `elapsed_ms` log is emitted from inside the spawned thread
-/// so Phase 2 can still observe `ipconfig` wall-clock latency even
-/// though the caller isn't blocked by it.
-pub fn flush_dns_cache() {
-    std::thread::spawn(|| {
-        let started = Instant::now();
-        let res = Command::new("ipconfig").arg("/flushdns").output();
-        let elapsed_ms = started.elapsed().as_millis() as u64;
-        match res {
-            Ok(_) => tracing::debug!(elapsed_ms, "flush_dns_cache"),
-            Err(e) => tracing::warn!(error = %e, elapsed_ms, "ipconfig /flushdns failed"),
-        }
-    });
-}
-
 /// Restore one adapter. Invoked from [`super::restore_all`].
 pub fn platform_restore_adapter(adapter: &DnsPriorAdapter) -> io::Result<()> {
-    let AdapterId::WindowsAlias { value: alias } = &adapter.id else {
-        return Err(io::Error::other(format!(
-            "expected WindowsAlias in DnsPriorAdapter.id, got {:?}",
-            adapter.id
-        )));
-    };
-    restore_v4(alias, &adapter.v4)?;
-    restore_v6(alias, &adapter.v6)?;
-    Ok(())
+    Win32Real.restore(adapter)
 }
 
-// Capture =============================================================================================================
-
-fn capture_one(alias: &str) -> io::Result<Option<DnsPriorAdapter>> {
-    let started = Instant::now();
-    let v4 = match show_dnsservers("ipv4", alias)? {
-        Some(out) => parse_netsh_dnsservers(&out),
-        None => {
-            tracing::debug!(
-                %alias,
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "capture_one: adapter not found"
-            );
-            return Ok(None);
-        }
-    };
-    let v6 = show_dnsservers("ipv6", alias)?.map(|o| parse_netsh_dnsservers(&o));
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "capture_one"
-    );
-    Ok(Some(DnsPriorAdapter {
-        id: AdapterId::WindowsAlias {
-            value: alias.to_string(),
-        },
-        name_at_capture: alias.to_string(),
-        v4,
-        v6: v6.unwrap_or(DnsPrior::None),
-    }))
+/// Flush the OS resolver cache. Inline call to [`DnsFlushResolverCache`]
+/// (~10 ms FFI). The pre-#397 implementation detached `ipconfig /flushdns`
+/// onto a `std::thread::spawn`'d thread because the subprocess took 1–5 s
+/// (Phase 4 #247). The FFI is ms-scale; inline is correct.
+pub fn flush_dns_cache() {
+    let _ = Win32Real.flush();
 }
 
-fn show_dnsservers(family: &str, alias: &str) -> io::Result<Option<String>> {
-    let started = Instant::now();
-    let output = Command::new(NETSH)
-        .args(["interface", family, "show", "dnsservers"])
-        .arg(format!("name={alias}"))
-        .output()?;
-    tracing::debug!(
-        %alias,
-        %family,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "show_dnsservers"
-    );
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // netsh emits "The system cannot find the file specified." on a
-        // nonexistent alias; treat that as "adapter not found" not error.
-        if stderr.contains("cannot find") || stderr.contains("not found") {
-            return Ok(None);
-        }
-        return Err(io::Error::other(format!(
-            "netsh show dnsservers failed: {} (stderr={})",
-            output.status, stderr
-        )));
-    }
-    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
+// Arc helpers — useful when MockBackend or Win32Real needs to cross
+// a `spawn_blocking` boundary as `Arc<dyn WinDnsBackend>`.
+
+/// Wrap a backend in an `Arc<dyn WinDnsBackend>` for trait-object use.
+pub fn boxed<B: WinDnsBackend>(backend: B) -> Arc<dyn WinDnsBackend> {
+    Arc::new(backend)
 }
 
-/// Parse `netsh interface {ipv4,ipv6} show dnsservers name=...` output
-/// into a [`DnsPrior`]. The expected shapes (English Windows) are:
-///
-/// ```text
-/// Configuration for interface "Ethernet"
-///     Statically Configured DNS Servers:  1.1.1.1
-///                                         8.8.8.8
-///     Register with which suffix:         Primary only
-/// ```
-/// or
-/// ```text
-/// Configuration for interface "Ethernet"
-///     DNS servers configured through DHCP:  192.168.1.1
-///     Register with which suffix:           Primary only
-/// ```
-/// or
-/// ```text
-///     DNS servers configured through DHCP:  None
-/// ```
-///
-/// Localized Windows installs produce different strings and will be
-/// misparsed. The feature is opt-in and the failure mode is "we don't
-/// know the prior state; treat as Dhcp" — covered by defaulting.
-pub(super) fn parse_netsh_dnsservers(stdout: &str) -> DnsPrior {
-    let mut kind: Option<&'static str> = None;
-    let mut ips: Vec<IpAddr> = Vec::new();
-
-    for raw_line in stdout.lines() {
-        let line = raw_line.trim();
-        if line.starts_with("Statically Configured DNS Servers") {
-            kind = Some("static");
-            // Use the *first* colon only — IPv6 addresses contain colons
-            // too, so `split(':')` would truncate them.
-            if let Some(rhs) = line.find(':').map(|idx| line[idx + 1..].trim()) {
-                if let Ok(ip) = rhs.parse::<IpAddr>() {
-                    ips.push(ip);
-                }
-            }
-            continue;
-        }
-        if line.starts_with("DNS servers configured through DHCP") {
-            kind = Some("dhcp");
-            if let Some(rhs) = line.find(':').map(|idx| line[idx + 1..].trim().to_string()) {
-                if rhs.eq_ignore_ascii_case("none") {
-                    kind = Some("none");
-                } else if let Ok(ip) = rhs.parse::<IpAddr>() {
-                    ips.push(ip);
-                }
-            }
-            continue;
-        }
-        // Continuation line: a raw IP on its own line (the netsh layout
-        // aligns multiple IPs under the first column). Only append if the
-        // line parses cleanly.
-        if let Ok(ip) = line.parse::<IpAddr>() {
-            ips.push(ip);
-        }
-    }
-
-    match kind {
-        Some("static") => {
-            if ips.is_empty() {
-                DnsPrior::None
-            } else {
-                DnsPrior::Static { servers: ips }
-            }
-        }
-        Some("dhcp") => DnsPrior::Dhcp,
-        Some("none") | None => DnsPrior::None,
-        Some(_) => DnsPrior::None,
-    }
-}
-
-// Apply ===============================================================================================================
-
-fn set_dns_ipv4(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
-    let started = Instant::now();
-    let mut cmd = Command::new(NETSH);
-    cmd.args(["interface", "ipv4", "set", "dnsservers"])
-        .arg(format!("name={alias}"));
-    match ip {
-        Some(ip) => {
-            cmd.arg("static").arg(ip.to_string()).arg("primary");
-        }
-        None => {
-            cmd.arg("static").arg("none");
-        }
-    }
-    let status = cmd.status()?;
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "set_dns_ipv4"
-    );
-    if !status.success() {
-        return Err(io::Error::other(format!("netsh set dnsservers failed: {status}")));
-    }
-    Ok(())
-}
-
-fn set_dhcp_ipv4(alias: &str) -> io::Result<()> {
-    let started = Instant::now();
-    let status = Command::new(NETSH)
-        .args(["interface", "ipv4", "set", "dnsservers"])
-        .arg(format!("name={alias}"))
-        .arg("dhcp")
-        .status()?;
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "set_dhcp_ipv4"
-    );
-    if !status.success() {
-        return Err(io::Error::other(format!("netsh set dnsservers dhcp failed: {status}")));
-    }
-    Ok(())
-}
-
-fn add_dns_ipv4(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
-    let started = Instant::now();
-    let status = Command::new(NETSH)
-        .args(["interface", "ipv4", "add", "dnsservers"])
-        .arg(format!("name={alias}"))
-        .arg(ip.to_string())
-        .arg(format!("index={index}"))
-        .status()?;
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "add_dns_ipv4"
-    );
-    if !status.success() {
-        return Err(io::Error::other(format!("netsh add dnsservers failed: {status}")));
-    }
-    Ok(())
-}
-
-fn set_dns_ipv6(alias: &str, ip: Option<IpAddr>) -> io::Result<()> {
-    let started = Instant::now();
-    let mut cmd = Command::new(NETSH);
-    cmd.args(["interface", "ipv6", "set", "dnsservers"])
-        .arg(format!("name={alias}"));
-    match ip {
-        Some(ip) => {
-            cmd.arg("static").arg(ip.to_string()).arg("primary");
-        }
-        None => {
-            cmd.arg("static").arg("none");
-        }
-    }
-    let status = cmd.status()?;
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "set_dns_ipv6"
-    );
-    if !status.success() {
-        return Err(io::Error::other(format!("netsh set dnsservers v6 failed: {status}")));
-    }
-    Ok(())
-}
-
-fn set_dhcp_ipv6(alias: &str) -> io::Result<()> {
-    let started = Instant::now();
-    let status = Command::new(NETSH)
-        .args(["interface", "ipv6", "set", "dnsservers"])
-        .arg(format!("name={alias}"))
-        .arg("dhcp")
-        .status()?;
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "set_dhcp_ipv6"
-    );
-    if !status.success() {
-        return Err(io::Error::other(format!(
-            "netsh set dnsservers v6 dhcp failed: {status}"
-        )));
-    }
-    Ok(())
-}
-
-fn add_dns_ipv6(alias: &str, ip: IpAddr, index: u32) -> io::Result<()> {
-    let started = Instant::now();
-    let status = Command::new(NETSH)
-        .args(["interface", "ipv6", "add", "dnsservers"])
-        .arg(format!("name={alias}"))
-        .arg(ip.to_string())
-        .arg(format!("index={index}"))
-        .status()?;
-    tracing::debug!(
-        %alias,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "add_dns_ipv6"
-    );
-    if !status.success() {
-        return Err(io::Error::other(format!("netsh add dnsservers v6 failed: {status}")));
-    }
-    Ok(())
-}
-
-// Restore =============================================================================================================
-
-fn restore_v4(alias: &str, prior: &DnsPrior) -> io::Result<()> {
-    match prior {
-        DnsPrior::None => set_dns_ipv4(alias, None),
-        DnsPrior::Dhcp => set_dhcp_ipv4(alias),
-        DnsPrior::Static { servers } => {
-            let mut iter = servers.iter();
-            if let Some(first) = iter.next() {
-                set_dns_ipv4(alias, Some(*first))?;
-                for (i, s) in iter.enumerate() {
-                    add_dns_ipv4(alias, *s, (i + 2) as u32)?;
-                }
-                Ok(())
-            } else {
-                set_dns_ipv4(alias, None)
-            }
-        }
-    }
-}
-
-fn restore_v6(alias: &str, prior: &DnsPrior) -> io::Result<()> {
-    match prior {
-        DnsPrior::None => set_dns_ipv6(alias, None),
-        DnsPrior::Dhcp => set_dhcp_ipv6(alias),
-        DnsPrior::Static { servers } => {
-            let mut iter = servers.iter();
-            if let Some(first) = iter.next() {
-                set_dns_ipv6(alias, Some(*first))?;
-                for (i, s) in iter.enumerate() {
-                    add_dns_ipv6(alias, *s, (i + 2) as u32)?;
-                }
-                Ok(())
-            } else {
-                set_dns_ipv6(alias, None)
-            }
-        }
-    }
-}
+#[cfg(test)]
+#[path = "windows_tests.rs"]
+mod windows_tests;

--- a/crates/bridge/src/dns/system/windows.rs
+++ b/crates/bridge/src/dns/system/windows.rs
@@ -21,17 +21,18 @@
 //!
 //! - The free-function shims [`capture_adapters`] / [`apply_loopback`] /
 //!   [`platform_restore_adapter`] / [`flush_dns_cache`] keep the
-//!   pre-#397 call-site contract intact until chunk 3 rewires
-//!   [`crate::proxy_manager::apply_dns_settings`] to call into
-//!   `SystemDns::apply` directly. Each shim instantiates [`Win32Real`]
-//!   and delegates.
+//!   crash-recovery call sites (see [`crate::dns::recovery`]) intact.
+//!   Each shim instantiates [`Win32Real`] and delegates. The
+//!   `Dns`-trait apply path inside `SystemDns::apply` goes through
+//!   `Arc<dyn WinDnsBackend>` directly.
 //!
 //! ## Windows version floor
 //!
 //! `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` were added in
 //! Windows 10 build 19041 (version 2004, May 2020). Pre-19041 systems
-//! will fail to link at runtime. The MSI installer gate
-//! (`WIN10BUILD >= 19041` launch condition) lands in a later chunk.
+//! will fail to link at runtime. The MSI installer `WIN10BUILD >=
+//! 19041` launch condition gate is tracked separately (see #397 plan
+//! step 12).
 //!
 //! ## v4 vs v6
 //!
@@ -283,6 +284,11 @@ fn get_one(guid: GUID, ipv6: bool) -> io::Result<DnsPrior> {
     // SAFETY: `settings` is an owned `DNS_INTERFACE_SETTINGS` whose
     // address is valid for the call. The OS writes a fresh `NameServer`
     // string we must free via `FreeInterfaceDnsSettings`.
+    // The `disallowed_methods` ban on `GetInterfaceDnsSettings` exists
+    // so that nothing outside `Win32Real` reaches around the
+    // `WinDnsBackend` test seam (bindreams/hole#397). This module IS
+    // the sanctioned caller.
+    #[allow(clippy::disallowed_methods)]
     let rc: WIN32_ERROR = unsafe { GetInterfaceDnsSettings(guid, &mut settings) };
     if rc != ERROR_SUCCESS {
         return Err(io::Error::from_raw_os_error(rc.0 as i32));
@@ -338,6 +344,9 @@ fn set_one(guid: GUID, ipv6: bool, prior: &DnsPrior) -> io::Result<()> {
     // SAFETY: `settings` and `wide` outlive the FFI call. The OS reads
     // `Version` first to interpret the struct; we always pass
     // `DNS_INTERFACE_SETTINGS_VERSION3`.
+    // Sanctioned `disallowed_methods` site — see `get_one` for the
+    // rationale; the rule exists to keep the FFI inside `Win32Real`.
+    #[allow(clippy::disallowed_methods)]
     let rc: WIN32_ERROR = unsafe { SetInterfaceDnsSettings(guid, &settings) };
     if rc != ERROR_SUCCESS {
         return Err(io::Error::from_raw_os_error(rc.0 as i32));
@@ -365,13 +374,11 @@ fn parse_servers(s: &str) -> Vec<IpAddr> {
         .collect()
 }
 
-// Free-function shims (pre-#397 call-site compat) =====================================================================
+// Free-function shims (crash-recovery + non-Dns-trait call sites) =====================================================
 //
-// `crate::proxy_manager::apply_dns_settings` and `super::restore_all`
-// still call these free functions; chunk 3 rewires them to call
-// `SystemDns::apply` directly. Until then, the shims delegate to
-// `Win32Real::default()` so the call sites get the Win32-native fast
-// path immediately without rewriting the call structure.
+// `crate::dns::recovery` and `super::restore_all` call these shims; the
+// new `Dns`-trait path inside `SystemDns::apply` goes through
+// `Arc<dyn WinDnsBackend>` directly.
 
 /// Capture the v4+v6 DNS state of every adapter in `aliases`. Adapters
 /// that don't exist are silently skipped. See [`Win32Real::get_settings`].

--- a/crates/bridge/src/dns/system/windows_tests.rs
+++ b/crates/bridge/src/dns/system/windows_tests.rs
@@ -5,6 +5,11 @@
 //! [`MockBackend`] to verify cancel-aware behavior in
 //! [`crate::dns::system::SystemDns::apply`] without touching the OS.
 
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per clippy.toml's "Bridge cancellation contract" sanctioned-
+// test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};

--- a/crates/bridge/src/dns/system/windows_tests.rs
+++ b/crates/bridge/src/dns/system/windows_tests.rs
@@ -188,6 +188,49 @@ async fn system_dns_apply_aborts_between_calls_on_cancel() {
     );
 }
 
+/// Regression: cancel mid-apply must clear `bridge-dns.json` alongside
+/// the inline-restore, so the next bridge start's `recover_dns_config`
+/// doesn't replay an already-restored prior over any user-side DNS
+/// changes made between the cancelled start and the next start.
+#[skuld::test]
+async fn inline_restore_clears_state_file_on_cancel() {
+    let backend = MockBackend::new();
+    let (entered_rx, release_tx) = backend.arm_set_rendezvous();
+
+    let dns = SystemDns::new_with_backend(Arc::clone(&backend) as Arc<dyn WinDnsBackend>);
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state_dir = tmp.path().to_path_buf();
+
+    tokio::spawn(async move {
+        entered_rx.await.expect("first set_loopback never entered");
+        cancel_clone.cancel();
+        let _ = release_tx.send(());
+    });
+
+    let srv = fake_local_dns_server().await;
+    let result = dns
+        .apply(
+            srv,
+            vec!["upstream-alias".into()],
+            vec!["wintun".into(), "upstream-alias".into()],
+            Some(state_dir.clone()),
+            cancel,
+        )
+        .await;
+    assert!(matches!(result, Err(DnsError::Cancelled)), "apply should cancel");
+
+    // `apply` writes the state file BEFORE the apply loop (the `save`
+    // call after capture). On cancel, inline_restore must clear it so
+    // the next start's recovery doesn't replay over user DNS changes.
+    assert!(
+        crate::dns_state::load(&state_dir).is_none(),
+        "inline_restore must clear bridge-dns.json on cancel; presence would replay restore on next start"
+    );
+}
+
 /// One `set_loopback` per `apply_aliases` entry — guards against accidental
 /// double-application or reordering.
 #[skuld::test]
@@ -226,8 +269,8 @@ async fn system_dns_apply_one_set_per_apply_alias() {
 /// The `DebugDropBomb` safeguard panics in debug builds when `shutdown`
 /// is not awaited before drop, catching missed-shutdown bugs at the
 /// first test run. Release builds use the no-op variant and fall through
-/// to the sync-fallback restore; that path is not tested here (it's a
-/// `warn!` log only).
+/// to the sync-fallback restore — exercised by
+/// [`drop_invokes_sync_fallback_when_shutdown_skipped`] below.
 #[skuld::test]
 #[cfg(debug_assertions)]
 #[should_panic(expected = "SystemDnsApplied dropped without awaiting shutdown()")]
@@ -244,4 +287,53 @@ async fn system_dns_applied_drop_panics_in_debug_if_shutdown_not_awaited() {
 
     // No .shutdown().await — bomb panics on drop.
     drop(applied);
+}
+
+/// Regression for the release-mode dead-code bug in `SystemDnsApplied::Drop`:
+/// the previous gate `if !self.bomb.is_defused()` was always `false` in
+/// release (`drop_bomb::FakeBomb::is_defused()` returns `true`
+/// unconditionally), so the sync-fallback restore never ran on a missed
+/// `shutdown().await` in release — the user's DNS would stay pointed at
+/// the loopback forwarder forever.
+///
+/// The fix tracks a separate `shutdown_completed: bool` field; this test
+/// asserts the manual `Drop` impl invokes the backend's `restore` for
+/// each captured prior in **both** build profiles. In debug, the bomb's
+/// own Drop still panics afterward (manual Drop runs first, then field
+/// drops trigger the bomb) — `std::panic::catch_unwind` absorbs that.
+#[skuld::test]
+async fn drop_invokes_sync_fallback_when_shutdown_skipped() {
+    let backend = MockBackend::new();
+    let dns = SystemDns::new_with_backend(Arc::clone(&backend) as Arc<dyn WinDnsBackend>);
+    let cancel = CancellationToken::new();
+
+    let srv = fake_local_dns_server().await;
+    let applied = dns
+        .apply(
+            srv,
+            vec!["upstream-alias".into()],
+            vec!["wintun".into(), "upstream-alias".into()],
+            None,
+            cancel,
+        )
+        .await
+        .expect("apply should succeed");
+
+    let restore_before = backend.restore_calls.load(SeqCst);
+    let flush_before = backend.flush_calls.load(SeqCst);
+
+    // Drop without shutdown. In debug, the bomb (a field of `applied`)
+    // panics on its own Drop AFTER our `impl Drop` has run the sync
+    // fallback — catch_unwind absorbs the panic so the test can assert
+    // on the backend's call counts in either build profile.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(applied)));
+
+    assert!(
+        backend.restore_calls.load(SeqCst) > restore_before,
+        "Drop must invoke sync-fallback restore when shutdown_completed=false (release dead-code regression)"
+    );
+    assert!(
+        backend.flush_calls.load(SeqCst) > flush_before,
+        "Drop must invoke flush after sync-fallback restore"
+    );
 }

--- a/crates/bridge/src/dns/system/windows_tests.rs
+++ b/crates/bridge/src/dns/system/windows_tests.rs
@@ -1,0 +1,242 @@
+//! Layer-2 unit tests for the Win32 DNS backend.
+//!
+//! See [`super::WinDnsBackend`] for the trait surface and
+//! [`super::Win32Real`] for the production impl. These tests use
+//! [`MockBackend`] to verify cancel-aware behavior in
+//! [`crate::dns::system::SystemDns::apply`] without touching the OS.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use super::WinDnsBackend;
+use crate::dns::system::{Dns, DnsApplied, DnsError, SystemDns};
+use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
+
+// MockBackend =========================================================================================================
+
+/// Test-only [`WinDnsBackend`]. Counts calls per method and supports
+/// parking the *first* `set_loopback` invocation on a rendezvous so cancel
+/// tests can fire `cancel.cancel()` while the FFI is mid-flight without
+/// any `sleep`-based synchronization.
+struct MockBackend {
+    get_calls: AtomicUsize,
+    set_calls: AtomicUsize,
+    restore_calls: AtomicUsize,
+    flush_calls: AtomicUsize,
+    /// One-shot rendezvous pair: when set, the first `set_loopback` call
+    /// fires `entered_tx`, then blocks on `release_rx` before returning.
+    set_rendezvous: Mutex<Option<Rendezvous>>,
+}
+
+struct Rendezvous {
+    entered_tx: oneshot::Sender<()>,
+    /// `std::sync::mpsc::Receiver` rather than `tokio::sync::oneshot::Receiver`
+    /// because `set_loopback` is sync and runs on the blocking pool.
+    release_rx: std::sync::mpsc::Receiver<()>,
+}
+
+impl MockBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            get_calls: AtomicUsize::new(0),
+            set_calls: AtomicUsize::new(0),
+            restore_calls: AtomicUsize::new(0),
+            flush_calls: AtomicUsize::new(0),
+            set_rendezvous: Mutex::new(None),
+        })
+    }
+
+    /// Arm the first-`set_loopback` rendezvous. Returns the receiver/sender
+    /// the test should park on / fire respectively:
+    /// - `entered_rx`: completes when the first `set_loopback` runs.
+    /// - `release_tx`: send to let the first `set_loopback` return.
+    fn arm_set_rendezvous(&self) -> (oneshot::Receiver<()>, std::sync::mpsc::Sender<()>) {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        *self.set_rendezvous.lock().unwrap() = Some(Rendezvous { entered_tx, release_rx });
+        (entered_rx, release_tx)
+    }
+}
+
+impl WinDnsBackend for MockBackend {
+    fn get_settings(&self, alias: &str) -> io::Result<Option<DnsPriorAdapter>> {
+        self.get_calls.fetch_add(1, SeqCst);
+        Ok(Some(DnsPriorAdapter {
+            id: AdapterId::WindowsAlias {
+                value: alias.to_string(),
+            },
+            name_at_capture: alias.to_string(),
+            v4: DnsPrior::Dhcp,
+            v6: DnsPrior::None,
+        }))
+    }
+
+    fn set_loopback(&self, _alias: &str, _ip: IpAddr) -> io::Result<()> {
+        let n = self.set_calls.fetch_add(1, SeqCst);
+        if n == 0 {
+            // First call — fire entered signal and park if rendezvous armed.
+            let r = self.set_rendezvous.lock().unwrap().take();
+            if let Some(r) = r {
+                let _ = r.entered_tx.send(());
+                let _ = r.release_rx.recv();
+            }
+        }
+        Ok(())
+    }
+
+    fn restore(&self, _adapter: &DnsPriorAdapter) -> io::Result<()> {
+        self.restore_calls.fetch_add(1, SeqCst);
+        Ok(())
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.flush_calls.fetch_add(1, SeqCst);
+        Ok(())
+    }
+}
+
+// Helpers =============================================================================================================
+
+/// Build a `LocalDnsServer` bound to an ephemeral loopback port. The
+/// bind is real (so the apply path's accept of a `LocalDnsServer` value
+/// is exercised end-to-end), but the test never sends traffic to it.
+async fn fake_local_dns_server() -> crate::dns::server::LocalDnsServer {
+    use crate::dns::server::LocalDnsServer;
+    use std::sync::Arc;
+
+    // Build a forwarder that's never actually used by these tests — its
+    // upstream connector is a placeholder. The server binds locally;
+    // packets are not sent.
+    let dns_cfg = hole_common::config::DnsConfig::default();
+    let connector = Arc::new(crate::dns::socks5_connector::Socks5Connector::new(
+        std::net::SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1080),
+    )) as Arc<dyn crate::dns::connector::UpstreamConnector>;
+    let forwarder = Arc::new(crate::dns::forwarder::DnsForwarder::new(dns_cfg, connector, false));
+    LocalDnsServer::bind_ladder(forwarder, CancellationToken::new())
+        .await
+        .expect("LocalDnsServer::bind_ladder")
+}
+
+// Tests ===============================================================================================================
+
+/// Cooperative cancel observed BETWEEN `set_loopback` calls aborts
+/// `apply` before the second adapter is touched and runs inline-restore
+/// for the captured prior. The first call is parked via the rendezvous;
+/// the test fires cancel from a peer task; the parked call is released
+/// and apply observes cancel before issuing the second call.
+#[skuld::test]
+async fn system_dns_apply_aborts_between_calls_on_cancel() {
+    let backend = MockBackend::new();
+    let (entered_rx, release_tx) = backend.arm_set_rendezvous();
+    let restore_calls = Arc::clone(&backend);
+    let set_calls = Arc::clone(&backend);
+
+    let dns = SystemDns::new_with_backend(Arc::clone(&backend) as Arc<dyn WinDnsBackend>);
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+
+    tokio::spawn(async move {
+        entered_rx.await.expect("first set_loopback never entered");
+        cancel_clone.cancel();
+        let _ = release_tx.send(());
+    });
+
+    let srv = fake_local_dns_server().await;
+    let result = dns
+        .apply(
+            srv,
+            vec!["upstream-alias".into()],
+            vec!["wintun".into(), "upstream-alias".into()],
+            None,
+            cancel,
+        )
+        .await;
+
+    // `SystemDnsApplied` is intentionally not `Debug` (its
+    // `LocalDnsServer` carries platform-specific handles that don't
+    // implement Debug). Sidestep `expect_err`'s `T: Debug` bound by
+    // matching the result directly.
+    match result {
+        Ok(mut applied) => {
+            // Test invariant violated; defuse the bomb before panicking
+            // so the panic message that surfaces is ours, not the bomb's.
+            applied.shutdown().await;
+            panic!("apply should have returned DnsError::Cancelled");
+        }
+        Err(DnsError::Cancelled) => {}
+        Err(e) => panic!("expected Cancelled, got {e:?}"),
+    }
+    assert_eq!(
+        set_calls.set_calls.load(SeqCst),
+        1,
+        "second apply (wintun) must NOT run after cancel"
+    );
+    assert_eq!(
+        restore_calls.restore_calls.load(SeqCst),
+        1,
+        "inline restore must run for the one captured upstream adapter"
+    );
+}
+
+/// One `set_loopback` per `apply_aliases` entry — guards against accidental
+/// double-application or reordering.
+#[skuld::test]
+async fn system_dns_apply_one_set_per_apply_alias() {
+    let backend = MockBackend::new();
+    let dns = SystemDns::new_with_backend(Arc::clone(&backend) as Arc<dyn WinDnsBackend>);
+    let cancel = CancellationToken::new();
+
+    let srv = fake_local_dns_server().await;
+    let mut applied = dns
+        .apply(
+            srv,
+            vec!["upstream-alias".into()],
+            vec!["wintun".into(), "upstream-alias".into()],
+            None,
+            cancel,
+        )
+        .await
+        .expect("apply should succeed");
+
+    assert_eq!(
+        backend.set_calls.load(SeqCst),
+        2,
+        "exactly one set_loopback per apply_alias"
+    );
+    assert_eq!(
+        backend.get_calls.load(SeqCst),
+        1,
+        "exactly one get_settings per capture_alias"
+    );
+
+    // Clean shutdown to defuse the bomb.
+    applied.shutdown().await;
+}
+
+/// The `DebugDropBomb` safeguard panics in debug builds when `shutdown`
+/// is not awaited before drop, catching missed-shutdown bugs at the
+/// first test run. Release builds use the no-op variant and fall through
+/// to the sync-fallback restore; that path is not tested here (it's a
+/// `warn!` log only).
+#[skuld::test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "SystemDnsApplied dropped without awaiting shutdown()")]
+async fn system_dns_applied_drop_panics_in_debug_if_shutdown_not_awaited() {
+    let backend = MockBackend::new();
+    let dns = SystemDns::new_with_backend(Arc::clone(&backend) as Arc<dyn WinDnsBackend>);
+    let cancel = CancellationToken::new();
+
+    let srv = fake_local_dns_server().await;
+    let applied = dns
+        .apply(srv, vec!["upstream-alias".into()], vec!["wintun".into()], None, cancel)
+        .await
+        .expect("apply should succeed");
+
+    // No .shutdown().await — bomb panics on drop.
+    drop(applied);
+}

--- a/crates/bridge/src/dns/system_tests.rs
+++ b/crates/bridge/src/dns/system_tests.rs
@@ -1,17 +1,13 @@
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 use crate::dns_state::DnsPrior;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 use std::net::{IpAddr, Ipv4Addr};
-
-#[cfg(target_os = "windows")]
-use std::net::Ipv6Addr;
 
 // Timing-log instrumentation tests (#247) =============================================================================
 //
 // These tests verify that Phase 1 diagnostic logs fire. They live outside
-// the `windows_parsers` / `macos_parsers` modules because they exercise
-// real OS command invocations (netsh / networksetup), which the parser
-// tests deliberately avoid.
+// the `macos_parsers` module because they exercise real OS command
+// invocations (networksetup), which the parser tests deliberately avoid.
 
 #[cfg(target_os = "windows")]
 mod windows_timing_logs {
@@ -21,35 +17,29 @@ mod windows_timing_logs {
     use tracing_subscriber::fmt;
     use tracing_subscriber::layer::{Layer, SubscriberExt};
 
-    /// Phase-4 (#247): `flush_dns_cache` must return immediately. The
-    /// flush itself runs on a detached `std::thread::spawn`'d thread so
-    /// `apply_loopback` and `RunningDns::drop` never block on the 1-5s
-    /// `ipconfig /flushdns` wall-clock. Phase-2 observation confirmed
-    /// flushdns was a major contributor to the 11.3s stall.
-    ///
-    /// The elapsed-ms DEBUG log still fires inside the spawned thread
-    /// so Phase-2 observation stays intact — we just can't assert on it
-    /// from here because `set_default` is thread-local (the spawned
-    /// thread doesn't inherit the subscriber). The contract-level
-    /// assertion below is the load-bearing one.
+    /// Post-#397 (Win32-native): `flush_dns_cache` calls
+    /// `DnsFlushResolverCache` inline (~10 ms FFI). The pre-#397
+    /// implementation detached `ipconfig /flushdns` onto a
+    /// `std::thread::spawn`'d thread because that subprocess took 1–5 s
+    /// (Phase 4 #247). The FFI is ms-scale, so inline is correct.
     #[skuld::test]
-    fn flush_dns_cache_returns_immediately() {
+    fn flush_dns_cache_returns_quickly() {
         let start = std::time::Instant::now();
         flush_dns_cache();
         let elapsed = start.elapsed();
         assert!(
-            elapsed < std::time::Duration::from_millis(50),
-            "flush_dns_cache must return immediately (fire-and-forget); \
-             returned after {elapsed:?} — if flushdns is still blocking callers, \
-             the teardown-side flush in RunningDns::drop will stall too."
+            elapsed < std::time::Duration::from_millis(200),
+            "flush_dns_cache must complete quickly; \
+             returned after {elapsed:?} — the Win32 DnsFlushResolverCache \
+             FFI should be ms-scale."
         );
     }
 
-    /// `capture_adapters` must emit per-alias DEBUG timing logs so a slow
-    /// netsh query against a freshly-created TUN adapter is visible in
-    /// Phase 2 logs. Uses a nonexistent adapter name so the test doesn't
-    /// depend on any specific network configuration — `netsh show` will
-    /// return "not found" quickly, and the timing log fires regardless.
+    /// `capture_adapters` (the pre-#397 free-function shim) routes
+    /// through `Win32Real::get_settings`, which emits per-alias DEBUG
+    /// timing logs. Uses a nonexistent adapter so the test doesn't
+    /// depend on host network configuration — `ConvertInterfaceAliasToLuid`
+    /// returns ERROR_INVALID_PARAMETER quickly and the timing log fires.
     #[skuld::test]
     fn capture_adapters_emits_per_alias_elapsed_ms_debug_log() {
         use crate::dns::system::capture_adapters;
@@ -74,100 +64,6 @@ mod windows_timing_logs {
             output.contains("hole-test-bogus-adapter-xyz"),
             "expected alias in log; got:\n{output}"
         );
-    }
-}
-
-// Windows parser tests ================================================================================================
-
-#[cfg(target_os = "windows")]
-mod windows_parsers {
-    use super::{DnsPrior, IpAddr, Ipv4Addr, Ipv6Addr};
-    use crate::dns::system::windows::parse_netsh_dnsservers;
-
-    #[skuld::test]
-    fn parse_static_single() {
-        let out = "
-Configuration for interface \"Ethernet\"
-    Statically Configured DNS Servers:  1.1.1.1
-    Register with which suffix:         Primary only
-";
-        let p = parse_netsh_dnsservers(out);
-        match p {
-            DnsPrior::Static { servers } => {
-                assert_eq!(servers, vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))]);
-            }
-            other => panic!("expected Static, got {other:?}"),
-        }
-    }
-
-    #[skuld::test]
-    fn parse_static_multiple() {
-        let out = "
-Configuration for interface \"Ethernet\"
-    Statically Configured DNS Servers:  1.1.1.1
-                                        8.8.8.8
-                                        9.9.9.9
-    Register with which suffix:         Primary only
-";
-        let p = parse_netsh_dnsservers(out);
-        match p {
-            DnsPrior::Static { servers } => {
-                assert_eq!(
-                    servers,
-                    vec![
-                        IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
-                        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
-                        IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)),
-                    ]
-                );
-            }
-            other => panic!("expected Static, got {other:?}"),
-        }
-    }
-
-    #[skuld::test]
-    fn parse_dhcp_with_ip() {
-        let out = "
-Configuration for interface \"Ethernet\"
-    DNS servers configured through DHCP:  192.168.1.1
-    Register with which suffix:           Primary only
-";
-        let p = parse_netsh_dnsservers(out);
-        assert!(matches!(p, DnsPrior::Dhcp));
-    }
-
-    #[skuld::test]
-    fn parse_dhcp_none() {
-        let out = "
-Configuration for interface \"Wi-Fi\"
-    DNS servers configured through DHCP:  None
-    Register with which suffix:           Primary only
-";
-        let p = parse_netsh_dnsservers(out);
-        assert!(matches!(p, DnsPrior::None));
-    }
-
-    #[skuld::test]
-    fn parse_empty_output_returns_none() {
-        let p = parse_netsh_dnsservers("");
-        assert!(matches!(p, DnsPrior::None));
-    }
-
-    #[skuld::test]
-    fn parse_ipv6_static() {
-        let out = "
-    Statically Configured DNS Servers:  2606:4700:4700::1111
-";
-        let p = parse_netsh_dnsservers(out);
-        match p {
-            DnsPrior::Static { servers } => {
-                assert_eq!(
-                    servers,
-                    vec![IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111))]
-                );
-            }
-            other => panic!("expected Static, got {other:?}"),
-        }
     }
 }
 

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -232,6 +232,8 @@ async fn handle_start<P: Proxy + 'static, R: Routing + 'static>(
     // without even attempting the start. If a concurrent start is already
     // in flight, reject this one — the slot is single-occupancy because a
     // Cancel targets exactly one in-flight start.
+    #[allow(clippy::disallowed_methods)]
+    // IPC root: every bridge cancel scope descends from this token. See clippy.toml CancellationToken::new rule.
     let token = CancellationToken::new();
     {
         let mut cs = state.start_cancel.lock().expect("start_cancel poisoned");

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -105,6 +105,7 @@ impl Drop for PluginChain {
 /// residual probe-drop-to-subprocess-bind TOCTOU is tracked in
 /// bindreams/hole#304. See bindreams/hole#285 §"Where the fix
 /// actually lands" for the rendezvous-port race class history.
+#[allow(clippy::too_many_arguments)] // 8 args — bundling into a struct adds more noise than the warning; matches spawn_plugin_runner_at below.
 pub async fn start_plugin_chain(
     plugin_name: &str,
     plugin_path: &str,
@@ -113,6 +114,7 @@ pub async fn start_plugin_chain(
     server_port: u16,
     state_dir: Option<&Path>,
     diagnostic_tap: bool,
+    cancel: &CancellationToken,
 ) -> Result<PluginChain, ProxyError> {
     // Inject a debug-level log directive into the plugin's
     // SS_PLUGIN_OPTIONS unconditionally — Hole owns plugin stderr (it's
@@ -132,6 +134,11 @@ pub async fn start_plugin_chain(
             // an `async move`; clone per attempt instead. `&str`/`&Path`
             // arguments are Copy and pass through unchanged.
             let merged_opts = merged_opts.clone();
+            // Each attempt gets its own child token derived from the
+            // bridge cancel: cancelling the bridge cancels every attempt;
+            // a failed attempt that drops its child does not signal the
+            // bridge or sibling retries.
+            let attempt_cancel = cancel.child_token();
             async move {
                 let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
                 spawn_plugin_runner_at(
@@ -143,13 +150,24 @@ pub async fn start_plugin_chain(
                     server_port,
                     state_dir,
                     diagnostic_tap,
+                    attempt_cancel,
                 )
                 .await
                 .map_err(proxy_err_to_io_err)
             }
         })
         .await
-        .map_err(|e| ProxyError::Plugin(format!("plugin chain start failed: {e}")))?;
+        .map_err(|e| {
+            // A cancel-attributed io::Error (from spawn_plugin_runner_at
+            // observing the child token) re-surfaces as Cancelled so the
+            // caller short-circuits cleanly instead of seeing
+            // ProxyError::Plugin("...cancelled").
+            if cancel.is_cancelled() {
+                ProxyError::Cancelled
+            } else {
+                ProxyError::Plugin(format!("plugin chain start failed: {e}"))
+            }
+        })?;
 
     Ok(PluginChain {
         handle,
@@ -197,7 +215,7 @@ fn resolve_tap_source(diagnostic_tap: bool) -> TapSource {
 /// `bind_ephemeral` doesn't leak the previous attempt's task. On
 /// success returns `(handle, cancel, ready_addr)` — the caller wraps
 /// these in a [`PluginChain`].
-#[allow(clippy::too_many_arguments)] // 8 args — already at the limit before #388 added diagnostic_tap; bundling into a struct adds more noise than the warning.
+#[allow(clippy::too_many_arguments)] // 9 args — already at the limit before #397 added cancel; bundling into a struct adds more noise than the warning.
 async fn spawn_plugin_runner_at(
     plugin_name: &str,
     plugin_path: &str,
@@ -207,6 +225,7 @@ async fn spawn_plugin_runner_at(
     server_port: u16,
     state_dir: Option<&Path>,
     diagnostic_tap: bool,
+    cancel: CancellationToken,
 ) -> Result<
     (
         tokio::task::JoinHandle<garter::Result<()>>,
@@ -234,7 +253,10 @@ async fn spawn_plugin_runner_at(
         plugin = plugin.pid_sink(sink);
     }
 
-    let cancel = CancellationToken::new();
+    // `cancel` is the externally-supplied child token from
+    // `start_plugin_chain`. Cancelling the bridge's start cancel cancels
+    // this token via the child link; PluginChain::Drop also cancels it
+    // (subtree-only) so the chain's RAII teardown stays self-contained.
     let (ready_tx, ready_rx) = oneshot::channel();
 
     let env = garter::PluginEnv {
@@ -272,18 +294,29 @@ async fn spawn_plugin_runner_at(
 
     let handle = tokio::spawn(async move { runner.run(env).await });
 
-    let ready_addr = match tokio::time::timeout(READINESS_TIMEOUT, ready_rx).await {
-        Ok(Ok(addr)) => addr,
-        Ok(Err(_)) => {
-            cancel.cancel();
+    // Race readiness against the bridge cancel: if the user cancels the
+    // start mid-spawn, abort the partially-spawned chain and return
+    // ProxyError::Cancelled so the caller short-circuits cleanly instead
+    // of waiting up to READINESS_TIMEOUT for a chain it no longer wants.
+    let ready_addr = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
             handle.abort();
-            return Err(ProxyError::Plugin("plugin exited before becoming ready".into()));
+            return Err(ProxyError::Cancelled);
         }
-        Err(_) => {
-            cancel.cancel();
-            handle.abort();
-            return Err(ProxyError::Plugin("plugin did not become ready within 30s".into()));
-        }
+        r = tokio::time::timeout(READINESS_TIMEOUT, ready_rx) => match r {
+            Ok(Ok(addr)) => addr,
+            Ok(Err(_)) => {
+                cancel.cancel();
+                handle.abort();
+                return Err(ProxyError::Plugin("plugin exited before becoming ready".into()));
+            }
+            Err(_) => {
+                cancel.cancel();
+                handle.abort();
+                return Err(ProxyError::Plugin("plugin did not become ready within 30s".into()));
+            }
+        },
     };
 
     Ok((handle, cancel, ready_addr))
@@ -298,13 +331,20 @@ async fn spawn_plugin_runner_at(
 /// subprocess spawn. Stderr-based classification of subprocess bind
 /// failures is the follow-up tracked in bindreams/hole#304.
 ///
-/// `spawn_plugin_runner_at` only emits `ProxyError::Plugin`; the
-/// `unreachable!` arm is the contract guard. Future contributors who
-/// add new variants must update this site to map them appropriately.
+/// `spawn_plugin_runner_at` emits `ProxyError::Plugin` (subprocess
+/// failure paths) or `ProxyError::Cancelled` (bridge cancel observed
+/// mid-spawn, #397). Both surface as non-bind-race `io::Error::other`
+/// so `bind_ephemeral` propagates them immediately; the outer
+/// `start_plugin_chain` then distinguishes Cancelled via
+/// `cancel.is_cancelled()` to re-emit the canonical variant. The
+/// `unreachable!` arm is the contract guard for future variants.
 fn proxy_err_to_io_err(e: ProxyError) -> std::io::Error {
     match e {
         ProxyError::Plugin(msg) => std::io::Error::other(msg),
-        other => unreachable!("spawn_plugin_runner_at only emits ProxyError::Plugin, got: {other}"),
+        ProxyError::Cancelled => std::io::Error::other("plugin spawn cancelled"),
+        other => {
+            unreachable!("spawn_plugin_runner_at only emits ProxyError::Plugin or ProxyError::Cancelled, got: {other}")
+        }
     }
 }
 

--- a/crates/bridge/src/proxy/plugin_tests.rs
+++ b/crates/bridge/src/proxy/plugin_tests.rs
@@ -1,7 +1,10 @@
+use tokio_util::sync::CancellationToken;
+
 use super::start_plugin_chain;
 
 #[skuld::test]
 async fn start_with_nonexistent_binary_returns_plugin_error() {
+    let cancel = CancellationToken::new();
     let result = start_plugin_chain(
         "v2ray-plugin",
         "/nonexistent/binary",
@@ -10,6 +13,7 @@ async fn start_with_nonexistent_binary_returns_plugin_error() {
         12345,
         None,
         false,
+        &cancel,
     )
     .await;
 

--- a/crates/bridge/src/proxy/plugin_tests.rs
+++ b/crates/bridge/src/proxy/plugin_tests.rs
@@ -1,3 +1,8 @@
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per clippy.toml's "Bridge cancellation contract" sanctioned-
+// test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use tokio_util::sync::CancellationToken;
 
 use super::start_plugin_chain;

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -241,7 +241,10 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// existing callers (tests, `reload`) that don't need cancel
     /// semantics.
     pub async fn start(&mut self, config: &ProxyConfig) -> Result<(), ProxyError> {
-        self.start_cancellable(config, CancellationToken::new()).await
+        #[allow(clippy::disallowed_methods)]
+        // Non-cancellable shim: callers explicitly opt out of cancel semantics. See clippy.toml CancellationToken::new rule.
+        let token = CancellationToken::new();
+        self.start_cancellable(config, token).await
     }
 
     /// Start the proxy with a caller-supplied `CancellationToken`.

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -45,6 +45,7 @@ use tracing::{debug, error, info, warn};
 use tun_engine::gateway::GatewayInfo;
 use tun_engine::routing::{Routing, SystemRouting};
 
+use crate::dns::system::{Dns, DnsApplied, DnsError, SystemDns};
 use crate::proxy::{build_ss_config, Proxy, ProxyError, RunningProxy, ShadowsocksProxy, TUN_DEVICE_NAME};
 
 /// Non-secret diagnostic view of a proxy-start event — suitable for
@@ -74,20 +75,26 @@ pub enum ProxyState {
 
 /// Per-cycle state owned only while a proxy is running.
 ///
-/// **Field declaration order is load-bearing.** DNS drops first (restores
-/// the user's OS DNS while routes + dispatcher + SS are still live so any
-/// in-flight OS DNS queries egress the restored path), then dispatcher
-/// (closes TUN, cancels handlers), then plugin chain (graceful stop via
-/// SIGTERM/CTRL_BREAK), then routes (teardown commands), then proxy
-/// (releases SS). `None` fields for SocksOnly mode where
-/// routing/dispatcher/DNS are skipped, or when no plugin is configured.
-struct RunningState<P: Proxy, R: Routing> {
-    /// DNS interception: system-DNS apply + LocalDnsServer. Drops FIRST
-    /// so the user's prior resolvers are restored before anything else
-    /// tears down. `None` when DNS forwarder is disabled or in SocksOnly
-    /// mode.
+/// **Tear-down order is load-bearing.** `ProxyManager::stop` runs the
+/// shutdown sequence in this order:
+/// 1. `dns_applied.shutdown().await` — restores OS DNS while routes +
+///    dispatcher + SS are still live so any in-flight OS DNS queries
+///    egress the restored path.
+/// 2. `dispatcher.shutdown().await` — closes TUN, cancels handlers.
+/// 3. `plugin_chain` drop — graceful stop via SIGTERM/CTRL_BREAK.
+/// 4. `proxy.stop().await` — releases SS task.
+/// 5. `routes` drop — RAII teardown.
+///
+/// `None` fields for SocksOnly mode where routing / dispatcher / DNS are
+/// skipped, or when no plugin is configured.
+struct RunningState<P: Proxy, R: Routing, D: Dns> {
+    /// DNS interception guard: holds the captured prior DNS state and
+    /// the `LocalDnsServer`. `stop()` awaits
+    /// [`DnsApplied::shutdown`] on this BEFORE dropping anything else so
+    /// the OS sees its restored resolvers while routes are still live.
+    /// `None` when DNS forwarder is disabled or in SocksOnly mode.
     #[allow(dead_code)]
-    dns: Option<RunningDns>,
+    dns: Option<D::Applied>,
     /// TCP dispatcher — owns TUN device, smoltcp, and per-connection
     /// handler tasks. Drops SECOND. `None` in SocksOnly mode and under
     /// `#[cfg(test)]`.
@@ -112,47 +119,13 @@ struct RunningState<P: Proxy, R: Routing> {
     ipv6_bypass_available: bool,
 }
 
-/// DNS interception state held for the proxy's lifetime. Drop restores
-/// system DNS (via `system::restore_all`) and clears `bridge-dns.json`,
-/// then drops `local_dns_server` (aborts its tasks, releasing the
-/// loopback port). Drop is synchronous because all underlying OS
-/// commands block; this matches the existing `SystemRoutes::drop`
-/// convention.
-struct RunningDns {
-    applied_prior: Vec<crate::dns_state::DnsPriorAdapter>,
-    /// State directory for the `bridge-dns.json` persisted file. `None`
-    /// when the caller didn't configure one (dev harness without a
-    /// state dir — a case the existing plugin / routes paths also
-    /// tolerate).
-    state_dir: Option<std::path::PathBuf>,
-    /// Held to keep the loopback `<ip>:53` bound and to keep the
-    /// forwarder tasks running. Dropped after system DNS is restored.
-    _local_dns_server: crate::dns::server::LocalDnsServer,
-}
-
-impl Drop for RunningDns {
-    fn drop(&mut self) {
-        let errors = crate::dns::system::restore_all(&self.applied_prior);
-        if !errors.is_empty() {
-            warn!(
-                count = errors.len(),
-                "RunningDns::drop: some adapters failed to restore"
-            );
-        }
-        if let Some(dir) = &self.state_dir {
-            if let Err(e) = crate::dns_state::clear(dir) {
-                warn!(error = %e, "RunningDns::drop: failed to clear bridge-dns.json");
-            }
-        }
-    }
-}
-
 // ProxyManager ========================================================================================================
 
-pub struct ProxyManager<P: Proxy = ShadowsocksProxy, R: Routing = SystemRouting> {
+pub struct ProxyManager<P: Proxy = ShadowsocksProxy, R: Routing = SystemRouting, D: Dns = SystemDns> {
     proxy: P,
     routing: R,
-    running: Option<RunningState<P, R>>,
+    dns: D,
+    running: Option<RunningState<P, R, D>>,
     last_error: Option<String>,
     /// Last successfully-started config. Used by `reload` to detect
     /// filter-only changes (hot-swap path vs full restart).
@@ -166,11 +139,23 @@ pub struct ProxyManager<P: Proxy = ShadowsocksProxy, R: Routing = SystemRouting>
     state_dir: Option<std::path::PathBuf>,
 }
 
-impl<P: Proxy, R: Routing> ProxyManager<P, R> {
+impl<P: Proxy, R: Routing> ProxyManager<P, R, SystemDns> {
     pub fn new(proxy: P, routing: R) -> Self {
+        Self::new_with_dns(proxy, routing, SystemDns::default())
+    }
+}
+
+impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
+    /// Construct a [`ProxyManager`] with an explicit [`Dns`] provider.
+    /// Used by Layer-1 unit tests to substitute `MockDns` so cancel /
+    /// shutdown propagation through `start_inner` can be observed
+    /// without touching the OS resolver. Production code uses
+    /// [`Self::new`].
+    pub fn new_with_dns(proxy: P, routing: R, dns: D) -> Self {
         Self {
             proxy,
             routing,
+            dns,
             running: None,
             last_error: None,
             active_config: None,
@@ -313,8 +298,15 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // "uncancellable sync phase" foot-gun where a future that
         // doesn't yield blocks the outer select! from observing cancel.
         debug!("awaiting start_inner");
-        let result: Result<RunningState<P, R>, ProxyError> =
-            Self::start_inner(&self.proxy, &self.routing, config, self.state_dir.as_deref(), cancel).await;
+        let result: Result<RunningState<P, R, D>, ProxyError> = Self::start_inner(
+            &self.proxy,
+            &self.routing,
+            &self.dns,
+            config,
+            self.state_dir.as_deref(),
+            cancel,
+        )
+        .await;
 
         // Commit (or record the error) in the outer function, so the
         // only path that mutates `self.running = Some(..)` is strictly
@@ -386,11 +378,14 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
     ///   observed at phase boundary only (`if cancel.is_cancelled()`).
     ///   These calls are millisecond-scale; mid-call preemption isn't
     ///   needed.
-    /// - **Phase 7 (apply_dns_settings)**: chunk-1 NOT yet
-    ///   cancel-aware (still routes through pre-#397 netsh sync path
-    ///   that the #395 reproduction caught taking 22 s). Cancel-aware
-    ///   apply lands in chunks 2–3 alongside the Win32-native DNS
-    ///   refactor.
+    /// - **Phase 7 (dns.apply)**: cooperative — the token is threaded
+    ///   into [`Dns::apply`], which observes cancel between per-adapter
+    ///   FFIs. A cancel arriving mid-apply triggers an inline-restore
+    ///   of any partially-applied adapters before `DnsError::Cancelled`
+    ///   propagates back as `ProxyError::Cancelled`. The
+    ///   `SystemDnsApplied` guard is returned only on the `Ok` path,
+    ///   so the `DebugDropBomb` is never armed during an Err unwind
+    ///   (`#397` plan-review #8).
     ///
     /// CRITICAL ORDERING: the routing provider is responsible for
     /// persisting the recovery state BEFORE mutating routes. A panic
@@ -401,10 +396,11 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
     async fn start_inner(
         proxy: &P,
         routing: &R,
+        dns: &D,
         config: &ProxyConfig,
         state_dir: Option<&std::path::Path>,
         cancel: CancellationToken,
-    ) -> Result<RunningState<P, R>, ProxyError> {
+    ) -> Result<RunningState<P, R, D>, ProxyError> {
         debug!("start_inner entered");
         // Pre-flight: short-circuit a pre-cancelled token before any work.
         if cancel.is_cancelled() {
@@ -623,24 +619,48 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
-        // (6) Apply system DNS AFTER routes install so the OS "best-route to
-        // DNS server" lookup resolves through the TUN (its DNS setting is
-        // our loopback IP). Persist the prior state to `bridge-dns.json`
-        // BEFORE mutating so a mid-apply crash leaves a recoverable file.
-        let dns_state = if let Some(srv) = local_dns_server.as_ref() {
-            apply_dns_settings(srv, &gw_info.interface_name, state_dir).await
+        // Phase 7: apply system DNS AFTER routes install so the OS
+        // "best-route to DNS server" lookup resolves through the TUN
+        // (its DNS setting is our loopback IP). Persist + apply are
+        // cancel-aware inside `Dns::apply`; cancel observed between
+        // FFIs runs the inline-restore on partially-applied adapters
+        // and returns `DnsError::Cancelled`, which we map back to
+        // `ProxyError::Cancelled`. Non-cancel failures (Io) downgrade
+        // to a `warn!` + `None`, preserving the pre-#397
+        // "best-effort apply" semantics so a single adapter failure
+        // doesn't tank an otherwise-working start.
+        let dns_applied = if let Some(srv) = local_dns_server {
+            // Capture runs on upstream only; the TUN was created by
+            // `routing.install` above so its prior is definitionally
+            // "defaults" (Phase 4 #247 — fast-path nonsensical capture).
+            // Apply runs on both: TUN needs loopback DNS so the OS's
+            // best-route-to-DNS lookup lands on our forwarder when the
+            // TUN becomes the primary interface.
+            let capture_aliases = vec![gw_info.interface_name.clone()];
+            let apply_aliases = vec![TUN_DEVICE_NAME.into(), gw_info.interface_name.clone()];
+            match dns
+                .apply(
+                    srv,
+                    capture_aliases,
+                    apply_aliases,
+                    state_dir.map(std::path::Path::to_path_buf),
+                    cancel.clone(),
+                )
+                .await
+            {
+                Ok(a) => Some(a),
+                Err(DnsError::Cancelled) => return Err(ProxyError::Cancelled),
+                Err(DnsError::Io(e)) => {
+                    warn!(error = %e, "system DNS apply failed; DNS forwarder unreachable by OS clients");
+                    None
+                }
+            }
         } else {
             None
         };
 
-        let dns = local_dns_server.zip(dns_state).map(|(srv, applied)| RunningDns {
-            applied_prior: applied,
-            state_dir: state_dir.map(std::path::Path::to_path_buf),
-            _local_dns_server: srv,
-        });
-
         Ok(RunningState {
-            dns,
+            dns: dns_applied,
             dispatcher,
             plugin_chain,
             routes: Some(routes),
@@ -670,7 +690,12 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
 
         // 0. Restore system DNS FIRST (while routes + SS are still live
         // so any in-flight OS queries egress via the restored resolver).
-        drop(dns);
+        // Async shutdown — defuses the `DebugDropBomb` in `SystemDnsApplied`
+        // before the field drops. Skipping the await would panic in debug
+        // builds (catching missed-shutdown bugs at first test run).
+        if let Some(mut d) = dns {
+            d.shutdown().await;
+        }
 
         // 1. Shut down dispatcher (closes TUN, cancels all handlers).
         if let Some(mut d) = dispatcher {
@@ -1084,105 +1109,4 @@ fn sample_self_test_query() -> Vec<u8> {
     q.extend_from_slice(&[0x00, 0x01]); // QTYPE=A
     q.extend_from_slice(&[0x00, 0x01]); // QCLASS=IN
     q
-}
-
-/// Capture prior system DNS for the adapters we're about to override,
-/// persist the `bridge-dns.json` recovery file, then apply the loopback
-/// IP. Returns the captured prior state on success, which
-/// [`RunningDns::drop`] will later replay.
-///
-/// Async because the underlying platform functions shell out to
-/// `netsh` / `networksetup` via `std::process::Command`. Keeping the
-/// body sync today (see `dns::system::windows`) blocks a tokio worker
-/// thread for the full duration, which #247 observed stalling the
-/// `start_inner` path by ~10s. The `async fn` signature is a
-/// Phase-1 no-behavior-change prerequisite for a Phase-4 swap to
-/// `tokio::process::Command`.
-///
-/// Instrumented with an `info_span!("apply_dns_settings")` entered via
-/// `.instrument()`. The happy-path exit logs
-/// `info!(elapsed_ms = ..., "apply_dns_settings done")` so Phase-2
-/// observation of #247 sees the total at INFO without needing to raise
-/// the log level — per-sub-call `elapsed_ms` lines live at DEBUG inside
-/// `dns::system::windows`.
-async fn apply_dns_settings(
-    server: &crate::dns::server::LocalDnsServer,
-    upstream_iface: &str,
-    state_dir: Option<&std::path::Path>,
-) -> Option<Vec<crate::dns_state::DnsPriorAdapter>> {
-    use tracing::Instrument;
-    let span = tracing::info_span!("apply_dns_settings", upstream_iface = %upstream_iface);
-    async { apply_dns_settings_body(server, upstream_iface, state_dir) }
-        .instrument(span)
-        .await
-}
-
-fn apply_dns_settings_body(
-    server: &crate::dns::server::LocalDnsServer,
-    upstream_iface: &str,
-    state_dir: Option<&std::path::Path>,
-) -> Option<Vec<crate::dns_state::DnsPriorAdapter>> {
-    let started = Instant::now();
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
-    let result = {
-        use crate::dns::system;
-        use crate::dns_state::{self, DnsState, SCHEMA_VERSION};
-        use crate::proxy::TUN_DEVICE_NAME;
-
-        // Capture runs on the upstream adapter only. The TUN adapter is
-        // fresh (just created by `routing.install`); its prior DNS state
-        // is definitionally "whatever Windows defaults a brand-new adapter
-        // to" — unknowable and uninteresting, and Phase-2 observation of
-        // #247 identified `netsh show dnsservers` against a newly-created
-        // TUN as one of the slowest sub-calls in the 11.3s stall.
-        //
-        // Apply runs on both adapters: the TUN still needs its DNS set to
-        // the loopback IP so the OS's "best-route to DNS server" lookup
-        // picks our forwarder when the TUN becomes the primary interface.
-        // On teardown, the TUN is destroyed with the routes so there is
-        // nothing to restore there — `RunningDns::drop` only replays the
-        // captured prior (upstream-only).
-        let capture_aliases: Vec<String> = vec![upstream_iface.to_string()];
-        let apply_aliases: Vec<String> = vec![TUN_DEVICE_NAME.into(), upstream_iface.to_string()];
-
-        let prior = match system::capture_adapters(&capture_aliases) {
-            Ok(v) => v,
-            Err(e) => {
-                warn!(error = %e, "system DNS capture failed; skipping apply");
-                return None;
-            }
-        };
-
-        // Persist BEFORE mutating so a mid-apply crash has a recoverable
-        // file. Matches the `tun_engine::routing::SystemRouting::install`
-        // precondition.
-        if let Some(dir) = state_dir {
-            let state = DnsState {
-                version: SCHEMA_VERSION,
-                chosen_loopback: server.addr(),
-                adapters: prior.clone(),
-            };
-            if let Err(e) = dns_state::save(dir, &state) {
-                warn!(error = %e, "dns_state::save failed; continuing without crash-recovery file");
-            }
-        }
-
-        if let Err(e) = system::apply_loopback(&apply_aliases, server.addr().ip()) {
-            warn!(error = %e, "system DNS apply failed; DNS forwarder unreachable by OS clients");
-            return None;
-        }
-
-        Some(prior)
-    };
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-    let result: Option<Vec<crate::dns_state::DnsPriorAdapter>> = {
-        let _ = (server, upstream_iface, state_dir);
-        None
-    };
-
-    info!(
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "apply_dns_settings done"
-    );
-    result
 }

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1,6 +1,6 @@
 // Proxy lifecycle manager — start/stop/reload orchestration.
 //
-// # Design notes (post-#165)
+// # Design notes (post-#165, post-#397)
 //
 // `ProxyManager` is parameterized over two traits:
 // - `P: Proxy`     — the proxy backend (production: `ShadowsocksProxy`).
@@ -8,18 +8,27 @@
 //
 // Both traits return RAII associated types on success (`P::Running` /
 // `R::Installed`) whose Drop impls clean up their respective side effects.
-// This is what makes `start_inner` cancel-safe: if the start future is
-// dropped mid-flight (for example because a `tokio::select!` cancel branch
-// fired), the locally-owned `Running` / `Installed` values are dropped in
-// reverse-declaration order — aborting the shadowsocks task and tearing
-// down routes without the ProxyManager fields ever being mutated.
+// RAII unwind covers the Err-return path of `start_inner` — if any phase
+// returns Err, locally-owned guards drop in reverse-declaration order,
+// aborting the shadowsocks task and tearing down routes without the
+// ProxyManager fields ever being mutated.
+//
+// **Cancellation is cooperative (#397).** The pre-#397 design wrapped
+// `start_inner` in an outer `tokio::select!` and relied on future-drop
+// for cancel propagation; that approach is fundamentally incompatible
+// with phases that need async cleanup (DNS apply, see #395) — once a
+// sync FFI is on a tokio worker the future can't be preempted. The
+// current design threads a `CancellationToken` *into* `start_inner` and
+// has every long-running phase observe it cooperatively. RAII Drop is
+// retained as the catastrophic / panic teardown safety net only.
 //
 // A cycle's transient state lives in `Option<RunningState<P, R>>`. When
 // `stop()` takes the state, the proxy handle is explicitly
 // `stop().await`ed (so errors are reported), then the routes guard drops
 // (tearing down). On a successful `start`, the full `RunningState` is
-// committed to `self.running` from the synchronous match arm, after the
-// `tokio::select!` that races the cancel token has already resolved.
+// committed to `self.running` strictly after `start_inner` returns
+// `Ok(state)`; the cooperative-cancel path returns `Err(Cancelled)`
+// before reaching the commit.
 //
 // There are deliberately no getters for `proxy` or `routing` — test access
 // to mock state happens via `Arc` clones captured before the mock is
@@ -255,22 +264,27 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
     /// `Err(ProxyError::Cancelled)` and rolls back partial state (via
     /// the RAII guards inside `start_inner`) without mutating `self`.
     ///
+    /// **Cooperative cancellation (#397).** The pre-#397 implementation
+    /// wrapped `start_inner` in an outer `tokio::select! { cancel.cancelled() => …, r = start_inner => r }`
+    /// and relied on future-drop to unwind locally-owned RAII guards.
+    /// That approach is sound for sync-cleanable resources but cannot
+    /// preempt phases whose inner future never yields (sync FFI on a
+    /// tokio worker, the #395 symptom). The current design instead
+    /// threads the token *into* `start_inner` and has every long-running
+    /// phase observe it cooperatively — see the `start_inner` doc and
+    /// the per-phase cancel-aware wrappers.
+    ///
     /// Three race scenarios are handled correctly:
     ///
-    /// 1. **Cancel before any `start_inner` await.** `tokio::select!`
-    ///    with `biased;` polls the cancel branch first, so an
-    ///    already-cancelled token returns `Cancelled` without invoking
-    ///    `start_inner` at all.
-    /// 2. **Cancel mid-flight.** `select!` drops the `start_inner`
-    ///    future, which runs every live RAII guard's `Drop` in
-    ///    reverse-declaration order — the proxy task is aborted (by
-    ///    `P::Running::drop`), routes are torn down (by
-    ///    `R::Installed::drop`), and the state file is cleared (by the
-    ///    same `R::Installed::drop`).
+    /// 1. **Cancel before `start_inner` starts.** The first phase's
+    ///    `cancel.is_cancelled()` check fires immediately and returns
+    ///    `Cancelled` without doing any work.
+    /// 2. **Cancel mid-flight.** Each phase's cancel-aware wrapper
+    ///    returns `Cancelled` cooperatively; locally-owned RAII guards
+    ///    drop in reverse-declaration order as the function unwinds.
     /// 3. **Cancel right after `start_inner` returns `Ok(started)`.**
-    ///    Commit to `self` happens in this outer function AFTER
-    ///    `select!` has already yielded `Ok(started)`, so the late
-    ///    cancel cannot race the commit. The started proxy is left
+    ///    Commit to `self` happens after `start_inner` yields, so the
+    ///    late cancel cannot race the commit. The started proxy is left
     ///    running; the client sees `Ok(())`. A caller that wanted to
     ///    cancel that late can follow up with an explicit stop.
     pub async fn start_cancellable(
@@ -290,21 +304,21 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             return Err(ProxyError::AlreadyRunning);
         }
 
-        // Run start_inner in a select! against the cancel token.
         // `start_inner` is a free associated function — it does NOT
-        // touch `self`, so dropping the future leaves `self` untouched.
-        // All partial state is owned by the locally-constructed RAII
-        // types inside start_inner and cleans up on drop.
+        // touch `self`, so any cancel-driven unwind leaves `self`
+        // untouched. All partial state is owned by the locally-
+        // constructed RAII types inside start_inner and cleans up on
+        // drop. The cancel token is threaded *into* start_inner instead
+        // of being raced against it (#397); this prevents the
+        // "uncancellable sync phase" foot-gun where a future that
+        // doesn't yield blocks the outer select! from observing cancel.
         debug!("awaiting start_inner");
-        let result: Result<RunningState<P, R>, ProxyError> = tokio::select! {
-            biased;
-            _ = cancel.cancelled() => Err(ProxyError::Cancelled),
-            r = Self::start_inner(&self.proxy, &self.routing, config, self.state_dir.as_deref()) => r,
-        };
+        let result: Result<RunningState<P, R>, ProxyError> =
+            Self::start_inner(&self.proxy, &self.routing, config, self.state_dir.as_deref(), cancel).await;
 
         // Commit (or record the error) in the outer function, so the
         // only path that mutates `self.running = Some(..)` is strictly
-        // after the select! has completed successfully.
+        // after start_inner has completed successfully.
         match result {
             Ok(state) => {
                 let server_ip = state.server_ip;
@@ -339,13 +353,44 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         }
     }
 
-    /// Produce a [`RunningState`] without touching `self`. All partial
-    /// state is owned by local RAII values so that dropping this future
-    /// at any `.await` point unwinds cleanly:
+    /// Produce a [`RunningState`] without touching `self`.
     ///
-    /// 1. `P::Running` — on drop, aborts the spawned proxy task.
-    /// 2. `R::Installed` — on drop, tears down routes and clears the
+    /// **Cooperative cancellation (#397).** Each long-running phase
+    /// observes the supplied `cancel` token and returns
+    /// `Err(ProxyError::Cancelled)` cooperatively. Earlier RAII guards
+    /// drop in reverse-declaration order when the function returns Err,
+    /// tearing down anything that was constructed before the cancel
+    /// observation:
+    ///
+    /// 1. `PluginChain` — on drop, cancels its garter token and clears
+    ///    the plugin state file.
+    /// 2. `P::Running` — on drop, aborts the spawned proxy task.
+    /// 3. `R::Installed` — on drop, tears down routes and clears the
     ///    crash-recovery state file.
+    ///
+    /// Per-phase cancellation strategy:
+    /// - **Phase 1 (plugin chain)**: the bridge cancel is threaded into
+    ///   `start_plugin_chain`, which derives child tokens for each
+    ///   attempt and races readiness against cancel.
+    /// - **Phase 2 (proxy.start)**: `tokio::select!` around
+    ///   `proxy.start(ss_config)`. Drop-on-cancel is sound — Proxy
+    ///   implementations own no async cleanup obligations on an
+    ///   in-flight start.
+    /// - **Phase 3 (build_local_dns / bind_ladder)**: cancel is passed
+    ///   to `bind_ladder` for per-candidate observation. Outer
+    ///   `tokio::select!` against cancel re-emits Cancelled canonically.
+    /// - **Phase 4 (forwarder self-test)**: cooperative — the token is
+    ///   threaded into `run_forwarder_self_test` which checks it
+    ///   between retry attempts and races the per-attempt forward.
+    /// - **Phases 5–6 (Dispatcher::new, routing.install)**: sync; cancel
+    ///   observed at phase boundary only (`if cancel.is_cancelled()`).
+    ///   These calls are millisecond-scale; mid-call preemption isn't
+    ///   needed.
+    /// - **Phase 7 (apply_dns_settings)**: chunk-1 NOT yet
+    ///   cancel-aware (still routes through pre-#397 netsh sync path
+    ///   that the #395 reproduction caught taking 22 s). Cancel-aware
+    ///   apply lands in chunks 2–3 alongside the Win32-native DNS
+    ///   refactor.
     ///
     /// CRITICAL ORDERING: the routing provider is responsible for
     /// persisting the recovery state BEFORE mutating routes. A panic
@@ -358,9 +403,16 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         routing: &R,
         config: &ProxyConfig,
         state_dir: Option<&std::path::Path>,
+        cancel: CancellationToken,
     ) -> Result<RunningState<P, R>, ProxyError> {
         debug!("start_inner entered");
-        // Start plugin chain via Garter if a plugin is configured.
+        // Pre-flight: short-circuit a pre-cancelled token before any work.
+        if cancel.is_cancelled() {
+            return Err(ProxyError::Cancelled);
+        }
+        // Phase 1: start plugin chain via Garter if a plugin is configured.
+        // `start_plugin_chain` threads `cancel` through to its readiness
+        // wait + bind_ephemeral retries.
         let plugin_chain = if let Some(ref plugin_name) = config.server.plugin {
             let plugin_path = crate::proxy::config::resolve_plugin_path(plugin_name);
             let chain = crate::proxy::plugin::start_plugin_chain(
@@ -371,12 +423,21 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
                 config.server.server_port,
                 state_dir,
                 config.diagnostic_plugin_tap,
+                &cancel,
             )
             .await?;
             Some(chain)
         } else {
             None
         };
+
+        // Cancel observed between phases — required because a
+        // pre-cancelled token can slip past `start_plugin_chain` when
+        // there is no plugin configured (the `if let` branch above is
+        // skipped entirely).
+        if cancel.is_cancelled() {
+            return Err(ProxyError::Cancelled);
+        }
 
         // Build shadowsocks config. When a plugin chain is running,
         // point ss-service at the chain's local port.
@@ -390,7 +451,12 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // only bind the SOCKS5 listener.
         if matches!(config.tunnel_mode, TunnelMode::SocksOnly) {
             debug!(local_count = ss_config.local.len(), "calling proxy.start");
-            let running_proxy = proxy.start(ss_config).await?;
+            // Phase 2 (SocksOnly): race proxy.start against cancel.
+            let running_proxy = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
+                r = proxy.start(ss_config) => r?,
+            };
             debug!("proxy.start returned Ok");
 
             // In-bridge SOCKS5 loopback self-test (#200 H2 vs H3 disambiguation).
@@ -482,35 +548,51 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
         // most likely regression (asserting routing.install was NOT
         // called when the gate fails).
 
-        // (1) Start the SS SOCKS5 proxy.
-        let running_proxy = proxy.start(ss_config).await?;
+        // Phase 2 (Full mode): start the SS SOCKS5 proxy, racing the
+        // start future against cancel. Drop on Running aborts the SS
+        // task on cancel via P::Running::drop.
+        let running_proxy = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
+            r = proxy.start(ss_config) => r?,
+        };
 
-        // (2) Build local DNS forwarder + server. Now Err on bind failure
+        // Phase 3: build local DNS forwarder + server. Now Err on bind failure
         // (was silent-degrade pre-#388). Returns the forwarder Arc so
-        // the gate can drive it without re-plumbing.
-        let (local_dns_server, local_dns_endpoint, forwarder) =
-            build_local_dns(&config.dns, config.local_port, gw_info.ipv6_available).await?;
+        // the gate can drive it without re-plumbing. `bind_ladder`
+        // observes the cancel token between candidates; the outer
+        // `tokio::select!` here catches cancel even mid-attempt.
+        let (local_dns_server, local_dns_endpoint, forwarder) = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
+            r = build_local_dns(&config.dns, config.local_port, gw_info.ipv6_available, cancel.clone()) => r?,
+        };
 
-        // (3) Blocking forwarder self-test gate. Runs synchronously
+        // Phase 4: blocking forwarder self-test gate. Runs synchronously
         // BEFORE Dispatcher::new / routing.install / apply_dns_settings.
         // On Err, the locally-owned `running_proxy` Drop aborts the SS
         // task and `plugin_chain` (further up the stack) Drop SIGTERMs
-        // the chain. System state is untouched. The gate is
-        // cancellation-safe via the outer `tokio::select!` in
-        // start_cancellable — dropping the future cleanly releases all
-        // in-flight forwarder connections.
+        // the chain. System state is untouched. `run_forwarder_self_test`
+        // observes cancel cooperatively between retry attempts and races
+        // each per-attempt forward against it (#397).
         if let Some(fwd) = forwarder.as_ref() {
             let started = std::time::Instant::now();
             let outcome = run_forwarder_self_test(
                 std::sync::Arc::clone(fwd),
                 config.dns.servers.clone(),
                 config.diagnostic_plugin_tap,
+                cancel.clone(),
             )
             .await;
             outcome.into_result(started.elapsed().as_millis() as u64)?;
         }
 
-        // (4) Start the dispatcher (owns TUN device + smoltcp). Skipped
+        // Phase 5: cancel checkpoint before Dispatcher::new (sync, cannot
+        // be preempted mid-call once entered).
+        if cancel.is_cancelled() {
+            return Err(ProxyError::Cancelled);
+        }
+        // Start the dispatcher (owns TUN device + smoltcp). Skipped
         // under #[cfg(test)] because creating a TUN requires elevation.
         #[cfg(not(test))]
         let dispatcher = {
@@ -532,7 +614,13 @@ impl<P: Proxy, R: Routing> ProxyManager<P, R> {
             None
         };
 
-        // (5) Install the routes — NOW traffic starts flowing to the TUN.
+        // Phase 6: cancel checkpoint before routing.install (sync; mid-
+        // call preemption isn't structurally possible — netsh/route
+        // shell-outs are uninterruptible from our process).
+        if cancel.is_cancelled() {
+            return Err(ProxyError::Cancelled);
+        }
+        // Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
         // (6) Apply system DNS AFTER routes install so the OS "best-route to
@@ -784,6 +872,7 @@ async fn build_local_dns(
     dns_cfg: &hole_common::config::DnsConfig,
     local_ss_port: u16,
     ipv6_bypass_available: bool,
+    cancel: CancellationToken,
 ) -> Result<
     (
         Option<crate::dns::server::LocalDnsServer>,
@@ -819,7 +908,7 @@ async fn build_local_dns(
         ipv6_bypass_available,
     ));
 
-    let server = crate::dns::server::LocalDnsServer::bind_ladder(Arc::clone(&forwarder)).await?;
+    let server = crate::dns::server::LocalDnsServer::bind_ladder(Arc::clone(&forwarder), cancel).await?;
     info!(addr = %server.addr(), "LocalDnsServer bound");
 
     let endpoint = if dns_cfg.intercept_udp53 {
@@ -860,6 +949,7 @@ async fn run_forwarder_self_test(
     forwarder: std::sync::Arc<crate::dns::forwarder::DnsForwarder>,
     servers: Vec<std::net::IpAddr>,
     diagnostic_tap_enabled: bool,
+    cancel: CancellationToken,
 ) -> SelfTestOutcome {
     const PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(1500);
     const OUTER_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
@@ -875,7 +965,21 @@ async fn run_forwarder_self_test(
     let outcome = tokio::time::timeout(OUTER_BUDGET, async {
         let mut last_err: Option<String> = None;
         for attempt in 1..=ATTEMPTS {
-            match tokio::time::timeout(PER_ATTEMPT, forwarder.forward(&query)).await {
+            // Cooperative cancel check between retry attempts (#397).
+            if cancel.is_cancelled() {
+                return SelfTestOutcome::Cancelled;
+            }
+            // Future-drop on `forwarder.forward(&query)` IS acceptable
+            // here — the single exception to the cooperative cancellation
+            // contract in this module (#397). The `DnsForwarder`'s only
+            // in-flight resource is a TCP/UDP socket that closes on Drop
+            // (sync, trivial); there is no async cleanup to await.
+            let result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,
+                r = tokio::time::timeout(PER_ATTEMPT, forwarder.forward(&query)) => r,
+            };
+            match result {
                 Ok(reply) => {
                     if is_dns_reply_ok(&reply) {
                         return SelfTestOutcome::Ok { attempts: attempt };
@@ -914,14 +1018,26 @@ async fn run_forwarder_self_test(
                 warn!("{TAP_DISABLED_HINT}");
             }
         }
+        SelfTestOutcome::Cancelled => {
+            info!(%first_server, elapsed_ms, "forwarder self-test cancelled");
+        }
     }
     outcome
 }
 
 #[derive(Debug)]
 enum SelfTestOutcome {
-    Ok { attempts: u32 },
-    Failed { attempts: u32, reason: String },
+    Ok {
+        attempts: u32,
+    },
+    Failed {
+        attempts: u32,
+        reason: String,
+    },
+    /// The bridge cancel token fired before the self-test could complete
+    /// or fail definitively (#397). Maps to `ProxyError::Cancelled` via
+    /// `into_result`; not a diagnostic failure (the user asked for it).
+    Cancelled,
 }
 
 impl SelfTestOutcome {
@@ -937,6 +1053,7 @@ impl SelfTestOutcome {
                 attempts,
                 elapsed_ms,
             }),
+            Self::Cancelled => Err(ProxyError::Cancelled),
         }
     }
 }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1114,7 +1114,7 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                let outcome = run_forwarder_self_test(forwarder, vec![], false).await;
+                let outcome = run_forwarder_self_test(forwarder, vec![], false, CancellationToken::new()).await;
                 assert!(matches!(outcome, SelfTestOutcome::Ok { attempts: 0 }));
             });
 
@@ -1147,7 +1147,13 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                let outcome = run_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()], false).await;
+                let outcome = run_forwarder_self_test(
+                    forwarder,
+                    vec!["127.0.0.1".parse().unwrap()],
+                    false,
+                    CancellationToken::new(),
+                )
+                .await;
                 let SelfTestOutcome::Failed { attempts, reason } = outcome else {
                     panic!("expected Failed");
                 };
@@ -1202,7 +1208,13 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                let _ = run_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()], true).await;
+                let _ = run_forwarder_self_test(
+                    forwarder,
+                    vec!["127.0.0.1".parse().unwrap()],
+                    true,
+                    CancellationToken::new(),
+                )
+                .await;
             });
 
         let output = writer.snapshot_string();
@@ -1236,7 +1248,13 @@ mod self_test {
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
                 let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
-                let _ = run_forwarder_self_test(forwarder, vec!["127.0.0.1".parse().unwrap()], false).await;
+                let _ = run_forwarder_self_test(
+                    forwarder,
+                    vec!["127.0.0.1".parse().unwrap()],
+                    false,
+                    CancellationToken::new(),
+                )
+                .await;
             });
 
         let output = writer.snapshot_string();
@@ -1268,7 +1286,7 @@ mod self_test {
                     protocol: DnsProtocol::PlainTcp,
                     intercept_udp53: true,
                 };
-                match build_local_dns(&cfg, 1080, false).await {
+                match build_local_dns(&cfg, 1080, false, CancellationToken::new()).await {
                     Err(ProxyError::ForwarderSelfTestFailed {
                         attempts: 0,
                         elapsed_ms: 0,
@@ -1346,7 +1364,7 @@ mod self_test {
                     protocol: DnsProtocol::PlainTcp,
                     intercept_udp53: true,
                 };
-                let res = build_local_dns(&cfg, 1080, false).await;
+                let res = build_local_dns(&cfg, 1080, false, CancellationToken::new()).await;
                 let (srv, ep, fwd) = match res {
                     Ok(t) => t,
                     Err(e) => panic!("expected Ok((None, None, None)) for disabled DNS, got {e:?}"),

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -897,17 +897,19 @@ fn reload_when_not_running_starts() {
 /// `networksetup` calls fail fast (adapter not found), but the wrapping
 /// instrumentation still emits the diagnostic.
 #[skuld::test]
-fn apply_dns_settings_emits_done_info_log() {
+fn dns_apply_emits_done_info_log() {
     use crate::dns::connector::DirectConnector;
     use crate::dns::forwarder::DnsForwarder;
     use crate::dns::server::LocalDnsServer;
+    use crate::dns::system::{Dns, SystemDns};
     use crate::test_support::log_capture::VecWriter;
     use hole_common::config::DnsConfig;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tokio_util::sync::CancellationToken;
     use tracing_subscriber::fmt;
     use tracing_subscriber::layer::{Layer, SubscriberExt};
 
-    // Current-thread runtime so `tokio::spawn` in `apply_dns_settings`
+    // Current-thread runtime so `tokio::spawn` in `SystemDns::apply`
     // (or anything downstream) stays on the test thread. The helper
     // asserts this at install time. See bindreams/hole#302.
     tokio::runtime::Builder::new_current_thread()
@@ -934,7 +936,21 @@ fn apply_dns_settings_emits_done_info_log() {
             let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
             let srv = LocalDnsServer::bind(addr, forwarder).await.expect("bind ephemeral");
 
-            let _ = apply_dns_settings(&srv, "hole-test-nonexistent-iface-xyz", None).await;
+            let dns = SystemDns::default();
+            // Adapter doesn't exist — `Win32Real::get_settings` returns
+            // `Ok(None)` so nothing is captured and apply also no-ops, but
+            // the surrounding `apply_dns_settings done` INFO log still fires.
+            let mut applied = dns
+                .apply(
+                    srv,
+                    vec!["hole-test-nonexistent-iface-xyz".into()],
+                    vec![],
+                    None,
+                    CancellationToken::new(),
+                )
+                .await
+                .expect("apply ok with missing adapter");
+            applied.shutdown().await;
 
             let output = writer.snapshot_string();
             assert!(
@@ -963,17 +979,20 @@ fn apply_dns_settings_emits_done_info_log() {
 
 #[cfg(target_os = "windows")]
 #[skuld::test]
-fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
+fn dns_apply_skips_tun_from_capture_keeps_in_apply() {
     use crate::dns::connector::DirectConnector;
     use crate::dns::forwarder::DnsForwarder;
     use crate::dns::server::LocalDnsServer;
+    use crate::dns::system::{Dns, SystemDns};
+    use crate::proxy::TUN_DEVICE_NAME;
     use crate::test_support::log_capture::VecWriter;
     use hole_common::config::DnsConfig;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use tokio_util::sync::CancellationToken;
     use tracing_subscriber::fmt;
     use tracing_subscriber::layer::{Layer, SubscriberExt};
 
-    // Current-thread runtime — see `apply_dns_settings_emits_done_info_log`
+    // Current-thread runtime — see `dns_apply_emits_done_info_log`
     // for why the multi-thread `rt()` is unsafe with `set_default`.
     // bindreams/hole#302.
     tokio::runtime::Builder::new_current_thread()
@@ -999,18 +1018,41 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
             let srv = LocalDnsServer::bind(addr, forwarder).await.expect("bind ephemeral");
 
             // Upstream alias uses a distinctive name so we can grep for it.
-            let _ = apply_dns_settings(&srv, "hole-p4-test-upstream-xyz", None).await;
+            // Mirrors `start_inner`'s phase 7 wiring: capture_aliases=
+            // [upstream] (TUN skipped per Phase 4 #247), apply_aliases=
+            // [TUN, upstream].
+            let dns = SystemDns::default();
+            let mut applied = dns
+                .apply(
+                    srv,
+                    vec!["hole-p4-test-upstream-xyz".into()],
+                    vec![TUN_DEVICE_NAME.into(), "hole-p4-test-upstream-xyz".into()],
+                    None,
+                    CancellationToken::new(),
+                )
+                .await
+                .expect("apply ok");
+            applied.shutdown().await;
 
             let output = writer.snapshot_string();
 
-            // CAPTURE side: only the upstream alias appears. The TUN alias
-            // `hole-tun` must NOT appear in any `Win32Real::get_settings`
-            // line, because we no longer query its prior state. (Post-#397
-            // the Win32 backend replaced the `capture_one` / `show_dnsservers`
-            // netsh helpers; the debug tag is now `Win32Real::get_settings`.)
+            // The per-FFI lines from `Win32Real` are emitted on the
+            // blocking pool thread (the `apply_windows` loop dispatches
+            // each backend call via `spawn_blocking`) so the test's
+            // thread-local subscriber never sees them. We assert on the
+            // wrapper lines from `apply_windows` instead — those run on
+            // the test thread.
+            //
+            // Both fake aliases are missing from the system: capture
+            // surfaces `"DNS capture: adapter not found; skipping
+            // alias=..."` (debug); apply surfaces `"DNS apply failed;
+            // continuing alias=..."` (warn). Capture must NEVER carry
+            // the TUN alias (Phase 4 #247); apply MUST carry both.
+
+            // CAPTURE side: only the upstream alias appears.
             let capture_lines: Vec<&str> = output
                 .lines()
-                .filter(|l| l.contains("Win32Real::get_settings"))
+                .filter(|l| l.contains("DNS capture: adapter not found"))
                 .collect();
             assert!(
                 !capture_lines.is_empty(),
@@ -1018,7 +1060,7 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
             );
             for line in &capture_lines {
                 assert!(
-                    !line.contains("alias=hole-tun "),
+                    !line.contains(&format!("alias={TUN_DEVICE_NAME}")),
                     "capture ran on TUN — expected to be skipped. line: {line}"
                 );
             }
@@ -1029,15 +1071,17 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
                 "capture should have run on upstream alias; got:\n{output}"
             );
 
-            // APPLY side: the TUN alias DOES appear — we still set loopback DNS
-            // on the TUN so the OS's best-route-to-DNS lookup lands on 127.x.
-            // Post-#397 the per-FFI tag is `Win32Real::set_loopback`.
+            // APPLY side: the TUN alias DOES appear — we still set
+            // loopback DNS on the TUN so the OS's best-route-to-DNS
+            // lookup lands on 127.x.
             let apply_lines: Vec<&str> = output
                 .lines()
-                .filter(|l| l.contains("Win32Real::set_loopback"))
+                .filter(|l| l.contains("DNS apply failed; continuing"))
                 .collect();
             assert!(
-                apply_lines.iter().any(|l| l.contains("alias=hole-tun")),
+                apply_lines
+                    .iter()
+                    .any(|l| l.contains(&format!("alias={TUN_DEVICE_NAME}"))),
                 "apply should have run on TUN alias; got:\n{output}"
             );
             assert!(

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1,3 +1,8 @@
+// `CancellationToken::new` is pervasive across these tests as the test
+// harness's root signal; module-level allow per clippy.toml's
+// "Bridge cancellation contract" sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use super::*;
 use crate::proxy::{Proxy, ProxyError, RunningProxy};
 use hole_common::config::ServerEntry;

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1004,11 +1004,13 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
             let output = writer.snapshot_string();
 
             // CAPTURE side: only the upstream alias appears. The TUN alias
-            // `hole-tun` must NOT appear in any `capture_one` / `show_dnsservers`
-            // line, because we no longer query its prior state.
+            // `hole-tun` must NOT appear in any `Win32Real::get_settings`
+            // line, because we no longer query its prior state. (Post-#397
+            // the Win32 backend replaced the `capture_one` / `show_dnsservers`
+            // netsh helpers; the debug tag is now `Win32Real::get_settings`.)
             let capture_lines: Vec<&str> = output
                 .lines()
-                .filter(|l| l.contains("show_dnsservers") || l.contains("capture_one"))
+                .filter(|l| l.contains("Win32Real::get_settings"))
                 .collect();
             assert!(
                 !capture_lines.is_empty(),
@@ -1029,9 +1031,10 @@ fn apply_dns_settings_skips_tun_from_capture_keeps_in_apply() {
 
             // APPLY side: the TUN alias DOES appear — we still set loopback DNS
             // on the TUN so the OS's best-route-to-DNS lookup lands on 127.x.
+            // Post-#397 the per-FFI tag is `Win32Real::set_loopback`.
             let apply_lines: Vec<&str> = output
                 .lines()
-                .filter(|l| l.contains("set_dns_ipv4") || l.contains("set_dns_ipv6"))
+                .filter(|l| l.contains("Win32Real::set_loopback"))
                 .collect();
             assert!(
                 apply_lines.iter().any(|l| l.contains("alias=hole-tun")),

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -221,6 +221,8 @@ async fn maybe_start_plugin(
     // would add noise without value here.
     // server_test is a one-shot probe with no caller-side cancel; pass a
     // never-signalled token so the chain runs to its natural conclusion.
+    #[allow(clippy::disallowed_methods)]
+    // One-shot CLI probe: no caller-side cancel exists. See clippy.toml CancellationToken::new rule.
     let chain_cancel = CancellationToken::new();
     let chain = crate::proxy::plugin::start_plugin_chain(
         plugin_name,

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -21,6 +21,7 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{lookup_host, TcpStream};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 const HEAD_REQUEST: &[u8] = b"HEAD / HTTP/1.0\r\nHost: 1.1.1.1\r\nConnection: close\r\n\r\n";
@@ -218,6 +219,9 @@ async fn maybe_start_plugin(
     // `diagnostic_tap = false`: one-shot probe; the user is connecting
     // for a quick test, not a debugging session. Per-conn tap metrics
     // would add noise without value here.
+    // server_test is a one-shot probe with no caller-side cancel; pass a
+    // never-signalled token so the chain runs to its natural conclusion.
+    let chain_cancel = CancellationToken::new();
     let chain = crate::proxy::plugin::start_plugin_chain(
         plugin_name,
         &plugin_path,
@@ -226,6 +230,7 @@ async fn maybe_start_plugin(
         server_port,
         None,
         false,
+        &chain_cancel,
     )
     .await
     .map_err(|e| ServerTestOutcome::PluginStartFailed { detail: e.to_string() })?;

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -219,7 +219,11 @@ impl ChainRunner {
         addrs.extend(intermediate);
         addrs.push(remote_addr);
 
-        // Shared shutdown token
+        // Shared shutdown token. ChainRunner owns its own shutdown scope —
+        // the external `cancel_token` builder option is wired into this
+        // token below so cancel propagation flows in either direction.
+        #[allow(clippy::disallowed_methods)]
+        // Garter's chain-shutdown root: distinct from any caller cancel scope. See hole's clippy.toml CancellationToken::new rule.
         let shutdown = CancellationToken::new();
         shutdown::register_signal_handler(shutdown.clone());
 

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -1,3 +1,8 @@
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per the hole workspace clippy.toml's "Bridge cancellation contract"
+// sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 

--- a/crates/garter/src/plugin_tests.rs
+++ b/crates/garter/src/plugin_tests.rs
@@ -1,3 +1,8 @@
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per the hole workspace clippy.toml's "Bridge cancellation contract"
+// sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use crate::plugin::ChainPlugin;
 use std::net::SocketAddr;
 use tokio_util::sync::CancellationToken;

--- a/crates/garter/src/shutdown_tests.rs
+++ b/crates/garter/src/shutdown_tests.rs
@@ -1,3 +1,8 @@
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per the hole workspace clippy.toml's "Bridge cancellation contract"
+// sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use std::time::Duration;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -13,6 +13,11 @@
 //! [bindreams/hole#302](https://github.com/bindreams/hole/issues/302).
 //! `#[skuld::test] async fn` builds a current-thread runtime by default.
 
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per the hole workspace clippy.toml's "Bridge cancellation contract"
+// sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use std::net::SocketAddr;
 use std::time::Duration;
 

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -1,3 +1,8 @@
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per the hole workspace clippy.toml's "Bridge cancellation contract"
+// sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;

--- a/crates/garter/tests/tap_integration.rs
+++ b/crates/garter/tests/tap_integration.rs
@@ -6,6 +6,11 @@
 //! Rust `StubPlugin`s, which is faster but doesn't verify
 //! Apache-2.0-process-boundary behavior.
 
+// `CancellationToken::new` is the cancel-test harness root; module-level
+// allow per the hole workspace clippy.toml's "Bridge cancellation contract"
+// sanctioned-test-file exception.
+#![allow(clippy::disallowed_methods)]
+
 use std::path::PathBuf;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -27,6 +27,32 @@
       AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of Hole is already installed." />
 
+    <!-- Windows-version floor: Hole's DNS bridge uses
+         `SetInterfaceDnsSettings` (added in Windows 10 build 19041 /
+         version 2004, May 2020) instead of the netsh subprocess chain.
+         The Win32 FFI is ~10× faster than netsh and unlike netsh is
+         cooperatively cancellable mid-apply, which is what fixes the
+         "3-click misery" symptom on Defender-active machines.
+         `SetInterfaceDnsSettings` is missing on Windows 10 LTSC 2019,
+         Server 2019, and any pre-2004 build — the launch condition
+         refuses cleanly rather than failing at first proxy-start.
+
+         `CurrentBuildNumber` is `REG_SZ`; WiX/MSI's expression
+         evaluator coerces numeric strings to integers when both sides
+         look numeric. `WIN10BUILD >= 19041` (no quotes around 19041)
+         is therefore an integer comparison. See bindreams/hole#397. -->
+    <Property Id="WIN10BUILD">
+      <RegistrySearch
+        Id="Win10BuildSearch"
+        Root="HKLM"
+        Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+        Name="CurrentBuildNumber"
+        Type="raw" />
+    </Property>
+    <Launch
+      Condition="Installed OR WIN10BUILD &gt;= 19041"
+      Message="Hole requires Windows 10 version 2004 (May 2020) or later. SetInterfaceDnsSettings is unavailable on older builds." />
+
     <!-- Embed cabinets inside the .msi so the installer is one self-contained
          file. WiX v4+ defaults to EmbedCab="no" (external cabs) when this
          element is omitted; that made v0.1.0 unusable (#357). -->

--- a/msi-installer/tests/test_hole_msi.py
+++ b/msi-installer/tests/test_hole_msi.py
@@ -440,6 +440,68 @@ def test_installdirdlg_next_override_wins(decompiled_tree: ET.ElementTree) -> No
     )
 
 
+# Launch-condition tests ===============================================================================================
+#
+# Source-side mirror lives in test_hole_wxs.py::test_launch_condition_requires_build_19041.
+# This test guards against the gate being silently dropped during the
+# WiX compile → MSI → decompile round-trip (e.g. a WiX schema migration
+# that changes how LaunchCondition is encoded).
+
+
+def test_decompiled_has_win10_launch_condition(decompiled_tree: ET.ElementTree) -> None:
+    """The built MSI must carry a LaunchCondition gating install on build >= 19041.
+
+    `wix msi decompile` lowers a MSI LaunchCondition table row to either
+    a `<Launch>` element (WiX v4+ schema) or a legacy
+    `<Condition Message="...">CONDITION_TEXT</Condition>` form. Accept
+    either shape; assert the condition text mentions WIN10BUILD and
+    19041. See bindreams/hole#397.
+    """
+    pkg = _decompiled_package(decompiled_tree)
+
+    found_conditions: list[str] = []
+    for el in pkg.iter(f"{{{NS['wix']}}}Launch"):
+        cond = el.get("Condition") or ""
+        if "WIN10BUILD" in cond:
+            found_conditions.append(cond)
+    for el in pkg.iter(f"{{{NS['wix']}}}Condition"):
+        # Legacy form: condition text is the element's .text, not a
+        # Condition= attribute. Only Conditions carrying a Message= are
+        # LaunchConditions (others gate components/features).
+        if el.get("Message") and el.text and "WIN10BUILD" in el.text:
+            found_conditions.append(el.text)
+
+    assert found_conditions, (
+        "Decompiled MSI has no LaunchCondition referencing WIN10BUILD. The "
+        "#397 Windows-version gate is missing from the built MSI."
+    )
+    assert any(
+        "19041" in c for c in found_conditions
+    ), (f"LaunchCondition(s) found referencing WIN10BUILD but none gate on 19041. "
+        f"Conditions: {found_conditions}")
+
+
+def test_decompiled_has_win10build_property(decompiled_tree: ET.ElementTree) -> None:
+    """The built MSI must declare a WIN10BUILD property backed by a RegistrySearch.
+
+    Without the property, the launch condition's WIN10BUILD reference
+    evaluates to empty and the gate becomes vacuous.
+    """
+    pkg = _decompiled_package(decompiled_tree)
+    prop = _find_property(pkg, "WIN10BUILD")
+    assert prop is not None, "WIN10BUILD property missing from built MSI"
+
+    search = prop.find(f"{{{NS['wix']}}}RegistrySearch")
+    assert search is not None, (
+        "WIN10BUILD property has no <RegistrySearch> child in the built MSI — "
+        "the gate has no value to evaluate against."
+    )
+    assert search.get("Name") == "CurrentBuildNumber", (
+        f"WIN10BUILD RegistrySearch must read CurrentBuildNumber, "
+        f"got Name='{search.get('Name')}'."
+    )
+
+
 def test_verifyreadydlg_back_override_wins(decompiled_tree: ET.ElementTree) -> None:
     """The last (NOT Installed) NewDialog row for (VerifyReadyDlg, Back) must target ShortcutsDlg.
 

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -327,6 +327,72 @@ def test_media_template_embeds_cab(package: ET.Element) -> None:
     )
 
 
+# Launch-condition tests ===============================================================================================
+#
+# Hole's #397 DNS refactor uses `SetInterfaceDnsSettings`, which is
+# missing on Windows builds older than 19041 (version 2004, May 2020).
+# The MSI must refuse to install on older builds rather than letting
+# the bridge crash at first proxy-start.
+
+
+def test_win10build_property_uses_registry_search(package: ET.Element) -> None:
+    """The WIN10BUILD property must read HKLM CurrentBuildNumber.
+
+    The Windows-version gate (Launch condition) reads from the
+    `CurrentBuildNumber` registry value, which is a `REG_SZ` whose
+    numeric content WiX's expression evaluator can compare as an
+    integer. The bridge requires build >= 19041 (#397).
+    """
+    win10build = None
+    for prop in package.iter(f"{{{NS['wix']}}}Property"):
+        if prop.get("Id") == "WIN10BUILD":
+            win10build = prop
+            break
+    assert win10build is not None, "Missing <Property Id='WIN10BUILD'> — #397 launch condition cannot evaluate"
+
+    search = win10build.find("wix:RegistrySearch", NS)
+    assert search is not None, "<Property Id='WIN10BUILD'> must contain a <RegistrySearch> child"
+    assert search.get("Root") == "HKLM", f"RegistrySearch Root must be HKLM, got {search.get('Root')}"
+    assert search.get("Key") == r"SOFTWARE\Microsoft\Windows NT\CurrentVersion", (
+        f"RegistrySearch Key must point at CurrentVersion, got {search.get('Key')}"
+    )
+    assert search.get("Name") == "CurrentBuildNumber", (
+        f"RegistrySearch Name must be CurrentBuildNumber, got {search.get('Name')}"
+    )
+    assert search.get("Type") == "raw", (
+        f"RegistrySearch Type must be 'raw' so the REG_SZ flows back numerically, got {search.get('Type')}"
+    )
+
+
+def test_launch_condition_requires_build_19041(package: ET.Element) -> None:
+    """A <Launch> condition must gate install on WIN10BUILD >= 19041.
+
+    Must be an integer comparison (no quotes around 19041) so MSI's
+    expression evaluator coerces the REG_SZ to int. The 'Installed OR'
+    prefix is required so uninstall + repair don't re-evaluate the gate
+    on older builds where an old install already exists.
+    """
+    launches = list(package.iter(f"{{{NS['wix']}}}Launch"))
+    assert launches, "No <Launch> condition in hole.wxs — #397 Windows-version gate missing"
+
+    matches = [el for el in launches if "WIN10BUILD" in (el.get("Condition") or "")]
+    assert len(matches) == 1, (
+        f"Expected exactly one <Launch> condition referencing WIN10BUILD, got {len(matches)}. "
+        f"Conditions: {[el.get('Condition') for el in launches]}"
+    )
+
+    launch = matches[0]
+    assert launch.get("Condition") == "Installed OR WIN10BUILD >= 19041", (
+        f"Launch condition must be exactly 'Installed OR WIN10BUILD >= 19041' "
+        f"(integer-shaped RHS — no quotes around 19041). Got: '{launch.get('Condition')}'"
+    )
+    message = launch.get("Message") or ""
+    assert "2004" in message or "19041" in message, (
+        f"Launch condition message must name the required Windows version "
+        f"so end users can act on the refusal. Got: '{message}'"
+    )
+
+
 # Custom action attribute tests ========================================================================================
 
 


### PR DESCRIPTION
## Summary

Closes #397. Two composing fixes for proxy-start "3-click misery", plus an architectural cancellation refactor:

- **Sub-bug A** — `apply_dns_settings` was uncancellable mid-flight. Cancel signal at 17:04:06 ignored for ~10s; `RunningState` committed despite the cancel. Fix: removed future-drop cancellation; threaded `&CancellationToken` cooperatively through every phase of `start_inner` (plugin chain, proxy start, DNS bind, forwarder self-test, dispatcher, routing, DNS apply). New "Bridge cancellation contract" in CLAUDE.md.
- **Sub-bug B** — 22s `apply_dns_settings` on Defender-active machines (4× sequential netsh subprocesses, ~5–7s each). Fix: direct Win32 FFIs `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` / `DnsFlushResolverCache`. ~22s → ~50ms.

New `Dns` trait + `WinDnsBackend` / `MacDnsBackend` inner test seams (mirrors `Routing` precedent from #165). `SystemDnsApplied` owns `drop_bomb::DebugDropBomb` defused by `shutdown().await` — missed-shutdown panics in debug, sync-fallback restore runs in release.

## User-visible change

MSI gains `<Launch Condition>` requiring Windows 10 build 19041 (version 2004, May 2020) — `SetInterfaceDnsSettings` was added there. Pre-19041 installs get a clean refusal: *"Hole requires Windows 10 version 2004 (May 2020) or later."*

## Composition with #398

This PR depends on #398's `bind_ladder` self-test probe. Rebase merged both changes cleanly: `bind_ladder` now accepts `cancel: CancellationToken` (this PR) AND wraps `bind_once_with_probe` with `SO_EXCLUSIVEADDRUSE` + `SelfTestProbe` (#398). Both are exercised by the post-rebase test suite.

## Test plan

- [x] `cargo xtask run hole-tests` — 1083/1085 pass locally. The 2 failures (`e2e_socks5_udp_associate_roundtrip`, `e2e_none_full_tunnel_roundtrip`) are admin-only TUN tests that need Windows Setup-API mutex acquisition — they fail identically in `nextest-bridge.log` snapshots from before this branch (pre-existing on non-elevated dev shells). CI runs elevated; expect both green.
- [x] `cargo xtask run hole-bridge` (post-rebase smoke, excluding the two admin-only tests) — all pass.
- [x] `cargo clippy --target x86_64-pc-windows-msvc -p hole-bridge --all-targets` — clean.
- [x] `uv run --directory msi-installer --group dev pytest -v` — 70 pass (incl. new `test_launch_condition_requires_build_19041`).
- [x] **Review agent pass + 5 must-fix follow-ups landed in `0245b14`**:
  - **Critical**: Drop sync-fallback was dead code in release (`DebugDropBomb::is_defused()` returns `true` unconditionally in release builds — `drop_bomb-0.1.5` `FakeBomb`). Replaced bomb-only gate with `shutdown_completed: bool` flag. New `drop_invokes_sync_fallback_when_shutdown_skipped` test asserts the fallback runs.
  - `inline_restore` now clears `bridge-dns.json` on cancel — previously the persisted state file dangled, so next-start recovery would replay over user-side DNS changes. New `inline_restore_clears_state_file_on_cancel` test.
  - `DnsFlushResolverCache` added to `clippy.toml disallowed_methods` for symmetry with the other Win32 DNS FFIs.
  - Workspace-wide `CancellationToken::new` ban now explicitly acknowledges scope (cargo has no per-crate `clippy.toml`; ex-Galoshes crates carry module-level `#![allow]` as accepted noise).
  - Unused `Win32_NetworkManagement_Dns` feature removed from `crates/bridge/Cargo.toml`.
- [ ] Manual verification on user's machine: bridge log shows `apply_dns_settings done: elapsed_ms < 200` (was 22680); cancel mid-apply returns within ms; 3-click misery doesn't reproduce.
- [ ] PR #2 (separate) — remove the 15s frontend `Promise.race` timeout (sub-bug C); now safe to remove because cancellation works promptly.