### PR TITLE
docs: correct stale/misplaced comments and remove dead code (audit #427)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ connections/sec).
 appends a debug-level log directive to the plugin's `SS_PLUGIN_OPTIONS`
 when the plugin's syntax is known:
 
-- `v2ray-plugin` / `ex-ray` → appends `;loglevel=debug`. The config name
+- `v2ray-plugin` / `ex-ray` → appends `loglevel=debug` (semicolon-separated). The config name
   `v2ray-plugin` resolves to the first-party `ex-ray` binary, and a config
   may also name `ex-ray` directly; the match arm covers both spellings.
   Both honor the last occurrence of any duplicate key (same v2ray-core
@@ -354,8 +354,8 @@ hole path remove                  → remove hole from system PATH
 
 ### Crash recovery
 
-While a proxy is active, the bridge persists two small state files for
-crash recovery, both in `<state_dir>/`:
+While a proxy is active, the bridge persists several small state files for
+crash recovery in `<state_dir>/`:
 
 - **`bridge-routes.json`** — records the installed TUN name, server IP,
   and upstream interface. Cleared on clean shutdown. On next startup,
@@ -384,7 +384,7 @@ crash recovery, both in `<state_dir>/`:
   `hole-bridge-etw-`. Sweep is keyed on the name prefix only, safe
   against PID reuse.
 
-All three recovery paths run *after* the IPC socket is bound. If the
+All recovery paths run *after* the IPC socket is bound. If the
 in-bridge recovery fails or the process can't restart,
 `scripts/network-reset.py` reads the route state file and performs an
 equivalent cleanup from outside (plugin reaping by name as a last
@@ -660,7 +660,7 @@ the class:
 1. **Test-of-timing.** The delay IS the behavior under test
    ([`SlowWriter` in logging_test_helpers.rs:379](crates/common/src/logging/logging_test_helpers.rs#L379)
    verifying backpressure-induced drops, or
-   [`SilentAfterRead { delay }` in tap_tests.rs:139](crates/garter/src/tap_tests.rs#L139)
+   [`SilentAfterRead` in tap_tests.rs](crates/garter/src/tap_tests.rs)
    exercising idle-close semantics).
 1. **External event with graceful failure bound.** The retry budget
    for a *remote/out-of-process* operation that might genuinely never

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ npm run dev &                                          # Vite on port 1420
 HOLE_BRIDGE_SOCKET=$TMPDIR/hole-dev.sock target/debug/hole
 ```
 
-`cargo xtask stage` populates a directory with `hole.exe`, `ex-ray.exe`, and (on Windows) `wintun.dll` — the same layout as the installed MSI in `Program Files\hole\bin\`. The canonical file list lives in [xtask/src/bindir.rs](xtask/src/bindir.rs); adding a new BINDIR file is a one-line change there and both `dev.py` and `msi-installer` pick it up automatically. The bridge binary must be staged out of the cargo target dir because the running bridge holds a file lock on its own exe — without staging, the next `cargo build` would fail with "Access is denied". The `ex-ray` sidecar (which serves the `v2ray-plugin` wire protocol) must be a sibling of the bridge so [resolve_plugin_path_inner](crates/bridge/src/proxy.rs) finds it.
+`cargo xtask stage` populates a directory with `hole.exe`, `ex-ray.exe`, and (on Windows) `wintun.dll` — the same layout as the installed MSI in `Program Files\hole\bin\`. The canonical file list lives in [xtask/src/bindir.rs](xtask/src/bindir.rs); adding a new BINDIR file is a one-line change there and both `dev.py` and `msi-installer` pick it up automatically. The bridge binary must be staged out of the cargo target dir because the running bridge holds a file lock on its own exe — without staging, the next `cargo build` would fail with "Access is denied". The `ex-ray` sidecar (which serves the `v2ray-plugin` wire protocol) must be a sibling of the bridge so [resolve_plugin_path_inner](crates/bridge/src/proxy/config.rs) finds it.
 
 ### Flags
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Shadowsocks GUI with transparent proxy (TUN), system tray, and v2ray-plugin supp
 - **System tray** — Enable/Disable, Start at Login, Settings, Exit
 - **Server import** — import from shadowsocks client config files (single and multi-server)
 - **v2ray-plugin** support — the v2ray-plugin wire protocol, served by the bundled first-party `ex-ray` binary (built from Go source)
-- **Logging** with daily rotation
+- **Logging** to stderr + a size-rotated file (10 MiB, one backup kept)
 
 ## Architecture
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -122,10 +122,9 @@ reason = "Use hole_test_observability::register!() at lib.rs level for tests. Se
 # `WinDnsBackend::Win32Real` impl. Direct callers bypass the
 # `MockBackend` test seam exactly the same way the #165 `setup_routes`
 # bypass did. The free-function shims `capture_adapters` /
-# `apply_loopback` / `platform_restore_adapter` in
-# `crates/bridge/src/dns/system/windows.rs` already route through
-# `Win32Real::default()`; the bans below cover anything reaching the
-# raw `windows` crate paths directly.
+# `platform_restore_adapter` in `crates/bridge/src/dns/system/windows.rs`
+# already route through `Win32Real::default()`; the bans below cover
+# anything reaching the raw `windows` crate paths directly.
 #
 # Sanctioned suppressions: only the two `Win32Real::{get_settings,
 # set_loopback, restore}` call sites in `dns/system/windows.rs`. Each
@@ -163,9 +162,8 @@ allow-invalid = true
 # phase of `proxy_manager::start_inner` via `child_token()`. Any fresh
 # token rooted elsewhere is unreachable from that root, and any
 # in-flight work observing only that fresh token cannot be preempted.
-# The historical regression at `plugin.rs:237` (a fresh token shadowing
-# the bridge cancel during plugin-chain spawn) is the case this rule
-# guards against.
+# This rule guards against a fresh token in the plugin-chain spawn path
+# shadowing the bridge cancel.
 #
 # **Scope is workspace-wide, not bridge-only.** Cargo's `clippy.toml`
 # resolution is workspace-rooted; there is no per-crate override

--- a/crates/bridge/src/diagnostics.rs
+++ b/crates/bridge/src/diagnostics.rs
@@ -1,22 +1,24 @@
-// Bridge runtime diagnostics — cross-cutting observability helpers.
-//
-// Modules here emit through the standard `tracing` subscriber so whatever
-// shows up in CI also shows up in user bug reports via `hole bridge log`.
-// Nothing here owns state beyond the single-call execution; these are
-// "take a snapshot and log it" helpers, not long-lived subsystems.
-//
-// # Shared conventions
-//
-// - Every submodule exposes `log_snapshot(phase: &'static str)` that
-//   runs its probe(s) and emits `info!` / `warn!` / `debug!` tiered
-//   output. See `wfp.rs` for the canonical shape.
-// - `WATCH_SUBSTRINGS` is the case-insensitive set of strings we treat
-//   as "possible wintun/hole residue" across all probes. Kept here so
-//   adding a new watch word (e.g. a different TUN driver someday)
-//   updates every probe at once.
-// - `DEBUG_OUTPUT_CAP_BYTES` caps debug-level output sizes per probe
-//   source so the bridge's size-rotated log file cannot be blown out
-//   by a single snapshot even when a probe produces multi-MB output.
+//! Bridge runtime diagnostics — cross-cutting observability helpers.
+//!
+//! Modules here emit through the standard `tracing` subscriber so whatever
+//! shows up in CI also shows up in user bug reports via `hole bridge log`.
+//! Nothing here owns state beyond the single-call execution; these are
+//! "take a snapshot and log it" helpers, not long-lived subsystems.
+//!
+//! # Shared conventions
+//!
+//! - The snapshot probes (`wfp`, `ndis`) each expose
+//!   `log_snapshot(phase: &'static str)` that runs its probe(s) and emits
+//!   `info!` / `warn!` / `debug!` tiered output; see `wfp.rs` for the
+//!   canonical shape. The `etw` consumer and `etw_sweep` follow their own
+//!   shapes.
+//! - `WATCH_SUBSTRINGS` is the case-insensitive set of strings we treat
+//!   as "possible wintun/hole residue" across all probes. Kept here so
+//!   adding a new watch word (e.g. a different TUN driver someday)
+//!   updates every probe at once.
+//! - `DEBUG_OUTPUT_CAP_BYTES` caps debug-level output sizes per probe
+//!   source so the bridge's size-rotated log file cannot be blown out
+//!   by a single snapshot even when a probe produces multi-MB output.
 
 #[cfg(target_os = "windows")]
 pub mod etw;

--- a/crates/bridge/src/diagnostics/etw.rs
+++ b/crates/bridge/src/diagnostics/etw.rs
@@ -294,7 +294,8 @@ pub fn start_consumer() -> Result<EtwGuard, EtwError> {
         .build();
 
     // Split-lifecycle: start session without the internal processing
-    // thread so we own the join handle. See [Drain on Drop] in module doc.
+    // thread so we own the join handle. See the "Drain on Drop" section
+    // of the module doc.
     //
     // Buffer sizing: now that [`TCPIP_KEYWORDS`] = !0, kernel event
     // volume per connect rises substantially (SendPath events are no

--- a/crates/bridge/src/dns/connector.rs
+++ b/crates/bridge/src/dns/connector.rs
@@ -2,12 +2,11 @@
 //!
 //! Two impls live behind [`UpstreamConnector`]:
 //!
-//! - [`DirectConnector`] — plain loopback / direct connection to an
-//!   upstream resolver. Used in tests and in the not-yet-wired sub-step
-//!   (c) path.
-//! - `Socks5Connector` (sub-step d) — routes every outbound connection
-//!   through the local shadowsocks SOCKS5 listener so user filter rules
-//!   cannot strand the forwarder.
+//! - [`DirectConnector`] — plain direct connection to an upstream
+//!   resolver; used by tests.
+//! - [`Socks5Connector`] — production path; routes every outbound
+//!   connection through the local shadowsocks SOCKS5 listener so user
+//!   filter rules cannot strand the forwarder.
 //!
 //! The trait returns [`ConnectedStream`] — a `BoxedStream` paired with
 //! [`StreamCounters`] observed by a [`CountingStream`] wrapper around
@@ -38,10 +37,10 @@ pub use garter::counting::{CountingStream, StreamCounters};
 pub trait AsyncDuplex: AsyncRead + AsyncWrite + Send + Unpin {}
 impl<T: AsyncRead + AsyncWrite + Send + Unpin + ?Sized> AsyncDuplex for T {}
 
-/// Boxed TCP stream — direct `TcpStream` or a SOCKS5-wrapped
-/// `Socks5Stream<TcpStream>` at runtime. Always wrapped in a
-/// [`CountingStream`] before boxing, so its byte counts are observable
-/// via the paired [`StreamCounters`].
+/// Boxed TCP stream — always a `CountingStream` wrapping a bare
+/// `TcpStream` (the SOCKS5 connector unwraps `Socks5Stream` to its inner
+/// `TcpStream` after CONNECT). Boxing erases the source so byte-counting
+/// is uniform via the paired [`StreamCounters`].
 pub type BoxedStream = Box<dyn AsyncDuplex>;
 
 /// A stream paired with its byte counters. Returned by

--- a/crates/bridge/src/dns/server_tests.rs
+++ b/crates/bridge/src/dns/server_tests.rs
@@ -412,7 +412,7 @@ async fn self_test_error_downcastable_to_typed_marker() {
 // Winsock matrix, and is not reproducible by a vanilla wildcard
 // `SO_REUSEADDR` bind. The load-bearing defense for that bug is the
 // post-bind self-test (see `bind_with_probe_returns_err_when_probe_fails`
-// + `bind_walks_to_next_addr_when_probe_fails_on_first`), which catches
+// + `probe_invoked_once_per_bind_with_probe_call`), which catches
 // any inbound-routing hijack (ICS, LSP/WFP shim, NKE, kernel firewall)
 // regardless of mechanism — the sentinel datagram simply doesn't come
 // back within budget, and `bind_ladder` walks to `127.53.0.X:53`.

--- a/crates/bridge/src/dns/socks5_connector_tests.rs
+++ b/crates/bridge/src/dns/socks5_connector_tests.rs
@@ -103,7 +103,8 @@ async fn udp_associate_rejected_for_tcp_only_plugin() {
 }
 
 /// Start a fake SOCKS5 proxy that accepts UDP ASSOCIATE and advertises a
-/// relay on 127.0.0.1 at a preset port. Returns both addresses.
+/// relay on 127.0.0.1 at a preset port. Returns the proxy's listen
+/// address; the relay port it advertises is the `relay_port` argument.
 async fn start_udp_accepting_proxy(relay_port: u16) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/bridge/src/dns/system.rs
+++ b/crates/bridge/src/dns/system.rs
@@ -49,8 +49,8 @@ use crate::dns_state::{AdapterId, DnsPriorAdapter};
 /// substitute a mock via [`crate::proxy_manager::ProxyManager::new_with_dns`].
 ///
 /// **Why a trait, not free functions.** Direct callers of the
-/// platform-free-function surface (`apply_loopback`, `capture_adapters`,
-/// `restore_all`) outside the `SystemDns` impl are rejected by workspace
+/// platform-free-function surface (`capture_adapters`, `restore_all`)
+/// outside the `SystemDns` impl are rejected by workspace
 /// `clippy.toml` `disallowed_methods`, mirroring the `setup_routes` /
 /// `teardown_routes` enforcement at
 /// [tun_engine::routing](../../../tun_engine/routing.rs). The motivation
@@ -640,16 +640,6 @@ pub mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::*;
 
-/// One applied DNS change, returned so a rollback on partial failure can
-/// restore exactly what was touched. Production code persists
-/// `Vec<DnsPriorAdapter>` to `bridge-dns.json` and feeds it to
-/// [`restore_all`] on shutdown.
-#[derive(Debug, Clone)]
-pub struct AppliedAdapter {
-    pub id: AdapterId,
-    pub name_at_capture: String,
-}
-
 /// Restore all adapters listed in `prior`. Each adapter is restored
 /// independently — one failure is logged and the rest proceed. This
 /// matches the crash-recovery contract (best-effort).
@@ -667,20 +657,6 @@ pub fn restore_all(prior: &[DnsPriorAdapter]) -> Vec<(AdapterId, io::Error)> {
         }
     }
     errors
-}
-
-/// Summary of the DNS state that was in effect before `apply` ran. The
-/// caller persists this (via `dns_state::save`) and feeds it to
-/// [`restore_all`] on shutdown or crash recovery.
-#[derive(Debug, Clone)]
-pub struct PriorSnapshot {
-    pub adapters: Vec<DnsPriorAdapter>,
-}
-
-impl PriorSnapshot {
-    pub fn empty() -> Self {
-        Self { adapters: Vec::new() }
-    }
 }
 
 /// Dispatch a single adapter's restore to the platform implementation.
@@ -703,11 +679,6 @@ pub fn platform_restore_adapter(_adapter: &DnsPriorAdapter) -> io::Result<()> {
 #[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub fn capture_adapters(_aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> {
     Err(io::Error::other("system DNS capture not implemented on this target OS"))
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-pub fn apply_loopback(_aliases: &[String], _loopback_ip: std::net::IpAddr) -> io::Result<Vec<AppliedAdapter>> {
-    Err(io::Error::other("system DNS apply not implemented on this target OS"))
 }
 
 // Re-export DnsPrior helpers so callers don't need a separate import just

--- a/crates/bridge/src/dns/system/macos.rs
+++ b/crates/bridge/src/dns/system/macos.rs
@@ -13,7 +13,7 @@
 //!   Production goes through [`Networksetup`]; unit tests substitute
 //!   `MockMacBackend` via [`crate::dns::system::SystemDns::new_with_mac_backend`].
 //!
-//! - The free-function shims [`capture_adapters`] / [`apply_loopback`] /
+//! - The free-function shims [`capture_adapters`] /
 //!   [`platform_restore_adapter`] / [`flush_dns_cache`] keep the
 //!   crash-recovery / non-Dns-trait call sites (see
 //!   [`crate::dns::recovery`]) intact. Each shim instantiates
@@ -24,7 +24,6 @@ use std::net::IpAddr;
 use std::process::Command;
 use std::sync::Arc;
 
-use super::AppliedAdapter;
 use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
 
 const NETWORKSETUP: &str = "networksetup";
@@ -157,23 +156,6 @@ pub fn capture_adapters(services: &[String]) -> io::Result<Vec<DnsPriorAdapter>>
         }
     }
     Ok(out)
-}
-
-pub fn apply_loopback(services: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
-    let backend = Networksetup;
-    let mut applied = Vec::with_capacity(services.len());
-    for svc in services {
-        if let Err(e) = backend.set_loopback(svc, loopback_ip) {
-            tracing::warn!(service = %svc, error = %e, "DNS apply failed; continuing");
-            continue;
-        }
-        applied.push(AppliedAdapter {
-            id: AdapterId::MacosServiceName { value: svc.clone() },
-            name_at_capture: svc.clone(),
-        });
-    }
-    flush_dns_cache();
-    Ok(applied)
 }
 
 /// Flush the macOS DNS cache.

--- a/crates/bridge/src/dns/system/windows.rs
+++ b/crates/bridge/src/dns/system/windows.rs
@@ -19,7 +19,7 @@
 //!   `windows::*` types) so the mock can be constructed without depending
 //!   on the Win32 crate.
 //!
-//! - The free-function shims [`capture_adapters`] / [`apply_loopback`] /
+//! - The free-function shims [`capture_adapters`] /
 //!   [`platform_restore_adapter`] / [`flush_dns_cache`] keep the
 //!   crash-recovery call sites (see [`crate::dns::recovery`]) intact.
 //!   Each shim instantiates [`Win32Real`] and delegates. The
@@ -30,9 +30,9 @@
 //!
 //! `SetInterfaceDnsSettings` / `GetInterfaceDnsSettings` were added in
 //! Windows 10 build 19041 (version 2004, May 2020). Pre-19041 systems
-//! will fail to link at runtime. The MSI installer `WIN10BUILD >=
-//! 19041` launch condition gate is tracked separately (see #397 plan
-//! step 12).
+//! would fail at runtime, so the MSI gates install on `WIN10BUILD >=
+//! 19041` (see `msi-installer/src/msi_installer/hole.wxs`); the
+//! unsupported FFI is never reached on shipped installs.
 //!
 //! ## v4 vs v6
 //!
@@ -67,7 +67,6 @@ unsafe extern "system" {
     fn DnsFlushResolverCache() -> i32;
 }
 
-use super::AppliedAdapter;
 use crate::dns_state::{AdapterId, DnsPrior, DnsPriorAdapter};
 
 // WinDnsBackend trait =================================================================================================
@@ -404,33 +403,6 @@ pub fn capture_adapters(aliases: &[String]) -> io::Result<Vec<DnsPriorAdapter>> 
         "capture_adapters"
     );
     Ok(out)
-}
-
-/// Apply `loopback_ip` as the v4 DNS server on each adapter in `aliases`.
-/// Returns one [`AppliedAdapter`] per adapter that was successfully set.
-/// Callers flush the DNS cache separately via [`flush_dns_cache`].
-pub fn apply_loopback(aliases: &[String], loopback_ip: IpAddr) -> io::Result<Vec<AppliedAdapter>> {
-    let started = Instant::now();
-    let backend = Win32Real;
-    let mut applied = Vec::with_capacity(aliases.len());
-    for alias in aliases {
-        if let Err(e) = backend.set_loopback(alias, loopback_ip) {
-            tracing::warn!(%alias, error = %e, "DNS apply failed; continuing");
-            continue;
-        }
-        applied.push(AppliedAdapter {
-            id: AdapterId::WindowsAlias { value: alias.clone() },
-            name_at_capture: alias.clone(),
-        });
-    }
-    flush_dns_cache();
-    tracing::debug!(
-        aliases = aliases.len(),
-        applied = applied.len(),
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "apply_loopback"
-    );
-    Ok(applied)
 }
 
 /// Restore one adapter. Invoked from [`super::restore_all`].

--- a/crates/bridge/src/dns_state.rs
+++ b/crates/bridge/src/dns_state.rs
@@ -3,8 +3,9 @@
 //! The bridge writes the chosen loopback bind address and prior system-DNS
 //! settings to a JSON file when the DNS forwarder starts, clears it on clean
 //! shutdown, and reads it on startup to restore DNS leaked by a previous
-//! crashed run. Mirrors the `route_state.rs` / `plugin_state.rs`
-//! crash-recovery pattern.
+//! crashed run. Mirrors the `tun_engine::routing::state`
+//! (crates/tun-engine/src/routing/state.rs) / `plugin_state` crash-recovery
+//! pattern.
 //!
 //! Single-writer assumption: the bridge is the only writer of this file
 //! within a process, and only one bridge runs at a time (the IPC socket bind

--- a/crates/bridge/src/endpoint.rs
+++ b/crates/bridge/src/endpoint.rs
@@ -78,7 +78,7 @@ pub trait Endpoint: Send + Sync {
     /// SOCKS5 carries IPv6 addresses via ATYP.
     fn supports_ipv6_dst(&self) -> bool;
 
-    /// Short diagnostic label (e.g. `"socks5"`, `"interface"`,
+    /// Short diagnostic label (e.g. `"socks5(ex-ray)"`, `"interface(#5)"`,
     /// `"block"`). Backed by the endpoint's own storage — no allocation
     /// per call.
     fn name(&self) -> &str;

--- a/crates/bridge/src/endpoint/local_dns.rs
+++ b/crates/bridge/src/endpoint/local_dns.rs
@@ -68,6 +68,7 @@ impl Endpoint for LocalDnsEndpoint {
     }
 
     fn supports_udp(&self) -> bool {
+        // The forwarder always carries UDP — that is its entire purpose.
         true
     }
 

--- a/crates/bridge/src/filter/engine.rs
+++ b/crates/bridge/src/filter/engine.rs
@@ -10,8 +10,8 @@ use hole_common::config::FilterAction;
 
 use super::rules::RuleSet;
 
-/// Layer-4 protocol of a connection. Filter rules apply to both
-/// uniformly today, but downstream code (Plans 2/3) may branch on this.
+/// Layer-4 protocol of a connection. The dispatcher branches on this:
+/// TCP flows are peeked for a domain, UDP flows are matched on IP only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum L4Proto {
     Tcp,

--- a/crates/bridge/src/filter/matcher.rs
+++ b/crates/bridge/src/filter/matcher.rs
@@ -201,10 +201,9 @@ fn canonicalize_domain(input: &str) -> Result<String, CompileError> {
 /// just because the sniffer handed us something we couldn't canonicalize,
 /// since rule compilation has already rejected its own malformed inputs.
 ///
-/// This is exposed publicly so the dispatcher (Plans 2/3) can call it
-/// once per connection at `ConnInfo` construction time. The matcher
-/// also calls it internally so contracts hold even if the dispatcher
-/// forgets.
+/// Exposed publicly for callers that want to pre-canonicalize a domain.
+/// The matcher calls it internally on every match, so passing the raw
+/// sniffer string is fine — that is exactly what the dispatcher does.
 pub fn canonicalize_for_match(domain: &str) -> String {
     let trimmed = domain.trim_end_matches('.');
     if trimmed.is_empty() {

--- a/crates/bridge/src/filter/sniffer.rs
+++ b/crates/bridge/src/filter/sniffer.rs
@@ -1,7 +1,7 @@
 //! Connection-level domain sniffer.
 //!
 //! When the dispatcher accepts a new TCP connection it peeks the first
-//! ~2 KiB of payload and asks the sniffer to extract a destination domain.
+//! ≤ 2 KiB of payload and asks the sniffer to extract a destination domain.
 //! The sniffer tries TLS SNI first (covers ~all HTTPS/DoH/DoT/SMTPS/IMAPS),
 //! then HTTP Host header (covers plaintext HTTP). If neither matches, the
 //! connection falls through to IP-only matching.

--- a/crates/bridge/src/filter/sniffer/http_host.rs
+++ b/crates/bridge/src/filter/sniffer/http_host.rs
@@ -22,7 +22,9 @@ const METHODS: &[&[u8]] = &[
 ];
 
 /// Maximum bytes scanned for the `Host:` header. We don't want to
-/// chase pathologically long header sections.
+/// chase pathologically long header sections. In production the
+/// upstream peek caps the buffer at 2048 bytes, so this bound only
+/// engages for direct callers/tests.
 const MAX_SCAN: usize = 4096;
 
 /// Try to extract the `Host` header value from a buffer that starts

--- a/crates/bridge/src/foreground.rs
+++ b/crates/bridge/src/foreground.rs
@@ -1,4 +1,4 @@
-// Foreground bridge runner for development.
+//! Foreground bridge runner for development.
 
 use std::path::Path;
 

--- a/crates/bridge/src/group.rs
+++ b/crates/bridge/src/group.rs
@@ -1,8 +1,8 @@
-// OS group management for IPC access control.
-//
-// Creates and manages a local "hole" group that gates access to the bridge's
-// IPC socket/pipe. Members of this group (plus root/Administrators) can
-// communicate with the bridge.
+//! OS group management for IPC access control.
+//!
+//! Creates and manages a local "hole" group that gates access to the bridge's
+//! IPC socket/pipe. Members of this group (plus root/Administrators) can
+//! communicate with the bridge.
 
 use std::io;
 

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -1,4 +1,4 @@
-// IPC server — HTTP/1.1 REST API over local Unix domain socket.
+//! IPC server — HTTP/1.1 REST API over local Unix domain socket.
 
 use tun_engine::routing::Routing;
 
@@ -403,7 +403,7 @@ async fn handle_diagnostics<P: Proxy + 'static, R: Routing + 'static>(
     };
 
     // vpn_server and internet are computed by the GUI from the selected
-    // ServerEntry's persisted validation state (see ui/sidebar.ts). The
+    // ServerEntry's persisted validation state (see ui/diagnostics.ts). The
     // wire fields are kept for backward compat but always "unknown" here.
     let vpn_server = "unknown".to_string();
     let internet = "unknown".to_string();

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -910,7 +910,7 @@ async fn error_message(resp: http::Response<hyper::body::Incoming>) -> String {
 #[skuld::test]
 fn cancel_while_start_in_flight_returns_cancelled() {
     // Two concurrent connections. A posts Start against a gated mock so
-    // start_ss hangs. B posts Cancel. A's Start response must come back
+    // start hangs inside MockProxy::start. B posts Cancel. A's Start response must come back
     // with 500 + "cancelled" promptly (not after the full gate duration,
     // which never elapses in this test).
     rt().block_on(async {
@@ -954,7 +954,7 @@ fn cancel_while_start_in_flight_returns_cancelled() {
         let (_client_a, resp_a) = start_future.await.expect("start task panicked");
         assert_eq!(error_message(resp_a).await, CANCELLED_MESSAGE);
 
-        // Release the gate so the mock's start_ss future can settle if it
+        // Release the gate so the mock's start() future can settle if it
         // is still parked anywhere; harmless no-op if already dropped.
         gate.notify_one();
         // run_n(2) returns naturally once both connections are handled, so
@@ -969,7 +969,7 @@ fn cancel_before_start_is_pre_armed_and_consumed() {
     // A cancel arriving before any start is in flight pre-arms a flag
     // that the next start consumes. The next Start returns 500 +
     // "cancelled" immediately without even attempting to acquire the
-    // proxy mutex or call backend.start_ss.
+    // proxy mutex or call Proxy::start.
     rt().block_on(async {
         let path = test_socket_path("cancel-prearm");
         let server = IpcServer::bind(&path, mock_proxy()).unwrap();
@@ -1021,7 +1021,7 @@ fn cancel_with_no_start_is_ack_idempotent() {
 
 #[skuld::test]
 fn concurrent_start_is_rejected_with_conflict() {
-    // Client A holds a start parked in start_ss on the gate. Client B
+    // Client A holds a start parked inside MockProxy::start on the gate. Client B
     // sends a second Start concurrently. B must be rejected with 409
     // Conflict rather than silently overwriting A's token slot — the
     // slot is single-occupancy because a Cancel targets exactly one
@@ -1034,7 +1034,7 @@ fn concurrent_start_is_rejected_with_conflict() {
         // 3 connections: A start, B start, C cancel.
         let handle = tokio::spawn(async move { server.run_n(3).await });
 
-        // Client A parks in start_ss.
+        // Client A parks inside MockProxy::start.
         let path_a = path.clone();
         let a_future = tokio::spawn(async move {
             let mut client_a = TestClient::connect(&path_a).await;
@@ -1130,7 +1130,7 @@ fn concurrent_double_cancel_during_start_both_succeed() {
         // 3 connections: A start, B cancel, C cancel.
         let handle = tokio::spawn(async move { server.run_n(3).await });
 
-        // Client A parks in start_ss.
+        // Client A parks inside MockProxy::start.
         let path_a = path.clone();
         let a_future = tokio::spawn(async move {
             let mut client_a = TestClient::connect(&path_a).await;

--- a/crates/bridge/src/logging.rs
+++ b/crates/bridge/src/logging.rs
@@ -1,4 +1,4 @@
-// Bridge logging — delegates to shared logging in hole-common.
+//! Bridge logging — delegates to shared logging in hole-common.
 
 use hole_common::logging::LogGuard;
 use std::path::Path;

--- a/crates/bridge/src/platform/macos.rs
+++ b/crates/bridge/src/platform/macos.rs
@@ -10,7 +10,8 @@ pub const PLIST_PATH: &str = "/Library/LaunchDaemons/com.hole.bridge.plist";
 pub const HELPER_PATH: &str = "/Library/PrivilegedHelperTools/com.hole.bridge";
 pub const SERVICE_LOG_DIR: &str = "/var/log/hole";
 /// System state directory for the launchd daemon (Apple convention:
-/// `/var/db/<daemon>`). Holds the route-recovery state file.
+/// `/var/db/<daemon>`). Holds the bridge crash-recovery state files
+/// (DNS, routes, plugins).
 pub const SERVICE_STATE_DIR: &str = "/var/db/hole/state";
 
 // Plist generation ====================================================================================================

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -198,9 +198,10 @@ fn service_log_dir() -> PathBuf {
 
 /// System state directory for the Windows service (`C:\ProgramData\hole\state`).
 ///
-/// Used for the route-recovery state file (`bridge-routes.json`). Writable by
-/// LocalSystem; pre-created by `install()` so the service has somewhere to
-/// write on its first run.
+/// Holds the bridge crash-recovery state files (`bridge-dns.json`,
+/// `bridge-routes.json`, `bridge-plugins.json`). Writable by LocalSystem;
+/// pre-created by `install()` so the service has somewhere to write on its
+/// first run.
 fn service_state_dir() -> PathBuf {
     PathBuf::from(std::env::var("ProgramData").unwrap_or_else(|_| r"C:\ProgramData".into()))
         .join("hole")

--- a/crates/bridge/src/plugin_state.rs
+++ b/crates/bridge/src/plugin_state.rs
@@ -1,9 +1,9 @@
-// Persisted plugin PID state for crash recovery.
-//
-// The bridge writes plugin PIDs to a JSON file when a plugin chain starts,
-// clears it on clean shutdown, and reads it on startup to kill leaked
-// plugin processes from a previous crashed run. Mirrors the
-// `route_state.rs` crash-recovery pattern.
+//! Persisted plugin PID state for crash recovery.
+//!
+//! The bridge writes plugin PIDs to a JSON file when a plugin chain starts,
+//! clears it on clean shutdown, and reads it on startup to kill leaked
+//! plugin processes from a previous crashed run. Mirrors the
+//! `routing::state` crash-recovery pattern.
 
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -38,7 +38,7 @@ fn state_file(state_dir: &Path) -> PathBuf {
 // I/O =================================================================================================================
 
 /// Write `state` to `<state_dir>/bridge-plugins.json` atomically.
-/// Same atomic-write pattern as `route_state::save`.
+/// Same atomic-write pattern as `routing::state::save`.
 pub fn save(state_dir: &Path, state: &PluginState) -> std::io::Result<()> {
     std::fs::create_dir_all(state_dir)?;
 

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -117,20 +117,19 @@ struct RunningState<P: Proxy, R: Routing, D: Dns> {
     #[allow(dead_code)]
     dns: Option<D::Applied>,
     /// TCP dispatcher — owns TUN device, smoltcp, and per-connection
-    /// handler tasks. Drops SECOND. `None` in SocksOnly mode and under
-    /// `#[cfg(test)]`.
+    /// handler tasks. `None` in SocksOnly mode and under `#[cfg(test)]`.
     #[allow(dead_code)]
     dispatcher: Option<crate::dispatcher::Dispatcher>,
-    /// Garter-managed plugin chain. Drops SECOND (cancel token triggers
-    /// SIP003u graceful shutdown). `None` when no plugin is configured.
+    /// Garter-managed plugin chain; drop triggers SIP003u graceful
+    /// shutdown via the cancel token. `None` when no plugin is configured.
     #[allow(dead_code)]
     plugin_chain: Option<crate::proxy::plugin::PluginChain>,
-    /// Installed routes. Dropped THIRD. `None` in SocksOnly mode.
+    /// Installed routes. `None` in SocksOnly mode.
     #[allow(dead_code)]
     routes: Option<R::Installed>,
-    /// Handle on the running proxy. Dropped LAST. Drop aborts
-    /// the task (best-effort); supported graceful shutdown is via
-    /// `stop().await` from [`ProxyManager::stop`].
+    /// Handle on the running proxy. Drop aborts the task (best-effort);
+    /// supported graceful shutdown is via `stop().await` from
+    /// [`ProxyManager::stop`].
     proxy: P::Running,
     server_ip: Option<IpAddr>,
     started_at: Instant,
@@ -569,7 +568,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         //      reachable through the cascade
         //   5. routing.install  — TUN routes go live, intercept_udp53
         //      activates
-        //   6. apply_dns_settings  — system DNS pointed at our loopback
+        //   6. Dns::apply  — system DNS pointed at our loopback
         //
         // Reordering steps 3..=6 re-introduces the #388 symptom (dead-
         // tunnel DNS hijack with the GUI reporting "Running"). The
@@ -598,7 +597,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         };
 
         // Phase 4: blocking forwarder self-test gate. Runs synchronously
-        // BEFORE Dispatcher::new / routing.install / apply_dns_settings.
+        // BEFORE Dispatcher::new / routing.install / Dns::apply.
         // On Err, the locally-owned `running_proxy` Drop aborts the SS
         // task and `plugin_chain` (further up the stack) Drop SIGTERMs
         // the chain. System state is untouched. `run_forwarder_self_test`
@@ -999,7 +998,7 @@ pub(crate) const TAP_DISABLED_HINT: &str =
 ///
 /// **#388 change**: replaces the pre-#388 `spawn_forwarder_self_test`
 /// (fire-and-forget). Called from `start_inner` BEFORE
-/// `Dispatcher::new` / `routing.install` / `apply_dns_settings`. A
+/// `Dispatcher::new` / `routing.install` / `Dns::apply`. A
 /// failure short-circuits the start; the locally-owned `running_proxy` +
 /// `plugin_chain` RAII guards unwind without ever hijacking system DNS
 /// into a dead tunnel.

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1190,7 +1190,7 @@ mod self_test {
     /// Empty servers → `run_forwarder_self_test` logs `skipped` and
     /// returns `Ok(0)`. Empty-servers in production is rejected at
     /// `build_local_dns` *before* `run_forwarder_self_test` is even
-    /// called (test below: `gate_returns_err_for_empty_servers_via_build_local_dns`);
+    /// called (test below: `build_local_dns_returns_err_for_empty_servers`);
     /// this test pins the helper's contract in isolation.
     #[skuld::test]
     fn self_test_empty_servers_returns_ok_zero() {

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -36,8 +36,9 @@ pub struct TestConfig {
     /// Two sentinel `host:port` strings (the second is the fallback).
     pub sentinels: [String; 2],
     /// Optional override for the plugin path. `None` → use
-    /// [`resolve_plugin_path_inner`]. Tests use this to point at the
-    /// cargo-built v2ray-plugin without depending on `PATH`.
+    /// [`resolve_plugin_path_inner`]. Tests use this to point at a specific
+    /// on-disk plugin binary (the xtask-built `ex-ray`, or a provisioned
+    /// upstream v2ray-plugin) without depending on `PATH`.
     pub plugin_path_override: Option<String>,
 }
 

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -415,8 +415,8 @@ fn run_test_with_v2ray_plugin_happy_path() {
         );
         entry.plugin = Some("v2ray-plugin".into());
 
-        // Generous plugin window for cold start. The CI default of 2 s in
-        // fast_test_config is too short for the WS handshake.
+        // Generous plugin window for cold start. fast_test_config's 800 ms
+        // SS/sentinel timeouts are too short for the WS handshake.
         let cfg = TestConfig {
             plugin_path_override: Some(plugin_path.to_str().unwrap().to_string()),
             // Generous SS connect/sentinel timeouts because the WS handshake

--- a/crates/bridge/src/test_support/dist_fixture.rs
+++ b/crates/bridge/src/test_support/dist_fixture.rs
@@ -10,12 +10,14 @@
 //!
 //! - `target/debug/dist/bin/hole[.exe]` — the bridge/GUI binary
 //! - `target/debug/dist/bin/ex-ray[.exe]` — the Go plugin sidecar
+//! - `target/debug/dist/bin/galoshes[.exe]` — the YAMUX plugin
 //! - `target/debug/dist/bin/wintun.dll` (Windows only)
 //!
 //! Each `DistHarness::spawn()` call runs `hole bridge run` from that
 //! directory, which means `current_exe()` is `dist/bin/hole` and
-//! `resolve_plugin_path` finds `ex-ray` next to it — the same
-//! resolution path production uses.
+//! `resolve_plugin_path` finds the named plugin next to it — the same
+//! resolution path production uses. The plugin found depends on the
+//! config name: `v2ray-plugin` → `ex-ray`, `galoshes` → `galoshes`.
 //!
 //! ## Concurrency
 //!

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -1,11 +1,12 @@
 //! Generates Rust types and route constants from the OpenAPI spec at `api/openapi.yaml`.
 //!
 //! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `PublicIpResponse`, `InvalidFilter`, `FilterMetrics`.
-//! Generated constants: `ROUTE_STATUS`, `ROUTE_START`, `ROUTE_STOP`, `ROUTE_RELOAD`, `ROUTE_METRICS`, `ROUTE_DIAGNOSTICS`, `ROUTE_PUBLIC_IP`, `ROUTE_TEST_SERVER`.
+//! Generated constants: one `ROUTE_*` const per `/v1/*` path in `api/openapi.yaml` (e.g. `ROUTE_STATUS`, `ROUTE_START`, `ROUTE_STOP`, `ROUTE_CANCEL`, `ROUTE_RELOAD`, …).
 //!
-//! `ProxyConfig`, `ServerEntry`, `ValidationState`, `ServerTestOutcome`, `TestServerRequest`,
-//! and `TestServerResponse` are defined in the spec for documentation purposes
-//! but are not generated — they are hand-written in `protocol.rs` and `config.rs`.
+//! The remaining schemas — including `ProxyConfig`, `ServerEntry`, `ValidationState`,
+//! `ServerTestOutcome`, `TestServerRequest`, `TestServerResponse`, and `TunnelMode` —
+//! are defined in the spec for documentation purposes but are not generated; they are
+//! hand-written in `protocol.rs` and `config.rs`.
 
 use schemars::schema::Schema;
 use typify::{TypeSpace, TypeSpaceSettings};

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -272,8 +272,6 @@ impl AppConfig {
         }
     }
 
-    // Restrict config file permissions on macOS — the config contains plaintext
-    // passwords and must not be world-readable (default umask 0022 yields 0644).
     pub fn save(&self, path: &Path) -> Result<(), ConfigError> {
         let json = serde_json::to_string_pretty(self)?;
 
@@ -289,6 +287,8 @@ impl AppConfig {
                 DirBuilder::new().recursive(true).mode(0o700).create(parent)?;
                 std::fs::set_permissions(parent, Permissions::from_mode(0o700))?;
             }
+            // Restrict config file permissions on macOS — the config contains plaintext
+            // passwords and must not be world-readable (default umask 0022 yields 0644).
             let mut file = OpenOptions::new()
                 .write(true)
                 .create(true)

--- a/crates/common/src/import.rs
+++ b/crates/common/src/import.rs
@@ -17,8 +17,9 @@ pub enum ImportError {
     /// must modify the profile to use one of the bundled plugins.
     ///
     /// The "bundled list" in the error message is derived from
-    /// [`crate::plugin::known_plugin_names_joined`] (the single source
-    /// of truth at [`crate::plugin::KNOWN_PLUGINS`]) so it can't drift.
+    /// [`crate::plugin::known_plugin_names_joined`], which lists only the
+    /// user-visible plugins from [`crate::plugin::KNOWN_PLUGINS`] (so the
+    /// `ex-ray` impl-detail entry is hidden) so it can't drift.
     #[error(
         "plugin \"{name}\" is not bundled with Hole. Bundled plugins: {}",
         crate::plugin::known_plugin_names_joined()

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -8,7 +8,7 @@
 //    `hole::stderr_relay` (which the file layer captures) and (b) the
 //    *saved-original* handle (which preserves dev-terminal / CLI-script
 //    visibility). Catches any third-party output that bypasses tracing —
-//    Go runtime stderr from v2ray-plugin, native libraries, the default panic
+//    Go runtime stderr from the ex-ray plugin, native libraries, the default panic
 //    printer, etc.
 //
 // 2. **Multi-layer tracing subscriber.** A `Registry` with two `fmt::layer()`s:

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -3,7 +3,7 @@
 // FD-redirect tests run in a child process so they don't corrupt sibling tests
 // that share FD 1 / FD 2 in the test runner. The child is the same test binary
 // re-invoked with `HOLE_LOGGING_TEST_KIND` set; `lib.rs::main` dispatches early
-// (before skuld) into `logging::run_redirect_test_child`. Each child writes a
+// (before skuld) into `logging::logging_test_helpers::run_child`. Each child writes a
 // JSON result file at `HOLE_LOGGING_TEST_OUTPUT` and exits, and the parent
 // reads + asserts on it.
 
@@ -46,9 +46,9 @@ fn run_child(kind: &str, dir: &Path) -> ChildResult {
         .env("HOLE_LOGGING_TEST_KIND", kind)
         .env("HOLE_LOGGING_TEST_OUTPUT", &result_path)
         .stdin(Stdio::null())
-        // Inherit stdout/stderr to a temp file so the child's actual stdio
-        // (post-redirect, post-tee) doesn't pollute the test runner output but
-        // is still recoverable for diagnostics if the test fails.
+        // Discard the child's actual stdio (post-redirect, post-tee) so it
+        // doesn't pollute the test runner output; the test's assertions read
+        // the JSON result file, not stdio.
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()

--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -16,8 +16,9 @@ pub(crate) fn default_user_subdir(leaf: &str) -> PathBuf {
 
 /// Default state directory: `<state>/hole/state`.
 ///
-/// Used to persist the bridge's route-recovery state file
-/// (`bridge-routes.json`) between runs. Resolved against the current
+/// Used to persist the bridge's crash-recovery state files
+/// (`bridge-routes.json`, `bridge-dns.json`, `bridge-plugins.json`) between
+/// runs. Resolved against the current
 /// effective user's profile — under `sudo` on macOS this is
 /// `/var/root/Library/Application Support/hole/state`, so dev tooling
 /// must pass an explicit `--state-dir` to place it somewhere the

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -2,7 +2,8 @@ use crate::config::{FilterRule, ServerEntry};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-// Generated from api/openapi.yaml — StatusResponse, ErrorResponse, EmptyResponse, route constants
+/// Typify-generated API types from `api/openapi.yaml` — `StatusResponse`,
+/// `ErrorResponse`, `EmptyResponse`, and route constants.
 #[allow(clippy::derivable_impls)]
 mod api_generated {
     include!(concat!(env!("OUT_DIR"), "/api_generated.rs"));
@@ -52,9 +53,9 @@ pub enum BridgeRequest {
     },
 }
 
-/// Error-payload message string that identifies a cancelled start. Both bridge
-/// and client compare against this constant rather than re-parsing the error
-/// text.
+/// The exact string the bridge writes into `ErrorResponse` when a `Start` is
+/// cancelled; the client matches against it. Changing it is a
+/// wire-compatibility break.
 pub const CANCELLED_MESSAGE: &str = "cancelled";
 
 /// Client-side response enum. Used by the GUI client API and elevation flow.

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -77,9 +77,7 @@ fn bridge_request_cancel_json_roundtrip() {
 
 #[skuld::test]
 fn cancelled_message_constant_is_stable() {
-    // The bridge writes this exact string into ErrorResponse when a Start is
-    // cancelled; the client matches against it. Changing it is a breaking
-    // change to the client/bridge contract.
+    // Pins the wire-contract value (see `CANCELLED_MESSAGE` docs in protocol.rs).
     assert_eq!(CANCELLED_MESSAGE, "cancelled");
 }
 

--- a/crates/dump/src/display.rs
+++ b/crates/dump/src/display.rs
@@ -8,7 +8,7 @@ use crate::DumpValue;
 
 /// Owns a [`DumpValue`] and renders it as YAML via [`std::fmt::Display`].
 ///
-/// This is what the `dump!` macro (added in a later commit) returns.
+/// This is what the [`crate::dump!`] macro returns.
 /// `Clone` is derived because `tracing` captures field values into
 /// span storage, and non-`Clone` wrappers are an ergonomic trap.
 #[derive(Clone, Debug)]

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -6,10 +6,6 @@
 //! is the third leg: human-readable, multi-line, YAML-shaped output
 //! suited for logging large structured values where Debug jams everything
 //! onto one unreadable line.
-//!
-//! This commit introduces only the data model and trait; the `dump!`
-//! macro, YAML formatter, derive macro, and built-in impls ship in
-//! subsequent commits.
 
 mod debug_bridge;
 mod display;

--- a/crates/dump/src/value.rs
+++ b/crates/dump/src/value.rs
@@ -9,8 +9,9 @@ pub enum DumpValue {
     /// YAML `null` / `~`.
     Null,
     Bool(bool),
-    /// Signed integer up to `i128`. `UInt` exists separately so that
-    /// the `i64::MAX..=u128::MAX` range round-trips losslessly.
+    /// Signed integer up to `i128`. `UInt` exists separately so the
+    /// `i128::MAX..=u128::MAX` range round-trips losslessly (values
+    /// above `i128::MAX` don't fit in `Int`).
     Int(i128),
     UInt(u128),
     /// NaN and ±infinity are emitted as `.nan` / `.inf` / `-.inf` per

--- a/crates/ex-ray/README.md
+++ b/crates/ex-ray/README.md
@@ -15,11 +15,9 @@ has). Its config-building construction is derived from
 `shadowsocks/v2ray-plugin` (MIT-licensed); see the root
 [`NOTICES.md`](../../NOTICES.md) for attribution.
 
-ex-ray exists to give Hole a plugin it fully controls: later it grows a
-"sitrep" control protocol on stdout and forces all logs to stderr. As of
-this commit it is a plain scaffold — it compiles and runs equivalently to
-the stock v2ray-plugin shim, with no sitrep support and no log-routing
-changes yet. **Sitrep support is added in a later commit.**
+ex-ray exists to give Hole a plugin it fully controls: it speaks a "sitrep"
+control protocol on stdout (see [`../garter/SITREP.md`](../garter/SITREP.md))
+and forces all v2ray-core logs to stderr.
 
 ## Build
 

--- a/crates/ex-ray/args.go
+++ b/crates/ex-ray/args.go
@@ -6,8 +6,6 @@ import (
 	"os"
 )
 
-// Key–value mappings for the representation of client and server options.
-
 // Args maps a string key to a list of values. It is similar to url.Values.
 type Args map[string][]string
 

--- a/crates/ex-ray/log.go
+++ b/crates/ex-ray/log.go
@@ -1,7 +1,3 @@
-// Copyright 2014 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package main
 
 import "log"

--- a/crates/ex-ray/log.go
+++ b/crates/ex-ray/log.go
@@ -6,6 +6,8 @@ package main
 
 import "log"
 
+// logInit is a no-op retained as a call hook in main(); the actual log
+// routing to stderr is configured in logsink.go's init().
 func logInit() {
 }
 

--- a/crates/ex-ray/main.go
+++ b/crates/ex-ray/main.go
@@ -22,7 +22,7 @@ var VERSION = "ex-ray"
 
 // parseOptsIntoFlags reads SS_PLUGIN env vars and cross-assigns them into the
 // package-level flag pointers. This is the env-remap seam: it is split out of
-// startV2Ray so main() can compute the listen address and run the confirming
+// buildV2Ray so main() can compute the listen address and run the confirming
 // probe BETWEEN the remap and core.New (the probe needs the resolved
 // *localAddr:*localPort, the config needs the remap to have happened).
 //

--- a/crates/galoshes/src/sitrep_out.rs
+++ b/crates/galoshes/src/sitrep_out.rs
@@ -3,14 +3,14 @@
 //! galoshes is spawned by the bridge as a `BinaryPlugin` and the bridge
 //! reads sitrep events from galoshes' **process stdout**. Internally
 //! galoshes builds its own `garter::ChainRunner` over a 2-plugin chain
-//! (`YamuxPlugin` outer + embedded `v2ray-plugin` inner); that runner's
+//! (`YamuxPlugin` outer + embedded `ex-ray` inner); that runner's
 //! `on_ready` channel fires the chain-level outcome. This module maps that
 //! chain-level outcome onto the PROCESS-level sitrep event galoshes emits
 //! on stdout.
 //!
 //! The mapping logic is split out here (rather than living inline in
 //! `main.rs`) so it is unit-testable without spawning the binary or
-//! requiring the embedded v2ray-plugin to be present.
+//! requiring the embedded ex-ray binary to be present.
 
 use std::io::Write as _;
 
@@ -21,11 +21,11 @@ use garter::{ChainReady, SitrepEvent, StartError, Transports};
 ///
 /// **This is deliberately NOT the inner chain's transport intersection.**
 /// galoshes' whole purpose is to carry UDP-over-YAMUX: its outer
-/// `YamuxPlugin` hop serves TCP *and* UDP, while the embedded v2ray-plugin
+/// `YamuxPlugin` hop serves TCP *and* UDP, while the embedded ex-ray
 /// inner hop is a TCP-only SIP003 transport (it reports `TCP` via the
 /// tier-2 probe). The naive chain intersection (`YamuxPlugin` TCP|UDP ∩
-/// v2ray TCP = TCP) would therefore lose galoshes' UDP capability. But the
-/// v2ray hop being TCP-only is an implementation detail *below* galoshes'
+/// ex-ray TCP = TCP) would therefore lose galoshes' UDP capability. But the
+/// ex-ray hop being TCP-only is an implementation detail *below* galoshes'
 /// abstraction: galoshes frames UDP datagrams over a YAMUX stream and the
 /// inner TCP hop carries them transparently. galoshes is precisely the
 /// component that ADDS UDP capability, so it reports its own true

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -698,9 +698,9 @@ async fn handle_inbound_stream(mut stream: yamux::Stream, remote: SocketAddr) ->
 /// `SS_PLUGIN_OPTIONS` string.
 ///
 /// Returns [`DEFAULT_UDP_TIMEOUT`] when the key is absent. The last occurrence
-/// wins (consistent with v2ray-plugin's duplicate-key semantics). A value that
+/// wins (consistent with ex-ray's duplicate-key semantics). A value that
 /// is not a positive integer is a hard error — `0` would evict every
-/// association immediately, breaking all UDP. v2ray-plugin ignores this key,
+/// association immediately, breaking all UDP. ex-ray ignores this key,
 /// so it can share the same options string.
 pub fn parse_udp_timeout(plugin_options: Option<&str>) -> Result<Duration> {
     let Some(opts) = plugin_options else {
@@ -762,7 +762,7 @@ impl garter::ChainPlugin for YamuxPlugin {
         //
         // This is galoshes' INTERNAL hop-readiness signal: it feeds
         // galoshes' OWN `ChainRunner` aggregator, which intersects it with
-        // the inner v2ray hop and fires the chain-level `on_ready`. The
+        // the inner ex-ray hop and fires the chain-level `on_ready`. The
         // PROCESS-level sitrep the bridge reads is emitted separately in
         // `main.rs` off that `on_ready` outcome (see `galoshes::sitrep_out`).
         // This probe knows only its own hop, not the chain, so it cannot

--- a/crates/garter/SITREP.md
+++ b/crates/garter/SITREP.md
@@ -335,18 +335,12 @@ responses, and the protocol does not constrain that choice.
 ## Reference implementation
 
 [`garter`](https://crates.io/crates/garter) is the reference
-implementation of sitrep. Its sitrep module — `src/sitrep.rs` —
-will define the wire types and the `SITREP_PROTOCOL` constant
-(`"sitrep-1.0.0"`).
+implementation of sitrep. Its sitrep module (`src/sitrep.rs`) defines
+the wire types and the `SITREP_PROTOCOL` constant (`"sitrep-1.0.0"`).
 
-> Note: at the time this document is first published, `src/sitrep.rs`
-> is forthcoming — it is added in the implementation work that follows
-> this standard. The standard is the source of truth; the module
-> conforms to it, not the reverse.
-
-Conforming emitters that ship at the time of this document: the
-`mock-plugin` test plugin and the `galoshes` SIP003u plugin, both in
-the Hole workspace. The protocol is independently adoptable: any
+Conforming emitters in the Hole workspace: the `mock-plugin` test
+plugin, the `galoshes` SIP003u plugin, and the `ex-ray` plugin. The
+protocol is independently adoptable: any
 SIP003 / SIP003u plugin or host may implement it without depending on
 `garter`.
 

--- a/crates/garter/src/sitrep.rs
+++ b/crates/garter/src/sitrep.rs
@@ -118,8 +118,8 @@ pub fn parse_event(line: &str) -> Result<Option<SitrepEvent>, serde_json::Error>
     }
 }
 
-/// True iff `line` is a `hello` handshake whose protocol is `sitrep-*`.
-/// Used as the tier-1 detection signal on the first stdout line.
+/// A tier-1 capability check: true iff `line` is a `hello` handshake whose
+/// protocol is `sitrep-*`.
 pub fn is_hello_handshake(line: &str) -> bool {
     matches!(parse_event(line), Ok(Some(SitrepEvent::Hello { protocol })) if protocol.starts_with("sitrep-"))
 }

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -10,7 +10,8 @@
 //!
 //! Designed for diagnostic mode — the extra loopback round-trip per byte
 //! is fine for an on-demand tap but inappropriate as default. Bridge gates
-//! it behind `HOLE_BRIDGE_PLUGIN_TAP=1`.
+//! it behind either the persistent `diagnostic_plugin_tap` config flag or
+//! the dev-only `HOLE_BRIDGE_PLUGIN_TAP=1` env var.
 //!
 //! Lifecycle:
 //! 1. Allocate an internal port for the inner plugin via probe-and-drop
@@ -270,8 +271,8 @@ async fn drain_inner(plugin_name: &str, inner_handle: tokio::task::JoinHandle<cr
 }
 
 /// Probe-and-drop a free TCP port on `(ip, 0)`. Retries on
-/// `AddrInUse` / `PermissionDenied` (the Windows excluded-port-range
-/// flake) up to [`INNER_PORT_ALLOC_ATTEMPTS`] times.
+/// `AddrInUse` / `PermissionDenied` / `AddrNotAvailable` (the Windows
+/// excluded-port-range flake) up to [`INNER_PORT_ALLOC_ATTEMPTS`] times.
 fn allocate_inner_port(ip: IpAddr) -> io::Result<SocketAddr> {
     let mut last_err: Option<io::Error> = None;
     for _ in 0..INNER_PORT_ALLOC_ATTEMPTS {

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -146,10 +146,9 @@ async fn pid_sink_fires_once_per_binary_plugin() {
     // Single-accept echo: this test only awaits `on_ready` and checks
     // pid counts — it does not send any client traffic. The plugins run
     // in the default `Probe` readiness mode, whose self-probe TCP-connects
-    // to each plugin's OWN listener (not through the chain to the echo),
-    // so the echo accept slot is never even reached here. A single-accept
-    // echo is therefore ample. The sister test
-    // (`two_plugin_chain_relays_data`) does send real client traffic.
+    // to each plugin's OWN listener (not through the chain to the echo).
+    // The sister test (`two_plugin_chain_relays_data`) does send real
+    // client traffic.
     let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let echo_addr = echo_listener.local_addr().unwrap();
     tokio::spawn(async move {

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -119,9 +119,9 @@ pub(crate) enum BridgeAction {
         /// Override the log directory
         #[arg(long)]
         log_dir: Option<std::path::PathBuf>,
-        /// Override the directory where the bridge writes its route-recovery
-        /// state file (`bridge-routes.json`). Default: platform-specific
-        /// user state dir.
+        /// Override the directory where the bridge writes its crash-recovery
+        /// state files (`bridge-routes.json`, `bridge-dns.json`,
+        /// `bridge-plugins.json`). Default: platform-specific user state dir.
         #[arg(long)]
         state_dir: Option<std::path::PathBuf>,
     },
@@ -261,12 +261,11 @@ pub(crate) fn resolve_cli_log_dir(command: &Command) -> Option<std::path::PathBu
 
 /// Dispatch a parsed subcommand to its handler. Exits the process when done.
 ///
-/// For write-action subcommands (Upgrade, Bridge::{Install, Uninstall, Status,
-/// GrantAccess, IpcSend}, and Path), install a CLI log guard so that
+/// For write-action subcommands, install a CLI log guard so that
 /// `cli_log!(...)` calls are recorded in `gui-cli.log` in addition to the
 /// user-facing terminal output. See [`should_install_cli_log_guard`] for
-/// the exemption list and [`resolve_cli_log_dir`] for how the directory is
-/// chosen.
+/// exactly which subcommands are exempted and [`resolve_cli_log_dir`] for
+/// how the directory is chosen.
 pub(crate) fn dispatch(command: Command) -> ! {
     let _cli_log_guard =
         resolve_cli_log_dir(&command).map(|d| hole_common::logging::init(&d, "gui-cli.log", "hole=info"));

--- a/crates/hole/src/cli_log.rs
+++ b/crates/hole/src/cli_log.rs
@@ -1,5 +1,5 @@
-// Shared `cli_log!` macro, used by CLI command paths in both the binary
-// (`main.rs` + `cli.rs`) and the library (`path_management.rs`, `setup.rs`).
+// Shared `cli_log!` macro, used by CLI command paths in the binary
+// (`cli.rs`) and the library (`path_management.rs`, `setup.rs`).
 // Lives in its own file so it can be declared from both `lib.rs` and
 // `main.rs` without the fragile cross-binary sibling-module dance.
 

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -498,10 +498,8 @@ pub async fn get_public_ip(state: State<'_, AppState>) -> Result<serde_json::Val
 
 /// Build a `ProxyConfig` from the currently selected server in app config.
 ///
-/// Always requests [`TunnelMode::Full`] — the GUI does not currently expose
-/// a tunnel-mode toggle, so every GUI-initiated `Start` installs the full
-/// TUN + routing pipeline. `TunnelMode::SocksOnly` is reachable through
-/// `hole proxy start --tunnel-mode socks-only` and through direct IPC.
+/// Always requests [`TunnelMode::Full`]; `TunnelMode::SocksOnly` is reachable
+/// via `hole proxy start --tunnel-mode socks-only` and direct IPC.
 pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
     let selected_id = config.selected_server.as_ref()?;
     let entry = config.servers.iter().find(|s| &s.id == selected_id)?;

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -216,8 +216,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<ToggleO
     // Bridge install gate: if the user is trying to enable the proxy and
     // the bridge isn't installed yet, prompt for installation BEFORE
     // flipping any config state. Cancelling here leaves `config.enabled`
-    // untouched (no rollback needed). Replaces the prior launch-time
-    // install check at `setup::check_bridge_on_launch`.
+    // untouched (no rollback needed).
     if enabled
         && crate::setup::bridge_install_status() == crate::setup::BridgeInstallStatus::NotInstalled
         && !crate::setup::prompt_bridge_install(app.clone()).await

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -1,2 +1,2 @@
-// Tray tests require a full Tauri app context.
-// See E2E tests in tests/webdriver/ for tray behavior coverage.
+//! Tray tests require a full Tauri app context.
+//! See E2E tests in tests/webdriver/ for tray behavior coverage.

--- a/crates/hole/src/update/check.rs
+++ b/crates/hole/src/update/check.rs
@@ -155,7 +155,7 @@ fn fetch_release_for_tag(tag_name: &str) -> Result<Option<GitHubRelease>, Update
 /// Filter and sort tags into candidate versions, highest first.
 ///
 /// A tag is a candidate if:
-/// - It parses as a valid strict semver (`vMAJOR.MINOR.PATCH`).
+/// - It is a hole-track tag (`releases/hole/v<MAJOR.MINOR.PATCH>`), parsed via `parse_hole_tag`.
 /// - Its version is greater than `current`, or equal to `current` when `is_snapshot` is true.
 pub(crate) fn candidate_tags(
     tags: &[GitHubTag],

--- a/crates/hole/src/update/periodic_tests.rs
+++ b/crates/hole/src/update/periodic_tests.rs
@@ -1,1 +1,1 @@
-// Periodic checker is thin plumbing — core logic tested in check_tests.rs.
+//! Periodic checker is thin plumbing — core logic tested in check_tests.rs.

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -88,7 +88,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     // Host-native errno: AddrInUse is 48 on macOS, 98 on Linux, 10048 (WSA)
     // on Windows. The bridge's BindRace mapping sets ErrorKind directly and
-    // ignores this number for classification (see Task 9), so a representative
+    // ignores this number for classification (see `ProxyError::BindRace`
+    // handling in crates/bridge/src/proxy/plugin.rs), so a representative
     // non-zero value is fine — but emit the real host value for diagnostic
     // honesty rather than a hardcoded foreign constant.
     let addr_in_use_errno: i32 = {

--- a/crates/test-observability/src/lib.rs
+++ b/crates/test-observability/src/lib.rs
@@ -159,7 +159,7 @@ pub fn install() {
 
         // Hole's tracing-emitting panic hook. Chains before the
         // stdlib default. Idempotent via its own AtomicBool, so
-        // safe alongside any production caller of `init_logging`.
+        // safe alongside the production caller `init_multi` (which also calls `install_panic_hook`).
         // Gated to Mac/Windows because `hole-common` only compiles
         // on those platforms (see this crate's Cargo.toml); on
         // Linux/etc. (where ex-Galoshes crates get clippy-checked

--- a/crates/tun-engine/src/engine/config.rs
+++ b/crates/tun-engine/src/engine/config.rs
@@ -27,15 +27,6 @@ pub struct EngineConfig {
     /// smoltcp TCP socket transmit buffer (per socket, bytes).
     pub tcp_tx_buf_size: usize,
 
-    /// smoltcp UDP receive metadata slots for the DNS-intercept socket.
-    pub udp_rx_meta_slots: usize,
-    /// smoltcp UDP receive payload size for the DNS-intercept socket (bytes).
-    pub udp_rx_payload_size: usize,
-    /// smoltcp UDP transmit metadata slots for the DNS-intercept socket.
-    pub udp_tx_meta_slots: usize,
-    /// smoltcp UDP transmit payload size for the DNS-intercept socket (bytes).
-    pub udp_tx_payload_size: usize,
-
     /// Interval at which the driver polls smoltcp outside of TUN reads.
     /// Needed because handler-to-driver data arrives via mpsc and would
     /// otherwise wait for an unrelated TUN packet to wake the driver.
@@ -62,10 +53,6 @@ impl Default for MutEngineConfig {
             max_sniffers: 1024,
             tcp_rx_buf_size: 65536,
             tcp_tx_buf_size: 65536,
-            udp_rx_meta_slots: 32,
-            udp_rx_payload_size: 8192,
-            udp_tx_meta_slots: 32,
-            udp_tx_payload_size: 8192,
             poll_interval: Duration::from_millis(1),
             idle_sweep_interval: Duration::from_secs(5),
             udp_flow_idle_timeout: Duration::from_secs(30),

--- a/crates/tun-engine/src/engine/dns.rs
+++ b/crates/tun-engine/src/engine/dns.rs
@@ -3,9 +3,9 @@
 //! Port 53 is special: callers implementing domain-based filtering often
 //! want to answer DNS queries with synthetic IPs so the TCP/UDP flow that
 //! follows can be recognised and routed by domain. Rather than force every
-//! consumer to reimplement packet construction and the smoltcp UDP
-//! short-circuit, the engine exposes this hook: it serves port-53 UDP
-//! inside smoltcp and delegates the actual DNS logic to the caller via
+//! consumer to reimplement packet construction, the engine exposes this
+//! hook: it intercepts port-53 UDP datagrams off the TUN before smoltcp
+//! sees them and delegates the actual DNS logic to the caller via
 //! [`DnsInterceptor::intercept`].
 
 use async_trait::async_trait;
@@ -15,9 +15,9 @@ use async_trait::async_trait;
 /// For each inbound UDP datagram destined for port 53, the engine calls
 /// `intercept(request)`:
 ///
-/// - `Some(reply)` → the engine emits `reply` as the UDP response and does
-///   not forward the request to the Router. The bytes are injected via
-///   smoltcp's UDP socket so the kernel sees a normal DNS reply.
+/// - `Some(reply)` → the engine builds a raw IP+UDP reply packet (5-tuple
+///   swapped, checksummed) and writes it straight to the TUN so the kernel
+///   sees a normal DNS reply, without forwarding the request to the Router.
 /// - `None` → the engine passes the datagram through to `Router::route_udp`
 ///   like any other UDP flow.
 #[async_trait]

--- a/msi-installer/src/msi_installer/__init__.py
+++ b/msi-installer/src/msi_installer/__init__.py
@@ -54,11 +54,10 @@ def cargo_build(console: Console) -> None:
 def stage_files(root: Path, stage_dir: Path, console: Console) -> None:
     """Stage the runnable BINDIR via `cargo xtask stage`.
 
-    The canonical list of files (hole.exe + ex-ray.exe + wintun.dll on
-    Windows) lives in `xtask/src/bindir.rs::bindir_files()`. dev.py and this
-    function both call into the same xtask subcommand, so adding a new BINDIR
-    file is a one-line change in xtask and both consumers pick it up
-    automatically. See issue #143.
+    The canonical list of files lives in `xtask/src/bindir.rs`
+    (`bindir_files()`). dev.py and this function both call into the same xtask
+    subcommand, so adding a new BINDIR file is a one-line change in xtask and
+    both consumers pick it up automatically. See issue #143.
     """
     console.print(f"[bold]Staging installer files[/] to {stage_dir} (via cargo xtask stage)")
     result = subprocess.run(

--- a/msi-installer/tests/test_hole_msi.py
+++ b/msi-installer/tests/test_hole_msi.py
@@ -32,9 +32,7 @@ def staged_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     relocated-extract test (#357) has files to find post-extraction.
     """
     d = tmp_path_factory.mktemp("stage")
-    # hole.pdb shipped alongside hole.exe for symbolicated panic
-    # backtraces — see bindreams/hole#393. Mirrors the bindir layout
-    # produced by `cargo xtask stage`.
+    # Mirror the bindir layout from `cargo xtask stage` (hole.exe + hole.pdb + ex-ray.exe + wintun.dll + NOTICES.md).
     for name in ("hole.exe", "hole.pdb", "ex-ray.exe", "wintun.dll", "NOTICES.md"):
         (d / name).write_bytes(b"x" * 1024)
     return d

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -1,6 +1,6 @@
 """Static validation tests for hole.wxs.
 
-Parse the WiX v6 source and verify structural correctness without building.
+Parse the WiX source (hole.wxs) and verify structural correctness without building.
 """
 
 import re

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -15,11 +15,11 @@ and the GUI so they read your real ~/Library config, while the bridge
 inherits root. On Windows, UAC is token-based so all three inherit the
 elevated token without an identity change.
 
-The bridge binary and its v2ray-plugin sidecar are staged in a per-pid
-subdirectory under the system temp dir (`$TMPDIR/hole-dev-<pid>/` or
+The bridge binary and its sidecars (ex-ray, galoshes) are staged in a
+per-pid subdirectory under the system temp dir (`$TMPDIR/hole-dev-<pid>/` or
 `%TEMP%\hole-dev-<pid>\`) so they sit side-by-side under their canonical
 names — same layout as the installed MSI in `Program Files\hole\bin\`.
-This is what `resolve_plugin_path_inner` (crates/bridge/src/proxy.rs)
+This is what `resolve_plugin_path_inner` (crates/bridge/src/proxy/config.rs)
 expects, and it isolates concurrent dev.py runs from each other.
 
 Dev uses the production IPC permission path: `hole bridge grant-access`
@@ -118,7 +118,7 @@ def ensure_node_modules(npm: str, target_user: tuple[int, int, str, str] | None)
 def cargo_build(cargo: str, target_user: tuple[int, int, str, str] | None) -> None:
     """Build the `hole` target via the orchestrator.
 
-    `cargo xtask build hole` walks the build.yaml DAG: v2ray-plugin → galoshes
+    `cargo xtask build hole` walks the build.yaml DAG: ex-ray → galoshes
     + wintun → cargo build (debug) → stage. Replaces the prior `cargo xtask
     deps` + `cargo build` sequence with a single declarative invocation. The
     per-pid stage that follows in main() is dev.py-specific and stays separate.

--- a/ui/connection-state.ts
+++ b/ui/connection-state.ts
@@ -4,7 +4,7 @@
 // ConnectionFailed, DisconnectionFailed) and three transition states
 // (Connecting, Disconnecting, Cancelling). This module owns the state
 // type, the text/CSS mapping, and the small set of predicates that the
-// DOM-wiring layer (`sidebar.ts`) uses to decide what to render.
+// DOM-wiring layer (`power-button.ts`) uses to decide what to render.
 //
 // The transition graph and rationale (idle states, transitions,
 // backend-cooperative cancellation) is documented in this file's
@@ -39,9 +39,8 @@ export const TRANSITION_STATES = new Set<ConnectionState>(["connecting", "discon
 export type ToggleOutcome = "running" | "stopped" | "cancelled";
 
 /// True if the UI represents the proxy as "running" for the user — i.e.
-/// clicking the button should initiate a disconnect. Includes the
-/// optimistic Running state and the DisconnectionFailed state (where the
-/// proxy is still up because a stop failed).
+/// clicking the button should initiate a disconnect. True for `connected`
+/// and for `disconnection-failed` (proxy still up because a stop failed).
 export function isEffectivelyOn(state: ConnectionState): boolean {
   return state === "connected" || state === "disconnection-failed";
 }

--- a/ui/country-flag.test.ts
+++ b/ui/country-flag.test.ts
@@ -69,8 +69,8 @@ describe("setCountryFlag", () => {
   });
 
   // The PublicIpData type at ui/types.ts:92 says `country_code: string`,
-  // but the backend's ipinfo.io fallback at crates/hole/src/commands.rs:483
-  // is `body["country"].as_str().unwrap_or("??")` — a null upstream would
+  // but the backend's ipinfo.io `body["country"].as_str().unwrap_or("??")`
+  // fallback in crates/hole/src/commands.rs — a null upstream would
   // still produce "??", but defense in depth.
   // biome-ignore lint/suspicious/noExplicitAny: cast through to test the runtime guard
   it("null / undefined: same as '??'", () => {

--- a/ui/toggle-flow.ts
+++ b/ui/toggle-flow.ts
@@ -1,6 +1,6 @@
-// Orchestration for the power-button toggle flow. Extracted from
-// sidebar.ts so the IPC-call + state-transition logic is unit-testable
-// without DOM scaffolding. sidebar.ts owns the DOM and wires
+// Orchestration for the power-button toggle flow, separated from DOM
+// wiring so the IPC-call + state-transition logic is unit-testable
+// without DOM scaffolding. power-button.ts owns the DOM and wires
 // `handlePowerClick` to call `toggleFromIdle` with a deps object
 // assembled from local state. See bindreams/hole#397 (sub-bug C) for
 // the timer-removal context and #393 for the failure-toast extraction
@@ -27,7 +27,7 @@ export interface ToggleDeps {
   /// Read the current `ConnectionState`. Used by the cancel-raced-with-
   /// success branch to detect whether the user clicked Cancel mid-start.
   getState(): ConnectionState;
-  /// Apply a new `ConnectionState`. sidebar.ts threads this into its
+  /// Apply a new `ConnectionState`. power-button.ts threads this into its
   /// DOM repaint pipeline.
   setState(next: ConnectionState): void;
   /// Refresh the displayed public IP. Awaited fire-and-forget at the

--- a/xtask-lib/src/lib.rs
+++ b/xtask-lib/src/lib.rs
@@ -3,10 +3,10 @@
 //! can depend on it as a build-dependency without dragging in `xtask`'s
 //! clap/glob/ureq machinery.
 //!
-//! See issue #143 for the motivation: version computation was previously
-//! duplicated across `crates/hole/build.rs::compute_git_version`,
-//! `msi-installer/src/msi_installer/__init__.py::get_version`, and
-//! `scripts/check-version.py`. This crate is the single source of truth.
+//! See issue #143 for the motivation. This crate is the single source of
+//! truth for group-aware version computation, shared by `crates/hole/build.rs`
+//! and `xtask` (`cargo xtask version`) instead of being reimplemented per
+//! consumer.
 
 pub mod ex_ray_version;
 pub mod version;

--- a/xtask-lib/src/test_support.rs
+++ b/xtask-lib/src/test_support.rs
@@ -20,7 +20,7 @@ pub(crate) fn init_git_repo(root: &Path) {
     git(root, &["commit", "--quiet", "-m", "init"]);
 }
 
-/// Create an annotated tag at HEAD in the repo at `root`.
+/// Create a lightweight tag at HEAD in the repo at `root`.
 pub(crate) fn create_tag(root: &Path, tag: &str) {
     let s = Command::new("git")
         .args(["tag", tag])

--- a/xtask-lib/src/version_tests.rs
+++ b/xtask-lib/src/version_tests.rs
@@ -425,8 +425,8 @@ fn multi_component_bump_rejected() {
 
 // validate_against_tag ================================================================================================
 //
-// These tests exercise the bootstrap path (no tag yet) since we cannot
-// easily create real tags inside a tempdir without spawning git init.
+// These cover the bootstrap (no-tag) path; the tagged/exact paths are
+// exercised in ex_ray_version_tests.rs via create_tag().
 // The error path (--exact without a tag) is structural and worth pinning.
 
 #[skuld::test]

--- a/xtask/src/bindir.rs
+++ b/xtask/src/bindir.rs
@@ -2,7 +2,7 @@
 //!
 //! **This is the single source of truth.** Adding a new file that must sit
 //! next to `hole.exe` is one line in `bindir_files()` below — both
-//! `scripts/dev.py` and `msi-installer/__init__.py:stage_files()` call into
+//! `scripts/dev.py` and `msi-installer/src/msi_installer/__init__.py:stage_files()` call into
 //! this via `cargo xtask stage`, so they pick it up automatically.
 //!
 //! See issue #143 for the motivation.

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -356,7 +356,7 @@ targets:
 fn target_with_no_run_steps_is_legal() {
     // The `run:` field is optional. Targets without it deserialize with an
     // empty `Vec<Step>`. `cargo xtask run X` will reject these at invocation
-    // time (orchestrate_tests::run_run_errors_on_empty_run pins that), but
+    // time (orchestrate_tests::execute_run_errors_on_empty_run pins that), but
     // the manifest itself accepts them.
     let m = parse(
         r"


### PR DESCRIPTION
@
PR1 of the repo-wide comment/docstring audit (#427). **Correctness only** — the style/trim pass (verbose + too-specific) follows as a separate PR.

## What changed

- **93 stale** comment/docstring fixes — comments rewritten to match current code. Highlights:
  - state-dir docs named only `bridge-routes.json`; now name all three recovery files
  - nonexistent `route_state.rs` / `route_state::save` → `tun_engine::routing::state`
  - genuinely-stale embedded-binary `v2ray-plugin` → `ex-ray` (#414) in galoshes/dev.py/ex-ray (wire-protocol & config-name references left untouched)
  - renamed symbols/tests: `apply_dns_settings`→`Dns::apply`, `start_ss`→`MockProxy::start`, dead test-name cross-refs, `init_logging`→`init_multi`, `compute_git_version` removal, etc.
  - wrong constants/values (`i64`→`i128`, 2 s→800 ms, daily→size rotation, WiX v6→v7), wrong file pointers, brittle line-number anchors dropped
- **13 misplaced** fixes — module-purpose `//` → `//!`; a few comment↔docstring relocations.
- **Dead-code removal** (root cause of stale comments): the 4 unused `udp_*` `EngineConfig` fields (described a nonexistent smoltcp DNS socket), the unused `PriorSnapshot` struct, and the dead `apply_loopback` free-fn + its `AppliedAdapter` type, with ripple edits to `clippy.toml` and the `Dns` trait / module docs. Verified zero remaining references; `capture_adapters`/`restore_all`/`restore_adapter` kept (live).

Governing rule: *trim history, keep the why* — git blame is the authoritative provenance.

## Verification

`cargo clippy --workspace --all-targets` ✅ · `cargo doc` (broken-intra-doc-links denied) ✅ · `prek` (cargo fmt, biome, mdformat, yapf, section-comments) ✅ · `golangci-lint run` on ex-ray → 0 issues ✅. Independent `review` agent: clean (two findings fixed: restored a dropped direct-IPC mention; reverted a `log.go` BSD license-header deletion — see below).

## Notes for review

- The `crates/ex-ray/log.go` "Go Authors / BSD" header deletion the audit proposed was **reverted** — removing a copyright/license header is a licensing decision, not a comment edit, and the header is ambiguous (it cites a "BSD LICENSE file" while ex-ray ships Apache-2.0). Leaving it for a deliberate call.
- `garter::tap::allocate_inner_port` has a pre-existing capped retry loop (not introduced here; only its doc was corrected). Same family as the `port_alloc` "no budget" doctrine / #424 — flagging, not fixing in a comment PR.

Related: #424 (belt-and-suspenders dead code — distinct scope, disjoint dead-code lists). A separate follow-up will track the `ui/power-button.test.ts` contradictory test.
@