### PR TITLE
chore(release): bump galoshes to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "galoshes"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "galoshes"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Closes #407 (release-tracking issue).

## Summary

- Bumps `crates/galoshes/Cargo.toml` from `0.1.0` to `0.1.1` and refreshes `Cargo.lock`.

## Why now

Two production-breaking fixes have landed since `releases/galoshes/v0.1.0` (2026-05-17):

- #402 — `fix(garter): wire SIP003 server-mode chains correctly`. Galoshes consumes `garter::Mode::Server` so server-mode SIP003 chains under `shadowsocks-rust` 1.24.0 stop restart-looping on `bind yamux server on [::1]:NNNNN`. Touched `crates/galoshes/src/main.rs` and `crates/galoshes/src/yamux.rs`. Also resolves the symptom in still-open #353.
- #403 — `fix(galoshes): #401 require exec-capable XDG runtime dir`. Strict runtime-dir resolution + noexec probe; galoshes refuses to start with a clear hint instead of dying on `exec '/proc/self/fd/9': Permission denied` in `noexec` tmpfs containers (Docker default `--tmpfs`, systemd `PrivateTmp=yes`, hardened distros). Closed #401.

Both are pure bugfixes with no API change → patch bump (`0.1.0 → 0.1.1`).

The garter track is already at `0.2.0` in `Cargo.toml` (bumped by #402) and needs no edit before its own draft.

## Test plan

- [x] `cargo xtask version --check --group galoshes` → `0.1.1`
- [x] `cargo xtask version --check --exact --group galoshes` with a local `releases/galoshes/v0.1.1` tag → `0.1.1` (simulates the reusable draft workflow's `validate` step)
- [x] `cargo check -p galoshes -p garter -p garter-bin --no-default-features` clean
- [ ] CI green on PR