### PR TITLE
fix(ex-ray): enable gosec, reject out-of-range mux/fwmark (#422)

### DIFF
--- a/crates/ex-ray/.golangci.yml
+++ b/crates/ex-ray/.golangci.yml
@@ -9,12 +9,7 @@ linters:
     - revive
     - misspell
     - unconvert
-  # gosec is deliberately OFF. Task 1 ported `generateConfig` / `readCertificate`
-  # verbatim from upstream v2ray-plugin, and gosec would fire G102 (all-interface
-  # bind), G304 (variable file path) and os.Exit findings on faithful-copy code.
-  # Enabling it would require pre-declared //nolint:gosec exclusions on the port;
-  # deferred as a follow-up — tracked in bindreams/hole#422. Leave off until
-  # intentionally audited.
+    - gosec
 
 formatters:
   # gofumpt is a strict superset of gofmt. `golangci-lint fmt` formats; the

--- a/crates/ex-ray/config.go
+++ b/crates/ex-ray/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"strconv"
@@ -99,6 +100,19 @@ func parseLocalAddr(localAddr string) []string {
 	return strings.Split(localAddr, "|")
 }
 
+// uint32Opt converts an operator-supplied integer option to uint32, rejecting
+// out-of-range values loudly instead of letting them silently wrap. The bound
+// guard wrapping the conversion is gosec G115's recognized mitigation, so the
+// cast needs no //nolint. The error propagates through generateConfig ->
+// buildV2Ray -> main's emitFatal + os.Exit(23), the same loud-failure path as a
+// bad port (main.go).
+func uint32Opt(name string, v int) (uint32, error) {
+	if v >= 0 && v <= math.MaxUint32 {
+		return uint32(v), nil
+	}
+	return 0, newError("invalid", name, "(expected 0..4294967295), got:", v)
+}
+
 func generateConfig() (*core.Config, error) {
 	lport, err := net.PortFromString(*localPort)
 	if err != nil {
@@ -107,6 +121,18 @@ func generateConfig() (*core.Config, error) {
 	rport, err := strconv.ParseUint(*remotePort, 10, 32)
 	if err != nil {
 		return nil, newError("invalid remotePort:", *remotePort).Base(err)
+	}
+	// Validate operator-supplied numeric options up-front, before the
+	// server/client split, so out-of-range mux/fwmark are rejected identically
+	// in both modes. This also makes the guard dominate both cast sites below,
+	// so gosec G115 clears with no cast remaining at those sites.
+	muxU32, err := uint32Opt("mux", *mux)
+	if err != nil {
+		return nil, err
+	}
+	fwmarkU32, err := uint32Opt("fwmark", *fwmark)
+	if err != nil {
+		return nil, err
 	}
 	outboundProxy := serial.ToTypedMessage(&freedom.Config{
 		DestinationOverride: &freedom.DestinationOverride{
@@ -152,7 +178,7 @@ func generateConfig() (*core.Config, error) {
 			socketConfig.Tfo = internet.SocketConfig_Enable
 		}
 		if *fwmark != 0 {
-			socketConfig.Mark = uint32(*fwmark)
+			socketConfig.Mark = fwmarkU32
 		}
 
 		streamConfig.SocketSettings = socketConfig
@@ -232,7 +258,7 @@ func generateConfig() (*core.Config, error) {
 
 	senderConfig := proxyman.SenderConfig{StreamSettings: &streamConfig}
 	if connectionReuse {
-		senderConfig.MultiplexSettings = &proxyman.MultiplexingConfig{Enabled: true, Concurrency: uint32(*mux)}
+		senderConfig.MultiplexSettings = &proxyman.MultiplexingConfig{Enabled: true, Concurrency: muxU32}
 	}
 	return &core.Config{
 		Inbound: []*core.InboundHandlerConfig{{

--- a/crates/ex-ray/config.go
+++ b/crates/ex-ray/config.go
@@ -104,8 +104,8 @@ func parseLocalAddr(localAddr string) []string {
 // out-of-range values loudly instead of letting them silently wrap. The bound
 // guard wrapping the conversion is gosec G115's recognized mitigation, so the
 // cast needs no //nolint. The error propagates through generateConfig ->
-// buildV2Ray -> main's emitFatal + os.Exit(23), the same loud-failure path as a
-// bad port (main.go).
+// buildV2Ray -> main's emitFatal + os.Exit(23), the same config-error path
+// (exit 23) as an invalid remotePort (main.go).
 func uint32Opt(name string, v int) (uint32, error) {
 	if v >= 0 && v <= math.MaxUint32 {
 		return uint32(v), nil

--- a/crates/ex-ray/config_test.go
+++ b/crates/ex-ray/config_test.go
@@ -51,3 +51,59 @@ func TestUint32OptOutOfRange(t *testing.T) {
 		}
 	}
 }
+
+// withFlags saves the mux/fwmark/server globals, applies the given values, and
+// returns a restore func for defer. generateConfig reads these package-level
+// flag pointers, so tests must leave them as they found them.
+func withFlags(t *testing.T, muxV, fwmarkV int, serverV bool) func() {
+	t.Helper()
+	origMux, origFwmark, origServer := *mux, *fwmark, *server
+	*mux, *fwmark, *server = muxV, fwmarkV, serverV
+	return func() { *mux, *fwmark, *server = origMux, origFwmark, origServer }
+}
+
+// generateConfig validates mux/fwmark *before* the server/client split, so an
+// out-of-range value must be rejected identically in BOTH modes — the "uniform
+// validation" invariant. A future refactor that pushed validation back down
+// into the client-only cast site would silently regress server mode (where a
+// negative mux still flips connectionReuse); this test guards against that.
+func TestGenerateConfigRejectsOutOfRange(t *testing.T) {
+	cases := []struct {
+		desc      string
+		server    bool
+		mux       int
+		fwmark    int
+		wantInErr string
+	}{
+		{"negative mux, client mode", false, -1, 0, "mux"},
+		{"negative mux, server mode", true, -1, 0, "mux"},
+		{"oversize mux, server mode", true, math.MaxUint32 + 1, 0, "mux"},
+		{"negative fwmark, client mode", false, 1, -1, "fwmark"},
+		{"negative fwmark, server mode", true, 1, -1, "fwmark"},
+	}
+	for _, c := range cases {
+		restore := withFlags(t, c.mux, c.fwmark, c.server)
+		_, err := generateConfig()
+		restore()
+		if err == nil {
+			t.Errorf("%s: generateConfig() = nil error, want error mentioning %q", c.desc, c.wantInErr)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.wantInErr) {
+			t.Errorf("%s: generateConfig() error %q does not mention %q", c.desc, err.Error(), c.wantInErr)
+		}
+	}
+}
+
+// The Hole default (mux=1, fwmark=0) and any in-range value must build a config
+// without error in both modes — proves the hardening adds no false rejections.
+func TestGenerateConfigAcceptsValidDefaults(t *testing.T) {
+	for _, srv := range []bool{false, true} {
+		restore := withFlags(t, 1, 0, srv)
+		_, err := generateConfig()
+		restore()
+		if err != nil {
+			t.Errorf("server=%v: generateConfig() with valid defaults returned error: %v", srv, err)
+		}
+	}
+}

--- a/crates/ex-ray/config_test.go
+++ b/crates/ex-ray/config_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestUint32OptInRange(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want uint32
+	}{
+		{"mux", 0, 0},
+		{"mux", 1, 1},
+		{"fwmark", math.MaxUint32, math.MaxUint32},
+	}
+	for _, c := range cases {
+		got, err := uint32Opt(c.name, c.in)
+		if err != nil {
+			t.Errorf("uint32Opt(%q, %d) returned error: %v", c.name, c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("uint32Opt(%q, %d) = %d, want %d", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestUint32OptOutOfRange(t *testing.T) {
+	// tooBig is evaluated in int context; this relies on int being 64-bit (true
+	// for all six CI targets). A hypothetical 32-bit port would make this
+	// constant overflow int at compile time — an intentional tripwire, not a
+	// silent bug.
+	const tooBig = math.MaxUint32 + 1
+	cases := []struct {
+		name string
+		in   int
+	}{
+		{"mux", -1},
+		{"fwmark", tooBig},
+	}
+	for _, c := range cases {
+		_, err := uint32Opt(c.name, c.in)
+		if err == nil {
+			t.Errorf("uint32Opt(%q, %d) = nil error, want out-of-range error", c.name, c.in)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.name) {
+			t.Errorf("uint32Opt(%q, %d) error %q does not mention option name", c.name, c.in, err.Error())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Audits and enables `gosec` for the `crates/ex-ray` Go module — follow-up to #414, per #422.

**Audit finding.** The "deliberately OFF" comment in `.golangci.yml` predicted G102 (all-interface bind), G304 (variable file path in `readCertificate`), and os.Exit findings. A real `golangci-lint run --enable gosec` surfaced **only 2× G115** (integer overflow `int`→`uint32`) on the operator-supplied `mux` / `fwmark` options. The predicted findings do **not** fire:

- **G304** — `readCertificate` uses v2ray-core's `filesystem.ReadFile`, not a stdlib file function; gosec's G304 only tracks the stdlib set.
- **G102** — the listen bind goes through a *variable* address into v2ray-core; gosec sees no hardcoded `0.0.0.0` literal.
- **os.Exit** — not a gosec rule at all.

So the deferral comment's own rationale was inaccurate; it's removed.

**Fix — harden, don't suppress.** Rather than `//nolint:gosec`, the two conversions are made provably safe. A small `uint32Opt(name, v) (uint32, error)` helper validates the value is in `[0, 2³²-1]` and is hoisted to the top of `generateConfig`, **before** the server/client split, so an out-of-range `mux`/`fwmark` is rejected loudly (error → `buildV2Ray` → `emitFatal` + `os.Exit(23)`, ex-ray's existing config-error path) in **both** modes. The uniform placement also matters because a negative `mux` flips `connectionReuse` in server mode (the `v1.mux.cool` branch), not just the client cast site.

Hole itself never sets these options (defaults `mux=1`, `fwmark=0` are safe); the overflow was only reachable by a standalone-server operator passing a negative value via `SS_PLUGIN_OPTIONS`, which previously silently wrapped to a large-but-valid `uint32`. The bound guard is gosec G115's recognized mitigation, so `golangci-lint run` is clean with **no suppression**.

## Changes

- **`.golangci.yml`** — enable `gosec` under `linters.enable`; remove the inaccurate deferral comment.
- **`config.go`** — add `uint32Opt`; hoist `mux`/`fwmark` validation up-front; use the validated values at the two former cast sites (no `uint32(...)` cast remains there).
- **`config_test.go`** — unit tests for `uint32Opt` (boundaries `0` / `1` / `MaxUint32` + out-of-range `-1` / `MaxUint32+1`) and integration tests asserting `generateConfig` rejects out-of-range `mux`/`fwmark` in **both** modes and accepts valid defaults.

## Verification

- `golangci-lint run` (gosec enabled) → **0 issues**.
- `golangci-lint fmt --diff` → clean (gofumpt).
- `go test ./...` → 10/10 pass.
- pre-commit prek `go-lint` / `go-fmt` hooks pass.

Closes #422.
