### PR TITLE
test(ui): drive real connection-failed state in power-button retry test (#432)

### DIFF
--- a/ui/power-button.test.ts
+++ b/ui/power-button.test.ts
@@ -64,21 +64,55 @@ describe("power-button state machine", () => {
   });
 
   it("click from `connection-failed` starts a fresh connect (retry path)", async () => {
-    // `connection-failed` is an idle state. `isEffectivelyOn` returns
-    // false → goingToConnect is true → another Start is attempted.
-    invokeMock.mockReturnValue(new Promise(() => {}));
-    const { initPowerButton, updateProxyStatus, getConnectionState } = await import("./power-button");
+    // `connection-failed` has no public setter — it is only ever reached
+    // by a `toggle_proxy` rejection on the connect path (the catch arm in
+    // toggleFromIdle: disconnected → connecting → connection-failed). So
+    // we drive the genuine failure first, then exercise the retry click,
+    // rather than synthesizing the state with a back-door setter that
+    // would bypass the production transition.
+    //
+    // First click: toggle_proxy rejects → the component lands in
+    // `connection-failed`. We hold the rejecting promise ourselves so we
+    // can await its settlement deterministically (no timeout-bounded poll).
+    let rejectToggle!: (reason: unknown) => void;
+    const firstToggle = new Promise<never>((_, reject) => {
+      rejectToggle = reject;
+    });
+    invokeMock.mockReturnValueOnce(firstToggle);
+    const { initPowerButton, getConnectionState } = await import("./power-button");
     initPowerButton();
-    // connection-failed and disconnected are both idle states where
-    // isEffectivelyOn() is false, so a click drives the same connect path.
-    updateProxyStatus({ running: false }); // ensures state is `disconnected`
-    expect(getConnectionState()).toBe("disconnected");
     document.getElementById("power-btn")!.click();
+    // Synchronous prelude ran: setState("connecting"), then parked on the
+    // `await invoke("toggle_proxy")`.
     await Promise.resolve();
     expect(getConnectionState()).toBe("connecting");
-    // toggle_proxy was fired (not cancel_proxy).
+
+    // Reject the in-flight toggle_proxy and wait for the production catch
+    // arm (which is registered ahead of this awaited continuation) to run
+    // setState("connection-failed"). Awaiting the same settled promise is
+    // a deterministic rendezvous, not a sleep.
+    rejectToggle("connect failed");
+    await firstToggle.catch(() => {});
+    await Promise.resolve();
+    expect(getConnectionState()).toBe("connection-failed");
+
+    // The first toggle_proxy attempt happened and failed; clear the call
+    // log so the retry assertion sees only the retry's invoke.
+    invokeMock.mockReset();
+    // Retry click: `connection-failed` is an idle state with
+    // `isEffectivelyOn` false → goingToConnect is true → a fresh Start is
+    // attempted. The second toggle_proxy never resolves so the component
+    // parks in `connecting`.
+    invokeMock.mockReturnValue(new Promise(() => {}));
+    document.getElementById("power-btn")!.click();
+    await Promise.resolve();
+
+    expect(getConnectionState()).toBe("connecting");
+    // The retry fired toggle_proxy (a fresh connect), not cancel_proxy.
     const toggleCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "toggle_proxy");
     expect(toggleCalls).toHaveLength(1);
+    const cancelCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "cancel_proxy");
+    expect(cancelCalls).toHaveLength(0);
   });
 
   it("click from `disconnection-failed` starts a stop (isEffectivelyOn returns true)", async () => {


### PR DESCRIPTION
@
Fixes #432 — the follow-up surfaced by the comment audit (#427), kept separate so the audit PRs stay comment-only.

## Problem

`ui/power-button.test.ts`s test "click from `connection-failed` starts a fresh connect (retry path)" never touched `connection-failed`: a comment admitted there was no setter for the failed state, so the body drove through `disconnected` and asserted on that instead. The name claimed coverage the test did not provide.

## Fix

Test-only change (+43/−14, no production source touched). Rather than add a synthetic state-setter seam — which would *bypass* the production transition — the test now drives the **genuine** path into `connection-failed`: a `toggle_proxy` rejection on the connect path (`disconnected → connecting → connection-failed`), then a retry click, asserting it fires a fresh `toggle_proxy` (not `cancel_proxy`). This mirrors the sibling `disconnection-failed` tests "reach real states through real wiring" style.

The settlement is a deterministic rendezvous — the test owns the rejecting promises `reject` and awaits the settled promise (the production catch arm is registered before the awaited continuation). No `vi.waitFor`/timeout/sleep, per the no-sleep-for-sync invariant.

Mutation-checked: flipping `isEffectivelyOn` to include `connection-failed` (the exact retry bug this guards) fails only the retry-click assertion.

## Verification

`npm run check` (tsc --noEmit) clean · focused `npx vitest run ui/power-button.test.ts` 7/7 · full `npm test` 82/82 · `cargo xtask run frontend-check` green.

Note: trivially conflicts with #431 (the audit style pass) which trimmed an unrelated comment in this file; resolve at merge.
@