### PR TITLE
ci(dmg): build the DMG once and surface the hdiutil flake (#446)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -479,14 +479,39 @@ jobs:
       - uses: astral-sh/setup-uv@v8.1.0
       - uses: ./.github/actions/setup-build
 
-      # `npx tauri build` (under `hole-dmg`) runs `npm install` itself via
-      # `beforeBuildCommand` in tauri.conf.json. Node.js is provided by
-      # `setup-build` above. See bindreams/hole#372.
-      - name: Build DMG
-        run: cargo xtask build hole-dmg
-
-      - name: Test DMG signing
+      # One build+test via the run-cascade (builds hole-dmg once, then the
+      # signing pytest). A separate `build hole-dmg` step would double-roll the
+      # flaky bundle_dmg.sh/hdiutil pipeline. See #446.
+      - name: Build DMG and test signing
         run: cargo xtask run hole-dmg-tests
+
+      # hdiutil DMG creation/mounting is a non-deterministic macOS
+      # DiskArbitration race; capture system state on any failure (build or the
+      # pytest mount) to diagnose the next occurrence (#446). `--last 30m` spans
+      # the job's whole lifetime (timeout-minutes: 30).
+      - name: Capture DiskArbitration/hdiutil state on failure
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          OUT="$RUNNER_TEMP/dmg-flake-diag"
+          mkdir -p "$OUT"
+          hdiutil info    > "$OUT/hdiutil-info.txt" 2>&1
+          ls -la /Volumes > "$OUT/volumes.txt"      2>&1
+          mount           > "$OUT/mount.txt"        2>&1
+          log show --last 30m --predicate \
+            'process == "diskarbitrationd" OR process == "diskimagesiod" OR process == "mds" OR process == "mds_stores"' \
+            > "$OUT/diskarb-log.txt" 2>&1
+          echo "captured DMG-flake diagnostics to $OUT"
+
+      - name: Upload DMG flake diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dmg-flake-diag-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/dmg-flake-diag/**
+          if-no-files-found: ignore
+          retention-days: 14
 
   # Renovate npm safety gate: builds the Vite bundle (via `cargo xtask build
   # frontend-build`) and type-checks (via `cargo xtask run frontend-check`,

--- a/build.yaml
+++ b/build.yaml
@@ -111,7 +111,8 @@ targets:
     # exists before `npx tauri build` runs — see the frontend-build note.
     depends: [galoshes, frontend-build]
     platforms: [darwin/amd64, darwin/arm64]
-    build: npx tauri build
+    # `-v` surfaces the hdiutil stderr tauri-bundler otherwise swallows (#446).
+    build: npx tauri build -v
 
   hole-dmg-tests:
     # Pytest harness that asserts the produced .app's code signature is

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::manifest::*;
+use crate::orchestrate::Plan;
 
 fn parse(yaml: &str) -> anyhow::Result<Manifest> {
     Manifest::parse(yaml)
@@ -725,6 +726,33 @@ fn frontend_build_target_shape() {
     // pin both as load-bearing.
     assert_eq!(t.depends, Vec::<String>::new());
     assert!(!t.has_run());
+}
+
+#[skuld::test]
+fn hole_dmg_tests_builds_dmg_once() {
+    // CI runs `cargo xtask run hole-dmg-tests` as the single DMG build+test
+    // step; pin the shape and the resolved build order so an edit can't
+    // re-split it into a double build.
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+
+    let t = m.get("hole-dmg-tests").expect("hole-dmg-tests target missing");
+    assert_eq!(t.depends, vec!["hole-dmg".to_string()]);
+    assert!(
+        t.build.is_empty(),
+        "hole-dmg-tests builds nothing itself — the DMG comes from its hole-dmg dep"
+    );
+    assert!(t.has_run(), "hole-dmg-tests must declare the signing pytest as run:");
+
+    let plan = Plan::new(&m).expect("plan builds from production manifest");
+    let order = plan
+        .order_for(&["hole-dmg-tests"], Platform::new(Os::Darwin, Arch::Amd64))
+        .expect("hole-dmg-tests applies to darwin/amd64");
+    assert_eq!(
+        order.iter().filter(|&&n| n == "hole-dmg").count(),
+        1,
+        "run cascade must build hole-dmg exactly once, got order {order:?}"
+    );
 }
 
 #[skuld::test]


### PR DESCRIPTION
Closes #446.

The macOS `test-dmg-signing` job was a standing flake generator (reds out unrelated PRs, needs 1–3 retries). Two independent causes:

**1. Double build (the ticket's primary ask).** The job ran `cargo xtask build hole-dmg` (one `npx tauri build`) *and* `cargo xtask run hole-dmg-tests`, whose run-cascade rebuilds `hole-dmg` (the orchestrator has no up-to-date checks, by design) — so the flaky `bundle_dmg.sh`/`hdiutil` DMG-creation pipeline rolled **twice per job**. Collapsed to a single `cargo xtask run hole-dmg-tests` (builds the DMG once via its cascade, then runs the signing pytest).

**2. Opaque flake.** tauri-bundler runs `bundle_dmg.sh` via `output_ok()`, which logs `hdiutil` stderr at `log::debug!` and drops it on failure — so failures surfaced only as `failed to run bundle_dmg.sh`. `npx tauri build -v` (added in `build.yaml`'s `hole-dmg`, so it also covers the release pipeline) flips tauri-cli to Debug and renders the real `hdiutil` error (verified against tauri-cli 2.11.2 source: `verbosity_level(1) => Level::Debug`). An `if: failure()` step additionally captures DiskArbitration / `/Volumes` / mount state as an artifact.

Per the GitHub runner-images maintainers there is **no deterministic userland fix** for the underlying macOS DiskArbitration race; this halves its CI exposure and makes the next occurrence diagnosable (verify-first). DMG round-trip test coverage is unchanged.

Guarded by a new `hole_dmg_tests_builds_dmg_once` test pinning that `cargo xtask run hole-dmg-tests` builds `hole-dmg` exactly once.

Verified locally: `cargo nextest run -p xtask` (75 pass), `cargo clippy -p xtask --all-targets -- -D warnings` (clean), `cargo fmt --check`, `actionlint`.