### PR TITLE
chore(release): bump hole to 0.3.0 and galoshes to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dump"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "dump-macros",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "dump-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "dump",
  "hole-test-observability",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "galoshes"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "handle-holders"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hole-test-observability",
  "skuld",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "hole"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "hole-bridge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "hole-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "dirs 6.0.0",
  "file-rotate",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "hole-test-observability"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ctor 1.0.6",
  "hole-common",
@@ -7920,7 +7920,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7947,7 +7947,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hole-test-observability",
  "proc-macro2",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-bridge"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-common"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump-macros"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the dump crate (provides #[derive(Dump)])."

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 description = "YAML-shaped representation for logging, analogous to Python's dump() alongside str()/repr()."

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "galoshes"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handle-holders"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-test-observability"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license = "GPL-3.0-or-later"
 publish = false

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine-macros"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the tun-engine crate (provides #[freeze])."

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 description = "Cross-platform TUN device, OS routing, gateway discovery, and a smoltcp-backed packet-loop engine for building split-tunnel VPN/proxy daemons."


### PR DESCRIPTION
Closes #441 (the version-bump step).

Prepares the **hole** and **galoshes** release tracks for cutting. The other two tracks are already at their target versions and need no change.

| Track | From | To | Bumped here? |
|---|---|---|---|
| hole (9 crates) | 0.2.0 | **0.3.0** | ✅ |
| galoshes | 0.1.1 | **0.2.0** | ✅ |
| garter | 0.2.0 | 0.3.0 | already bumped in #420 |
| ex-ray | — | 0.1.0 | already at first-release version |

## Why these versions
- **hole → 0.3.0 (minor)**: 13 commits since v0.2.0 including features — crash observability (#440), first-party ex-ray replacing vendored v2ray-plugin (#414), import-parser improvements (#385) — plus DNS-hijack and cooperative-cancellation fixes. The prior 0.1.1→0.2.0 bump was minor for fixes alone, so a release carrying actual features clearly merits a minor.
- **galoshes → 0.2.0 (minor)**: new bidirectional client UDP relay with NAT associations (#415/#417), sitrep readiness output, ex-ray embedding, crash observability.

## Changes
- 9 hole-group manifests `0.2.0 → 0.3.0`; `galoshes` manifest `0.1.1 → 0.2.0`; `Cargo.lock` regenerated.
- `cargo xtask version --check` passes for all four groups (hole 0.3.0, galoshes 0.2.0, garter 0.3.0, ex-ray 0.1.0).

## Next steps (after merge)
Run each track's draft → publish release workflow pair (per the engineer/boss split): hole, galoshes, garter, ex-ray.