### PR TITLE
refactor: remove unreachable belt-and-suspenders dead code

### DIFF
--- a/crates/bridge/src/endpoint/interface.rs
+++ b/crates/bridge/src/endpoint/interface.rs
@@ -39,11 +39,14 @@ impl InterfaceEndpoint {
 #[async_trait]
 impl Endpoint for InterfaceEndpoint {
     async fn serve_tcp(&self, flow: &mut TcpFlow, dst: SocketAddr) -> io::Result<()> {
-        if dst.is_ipv6() && !self.ipv6_available {
-            debug_assert!(false, "InterfaceEndpoint::serve_tcp IPv6 dst despite !ipv6_available");
-            tracing::error!(%dst, "cascade invariant violated: InterfaceEndpoint::serve_tcp v6 on !v6; dropping");
-            return Ok(());
-        }
+        // Precondition: the `HoleRouter::resolve_endpoint` cascade drops
+        // `Bypass` + IPv6 when `!supports_ipv6_dst()`, so this endpoint
+        // never serves an IPv6 dst it can't reach. `ipv6_available` is
+        // immutable, so this is a true contract (zero-cost in release).
+        debug_assert!(
+            !dst.is_ipv6() || self.ipv6_available,
+            "InterfaceEndpoint::serve_tcp: IPv6 dst despite !ipv6_available — cascade should have dropped"
+        );
 
         let mut upstream = create_bypass_tcp(dst, self.iface_index).await?;
         copy_bidirectional(flow, &mut upstream).await?;
@@ -51,11 +54,13 @@ impl Endpoint for InterfaceEndpoint {
     }
 
     async fn serve_udp(&self, mut flow: UdpFlow, dst: SocketAddr) -> io::Result<()> {
-        if dst.is_ipv6() && !self.ipv6_available {
-            debug_assert!(false, "InterfaceEndpoint::serve_udp IPv6 dst despite !ipv6_available");
-            tracing::error!(%dst, "cascade invariant violated: InterfaceEndpoint::serve_udp v6 on !v6; dropping");
-            return Ok(());
-        }
+        // Precondition mirror of `serve_tcp`: the cascade drops `Bypass` +
+        // IPv6 when `!supports_ipv6_dst()`. `ipv6_available` is immutable, so
+        // this is a true contract (zero-cost in release).
+        debug_assert!(
+            !dst.is_ipv6() || self.ipv6_available,
+            "InterfaceEndpoint::serve_udp: IPv6 dst despite !ipv6_available — cascade should have dropped"
+        );
 
         let socket = create_bypass_udp(self.iface_index, dst.is_ipv6()).await?;
         socket.connect(dst).await?;

--- a/crates/bridge/src/endpoint/socks5.rs
+++ b/crates/bridge/src/endpoint/socks5.rs
@@ -70,19 +70,14 @@ impl Endpoint for Socks5Endpoint {
     }
 
     async fn serve_udp(&self, mut flow: UdpFlow, dst: SocketAddr) -> io::Result<()> {
-        // Defense-in-depth for the privacy invariant. The cascade
-        // (`HoleRouter::resolve_endpoint`) is supposed to keep UDP off
-        // this endpoint when `!self.udp_supported`, but we refuse to
-        // rely on comments alone for a leak-critical invariant in
-        // release builds. Log and drop on violation.
-        if !self.udp_supported {
-            debug_assert!(false, "Socks5Endpoint::serve_udp called despite udp_supported=false");
-            tracing::error!(
-                plugin = self.plugin_name.as_deref().unwrap_or("<none>"),
-                "privacy invariant violated: serve_udp called on TCP-only SOCKS5 endpoint; dropping"
-            );
-            return Ok(());
-        }
+        // Precondition: the `HoleRouter::resolve_endpoint` cascade drops
+        // `Proxy` + UDP when `!supports_udp()`, so this endpoint never
+        // serves UDP on a TCP-only plugin. `udp_supported` is immutable, so
+        // this is a true contract — assert it (zero-cost in release).
+        debug_assert!(
+            self.udp_supported,
+            "serve_udp on TCP-only SOCKS5 endpoint — HoleRouter cascade should have dropped this UDP flow"
+        );
 
         let relay = Arc::new(Socks5UdpRelay::associate(self.addr).await?);
 

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -131,10 +131,11 @@ impl ChainPlugin for TapPlugin {
         //    against the inner task itself so an early plugin failure
         //    doesn't leave us blocked on a port that will never bind.
         let ready_token = shutdown.clone();
+        // The join arm diverges (returns), so this `select!` always yields
+        // the timeout arm's `Result<Option<SocketAddr>, Elapsed>` — no
+        // `Option` wrapper / impossible `None` state to handle below.
         let ready_outcome = tokio::select! {
-            r = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => {
-                Some(r)
-            }
+            r = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => r,
             join = &mut inner_handle => {
                 // Inner exited before binding — propagate its result. No
                 // tap listener was ever opened. Report the inner's failure
@@ -151,14 +152,14 @@ impl ChainPlugin for TapPlugin {
             }
         };
         match ready_outcome {
-            Some(Ok(Some(_))) => {}
-            Some(Ok(None)) => {
+            Ok(Some(_)) => {}
+            Ok(None) => {
                 // Shutdown fired before inner was ready. Drop `ready` unsent
                 // (RecvError, matching the "shutdown before ready"
                 // semantics). Wait for inner to unwind and propagate.
                 return drain_inner(plugin_name.as_str(), inner_handle).await;
             }
-            Some(Err(_)) => {
+            Err(_) => {
                 inner_handle.abort();
                 let _ = inner_handle.await;
                 let _ = ready.send(Err(StartError::Fatal {
@@ -171,7 +172,6 @@ impl ChainPlugin for TapPlugin {
                     "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
                 )));
             }
-            None => unreachable!(),
         }
 
         // 4. Bind the public-facing tap listener.
@@ -286,7 +286,10 @@ fn allocate_inner_port(ip: IpAddr) -> io::Result<SocketAddr> {
             },
         }
     }
-    Err(last_err.unwrap_or_else(|| io::Error::other("alloc_inner_port: no error captured")))
+    // Reaching here means the loop ran its full `INNER_PORT_ALLOC_ATTEMPTS`
+    // (>= 1) iterations and every one took the transient-error branch, each
+    // of which records `last_err` — so it is always `Some` at this point.
+    Err(last_err.expect("INNER_PORT_ALLOC_ATTEMPTS >= 1 and every transient retry records last_err"))
 }
 
 async fn handle_tap_connection(

--- a/crates/tun-engine/src/helpers/socks5_udp.rs
+++ b/crates/tun-engine/src/helpers/socks5_udp.rs
@@ -76,10 +76,9 @@ pub fn decode_socks5_udp(data: &[u8]) -> Option<(SocketAddr, usize)> {
     let atyp = data[3];
     match atyp {
         0x01 => {
-            // IPv4: 4 bytes address
-            if data.len() < 10 {
-                return None;
-            }
+            // IPv4: 4 bytes address. The function-level `data.len() < 10`
+            // guard above already covers the minimum IPv4 datagram, so no
+            // per-arm length re-check is needed here.
             let ip = IpAddr::V4(Ipv4Addr::new(data[4], data[5], data[6], data[7]));
             let port = u16::from_be_bytes([data[8], data[9]]);
             Some((SocketAddr::new(ip, port), 10))

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -250,15 +250,12 @@ def render_bullet(commit: Commit) -> str:
 def render_notes(
     grouped: dict[str, list[Commit]],
     new_tag: str,
-    previous_tag: str | None,
+    previous_tag: str,
     repo_url: str,
 ) -> str:
+    # `main` handles the first-of-track case (previous_tag is None) and
+    # returns before calling this, so `previous_tag` is always a real tag here.
     parts: list[str] = []
-
-    if previous_tag is None:
-        # Caller should have already emitted initial_release stub; this
-        # branch is defensive.
-        return f"Initial release {new_tag}.\n"
 
     # Non-empty category list rendered as `## <title>` followed by bullets.
     has_any = any(commits for commits in grouped.values())


### PR DESCRIPTION
Closes #424.

## What

Removes "belt-and-suspenders" dead code — second-line defenses whose trigger is provably unreachable because the first line is exhaustive over the *same* failure-and-trust domain — found by a repo-wide audit. Defenses that were really *preconditions* are reduced to zero-cost `debug_assert!` contracts.

Most of the repo's labeled "belt-and-suspenders" / "safety net" code covers a **different** domain (panic/crash, externally-edited drafts, hand-edited configs) and is legitimate defense-in-depth — left untouched.

## Changes

**Dead-code removals (4):**
1. `crates/tun-engine/src/helpers/socks5_udp.rs` — deleted the IPv4-arm `data.len() < 10` re-check; the function-level guard already covers it (`data` immutable in between). The domain/IPv6 arms validate larger minimums and are kept.
2. `crates/garter/src/tap.rs` — the `select!` join arm diverges, so `ready_outcome` is never `None`; dropped the `Some(..)` wrapper and the `None => unreachable!()` arm at the type level.
3. `crates/garter/src/tap.rs` — `allocate_inner_port`'s `unwrap_or_else(synthetic)` is unreachable (the `0..4` loop always records `last_err` before falling through) → `.expect` documenting the invariant.
4. `scripts/generate-release-notes.py` — deleted `render_notes`'s `if previous_tag is None` branch (the sole caller returns early on that condition) and tightened the param type to `str`.

**Defenses reduced to debug contracts (3):**
5. `crates/bridge/src/endpoint/socks5.rs` `serve_udp`
6. `crates/bridge/src/endpoint/interface.rs` `serve_udp`
7. `crates/bridge/src/endpoint/interface.rs` `serve_tcp`

Each had a release-build `if {debug_assert!(false); error!; return Ok(())}` guard re-enforcing a precondition the `HoleRouter::resolve_endpoint` cascade already guarantees (UDP-drop for `!supports_udp()`, IPv6-bypass-drop for `!supports_ipv6_dst()`), over immutable capability fields. Reduced to a single top-of-function `debug_assert!`. Inline `debug_assert!` rather than `#[contracts::debug_requires]` because the latter's `return`-rewrite is incompatible with `#[async_trait]` (footgun documented at `garter/src/chain.rs:296-299`).

## Verification

- `cargo clippy --all-targets` clean across `hole-bridge`, `garter`, `tun-engine`; pre-commit fmt/clippy/ty all pass.
- `garter` + `tun-engine`: 175/175 tests pass.
- `hole-bridge`: 439 pass; the 21 dist/interop failures are environmental (local worktree lacks the ex-ray binary from `cargo xtask deps`) — CI provisions it. The unit tests covering these changes (`cascade_table`, endpoint-capability tests, IPv6-bypass tests, `parse_socks5_udp_header_*`) all pass.
- Plan was vetted by the `plan-review` agent; the implementation by the `review` agent (clean verdict: every removed branch provably unreachable, predicates correct, no leak-critical defense can fire).