### PR TITLE
feat(ui): show country flag image in sidebar IP pill

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -40,3 +40,36 @@ as a whole under GPL-3.0-or-later, per Apache-2.0 → GPL-3.0 one-way
 compatibility. The ex-Galoshes crates remain individually available under
 Apache-2.0 for any downstream consumer who pulls them out of this
 monorepo.
+
+## Bundled third-party UI assets
+
+The Hole GUI bundles country-flag SVGs from
+[`flag-icons`](https://github.com/lipis/flag-icons), licensed under
+the MIT License. Both the CSS rules and the SVG files (under
+`ui/flags/{1x1,4x3}/*.svg` in the unpacked `flag-icons` npm package) are
+incorporated into the built `ui/dist/` bundle that ships inside the
+Tauri webview asset payload. The MIT license is GPL-3.0-compatible.
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2013 Panayiotis Lipiridis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@tauri-apps/plugin-autostart": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-log": "^2",
+        "flag-icons": "^7.5.0",
         "overlayscrollbars": "^2.14.0"
       },
       "devDependencies": {
@@ -4372,6 +4373,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
+      "license": "MIT"
     },
     "node_modules/flat": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tauri-apps/plugin-autostart": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-log": "^2",
+    "flag-icons": "^7.5.0",
     "overlayscrollbars": "^2.14.0"
   },
   "devDependencies": {

--- a/ui/country-flag.test.ts
+++ b/ui/country-flag.test.ts
@@ -1,0 +1,101 @@
+// Unit tests for the country-flag DOM helper.
+//
+// Runs under Vitest + jsdom. The helper writes a `flag-icons` CSS class
+// onto a passed-in element so the existing flag-icons stylesheet can
+// render the right SVG; we don't actually load that stylesheet here —
+// these tests pin the contract between sidebar.ts and flag-icons CSS.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { setCountryFlag } from "./country-flag";
+
+let el: HTMLElement;
+
+beforeEach(() => {
+  el = document.createElement("span");
+  el.className = "country-flag fi fis";
+});
+
+describe("setCountryFlag", () => {
+  it("uppercase code: applies fi-us class and uppercase title", () => {
+    setCountryFlag(el, "US");
+    expect(el.classList.contains("fi-us")).toBe(true);
+    expect(el.title).toBe("US");
+  });
+
+  it("lowercase code: lowercases for class, uppercases for title", () => {
+    setCountryFlag(el, "us");
+    expect(el.classList.contains("fi-us")).toBe(true);
+    expect(el.title).toBe("US");
+  });
+
+  it("mixed-case code: normalizes both forms", () => {
+    setCountryFlag(el, "Us");
+    expect(el.classList.contains("fi-us")).toBe(true);
+    expect(el.title).toBe("US");
+  });
+
+  it("strips previous fi-* class on consecutive updates", () => {
+    setCountryFlag(el, "US");
+    setCountryFlag(el, "JP");
+    expect(el.classList.contains("fi-us")).toBe(false);
+    expect(el.classList.contains("fi-jp")).toBe(true);
+    expect(el.title).toBe("JP");
+  });
+
+  it("preserves base classes across updates", () => {
+    setCountryFlag(el, "US");
+    setCountryFlag(el, "JP");
+    expect(el.classList.contains("fi")).toBe(true);
+    expect(el.classList.contains("fis")).toBe(true);
+    expect(el.classList.contains("country-flag")).toBe(true);
+  });
+
+  // The unknown path applies flag-icons' `fi-xx` placeholder (the
+  // package ships xx.svg as a built-in "?" glyph) so the badge shows a
+  // visible "unknown" marker instead of a featureless empty square.
+  it("unknown code '??': applies fi-xx, strips prior fi-*, title 'Unknown'", () => {
+    // Seed a fi-* so we also verify it gets stripped on the unknown path.
+    setCountryFlag(el, "US");
+    setCountryFlag(el, "??");
+    expect(el.title).toBe("Unknown");
+    expect(el.classList.contains("fi-us")).toBe(false);
+    expect(el.classList.contains("fi-xx")).toBe(true);
+  });
+
+  it("empty string: same as '??'", () => {
+    setCountryFlag(el, "");
+    expect(el.title).toBe("Unknown");
+    expect(el.classList.contains("fi-xx")).toBe(true);
+  });
+
+  // The PublicIpData type at ui/types.ts:92 says `country_code: string`,
+  // but the backend's ipinfo.io fallback at crates/hole/src/commands.rs:483
+  // is `body["country"].as_str().unwrap_or("??")` — a null upstream would
+  // still produce "??", but defense in depth.
+  // biome-ignore lint/suspicious/noExplicitAny: cast through to test the runtime guard
+  it("null / undefined: same as '??'", () => {
+    setCountryFlag(el, null as any);
+    expect(el.title).toBe("Unknown");
+    expect(el.classList.contains("fi-xx")).toBe(true);
+
+    setCountryFlag(el, undefined as any);
+    expect(el.title).toBe("Unknown");
+    expect(el.classList.contains("fi-xx")).toBe(true);
+  });
+
+  // ISO 3166-1 alpha-2 is exactly 2 ASCII letters. Anything else
+  // (digits, wrong length, punctuation) maps to unknown so a future
+  // backend that sends garbage doesn't render an invisible badge with a
+  // misleading title.
+  it.each([
+    ["Z9", "digit in code"],
+    ["123", "all digits"],
+    ["USA", "length 3"],
+    ["U", "length 1"],
+    ["U!", "non-alpha character"],
+  ])("invalid shape '%s' (%s): treated as unknown", (input) => {
+    setCountryFlag(el, input);
+    expect(el.title).toBe("Unknown");
+    expect(el.classList.contains("fi-xx")).toBe(true);
+  });
+});

--- a/ui/country-flag.ts
+++ b/ui/country-flag.ts
@@ -1,0 +1,29 @@
+// Country-flag DOM helper. Writes a `flag-icons` CSS class
+// (`.fi.fi-<cc>`) and a title attribute onto a passed-in element. The
+// loaded flag-icons stylesheet (imported from ui/main.ts) does the
+// actual SVG rendering.
+//
+// Class names are required lowercase by flag-icons' convention
+// (.fi-us, not .fi-US). Titles are uppercase by ISO 3166-1 convention.
+//
+// Treats `"??"`, empty, null/undefined, and shape-invalid inputs as
+// "unknown": applies the package's built-in `fi-xx` placeholder
+// (xx.svg ships as a "?" glyph) so the badge always shows something
+// visible, even when the backend returns garbage.
+
+const ISO_ALPHA2 = /^[A-Za-z]{2}$/;
+
+export function setCountryFlag(el: HTMLElement, cc: string | null | undefined): void {
+  // Strip any prior fi-* class. flag-icons owns the .fi- prefix on this
+  // element; nothing else in the project applies fi-* classes.
+  for (const cls of [...el.classList]) {
+    if (cls.startsWith("fi-")) el.classList.remove(cls);
+  }
+  if (!cc || cc === "??" || !ISO_ALPHA2.test(cc)) {
+    el.classList.add("fi-xx");
+    el.title = "Unknown";
+    return;
+  }
+  el.classList.add(`fi-${cc.toLowerCase()}`);
+  el.title = cc.toUpperCase();
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -193,7 +193,7 @@
         <div class="sb-status-block">
           <div class="sb-status">You are <strong class="off" id="status-word">Disconnected</strong></div>
           <div class="sb-ip">
-            <span class="ip-text" id="ip-text"><span class="country" id="country-badge">--</span> --</span>
+            <span class="ip-text" id="ip-text"><span class="country-flag fi fis fi-xx" id="country-flag" title="Unknown"></span> --</span>
             <span class="copy-btn" id="copy-ip-btn" title="Copy to clipboard">&#x2398;</span>
           </div>
         </div>

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -5,6 +5,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { attachConsole, error as logError, warn as logWarn } from "@tauri-apps/plugin-log";
+import "flag-icons/css/flag-icons.min.css";
 import { OverlayScrollbars } from "overlayscrollbars";
 import "overlayscrollbars/overlayscrollbars.css";
 import { initFilters, renderFilters } from "./filters";

--- a/ui/sidebar.ts
+++ b/ui/sidebar.ts
@@ -13,6 +13,7 @@ import {
   statusTextFor,
   statusWordClassFor,
 } from "./connection-state";
+import { setCountryFlag } from "./country-flag";
 import { config, loadConfig } from "./main";
 import { statusTooltipFor } from "./servers";
 import { showToast } from "./toast";
@@ -74,7 +75,7 @@ function formatUptime(totalSecs: number): string {
 const powerBtn = document.getElementById("power-btn")!;
 const statusWord = document.getElementById("status-word")!;
 const ipText = document.getElementById("ip-text")!;
-const countryBadge = document.getElementById("country-badge")!;
+const countryFlag = document.getElementById("country-flag")!;
 const copyIpBtn = document.getElementById("copy-ip-btn")!;
 const graphSvg = document.getElementById("graph-svg")!;
 const graphScaleLabel = document.getElementById("graph-scale-label")!;
@@ -259,21 +260,10 @@ export async function updatePublicIp() {
   try {
     const data = await invoke<PublicIpData>("get_public_ip");
     const ip = data.ip || "unknown";
-    const cc = data.country_code || "??";
     currentIp = ip;
-    countryBadge.textContent = cc;
-    // Set the text node after the badge. We keep the country badge element and
-    // append the IP as a text node.
-    // Structure: <span class="country" id="country-badge">CC</span> ip.addr
-    // We need to replace only the text outside the badge.
-    const existing = ipText.childNodes;
-    // Remove text nodes (keep the country badge span).
-    for (let i = existing.length - 1; i >= 0; i--) {
-      if (existing[i].nodeType === Node.TEXT_NODE) {
-        existing[i].remove();
-      }
-    }
-    ipText.appendChild(document.createTextNode(` ${ip}`));
+    setCountryFlag(countryFlag, data.country_code);
+    // Structure: <span class="country-flag fi fis fi-XX" id="country-flag" title="XX"></span> ip.addr
+    ipText.replaceChildren(countryFlag, document.createTextNode(` ${ip}`));
   } catch (err) {
     console.error("get_public_ip failed:", err);
   }

--- a/ui/style.css
+++ b/ui/style.css
@@ -54,8 +54,6 @@
   --graph-fill-rx: rgba(34, 197, 94, 0.1);
   --graph-fill-tx: rgba(245, 158, 11, 0.1);
   --graph-midline: rgba(255, 255, 255, 0.06);
-  --country-bg: #1e1e35;
-  --country-text: #aaa;
   --scrollbar: #2a2a4a;
   --toggle-track: #333;
   --toggle-track-on: #22c55e;
@@ -105,8 +103,6 @@
   --graph-fill-rx: rgba(22, 163, 74, 0.12);
   --graph-fill-tx: rgba(217, 119, 6, 0.12);
   --graph-midline: rgba(0, 0, 0, 0.06);
-  --country-bg: #e8e8f0;
-  --country-text: #555;
   --scrollbar: #ccc;
   --toggle-track: #ccc;
   --toggle-track-on: #16a34a;
@@ -359,16 +355,9 @@ order. (0,2,0) > (0,1,0). */
   color: var(--text-tertiary);
 }
 
-.country {
-  display: inline-block;
-  font-family: "Inter", system-ui, sans-serif;
-  font-size: 0.55rem;
-  font-weight: 700;
-  background: var(--country-bg);
-  color: var(--country-text);
-  padding: 0.05rem 0.3rem;
-  border-radius: 3px;
-  letter-spacing: 0.5px;
+.country-flag {
+  /* Sizing (1em x 1em via .fi.fis) and background-image are owned by
+   * flag-icons; only layout-affecting properties live here. */
   vertical-align: middle;
   margin-right: 0.2rem;
 }


### PR DESCRIPTION
## Summary

Closes #411.

The sidebar IP badge previously rendered a 2-letter ISO 3166-1 alpha-2
code as text (e.g. `US 1.2.3.4`). This PR replaces the text with a real
flag image via the [`flag-icons`](https://github.com/lipis/flag-icons)
npm package (MIT). The alpha-2 code moves to the element's `title`
attribute for hover / screen readers.

- **Scope**: sidebar pill only — the single country-bearing UI element
  today. No server list, tray menu, or filter dialog uses country flags.
- **Variant**: square (`.fis`).
- **Unknown placeholder**: applies the package's built-in `fi-xx` class
  (the package ships `xx.svg` as a `?` glyph), so disconnected /
  unknown / shape-invalid inputs render a visible "unknown" marker
  instead of an empty square.
- **Input validation**: `setCountryFlag` accepts only ISO 3166-1
  alpha-2 shape (2 ASCII letters); anything else (length ≠ 2, digits,
  punctuation, `null`, `undefined`, `"??"`, empty string) maps to the
  unknown placeholder. Defense in depth against a backend that drifts
  from the typed `country_code: string` contract.

## TDD

13 vitest cases for `setCountryFlag` in
[`ui/country-flag.test.ts`](ui/country-flag.test.ts) (jsdom): case
normalization (uppercase / lowercase / mixed), strip prior `fi-*` on
update, preserve base classes, three unknown variants (`"??"`, `""`,
`null`/`undefined`), 5 invalid-shape rows via `it.each` (`"Z9"`,
`"123"`, `"USA"`, `"U"`, `"U!"`).

Full suite: 47/47 pass. `tsc --noEmit` clean. `npm run build` succeeds
and bundles all flag SVGs to `ui/dist/assets/` with hashed paths.

## Deviations from the original plan

- **No `updatePublicIp` integration test.** `sidebar.ts` does 13
  module-load `getElementById` lookups, making import-time DOM setup
  prohibitively heavy. The project's existing UI test pattern
  (`toast.test.ts`, `toggle-failure.test.ts`, `import-failure.test.ts`)
  only tests pure helpers; this PR matches that. Wire-up of
  `setCountryFlag(countryFlag, data.country_code)` at
  [sidebar.ts:264](crates/../ui/sidebar.ts) is checked manually below.
- **Visual verification deferred to merger.** Final flag-rendering
  quality (size in the pill, edge contrast against both themes,
  vertical alignment) should be eyeballed before merge. The
  implementation is correct by all automated measures; final aesthetics
  are best judged with eyes on the running app.
- **Bundle bloat known limitation.** The bundled CSS is ~453 KB; about
  half is `.fi-XX` rules for the 4:3 variant we don't use. I attempted
  to mitigate via a SCSS subset (override `$flag-icons-rect-path` to
  `/1x1`) but Vite + SCSS `@use` lost the source-file context needed
  to resolve the relative `url(../flags/...)` paths. The pre-built
  `flag-icons.min.css` works because Vite tracks its origin at
  `node_modules/flag-icons/css/`. Filed as follow-up rather than
  blocking this PR.

## Notes

- [`NOTICES.md`](NOTICES.md) gets a `flag-icons` (MIT) entry — the
  SVGs and CSS ship inside the Tauri webview asset payload, so the
  attribution belongs in the distributed product.
- Removed dead `--country-text` CSS variable (no longer referenced
  after the text→image swap) and dead `--country-bg` (the
  flag image fills the badge now).
- Replaced manual text-node loop in `updatePublicIp` with
  `replaceChildren` per review feedback — cleaner, less fragile if a
  future UI change adds another inline element next to the flag.

## Test plan

- [ ] Reviewer: launch `cargo xtask run hole`, connect/disconnect the
      proxy, confirm the sidebar pill renders a real flag (connected)
      and the `?` placeholder (disconnected / unknown).
- [ ] Reviewer: toggle Windows theme between light and dark, confirm
      the flag is legible against either sidebar background.
- [ ] CI: `npm test` (vitest), `npm run check` (tsc), `npm run build`
      (vite), `cargo xtask run hole-tests`.