### PR TITLE
feat(garter): sitrep plugin-readiness protocol; fix multi-plugin readiness race (#414)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,12 +2203,16 @@ dependencies = [
 
 [[package]]
 name = "garter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
+ "bitflags 2.11.1",
  "contracts",
  "hole-test-observability",
  "libc",
+ "semver",
+ "serde",
+ "serde_json",
  "skuld",
  "socket2",
  "thiserror 2.0.18",
@@ -2221,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "garter-bin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "garter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ dependencies = [
  "garter",
  "hole-test-observability",
  "libc",
+ "serde_json",
  "sha2 0.11.0",
  "skuld",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,6 +3953,8 @@ dependencies = [
 name = "mock-plugin"
 version = "0.1.0"
 dependencies = [
+ "garter",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,11 @@ webpki-roots = "1"
 # Shared across ex-Galoshes crates; Hole-side crates can opt in via `{ workspace = true }` too.
 anyhow = "1"
 async-trait = "0.1"
+bitflags = "2"
 contracts = "0.6"
+semver = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [workspace.lints.clippy]
 disallowed_methods = "deny"

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -49,6 +49,14 @@ pub enum ProxyError {
     WintunLoad { path: PathBuf, message: String },
     #[error("plugin error: {0}")]
     Plugin(String),
+    /// A plugin reported a typed bind conflict (`StartError::BindConflict`
+    /// via sitrep — #414) at its local listener. This is the retryable
+    /// class: `proxy_err_to_io_err` synthesizes an `AddrInUse`-kind
+    /// `io::Error` from it so `bind_ephemeral` allocates a fresh port and
+    /// retries. The `errno` is the plugin's host-native OS error (0 if
+    /// unknown), preserved for `bridge.log` diagnostics.
+    #[error("plugin bind conflict on {addr} (errno {errno})")]
+    BindRace { errno: i32, addr: SocketAddr },
     /// `tunnel_mode == Full` requires the SOCKS5 listener, because the
     /// TUN dispatcher hands captured traffic to it on `local_port`.
     #[error("tunnel_mode=full requires the SOCKS5 listener; enable proxy_socks5 or switch to tunnel_mode=socks-only")]
@@ -278,6 +286,14 @@ pub fn resolve_plugin_path(name: &str) -> String {
 /// [`hole_common::protocol::BridgeResponse::Status::udp_proxy_available`]
 /// keeps its historical name for API stability. This helper uses the
 /// more accurate internal name.
+// TODO(#414 plan 2): remove this helper once port-alloc also derives UDP
+// capability from reported transports. The UDP-drop policy no longer calls
+// it — `proxy_manager.rs` now reads `PluginChain::transports()` (the live
+// sitrep signal) instead. It survives because the underlying static
+// `PluginDescriptor.udp_supported` is still read at port-alloc time (via
+// `plugin::plugin_protocols`), and Plan 2 retires both together. (Currently
+// only `config_tests.rs` exercises this `pub` helper directly — kept `pub`
+// + re-exported, so no dead-code warning fires.)
 pub fn plugin_supports_udp(config: &ProxyConfig) -> bool {
     match &config.server.plugin {
         None => true,

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -328,6 +328,11 @@ async fn spawn_plugin_runner_at(
             handle.abort();
             return Err(ProxyError::Cancelled);
         }
+        // sync-exception(external-event, CLAUDE.md class 2): READINESS_TIMEOUT is the
+        // terminal failure-to-human bound for a plugin subprocess that may never become
+        // ready (wedged child); it is NOT intra-process sync. Cooperative cancel via the
+        // biased cancel arm above is the primary escape; this timeout only bounds the
+        // genuinely-stuck case.
         r = tokio::time::timeout(READINESS_TIMEOUT, ready_rx) => match r {
             Ok(Ok(Ok(chain_ready))) => chain_ready,
             // The only retryable start class: a plugin reported it could

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -32,6 +32,11 @@ pub struct PluginChain {
     handle: tokio::task::JoinHandle<garter::Result<()>>,
     cancel: CancellationToken,
     local_addr: SocketAddr,
+    /// Transports the live chain actually reported via sitrep `ready`
+    /// (#414) — the end-to-end intersection across every hop. The UDP-drop
+    /// policy in `proxy_manager.rs` reads this as the authoritative runtime
+    /// signal, replacing the static `PluginDescriptor.udp_supported` guess.
+    transports: garter::Transports,
     state_dir: Option<PathBuf>,
 }
 
@@ -47,6 +52,13 @@ impl std::fmt::Debug for PluginChain {
 impl PluginChain {
     pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
+    }
+
+    /// Transports the live chain reported via sitrep `ready` (#414). The
+    /// UDP-drop policy reads this to decide whether `Proxy`-routed UDP
+    /// flows can be carried through the tunnel or must be dropped.
+    pub fn transports(&self) -> garter::Transports {
+        self.transports
     }
 
     /// Explicitly kill all tracked plugin PIDs and clear the state file.
@@ -128,7 +140,7 @@ pub async fn start_plugin_chain(
     let merged_opts = inject_plugin_debug_logging(plugin_name, plugin_opts);
     let protocols = plugin_protocols(plugin_name);
 
-    let (_port, (handle, cancel, ready_addr)) =
+    let (_port, (handle, cancel, ready_addr, transports)) =
         port_alloc::bind_ephemeral(IpAddr::V4(Ipv4Addr::LOCALHOST), protocols, |port| {
             // The Fn closure cannot move `merged_opts` (owned String) into
             // an `async move`; clone per attempt instead. `&str`/`&Path`
@@ -173,6 +185,7 @@ pub async fn start_plugin_chain(
         handle,
         cancel,
         local_addr: ready_addr,
+        transports,
         state_dir: state_dir.map(Path::to_path_buf),
     })
 }
@@ -213,8 +226,14 @@ fn resolve_tap_source(diagnostic_tap: bool) -> TapSource {
 /// and awaits readiness with a 30-second timeout. On failure runs
 /// `cancel.cancel(); handle.abort()` so a retried attempt by
 /// `bind_ephemeral` doesn't leak the previous attempt's task. On
-/// success returns `(handle, cancel, ready_addr)` — the caller wraps
-/// these in a [`PluginChain`].
+/// success returns `(handle, cancel, ready_addr, transports)` — the
+/// caller wraps these in a [`PluginChain`]. The `transports` is the
+/// sitrep-reported end-to-end transport set (#414), threaded into the
+/// bridge's UDP-drop policy.
+///
+/// A plugin `StartError::BindConflict` (the only retryable start class)
+/// maps to [`ProxyError::BindRace`] so the outer `bind_ephemeral` retries
+/// on a fresh port; a `StartError::Fatal` maps to [`ProxyError::Plugin`].
 #[allow(clippy::too_many_arguments)] // 9 args — already at the limit before #397 added cancel; bundling into a struct adds more noise than the warning.
 async fn spawn_plugin_runner_at(
     plugin_name: &str,
@@ -231,6 +250,7 @@ async fn spawn_plugin_runner_at(
         tokio::task::JoinHandle<garter::Result<()>>,
         CancellationToken,
         SocketAddr,
+        garter::Transports,
     ),
     ProxyError,
 > {
@@ -301,19 +321,30 @@ async fn spawn_plugin_runner_at(
     // `ready_rx` now yields `Result<ChainReady, StartError>` (per-plugin
     // readiness aggregated by the runner — #414); the timeout adds one
     // `Result` layer and the channel another. Flatten and extract the
-    // chain-public listen address.
-    let ready_addr = tokio::select! {
+    // chain-public listen address + reported transports.
+    let chain_ready = tokio::select! {
         biased;
         _ = cancel.cancelled() => {
             handle.abort();
             return Err(ProxyError::Cancelled);
         }
         r = tokio::time::timeout(READINESS_TIMEOUT, ready_rx) => match r {
-            Ok(Ok(Ok(chain_ready))) => chain_ready.listen,
-            Ok(Ok(Err(start_err))) => {
+            Ok(Ok(Ok(chain_ready))) => chain_ready,
+            // The only retryable start class: a plugin reported it could
+            // not bind its listener. Surface as `ProxyError::BindRace` so
+            // `bind_ephemeral` (via `proxy_err_to_io_err`) retries on a
+            // fresh port. The errno is preserved for `bridge.log`.
+            Ok(Ok(Err(garter::StartError::BindConflict { errno, addr }))) => {
                 cancel.cancel();
                 handle.abort();
-                return Err(ProxyError::Plugin(format!("plugin failed to start: {start_err}")));
+                return Err(ProxyError::BindRace { errno, addr });
+            }
+            // Terminal start failure (config error, upstream-dial failure,
+            // bare process exit) — never retried.
+            Ok(Ok(Err(garter::StartError::Fatal { detail, .. }))) => {
+                cancel.cancel();
+                handle.abort();
+                return Err(ProxyError::Plugin(format!("plugin failed to start: {detail}")));
             }
             Ok(Err(_)) => {
                 cancel.cancel();
@@ -328,31 +359,51 @@ async fn spawn_plugin_runner_at(
         },
     };
 
-    Ok((handle, cancel, ready_addr))
+    Ok((handle, cancel, chain_ready.listen, chain_ready.transports))
 }
 
-/// Convert a [`ProxyError`] from `spawn_plugin_runner_at` into a
-/// non-bind-race [`io::Error`] so [`port_alloc::bind_ephemeral`]
-/// propagates it immediately. Plugin failures (subprocess exit before
-/// ready, readiness timeout) are not bind races we can in-band
-/// classify; the in-process probe step inside `bind_ephemeral`
-/// already catches Windows excluded-range disagreements before the
-/// subprocess spawn. Stderr-based classification of subprocess bind
-/// failures is the follow-up tracked in bindreams/hole#304.
+/// Convert a [`ProxyError`] from `spawn_plugin_runner_at` into an
+/// [`io::Error`] so [`port_alloc::bind_ephemeral`] can classify it.
 ///
-/// `spawn_plugin_runner_at` emits `ProxyError::Plugin` (subprocess
-/// failure paths) or `ProxyError::Cancelled` (bridge cancel observed
-/// mid-spawn, #397). Both surface as non-bind-race `io::Error::other`
-/// so `bind_ephemeral` propagates them immediately; the outer
-/// `start_plugin_chain` then distinguishes Cancelled via
-/// `cancel.is_cancelled()` to re-emit the canonical variant. The
-/// `unreachable!` arm is the contract guard for future variants.
+/// `spawn_plugin_runner_at` emits exactly three variants:
+///
+/// - [`ProxyError::BindRace`] (a plugin's `StartError::BindConflict`,
+///   #414) — synthesized into an `AddrInUse`-kind `io::Error` so
+///   [`hole_common::retry::is_bind_race`] classifies it as retryable and
+///   `bind_ephemeral` allocates a fresh port. This is the load-bearing
+///   case: a plugin that loses its local-port bind race gets retried
+///   in-band like the in-process binders, instead of failing the start.
+/// - [`ProxyError::Plugin`] (subprocess exit before ready, readiness
+///   timeout, fatal start error) — a non-bind-race `io::Error::other`
+///   so `bind_ephemeral` propagates it immediately. These are not bind
+///   races we can in-band classify; the in-process probe step inside
+///   `bind_ephemeral` already catches Windows excluded-range
+///   disagreements before the subprocess spawn (stderr-based
+///   classification of subprocess bind failures is bindreams/hole#304).
+/// - [`ProxyError::Cancelled`] (bridge cancel observed mid-spawn, #397)
+///   — a non-bind-race `io::Error::other`; the outer `start_plugin_chain`
+///   distinguishes it via `cancel.is_cancelled()` to re-emit the
+///   canonical variant.
+///
+/// The `unreachable!` arm is the contract guard for any OTHER variant.
 fn proxy_err_to_io_err(e: ProxyError) -> std::io::Error {
     match e {
+        ProxyError::BindRace { errno, addr } => {
+            // Synthesize an AddrInUse-kind io::Error DIRECTLY so is_bind_race
+            // (which keys on ErrorKind, not raw_os_error) classifies it on
+            // every OS regardless of the platform-native errno value
+            // (errno 48 is AddrInUse on macOS but garbage on Windows). The
+            // errno is preserved in the message for bridge.log diagnostics
+            // (#414).
+            std::io::Error::new(
+                std::io::ErrorKind::AddrInUse,
+                format!("plugin bind conflict on {addr} (errno {errno})"),
+            )
+        }
         ProxyError::Plugin(msg) => std::io::Error::other(msg),
         ProxyError::Cancelled => std::io::Error::other("plugin spawn cancelled"),
         other => {
-            unreachable!("spawn_plugin_runner_at only emits ProxyError::Plugin or ProxyError::Cancelled, got: {other}")
+            unreachable!("spawn_plugin_runner_at only emits ProxyError::BindRace, ProxyError::Plugin, or ProxyError::Cancelled, got: {other}")
         }
     }
 }

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -298,6 +298,10 @@ async fn spawn_plugin_runner_at(
     // start mid-spawn, abort the partially-spawned chain and return
     // ProxyError::Cancelled so the caller short-circuits cleanly instead
     // of waiting up to READINESS_TIMEOUT for a chain it no longer wants.
+    // `ready_rx` now yields `Result<ChainReady, StartError>` (per-plugin
+    // readiness aggregated by the runner — #414); the timeout adds one
+    // `Result` layer and the channel another. Flatten and extract the
+    // chain-public listen address.
     let ready_addr = tokio::select! {
         biased;
         _ = cancel.cancelled() => {
@@ -305,7 +309,12 @@ async fn spawn_plugin_runner_at(
             return Err(ProxyError::Cancelled);
         }
         r = tokio::time::timeout(READINESS_TIMEOUT, ready_rx) => match r {
-            Ok(Ok(addr)) => addr,
+            Ok(Ok(Ok(chain_ready))) => chain_ready.listen,
+            Ok(Ok(Err(start_err))) => {
+                cancel.cancel();
+                handle.abort();
+                return Err(ProxyError::Plugin(format!("plugin failed to start: {start_err}")));
+            }
             Ok(Err(_)) => {
                 cancel.cancel();
                 handle.abort();

--- a/crates/bridge/src/proxy/plugin_tests.rs
+++ b/crates/bridge/src/proxy/plugin_tests.rs
@@ -3,9 +3,12 @@
 // test-file exception.
 #![allow(clippy::disallowed_methods)]
 
+use std::net::SocketAddr;
+
 use tokio_util::sync::CancellationToken;
 
-use super::start_plugin_chain;
+use super::{proxy_err_to_io_err, start_plugin_chain};
+use crate::proxy::ProxyError;
 
 #[skuld::test]
 async fn start_with_nonexistent_binary_returns_plugin_error() {
@@ -24,7 +27,74 @@ async fn start_with_nonexistent_binary_returns_plugin_error() {
 
     let err = result.unwrap_err();
     assert!(
-        matches!(err, crate::proxy::ProxyError::Plugin(_)),
+        matches!(err, ProxyError::Plugin(_)),
         "expected ProxyError::Plugin, got: {err:?}"
+    );
+}
+
+// Bind-race classification (#414) =====================================================================================
+//
+// The load-bearing guarantee: a plugin-reported `StartError::BindConflict`
+// (mapped to `ProxyError::BindRace` in `spawn_plugin_runner_at`) must be
+// retryable on EVERY OS. `proxy_err_to_io_err` synthesizes an
+// `AddrInUse`-kind `io::Error` directly (NOT via `from_raw_os_error`,
+// which is platform-fragile), and `bind_ephemeral` retries when
+// `hole_common::retry::is_bind_race` returns true. These tests pin both
+// halves: BindRace IS a bind race; Plugin / Cancelled are NOT.
+
+fn dummy_addr() -> SocketAddr {
+    "127.0.0.1:5300".parse().unwrap()
+}
+
+#[skuld::test]
+fn bind_race_maps_to_retryable_addr_in_use_io_error() {
+    // errno 0 (unknown) is the worst case — even with no host-native errno
+    // the synthesized ErrorKind must still classify as a bind race.
+    let io_err = proxy_err_to_io_err(ProxyError::BindRace {
+        errno: 0,
+        addr: dummy_addr(),
+    });
+    assert_eq!(
+        io_err.kind(),
+        std::io::ErrorKind::AddrInUse,
+        "BindRace must synthesize an AddrInUse-kind io::Error"
+    );
+    assert!(
+        hole_common::retry::is_bind_race(&io_err),
+        "BindRace io::Error must classify as a retryable bind race on every OS"
+    );
+}
+
+#[skuld::test]
+fn bind_race_with_nonzero_errno_still_retryable() {
+    // A host-native errno (e.g. macOS 48, Windows 10048, Linux 98) must
+    // not change the classification — it keys on ErrorKind, not errno.
+    let io_err = proxy_err_to_io_err(ProxyError::BindRace {
+        errno: 10048,
+        addr: dummy_addr(),
+    });
+    assert!(hole_common::retry::is_bind_race(&io_err));
+    // The errno is preserved in the message for bridge.log diagnostics.
+    assert!(
+        io_err.to_string().contains("10048"),
+        "errno should be preserved in the io::Error message, got: {io_err}"
+    );
+}
+
+#[skuld::test]
+fn plugin_error_is_not_a_bind_race() {
+    let io_err = proxy_err_to_io_err(ProxyError::Plugin("upstream dial failed".into()));
+    assert!(
+        !hole_common::retry::is_bind_race(&io_err),
+        "ProxyError::Plugin must NOT classify as a bind race (terminal failure)"
+    );
+}
+
+#[skuld::test]
+fn cancelled_is_not_a_bind_race() {
+    let io_err = proxy_err_to_io_err(ProxyError::Cancelled);
+    assert!(
+        !hole_common::retry::is_bind_race(&io_err),
+        "ProxyError::Cancelled must NOT classify as a bind race"
     );
 }

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -63,6 +63,27 @@ struct ProxyStartedDiag<'a> {
     ipv6_bypass_available: bool,
 }
 
+/// Derive whether `Proxy`-routed UDP flows can be carried through the
+/// tunnel, from a live plugin chain's sitrep-reported transports (#414).
+///
+/// - `Some(transports)` — a plugin chain is running; UDP is available iff
+///   the end-to-end transport intersection it reported includes
+///   [`garter::Transports::UDP`]. This replaces the static
+///   `PluginDescriptor.udp_supported` guess with the authoritative
+///   runtime signal.
+/// - `None` — no plugin chain; the raw SOCKS5 path always carries UDP, so
+///   UDP is available.
+///
+/// Takes `Option<Transports>` rather than `Option<&PluginChain>` so it is
+/// trivially unit-testable without standing up a real chain (which owns a
+/// `JoinHandle` + `CancellationToken`).
+fn udp_available_from_chain(transports: Option<garter::Transports>) -> bool {
+    match transports {
+        Some(t) => t.contains(garter::Transports::UDP),
+        None => true,
+    }
+}
+
 // State ===============================================================================================================
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -438,6 +459,15 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             return Err(ProxyError::Cancelled);
         }
 
+        // UDP availability: when a plugin chain is running, use the
+        // transports it actually reported via sitrep (#414) — the
+        // authoritative runtime signal, replacing the static
+        // `PluginDescriptor.udp_supported` guess. With no plugin, the raw
+        // SOCKS5 path carries UDP, so default to available. Computed once
+        // here (in scope for both the SocksOnly and Full branches below)
+        // so all three start sites read the same live value.
+        let udp_proxy_available = udp_available_from_chain(plugin_chain.as_ref().map(|c| c.transports()));
+
         // Build shadowsocks config. When a plugin chain is running,
         // point ss-service at the chain's local port.
         let plugin_local = plugin_chain.as_ref().map(|c| c.local_addr());
@@ -502,7 +532,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 proxy: running_proxy,
                 server_ip: None,
                 started_at: Instant::now(),
-                udp_proxy_available: crate::proxy::plugin_supports_udp(config),
+                udp_proxy_available,
                 ipv6_bypass_available: false,
             });
         }
@@ -600,7 +630,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 gw_info.interface_index,
                 gw_info.ipv6_available,
                 config.server.plugin.clone(),
-                crate::proxy::plugin_supports_udp(config),
+                udp_proxy_available,
                 ruleset,
                 local_dns_endpoint,
             )?;
@@ -670,7 +700,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             proxy: running_proxy,
             server_ip: Some(server_ip),
             started_at: Instant::now(),
-            udp_proxy_available: crate::proxy::plugin_supports_udp(config),
+            udp_proxy_available,
             ipv6_bypass_available: gw_info.ipv6_available,
         })
     }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1098,6 +1098,50 @@ fn dns_apply_skips_tun_from_capture_keeps_in_apply() {
         });
 }
 
+// #414 — transports-driven UDP-drop policy ============================================================================
+//
+// The three `RunningState`/`Dispatcher::new` start sites read
+// `udp_available_from_chain(plugin_chain.transports())` instead of the
+// static `plugin_supports_udp(config)`. The derivation is the testable
+// unit: a TCP-only chain (`[tcp]`) yields `false`, a TCP+UDP chain yields
+// `true`, and no plugin yields `true`. Standing up a real `ProxyManager`
+// start needs elevation (routing/TUN), so the derivation is extracted
+// into `udp_available_from_chain(Option<Transports>)` and tested directly
+// — the same value flows into all three start sites.
+
+#[skuld::test]
+fn udp_unavailable_when_chain_reports_tcp_only() {
+    // A TCP-only plugin (plain v2ray-plugin) reports `[tcp]` via sitrep.
+    assert!(!udp_available_from_chain(Some(garter::Transports::TCP)));
+}
+
+#[skuld::test]
+fn udp_available_when_chain_reports_tcp_and_udp() {
+    // A UDP-capable plugin (galoshes, YAMUX) reports `[tcp, udp]`.
+    assert!(udp_available_from_chain(Some(
+        garter::Transports::TCP | garter::Transports::UDP
+    )));
+}
+
+#[skuld::test]
+fn udp_available_when_chain_reports_udp_only() {
+    // Defensive: UDP present in the set is sufficient regardless of TCP.
+    assert!(udp_available_from_chain(Some(garter::Transports::UDP)));
+}
+
+#[skuld::test]
+fn udp_available_when_no_plugin() {
+    // No plugin chain — the raw SOCKS5 path always carries UDP.
+    assert!(udp_available_from_chain(None));
+}
+
+#[skuld::test]
+fn udp_unavailable_when_chain_reports_empty_transports() {
+    // Degenerate (a chain that serves nothing): UDP is not present, so
+    // the privacy-preserving default is to drop Proxy-routed UDP.
+    assert!(!udp_available_from_chain(Some(garter::Transports::empty())));
+}
+
 // #388 — forwarder self-test gate tests ===============================================================================
 //
 // `start_inner` runs `run_forwarder_self_test` synchronously BEFORE

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+serde_json = { workspace = true }
 anyhow = { workspace = true }
 contracts = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/galoshes/src/lib.rs
+++ b/crates/galoshes/src/lib.rs
@@ -1,10 +1,13 @@
 #![cfg_attr(v2ray_plugin_missing, allow(dead_code, unused_imports))]
 
 pub mod embedded;
+pub mod sitrep_out;
 pub mod yamux;
 
 #[cfg(test)]
 mod embedded_tests;
+#[cfg(test)]
+mod sitrep_out_tests;
 #[cfg(test)]
 mod yamux_tests;
 

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(v2ray_plugin_missing, allow(dead_code, unused_imports))]
 
-use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv};
+use galoshes::sitrep_out::{chain_result_to_event, emit};
+use garter::{BinaryPlugin, ChainReady, ChainRunner, Mode, PluginEnv, SitrepEvent, StartError, SITREP_PROTOCOL};
 
 #[cfg(not(v2ray_plugin_missing))]
 const V2RAY_BYTES: &[u8] = include_bytes!(env!("V2RAY_PLUGIN_PATH"));
@@ -18,10 +19,23 @@ async fn main() -> anyhow::Result<()> {
 async fn main() -> anyhow::Result<()> {
     // Sanctioned production caller of `fmt::SubscriberBuilder::init`;
     // banned in tests via clippy.toml `disallowed_methods`. See #301.
+    //
+    // Logs go to STDERR: galoshes' process STDOUT is reserved for the
+    // sitrep event stream (newline-delimited JSON) that the bridge reads.
+    // The `tracing_subscriber::fmt` default writer is `io::stdout`, which
+    // would interleave human logs into the JSON stream and corrupt it.
     #[allow(clippy::disallowed_methods)]
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with_writer(std::io::stderr)
         .init();
+
+    // sitrep handshake: ALWAYS the first stdout line, emitted before we
+    // parse the environment or build the chain so it lands as line 1 even
+    // if a later step fails.
+    emit(&SitrepEvent::Hello {
+        protocol: SITREP_PROTOCOL.to_string(),
+    });
 
     let env = PluginEnv::from_env().map_err(|e| anyhow::anyhow!("failed to parse SIP003u environment: {e}"))?;
 
@@ -47,14 +61,38 @@ async fn main() -> anyhow::Result<()> {
     let yamux_plugin = galoshes::yamux::YamuxPlugin::new(mode == Mode::Server);
     let v2ray_plugin = BinaryPlugin::new(verified.exec_path(), env.plugin_options.as_deref());
 
+    // Bridge-facing readiness: galoshes' OWN ChainRunner aggregates the
+    // per-plugin readiness of [yamux, v2ray] and fires this channel with
+    // the chain-level outcome. We map that to a PROCESS-stdout sitrep event
+    // (overriding the inner-chain transport intersection with galoshes'
+    // true TCP|UDP capability — see `sitrep_out`) so the bridge sees a
+    // structured `ready`/`bind_conflict`/`fatal` on galoshes' stdout.
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<ChainReady, StartError>>();
+
+    // The emitter must run concurrently with `runner.run`: the plugins
+    // only start (and report ready) once `run` is driving them, so we
+    // cannot await `ready_rx` before calling `run`. On channel drop
+    // (RecvError) we emit nothing — galoshes will exit and the bridge sees
+    // stdout EOF, which is the backstop.
+    let emitter = tokio::spawn(async move {
+        if let Ok(outcome) = ready_rx.await {
+            emit(&chain_result_to_event(outcome));
+        }
+    });
+
     let runner = ChainRunner::new()
         .mode(mode)
+        .on_ready(ready_tx)
         .add(Box::new(yamux_plugin))
         .add(Box::new(v2ray_plugin));
 
     // `verified` must remain alive here -- its open handle prevents TOCTOU
     // attacks on the extracted binary. It is dropped after `run()` returns.
     let result = runner.run(env).await.map_err(|e| anyhow::anyhow!(e));
+    // The aggregator drops `ready_tx` once the chain ends (or on shutdown),
+    // so the emitter task either already emitted or sees RecvError; await
+    // it to completion rather than fire-and-forget.
+    let _ = emitter.await;
     drop(verified);
     result
 }

--- a/crates/galoshes/src/sitrep_out.rs
+++ b/crates/galoshes/src/sitrep_out.rs
@@ -1,0 +1,71 @@
+//! Process-stdout sitrep emission for the galoshes binary.
+//!
+//! galoshes is spawned by the bridge as a `BinaryPlugin` and the bridge
+//! reads sitrep events from galoshes' **process stdout**. Internally
+//! galoshes builds its own `garter::ChainRunner` over a 2-plugin chain
+//! (`YamuxPlugin` outer + embedded `v2ray-plugin` inner); that runner's
+//! `on_ready` channel fires the chain-level outcome. This module maps that
+//! chain-level outcome onto the PROCESS-level sitrep event galoshes emits
+//! on stdout.
+//!
+//! The mapping logic is split out here (rather than living inline in
+//! `main.rs`) so it is unit-testable without spawning the binary or
+//! requiring the embedded v2ray-plugin to be present.
+
+use std::io::Write as _;
+
+use garter::{ChainReady, SitrepEvent, StartError, Transports};
+
+/// The transports galoshes advertises end-to-end on its process-stdout
+/// `ready` event.
+///
+/// **This is deliberately NOT the inner chain's transport intersection.**
+/// galoshes' whole purpose is to carry UDP-over-YAMUX: its outer
+/// `YamuxPlugin` hop serves TCP *and* UDP, while the embedded v2ray-plugin
+/// inner hop is a TCP-only SIP003 transport (it reports `TCP` via the
+/// tier-2 probe). The naive chain intersection (`YamuxPlugin` TCP|UDP ∩
+/// v2ray TCP = TCP) would therefore lose galoshes' UDP capability. But the
+/// v2ray hop being TCP-only is an implementation detail *below* galoshes'
+/// abstraction: galoshes frames UDP datagrams over a YAMUX stream and the
+/// inner TCP hop carries them transparently. galoshes is precisely the
+/// component that ADDS UDP capability, so it reports its own true
+/// end-to-end capability (TCP|UDP), a constant, to the bridge.
+///
+/// The bridge's UDP-drop policy reads this value
+/// (`transports.contains(UDP)`) to decide whether to allow proxied UDP, so
+/// reporting the naive intersection here would make the bridge wrongly
+/// drop UDP that galoshes can in fact carry.
+pub const GALOSHES_TRANSPORTS: Transports = Transports::TCP.union(Transports::UDP);
+
+/// Map galoshes' internal `ChainRunner::on_ready` outcome to the
+/// process-stdout sitrep event galoshes emits for the bridge.
+///
+/// On `Ok(ChainReady)` the forwarded `listen` is the real outer bind
+/// address (correct to forward), but the forwarded `transports` is
+/// [`GALOSHES_TRANSPORTS`] — galoshes' own capability — NOT
+/// `chain_ready.transports`. See [`GALOSHES_TRANSPORTS`] for why.
+///
+/// On `Err(StartError)` the typed start failure maps 1:1 to the
+/// corresponding sitrep event.
+pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEvent {
+    match result {
+        Ok(chain_ready) => SitrepEvent::Ready {
+            listen: chain_ready.listen,
+            // Override: galoshes' end-to-end capability, not the inner
+            // chain intersection. See GALOSHES_TRANSPORTS.
+            transports: GALOSHES_TRANSPORTS,
+        },
+        Err(StartError::BindConflict { errno, addr }) => SitrepEvent::BindConflict { errno, addr },
+        Err(StartError::Fatal { detail, errno }) => SitrepEvent::Fatal { detail, errno },
+    }
+}
+
+/// Emit a sitrep event as one JSON line on **process stdout**, then flush.
+///
+/// Mirrors mock-plugin's `emit`. Flushing matters because the bridge reads
+/// galoshes' stdout line-by-line; an unflushed `ready` would leave the
+/// bridge blocked waiting for readiness that has already happened.
+pub fn emit(ev: &SitrepEvent) {
+    println!("{}", serde_json::to_string(ev).expect("serialize sitrep event"));
+    let _ = std::io::stdout().flush();
+}

--- a/crates/galoshes/src/sitrep_out_tests.rs
+++ b/crates/galoshes/src/sitrep_out_tests.rs
@@ -1,0 +1,111 @@
+use std::net::SocketAddr;
+
+use garter::{ChainReady, SitrepEvent, StartError, Transports};
+
+use crate::sitrep_out::{chain_result_to_event, GALOSHES_TRANSPORTS};
+
+fn addr() -> SocketAddr {
+    "127.0.0.1:1080".parse().unwrap()
+}
+
+#[skuld::test]
+fn galoshes_transports_is_tcp_and_udp() {
+    // The load-bearing constant: galoshes advertises BOTH transports
+    // (its YAMUX capability), regardless of the inner v2ray TCP-only hop.
+    assert_eq!(GALOSHES_TRANSPORTS, Transports::TCP | Transports::UDP);
+}
+
+#[skuld::test]
+fn ready_overrides_tcp_only_chain_to_tcp_udp() {
+    // The inner chain reports TCP only (v2ray hop is tier-2-probed TCP),
+    // but galoshes must forward TCP|UDP — it carries UDP over YAMUX. This
+    // override is the whole reason this mapping exists.
+    let chain_ready = ChainReady {
+        listen: addr(),
+        transports: Transports::TCP,
+    };
+    let ev = chain_result_to_event(Ok(chain_ready));
+    assert_eq!(
+        ev,
+        SitrepEvent::Ready {
+            listen: addr(),
+            transports: Transports::TCP | Transports::UDP,
+        }
+    );
+}
+
+#[skuld::test]
+fn ready_forwards_listen_address() {
+    // The listen address is forwarded verbatim (the real outer bind addr).
+    let listen: SocketAddr = "127.0.0.1:54321".parse().unwrap();
+    let ev = chain_result_to_event(Ok(ChainReady {
+        listen,
+        transports: Transports::TCP,
+    }));
+    match ev {
+        SitrepEvent::Ready { listen: l, .. } => assert_eq!(l, listen),
+        other => panic!("expected Ready, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn ready_override_holds_even_if_chain_already_reports_udp() {
+    // Defensive: even if the inner chain somehow reported TCP|UDP already,
+    // the forwarded value is the galoshes constant (TCP|UDP), unchanged.
+    let ev = chain_result_to_event(Ok(ChainReady {
+        listen: addr(),
+        transports: Transports::TCP | Transports::UDP,
+    }));
+    assert_eq!(
+        ev,
+        SitrepEvent::Ready {
+            listen: addr(),
+            transports: Transports::TCP | Transports::UDP,
+        }
+    );
+}
+
+#[skuld::test]
+fn bind_conflict_maps_through() {
+    let ev = chain_result_to_event(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: addr(),
+    }));
+    assert_eq!(
+        ev,
+        SitrepEvent::BindConflict {
+            errno: 10048,
+            addr: addr(),
+        }
+    );
+}
+
+#[skuld::test]
+fn fatal_maps_through_with_errno() {
+    let ev = chain_result_to_event(Err(StartError::Fatal {
+        detail: "upstream dial failed".into(),
+        errno: Some(111),
+    }));
+    assert_eq!(
+        ev,
+        SitrepEvent::Fatal {
+            detail: "upstream dial failed".into(),
+            errno: Some(111),
+        }
+    );
+}
+
+#[skuld::test]
+fn fatal_maps_through_without_errno() {
+    let ev = chain_result_to_event(Err(StartError::Fatal {
+        detail: "config error".into(),
+        errno: None,
+    }));
+    assert_eq!(
+        ev,
+        SitrepEvent::Fatal {
+            detail: "config error".into(),
+            errno: None,
+        }
+    );
+}

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -460,9 +460,17 @@ impl garter::ChainPlugin for YamuxPlugin {
         // success report TCP|UDP readiness, on shutdown-first drop `ready`
         // unsent (RecvError — the "shutdown before ready" semantics).
         //
-        // TODO(galoshes readiness, later task): once galoshes speaks sitrep,
-        // emit a structured `ready` from inside run_server/run_client at the
-        // exact bind point instead of probing.
+        // This is galoshes' INTERNAL hop-readiness signal: it feeds
+        // galoshes' OWN `ChainRunner` aggregator, which intersects it with
+        // the inner v2ray hop and fires the chain-level `on_ready`. The
+        // PROCESS-level sitrep the bridge reads is emitted separately in
+        // `main.rs` off that `on_ready` outcome (see `galoshes::sitrep_out`).
+        // This probe knows only its own hop, not the chain, so it cannot
+        // own the process-stdout contract.
+        //
+        // A future refinement could replace the TCP-connect probe with a
+        // structured `ready` emitted from inside run_server/run_client at
+        // the exact bind point; the probe is the current pragmatic stand-in.
         let probe_local = local;
         let probe_shutdown = shutdown.clone();
         tokio::spawn(async move {

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -453,7 +453,27 @@ impl garter::ChainPlugin for YamuxPlugin {
         local: SocketAddr,
         remote: SocketAddr,
         shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<std::result::Result<garter::PluginReady, garter::StartError>>,
     ) -> garter::Result<()> {
+        // Self-probe readiness: a YAMUX plugin serves both TCP and UDP at
+        // its local listener. Spawn a TCP-connect probe against `local`; on
+        // success report TCP|UDP readiness, on shutdown-first drop `ready`
+        // unsent (RecvError — the "shutdown before ready" semantics).
+        //
+        // TODO(galoshes readiness, later task): once galoshes speaks sitrep,
+        // emit a structured `ready` from inside run_server/run_client at the
+        // exact bind point instead of probing.
+        let probe_local = local;
+        let probe_shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            if probe_tcp_ready(probe_local, &probe_shutdown).await {
+                let _ = ready.send(Ok(garter::PluginReady {
+                    listen: probe_local,
+                    transports: garter::Transports::TCP | garter::Transports::UDP,
+                }));
+            }
+        });
+
         let result = if self.is_server {
             run_server(self.config, local, remote, shutdown).await
         } else {
@@ -461,5 +481,30 @@ impl garter::ChainPlugin for YamuxPlugin {
         };
 
         result.map_err(|e| garter::Error::Chain(e.to_string()))
+    }
+}
+
+/// TCP-connect probe with exponential backoff. Returns `true` once `addr`
+/// accepts a connection, `false` if shutdown fires first. Mirrors garter's
+/// internal `poll_ready` (not exported), used to detect the YAMUX local
+/// listener coming up.
+async fn probe_tcp_ready(addr: SocketAddr, shutdown: &CancellationToken) -> bool {
+    let mut delay = Duration::from_millis(10);
+    let max_delay = Duration::from_secs(1);
+    loop {
+        tokio::select! {
+            result = TcpStream::connect(addr) => {
+                if result.is_ok() {
+                    return true;
+                }
+            }
+            () = shutdown.cancelled() => return false,
+        }
+        tokio::select! {
+            () = tokio::time::sleep(delay) => {
+                delay = (delay * 2).min(max_delay);
+            }
+            () = shutdown.cancelled() => return false,
+        }
     }
 }

--- a/crates/garter-bin/Cargo.toml
+++ b/crates/garter-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garter-bin"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garter"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license = "Apache-2.0"
 description = "Plugin-chain runner for SIP003u shadowsocks plugins."
@@ -26,6 +26,10 @@ workspace = true
 test-utils = ["dep:tracing-subscriber"]
 
 [dependencies]
+bitflags = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"

--- a/crates/garter/README.md
+++ b/crates/garter/README.md
@@ -37,12 +37,28 @@ byte-level diagnostics.
 - `Mode::Server` — data flows from the public-facing endpoint
   (`SS_REMOTE_*`) through the chain back to a local `ssserver`
   (`SS_LOCAL_*`). The plugin add-order stays the same in both modes
-  (data-source-side first); garter inverts the address wiring and the
-  `on_ready` probe target accordingly.
+  (data-source-side first); in Server mode garter inverts the address
+  wiring — including which plugin position faces the public endpoint.
+  Per-plugin readiness is declared by each link (see the sitrep
+  protocol below) and aggregated by the runner.
 
 Use `Mode::from_plugin_options(env.plugin_options.as_deref())` to derive
 the mode automatically from the SIP003 `server` keyword in
 `SS_PLUGIN_OPTIONS`.
+
+## sitrep protocol
+
+A SIP003 plugin reports its startup to the host that spawned it —
+readiness, the actual bound listen address, the transports it serves,
+and any typed start failure — over **sitrep**, a one-way,
+line-delimited JSON control stream on the plugin's stdout. It replaces
+connect-probing the plugin's port and scraping its logs.
+
+`garter` is the reference implementation of sitrep, but the protocol is
+independently adoptable: any SIP003 / SIP003u plugin or host may
+implement it without depending on `garter`.
+
+See [SITREP.md](SITREP.md) for the full normative specification.
 
 ## Example
 

--- a/crates/garter/SITREP.md
+++ b/crates/garter/SITREP.md
@@ -1,0 +1,429 @@
+# sitrep 1.0.0 — SIP003u plugin → host situation-report protocol
+
+- **Version:** 1.0 (document); wire `protocol` string `sitrep-1.0.0`
+- **Status:** Draft
+- **License:** Apache-2.0 (this document ships with the [`garter`](https://crates.io/crates/garter) reference implementation)
+
+The document version tracks `MAJOR.MINOR`; the on-the-wire `protocol`
+field carries a full three-component semver (`sitrep-MAJOR.MINOR.PATCH`).
+The two move together: a `MAJOR.MINOR` revision of this document
+corresponds to a wire `protocol` whose `MAJOR.MINOR` match.
+
+## Abstract
+
+sitrep is a one-way, line-delimited JSON control stream that a SIP003 /
+SIP003u shadowsocks plugin emits on its standard output so the process
+that spawned it (the "host") learns the plugin's readiness, its actual
+bound listen address, the transports it serves, and any typed start
+failure. It replaces the brittle older approach of TCP-connect-probing
+the plugin's port and scraping the plugin's human-readable log output.
+
+## Motivation
+
+A host that supervises a SIP003 plugin needs to know three things before
+it can route traffic: did the plugin come up, where did it actually
+bind, and — if it did not come up — why. The pre-sitrep approach
+answered these by connect-probing a presumed port and reading the
+plugin's logs. Both fail in ways that sitrep is designed to remove:
+
+- **Single-address probing cannot see inner-hop readiness in a
+  multi-plugin chain.** When several plugins are composed end to end,
+  a successful TCP connect to the chain's public-facing port does not
+  prove that an *inner* hop finished binding; the connect can succeed
+  against a half-initialized chain, or fail spuriously against one that
+  is merely slow.
+
+- **A connect probe cannot distinguish "starting" from "exited."** A
+  refused connection looks the same whether the plugin is still binding
+  its listener or has already crashed. The host is forced to guess with
+  a timer, which is both racy and slow.
+
+- **Bind-failure causes are lost to localized OS log text.** When a
+  bind fails, the only signal in the old model is free-form text in the
+  plugin's log, whose wording and language vary by platform and locale.
+  A host cannot reliably parse it to recover the structured fact
+  ("address already in use") that it needs to drive a retry decision.
+
+sitrep gives the host these facts directly, as typed events, on a
+dedicated control channel.
+
+## Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL
+NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**, and
+**OPTIONAL** in this document are to be interpreted as described in
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+Throughout this document:
+
+- **host** — the process that spawned the plugin and supervises its
+  startup (e.g. a shadowsocks client, a chain runner).
+- **plugin** — the SIP003 child process the host spawned.
+
+## Transport
+
+sitrep travels on the plugin's **standard output**. It is a control
+channel, not the data plane: it carries no proxied traffic and never
+the bytes of any tunneled connection.
+
+Conformance is specified separately for producers (plugins) and
+consumers (hosts) so an implementer of either side knows exactly what
+it owes.
+
+### Producer (plugin) conformance
+
+- A plugin that speaks sitrep **MUST** emit, on standard output,
+  newline-delimited UTF-8 JSON objects and nothing else.
+- The **first** stdout line **MUST** be the `hello` handshake event.
+- After `hello`, the plugin **MUST NOT** emit any non-JSON line on
+  stdout.
+- Standard error is unconstrained: it carries the plugin's
+  human-readable logs and is not part of the sitrep stream.
+
+### Consumer (host) conformance
+
+- A host **SHOULD** tolerate a non-JSON stdout line by treating it as a
+  log line rather than a protocol error. This is Postel's law: it keeps
+  the host robust against a noncompliant or pre-sitrep producer.
+- A host **MUST** ignore unknown `event` values and unknown object
+  fields, so that a future minor revision that adds events or fields
+  does not break an older consumer (forward compatibility — see
+  [Versioning](#versioning) and [Unknown-event
+  handling](#unknown-event-handling)).
+- The wire carries no "I exited" event. A host **MUST** therefore
+  detect plugin process exit and stdout end-of-file out of band (by
+  observing the child process and its stdout pipe), and apply the
+  [absence backstop](#event-ordering-and-the-absence-backstop).
+
+## Framing
+
+The stream is one JSON object per line, separated by a single `\n`
+(`U+000A`). Each object has a string field named `event` that is the
+discriminant identifying the event type; the remaining fields depend on
+the event. Lines are independent: there is no enclosing array and no
+inter-line state beyond the ordering rules in this document.
+
+## Versioning
+
+The wire `protocol` field is the string `"sitrep-<semver>"`, where
+`<semver>` is a full three-component semantic version
+(`MAJOR.MINOR.PATCH`). This document's own version tracks `MAJOR.MINOR`.
+
+Compatibility is gated on **MAJOR**:
+
+- **MAJOR** — incompatible wire change. A consumer that does not
+  recognize a producer's MAJOR cannot assume any event shape.
+- **MINOR** — additive only: new events or new fields. Older consumers
+  ignore what they do not recognize and keep working
+  ([forward compatibility](#unknown-event-handling)).
+- **PATCH** — no wire-visible change (clarifications, implementation
+  fixes). It does not affect interoperability.
+
+### Scope of the unknown-MAJOR fallback rule
+
+There are two host models, and the "unrecognized MAJOR" rule binds only
+one of them. An implementer must know which model their host uses.
+
+- **Detection host (first-line sniffing).** A host that decides
+  *whether* a plugin speaks sitrep by reading the first stdout line and
+  inspecting `hello` is performing capability auto-detection. Such a
+  host, on encountering a MAJOR it does not recognize, **MUST** fall
+  back to its non-sitrep readiness behavior (e.g. its prior
+  connect-probe), and **MUST NOT** hard-fail. The plugin might be
+  speaking a newer protocol the host genuinely cannot interpret;
+  refusing to start it would be a regression against the pre-sitrep
+  baseline.
+
+- **Preselection host (out-of-band configuration).** A host that was
+  told by configuration that a specific plugin speaks sitrep is *not*
+  performing detection; the unrecognized-MAJOR fallback clause does not
+  bind it. Such a host **MAY** treat an unknown MAJOR from a plugin it
+  was configured to expect as sitrep-speaking as a `fatal`-class start
+  error, because the mismatch indicates a misconfiguration or a plugin
+  upgrade the operator has not accounted for.
+
+## Event catalog
+
+This is the normative core. Each event below specifies when it MUST or
+MAY be emitted, the type of each field, and a pinned illustrative
+example line. The example lines are illustrative of *shape*; a value
+shown as platform-specific (notably `errno`) is **not** normative.
+
+### The `errno` field
+
+Several failure events carry `errno`: a **signed integer** holding the
+platform-native OS error code for the failure (for example, the
+"address already in use" condition is `48` on macOS, `98` on Linux, and
+`10048` on Windows). Because the same condition has different numeric
+codes on different platforms:
+
+- A host **SHOULD** classify the failure by its own platform's
+  semantics.
+- A host **MUST NOT** compare the number across platforms (a Linux host
+  must not assume `48` means the same thing it does on macOS).
+- A host treats `0` — or an absent `errno` where the field is optional
+  — as "unknown."
+
+### `hello`
+
+The handshake. **MUST** be the first line a sitrep producer emits.
+
+| Field      | Type   | Required | Meaning                          |
+| ---------- | ------ | -------- | -------------------------------- |
+| `event`    | string | yes      | Literal `"hello"`.               |
+| `protocol` | string | yes      | `"sitrep-<semver>"` (see above). |
+
+Example (illustrative):
+
+```json
+{"event":"hello","protocol":"sitrep-1.0.0"}
+```
+
+### `ready`
+
+Emitted **once** the plugin's listener is bound and accepting
+connections. It reports the authoritative bound address and the
+transports actually served.
+
+| Field        | Type     | Required | Meaning                                                       |
+| ------------ | -------- | -------- | ------------------------------------------------------------- |
+| `event`      | string   | yes      | Literal `"ready"`.                                            |
+| `listen`     | string   | yes      | The authoritative bound address as `"ip:port"`.               |
+| `transports` | [string] | yes      | Non-empty array of lowercase transport names actually served. |
+
+`listen` is the address the plugin actually bound, not the address it
+was asked to bind. This enables the OS-assigned-port pattern: a plugin
+told to bind port `0` lets the kernel choose a free port and reports
+the chosen `ip:port` back in `listen`, and the host learns where to
+connect without a side channel.
+
+`transports` lists lowercase transport names — currently `"tcp"` and
+`"udp"`. A consumer **MUST** ignore transport names it does not
+recognize (forward compatibility, the same rule as for unknown events
+and fields).
+
+**Empty `transports` is illegal.** A plugin **MUST** list at least one
+transport in `ready`. A host **MUST** treat a `ready` whose
+`transports` is empty — or whose every entry is an unrecognized name,
+leaving nothing the host can use — as a `fatal`-class failure, **not**
+as "the plugin came up but serves nothing." A listener that serves no
+usable transport is not ready in any sense the host can act on.
+
+Example (illustrative):
+
+```json
+{"event":"ready","listen":"127.0.0.1:1984","transports":["tcp"]}
+```
+
+### `bind_conflict`
+
+Emitted when the plugin's listener failed to bind. This is a terminal
+start failure.
+
+| Field   | Type   | Required | Meaning                                        |
+| ------- | ------ | -------- | ---------------------------------------------- |
+| `event` | string | yes      | Literal `"bind_conflict"`.                     |
+| `errno` | int    | yes      | Platform-native OS error code; `0` if unknown. |
+| `addr`  | string | yes      | The `"ip:port"` the plugin attempted to bind.  |
+
+`errno` is **always present** on `bind_conflict`; a producer that
+cannot determine the OS error code **MUST** emit `0` rather than omit
+the field.
+
+Example (illustrative — the `errno` shown is the macOS code for
+address-in-use):
+
+```json
+{"event":"bind_conflict","errno":48,"addr":"127.0.0.1:1984"}
+```
+
+### `fatal`
+
+A terminal start failure that is not specifically a bind conflict
+(invalid configuration, a failed upstream dial during startup, an
+internal error, and so on).
+
+| Field    | Type   | Required | Meaning                                          |
+| -------- | ------ | -------- | ------------------------------------------------ |
+| `event`  | string | yes      | Literal `"fatal"`.                               |
+| `detail` | string | yes      | Human-readable description of the failure.       |
+| `errno`  | int    | no       | Platform-native OS error code, when one applies. |
+
+Unlike `bind_conflict`, the `errno` key on `fatal` is **omitted** when
+no OS error code applies or it is unknown (rather than emitted as `0`).
+
+Example (illustrative):
+
+```json
+{"event":"fatal","detail":"config invalid"}
+```
+
+### Event ordering and the absence backstop
+
+Before entering its long-lived serving phase, a plugin **MUST** emit
+exactly one of:
+
+- a `ready` event (startup succeeded), **or**
+- a failure event — `bind_conflict` or `fatal` (startup failed).
+
+A plugin **MAY** exit without emitting any event at all (for example,
+it crashed before it could report). The wire carries no "I exited"
+event by design. The host therefore detects this case out of band, via
+stdout end-of-file / process exit, and **MUST** treat it as a terminal
+start failure. This is the **absence backstop**: the absence of both
+`ready` and a failure event, observed as the stream ending, is itself
+the terminal signal.
+
+## Unknown-event handling
+
+Two rules appear to pull in opposite directions; they do not, and this
+section reconciles them explicitly.
+
+1. **Unknown `event` values are ignored** (non-terminal). This is what
+   makes MINOR revisions additive: an older host skips an event type it
+   was not written to understand and keeps waiting.
+
+1. **The host defaults to terminal on an unexpected startup failure**
+   (via the absence backstop above).
+
+These do not conflict, because a host **never** derives a terminal
+decision by *inferring meaning* from an ignored unknown event. A future
+protocol version that needs to signal a new unrecoverable state
+**MUST** do so by *also* ceasing to emit `ready` and then exiting —
+which triggers the absence backstop. The host's terminal decision
+always comes from the absence backstop (`ready`/failure absent + stream
+ended), and never from guessing at the semantics of an event it does
+not recognize. An unknown event, on its own, is silence as far as the
+terminal decision is concerned.
+
+## Host obligations
+
+A host supervising a sitrep plugin's startup **MUST** await exactly one
+of three mutually exclusive outcomes:
+
+- a `ready` event,
+- a failure event (`bind_conflict` or `fatal`), or
+- stdout end-of-file / process exit (the absence backstop).
+
+The host then maps the outcome onto **its own** retry policy. sitrep
+deliberately carries facts, not directives: there is no `retryable`
+field. The protocol tells the host *what happened* (the listener bound
+at this address; the bind failed with this OS error code; the plugin
+exited without reporting); the host alone decides whether and how to
+retry, using its own platform knowledge and configuration. Two hosts
+observing the same `bind_conflict` may legitimately choose different
+responses, and the protocol does not constrain that choice.
+
+## Security considerations
+
+- **stdout is a local IPC side-channel, never the wire.** sitrep is
+  exchanged between a parent process and its child over an inherited
+  pipe; it is not transmitted over any network and is not part of the
+  proxied data plane.
+- **sitrep MUST NOT alter the plugin's network or data-plane
+  behavior.** Speaking sitrep is purely a reporting concern; it changes
+  what the plugin says on stdout, never what bytes it puts on the wire
+  or how it handles tunneled traffic.
+- **A host MUST NOT trust `listen` to point outside the
+  loopback/host-controlled range it expects.** The `listen` value comes
+  from the (possibly buggy or hostile) child. A host that intends to
+  connect to a loopback listener **MUST** validate that the reported
+  address falls within the range it controls before connecting, so a
+  malformed or malicious `listen` cannot redirect the host's
+  connections to an unintended destination.
+
+## Reference implementation
+
+[`garter`](https://crates.io/crates/garter) is the reference
+implementation of sitrep. Its sitrep module — `src/sitrep.rs` —
+defines the wire types and the `SITREP_PROTOCOL` constant
+(`"sitrep-1.0.0"`).
+
+> Note: at the time this document is first published, `src/sitrep.rs`
+> is forthcoming — it is added in the implementation work that follows
+> this standard. The standard is the source of truth; the module
+> conforms to it, not the reverse.
+
+Conforming emitters that ship at the time of this document: the
+`mock-plugin` test plugin and the `galoshes` SIP003u plugin, both in
+the Hole workspace. The protocol is independently adoptable: any
+SIP003 / SIP003u plugin or host may implement it without depending on
+`garter`.
+
+## Appendix A — JSON schema (per-event field tables)
+
+Every event object has a string `event` field that discriminates the
+type. Consumers ignore unknown `event` values and unknown fields.
+
+**`hello`**
+
+| Field      | Type               | Required |
+| ---------- | ------------------ | -------- |
+| `event`    | string (`"hello"`) | yes      |
+| `protocol` | string             | yes      |
+
+**`ready`**
+
+| Field        | Type                                   | Required |
+| ------------ | -------------------------------------- | -------- |
+| `event`      | string (`"ready"`)                     | yes      |
+| `listen`     | string (`"ip:port"`)                   | yes      |
+| `transports` | array of string (non-empty, lowercase) | yes      |
+
+**`bind_conflict`**
+
+| Field   | Type                        | Required |
+| ------- | --------------------------- | -------- |
+| `event` | string (`"bind_conflict"`)  | yes      |
+| `errno` | int (signed; `0` = unknown) | yes      |
+| `addr`  | string (`"ip:port"`)        | yes      |
+
+**`fatal`**
+
+| Field    | Type               | Required                  |
+| -------- | ------------------ | ------------------------- |
+| `event`  | string (`"fatal"`) | yes                       |
+| `detail` | string             | yes                       |
+| `errno`  | int (signed)       | no — omitted when unknown |
+
+## Appendix B — Worked transcripts
+
+The lines below are byte-identical to the pinned examples in the
+[Event catalog](#event-catalog).
+
+**Successful startup** — `hello`, then `ready`:
+
+```json
+{"event":"hello","protocol":"sitrep-1.0.0"}
+{"event":"ready","listen":"127.0.0.1:1984","transports":["tcp"]}
+```
+
+The host reads `hello`, recognizes the MAJOR, awaits readiness, reads
+`ready`, and connects to `127.0.0.1:1984`.
+
+**Failing startup** — `hello`, then `bind_conflict`, then the plugin
+exits:
+
+```json
+{"event":"hello","protocol":"sitrep-1.0.0"}
+{"event":"bind_conflict","errno":48,"addr":"127.0.0.1:1984"}
+```
+
+After `bind_conflict` the plugin exits; the host observed a terminal
+failure event and maps the (platform-native) `errno` onto its own
+retry policy. Had the plugin instead crashed silently after `hello`,
+the host would observe stdout end-of-file with neither `ready` nor a
+failure event and apply the absence backstop — also a terminal
+failure.
+
+## Changelog
+
+- **1.0** (Draft) — initial protocol: `hello`, `ready`, `bind_conflict`,
+  `fatal` events; absence backstop; MAJOR-gated compatibility.
+
+## Acknowledgements
+
+sitrep was developed for the [Hole](https://github.com/bindreams/hole)
+shadowsocks client to replace connect-probe + log-scrape plugin
+readiness detection, and is published with `garter` as an independently
+adoptable standard.

--- a/crates/garter/SITREP.md
+++ b/crates/garter/SITREP.md
@@ -336,7 +336,7 @@ responses, and the protocol does not constrain that choice.
 
 [`garter`](https://crates.io/crates/garter) is the reference
 implementation of sitrep. Its sitrep module — `src/sitrep.rs` —
-defines the wire types and the `SITREP_PROTOCOL` constant
+will define the wire types and the `SITREP_PROTOCOL` constant
 (`"sitrep-1.0.0"`).
 
 > Note: at the time this document is first published, `src/sitrep.rs`

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -5,11 +5,25 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
 use crate::chain::Mode;
 use crate::plugin::ChainPlugin;
 use crate::shutdown;
+use crate::sitrep::{PluginReady, StartError};
+
+/// How a [`BinaryPlugin`] learns it is ready.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReadinessMode {
+    /// Parse the child's stdout for a sitrep `hello`/`ready` handshake.
+    /// Use for plugins known to speak sitrep (ex-ray, galoshes-embedded).
+    ExpectSitrep,
+    /// Self-probe `local` with a TCP connect (the relocated poll_ready).
+    /// The conservative default for arbitrary / legacy plugins.
+    #[default]
+    Probe,
+}
 
 /// Resolved SIP003 environment-variable mapping for a `BinaryPlugin`'s
 /// child process. The plugin's `(local, remote)` from
@@ -38,6 +52,7 @@ pub struct BinaryPlugin {
     options: Option<String>,
     name: String,
     pid_sink: Option<PidSink>,
+    readiness: ReadinessMode,
 }
 
 impl BinaryPlugin {
@@ -49,6 +64,7 @@ impl BinaryPlugin {
             options: options.map(String::from),
             name,
             pid_sink: None,
+            readiness: ReadinessMode::default(),
         }
     }
 
@@ -56,6 +72,18 @@ impl BinaryPlugin {
     pub fn pid_sink(mut self, sink: PidSink) -> Self {
         self.pid_sink = Some(sink);
         self
+    }
+
+    /// Select how this plugin learns it is ready. Defaults to
+    /// [`ReadinessMode::Probe`].
+    pub fn readiness(mut self, mode: ReadinessMode) -> Self {
+        self.readiness = mode;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn readiness_mode_for_test(&self) -> ReadinessMode {
+        self.readiness
     }
 
     /// Compute the SIP003 env-var mapping for `(local, remote)`. Public
@@ -98,6 +126,7 @@ impl ChainPlugin for BinaryPlugin {
         local: SocketAddr,
         remote: SocketAddr,
         shutdown: CancellationToken,
+        ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
         let env = self.sip003_env(local, remote);
         let mut cmd = Command::new(&self.path);
@@ -125,25 +154,55 @@ impl ChainPlugin for BinaryPlugin {
             sink(pid);
         }
 
-        // Capture stdout
+        // Stdout consumer: in Probe mode it forwards lines to tracing and
+        // readiness comes from a separate self-probe task; in ExpectSitrep
+        // mode it parses sitrep events and IS the readiness source. Build
+        // the right one per `self.readiness`.
         let stdout = child.stdout.take().expect("stdout was piped");
-        let plugin_name = self.name.clone();
-        let stdout_task = tokio::spawn(async move {
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
-            loop {
-                match lines.next_line().await {
-                    Ok(Some(line)) => {
-                        tracing::info!(plugin = %plugin_name, "{line}");
+        let stdout_task = match self.readiness {
+            ReadinessMode::Probe => {
+                // Tier-2: the stdout reader is a pure log passthrough
+                // (unchanged from the pre-sitrep behavior); a separate
+                // self-probe task owns readiness.
+                let plugin_name = self.name.clone();
+                let log_task = tokio::spawn(async move {
+                    let reader = BufReader::new(stdout);
+                    let mut lines = reader.lines();
+                    loop {
+                        match lines.next_line().await {
+                            Ok(Some(line)) => {
+                                tracing::info!(plugin = %plugin_name, "{line}");
+                            }
+                            Ok(None) => break, // EOF
+                            Err(e) => {
+                                tracing::debug!(plugin = %plugin_name, "log reader error: {e}");
+                                break;
+                            }
+                        }
                     }
-                    Ok(None) => break, // EOF
-                    Err(e) => {
-                        tracing::debug!(plugin = %plugin_name, "log reader error: {e}");
-                        break;
+                });
+
+                // Self-probe readiness. On a successful connect, report TCP
+                // readiness; on shutdown-first, drop `ready` unsent
+                // (RecvError, matching the old "shutdown before ready"
+                // semantics).
+                let probe_local = local;
+                let probe_shutdown = shutdown.clone();
+                tokio::spawn(async move {
+                    if let Some(addr) = crate::chain::poll_ready(probe_local, probe_shutdown).await {
+                        let _ = ready.send(Ok(PluginReady {
+                            listen: addr,
+                            transports: crate::sitrep::Transports::TCP,
+                        }));
                     }
-                }
+                });
+
+                log_task
             }
-        });
+            ReadinessMode::ExpectSitrep => {
+                spawn_sitrep_stdout_reader(stdout, self.name.clone(), local, shutdown.clone(), ready)
+            }
+        };
 
         // Capture stderr
         let stderr = child.stderr.take().expect("stderr was piped");
@@ -165,7 +224,23 @@ impl ChainPlugin for BinaryPlugin {
             }
         });
 
-        // Wait for child exit or shutdown signal
+        // Wait for child exit or shutdown signal.
+        //
+        // Readiness duality / backstop (see the trait + chain aggregator):
+        //
+        // - DOUBLE-REPORT IS CORRECT. In ExpectSitrep a plugin that emits
+        //   `fatal` then exits nonzero produces BOTH a `StartError::Fatal`
+        //   via the readiness sender (the START-GATE for `on_ready`) AND the
+        //   `child.wait()` → `Err` return below (the LIFECYCLE error that
+        //   drives `record_exit`/teardown). Keep both; do NOT suppress
+        //   either — they are intentionally separate observers of one event.
+        //
+        // - ORPHANED READINESS ON CLEAN SHUTDOWN IS THE INTENDED BACKSTOP.
+        //   If the child binds, never emits `ready`, then the parent shuts
+        //   down, the sitrep reader holds the readiness sender until stdout
+        //   EOF; the 100ms drain may abandon the task, dropping the sender
+        //   unsent → the aggregator sees RecvError → `Fatal{"exited before
+        //   ready"}`. That is CORRECT — the plugin did fail to ready.
         let drain_timeout = std::time::Duration::from_secs(5);
         tokio::select! {
             status = child.wait() => {
@@ -200,5 +275,129 @@ impl ChainPlugin for BinaryPlugin {
                 Ok(())
             }
         }
+    }
+}
+
+/// The single readiness sender, shared between the sitrep stdout reader
+/// and (only on a [`ProtocolSupport::FallBackToTier2`] handoff) a
+/// self-probe task. Wrapping in `Arc<Mutex<Option<..>>>` keeps the
+/// "send AT MOST once" invariant while letting either owner make the
+/// attempt: whichever runs first `take()`s the sender; the other finds
+/// `None` and does nothing.
+///
+/// [`ProtocolSupport::FallBackToTier2`]: crate::sitrep::ProtocolSupport::FallBackToTier2
+type SharedReady = Arc<tokio::sync::Mutex<Option<oneshot::Sender<Result<PluginReady, StartError>>>>>;
+
+/// Spawn the ExpectSitrep stdout reader.
+///
+/// The reader is the readiness source: it parses `@sitrep` events and
+/// sends exactly one readiness result. On an unknown protocol major
+/// (`FallBackToTier2`) it hands readiness ownership to a self-probe task
+/// (the tier-2 strategy), sharing the single sender via [`SharedReady`]
+/// so at most one send ever happens. Non-event lines pass through to
+/// tracing as ordinary logs. On stdout EOF without ever sending, the
+/// sender drops unsent → the chain aggregator synthesizes a process-exit
+/// failure (the intended backstop).
+fn spawn_sitrep_stdout_reader(
+    stdout: tokio::process::ChildStdout,
+    plugin_name: String,
+    local: SocketAddr,
+    shutdown: CancellationToken,
+    ready: oneshot::Sender<Result<PluginReady, StartError>>,
+) -> tokio::task::JoinHandle<()> {
+    use crate::sitrep::{ProtocolSupport, SitrepEvent};
+
+    let shared: SharedReady = Arc::new(tokio::sync::Mutex::new(Some(ready)));
+    tokio::spawn(async move {
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+        let mut handshake_ok = false;
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => match crate::sitrep::parse_event(&line) {
+                    Ok(Some(SitrepEvent::Hello { protocol })) => {
+                        match crate::sitrep::protocol_support(&protocol) {
+                            ProtocolSupport::Supported => {
+                                handshake_ok = true;
+                                tracing::debug!(plugin = %plugin_name, %protocol, "sitrep handshake");
+                            }
+                            ProtocolSupport::FallBackToTier2 => {
+                                tracing::info!(
+                                    plugin = %plugin_name,
+                                    %protocol,
+                                    "unknown sitrep protocol major; readiness falls back to probe"
+                                );
+                                // Hand readiness to a tier-2 self-probe,
+                                // sharing the single sender. The reader
+                                // continues only as a log passthrough (it
+                                // never sends readiness again).
+                                let probe_shared = shared.clone();
+                                let probe_local = local;
+                                let probe_shutdown = shutdown.clone();
+                                tokio::spawn(async move {
+                                    if let Some(addr) = crate::chain::poll_ready(probe_local, probe_shutdown).await {
+                                        if let Some(tx) = probe_shared.lock().await.take() {
+                                            let _ = tx.send(Ok(PluginReady {
+                                                listen: addr,
+                                                transports: crate::sitrep::Transports::TCP,
+                                            }));
+                                        }
+                                    }
+                                });
+                                // Drain the rest of stdout as logs so the
+                                // child's pipe never blocks; the probe task
+                                // owns readiness from here on.
+                                drain_remaining_logs(&mut lines, &plugin_name).await;
+                                break;
+                            }
+                        }
+                    }
+                    Ok(Some(SitrepEvent::Ready { listen, transports })) if handshake_ok => {
+                        if let Some(tx) = shared.lock().await.take() {
+                            // Empty/all-unknown transports is illegal per
+                            // SITREP: a `ready` MUST list >=1 served
+                            // transport. Reject as Fatal.
+                            if transports.is_empty() {
+                                let _ = tx.send(Err(StartError::Fatal {
+                                    detail: "sitrep ready reported empty transports (protocol violation)".into(),
+                                    errno: None,
+                                }));
+                            } else {
+                                let _ = tx.send(Ok(PluginReady { listen, transports }));
+                            }
+                        }
+                    }
+                    Ok(Some(SitrepEvent::BindConflict { errno, addr })) if handshake_ok => {
+                        if let Some(tx) = shared.lock().await.take() {
+                            let _ = tx.send(Err(StartError::BindConflict { errno, addr }));
+                        }
+                    }
+                    Ok(Some(SitrepEvent::Fatal { detail, errno })) if handshake_ok => {
+                        if let Some(tx) = shared.lock().await.take() {
+                            let _ = tx.send(Err(StartError::Fatal { detail, errno }));
+                        }
+                    }
+                    // log line / pre-handshake / unknown event → passthrough
+                    _ => tracing::info!(plugin = %plugin_name, "{line}"),
+                },
+                Ok(None) => break, // EOF
+                Err(e) => {
+                    tracing::debug!(plugin = %plugin_name, "log reader error: {e}");
+                    break;
+                }
+            }
+        }
+        // If the child closed stdout without ever sending readiness,
+        // dropping the shared sender here signals process-exit to the
+        // aggregator (the intended backstop).
+    })
+}
+
+/// Forward all remaining stdout lines to tracing as ordinary logs. Used
+/// after a `FallBackToTier2` handoff so the child's stdout pipe never
+/// blocks while the self-probe owns readiness.
+async fn drain_remaining_logs(lines: &mut tokio::io::Lines<BufReader<tokio::process::ChildStdout>>, plugin_name: &str) {
+    while let Ok(Some(line)) = lines.next_line().await {
+        tracing::info!(plugin = %plugin_name, "{line}");
     }
 }

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -53,6 +53,7 @@ pub struct BinaryPlugin {
     name: String,
     pid_sink: Option<PidSink>,
     readiness: ReadinessMode,
+    extra_env: Vec<(String, String)>,
 }
 
 impl BinaryPlugin {
@@ -65,12 +66,21 @@ impl BinaryPlugin {
             name,
             pid_sink: None,
             readiness: ReadinessMode::default(),
+            extra_env: Vec::new(),
         }
     }
 
     /// Set a callback that fires with the child PID immediately after spawn.
     pub fn pid_sink(mut self, sink: PidSink) -> Self {
         self.pid_sink = Some(sink);
+        self
+    }
+
+    /// Inject an additional environment variable into the spawned child
+    /// process. Primarily for tests (fault injection); production plugins
+    /// are configured via `SS_PLUGIN_OPTIONS`.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra_env.push((key.into(), value.into()));
         self
     }
 
@@ -136,6 +146,9 @@ impl ChainPlugin for BinaryPlugin {
         cmd.env("SS_REMOTE_PORT", env.ss_remote_port.to_string());
         if let Some(ref opts) = self.options {
             cmd.env("SS_PLUGIN_OPTIONS", opts);
+        }
+        for (k, v) in &self.extra_env {
+            cmd.env(k, v);
         }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -74,3 +74,11 @@ fn sip003_env_client_mode_when_options_only_have_servername() {
     assert_eq!(env.ss_remote_host, "203.0.113.1");
     assert_eq!(env.ss_remote_port, 8388);
 }
+
+// Readiness-mode tests ================================================================================================
+
+#[skuld::test]
+fn readiness_mode_defaults_to_probe() {
+    let p = crate::BinaryPlugin::new("/nonexistent", None);
+    assert_eq!(p.readiness_mode_for_test(), crate::binary::ReadinessMode::Probe);
+}

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -34,10 +34,13 @@ pub struct ChainReady {
 /// public-facing endpoint that external clients connect to) to
 /// `SS_LOCAL_*` (the local `ssserver` instance). The plugin chain is
 /// supplied in the SAME order in both modes (data-source-side first),
-/// but garter inverts the address walk and the `on_ready` probe target
-/// so position 0 forwards to `SS_LOCAL` and position N-1 listens on
-/// `SS_REMOTE`. This is what the SIP003 spec calls "server mode" and
-/// what `ssserver --plugin <chain-runner>` requires.
+/// but garter inverts the address wiring so position 0 forwards to
+/// `SS_LOCAL` and position N-1 listens on `SS_REMOTE` (the public
+/// endpoint). Accordingly, the chain-level readiness address reported
+/// via [`ChainRunner::on_ready`] is the position N-1 plugin's listen
+/// address in Server mode (versus position 0 in Client mode). This is
+/// what the SIP003 spec calls "server mode" and what
+/// `ssserver --plugin <chain-runner>` requires.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Mode {
     #[default]

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -8,8 +8,20 @@ use tracing::Instrument;
 
 use crate::plugin::ChainPlugin;
 use crate::shutdown;
+use crate::sitrep::{PluginReady, StartError, Transports};
 
 const MAX_PORT_RETRIES: usize = 3;
+
+/// Whole-chain readiness reported via [`ChainRunner::on_ready`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainReady {
+    /// The address the data-source-facing plugin is accepting on
+    /// (position 0 in Client mode, position N-1 in Server mode).
+    pub listen: SocketAddr,
+    /// End-to-end transports: the intersection across all hops. A
+    /// transport is carried only if every plugin in the chain serves it.
+    pub transports: Transports,
+}
 
 /// Direction of the SIP003 chain.
 ///
@@ -122,7 +134,7 @@ fn allocate_one_port() -> crate::Result<SocketAddr> {
 pub struct ChainRunner {
     plugins: Vec<Box<dyn ChainPlugin>>,
     drain_timeout: Duration,
-    ready_tx: Option<oneshot::Sender<SocketAddr>>,
+    ready_tx: Option<oneshot::Sender<Result<ChainReady, StartError>>>,
     external_cancel: Option<CancellationToken>,
     mode: Mode,
 }
@@ -172,16 +184,20 @@ impl ChainRunner {
         self
     }
 
-    /// Register a oneshot that fires when the first plugin in the chain is
-    /// confirmed listening on its local address.
+    /// Register a oneshot that fires when the whole chain is ready, or
+    /// with the first plugin's start error if any plugin fails to start.
     ///
-    /// Readiness is detected via a TCP connect probe, which means the plugin
-    /// will briefly accept and then see a connection reset. The probe has no
-    /// overall timeout — callers should apply their own timeout on the receiver.
+    /// Fires `Ok(ChainReady)` once EVERY plugin has reported `PluginReady`;
+    /// `Err(StartError)` as soon as any plugin reports a start failure or
+    /// exits before readying. Each plugin owns its own readiness now (it
+    /// sends through the `ready` channel passed to [`ChainPlugin::run`]);
+    /// the aggregator below collects the N per-plugin results into a single
+    /// chain-level outcome.
     ///
-    /// If the plugin exits before becoming ready, `tx` is dropped and the
-    /// receiver gets `RecvError`.
-    pub fn on_ready(mut self, tx: oneshot::Sender<SocketAddr>) -> Self {
+    /// If shutdown fires before every plugin has readied, `tx` is dropped
+    /// and the receiver gets `RecvError` (the prior "shutdown before ready"
+    /// semantics).
+    pub fn on_ready(mut self, tx: oneshot::Sender<Result<ChainReady, StartError>>) -> Self {
         self.ready_tx = Some(tx);
         self
     }
@@ -243,10 +259,13 @@ impl ChainRunner {
         // Capture `Copy` field before the partial move below.
         let mode = self.mode;
 
-        // Spawn all plugins. In Client mode, plugin i listens on addrs[i] and
-        // forwards to addrs[i+1]. In Server mode, the direction is inverted:
-        // plugin i listens on addrs[i+1] and forwards to addrs[i]. See `Mode`.
+        // Spawn all plugins, each with its own readiness channel. In Client
+        // mode, plugin i listens on addrs[i] and forwards to addrs[i+1]. In
+        // Server mode, the direction is inverted: plugin i listens on
+        // addrs[i+1] and forwards to addrs[i]. See `Mode`. The aggregator
+        // below collects the N per-plugin readiness results.
         let mut set = tokio::task::JoinSet::new();
+        let mut ready_rxs: Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)> = Vec::with_capacity(n);
         for (i, plugin) in self.plugins.into_iter().enumerate() {
             let (local, remote) = match mode {
                 Mode::Client => (addrs[i], addrs[i + 1]),
@@ -254,6 +273,8 @@ impl ChainRunner {
             };
             let token = shutdown.child_token();
             let plugin_name = plugin.name().to_string();
+            let (rtx, rrx) = oneshot::channel();
+            ready_rxs.push((i, rrx));
 
             let span = tracing::info_span!(
                 "plugin",
@@ -262,27 +283,19 @@ impl ChainRunner {
                 chain_mode = ?mode,
             );
             set.spawn(async move {
-                let result = plugin.run(local, remote, token).instrument(span).await;
+                let result = plugin.run(local, remote, token, rtx).instrument(span).await;
                 (plugin_name, result)
             });
         }
 
-        // Readiness polling: probe the public-facing local address. In Client
-        // mode that is the position-0 plugin (addrs[0] = SS_LOCAL); in Server
-        // mode it is the position-(N-1) plugin (addrs[n] = SS_REMOTE).
+        // Readiness aggregator: await all N plugin results, racing the
+        // shared shutdown token so a cancel during startup doesn't hang.
+        // The aggregator body lives in a free async fn (not an inline
+        // `async move`) because `#[debug_requires]` rewrites `return` in
+        // this fn's body into `break 'run`, which is illegal across an
+        // async-block boundary; a free fn keeps the rewrite out of it.
         if let Some(ready_tx) = self.ready_tx {
-            let probe_addr = match mode {
-                Mode::Client => addrs[0],
-                Mode::Server => addrs[n],
-            };
-            let shutdown = shutdown.clone();
-            tokio::spawn(async move {
-                if let Some(addr) = poll_ready(probe_addr, shutdown).await {
-                    let _ = ready_tx.send(addr);
-                }
-                // If poll_ready returns None (shutdown before ready), ready_tx
-                // is dropped and the receiver gets RecvError.
-            });
+            tokio::spawn(run_readiness_aggregator(ready_rxs, n, mode, shutdown.clone(), ready_tx));
         }
 
         // Phase 1: run unbounded until either all plugins exit naturally or
@@ -327,6 +340,72 @@ impl ChainRunner {
 }
 
 // Helpers =============================================================================================================
+
+/// Aggregate the N per-plugin readiness results into a single chain-level
+/// outcome on `ready_tx`.
+///
+/// Awaits each plugin's `ready` receiver in turn, racing the shared
+/// `shutdown` token so a cancel during startup doesn't hang. The
+/// position-0 plugin's reported `listen` is the chain's public address in
+/// Client mode; in Server mode it is position N-1. The chain's transports
+/// are the intersection across all hops.
+async fn run_readiness_aggregator(
+    ready_rxs: Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)>,
+    n: usize,
+    mode: Mode,
+    shutdown: CancellationToken,
+    ready_tx: oneshot::Sender<Result<ChainReady, StartError>>,
+) {
+    let mut plugin_listens: Vec<Option<SocketAddr>> = vec![None; n];
+    // Intersection identity (the full transport set); each plugin's
+    // reported transports narrow this. `all()` lives on the
+    // `bitflags::Flags` trait for this generated type.
+    let mut transports = <Transports as bitflags::Flags>::all();
+    let public_index = match mode {
+        Mode::Client => 0,
+        Mode::Server => n - 1,
+    };
+    for (i, rrx) in ready_rxs {
+        let outcome = tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                // Shutdown before all plugins readied → drop ready_tx;
+                // receiver gets RecvError. Matches the old "shutdown before
+                // ready" semantics.
+                return;
+            }
+            r = rrx => r,
+        };
+        match outcome {
+            Ok(Ok(pr)) => {
+                plugin_listens[i] = Some(pr.listen);
+                transports &= pr.transports;
+            }
+            Ok(Err(start_err)) => {
+                let _ = ready_tx.send(Err(start_err));
+                return;
+            }
+            Err(_recv) => {
+                // Plugin dropped its sender unsent → it exited before
+                // readying. Synthesize a process-exit Fatal. This is the
+                // START-GATE channel; the SAME exit is independently
+                // observed by the Phase-1 record_exit loop, which sets
+                // first_error + cancels — that is the LIFECYCLE channel that
+                // becomes run()'s return. The two are intentionally separate
+                // observers of one event (typed cause to on_ready AND
+                // lifecycle error to teardown). Do NOT try to reconcile them
+                // into one value.
+                let _ = ready_tx.send(Err(StartError::Fatal {
+                    detail: "plugin exited before becoming ready".into(),
+                    errno: None,
+                }));
+                return;
+            }
+        }
+    }
+    let listen = plugin_listens[public_index].expect("public plugin must have reported a listen address");
+    let _ = ready_tx.send(Ok(ChainReady { listen, transports }));
+}
 
 /// Shared handler for a single plugin-task exit result. Updates
 /// `first_error` on a first-write-wins basis and fires `shutdown` so the

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::chain::{allocate_ports, ChainRunner};
 use crate::plugin::ChainPlugin;
+use crate::sitrep::{PluginReady, StartError, Transports};
 
 // Port allocation tests ===============================================================================================
 
@@ -139,7 +140,10 @@ impl ChainPlugin for InstantPlugin {
         _local: SocketAddr,
         _remote: SocketAddr,
         _shutdown: CancellationToken,
+        _ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
+        // Exits immediately without ever readying; dropping `_ready` unsent
+        // is the "exited before ready" backstop the aggregator handles.
         Ok(())
     }
 }
@@ -160,8 +164,15 @@ impl ChainPlugin for ListeningPlugin {
         local: SocketAddr,
         _remote: SocketAddr,
         shutdown: CancellationToken,
+        ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
-        let _listener = tokio::net::TcpListener::bind(local).await?;
+        let listener = tokio::net::TcpListener::bind(local).await?;
+        let actual = listener.local_addr().unwrap_or(local);
+        let _ = ready.send(Ok(PluginReady {
+            listen: actual,
+            transports: Transports::TCP,
+        }));
+        let _listener = listener;
         shutdown.cancelled().await;
         Ok(())
     }
@@ -181,7 +192,10 @@ impl ChainPlugin for FailingPlugin {
         _local: SocketAddr,
         _remote: SocketAddr,
         _shutdown: CancellationToken,
+        _ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
+        // Fails before readying; dropping `_ready` unsent is the
+        // "exited before ready" backstop.
         Err(crate::Error::PluginExit {
             name: "failing".into(),
             code: 1,
@@ -207,6 +221,7 @@ impl ChainPlugin for StubbornPlugin {
         _local: SocketAddr,
         _remote: SocketAddr,
         _shutdown: CancellationToken,
+        _ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
         std::future::pending::<crate::Result<()>>().await
     }
@@ -227,6 +242,7 @@ impl ChainPlugin for PanickingPlugin {
         _local: SocketAddr,
         _remote: SocketAddr,
         _shutdown: CancellationToken,
+        _ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
         panic!("deliberate panic for testing")
     }
@@ -275,10 +291,13 @@ async fn on_ready_fires_with_local_addr() {
 
     let handle = tokio::spawn(runner.run(env));
 
-    // rx fires with the local address once the plugin is listening.
-    let ready_addr = rx.await.expect("ready_tx was dropped without sending");
+    // rx fires with the chain-ready payload once every plugin is listening.
+    let chain_ready = rx
+        .await
+        .expect("ready_tx was dropped without sending")
+        .expect("chain should be ready, not a start error");
 
-    assert_eq!(ready_addr.port(), addr.port());
+    assert_eq!(chain_ready.listen.port(), addr.port());
 
     // Clean up: abort the chain (it's waiting for shutdown).
     handle.abort();
@@ -295,12 +314,18 @@ async fn on_ready_dropped_on_plugin_failure() {
 
     let handle = tokio::spawn(runner.run(env));
 
-    // The plugin fails immediately, so ready_tx is dropped → rx gets RecvError.
-    let result = rx.await;
-    assert!(
-        result.is_err(),
-        "rx should get RecvError when plugin fails before ready"
-    );
+    // The plugin exits before readying, so the aggregator synthesizes a
+    // process-exit `StartError::Fatal` and sends it through ready_tx.
+    let outcome = rx.await.expect("aggregator should report a start error, not drop");
+    match outcome {
+        Err(StartError::Fatal { detail, .. }) => {
+            assert!(
+                detail.contains("exited before becoming ready"),
+                "expected exited-before-ready Fatal, got: {detail}"
+            );
+        }
+        other => panic!("expected StartError::Fatal, got {other:?}"),
+    }
 
     // The chain should have returned an error.
     let chain_result = handle.await.unwrap();
@@ -328,7 +353,10 @@ async fn cancel_token_triggers_graceful_shutdown() {
     let handle = tokio::spawn(runner.run(env));
 
     // Wait for the plugin to actually bind (no sleep race).
-    ready_rx.await.expect("plugin should become ready");
+    ready_rx
+        .await
+        .expect("ready_tx dropped")
+        .expect("plugin should become ready");
 
     // Cancel externally.
     cancel.cancel();
@@ -363,6 +391,7 @@ impl ChainPlugin for RecordingPlugin {
         local: SocketAddr,
         remote: SocketAddr,
         _shutdown: CancellationToken,
+        _ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
         *self.record.lock().unwrap() = Some((local, remote));
         Ok(())
@@ -453,11 +482,11 @@ async fn chain_runner_server_mode_inverts_on_ready_probe_target() {
     };
 
     let handle = tokio::spawn(runner.run(env));
-    let ready_addr = rx.await.expect("ready_tx dropped");
+    let chain_ready = rx.await.expect("ready_tx dropped").expect("chain should be ready");
     assert_eq!(
-        ready_addr.port(),
+        chain_ready.listen.port(),
         listen_addr.port(),
-        "on_ready in Server mode must probe SS_REMOTE (outer's local), not SS_LOCAL (inner's remote)"
+        "on_ready in Server mode must report SS_REMOTE (outer's local), not SS_LOCAL (inner's remote)"
     );
     handle.abort();
 }

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -178,6 +178,40 @@ impl ChainPlugin for ListeningPlugin {
     }
 }
 
+/// Plugin that binds a TCP listener, reports a caller-chosen transport
+/// set on readiness, then waits for shutdown. Used to exercise the
+/// aggregator's transports-intersection across hops without a real
+/// subprocess.
+struct TransportsPlugin {
+    name: String,
+    transports: Transports,
+}
+
+#[async_trait::async_trait]
+impl ChainPlugin for TransportsPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        _remote: SocketAddr,
+        shutdown: CancellationToken,
+        ready: oneshot::Sender<Result<PluginReady, StartError>>,
+    ) -> crate::Result<()> {
+        let listener = tokio::net::TcpListener::bind(local).await?;
+        let actual = listener.local_addr().unwrap_or(local);
+        let _ = ready.send(Ok(PluginReady {
+            listen: actual,
+            transports: self.transports,
+        }));
+        let _listener = listener;
+        shutdown.cancelled().await;
+        Ok(())
+    }
+}
+
 /// Plugin that exits immediately with an error.
 struct FailingPlugin;
 
@@ -330,6 +364,55 @@ async fn on_ready_dropped_on_plugin_failure() {
     // The chain should have returned an error.
     let chain_result = handle.await.unwrap();
     assert!(chain_result.is_err());
+}
+
+/// The aggregator reports the end-to-end transports as the intersection
+/// across every hop: a transport is carried only if EVERY plugin serves
+/// it. Here a TCP|UDP hop and a TCP-only hop must intersect to TCP. The
+/// `listen` must be the position-0 plugin's (Client mode), not whichever
+/// readied first.
+#[skuld::test]
+async fn on_ready_transports_are_intersection_across_hops() {
+    let (tx, rx) = oneshot::channel();
+
+    // Position 0 is the chain-public hop; it serves TCP+UDP. Position 1
+    // (downstream) is TCP-only, so the end-to-end set narrows to TCP.
+    let addrs = allocate_ports(1).unwrap();
+    let public_addr = addrs[0];
+
+    let runner = ChainRunner::new()
+        .add(Box::new(TransportsPlugin {
+            name: "public".into(),
+            transports: Transports::TCP | Transports::UDP,
+        }))
+        .add(Box::new(TransportsPlugin {
+            name: "downstream".into(),
+            transports: Transports::TCP,
+        }))
+        .on_ready(tx);
+
+    let mut env = test_env();
+    env.local_port = public_addr.port();
+
+    let handle = tokio::spawn(runner.run(env));
+
+    let chain_ready = rx
+        .await
+        .expect("ready_tx dropped")
+        .expect("chain should be ready, not a start error");
+
+    assert_eq!(
+        chain_ready.transports,
+        Transports::TCP,
+        "end-to-end transports must be the intersection (TCP+UDP ∩ TCP = TCP)"
+    );
+    assert_eq!(
+        chain_ready.listen.port(),
+        public_addr.port(),
+        "Client-mode listen must be the position-0 (public) plugin's bind, not whichever readied first"
+    );
+
+    handle.abort();
 }
 
 // External cancellation tests =========================================================================================

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -13,8 +13,8 @@ pub mod test_utils;
 #[doc(hidden)]
 pub mod tracing_test;
 
-pub use binary::{BinaryPlugin, PidSink};
-pub use chain::{ChainRunner, Mode};
+pub use binary::{BinaryPlugin, PidSink, ReadinessMode};
+pub use chain::{ChainReady, ChainRunner, Mode};
 pub use counting::{CountingStream, StreamCounters};
 pub use error::{Error, Result};
 pub use plugin::ChainPlugin;

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod plugin;
 pub mod shutdown;
 pub mod sip003;
+pub mod sitrep;
 pub mod tap;
 #[cfg(any(test, feature = "test-utils"))]
 #[doc(hidden)]
@@ -19,6 +20,7 @@ pub use error::{Error, Result};
 pub use plugin::ChainPlugin;
 pub use sip003::parse_plugin_options;
 pub use sip003::PluginEnv;
+pub use sitrep::{PluginReady, ProtocolSupport, SitrepEvent, StartError, Transports, SITREP_PROTOCOL};
 pub use tap::TapPlugin;
 
 #[cfg(test)]
@@ -35,6 +37,8 @@ mod plugin_tests;
 mod shutdown_tests;
 #[cfg(test)]
 mod sip003_tests;
+#[cfg(test)]
+mod sitrep_tests;
 #[cfg(test)]
 mod tap_tests;
 #[cfg(test)]

--- a/crates/garter/src/plugin.rs
+++ b/crates/garter/src/plugin.rs
@@ -1,12 +1,16 @@
 use std::net::SocketAddr;
+
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
+
+use crate::sitrep::{PluginReady, StartError};
 
 /// A plugin in a SIP003u chain.
 ///
 /// Each plugin accepts connections on a local address and forwards
 /// (potentially transformed) traffic to a remote address. The plugin
-/// owns its runtime: it binds listeners, manages connections, and
-/// shuts down when the cancellation token fires.
+/// owns its runtime: it binds listeners, manages connections, reports
+/// readiness, and shuts down when the cancellation token fires.
 #[async_trait::async_trait]
 pub trait ChainPlugin: Send {
     /// Human-readable name for logging spans.
@@ -17,10 +21,19 @@ pub trait ChainPlugin: Send {
     /// - `local`: bind here, accept from previous stage (or SS client)
     /// - `remote`: forward here, to next stage (or SS server)
     /// - `shutdown`: fires when graceful shutdown is requested
+    /// - `ready`: the plugin MUST send exactly one of:
+    ///     - `Ok(PluginReady { .. })` once its listener is bound & accepting, OR
+    ///     - `Err(StartError)` if it fails to start.
+    ///
+    ///   If the plugin returns from `run` without sending (e.g. it crashed
+    ///   or exited early), dropping `ready` unsent signals the runner to
+    ///   synthesize a process-exit failure. Send readiness BEFORE the
+    ///   long-lived accept loop, not as the return value.
     async fn run(
         self: Box<Self>,
         local: SocketAddr,
         remote: SocketAddr,
         shutdown: CancellationToken,
+        ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()>;
 }

--- a/crates/garter/src/plugin_tests.rs
+++ b/crates/garter/src/plugin_tests.rs
@@ -21,6 +21,7 @@ impl ChainPlugin for NoopPlugin {
         _local: SocketAddr,
         _remote: SocketAddr,
         _shutdown: CancellationToken,
+        _ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
     ) -> crate::Result<()> {
         Ok(())
     }
@@ -40,7 +41,8 @@ async fn noop_plugin_runs_and_returns() {
     let local: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let remote: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let shutdown = CancellationToken::new();
+    let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
 
-    let result = plugin.run(local, remote, shutdown).await;
+    let result = plugin.run(local, remote, shutdown, ready_tx).await;
     assert!(result.is_ok());
 }

--- a/crates/garter/src/sitrep.rs
+++ b/crates/garter/src/sitrep.rs
@@ -97,6 +97,10 @@ pub enum ProtocolSupport {
 /// - `Ok(None)` — a log line (non-JSON), a JSON object without a known
 ///   `event` (unknown event = ignored, forward-compat), or a JSON object
 ///   that isn't a sitrep envelope. Callers treat this as log passthrough.
+///   Note: a `{`-prefixed line whose `event` matches a known variant but
+///   contains a malformed field (e.g. an unparseable `listen` address) is
+///   also swallowed to `Ok(None)` — the reserved `Err` arm is where a
+///   future strict mode would surface it.
 /// - `Err(_)` — reserved; currently never returned (unknown events are
 ///   ignored, not errors). Kept in the signature so a future strict mode
 ///   can surface malformed envelopes without an API break.

--- a/crates/garter/src/sitrep.rs
+++ b/crates/garter/src/sitrep.rs
@@ -1,0 +1,166 @@
+//! sitrep — a structured plugin→client control protocol.
+//!
+//! A plugin emits newline-delimited JSON events on its **stdout**; human
+//! logs stay on **stderr**. The first stdout line MUST be the `hello`
+//! handshake `{"event":"hello","protocol":"sitrep-<semver>"}` — its
+//! presence (a `protocol` matching `^sitrep-`) is the tier-1 capability
+//! signal. Subsequent JSON-object lines are events (dispatched by
+//! `event`; unknown events are ignored for forward-compat); non-JSON
+//! lines are log passthrough. The normative protocol spec is in
+//! `crates/garter/SITREP.md`; this module is its reference implementation.
+//!
+//! `SITREP_PROTOCOL` is the protocol version this consumer SPEAKS. Bump
+//! the MAJOR only for breaking envelope/semantics changes; MINOR is
+//! additive (old consumers ignore new events/fields); PATCH is non-wire.
+pub const SITREP_PROTOCOL: &str = "sitrep-1.0.0";
+
+use std::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+
+bitflags::bitflags! {
+    /// IP transports a plugin actually serves at its local listener.
+    /// Reported on `ready`; retires the static `udp_supported` flag.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Transports: u8 {
+        const TCP = 0b01;
+        const UDP = 0b10;
+    }
+}
+
+/// Readiness payload reported by a single plugin when its listener is up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginReady {
+    /// The address the plugin is actually accepting on.
+    pub listen: SocketAddr,
+    /// Transports served at `listen`.
+    pub transports: Transports,
+}
+
+/// A typed start failure reported by a plugin (or synthesized from a
+/// bare process exit by the runner). The consumer maps this to a retry
+/// decision — `BindConflict` is the only retryable class.
+#[derive(Debug, Clone)]
+pub enum StartError {
+    /// The plugin could not bind its listener. `errno` is the raw OS
+    /// error (locale-proof) where the plugin could type it; 0 if unknown.
+    BindConflict { errno: i32, addr: SocketAddr },
+    /// Any terminal start failure (config error, upstream-dial failure,
+    /// bare process exit). Never retried.
+    Fatal { detail: String, errno: Option<i32> },
+}
+
+impl std::fmt::Display for StartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StartError::BindConflict { errno, addr } => {
+                write!(f, "bind conflict on {addr} (errno {errno})")
+            }
+            StartError::Fatal { detail, .. } => write!(f, "{detail}"),
+        }
+    }
+}
+
+/// A parsed sitrep control event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum SitrepEvent {
+    Hello {
+        protocol: String,
+    },
+    Ready {
+        listen: SocketAddr,
+        #[serde(with = "transports_serde")]
+        transports: Transports,
+    },
+    BindConflict {
+        errno: i32,
+        addr: SocketAddr,
+    },
+    Fatal {
+        detail: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        errno: Option<i32>,
+    },
+}
+
+/// Whether this consumer can speak a plugin's advertised protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtocolSupport {
+    Supported,
+    FallBackToTier2,
+}
+
+/// Parse one stdout line.
+///
+/// - `Ok(Some(event))` — a recognized sitrep event.
+/// - `Ok(None)` — a log line (non-JSON), a JSON object without a known
+///   `event` (unknown event = ignored, forward-compat), or a JSON object
+///   that isn't a sitrep envelope. Callers treat this as log passthrough.
+/// - `Err(_)` — reserved; currently never returned (unknown events are
+///   ignored, not errors). Kept in the signature so a future strict mode
+///   can surface malformed envelopes without an API break.
+pub fn parse_event(line: &str) -> Result<Option<SitrepEvent>, serde_json::Error> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('{') {
+        return Ok(None); // not JSON → log line
+    }
+    // Untagged-tolerant: an unknown `event` (or no `event`) deserializes
+    // to None rather than erroring, so newer plugins / non-sitrep JSON
+    // never break an older consumer.
+    match serde_json::from_str::<SitrepEvent>(trimmed) {
+        Ok(ev) => Ok(Some(ev)),
+        Err(_) => Ok(None),
+    }
+}
+
+/// True iff `line` is a `hello` handshake whose protocol is `sitrep-*`.
+/// Used as the tier-1 detection signal on the first stdout line.
+pub fn is_hello_handshake(line: &str) -> bool {
+    matches!(parse_event(line), Ok(Some(SitrepEvent::Hello { protocol })) if protocol.starts_with("sitrep-"))
+}
+
+/// Gate a plugin's advertised `protocol` string against what we speak.
+/// Compatibility is on MAJOR only; an unknown major (or malformed
+/// string) degrades gracefully to the tier-2 probe path.
+pub fn protocol_support(protocol: &str) -> ProtocolSupport {
+    let ours = SITREP_PROTOCOL
+        .strip_prefix("sitrep-")
+        .and_then(|s| semver::Version::parse(s).ok());
+    let theirs = protocol
+        .strip_prefix("sitrep-")
+        .and_then(|s| semver::Version::parse(s).ok());
+    match (ours, theirs) {
+        (Some(o), Some(t)) if o.major == t.major => ProtocolSupport::Supported,
+        _ => ProtocolSupport::FallBackToTier2,
+    }
+}
+
+mod transports_serde {
+    use super::Transports;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(t: &Transports, s: S) -> Result<S::Ok, S::Error> {
+        let mut v = Vec::new();
+        if t.contains(Transports::TCP) {
+            v.push("tcp");
+        }
+        if t.contains(Transports::UDP) {
+            v.push("udp");
+        }
+        s.collect_seq(v)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Transports, D::Error> {
+        let names: Vec<String> = Vec::deserialize(d)?;
+        let mut t = Transports::empty();
+        for n in names {
+            match n.as_str() {
+                "tcp" => t |= Transports::TCP,
+                "udp" => t |= Transports::UDP,
+                _ => {} // unknown transport name ignored (forward-compat)
+            }
+        }
+        Ok(t)
+    }
+}

--- a/crates/garter/src/sitrep_tests.rs
+++ b/crates/garter/src/sitrep_tests.rs
@@ -95,3 +95,76 @@ fn empty_transports_deserializes_to_empty_set() {
         other => panic!("expected Ready, got {other:?}"),
     }
 }
+
+#[skuld::test]
+fn ready_serializes_to_canonical_wire_form() {
+    let ev = SitrepEvent::Ready {
+        listen: "127.0.0.1:1984".parse().unwrap(),
+        transports: Transports::TCP,
+    };
+    assert_eq!(
+        serde_json::to_string(&ev).unwrap(),
+        r#"{"event":"ready","listen":"127.0.0.1:1984","transports":["tcp"]}"#
+    );
+}
+
+#[skuld::test]
+fn ready_serializes_tcp_before_udp() {
+    // Pin transport ordering in the serialized array (TCP first, then UDP).
+    let ev = SitrepEvent::Ready {
+        listen: "127.0.0.1:1984".parse().unwrap(),
+        transports: Transports::TCP | Transports::UDP,
+    };
+    assert_eq!(
+        serde_json::to_string(&ev).unwrap(),
+        r#"{"event":"ready","listen":"127.0.0.1:1984","transports":["tcp","udp"]}"#
+    );
+}
+
+#[skuld::test]
+fn hello_serializes_to_canonical_wire_form() {
+    let ev = SitrepEvent::Hello {
+        protocol: SITREP_PROTOCOL.to_string(),
+    };
+    assert_eq!(
+        serde_json::to_string(&ev).unwrap(),
+        r#"{"event":"hello","protocol":"sitrep-1.0.0"}"#
+    );
+}
+
+#[skuld::test]
+fn bind_conflict_serializes_to_canonical_wire_form() {
+    let ev = SitrepEvent::BindConflict {
+        errno: 48,
+        addr: "127.0.0.1:1984".parse().unwrap(),
+    };
+    assert_eq!(
+        serde_json::to_string(&ev).unwrap(),
+        r#"{"event":"bind_conflict","errno":48,"addr":"127.0.0.1:1984"}"#
+    );
+}
+
+#[skuld::test]
+fn fatal_omits_errno_key_when_none() {
+    // skip_serializing_if = Option::is_none → no "errno" key on the wire.
+    let ev = SitrepEvent::Fatal {
+        detail: "config invalid".to_string(),
+        errno: None,
+    };
+    assert_eq!(
+        serde_json::to_string(&ev).unwrap(),
+        r#"{"event":"fatal","detail":"config invalid"}"#
+    );
+}
+
+#[skuld::test]
+fn fatal_includes_errno_key_when_some() {
+    let ev = SitrepEvent::Fatal {
+        detail: "boom".to_string(),
+        errno: Some(13),
+    };
+    assert_eq!(
+        serde_json::to_string(&ev).unwrap(),
+        r#"{"event":"fatal","detail":"boom","errno":13}"#
+    );
+}

--- a/crates/garter/src/sitrep_tests.rs
+++ b/crates/garter/src/sitrep_tests.rs
@@ -1,0 +1,97 @@
+use super::sitrep::*;
+
+#[skuld::test]
+fn hello_round_trips() {
+    let line = r#"{"event":"hello","protocol":"sitrep-1.0.0"}"#;
+    let ev = parse_event(line).expect("valid").expect("an event");
+    assert!(matches!(ev, SitrepEvent::Hello { .. }));
+    if let SitrepEvent::Hello { protocol } = ev {
+        assert_eq!(protocol, "sitrep-1.0.0");
+    }
+}
+
+#[skuld::test]
+fn ready_round_trips_with_transports() {
+    let line = r#"{"event":"ready","listen":"127.0.0.1:52344","transports":["tcp","udp"]}"#;
+    let ev = parse_event(line).expect("valid").expect("an event");
+    match ev {
+        SitrepEvent::Ready { listen, transports } => {
+            assert_eq!(listen, "127.0.0.1:52344".parse().unwrap());
+            assert_eq!(transports, Transports::TCP | Transports::UDP);
+        }
+        other => panic!("expected Ready, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn bind_conflict_round_trips() {
+    let line = r#"{"event":"bind_conflict","errno":48,"addr":"127.0.0.1:1984"}"#;
+    let ev = parse_event(line).expect("valid").expect("an event");
+    match ev {
+        SitrepEvent::BindConflict { errno, addr } => {
+            assert_eq!(errno, 48);
+            assert_eq!(addr, "127.0.0.1:1984".parse().unwrap());
+        }
+        other => panic!("expected BindConflict, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn fatal_round_trips() {
+    let line = r#"{"event":"fatal","detail":"config invalid"}"#;
+    let ev = parse_event(line).expect("valid").expect("an event");
+    assert!(matches!(ev, SitrepEvent::Fatal { .. }));
+}
+
+#[skuld::test]
+fn non_json_line_is_log_passthrough() {
+    // A non-JSON line is not an error and not an event — it's a log line.
+    assert_eq!(parse_event("plain log text").unwrap(), None);
+}
+
+#[skuld::test]
+fn unknown_event_is_ignored_not_error() {
+    // Forward-compat: an unknown `event` parses to None (ignored), not Err.
+    let line = r#"{"event":"some_future_event","x":1}"#;
+    assert_eq!(parse_event(line).unwrap(), None);
+}
+
+#[skuld::test]
+fn json_without_event_key_is_log_passthrough() {
+    // A JSON object that isn't a sitrep envelope (no `event`) is a log line.
+    assert_eq!(parse_event(r#"{"level":"info","msg":"hi"}"#).unwrap(), None);
+}
+
+#[skuld::test]
+fn is_hello_handshake_detects_sitrep_prefix() {
+    assert!(is_hello_handshake(r#"{"event":"hello","protocol":"sitrep-1.0.0"}"#));
+    assert!(!is_hello_handshake("plain log"));
+    assert!(!is_hello_handshake(r#"{"event":"ready","listen":"127.0.0.1:1"}"#));
+}
+
+#[skuld::test]
+fn major_version_gate_accepts_same_major() {
+    assert_eq!(protocol_support("sitrep-1.0.0"), ProtocolSupport::Supported);
+    assert_eq!(protocol_support("sitrep-1.9.3"), ProtocolSupport::Supported);
+}
+
+#[skuld::test]
+fn major_version_gate_falls_back_on_unknown_major() {
+    assert_eq!(protocol_support("sitrep-2.0.0"), ProtocolSupport::FallBackToTier2);
+}
+
+#[skuld::test]
+fn malformed_protocol_falls_back() {
+    assert_eq!(protocol_support("garbage"), ProtocolSupport::FallBackToTier2);
+    assert_eq!(protocol_support("sitrep-notsemver"), ProtocolSupport::FallBackToTier2);
+}
+
+#[skuld::test]
+fn empty_transports_deserializes_to_empty_set() {
+    let line = r#"{"event":"ready","listen":"127.0.0.1:1","transports":[]}"#;
+    let ev = parse_event(line).expect("valid").expect("an event");
+    match ev {
+        SitrepEvent::Ready { transports, .. } => assert!(transports.is_empty()),
+        other => panic!("expected Ready, got {other:?}"),
+    }
+}

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -40,11 +40,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use crate::counting::CountingStream;
 use crate::plugin::ChainPlugin;
+use crate::sitrep::{PluginReady, StartError, Transports};
 
 /// Process-wide monotonic id assigned to each tap connection. Logged as
 /// `tap_conn_id` so log readers can correlate the `accepted` and
@@ -95,28 +97,49 @@ impl ChainPlugin for TapPlugin {
         local: SocketAddr,
         remote: SocketAddr,
         shutdown: CancellationToken,
+        ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
         let plugin_name = self.inner.name().to_string();
 
         // 1. Allocate inner port (probe-and-drop, with bind-race retry).
-        let inner_local = allocate_inner_port(local.ip())
-            .map_err(|e| crate::Error::Chain(format!("tap[{plugin_name}]: alloc inner port: {e}")))?;
+        let inner_local = match allocate_inner_port(local.ip()) {
+            Ok(addr) => addr,
+            Err(e) => {
+                let _ = ready.send(Err(StartError::Fatal {
+                    detail: format!("tap[{plugin_name}]: alloc inner port: {e}"),
+                    errno: e.raw_os_error(),
+                }));
+                return Err(crate::Error::Chain(format!(
+                    "tap[{plugin_name}]: alloc inner port: {e}"
+                )));
+            }
+        };
 
-        // 2. Spawn the inner plugin against `inner_local`.
+        // 2. Spawn the inner plugin against `inner_local`, giving it its
+        //    own readiness channel. The tap consumes the inner's readiness
+        //    only to know the data plane is wired; it reports its OWN
+        //    readiness (below) once the public listener is bound.
         let inner_shutdown = shutdown.clone();
-        let mut inner_handle = tokio::spawn(self.inner.run(inner_local, remote, inner_shutdown));
+        let (inner_ready_tx, _inner_ready_rx) = oneshot::channel();
+        let mut inner_handle = tokio::spawn(self.inner.run(inner_local, remote, inner_shutdown, inner_ready_tx));
 
         // 3. Wait for the inner plugin to bind the inner port. Race
         //    against the inner task itself so an early plugin failure
         //    doesn't leave us blocked on a port that will never bind.
         let ready_token = shutdown.clone();
         let ready_outcome = tokio::select! {
-            ready = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => {
-                Some(ready)
+            r = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => {
+                Some(r)
             }
             join = &mut inner_handle => {
                 // Inner exited before binding — propagate its result. No
-                // tap listener was ever opened, so nothing to clean up.
+                // tap listener was ever opened. Report the inner's failure
+                // through our own readiness channel so the chain aggregator
+                // sees a typed cause.
+                let _ = ready.send(Err(StartError::Fatal {
+                    detail: format!("tap[{plugin_name}]: inner exited before becoming ready"),
+                    errno: None,
+                }));
                 return match join {
                     Ok(result) => result,
                     Err(je) => Err(crate::Error::Chain(format!("tap[{plugin_name}]: inner task: {je}"))),
@@ -126,13 +149,20 @@ impl ChainPlugin for TapPlugin {
         match ready_outcome {
             Some(Ok(Some(_))) => {}
             Some(Ok(None)) => {
-                // Shutdown fired before inner was ready. Wait for inner to
-                // unwind and propagate its result.
+                // Shutdown fired before inner was ready. Drop `ready` unsent
+                // (RecvError, matching the "shutdown before ready"
+                // semantics). Wait for inner to unwind and propagate.
                 return drain_inner(plugin_name.as_str(), inner_handle).await;
             }
             Some(Err(_)) => {
                 inner_handle.abort();
                 let _ = inner_handle.await;
+                let _ = ready.send(Err(StartError::Fatal {
+                    detail: format!(
+                        "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
+                    ),
+                    errno: None,
+                }));
                 return Err(crate::Error::Chain(format!(
                     "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
                 )));
@@ -141,15 +171,32 @@ impl ChainPlugin for TapPlugin {
         }
 
         // 4. Bind the public-facing tap listener.
-        let listener = TcpListener::bind(local)
-            .await
-            .map_err(|e| crate::Error::Chain(format!("tap[{plugin_name}]: bind {local}: {e}")))?;
+        let listener = match TcpListener::bind(local).await {
+            Ok(l) => l,
+            Err(e) => {
+                let _ = ready.send(Err(StartError::BindConflict {
+                    // `BindConflict.errno` is a raw OS error (0 if unknown,
+                    // per sitrep); `io::Error::raw_os_error` is `Option<i32>`.
+                    errno: e.raw_os_error().unwrap_or(0),
+                    addr: local,
+                }));
+                inner_handle.abort();
+                let _ = inner_handle.await;
+                return Err(crate::Error::Chain(format!("tap[{plugin_name}]: bind {local}: {e}")));
+            }
+        };
+        let listen_addr = listener.local_addr().unwrap_or(local);
         tracing::info!(
             plugin = %plugin_name,
             %local,
             %inner_local,
             "plugin tap: ready"
         );
+        // The tap proxies TCP only; report readiness on the public listener.
+        let _ = ready.send(Ok(PluginReady {
+            listen: listen_addr,
+            transports: Transports::TCP,
+        }));
 
         // 5. Accept loop. Per-connection forwarders go into a JoinSet so
         //    shutdown can abort them; we never leak a forwarder past the

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -19,12 +19,15 @@
 //! 2. Spawn the inner plugin's `run` future in a task, configured to bind
 //!    that internal port.
 //! 3. Wait for the inner plugin to actually accept TCP via
-//!    [`crate::chain::poll_ready`] (same backoff schedule [`ChainRunner`]
-//!    uses for its own readiness probe). Bounded at 30s; on timeout the
+//!    [`crate::chain::poll_ready`], racing the inner task's `JoinHandle`
+//!    so an early inner failure unblocks us. (The inner's own readiness
+//!    channel is discarded — the tap detects inner readiness by the probe
+//!    and inner failure by the join.) Bounded at 30s; on timeout the
 //!    inner task is aborted and `Error::Chain` propagates.
-//! 4. Bind the tap's public listener on `local` (only after step 3 — the
-//!    bind has to be observable to `ChainRunner::poll_ready` only when
-//!    the data plane is actually wired through).
+//! 4. Bind the tap's public listener on `local` (only after step 3, so the
+//!    public bind happens only once the data plane is actually wired
+//!    through), then report the tap's OWN readiness on the `ready` channel
+//!    passed to [`ChainPlugin::run`] — the chain aggregator awaits that.
 //! 5. Accept loop in a `JoinSet`; per-connection forwarder calls
 //!    `tokio::io::copy_bidirectional` with [`CountingStream`] wrappers.
 //! 6. On shutdown: abort all in-flight forwarders, await the inner task,
@@ -115,10 +118,11 @@ impl ChainPlugin for TapPlugin {
             }
         };
 
-        // 2. Spawn the inner plugin against `inner_local`, giving it its
-        //    own readiness channel. The tap consumes the inner's readiness
-        //    only to know the data plane is wired; it reports its OWN
-        //    readiness (below) once the public listener is bound.
+        // 2. Spawn the inner plugin against `inner_local`. The trait
+        //    requires a readiness channel, but the tap discards the inner's
+        //    (it detects inner readiness via the TCP probe in step 3 and
+        //    inner failure via the join); the tap reports its OWN readiness
+        //    (below) once the public listener is bound.
         let inner_shutdown = shutdown.clone();
         let (inner_ready_tx, _inner_ready_rx) = oneshot::channel();
         let mut inner_handle = tokio::spawn(self.inner.run(inner_local, remote, inner_shutdown, inner_ready_tx));

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -74,10 +74,16 @@ impl ChainPlugin for StubPlugin {
         local: SocketAddr,
         _remote: SocketAddr,
         shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
     ) -> crate::Result<()> {
         let listener = TcpListener::bind(local)
             .await
             .map_err(|e| crate::Error::Chain(format!("stub bind {local}: {e}")))?;
+        let actual = listener.local_addr().unwrap_or(local);
+        let _ = ready.send(Ok(crate::sitrep::PluginReady {
+            listen: actual,
+            transports: crate::sitrep::Transports::TCP,
+        }));
         let behavior = self.behavior;
         loop {
             tokio::select! {
@@ -160,7 +166,10 @@ where
     let closed_rx = writer.wait_for("plugin tap: closed");
 
     let plugin_shutdown = shutdown.clone();
-    let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown).await });
+    // The tests synchronize on the "plugin tap: ready" tracing event, not
+    // the readiness channel; a throwaway oneshot satisfies the new param.
+    let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
+    let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown, ready_tx).await });
 
     // Park until tap signals ready via tracing event. No timeout — the
     // test framework bounds wall time; if tap is broken the failure is
@@ -336,7 +345,10 @@ async fn shutdown_cancels_in_flight_connection_without_panic() {
     let ready_rx = writer.wait_for("plugin tap: ready");
 
     let plugin_shutdown = shutdown.clone();
-    let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown).await });
+    // The tests synchronize on the "plugin tap: ready" tracing event, not
+    // the readiness channel; a throwaway oneshot satisfies the new param.
+    let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
+    let plugin_handle = tokio::spawn(async move { tap.run(local, remote, plugin_shutdown, ready_tx).await });
 
     // Park until tap signals ready via tracing event. Deterministic.
     tokio::task::spawn_blocking(move || ready_rx.recv().expect("tap never signaled ready"))

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -37,16 +37,25 @@ fn mock_plugin_path() -> PathBuf {
 
 /// Spin up an echo server and a chain of 2 mock plugins, send data through,
 /// verify it arrives.
+///
+/// This is the #414 regression test. Readiness is now signaled by BOTH
+/// plugins' sitrep `ready` events (both plugins run in `ExpectSitrep`
+/// mode); the client connects only after the aggregator has collected
+/// every plugin's `ready`, so the connect can never race ahead of a bound
+/// listener. Pre-#414 the client raced the readiness signal and saw
+/// intermittent Connection reset/refused.
 #[skuld::test]
 async fn two_plugin_chain_relays_data() {
     let mock_path = mock_plugin_path();
 
-    // Multi-connection echo server. `on_ready`'s TCP-connect probe is
-    // forwarded through the chain to the echo server, consuming an
-    // accept slot before the real client connection arrives — so echo
-    // must loop. (The previous poll-based readiness check connected
-    // directly to the outermost listener before traffic flowed through
-    // the chain, masking this.) See bindreams/hole#383.
+    // Multi-connection echo server. Under `ExpectSitrep` there is NO
+    // readiness probe connecting through the chain (the old poll-based
+    // readiness check connected to the outermost listener and consumed an
+    // accept slot — that rationale no longer applies, since each plugin
+    // now declares readiness directly via its sitrep `ready` event). The
+    // single real client connection would be served by a single-accept
+    // echo, but multi-accept is retained as a harmless safety margin and
+    // mirrors the server-mode sister test. See bindreams/hole#414.
     let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let echo_addr = echo_listener.local_addr().unwrap();
 
@@ -71,13 +80,17 @@ async fn two_plugin_chain_relays_data() {
 
     let (ready_tx, ready_rx) = oneshot::channel();
 
-    // Build chain: mock-plugin-1 -> mock-plugin-2. `on_ready` fires
-    // when the outermost plugin has bound `chain_local` — see
-    // bindreams/hole#383 for why the previous poll-connect was a flake
-    // hazard.
+    // Build chain: mock-plugin-1 -> mock-plugin-2, both in ExpectSitrep
+    // mode so readiness comes from each plugin's sitrep `ready` event.
+    // `on_ready` fires `Ok(ChainReady)` once EVERY plugin has emitted
+    // `ready`.
     let runner = ChainRunner::new()
-        .add(Box::new(BinaryPlugin::new(&mock_path, None)))
-        .add(Box::new(BinaryPlugin::new(&mock_path, None)))
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None).readiness(garter::binary::ReadinessMode::ExpectSitrep),
+        ))
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None).readiness(garter::binary::ReadinessMode::ExpectSitrep),
+        ))
         .on_ready(ready_tx)
         .drain_timeout(Duration::from_secs(3));
 
@@ -92,11 +105,14 @@ async fn two_plugin_chain_relays_data() {
     let chain_task = tokio::spawn(async move { runner.run(env).await });
 
     // Park until the chain signals ready. Deterministic, no poll-retry.
-    ready_rx
+    // Connect to the authoritative bound address reported by the chain.
+    let chain_ready = ready_rx
         .await
         .expect("chain never signaled ready")
         .expect("chain should be ready, not a start error");
-    let mut client = TcpStream::connect(chain_local).await.expect("connect to chain local");
+    let mut client = TcpStream::connect(chain_ready.listen)
+        .await
+        .expect("connect to chain local");
     client.write_all(b"hello through chain").await.unwrap();
 
     let mut buf = [0u8; 1024];
@@ -128,11 +144,12 @@ async fn pid_sink_fires_once_per_binary_plugin() {
     });
 
     // Single-accept echo: this test only awaits `on_ready` and checks
-    // pid counts — it does not send any client traffic. `on_ready`'s
-    // TCP probe is forwarded through the chain and consumes this one
-    // accept slot, which is sufficient because no real client follows.
-    // The sister test (`two_plugin_chain_relays_data`) does send
-    // traffic and therefore uses a multi-accept echo.
+    // pid counts — it does not send any client traffic. The plugins run
+    // in the default `Probe` readiness mode, whose self-probe TCP-connects
+    // to each plugin's OWN listener (not through the chain to the echo),
+    // so the echo accept slot is never even reached here. A single-accept
+    // echo is therefore ample. The sister test
+    // (`two_plugin_chain_relays_data`) does send real client traffic.
     let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let echo_addr = echo_listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -254,6 +271,291 @@ async fn two_plugin_chain_server_mode_relays_data() {
     let mut buf = [0u8; 1024];
     let n = client.read(&mut buf).await.expect("read failed");
     assert_eq!(&buf[..n], b"hello server-mode chain");
+
+    drop(client);
+    echo_task.abort();
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// Tier-2 fallback: a plugin that emits NO sitrep handshake (a pre-sitrep
+/// plain forwarder) still readies — readiness comes from the default
+/// `Probe` self-probe TCP-connect, not from a sitrep `ready` event. Proves
+/// the tier-2 path is live end-to-end (the chain reaches `Ok(ChainReady)`
+/// AND relays a payload through to the echo).
+#[skuld::test]
+async fn tier2_plugin_without_sitrep_still_readies_via_probe() {
+    let mock_path = mock_plugin_path();
+
+    // Multi-accept echo. In `Probe` mode the self-probe TCP-connects to
+    // the plugin's own listener (not through the chain), so it does not
+    // consume an echo accept slot — but keep multi-accept as a harmless
+    // safety margin.
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    let echo_task = tokio::spawn(async move {
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut reader, mut writer) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut reader, &mut writer).await;
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    // Single plugin, NO_SITREP so it emits nothing on stdout, default
+    // `Probe` readiness (do NOT set ExpectSitrep) — readiness must come
+    // from the self-probe.
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None).env("MOCK_PLUGIN_NO_SITREP", "1"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: echo_addr.ip().to_string(),
+        remote_port: echo_addr.port(),
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let chain_ready = ready_rx
+        .await
+        .expect("chain never signaled ready")
+        .expect("chain should ready via tier-2 probe, not a start error");
+
+    let mut client = TcpStream::connect(chain_ready.listen)
+        .await
+        .expect("connect to chain local");
+    client.write_all(b"hello via probe").await.unwrap();
+    let mut buf = [0u8; 1024];
+    let n = client.read(&mut buf).await.expect("read from chain returned error");
+    assert_eq!(&buf[..n], b"hello via probe");
+
+    drop(client);
+    echo_task.abort();
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// A plugin that emits `fatal` then exits surfaces a typed
+/// `StartError::Fatal` on the readiness channel, AND the chain `run()`
+/// future returns `Err`. The plugin exits before serving, so no client
+/// traffic is exchanged.
+#[skuld::test]
+async fn fatal_start_error_surfaces_typed() {
+    let mock_path = mock_plugin_path();
+
+    // No echo / client needed: the plugin exits before binding.
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_FAIL", "fatal"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9, // discard; never dialed (plugin exits first)
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    assert!(
+        matches!(outcome, Err(garter::StartError::Fatal { .. })),
+        "expected StartError::Fatal, got {outcome:?}"
+    );
+
+    // The chain's lifecycle channel independently observes the nonzero exit.
+    let run_result = chain_task.await.expect("chain task panicked");
+    assert!(run_result.is_err(), "chain run() should return Err on fatal exit");
+}
+
+/// A plugin that emits `bind_conflict` then exits surfaces a typed
+/// `StartError::BindConflict` with the host-native errno and the
+/// allocated listen address.
+#[skuld::test]
+async fn bind_conflict_start_error_surfaces_typed() {
+    let mock_path = mock_plugin_path();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_FAIL", "bind_conflict"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    match outcome {
+        Err(garter::StartError::BindConflict { errno, addr }) => {
+            // Host-native errno (10048 / 98 / 48) — assert nonzero rather
+            // than a specific foreign constant.
+            assert_ne!(errno, 0, "bind_conflict errno should be the host-native value");
+            // mock-plugin emits `addr: local_addr`, which in a single-plugin
+            // Client chain is the chain's local (public) port.
+            assert_eq!(
+                addr.port(),
+                chain_local.port(),
+                "bind_conflict addr should be the allocated chain local port"
+            );
+        }
+        other => panic!("expected StartError::BindConflict, got {other:?}"),
+    }
+
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// A `ready` event that lists an empty transports set is a SITREP
+/// protocol violation; the consumer rejects it as `StartError::Fatal`.
+#[skuld::test]
+async fn empty_transports_ready_surfaces_fatal() {
+    let mock_path = mock_plugin_path();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_EMPTY_TRANSPORTS", "1"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    assert!(
+        matches!(outcome, Err(garter::StartError::Fatal { .. })),
+        "empty transports should surface StartError::Fatal, got {outcome:?}"
+    );
+
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// Version-skew fallback: a plugin advertises an unknown sitrep MAJOR
+/// (`sitrep-2.0.0`) in its `hello`. The consumer's protocol gate hands
+/// readiness to the tier-2 self-probe (and drains the rest of stdout to
+/// EOF — the deadlock-fix path). The plugin still binds + emits `ready`
+/// (which is ignored because the handshake never validated), so the
+/// probe succeeds and the chain reaches `Ok(ChainReady)`. A client then
+/// relays a payload through, proving the probe-fallback readiness is real
+/// and not just a fired channel.
+#[skuld::test]
+async fn version_skew_falls_back_to_probe() {
+    let mock_path = mock_plugin_path();
+
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    let echo_task = tokio::spawn(async move {
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut reader, mut writer) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut reader, &mut writer).await;
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_BAD_PROTOCOL", "1"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: echo_addr.ip().to_string(),
+        remote_port: echo_addr.port(),
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let chain_ready = ready_rx
+        .await
+        .expect("chain never signaled ready")
+        .expect("unknown-major should fall back to probe, not a start error");
+
+    let mut client = TcpStream::connect(chain_ready.listen)
+        .await
+        .expect("connect to chain local");
+    client.write_all(b"hello across version skew").await.unwrap();
+    let mut buf = [0u8; 1024];
+    let n = client.read(&mut buf).await.expect("read from chain returned error");
+    assert_eq!(&buf[..n], b"hello across version skew");
 
     drop(client);
     echo_task.abort();

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -92,7 +92,10 @@ async fn two_plugin_chain_relays_data() {
     let chain_task = tokio::spawn(async move { runner.run(env).await });
 
     // Park until the chain signals ready. Deterministic, no poll-retry.
-    ready_rx.await.expect("chain never signaled ready");
+    ready_rx
+        .await
+        .expect("chain never signaled ready")
+        .expect("chain should be ready, not a start error");
     let mut client = TcpStream::connect(chain_local).await.expect("connect to chain local");
     client.write_all(b"hello through chain").await.unwrap();
 
@@ -163,7 +166,10 @@ async fn pid_sink_fires_once_per_binary_plugin() {
 
     let handle = tokio::spawn(async move { runner.run(env).await });
 
-    ready_rx.await.expect("chain should become ready");
+    ready_rx
+        .await
+        .expect("ready_tx dropped")
+        .expect("chain should become ready");
 
     {
         let recorded = pids.lock().unwrap();
@@ -230,9 +236,12 @@ async fn two_plugin_chain_server_mode_relays_data() {
     let chain_task = tokio::spawn(async move { runner.run(env).await });
 
     // on_ready fires when the OUTER plugin has bound the public port.
-    let ready_addr = ready_rx.await.expect("chain never signaled ready");
+    let chain_ready = ready_rx
+        .await
+        .expect("chain never signaled ready")
+        .expect("chain should be ready, not a start error");
     assert_eq!(
-        ready_addr.port(),
+        chain_ready.listen.port(),
         public_addr.port(),
         "on_ready in Server mode must report SS_REMOTE (the public port)"
     );

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -499,6 +499,12 @@ async fn empty_transports_ready_surfaces_fatal() {
 /// probe succeeds and the chain reaches `Ok(ChainReady)`. A client then
 /// relays a payload through, proving the probe-fallback readiness is real
 /// and not just a fired channel.
+///
+/// The `MOCK_PLUGIN_BAD_PROTOCOL` knob emits its ignored `ready` with
+/// `transports: [tcp, udp]`, while the tier-2 TCP self-probe always
+/// reports `transports: [tcp]` only. Asserting `TCP`-only on the
+/// `ChainReady` discriminates the source and proves that the bad-major
+/// `ready` was not honored.
 #[skuld::test]
 async fn version_skew_falls_back_to_probe() {
     let mock_path = mock_plugin_path();
@@ -548,6 +554,17 @@ async fn version_skew_falls_back_to_probe() {
         .await
         .expect("chain never signaled ready")
         .expect("unknown-major should fall back to probe, not a start error");
+
+    // The probe-fallback readiness reports Transports::TCP (the tier-2
+    // self-probe is TCP-connect only). If the consumer had WRONGLY honored
+    // the unknown-major plugin's `ready` (which this knob emits with
+    // [tcp,udp]), transports would include UDP. Asserting TCP-only proves
+    // readiness came from the probe, not the ignored bad-major ready.
+    assert_eq!(
+        chain_ready.transports,
+        garter::Transports::TCP,
+        "version-skew readiness must come from the tier-2 TCP probe, not the ignored bad-major ready"
+    );
 
     let mut client = TcpStream::connect(chain_ready.listen)
         .await

--- a/crates/garter/tests/tap_integration.rs
+++ b/crates/garter/tests/tap_integration.rs
@@ -89,7 +89,10 @@ async fn tap_relays_data_through_binary_plugin_to_echo_server() {
 
     let shutdown = CancellationToken::new();
     let plugin_shutdown = shutdown.clone();
-    let plugin_handle = tokio::spawn(async move { tap.run(chain_local, echo_addr, plugin_shutdown).await });
+    // This test synchronizes on the "plugin tap: ready" tracing event, not
+    // the readiness channel; a throwaway oneshot satisfies the new param.
+    let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
+    let plugin_handle = tokio::spawn(async move { tap.run(chain_local, echo_addr, plugin_shutdown, ready_tx).await });
 
     // Park until tap signals ready via the tracing event the
     // `WaitableWriter` is watching for. Deterministic, no polling.

--- a/crates/mock-plugin/Cargo.toml
+++ b/crates/mock-plugin/Cargo.toml
@@ -9,4 +9,6 @@ publish = false
 workspace = true
 
 [dependencies]
+garter = { path = "../garter" }
+serde_json = { workspace = true }
 tokio = { version = "1", features = ["full"] }

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -1,7 +1,28 @@
 use std::net::SocketAddr;
 
+use garter::sitrep::{SitrepEvent, Transports, SITREP_PROTOCOL};
 use tokio::io;
 use tokio::net::{TcpListener, TcpStream};
+
+fn emit(ev: &SitrepEvent) {
+    // sitrep events go to STDOUT, one JSON object per line.
+    println!("{}", serde_json::to_string(ev).expect("serialize sitrep event"));
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+}
+
+/// True on the FIRST call across process invocations sharing the sentinel
+/// path; false thereafter. Atomic via O_CREAT|O_EXCL semantics — no TOCTOU.
+fn first_failure_for_sentinel() -> bool {
+    let Some(path) = std::env::var_os("MOCK_PLUGIN_FAIL_SENTINEL") else {
+        return true; // no sentinel configured → always "first" (plain bind_conflict)
+    };
+    match std::fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(_) => true, // we created it → this is the first failure
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => false, // retry → succeed
+        Err(_) => true, // any other error → behave as first failure (fail loud)
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,40 +34,76 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let local_addr: SocketAddr = format!("{local_host}:{local_port}").parse()?;
     let remote_addr = format!("{remote_host}:{remote_port}");
 
-    // bindreams/hole#388: when `MOCK_PLUGIN_ECHO_ENV=1` is set, echo
-    // `SS_PLUGIN_OPTIONS` on stderr at startup. Lets integration tests
-    // verify the bridge correctly propagated the merged options string
-    // (e.g. `loglevel=debug` injection from `inject_plugin_debug_logging`).
-    // Gated behind an env var so production-equivalent uses of
-    // mock-plugin don't pollute logs.
     if std::env::var_os("MOCK_PLUGIN_ECHO_ENV").is_some() {
         if let Ok(opts) = std::env::var("SS_PLUGIN_OPTIONS") {
             eprintln!("mock-plugin: SS_PLUGIN_OPTIONS={opts}");
         }
     }
 
+    // sitrep handshake: ALWAYS the first stdout line.
+    emit(&SitrepEvent::Hello {
+        protocol: SITREP_PROTOCOL.to_string(),
+    });
+
+    // Fault-injection knob: MOCK_PLUGIN_FAIL=fatal | bind_conflict | bind_conflict_once
+    let fail = std::env::var("MOCK_PLUGIN_FAIL").unwrap_or_default();
+    if fail == "fatal" {
+        emit(&SitrepEvent::Fatal {
+            detail: "injected fatal".into(),
+            errno: None,
+        });
+        std::process::exit(1);
+    }
+    // Host-native errno: AddrInUse is 48 on macOS, 98 on Linux, 10048 (WSA)
+    // on Windows. The bridge's BindRace mapping sets ErrorKind directly and
+    // ignores this number for classification (see Task 9), so a representative
+    // non-zero value is fine — but emit the real host value for diagnostic
+    // honesty rather than a hardcoded foreign constant.
+    let addr_in_use_errno: i32 = {
+        #[cfg(target_os = "windows")]
+        {
+            10048
+        }
+        #[cfg(target_os = "linux")]
+        {
+            98
+        }
+        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+        {
+            48
+        }
+    };
+    if fail == "bind_conflict" || (fail == "bind_conflict_once" && first_failure_for_sentinel()) {
+        emit(&SitrepEvent::BindConflict {
+            errno: addr_in_use_errno,
+            addr: local_addr,
+        });
+        std::process::exit(1);
+    }
+
     eprintln!("mock-plugin: listening on {local_addr}, forwarding to {remote_addr}");
     let listener = TcpListener::bind(local_addr).await?;
+
+    // sitrep ready: listener is bound & accepting.
+    emit(&SitrepEvent::Ready {
+        listen: local_addr,
+        transports: Transports::TCP,
+    });
 
     loop {
         let (inbound, peer) = listener.accept().await?;
         eprintln!("mock-plugin: accepted connection from {peer}");
         let remote = remote_addr.clone();
-
         tokio::spawn(async move {
             match TcpStream::connect(&remote).await {
                 Ok(outbound) => {
                     let (mut ri, mut wi) = io::split(inbound);
                     let (mut ro, mut wo) = io::split(outbound);
-
                     let c2s = io::copy(&mut ri, &mut wo);
                     let s2c = io::copy(&mut ro, &mut wi);
-
                     let _ = tokio::try_join!(c2s, s2c);
                 }
-                Err(e) => {
-                    eprintln!("mock-plugin: failed to connect to {remote}: {e}");
-                }
+                Err(e) => eprintln!("mock-plugin: failed to connect to {remote}: {e}"),
             }
         });
     }

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -4,8 +4,14 @@ use garter::sitrep::{SitrepEvent, Transports, SITREP_PROTOCOL};
 use tokio::io;
 use tokio::net::{TcpListener, TcpStream};
 
-fn emit(ev: &SitrepEvent) {
-    // sitrep events go to STDOUT, one JSON object per line.
+/// Emit a sitrep event to STDOUT (one JSON object per line) unless
+/// `sitrep_enabled` is false, in which case the plugin behaves like a
+/// pre-sitrep plain forwarder (prints nothing to stdout). Gated by the
+/// `MOCK_PLUGIN_NO_SITREP` knob — see `main`.
+fn emit(ev: &SitrepEvent, sitrep_enabled: bool) {
+    if !sitrep_enabled {
+        return;
+    }
     println!("{}", serde_json::to_string(ev).expect("serialize sitrep event"));
     use std::io::Write;
     let _ = std::io::stdout().flush();
@@ -40,18 +46,44 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // sitrep handshake: ALWAYS the first stdout line.
-    emit(&SitrepEvent::Hello {
-        protocol: SITREP_PROTOCOL.to_string(),
-    });
+    // Knob: MOCK_PLUGIN_NO_SITREP — suppress ALL stdout sitrep emits so the
+    // plugin behaves like a pre-sitrep plain forwarder (the tier-2 self-probe
+    // path). It still binds + forwards; it just prints nothing to stdout.
+    // Fault knobs that emit-then-exit still EXIT (the emit is just skipped).
+    let sitrep_enabled = std::env::var_os("MOCK_PLUGIN_NO_SITREP").is_none();
+    // Knob: MOCK_PLUGIN_BAD_PROTOCOL — emit a `hello` with an unknown major
+    // (`sitrep-2.0.0`) so the consumer's protocol gate falls back to tier-2
+    // probe; the plugin still binds + emits `ready` (which the consumer
+    // ignores because handshake_ok stayed false).
+    let bad_protocol = std::env::var_os("MOCK_PLUGIN_BAD_PROTOCOL").is_some();
+    // Knob: MOCK_PLUGIN_EMPTY_TRANSPORTS — emit `ready` with an empty
+    // transports set (a SITREP protocol violation) so the consumer rejects
+    // it as Fatal. The `hello` handshake is still well-formed.
+    let empty_transports = std::env::var_os("MOCK_PLUGIN_EMPTY_TRANSPORTS").is_some();
+
+    // sitrep handshake: ALWAYS the first stdout line (when sitrep is enabled).
+    let hello_protocol = if bad_protocol {
+        "sitrep-2.0.0".to_string()
+    } else {
+        SITREP_PROTOCOL.to_string()
+    };
+    emit(
+        &SitrepEvent::Hello {
+            protocol: hello_protocol,
+        },
+        sitrep_enabled,
+    );
 
     // Fault-injection knob: MOCK_PLUGIN_FAIL=fatal | bind_conflict | bind_conflict_once
     let fail = std::env::var("MOCK_PLUGIN_FAIL").unwrap_or_default();
     if fail == "fatal" {
-        emit(&SitrepEvent::Fatal {
-            detail: "injected fatal".into(),
-            errno: None,
-        });
+        emit(
+            &SitrepEvent::Fatal {
+                detail: "injected fatal".into(),
+                errno: None,
+            },
+            sitrep_enabled,
+        );
         std::process::exit(1);
     }
     // Host-native errno: AddrInUse is 48 on macOS, 98 on Linux, 10048 (WSA)
@@ -74,21 +106,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
     if fail == "bind_conflict" || (fail == "bind_conflict_once" && first_failure_for_sentinel()) {
-        emit(&SitrepEvent::BindConflict {
-            errno: addr_in_use_errno,
-            addr: local_addr,
-        });
+        emit(
+            &SitrepEvent::BindConflict {
+                errno: addr_in_use_errno,
+                addr: local_addr,
+            },
+            sitrep_enabled,
+        );
         std::process::exit(1);
     }
 
     eprintln!("mock-plugin: listening on {local_addr}, forwarding to {remote_addr}");
     let listener = TcpListener::bind(local_addr).await?;
 
-    // sitrep ready: listener is bound & accepting.
-    emit(&SitrepEvent::Ready {
-        listen: local_addr,
-        transports: Transports::TCP,
-    });
+    // sitrep ready: listener is bound & accepting. With
+    // MOCK_PLUGIN_EMPTY_TRANSPORTS the transports set is empty (a protocol
+    // violation the consumer rejects as Fatal).
+    let ready_transports = if empty_transports {
+        Transports::empty()
+    } else {
+        Transports::TCP
+    };
+    emit(
+        &SitrepEvent::Ready {
+            listen: local_addr,
+            transports: ready_transports,
+        },
+        sitrep_enabled,
+    );
 
     loop {
         let (inbound, peer) = listener.accept().await?;

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -121,9 +121,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // sitrep ready: listener is bound & accepting. With
     // MOCK_PLUGIN_EMPTY_TRANSPORTS the transports set is empty (a protocol
-    // violation the consumer rejects as Fatal).
+    // violation the consumer rejects as Fatal). With MOCK_PLUGIN_BAD_PROTOCOL
+    // the ready emits TCP|UDP so the tier-2 probe (which always reports TCP
+    // only) is distinguishable from a wrongly-honored bad-major ready.
     let ready_transports = if empty_transports {
         Transports::empty()
+    } else if bad_protocol {
+        Transports::TCP | Transports::UDP
     } else {
         Transports::TCP
     };


### PR DESCRIPTION
Fixes #414. Also closes #259 and #304.

Plan 1 of 2 of the **sitrep** effort — a structured plugin→host readiness protocol that replaces garter's single-address TCP-connect probe (the root cause of the #414 flake). Plan 2 (ex-ray, retiring the vendored v2ray-plugin) is a separate follow-up branch and is **not** in this PR.

## What changed

garter previously inferred plugin-chain readiness by TCP-connect-probing a single address (`poll_ready` on `addrs[0]`), which couldn't see inner-hop readiness in a multi-plugin chain → `two_plugin_chain_relays_data` flaked with `Connection refused`/`reset`. This PR moves readiness ownership **into each plugin**, declared over a one-way JSON-lines control protocol (**sitrep**) on stdout, and has `ChainRunner` aggregate the per-plugin results.

- **`crates/garter/SITREP.md`** — the protocol as a normative, externally-adoptable standard (RFC-2119); garter is the reference implementation.
- **garter** — `ChainPlugin::run` gains a `ready: oneshot::Sender<Result<PluginReady, StartError>>`; `ChainRunner` aggregates (transports = intersection across hops, listen = public-facing plugin); `BinaryPlugin` gets `ExpectSitrep` (parse sitrep stdout) / `Probe` (self-probe, tier-2 fallback) modes; version-skew falls back to probe with stdout drained to EOF (no pipe-full deadlock).
- **mock-plugin** — emits sitrep + fault-injection knobs (`MOCK_PLUGIN_FAIL=fatal|bind_conflict|bind_conflict_once`, `NO_SITREP`, `BAD_PROTOCOL`, `EMPTY_TRANSPORTS`) for deterministic tests.
- **bridge** — maps a typed plugin `bind_conflict` → `ProxyError::BindRace` → retryable `AddrInUse` io::Error (so `bind_ephemeral` retries on a fresh port, #304); derives its UDP-drop policy from the plugin's **reported** `transports` instead of the static `udp_supported` descriptor.
- **galoshes** — emits sitrep on its process stdout (logs moved to stderr); reports `[tcp,udp]` (its true YAMUX capability, overriding the TCP-only inner-chain intersection).

### Bugs closed
- **#414** (multi-plugin readiness race) — structural: per-plugin declared readiness, no single-address probe. `two_plugin_chain_relays_data` is deterministic.
- **#259** (bare `RecvError`) — the aggregator surfaces a typed `StartError` (`Fatal`/`BindConflict`) on `on_ready`, including a synthesized `Fatal` for exit-before-ready.
- **#304** (unclassifiable bind failure) — a typed `bind_conflict` is now a retryable bind race.

## Test plan
- [x] `garter + garter-bin + galoshes + mock-plugin`: 118/118 pass.
- [x] `hole-bridge + hole-common` (non-TUN): 658/658 pass.
- [x] `two_plugin_chain_relays_data` (the #414 flake): deterministic, 5/5 repeated runs, no `Connection reset`/`refused`.
- [x] `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`: clean.
- [ ] **2 TUN e2e tests** (`e2e_none_full_tunnel_roundtrip`, `e2e_socks5_udp_associate_roundtrip`) need admin elevation — not run locally; CI exercises them. They are no-plugin paths, behaviorally inert to this change.
- [ ] CI green across the matrix.

## Follow-ups
- **#418** — spike a v2ray-core `Unwrap()` patch to fully close the sub-microsecond bind-race residual (currently mitigated by the confirming-probe + `bind_ephemeral` retry; relevant once ex-ray lands in Plan 2).
- Plan 2 (ex-ray) replaces the embedded v2ray-plugin with a sitrep-native Go shim and flips the bridge to spawn galoshes in `ExpectSitrep` mode.
