### PR TITLE
fix(galoshes): bidirectional client UDP relay with NAT associations (#415)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,6 +2197,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "windows 0.62.2",
  "xtask-lib",
  "yamux",
 ]

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -31,6 +31,11 @@ tempfile = "3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+# WSAIoctl(SIO_UDP_CONNRESET) — see `bind_udp` in yamux.rs (#415).
+# Win32_System_IO supplies WSAOVERLAPPED, referenced by WSAIoctl's signature.
+windows = { version = "0.62", features = ["Win32_Networking_WinSock", "Win32_System_IO"] }
+
 [dev-dependencies]
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -34,6 +34,9 @@ libc = "0.2"
 [dev-dependencies]
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }
+# Enable garter's `test_utils::WaitableWriter` for the E2E relay tests
+# (the module is gated behind garter's `test-utils` feature).
+garter = { path = "../garter", features = ["test-utils"] }
 
 [build-dependencies]
 sha2 = "0.11"

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -44,7 +44,11 @@ async fn main() -> anyhow::Result<()> {
     let verified = v2ray_binary.prepare()?;
 
     let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
-    let yamux_plugin = galoshes::yamux::YamuxPlugin::new(mode == Mode::Server);
+    // Parse the galoshes-specific client UDP NAT idle-eviction timeout from the
+    // shared options string before any I/O so a misconfiguration fails loudly
+    // at startup. v2ray-plugin ignores this key (it only reads keys it knows).
+    let udp_timeout = galoshes::yamux::parse_udp_timeout(env.plugin_options.as_deref())?;
+    let yamux_plugin = galoshes::yamux::YamuxPlugin::new(mode == Mode::Server, udp_timeout);
     let v2ray_plugin = BinaryPlugin::new(verified.exec_path(), env.plugin_options.as_deref());
 
     let runner = ChainRunner::new()

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -1,13 +1,27 @@
-use std::net::SocketAddr;
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use futures::AsyncReadExt as _;
 use futures::AsyncWriteExt as _;
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tokio_util::sync::CancellationToken;
+
+/// Maximum buffered outbound datagrams per UDP association before new ones are
+/// dropped. Bounded (not unbounded) so a stalled association — e.g. yamux
+/// backpressure while the app floods UDP — can't grow without limit; dropping
+/// on a full buffer is the correct lossy-UDP semantic. This is a buffer size,
+/// not a retry/timeout budget.
+const UDP_ASSOC_CHANNEL_CAPACITY: usize = 64;
+
+/// Default UDP NAT idle-eviction timeout when `udp_timeout` is not configured
+/// in `SS_PLUGIN_OPTIONS`. Matches shadowsocks-rust's `udp_timeout` default.
+pub const DEFAULT_UDP_TIMEOUT: Duration = Duration::from_secs(300);
 
 // Protocol framing ====================================================================================================
 
@@ -54,6 +68,43 @@ pub fn deframe_udp_datagram(buf: &[u8]) -> Option<(&[u8], &[u8])> {
         return None;
     }
     Some((&buf[2..2 + len], &buf[2 + len..]))
+}
+
+/// Reassembles length-prefixed UDP datagrams from a yamux substream.
+///
+/// yamux substreams are reliable **byte** streams, not message-preserving:
+/// one `read` may return a partial frame or several coalesced frames. This
+/// buffers raw bytes and drains every complete frame, retaining any trailing
+/// partial for the next `push`. Without it, a single `deframe` per `read`
+/// (the pre-#415 behavior) corrupts split frames and drops coalesced ones.
+///
+/// Buffer growth is bounded: the 2-byte length prefix is a `u16`, so a
+/// pending frame never exceeds `2 + u16::MAX` bytes.
+#[derive(Debug, Default)]
+pub(crate) struct FrameAccumulator {
+    buf: Vec<u8>,
+}
+
+impl FrameAccumulator {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append freshly-read bytes.
+    pub(crate) fn push(&mut self, data: &[u8]) {
+        self.buf.extend_from_slice(data);
+    }
+
+    /// Pop the next complete datagram payload, or `None` if the buffer does
+    /// not yet hold a full frame.
+    pub(crate) fn next_frame(&mut self) -> Option<Vec<u8>> {
+        let (payload, consumed) = {
+            let (payload, rest) = deframe_udp_datagram(&self.buf)?;
+            (payload.to_vec(), self.buf.len() - rest.len())
+        };
+        self.buf.drain(..consumed);
+        Some(payload)
+    }
 }
 
 // Driver ==============================================================================================================
@@ -153,6 +204,26 @@ async fn open_stream(open_tx: &mpsc::Sender<OpenStreamReply>) -> Result<yamux::S
 
 // TCP/UDP relay helpers ===============================================================================================
 
+/// An unspecified-address `SocketAddr` of the same family as `target`, port 0.
+///
+/// A UDP socket must be bound in the same address family as the peer it will
+/// `connect()`/`send_to()`; binding IPv4 (`0.0.0.0`) then connecting an IPv6
+/// peer fails with an address-family error (#415, defect B).
+fn unspecified_for(target: SocketAddr) -> SocketAddr {
+    if target.is_ipv4() {
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))
+    } else {
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))
+    }
+}
+
+/// Write a stream's leading tag byte and flush it. Every yamux substream
+/// begins with one [`StreamTag`] so the server can dispatch TCP vs UDP.
+async fn write_tag(stream: &mut yamux::Stream, tag: StreamTag) -> std::io::Result<()> {
+    stream.write_all(&[tag.to_byte()]).await?;
+    stream.flush().await
+}
+
 /// Relay between a tokio TCP stream and a yamux stream (bidirectional).
 async fn relay_tcp(mut yamux_stream: yamux::Stream, mut tcp_stream: TcpStream) -> Result<()> {
     // Convert yamux stream (futures AsyncRead/Write) to tokio-compatible.
@@ -172,22 +243,27 @@ async fn relay_tcp(mut yamux_stream: yamux::Stream, mut tcp_stream: TcpStream) -
 
 /// Relay UDP datagrams on the server side: yamux stream <-> remote UDP socket.
 async fn relay_udp_server(mut yamux_stream: yamux::Stream, remote: SocketAddr) -> Result<()> {
-    let udp = UdpSocket::bind("127.0.0.1:0").await.context("bind udp")?;
+    // Bind in the remote's address family, else an IPv6 `remote` (ss server
+    // configured with `server: "::"` hands the plugin an `[::1]` loopback)
+    // fails the connect with an address-family mismatch (#415, defect B).
+    let udp = UdpSocket::bind(unspecified_for(remote)).await.context("bind udp")?;
     udp.connect(remote).await.context("connect udp")?;
 
-    let mut recv_buf = [0u8; 65536 + 2];
+    let mut read_buf = [0u8; 65536 + 2];
     let mut udp_buf = [0u8; 65536];
+    let mut acc = FrameAccumulator::new();
 
     loop {
         tokio::select! {
             // yamux -> UDP
-            result = yamux_stream.read(&mut recv_buf) => {
+            result = yamux_stream.read(&mut read_buf) => {
                 let n = result.context("yamux read")?;
                 if n == 0 {
                     break;
                 }
-                if let Some((payload, _)) = deframe_udp_datagram(&recv_buf[..n]) {
-                    udp.send(payload).await.context("udp send")?;
+                acc.push(&read_buf[..n]);
+                while let Some(payload) = acc.next_frame() {
+                    udp.send(&payload).await.context("udp send")?;
                 }
             }
             // UDP -> yamux
@@ -224,11 +300,97 @@ async fn connect_with_backoff(addr: SocketAddr, shutdown: &CancellationToken) ->
     }
 }
 
-async fn run_client(
+/// One client-side UDP NAT association.
+///
+/// Relays datagrams for a single originating local peer over a dedicated yamux
+/// stream, bidirectionally (mirroring [`relay_udp_server`]), until the
+/// association is idle-evicted or the stream/connection closes. Outbound
+/// datagrams arrive on `outbound_rx` from the [`run_client`] loop; inbound
+/// replies are delivered straight to `peer` via the shared `udp_socket`.
+///
+/// On exit it closes the stream (FINs the substream so the server's
+/// `relay_udp_server` read returns 0 and its UDP socket is reclaimed) and
+/// notifies the loop via `cleanup_tx` so the stale table entry is dropped.
+#[allow(clippy::too_many_arguments)]
+async fn run_udp_association(
+    open_tx: mpsc::Sender<OpenStreamReply>,
+    udp_socket: Arc<UdpSocket>,
+    peer: SocketAddr,
+    generation: u64,
+    mut outbound_rx: mpsc::Receiver<Vec<u8>>,
+    cleanup_tx: mpsc::Sender<(SocketAddr, u64)>,
+    udp_timeout: Duration,
+) {
+    let mut stream = match open_stream(&open_tx).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(peer = %peer, error = %e, "failed to open yamux stream for UDP");
+            let _ = cleanup_tx.send((peer, generation)).await;
+            return;
+        }
+    };
+    if let Err(e) = write_tag(&mut stream, StreamTag::Udp).await {
+        tracing::error!(peer = %peer, error = %e, "failed to write UDP tag");
+        let _ = cleanup_tx.send((peer, generation)).await;
+        return;
+    }
+
+    let mut read_buf = [0u8; 65536 + 2];
+    let mut acc = FrameAccumulator::new();
+
+    // NAT idle-eviction timer. The delay IS the behavior under management
+    // (conntrack-style idle expiry of a UDP association), not synchronization
+    // between our own code paths — sanctioned per the synchronization
+    // invariant's "the delay IS the behavior" exception. See bindreams/hole#415.
+    let idle = tokio::time::sleep(udp_timeout);
+    tokio::pin!(idle);
+
+    let reason = loop {
+        tokio::select! {
+            // local app -> server
+            maybe = outbound_rx.recv() => {
+                let Some(payload) = maybe else { break "channel closed" };
+                idle.as_mut().reset(Instant::now() + udp_timeout);
+                let framed = frame_udp_datagram(&payload);
+                if stream.write_all(&framed).await.is_err() {
+                    break "stream write error";
+                }
+                if stream.flush().await.is_err() {
+                    break "stream flush error";
+                }
+            }
+            // server -> local app
+            result = stream.read(&mut read_buf) => {
+                let n = match result {
+                    Ok(0) => break "stream closed",
+                    Ok(n) => n,
+                    Err(_) => break "stream read error",
+                };
+                idle.as_mut().reset(Instant::now() + udp_timeout);
+                acc.push(&read_buf[..n]);
+                while let Some(payload) = acc.next_frame() {
+                    if let Err(e) = udp_socket.send_to(&payload, peer).await {
+                        tracing::debug!(peer = %peer, error = %e, "failed to send UDP reply to local peer");
+                    }
+                }
+            }
+            // NAT idle eviction.
+            _ = &mut idle => break "evicted",
+        }
+    };
+
+    tracing::debug!(peer = %peer, reason, "udp association closed");
+    let _ = stream.close().await;
+    let _ = cleanup_tx.send((peer, generation)).await;
+}
+
+pub(crate) async fn run_client(
     config: yamux::Config,
     local: SocketAddr,
     remote: SocketAddr,
+    udp_timeout: Duration,
     shutdown: CancellationToken,
+    mut bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<()> {
     loop {
         // Connect to the remote yamux server.
@@ -247,11 +409,28 @@ async fn run_client(
 
         let driver = tokio::spawn(drive_connection(conn, open_rx, _inbound_tx));
 
-        // Bind local TCP + UDP listeners.
+        // Bind local TCP + UDP listeners (fresh per connection).
         let tcp_listener = TcpListener::bind(local).await.context("bind local TCP")?;
-        let udp_socket = UdpSocket::bind(local).await.context("bind local UDP")?;
+        let udp_socket = Arc::new(UdpSocket::bind(local).await.context("bind local UDP")?);
+
+        // Signal the actual bound UDP address on the FIRST successful bind only
+        // (test seam; `run_client` rebinds on reconnect but the oneshot fires
+        // once). Production passes `None`.
+        if let Some(tx) = bound_addr_tx.take() {
+            let addr = udp_socket.local_addr().context("local udp addr")?;
+            let _ = tx.send(addr);
+        }
 
         let result: Result<()> = async {
+            // NAT association table: local peer -> (generation, outbound sender).
+            // Owned solely by this loop (no shared mutex) and scoped to this
+            // connection — on reconnect it drops, every association task sees
+            // its `outbound_rx` close and exits, and the next iteration starts
+            // empty. `generation` closes the re-create-during-teardown race:
+            // a stale cleanup only removes an entry whose generation matches.
+            let mut associations: HashMap<SocketAddr, (u64, mpsc::Sender<Vec<u8>>)> = HashMap::new();
+            let (cleanup_tx, mut cleanup_rx) = mpsc::channel::<(SocketAddr, u64)>(64);
+            let mut next_gen: u64 = 0;
             let mut udp_buf = [0u8; 65536];
 
             loop {
@@ -264,13 +443,8 @@ async fn run_client(
                         tokio::spawn(async move {
                             match open_stream(&open_tx).await {
                                 Ok(mut yamux_stream) => {
-                                    // Write tag byte.
-                                    if let Err(e) = yamux_stream.write_all(&[StreamTag::Tcp.to_byte()]).await {
+                                    if let Err(e) = write_tag(&mut yamux_stream, StreamTag::Tcp).await {
                                         tracing::error!(error = %e, "failed to write TCP tag");
-                                        return;
-                                    }
-                                    if let Err(e) = yamux_stream.flush().await {
-                                        tracing::error!(error = %e, "failed to flush TCP tag");
                                         return;
                                     }
                                     if let Err(e) = relay_tcp(yamux_stream, tcp_stream).await {
@@ -283,42 +457,54 @@ async fn run_client(
                             }
                         });
                     }
-                    // Receive local UDP datagrams.
+                    // Receive local UDP datagrams; route each to its peer's association.
                     recv = udp_socket.recv_from(&mut udp_buf) => {
-                        let (n, _peer) = recv.context("udp recv")?;
-                        let open_tx = open_tx.clone();
+                        let (n, peer) = recv.context("udp recv")?;
                         let payload = udp_buf[..n].to_vec();
-                        tokio::spawn(async move {
-                            match open_stream(&open_tx).await {
-                                Ok(mut yamux_stream) => {
-                                    // Write tag byte.
-                                    if let Err(e) = yamux_stream.write_all(&[StreamTag::Udp.to_byte()]).await {
-                                        tracing::error!(error = %e, "failed to write UDP tag");
-                                        return;
-                                    }
-                                    if let Err(e) = yamux_stream.flush().await {
-                                        tracing::error!(error = %e, "failed to flush UDP tag");
-                                        return;
-                                    }
-                                    // Send the initial datagram.
-                                    let framed = frame_udp_datagram(&payload);
-                                    if let Err(e) = yamux_stream.write_all(&framed).await {
-                                        tracing::error!(error = %e, "failed to write initial UDP datagram");
-                                        return;
-                                    }
-                                    if let Err(e) = yamux_stream.flush().await {
-                                        tracing::error!(error = %e, "failed to flush UDP datagram");
-                                        return;
-                                    }
-                                    // One datagram per stream; bidirectional UDP relay
-                                    // would keep the stream open longer.
-                                    let _ = yamux_stream.close().await;
+
+                        // Forward to an existing association if one is live.
+                        // `Closed` returns the payload so we can re-create
+                        // without cloning on the hot path; `Full` drops it
+                        // (correct lossy-UDP semantics).
+                        let payload = match associations.get(&peer) {
+                            Some((_, tx)) => match tx.try_send(payload) {
+                                Ok(()) => continue,
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    tracing::debug!(peer = %peer, "udp association buffer full, dropping datagram");
+                                    continue;
                                 }
-                                Err(e) => {
-                                    tracing::error!(error = %e, "failed to open yamux stream for UDP");
+                                Err(mpsc::error::TrySendError::Closed(payload)) => {
+                                    associations.remove(&peer);
+                                    payload
                                 }
+                            },
+                            None => payload,
+                        };
+
+                        // Create a new association.
+                        let generation = next_gen;
+                        next_gen += 1;
+                        let (tx, rx) = mpsc::channel::<Vec<u8>>(UDP_ASSOC_CHANNEL_CAPACITY);
+                        // First datagram always fits the fresh buffer.
+                        let _ = tx.try_send(payload);
+                        associations.insert(peer, (generation, tx));
+                        tokio::spawn(run_udp_association(
+                            open_tx.clone(),
+                            Arc::clone(&udp_socket),
+                            peer,
+                            generation,
+                            rx,
+                            cleanup_tx.clone(),
+                            udp_timeout,
+                        ));
+                    }
+                    // An association task exited; drop its entry iff still current.
+                    Some((peer, generation)) = cleanup_rx.recv() => {
+                        if let Some((current, _)) = associations.get(&peer) {
+                            if *current == generation {
+                                associations.remove(&peer);
                             }
-                        });
+                        }
                     }
                 }
             }
@@ -343,16 +529,23 @@ async fn run_client(
 
 // Server mode =========================================================================================================
 
-async fn run_server(
+pub(crate) async fn run_server(
     config: yamux::Config,
     local: SocketAddr,
     remote: SocketAddr,
     shutdown: CancellationToken,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<()> {
     let listener = TcpListener::bind(local)
         .await
         .with_context(|| format!("bind yamux server on {local}"))?;
     tracing::info!(local = %local, "yamux server listening");
+
+    // Signal the actual bound listen address (test seam). Production passes `None`.
+    if let Some(tx) = bound_addr_tx {
+        let addr = listener.local_addr().context("local tcp addr")?;
+        let _ = tx.send(addr);
+    }
 
     loop {
         // Accept one underlying TCP connection.
@@ -424,16 +617,46 @@ async fn handle_inbound_stream(mut stream: yamux::Stream, remote: SocketAddr) ->
 
 // Plugin ==============================================================================================================
 
+/// Parse the optional client-side `udp_timeout` (whole seconds) from an
+/// `SS_PLUGIN_OPTIONS` string.
+///
+/// Returns [`DEFAULT_UDP_TIMEOUT`] when the key is absent. The last occurrence
+/// wins (consistent with v2ray-plugin's duplicate-key semantics). A value that
+/// is not a positive integer is a hard error — `0` would evict every
+/// association immediately, breaking all UDP. v2ray-plugin ignores this key,
+/// so it can share the same options string.
+pub fn parse_udp_timeout(plugin_options: Option<&str>) -> Result<Duration> {
+    let Some(opts) = plugin_options else {
+        return Ok(DEFAULT_UDP_TIMEOUT);
+    };
+    let mut timeout = DEFAULT_UDP_TIMEOUT;
+    for (key, value) in garter::parse_plugin_options(opts) {
+        if key == "udp_timeout" {
+            let secs: u64 = value
+                .parse()
+                .with_context(|| format!("invalid udp_timeout (expected a positive integer of seconds): {value:?}"))?;
+            if secs == 0 {
+                anyhow::bail!("udp_timeout must be greater than 0 seconds");
+            }
+            timeout = Duration::from_secs(secs);
+        }
+    }
+    Ok(timeout)
+}
+
 pub struct YamuxPlugin {
     config: yamux::Config,
     is_server: bool,
+    /// Client-side UDP NAT idle-eviction timeout. Ignored in server mode.
+    udp_timeout: Duration,
 }
 
 impl YamuxPlugin {
-    pub fn new(is_server: bool) -> Self {
+    pub fn new(is_server: bool, udp_timeout: Duration) -> Self {
         Self {
             config: yamux::Config::default(),
             is_server,
+            udp_timeout,
         }
     }
 }
@@ -455,9 +678,9 @@ impl garter::ChainPlugin for YamuxPlugin {
         shutdown: CancellationToken,
     ) -> garter::Result<()> {
         let result = if self.is_server {
-            run_server(self.config, local, remote, shutdown).await
+            run_server(self.config, local, remote, shutdown, None).await
         } else {
-            run_client(self.config, local, remote, shutdown).await
+            run_client(self.config, local, remote, self.udp_timeout, shutdown, None).await
         };
 
         result.map_err(|e| garter::Error::Chain(e.to_string()))

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -346,7 +346,12 @@ async fn run_udp_association(
     tokio::pin!(idle);
 
     let reason = loop {
+        // `biased`: traffic in either direction always wins over the idle
+        // timer, so an association is never evicted while a datagram is already
+        // buffered or a reply is pending. The timer fires only when both
+        // directions are genuinely idle.
         tokio::select! {
+            biased;
             // local app -> server
             maybe = outbound_rx.recv() => {
                 let Some(payload) = maybe else { break "channel closed" };
@@ -379,6 +384,12 @@ async fn run_udp_association(
         }
     };
 
+    // Close the outbound channel before the (awaiting) stream teardown so a
+    // datagram the `run_client` loop tries to forward during the teardown
+    // window hits `Closed` and re-creates the association, rather than being
+    // silently buffered into a receiver that will never read it.
+    outbound_rx.close();
+
     tracing::debug!(peer = %peer, reason, "udp association closed");
     let _ = stream.close().await;
     let _ = cleanup_tx.send((peer, generation)).await;
@@ -390,8 +401,23 @@ pub(crate) async fn run_client(
     remote: SocketAddr,
     udp_timeout: Duration,
     shutdown: CancellationToken,
-    mut bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<()> {
+    // Bind the local TCP + UDP listeners once for the client's lifetime. They
+    // belong to `local` (the SS_LOCAL address), not to any single upstream
+    // connection, so they persist across reconnects — only the yamux connection
+    // churns. Binding per-reconnect would race the previous connection's
+    // detached association tasks (which hold `Arc<UdpSocket>` clones) for the
+    // port and could fail the rebind, terminating the client.
+    let tcp_listener = TcpListener::bind(local).await.context("bind local TCP")?;
+    let udp_socket = Arc::new(UdpSocket::bind(local).await.context("bind local UDP")?);
+
+    // Report the actual bound UDP address (test seam). Production passes `None`.
+    if let Some(tx) = bound_addr_tx {
+        let addr = udp_socket.local_addr().context("local udp addr")?;
+        let _ = tx.send(addr);
+    }
+
     loop {
         // Connect to the remote yamux server.
         let tcp = match connect_with_backoff(remote, &shutdown).await {
@@ -408,18 +434,6 @@ pub(crate) async fn run_client(
         let (_inbound_tx, _inbound_rx) = mpsc::channel::<yamux::Stream>(32);
 
         let driver = tokio::spawn(drive_connection(conn, open_rx, _inbound_tx));
-
-        // Bind local TCP + UDP listeners (fresh per connection).
-        let tcp_listener = TcpListener::bind(local).await.context("bind local TCP")?;
-        let udp_socket = Arc::new(UdpSocket::bind(local).await.context("bind local UDP")?);
-
-        // Signal the actual bound UDP address on the FIRST successful bind only
-        // (test seam; `run_client` rebinds on reconnect but the oneshot fires
-        // once). Production passes `None`.
-        if let Some(tx) = bound_addr_tx.take() {
-            let addr = udp_socket.local_addr().context("local udp addr")?;
-            let _ = tx.send(addr);
-        }
 
         let result: Result<()> = async {
             // NAT association table: local peer -> (generation, outbound sender).

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -217,6 +217,61 @@ fn unspecified_for(target: SocketAddr) -> SocketAddr {
     }
 }
 
+/// Bind a non-blocking tokio [`UdpSocket`], with `SIO_UDP_CONNRESET` disabled on
+/// Windows.
+///
+/// Both UDP relay sockets here send *and* receive on the same handle. On Windows
+/// a UDP `send_to` to a loopback peer with no live listener makes the kernel
+/// surface the resulting ICMP port-unreachable as a phantom `WSAECONNRESET`
+/// (10054) on the socket's *next* `recv` — which, on the client's shared socket,
+/// would tear the whole tunnel down (every flow reconnects). The peers here are
+/// loopback (SS_LOCAL on the client; the ss server's plugin loopback on the
+/// server) and routinely come and go, so this is reachable under ordinary UDP
+/// churn (e.g. finished DNS queries). Disabling `SIO_UDP_CONNRESET` is the
+/// standard fix (also applied by quinn / hickory-dns); tokio/mio leave the
+/// Windows default (enabled). See bindreams/hole#415 and the documented hazard
+/// in `crates/bridge/src/dns/forwarder.rs`.
+pub(crate) fn bind_udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
+    // Bind via std so the raw handle is available for the Windows ioctl before
+    // the socket is registered with tokio's reactor.
+    let sock = std::net::UdpSocket::bind(addr)?;
+    sock.set_nonblocking(true)?;
+    #[cfg(windows)]
+    disable_udp_connreset(&sock)?;
+    UdpSocket::from_std(sock)
+}
+
+#[cfg(windows)]
+fn disable_udp_connreset(sock: &std::net::UdpSocket) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawSocket as _;
+
+    use windows::Win32::Networking::WinSock::{WSAIoctl, SOCKET};
+
+    // SIO_UDP_CONNRESET = _WSAIOW(IOC_VENDOR, 12) == 0x9800000C. Passing FALSE
+    // disables the phantom-reset behavior described on `bind_udp`.
+    const SIO_UDP_CONNRESET: u32 = 0x9800_000C;
+
+    let disable: u32 = 0; // BOOL FALSE
+    let mut bytes_returned: u32 = 0;
+    let rc = unsafe {
+        WSAIoctl(
+            SOCKET(sock.as_raw_socket() as usize),
+            SIO_UDP_CONNRESET,
+            Some(std::ptr::addr_of!(disable).cast()),
+            std::mem::size_of::<u32>() as u32,
+            None,
+            0,
+            &mut bytes_returned,
+            None,
+            None,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 /// Write a stream's leading tag byte and flush it. Every yamux substream
 /// begins with one [`StreamTag`] so the server can dispatch TCP vs UDP.
 async fn write_tag(stream: &mut yamux::Stream, tag: StreamTag) -> std::io::Result<()> {
@@ -246,7 +301,7 @@ async fn relay_udp_server(mut yamux_stream: yamux::Stream, remote: SocketAddr) -
     // Bind in the remote's address family, else an IPv6 `remote` (ss server
     // configured with `server: "::"` hands the plugin an `[::1]` loopback)
     // fails the connect with an address-family mismatch (#415, defect B).
-    let udp = UdpSocket::bind(unspecified_for(remote)).await.context("bind udp")?;
+    let udp = bind_udp(unspecified_for(remote)).context("bind udp")?;
     udp.connect(remote).await.context("connect udp")?;
 
     let mut read_buf = [0u8; 65536 + 2];
@@ -384,10 +439,18 @@ async fn run_udp_association(
         }
     };
 
-    // Close the outbound channel before the (awaiting) stream teardown so a
-    // datagram the `run_client` loop tries to forward during the teardown
-    // window hits `Closed` and re-creates the association, rather than being
-    // silently buffered into a receiver that will never read it.
+    // Close the outbound channel so that, from here on, a datagram the
+    // `run_client` loop tries to forward hits `Closed` and re-creates the
+    // association instead of vanishing into a receiver that will never read it.
+    // This does not recover datagrams already buffered (or `try_send`-accepted
+    // in the brief, multi-thread-only window between the loop `break` and this
+    // call): those are dropped when `outbound_rx` is dropped at return. That is
+    // correct NAT-teardown lossy-UDP behavior — an `evicted` flow was idle for
+    // `udp_timeout`, so a datagram arriving exactly at eviction is the first of
+    // a resumed flow that the app will retransmit (DNS/QUIC do); on an error
+    // teardown the stream is already dead and those datagrams could not have
+    // been delivered anyway. Conntrack/shadowsocks-rust drop the same boundary
+    // packet.
     outbound_rx.close();
 
     tracing::debug!(peer = %peer, reason, "udp association closed");
@@ -410,7 +473,7 @@ pub(crate) async fn run_client(
     // detached association tasks (which hold `Arc<UdpSocket>` clones) for the
     // port and could fail the rebind, terminating the client.
     let tcp_listener = TcpListener::bind(local).await.context("bind local TCP")?;
-    let udp_socket = Arc::new(UdpSocket::bind(local).await.context("bind local UDP")?);
+    let udp_socket = Arc::new(bind_udp(local).context("bind local UDP")?);
 
     // Report the actual bound UDP address (test seam). Production passes `None`.
     if let Some(tx) = bound_addr_tx {

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -1,4 +1,22 @@
-use crate::yamux::{deframe_udp_datagram, frame_udp_datagram, StreamTag};
+// `CancellationToken::new` is the cancel-test harness root for the E2E relay
+// tests; module-level allow per the workspace clippy.toml's sanctioned
+// test-file exception (mirrors garter's tap_tests.rs).
+#![allow(clippy::disallowed_methods)]
+
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use tokio::net::UdpSocket;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use garter::test_utils::WaitableWriter;
+use garter::tracing_test::set_default_in_current_thread;
+
+use crate::yamux::{
+    deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client, run_server, FrameAccumulator, StreamTag,
+    DEFAULT_UDP_TIMEOUT,
+};
 
 #[skuld::test]
 fn stream_tag_tcp_roundtrip() {
@@ -34,4 +52,272 @@ fn udp_frame_max_size() {
     let framed = frame_udp_datagram(&payload);
     let (decoded, _) = deframe_udp_datagram(&framed).unwrap();
     assert_eq!(decoded.len(), 65535);
+}
+
+// FrameAccumulator (Defect C) -----------------------------------------------------------------------------------------
+
+/// Helper: collect every frame currently available from the accumulator.
+fn drain_all(acc: &mut FrameAccumulator) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    while let Some(frame) = acc.next_frame() {
+        out.push(frame);
+    }
+    out
+}
+
+#[skuld::test]
+fn accumulator_single_frame_in_one_push() {
+    let mut acc = FrameAccumulator::new();
+    acc.push(&frame_udp_datagram(b"hello"));
+    assert_eq!(drain_all(&mut acc), vec![b"hello".to_vec()]);
+}
+
+#[skuld::test]
+fn accumulator_two_coalesced_frames_in_one_push() {
+    // The bug: a single read returning two frames must yield BOTH payloads,
+    // not just the first.
+    let mut buf = frame_udp_datagram(b"first");
+    buf.extend_from_slice(&frame_udp_datagram(b"second"));
+    let mut acc = FrameAccumulator::new();
+    acc.push(&buf);
+    assert_eq!(drain_all(&mut acc), vec![b"first".to_vec(), b"second".to_vec()]);
+}
+
+#[skuld::test]
+fn accumulator_frame_split_across_pushes() {
+    // The bug: a frame split across two reads must reassemble, not corrupt.
+    let framed = frame_udp_datagram(b"split me up");
+    let (head, tail) = framed.split_at(4);
+    let mut acc = FrameAccumulator::new();
+    acc.push(head);
+    assert!(acc.next_frame().is_none(), "partial frame must not yield");
+    acc.push(tail);
+    assert_eq!(drain_all(&mut acc), vec![b"split me up".to_vec()]);
+}
+
+#[skuld::test]
+fn accumulator_one_byte_at_a_time() {
+    let framed = frame_udp_datagram(b"drip");
+    let mut acc = FrameAccumulator::new();
+    for (i, byte) in framed.iter().enumerate() {
+        acc.push(&[*byte]);
+        // Only the final byte completes the frame.
+        if i + 1 < framed.len() {
+            assert!(acc.next_frame().is_none());
+        }
+    }
+    assert_eq!(drain_all(&mut acc), vec![b"drip".to_vec()]);
+}
+
+#[skuld::test]
+fn accumulator_length_prefix_split() {
+    // Split in the middle of the 2-byte length prefix.
+    let framed = frame_udp_datagram(b"x");
+    let mut acc = FrameAccumulator::new();
+    acc.push(&framed[..1]);
+    assert!(acc.next_frame().is_none());
+    acc.push(&framed[1..]);
+    assert_eq!(drain_all(&mut acc), vec![b"x".to_vec()]);
+}
+
+#[skuld::test]
+fn accumulator_one_and_a_half_frames() {
+    // One complete frame plus the start of a second: yields the first, keeps
+    // the partial, then completes the second on the next push.
+    let mut buf = frame_udp_datagram(b"whole");
+    let second = frame_udp_datagram(b"partial then rest");
+    buf.extend_from_slice(&second[..3]);
+    let mut acc = FrameAccumulator::new();
+    acc.push(&buf);
+    assert_eq!(drain_all(&mut acc), vec![b"whole".to_vec()]);
+    acc.push(&second[3..]);
+    assert_eq!(drain_all(&mut acc), vec![b"partial then rest".to_vec()]);
+}
+
+#[skuld::test]
+fn accumulator_empty_payload_frame() {
+    // A zero-length datagram is a valid frame (2-byte length == 0).
+    let mut acc = FrameAccumulator::new();
+    acc.push(&frame_udp_datagram(b""));
+    assert_eq!(drain_all(&mut acc), vec![Vec::<u8>::new()]);
+}
+
+// parse_udp_timeout (#415) --------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn udp_timeout_defaults_when_absent() {
+    assert_eq!(parse_udp_timeout(None).unwrap(), DEFAULT_UDP_TIMEOUT);
+    assert_eq!(parse_udp_timeout(Some("server")).unwrap(), DEFAULT_UDP_TIMEOUT);
+    assert_eq!(
+        parse_udp_timeout(Some("mode=quic;host=cdn")).unwrap(),
+        DEFAULT_UDP_TIMEOUT
+    );
+}
+
+#[skuld::test]
+fn udp_timeout_parsed_value() {
+    assert_eq!(
+        parse_udp_timeout(Some("udp_timeout=10")).unwrap(),
+        Duration::from_secs(10)
+    );
+    // Coexists with other (v2ray) keys.
+    assert_eq!(
+        parse_udp_timeout(Some("server;udp_timeout=42;mode=quic")).unwrap(),
+        Duration::from_secs(42)
+    );
+}
+
+#[skuld::test]
+fn udp_timeout_last_occurrence_wins() {
+    assert_eq!(
+        parse_udp_timeout(Some("udp_timeout=5;udp_timeout=20")).unwrap(),
+        Duration::from_secs(20)
+    );
+}
+
+#[skuld::test]
+fn udp_timeout_invalid_is_error() {
+    assert!(parse_udp_timeout(Some("udp_timeout=abc")).is_err());
+    assert!(parse_udp_timeout(Some("udp_timeout=")).is_err());
+    // 0 would evict every association immediately — rejected.
+    assert!(parse_udp_timeout(Some("udp_timeout=0")).is_err());
+    assert!(parse_udp_timeout(Some("udp_timeout=-1")).is_err());
+}
+
+// End-to-end UDP relay (#415) -----------------------------------------------------------------------------------------
+
+/// Spawn a UDP echo server bound on `ip:0`; returns its bound address. The task
+/// echoes every datagram back to its sender and lives until the runtime drops.
+async fn spawn_udp_echo(ip: IpAddr) -> SocketAddr {
+    let sock = UdpSocket::bind(SocketAddr::new(ip, 0)).await.expect("bind echo");
+    let addr = sock.local_addr().expect("echo local_addr");
+    tokio::spawn(async move {
+        let mut buf = [0u8; 65536];
+        while let Ok((n, peer)) = sock.recv_from(&mut buf).await {
+            let _ = sock.send_to(&buf[..n], peer).await;
+        }
+    });
+    addr
+}
+
+/// Stand up a client+server yamux relay whose upstream is a UDP echo server
+/// bound on `echo_ip`. Returns the client's local UDP address (where a test
+/// "app" socket sends) and the shutdown token.
+///
+/// No artificial delay orders startup: `run_server`/`run_client` report their
+/// bound address via the readiness oneshot, and we await each before using it.
+async fn setup_relay(echo_ip: IpAddr, udp_timeout: Duration) -> (SocketAddr, CancellationToken) {
+    let echo_addr = spawn_udp_echo(echo_ip).await;
+    let shutdown = CancellationToken::new();
+    let loopback_v4: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+    let (srv_tx, srv_rx) = oneshot::channel();
+    tokio::spawn(run_server(
+        ::yamux::Config::default(),
+        loopback_v4,
+        echo_addr,
+        shutdown.clone(),
+        Some(srv_tx),
+    ));
+    let server_addr = srv_rx.await.expect("server bound");
+
+    let (cli_tx, cli_rx) = oneshot::channel();
+    tokio::spawn(run_client(
+        ::yamux::Config::default(),
+        loopback_v4,
+        server_addr,
+        udp_timeout,
+        shutdown.clone(),
+        Some(cli_tx),
+    ));
+    let client_udp_addr = cli_rx.await.expect("client bound");
+
+    (client_udp_addr, shutdown)
+}
+
+/// Send one datagram from `app` to the client's local UDP port and await the
+/// echoed reply. A reply that never arrives (the pre-#415 bug) hangs until the
+/// test-framework timeout — the sanctioned "external event" failure bound.
+async fn round_trip(app: &UdpSocket, client_addr: SocketAddr, payload: &[u8]) -> Vec<u8> {
+    app.send_to(payload, client_addr).await.expect("app send");
+    let mut buf = [0u8; 65536];
+    let (n, _from) = app.recv_from(&mut buf).await.expect("app recv");
+    buf[..n].to_vec()
+}
+
+#[skuld::test]
+async fn udp_reply_delivered() {
+    let (client_addr, shutdown) = setup_relay("127.0.0.1".parse().unwrap(), DEFAULT_UDP_TIMEOUT).await;
+    let app = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    assert_eq!(round_trip(&app, client_addr, b"ping").await, b"ping");
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn udp_multiple_datagrams_one_association() {
+    let (client_addr, shutdown) = setup_relay("127.0.0.1".parse().unwrap(), DEFAULT_UDP_TIMEOUT).await;
+    // Reuse one app socket so all datagrams share a single NAT association /
+    // yamux stream; every reply must still route back.
+    let app = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    for msg in [b"one".as_slice(), b"two", b"three", b"four"] {
+        assert_eq!(round_trip(&app, client_addr, msg).await, msg);
+    }
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn udp_distinct_peers_isolated() {
+    let (client_addr, shutdown) = setup_relay("127.0.0.1".parse().unwrap(), DEFAULT_UDP_TIMEOUT).await;
+    let app_a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let app_b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    app_a.send_to(b"aaaa", client_addr).await.unwrap();
+    app_b.send_to(b"bbbb", client_addr).await.unwrap();
+
+    let mut buf = [0u8; 64];
+    let (na, _) = app_a.recv_from(&mut buf).await.unwrap();
+    assert_eq!(&buf[..na], b"aaaa", "peer A must receive its own echo");
+    let (nb, _) = app_b.recv_from(&mut buf).await.unwrap();
+    assert_eq!(&buf[..nb], b"bbbb", "peer B must receive its own echo");
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn udp_ipv6_remote() {
+    // Defect B: the server relay must bind a UDP socket in the remote's address
+    // family. An IPv6 upstream fails the pre-#415 hardcoded IPv4 bind.
+    let (client_addr, shutdown) = setup_relay("::1".parse().unwrap(), DEFAULT_UDP_TIMEOUT).await;
+    let app = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    assert_eq!(round_trip(&app, client_addr, b"over-v6").await, b"over-v6");
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn udp_idle_eviction_and_recreation() {
+    // The short idle timeout IS the behavior under test (NAT idle eviction);
+    // we park on the deterministic "udp association closed" log event, never on
+    // a sleep. 500ms gives a comfortable margin over a loopback round-trip so
+    // the first exchange can never race the eviction. See #415 / #383.
+    let writer = WaitableWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .with_ansi(false)
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    let _g = set_default_in_current_thread(subscriber);
+
+    let (client_addr, shutdown) = setup_relay("127.0.0.1".parse().unwrap(), Duration::from_millis(500)).await;
+    let app = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+    // First exchange establishes the association.
+    assert_eq!(round_trip(&app, client_addr, b"first").await, b"first");
+
+    // The now-idle association is evicted; park on the close event.
+    let closed = writer.wait_for("udp association closed");
+    tokio::task::spawn_blocking(move || closed.recv().expect("association never evicted"))
+        .await
+        .unwrap();
+
+    // A datagram from the same peer transparently re-creates the association.
+    assert_eq!(round_trip(&app, client_addr, b"second").await, b"second");
+    shutdown.cancel();
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -14,8 +14,8 @@ use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client, run_server, FrameAccumulator, StreamTag,
-    DEFAULT_UDP_TIMEOUT,
+    bind_udp, deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client, run_server, FrameAccumulator,
+    StreamTag, DEFAULT_UDP_TIMEOUT,
 };
 
 #[skuld::test]
@@ -289,6 +289,29 @@ async fn udp_ipv6_remote() {
     let app = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     assert_eq!(round_trip(&app, client_addr, b"over-v6").await, b"over-v6");
     shutdown.cancel();
+}
+
+#[cfg(windows)]
+#[skuld::test]
+async fn bind_udp_send_to_dead_peer_does_not_poison_recv() {
+    // Windows-only regression for #415: a UDP send to a loopback peer with no
+    // listener must NOT surface a phantom WSAECONNRESET on the socket's next
+    // recv. With SIO_UDP_CONNRESET left enabled (tokio/mio default) the recv
+    // below would return Err(ConnectionReset) instead of the self-datagram,
+    // which in run_client would tear down the whole tunnel. `bind_udp` disables
+    // it.
+    let sock = bind_udp("127.0.0.1:0".parse().unwrap()).expect("bind_udp");
+    let me = sock.local_addr().unwrap();
+
+    // Send to a dead loopback port (no listener) — would poison the next recv.
+    let dead: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    sock.send_to(b"into the void", dead).await.unwrap();
+
+    // Then exercise the socket normally; recv must succeed, not ConnectionReset.
+    sock.send_to(b"still alive", me).await.unwrap();
+    let mut buf = [0u8; 32];
+    let (n, _) = sock.recv_from(&mut buf).await.expect("recv must not be poisoned");
+    assert_eq!(&buf[..n], b"still alive");
 }
 
 #[skuld::test]

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -14,9 +14,12 @@ use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    bind_udp, deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client, run_server, FrameAccumulator,
-    StreamTag, DEFAULT_UDP_TIMEOUT,
+    deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client, run_server, FrameAccumulator, StreamTag,
+    DEFAULT_UDP_TIMEOUT,
 };
+// Only the Windows-gated CONNRESET regression test uses this.
+#[cfg(windows)]
+use crate::yamux::bind_udp;
 
 #[skuld::test]
 fn stream_tag_tcp_roundtrip() {


### PR DESCRIPTION
Fixes #415.

## Problem

galoshes v0.1.1’s client-side SIP003u UDP relay was fire-and-forget: it forwarded the outbound datagram to the server but discarded the originating peer and `close()`d the yamux stream immediately, so replies (DNS, QUIC, any round-trip) had nowhere to go and silently timed out. TCP worked; the server side was already bidirectional.

## Fix (three defects)

- **A — client fire-and-forget.** `run_client` now keeps a NAT-style association table keyed by the originating local peer. Each peer gets a `run_udp_association` task owning a yamux stream and relaying bidirectionally (mirroring `relay_udp_server`), with a shared `Arc<UdpSocket>` delivering replies back via `send_to(peer)`. Idle associations are evicted after `udp_timeout` (NAT/conntrack-style); a generation counter + cleanup channel close the re-create-during-teardown race.
- **B — server IPv4-only UDP bind.** `relay_udp_server` binds a socket in the upstream’s address family (`unspecified_for(remote)`), so an IPv6 ss server (`server: "::"` → `[::1]` plugin loopback) no longer fails the connect.
- **C — framing assumed message-preserving reads (latent).** yamux substreams are byte streams; a single `read` can return a partial or coalesced frame. New `FrameAccumulator` (reusing the existing `deframe_udp_datagram`) drains every complete frame and retains partials, on both client and server.

## Configurable idle timeout

`udp_timeout` (whole seconds) is parsed from `SS_PLUGIN_OPTIONS` (default 300s, matching shadowsocks-rust; last-occurrence wins; `0`/invalid rejected at startup). v2ray-plugin ignores the unknown key, so the shared options string is safe.

## Testing

- `FrameAccumulator` unit tests: coalesced, split-across-reads, one-byte-at-a-time, split length-prefix, 1.5 frames, empty payload.
- E2E (client+server over loopback + a UDP echo upstream): reply delivered, multiple datagrams over one association, distinct peers isolated, IPv6 upstream, idle eviction + transparent re-creation.
- `parse_udp_timeout` parsing tests (default / value / last-wins / invalid / 0).
- TDD red confirmed: `udp_reply_delivered` hangs and fails when the fire-and-forget behavior is restored, passes with the fix.
- Synchronization is event-driven (bound-address oneshots, `WaitableWriter` log event for eviction) — no sleeps-for-sync. The one `tokio::time::sleep` is the NAT idle timer (the behavior under management), documented inline per the synchronization invariant.

28/28 galoshes tests pass; `cargo clippy -p garter -p garter-bin -p galoshes -p mock-plugin --all-targets -- -D warnings` clean.

## Review follow-up

A code review surfaced two issues, both fixed here: a reconnect rebind-vs-detached-task race (local listeners now bound once outside the reconnect loop) and an eviction-window datagram loss (`biased` select + `outbound_rx.close()` on teardown). A pre-existing graceful-shutdown hang (driver doesn’t observe the shutdown token) is tracked separately in #416.