### PR TITLE
fix(dns): stamp DNS_INTERFACE_SETTINGS Version=V1 to fix OOB FFI access (#437)

### DIFF
--- a/crates/bridge/src/dns/system/windows.rs
+++ b/crates/bridge/src/dns/system/windows.rs
@@ -52,8 +52,8 @@ use windows::core::{GUID, PCWSTR, PWSTR};
 use windows::Win32::Foundation::{ERROR_SUCCESS, WIN32_ERROR};
 use windows::Win32::NetworkManagement::IpHelper::{
     ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToGuid, FreeInterfaceDnsSettings, GetInterfaceDnsSettings,
-    SetInterfaceDnsSettings, DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS_VERSION3, DNS_SETTING_IPV6,
-    DNS_SETTING_NAMESERVER,
+    SetInterfaceDnsSettings, DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS3, DNS_INTERFACE_SETTINGS_VERSION1,
+    DNS_SETTING_IPV6, DNS_SETTING_NAMESERVER,
 };
 use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
@@ -242,16 +242,42 @@ fn alias_to_guid(alias: &str) -> io::Result<Option<GUID>> {
     Ok(Some(guid))
 }
 
+/// The `Version` stamped into every `DNS_INTERFACE_SETTINGS` this module
+/// hands to the OS. **Must be `VERSION1`.** windows-rs models all three DNS
+/// FFIs (`GetInterfaceDnsSettings` / `SetInterfaceDnsSettings` /
+/// `FreeInterfaceDnsSettings`) as taking the V1 `DNS_INTERFACE_SETTINGS`
+/// (64 bytes), and Windows sizes the buffer it reads/writes **solely** from
+/// this field — there is no length parameter. Stamping any higher version
+/// makes the OS access the larger `DNS_INTERFACE_SETTINGS3` (112-byte)
+/// layout off the end of our V1 stack allocation: the 48-byte out-of-bounds
+/// FFI access of bindreams/hole#437.
+const SETTINGS_VERSION: u32 = DNS_INTERFACE_SETTINGS_VERSION1;
+
+/// Compile-time pin of the *premise* behind [`SETTINGS_VERSION`]: the V1
+/// `DNS_INTERFACE_SETTINGS` (the type the DNS FFIs accept) is strictly
+/// smaller than `DNS_INTERFACE_SETTINGS3`. Because `Version` is the only
+/// size signal, that size gap is exactly why stamping a version above V1
+/// over-reads/over-writes our V1 allocation (#437). This fails the build if
+/// a windows-rs bump ever makes the layouts equal; it does NOT guard the
+/// stamped value — the `empty_settings_always_stamps_version1` test does.
+const _: () = assert!(std::mem::size_of::<DNS_INTERFACE_SETTINGS>() < std::mem::size_of::<DNS_INTERFACE_SETTINGS3>());
+
 /// Build an empty `DNS_INTERFACE_SETTINGS` with `Version` set and
 /// `Flags` populated to indicate "the `NameServer` field is meaningful".
 /// `ipv6` controls the `DNS_SETTING_IPV6` flag (selects v6 vs v4).
+///
+/// Always the V1 layout — the only one windows-rs's DNS FFI signatures
+/// accept; see [`SETTINGS_VERSION`] for why `Version` must be `VERSION1`.
+/// Fields are listed explicitly (rather than `..Default::default()`) so a
+/// future windows-rs change to the V1 layout breaks this constructor at
+/// compile time instead of being silently absorbed.
 fn empty_settings(ipv6: bool) -> DNS_INTERFACE_SETTINGS {
     let mut flags: u64 = DNS_SETTING_NAMESERVER as u64;
     if ipv6 {
         flags |= DNS_SETTING_IPV6 as u64;
     }
     DNS_INTERFACE_SETTINGS {
-        Version: DNS_INTERFACE_SETTINGS_VERSION3,
+        Version: SETTINGS_VERSION,
         Flags: flags,
         Domain: PWSTR::null(),
         NameServer: PWSTR::null(),
@@ -276,9 +302,13 @@ fn empty_settings(ipv6: bool) -> DNS_INTERFACE_SETTINGS {
 /// on consumer setups). This is best-effort.
 fn get_one(guid: GUID, ipv6: bool) -> io::Result<DnsPrior> {
     let mut settings = empty_settings(ipv6);
-    // SAFETY: `settings` is an owned `DNS_INTERFACE_SETTINGS` whose
-    // address is valid for the call. The OS writes a fresh `NameServer`
-    // string we must free via `FreeInterfaceDnsSettings`.
+    // SAFETY: `settings` is an owned V1 `DNS_INTERFACE_SETTINGS` whose
+    // address is valid for the call. `empty_settings` stamps
+    // `SETTINGS_VERSION` (V1), matching the 64-byte buffer we allocate, so
+    // the OS reads/writes exactly those 64 bytes (a higher version would
+    // write the larger V3 layout off the end — bindreams/hole#437). The OS
+    // writes a fresh `NameServer` string we must free via
+    // `FreeInterfaceDnsSettings`.
     // The `disallowed_methods` ban on `GetInterfaceDnsSettings` exists
     // so that nothing outside `Win32Real` reaches around the
     // `WinDnsBackend` test seam (bindreams/hole#397). This module IS
@@ -305,9 +335,10 @@ fn get_one(guid: GUID, ipv6: bool) -> io::Result<DnsPrior> {
             }
         }
     };
-    // SAFETY: `settings` was filled by `GetInterfaceDnsSettings` above.
-    // `FreeInterfaceDnsSettings` is the documented counterpart that
-    // frees PWSTRs allocated by the get call.
+    // SAFETY: `settings` is the same 64-byte V1 buffer, populated by the V1
+    // `GetInterfaceDnsSettings` call above; the OS returns a V1-layout
+    // struct, so `FreeInterfaceDnsSettings` (also V1) frees the PWSTRs that
+    // call allocated and its walk stays inside our allocation.
     unsafe { FreeInterfaceDnsSettings(&mut settings) };
     Ok(result)
 }
@@ -336,9 +367,11 @@ fn set_one(guid: GUID, ipv6: bool, prior: &DnsPrior) -> io::Result<()> {
     };
     let mut wide: Vec<u16> = nameserver_string.encode_utf16().chain(std::iter::once(0)).collect();
     settings.NameServer = PWSTR(wide.as_mut_ptr());
-    // SAFETY: `settings` and `wide` outlive the FFI call. The OS reads
-    // `Version` first to interpret the struct; we always pass
-    // `DNS_INTERFACE_SETTINGS_VERSION3`.
+    // SAFETY: `settings` and `wide` outlive the FFI call. `empty_settings`
+    // stamps `SETTINGS_VERSION` (V1); the OS reads `Version` to size the
+    // buffer it interprets, so passing V1 — matching the 64-byte V1
+    // allocation — makes it read exactly those 64 bytes (a higher version
+    // would over-read into the larger V3 layout — bindreams/hole#437).
     // Sanctioned `disallowed_methods` site — see `get_one` for the
     // rationale; the rule exists to keep the FFI inside `Win32Real`.
     #[allow(clippy::disallowed_methods)]

--- a/crates/bridge/src/dns/system/windows_tests.rs
+++ b/crates/bridge/src/dns/system/windows_tests.rs
@@ -335,3 +335,37 @@ async fn drop_invokes_sync_fallback_when_shutdown_skipped() {
         "Drop must invoke flush after sync-fallback restore"
     );
 }
+
+// empty_settings contract (regression: bindreams/hole#437) ============================================================
+//
+// CONTRACT PINS, not OOB detectors. The original 48-byte out-of-bounds FFI
+// access is NOT observable from a unit test: `MockBackend` substitutes at
+// the `WinDnsBackend` level — ABOVE `empty_settings` and the real Win32 FFI
+// — so no unit test reaches the corrupting path. These pin the constructor's
+// contract (the layer that carried the bug); the
+// `const _: () = assert!(size_of::<V1>() < size_of::<V3>())` guard in
+// windows.rs is the compile-time companion.
+
+use windows::Win32::NetworkManagement::IpHelper::{
+    DNS_INTERFACE_SETTINGS_VERSION1, DNS_SETTING_IPV6, DNS_SETTING_NAMESERVER,
+};
+
+#[skuld::test]
+fn empty_settings_always_stamps_version1() {
+    // #437: stamping VERSION3 onto the 64-byte V1 allocation was the OOB.
+    // windows-rs models all three DNS FFIs as taking the V1 struct, so V1
+    // is the only version that matches the buffer we allocate.
+    assert_eq!(super::empty_settings(false).Version, DNS_INTERFACE_SETTINGS_VERSION1);
+    assert_eq!(super::empty_settings(true).Version, DNS_INTERFACE_SETTINGS_VERSION1);
+}
+
+#[skuld::test]
+fn empty_settings_flags_select_family() {
+    let v4 = super::empty_settings(false).Flags;
+    assert_ne!(v4 & DNS_SETTING_NAMESERVER as u64, 0, "NAMESERVER must always be set");
+    assert_eq!(v4 & DNS_SETTING_IPV6 as u64, 0, "v4 must not set the IPV6 flag");
+
+    let v6 = super::empty_settings(true).Flags;
+    assert_ne!(v6 & DNS_SETTING_NAMESERVER as u64, 0, "NAMESERVER must always be set");
+    assert_ne!(v6 & DNS_SETTING_IPV6 as u64, 0, "v6 must set the IPV6 flag");
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent **silent native crash** on Windows full-tunnel start (#437).

`crates/bridge/src/dns/system/windows.rs::empty_settings()` built the 64-byte **V1** `DNS_INTERFACE_SETTINGS` but stamped `Version = DNS_INTERFACE_SETTINGS_VERSION3`. All three FFIs it feeds — `GetInterfaceDnsSettings`, `SetInterfaceDnsSettings`, `FreeInterfaceDnsSettings` — take the V1 type, and Windows sizes the buffer it reads/writes **solely** from the `Version` field (there is no length parameter). So `Version=3` told the OS to treat our 64-byte stack allocation as the 112-byte `DNS_INTERFACE_SETTINGS3` layout → a **48-byte out-of-bounds** access. Capture (`Get`) does an OOB write; apply (`Set`) reads uninitialized trailing pointer slots and may dereference them. A native fault here bypasses Rust's panic hook, so it surfaced as a silent disappearance mid-Phase-7 `dns.apply`.

Verified against `windows-0.62.2`: V1 = 64 bytes (10 fields), V3 = 112 bytes (6 extra trailing fields = the 48-byte differential); `empty_settings` is the **sole** constructor, so one fix covers capture, apply, and the crash-recovery restore path.

## The fix

- Stamp `DNS_INTERFACE_SETTINGS_VERSION1`. The version now lives in one named const `SETTINGS_VERSION` (documented as the only sound value, since the windows-rs FFI parameter type *is* the V1 struct).
- `const _: () = assert!(size_of::<DNS_INTERFACE_SETTINGS>() < size_of::<DNS_INTERFACE_SETTINGS3>())` — compile-time pin of the size premise (V1 < V3 is *why* a higher version over-reads); breaks the build if a future windows-rs bump collapses the layouts.
- Keep the constructor's fields **explicit** (not `..Default::default()`) so a future windows-rs change to the V1 layout fails the build instead of being silently absorbed.
- Correct the three SAFETY comments (the `set_one` one previously claimed "we always pass `DNS_INTERFACE_SETTINGS_VERSION3`").
- Regression tests: `empty_settings_always_stamps_version1` (the guard — was red `3 != 1`, now green) + `empty_settings_flags_select_family`.

## Robustness notes (the deeper ask)

A workspace audit of all 34 unsafe/FFI sites in `bridge` + `tun-engine` found **only #437** carried this defect — the unsafe is, in aggregate, careful. The bug was a wrong *value* fed to a sound call, not an oversized `unsafe` block (each is already a single irreducible FFI call), so the hardening constrains the value at its single construction site rather than narrowing the blocks.

Two earlier-proposed guards were **deliberately cut as dead/speculative** (per adversarial plan-review + the repo's "no dead defense layers" rule): a pre-FFI `debug_assert_eq!` (would check a value `empty_settings` set two lines up — can't fire) and a `Version` re-stamp before `FreeInterfaceDnsSettings` (once construction is V1 the whole path is V1-consistent; a re-stamp would rest on undocumented OS behavior).

The ETW `EVENT_TRACE_PROPERTIES` sites (`diagnostics/etw.rs`, `etw_sweep.rs`) were audited and verified **not** the same class — they're sized by `Wnode.BufferSize` (a length field, not a version selector; no versioned variant; zero-init buffers) — so they're correctly out of scope, not deferred. macOS is unaffected (uses `networksetup`).

## Verification

- `empty_settings_always_stamps_version1` confirmed RED (`3 != 1`) before the fix, GREEN after.
- `cargo clippy -p hole-bridge --all-targets -- -D warnings` — clean.
- `cargo nextest run -p hole-bridge dns` — 30/30 pass; new tests confirmed enumerated in the default (`package(hole-bridge)`) set CI runs.
- Adversarial workflow + `plan-review` + `review` agents: no remaining issues.

Closes #437
