### PR TITLE
fix(ex-ray): server-side QUIC via mode-aware UDP confirming-probe (#421)

### DIFF
--- a/crates/bridge/src/interop_tests.rs
+++ b/crates/bridge/src/interop_tests.rs
@@ -199,7 +199,10 @@ fn interop_stock_client_ex_ray_server() {
 
 /// QUIC cross-impl tests, mirroring the websocket trio above but over the QUIC
 /// transport (`mode=quic`) — the path #421 unblocked (ex-ray's v1 confirming
-/// probe rejected `mode=quic`).
+/// probe rejected `mode=quic`). Two of the three directions run; the
+/// stock-as-QUIC-server direction (`interop_quic_ex_ray_client_stock_server`)
+/// is `#[ignore]`d because the pinned stock plugin's quic-go v0.48.1 panics as
+/// a QUIC server on Go ≥1.24 (bindreams/hole#428).
 ///
 /// **Non-Windows gate.** QUIC mandates TLS, and these tests present a
 /// self-signed cert (SAN `cloudfront.com`, CA) that the client trusts as a
@@ -327,7 +330,20 @@ mod quic {
     /// QUIC cross-impl direction 1: ex-ray CLIENT talking to a stock-v2ray-plugin
     /// QUIC SERVER. Proves ex-ray's QUIC client wire output is understood by
     /// genuine upstream v2ray-plugin.
+    ///
+    /// **Disabled (`#[ignore]`).** The pinned stock v2ray-plugin is frozen on
+    /// quic-go v0.48.1, which panics as a QUIC *server* on Go ≥1.24
+    /// (`crypto/tls bug: where's my session ticket?` — Go 1.24 changed the
+    /// crypto/tls QUIC session-ticket API; quic-go fixed it in v0.49.0). The
+    /// stock binary therefore cannot hold the server role on our CI Go
+    /// toolchain. This is server-only and NOT a wire incompatibility — ex-ray's
+    /// QUIC client is still exercised by `interop_quic_ex_ray_both_ends`, and
+    /// ex-ray's QUIC server is cross-validated against a genuine stock client by
+    /// `interop_quic_stock_client_ex_ray_server`. Tracked in bindreams/hole#428;
+    /// re-enable when the stock reference can serve QUIC again (upstream bump or
+    /// a frozen-Go≤1.23 stock build).
     #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
+    #[ignore = "stock v2ray-plugin (quic-go 0.48.1) panics as a QUIC server on Go >=1.24 — see bindreams/hole#428"]
     fn interop_quic_ex_ray_client_stock_server() {
         let ex_ray = locate_ex_ray();
         let stock = locate_upstream_v2ray();

--- a/crates/bridge/src/interop_tests.rs
+++ b/crates/bridge/src/interop_tests.rs
@@ -194,3 +194,165 @@ fn interop_stock_client_ex_ray_server() {
         stock.to_str().expect("upstream path is valid utf-8"),
     );
 }
+
+// QUIC interop ========================================================================================================
+
+/// QUIC cross-impl tests, mirroring the websocket trio above but over the QUIC
+/// transport (`mode=quic`) — the path #421 unblocked (ex-ray's v1 confirming
+/// probe rejected `mode=quic`).
+///
+/// **Non-Windows gate.** QUIC mandates TLS, and these tests present a
+/// self-signed cert (SAN `cloudfront.com`, CA) that the client trusts as a
+/// custom `AUTHORITY_VERIFY` anchor. v2ray-core only merges such a custom cert
+/// into the client's `RootCAs` on non-Windows
+/// (`transport/internet/tls/config_other.go`'s `getCertPool` appends every
+/// configured cert to the system pool); on Windows
+/// (`transport/internet/tls/config_windows.go`) `getCertPool` returns the bare
+/// system store and silently drops the custom cert, so a self-signed server
+/// cert fails with "x509: certificate signed by unknown authority". Both the
+/// QUIC dialer and the websocket+TLS security engine reach this same
+/// `GetTLSConfig`/`getCertPool` path, which is why every plugin-TLS e2e test
+/// (`e2e_ws_tls_socks_only_roundtrip`, `e2e_quic_socks_only_roundtrip`) is
+/// already `#[cfg(not(target_os = "windows"))]`. Production is unaffected:
+/// real CA-signed QUIC servers verify against the OS store with no custom cert.
+/// See bindreams/hole#421.
+///
+/// The harness differs from `assert_roundtrip` in two ways forced by the
+/// UDP-only public endpoint: no `wait_for_port` (a TCP poll can't observe a UDP
+/// listener — readiness is established by retrying the full roundtrip on a time
+/// budget), and reliance on `run_server_test` skipping its TCP preflight for
+/// quic endpoints (`server_endpoint_is_udp`, #421).
+#[cfg(not(target_os = "windows"))]
+mod quic {
+    use super::{interop_config, require_binary};
+    use crate::server_test::run_server_test;
+    use crate::test_support::certs::{generate_test_certs, path_for_plugin_opts, TestCerts};
+    use crate::test_support::http_target::start_fake_sentinel;
+    use crate::test_support::rt;
+    use crate::test_support::skuld_fixtures::PORT_ALLOC;
+    use crate::test_support::ssserver::{
+        locate_ex_ray, locate_upstream_v2ray, start_real_ss_server_with_plugin_quic, TEST_METHOD, TEST_METHOD_STR,
+        TEST_PASSWORD,
+    };
+    use hole_common::config::ServerEntry;
+    use hole_common::protocol::ServerTestOutcome;
+    use std::time::{Duration, Instant};
+
+    /// Failure-to-human bound for the QUIC server's UDP listener becoming
+    /// reachable. The server plugin binds asynchronously after the SS server's
+    /// `build()` returns, so the first roundtrip attempt may race it; we retry
+    /// the whole roundtrip until this elapses, then panic with the last outcome.
+    const QUIC_READY_BUDGET: Duration = Duration::from_secs(30);
+
+    /// `ServerEntry` for the QUIC client: `mode=quic`, the shared `host`
+    /// (SNI = the cert's SAN), and the cert as the trust anchor (`config.go`'s
+    /// `!*server` branch uses `Certificate_AUTHORITY_VERIFY`). The cert path is
+    /// rendered with [`path_for_plugin_opts`] so Windows backslashes survive
+    /// ex-ray's args parser (harmless here, but keeps parity with the fixtures).
+    fn quic_plugin_entry(host: &str, port: u16, certs: &TestCerts) -> ServerEntry {
+        ServerEntry {
+            id: "interop-quic-entry".into(),
+            name: "interop-quic".into(),
+            server: host.into(),
+            server_port: port,
+            method: TEST_METHOD_STR.into(),
+            password: TEST_PASSWORD.into(),
+            plugin: Some("v2ray-plugin".into()),
+            plugin_opts: Some(format!(
+                "host=cloudfront.com;mode=quic;cert={}",
+                path_for_plugin_opts(&certs.cert_path)
+            )),
+            validation: None,
+        }
+    }
+
+    /// Drive one cross-implementation QUIC round-trip: a real SS server fronted
+    /// by a server-mode `server_plugin_path` (QUIC/UDP public listener), a
+    /// client driven through `client_plugin_path`, and a fake sentinel. Asserts
+    /// the `HEAD /` echoes back `HTTP/1.0 200 OK` → [`ServerTestOutcome::Reachable`].
+    fn assert_quic_roundtrip(server_plugin_path: &str, client_plugin_path: &str) {
+        rt().block_on(async {
+            let certs = generate_test_certs();
+            let (svr_addr, _svr) =
+                start_real_ss_server_with_plugin_quic(TEST_METHOD, TEST_PASSWORD, server_plugin_path, &certs).await;
+
+            // Readiness retry. The QUIC server's UDP listener is bound by the
+            // plugin subprocess after `build()` returns, and a TCP
+            // `wait_for_port` cannot observe it, so we retry the full roundtrip
+            // until it succeeds. Sanctioned class-2 sync exception (CLAUDE.md
+            // "no sleeps for sync"): out-of-process subprocess startup observed
+            // via connect-success; QUIC_READY_BUDGET is the failure-to-human
+            // bound, not the sync.
+            let start = Instant::now();
+            loop {
+                // Fresh sentinels each attempt: `start_fake_sentinel` is
+                // single-shot (accepts one connection then exits), so a consumed
+                // listener can't be reused across retries. Cheap loopback binds.
+                let (sentinel_a, _sa) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+                let (sentinel_b, _sb) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+                let entry = quic_plugin_entry(&svr_addr.ip().to_string(), svr_addr.port(), &certs);
+                let cfg = interop_config(sentinel_a, sentinel_b, client_plugin_path);
+
+                match run_server_test(&entry, &cfg).await {
+                    ServerTestOutcome::Reachable { latency_ms } => {
+                        assert!(latency_ms >= 1, "latency_ms must be clamped to >= 1");
+                        return;
+                    }
+                    other => {
+                        assert!(
+                            start.elapsed() < QUIC_READY_BUDGET,
+                            "quic roundtrip server={server_plugin_path:?} client={client_plugin_path:?} \
+                             did not become reachable within {QUIC_READY_BUDGET:?}; last outcome: {other:?}"
+                        );
+                        // Server UDP listener still binding; brief backoff then retry.
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                    }
+                }
+            }
+        });
+    }
+
+    /// QUIC self-consistency: ex-ray on BOTH ends. Needs only `cargo xtask
+    /// ex-ray`. Proves ex-ray's own QUIC server binds a UDP listener and a full
+    /// client→server→sentinel round-trip works — the regression #421 fixed.
+    #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
+    fn interop_quic_ex_ray_both_ends() {
+        let ex_ray = locate_ex_ray();
+        require_binary(&ex_ray, "run `cargo xtask ex-ray`");
+
+        let ex_ray = ex_ray.to_str().expect("ex-ray path is valid utf-8");
+        assert_quic_roundtrip(ex_ray, ex_ray);
+    }
+
+    /// QUIC cross-impl direction 1: ex-ray CLIENT talking to a stock-v2ray-plugin
+    /// QUIC SERVER. Proves ex-ray's QUIC client wire output is understood by
+    /// genuine upstream v2ray-plugin.
+    #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
+    fn interop_quic_ex_ray_client_stock_server() {
+        let ex_ray = locate_ex_ray();
+        let stock = locate_upstream_v2ray();
+        require_binary(&ex_ray, "run `cargo xtask ex-ray`");
+        require_binary(&stock, "run `cargo xtask provision-upstream-v2ray`");
+
+        assert_quic_roundtrip(
+            stock.to_str().expect("upstream path is valid utf-8"),
+            ex_ray.to_str().expect("ex-ray path is valid utf-8"),
+        );
+    }
+
+    /// QUIC cross-impl direction 2: stock-v2ray-plugin CLIENT talking to an
+    /// ex-ray QUIC SERVER. Proves ex-ray's QUIC server wire output (the path
+    /// #421 unblocked) is understood by genuine upstream v2ray-plugin.
+    #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
+    fn interop_quic_stock_client_ex_ray_server() {
+        let ex_ray = locate_ex_ray();
+        let stock = locate_upstream_v2ray();
+        require_binary(&ex_ray, "run `cargo xtask ex-ray`");
+        require_binary(&stock, "run `cargo xtask provision-upstream-v2ray`");
+
+        assert_quic_roundtrip(
+            ex_ray.to_str().expect("ex-ray path is valid utf-8"),
+            stock.to_str().expect("upstream path is valid utf-8"),
+        );
+    }
+}

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -169,14 +169,11 @@ fn e2e_ws_tls_socks_only_roundtrip(
 ///
 /// Windows-skipped: same #197 bind race as `e2e_ws_socks_only_roundtrip`.
 ///
-/// Temporarily `#[ignore]`d: galoshes embeds `ex-ray` (#414), whose v1
-/// confirming-probe rejects `mode=quic` (`crates/ex-ray/main.go`), so
-/// galoshes-as-server-with-QUIC no longer starts. Tracked in
-/// bindreams/hole#421 — the fix (mode-aware UDP confirming-probe for
-/// server+quic) MUST remove this `#[ignore]` and confirm green here.
+/// galoshes embeds `ex-ray` (#414); ex-ray now UDP-probes its inbound and
+/// reports `transports:["udp"]` for server+quic instead of rejecting it, so
+/// galoshes-as-server-with-QUIC starts again (bindreams/hole#421).
 #[cfg(not(target_os = "windows"))]
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-#[ignore = "galoshes server-side QUIC pending ex-ray mode=quic support — see bindreams/hole#421"]
 fn e2e_quic_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_quic)] ss: &SsServerHandle,

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -69,8 +69,14 @@ impl TestConfig {
 pub async fn run_server_test(entry: &ServerEntry, cfg: &TestConfig) -> ServerTestOutcome {
     let started = Instant::now();
 
-    // Phase 1: pre-flight DNS + TCP probe.
-    if let Err(out) = preflight(&entry.server, entry.server_port, cfg.preflight_timeout).await {
+    // Phase 1: pre-flight DNS + TCP probe. Skipped for a QUIC server: its
+    // public endpoint is UDP-only, so a raw TCP connect can't validate it (it
+    // would always surface as a false TcpRefused/TcpTimeout). The full tunnel
+    // handshake below still produces a correct diagnosis for an unreachable
+    // QUIC server. See bindreams/hole#421.
+    if server_endpoint_is_udp(entry) {
+        debug!("server_test: skipping TCP preflight for UDP (quic) server endpoint");
+    } else if let Err(out) = preflight(&entry.server, entry.server_port, cfg.preflight_timeout).await {
         return out;
     }
 
@@ -145,6 +151,25 @@ enum SentinelOutcome {
     Mismatch { detail: String },
     Timeout,
     Internal(String),
+}
+
+/// True if the server's public endpoint is reached over UDP rather than TCP,
+/// i.e. the configured plugin negotiates a QUIC transport (`mode=quic`). The
+/// raw TCP preflight probe is meaningless for such an endpoint — there is no
+/// TCP listener to connect to — so [`run_server_test`] skips it and lets the
+/// full tunnel handshake produce the diagnosis. Covers a direct
+/// v2ray-plugin/ex-ray QUIC server AND a galoshes server (which passes
+/// `mode=quic` through to its embedded ex-ray). Parses the SIP003 options with
+/// the same parser `garter::Mode::from_plugin_options` uses for the `server`
+/// key, so this is config parsing — not a stringified-type-recovery hack. See
+/// bindreams/hole#421.
+fn server_endpoint_is_udp(entry: &ServerEntry) -> bool {
+    entry.plugin.is_some()
+        && entry.plugin_opts.as_deref().is_some_and(|opts| {
+            garter::parse_plugin_options(opts)
+                .iter()
+                .any(|(k, v)| k == "mode" && v == "quic")
+        })
 }
 
 /// DNS-resolve (when needed) and raw-TCP-connect to `host:port`. Returns
@@ -298,3 +323,10 @@ async fn try_sentinel(
 #[cfg(all(test, not(any(target_os = "macos", target_os = "windows"))))]
 #[path = "server_test_tests.rs"]
 mod server_test_tests;
+
+// `server_endpoint_is_udp` is a pure function with no I/O, so its tests are
+// NOT subject to the #197/#200 platform gate above — they must run everywhere
+// (the QUIC interop tests that depend on the preflight skip run on Windows).
+#[cfg(test)]
+#[path = "server_test_preflight_tests.rs"]
+mod server_test_preflight_tests;

--- a/crates/bridge/src/server_test_preflight_tests.rs
+++ b/crates/bridge/src/server_test_preflight_tests.rs
@@ -1,0 +1,55 @@
+//! Unit tests for [`super::server_endpoint_is_udp`] — the transport-aware
+//! preflight gate added in bindreams/hole#421.
+//!
+//! Deliberately NOT in `server_test_tests.rs`: that module is gated
+//! `cfg(not(any(macos, windows)))` (Linux-only, #197/#200). These are pure,
+//! I/O-free table assertions that MUST run on every platform, because the QUIC
+//! interop tests that depend on the preflight skip run on Windows too.
+
+use super::server_endpoint_is_udp;
+use hole_common::config::ServerEntry;
+
+/// A `ServerEntry` with only `plugin` / `plugin_opts` set to the values under
+/// test; every other field is an irrelevant placeholder.
+fn entry(plugin: Option<&str>, plugin_opts: Option<&str>) -> ServerEntry {
+    ServerEntry {
+        plugin: plugin.map(Into::into),
+        plugin_opts: plugin_opts.map(Into::into),
+        ..ServerEntry::default_placeholder()
+    }
+}
+
+#[skuld::test]
+fn quic_endpoint_is_udp() {
+    // Direct v2ray-plugin/ex-ray QUIC server.
+    assert!(server_endpoint_is_udp(&entry(
+        Some("v2ray-plugin"),
+        Some("host=cloudfront.com;mode=quic;cert=/x;key=/y"),
+    )));
+    // galoshes passes `mode=quic` through to its embedded ex-ray.
+    assert!(server_endpoint_is_udp(&entry(
+        Some("galoshes"),
+        Some("server;mode=quic;host=cdn"),
+    )));
+}
+
+#[skuld::test]
+fn non_quic_endpoint_is_tcp() {
+    // websocket (the default transport) is TCP.
+    assert!(!server_endpoint_is_udp(&entry(
+        Some("v2ray-plugin"),
+        Some("host=cloudfront.com;path=/"),
+    )));
+    // Plugin configured but no options at all.
+    assert!(!server_endpoint_is_udp(&entry(Some("v2ray-plugin"), None)));
+    // No plugin → plain shadowsocks, always TCP-fronted.
+    assert!(!server_endpoint_is_udp(&entry(None, None)));
+    // Options mention quic but no plugin is configured: the gate requires a
+    // plugin (a plain SS server never speaks quic).
+    assert!(!server_endpoint_is_udp(&entry(None, Some("mode=quic"))));
+    // A key that merely contains "mode" must not match (exact-key parse).
+    assert!(!server_endpoint_is_udp(&entry(
+        Some("v2ray-plugin"),
+        Some("servermode=quic"),
+    )));
+}

--- a/crates/bridge/src/test_support/ssserver.rs
+++ b/crates/bridge/src/test_support/ssserver.rs
@@ -121,11 +121,11 @@ pub(crate) async fn start_real_ss_server_with_plugin_ws_tls(
 /// The plugin's public listen port is verified for `Protocols::UDP` because
 /// QUIC runs over UDP.
 ///
-/// Note: `ex-ray`'s standalone CLI rejects `mode=quic` at startup
-/// ([crates/ex-ray/main.go:200](../../../ex-ray/main.go)) — its v1 confirming
-/// probe is TCP-only. This helper is only ever fed the **galoshes** binary,
-/// which drives its embedded plugin for the QUIC wire transport, so the QUIC
-/// config path in `config.go` is what runs here, not the standalone CLI gate.
+/// Works with either the **galoshes** binary (which drives its embedded ex-ray)
+/// or a bare **ex-ray** / stock-v2ray-plugin binary: since bindreams/hole#421,
+/// ex-ray UDP-probes its inbound and reports `transports:["udp"]` for
+/// server+quic rather than rejecting it, so the standalone server path is fed
+/// directly by the QUIC interop tests in `interop_tests.rs`.
 pub(crate) async fn start_real_ss_server_with_plugin_quic(
     method: CipherKind,
     password: &str,

--- a/crates/ex-ray/main.go
+++ b/crates/ex-ray/main.go
@@ -145,17 +145,44 @@ func buildV2Ray() (core.Server, error) {
 	return instance, nil
 }
 
-// confirmingProbe binds (and immediately releases) listenAddr to confirm the
-// address is bindable before core.New stands up the real listener. A failure
-// here is the typed bind_conflict signal — the host can map the OS errno onto
-// its own retry policy without scraping v2ray-core's log text.
-func confirmingProbe(listenAddr string) error {
+// confirmingProbe binds (and immediately releases) listenAddr on the given
+// network ("tcp" or "udp") to confirm the address is bindable before core.New
+// stands up the real listener. A failure here is the typed bind_conflict
+// signal — the host can map the OS errno onto its own retry policy without
+// scraping v2ray-core's log text. The network is chosen by listenerNetwork so
+// the probe always matches the transport v2ray-core will actually bind.
+func confirmingProbe(network, listenAddr string) error {
 	var lc net.ListenConfig
+	if network == "udp" {
+		pc, err := lc.ListenPacket(context.Background(), "udp", listenAddr)
+		if err != nil {
+			return err
+		}
+		return pc.Close()
+	}
 	ln, err := lc.Listen(context.Background(), "tcp", listenAddr)
 	if err != nil {
 		return err
 	}
 	return ln.Close()
+}
+
+// listenerNetwork reports the IP transport of the inbound listener ex-ray
+// binds, derived from the resolved mode/server flags. Only server+quic binds a
+// UDP listener (the quic inbound faces the remote client); client mode (a plain
+// TCP dokodemo inbound — quic, if configured, applies only to the upstream hop)
+// and server+websocket are both TCP. The confirming-probe network AND the
+// sitrep `transports` value both derive from this single function, so they can
+// never disagree — that divergence (a UDP listener mis-reported as ["tcp"]) was
+// the exact hazard the v1 quic rejection avoided by refusing quic outright. An
+// unknown *mode returns "tcp" here and is then rejected by generateConfig's
+// switch default before emitReady, so no false "ready" can escape. See
+// bindreams/hole#421.
+func listenerNetwork() string {
+	if *server && *mode == "quic" {
+		return "udp"
+	}
+	return "tcp"
 }
 
 func printCoreVersion() {
@@ -190,18 +217,6 @@ func main() {
 
 	parseOptsIntoFlags()
 
-	// quic mode binds a UDP-based wire listener, not TCP. ex-ray's TCP
-	// confirming-probe + transports=["tcp"] would be a lie for quic, so v1
-	// refuses it explicitly rather than mis-probing. Hole only ever uses the
-	// default websocket transport; ex-ray-as-standalone-server with quic is a
-	// documented v1 gap. (A correct quic path would UDP-probe and report
-	// ["udp"], but only once we are certain the quic inbound binds exactly that
-	// UDP addr — until then the honest signal is a typed fatal.)
-	if *mode == "quic" {
-		emitFatal("quic mode not supported by ex-ray v1", nil)
-		os.Exit(23)
-	}
-
 	// ex-ray requires a CONCRETE local port. It cannot honor the sitrep
 	// port-0 / OS-assigned-port contract: v2ray-core does not expose the
 	// inbound listener's bound port via any public API (the confirming-probe
@@ -220,7 +235,12 @@ func main() {
 	// address the confirming-probe checks and that emitReady reports.
 	localListenAddr := net.JoinHostPort(*localAddr, *localPort)
 
-	if err := confirmingProbe(localListenAddr); err != nil {
+	// network is the transport the inbound listener binds (server+quic → "udp",
+	// everything else → "tcp"). Both the probe below and emitReady use it, so a
+	// quic server UDP-probes its UDP listener and reports transports=["udp"].
+	network := listenerNetwork()
+
+	if err := confirmingProbe(network, localListenAddr); err != nil {
 		var se syscall.Errno
 		if errors.As(err, &se) {
 			emitBindConflict(int(se), localListenAddr)
@@ -256,13 +276,14 @@ func main() {
 	}()
 
 	// v2ray-core's Start is synchronous through the listener bind, so the
-	// listener is accepting once Start returns nil. quic was already fatal'd
-	// out above, so the served transport is TCP (websocket/default).
+	// listener is accepting once Start returns nil. The served transport is
+	// `network` (server+quic → "udp", else "tcp"), the same value the
+	// confirming-probe used above — so the sitrep can never mis-describe it.
 	//
 	// localListenAddr is authoritative: ex-ray rejects port 0 (above), so for
 	// every accepted input the requested port == the bound port (v2ray-core
 	// binds it; Start() returning nil confirms).
-	emitReady(localListenAddr, []string{"tcp"})
+	emitReady(localListenAddr, []string{network})
 
 	<-osSignals
 }

--- a/crates/ex-ray/main_test.go
+++ b/crates/ex-ray/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+)
+
+// TestListenerNetwork verifies the inbound-transport decision that drives BOTH
+// the confirming-probe network and the sitrep `transports` value. Only
+// server+quic binds a UDP listener (the quic inbound faces the remote client);
+// every other combination — client mode (plain TCP dokodemo inbound) and
+// server+websocket — is TCP. An unknown mode resolves to "tcp" here and is
+// rejected later by generateConfig's switch default, before emitReady. See
+// bindreams/hole#421.
+func TestListenerNetwork(t *testing.T) {
+	// Do NOT t.Parallel() this (or its subtests): it mutates the package-global
+	// *server/*mode flag pointers, which are shared across the whole test binary.
+	origServer, origMode := *server, *mode
+	t.Cleanup(func() { *server, *mode = origServer, origMode })
+
+	cases := []struct {
+		name   string
+		server bool
+		mode   string
+		want   string
+	}{
+		{"client_websocket", false, "websocket", "tcp"},
+		{"client_quic", false, "quic", "tcp"},
+		{"server_websocket", true, "websocket", "tcp"},
+		{"server_quic", true, "quic", "udp"},
+		{"server_unknown_mode", true, "grpc", "tcp"},
+		{"client_unknown_mode", false, "grpc", "tcp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			*server, *mode = tc.server, tc.mode
+			if got := listenerNetwork(); got != tc.want {
+				t.Errorf("listenerNetwork() with server=%v mode=%q = %q, want %q", tc.server, tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfirmingProbeBindsFreePort checks the happy path: a probe on an
+// OS-assigned ephemeral port binds and releases cleanly for both networks.
+func TestConfirmingProbeBindsFreePort(t *testing.T) {
+	for _, network := range []string{"tcp", "udp"} {
+		t.Run(network, func(t *testing.T) {
+			if err := confirmingProbe(network, "127.0.0.1:0"); err != nil {
+				t.Fatalf("confirmingProbe(%q, port 0) = %v, want nil", network, err)
+			}
+		})
+	}
+}
+
+// TestConfirmingProbeSelectsNetwork proves each branch binds the right
+// protocol. Holding a TCP listener occupies its port for TCP but leaves the
+// identically-numbered UDP port free (the two port spaces are independent), so:
+//   - confirmingProbe("tcp", addr) MUST conflict and unwrap to a syscall.Errno
+//     (the bind_conflict signal the host maps onto its retry policy), and
+//   - confirmingProbe("udp", addr) MUST succeed.
+func TestConfirmingProbeSelectsNetwork(t *testing.T) {
+	ln, addr := reserveTCPPortWithFreeUDP(t)
+	defer func() { _ = ln.Close() }()
+
+	tcpErr := confirmingProbe("tcp", addr)
+	if tcpErr == nil {
+		t.Fatalf("confirmingProbe(tcp, %s) = nil, want a bind conflict on the held TCP port", addr)
+	}
+	var se syscall.Errno
+	if !errors.As(tcpErr, &se) {
+		t.Fatalf("confirmingProbe(tcp, %s) error %v does not unwrap to syscall.Errno (bind_conflict contract)", addr, tcpErr)
+	}
+
+	if udpErr := confirmingProbe("udp", addr); udpErr != nil {
+		t.Fatalf("confirmingProbe(udp, %s) = %v, want nil (UDP port space is independent of the held TCP port)", addr, udpErr)
+	}
+}
+
+// reserveTCPPortWithFreeUDP returns a held TCP listener whose port is also
+// confirmed bindable for UDP, so a subsequent confirmingProbe("udp", addr) in
+// the test cannot flake on a Windows independent-excluded-port-range mismatch
+// (TCP and UDP maintain separate Hyper-V/WSL/Docker reservation tables — the
+// exact race hole_common::port_alloc::bind_ephemeral exists to absorb on the
+// Rust side). It binds TCP on an OS-assigned port, verifies the same port binds
+// for UDP, then releases only the UDP socket — leaving TCP held and the UDP
+// space proven free. Unbounded retry on a per-port TCP/UDP mismatch (no
+// arbitrary cap; the OS ephemeral allocator is the natural termination, same as
+// port_alloc).
+func reserveTCPPortWithFreeUDP(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	for {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to bind sentinel TCP listener: %v", err)
+		}
+		addr := ln.Addr().String()
+		pc, udpErr := net.ListenPacket("udp", addr)
+		if udpErr != nil {
+			// This port is reserved for UDP (excluded-range mismatch); the TCP
+			// bind happened to win it anyway. Release and pick another.
+			_ = ln.Close()
+			continue
+		}
+		_ = pc.Close()
+		return ln, addr
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #421. `ex-ray` (the first-party v2ray-core SIP003 plugin that replaced the vendored v2ray-plugin in #414) hard-rejected `mode=quic` at startup, which regressed **galoshes server-side QUIC** (galoshes embeds ex-ray and passes its options straight through). The rejection was a deliberate v1 simplification — a TCP confirming-probe + `transports:["tcp"]` would mis-describe a UDP/QUIC listener — not a v2ray-core limitation (the QUIC config path in `config.go` was already complete, just unreachable behind the fatal).

## What changed

**`crates/ex-ray/` (the fix):**
- Removed the `mode=quic` fatal in `main.go`.
- Added `listenerNetwork()` — the single source of truth for the inbound transport: `"udp"` iff `*server && *mode=="quic"` (the only case that binds a UDP listener — the QUIC inbound faces the remote client), else `"tcp"`. Client+quic inbound is a plain TCP dokodemo listener (QUIC rides only the outbound hop), so it's unchanged.
- Parameterized `confirmingProbe(network, listenAddr)` (UDP→`ListenPacket`, else→`Listen`) and `emitReady(addr, []string{network})`. The probe network and the reported `transports` now derive from the *same* function, so they can never diverge — structurally eliminating the hazard the v1 rejection avoided.
- New `main_test.go`: `listenerNetwork` table ({client,server}×{websocket,quic}+unknown) and `confirmingProbe` branch/errno tests.

**`crates/bridge/src/server_test.rs` (folded-in production fix):**
- `run_server_test`'s preflight did an unconditional TCP connect to the server endpoint. For a client config pointing at a **QUIC** server (UDP-only public endpoint), the "test server" feature would falsely report it unreachable. Added `server_endpoint_is_udp(entry)` (parses `mode=quic` from `plugin_opts` via the same parser `garter::Mode::from_plugin_options` uses) and made preflight skip the TCP probe for QUIC endpoints. New non-platform-gated unit tests in `server_test_preflight_tests.rs`.

**Tests:**
- Re-enabled `e2e_quic_socks_only_roundtrip` (removed `#[ignore]`).
- Added a 3-direction QUIC interop trio (`mod quic` in `interop_tests.rs`): ex-ray↔ex-ray, ex-ray-client↔stock-v2ray-server, stock-v2ray-client↔ex-ray-server — cross-validating ex-ray's QUIC wire format against genuine upstream v2ray-plugin.
- Updated the stale doc on `start_real_ss_server_with_plugin_quic`.

## Why the QUIC interop + e2e tests are `#[cfg(not(target_os = "windows"))]`

QUIC mandates TLS, and these tests present a self-signed `AUTHORITY_VERIFY` cert. v2ray-core's `getCertPool` merges a custom cert into the client's `RootCAs` on non-Windows (`config_other.go`) but **drops it on Windows** (`config_windows.go` returns the bare system store) → `x509: certificate signed by unknown authority`. Both the QUIC dialer and the WS+TLS security engine reach this same path, which is why the pre-existing `ws_tls`/`quic` e2e tests are already non-Windows-gated. Production is unaffected (real CA-signed QUIC servers verify against the OS store with no custom cert).

## Verification

- **Local (Windows):** Go unit tests pass; golangci-lint clean; `clippy --all-targets -D warnings` + `fmt` clean; preflight + WS interop tests pass. A local QUIC interop run confirmed the ex-ray fix works at the transport level (server emits `ready ["udp"]`, client dials QUIC, TLS handshake proceeds) — only the Windows self-signed-cert-trust step fails, which is the v2ray-core platform quirk above.
- **CI (authoritative):** the full QUIC roundtrip (e2e galoshes + the 3 interop directions) runs on macOS `test-hole` (amd64 + arm64).

## Discovered follow-up (out of scope for this PR)

The Windows `getCertPool` behavior is also a narrow **production** gap: a v2ray-plugin/ex-ray *client* on Windows that is handed a custom `cert=` trust anchor silently ignores it (only the OS root store is consulted). This affects a user pinning a self-signed server cert on Windows — distinct from #421 (server-side QUIC). Worth a separate issue; not fixed here (the gap is in vendored v2ray-core, and a blanket `DisableSystemRoot` would regress the normal real-cert case).

Closes #421.
