### PR TITLE
fix(garter): cross-platform process-tree reaping + deterministic e2e launcher (#197)

### DIFF
--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -77,12 +77,10 @@ windows = { version = "0.62", features = [
     "Win32_System_Threading",
 ] }
 
-[target.'cfg(unix)'.dev-dependencies]
-libc = "0.2"
-
 [target.'cfg(windows)'.dev-dependencies]
-windows = { version = "0.62", features = [
-    "Win32_Networking_WinSock",
-    "Win32_Foundation",
-    "Win32_System_Threading",
-] }
+# Win32_Networking_WinSock: chain_tests.rs binds 0.0.0.0:port with
+# SO_EXCLUSIVEADDRUSE to exercise the Winsock wildcard-exclusion race. It is the
+# only test-only feature — Foundation / Threading used by other tests come from
+# the regular `windows` dep above (Cargo unions features across the two tables
+# for the test build).
+windows = { version = "0.62", features = ["Win32_Networking_WinSock"] }

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -71,10 +71,18 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [
     "Win32_Foundation",
+    "Win32_Security",          # SECURITY_ATTRIBUTES param of CreateJobObjectW
     "Win32_System_Console",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dev-dependencies]
-windows = { version = "0.62", features = ["Win32_Networking_WinSock"] }
+windows = { version = "0.62", features = [
+    "Win32_Networking_WinSock",
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }

--- a/crates/garter/SITREP.md
+++ b/crates/garter/SITREP.md
@@ -124,15 +124,26 @@ Compatibility is gated on **MAJOR**:
 There are two host models, and the "unrecognized MAJOR" rule binds only
 one of them. An implementer must know which model their host uses.
 
-- **Detection host (first-line sniffing).** A host that decides
-  *whether* a plugin speaks sitrep by reading the first stdout line and
-  inspecting `hello` is performing capability auto-detection. Such a
-  host, on encountering a MAJOR it does not recognize, **MUST** fall
-  back to its non-sitrep readiness behavior (e.g. its prior
-  connect-probe), and **MUST NOT** hard-fail. The plugin might be
-  speaking a newer protocol the host genuinely cannot interpret;
-  refusing to start it would be a regression against the pre-sitrep
-  baseline.
+- **Detection host (capability auto-detection).** A host that decides
+  *whether* a plugin speaks sitrep — by inspecting `hello` — is
+  performing capability auto-detection. Such a host, on encountering a
+  MAJOR it does not recognize, **MUST** fall back to its non-sitrep
+  readiness behavior (e.g. its prior connect-probe), and **MUST NOT**
+  hard-fail. The plugin might be speaking a newer protocol the host
+  genuinely cannot interpret; refusing to start it would be a regression
+  against the pre-sitrep baseline.
+
+  Detection can be done two ways. *First-line sniffing* reads the first
+  stdout line and classifies on it — but a non-sitrep plugin that is
+  **silent on stdout** never produces a line to classify, so a pure
+  sniffing host would hang waiting for one. The robust alternative is to
+  run the non-sitrep readiness probe **concurrently** with the sitrep
+  reader from the start (sharing a single send-once readiness slot) and
+  let a recognized `hello` *stand the probe down*; a plugin that emits no
+  `hello` (silent or not) is then readied by the probe with no timeout.
+  Because a `bind_conflict` plugin never binds its listener, the
+  concurrent connect-probe can never win that race — `bind_conflict`
+  remains the deterministic outcome.
 
 - **Preselection host (out-of-band configuration).** A host that was
   told by configuration that a specific plugin speaks sitrep is *not*

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -23,6 +23,25 @@ pub enum ReadinessMode {
     /// The conservative default for arbitrary / legacy plugins.
     #[default]
     Probe,
+    /// Infer the strategy from the plugin's own sitrep `hello`, with NO timeout.
+    /// Runs the sitrep stdout reader AND an unconditional concurrent self-probe
+    /// (like [`ReadinessMode::Probe`]) sharing one send-once sender. A SUPPORTED
+    /// `hello` stands the probe down (cancels a `probe_standdown` child token) so
+    /// the plugin's richer `ready` (authoritative transports + the `bind_conflict`
+    /// retry signal) is the readiness source; a plugin that emits no `hello` (a
+    /// non-sitrep plugin, including one that is silent on stdout) is readied by
+    /// the probe. `probe_standdown` is a child of `shutdown`, so chain shutdown
+    /// also stops the probe.
+    ///
+    /// Use for harnesses that mix sitrep and non-sitrep plugins (the plugin-e2e
+    /// server fixture: ex-ray/galoshes speak sitrep, stock v2ray-plugin does not).
+    /// On a bind conflict the port never binds, so the probe can never win —
+    /// `BindConflict` always comes from sitrep (deterministic). On success either
+    /// path may win; both report the same listen address, so the sitrep-preference
+    /// (better transports) is best-effort, not guaranteed. Prefer explicit
+    /// `ExpectSitrep` when the plugin is known to speak sitrep AND authoritative
+    /// transports matter (the bridge does).
+    Auto,
 }
 
 /// Resolved SIP003 environment-variable mapping for a `BinaryPlugin`'s
@@ -223,7 +242,10 @@ impl ChainPlugin for BinaryPlugin {
                 log_task
             }
             ReadinessMode::ExpectSitrep => {
-                spawn_sitrep_stdout_reader(stdout, self.name.clone(), local, shutdown.clone(), ready)
+                spawn_sitrep_stdout_reader(stdout, self.name.clone(), local, shutdown.clone(), ready, false)
+            }
+            ReadinessMode::Auto => {
+                spawn_sitrep_stdout_reader(stdout, self.name.clone(), local, shutdown.clone(), ready, true)
             }
         };
 
@@ -304,27 +326,56 @@ impl ChainPlugin for BinaryPlugin {
 /// [`ProtocolSupport::FallBackToTier2`]: crate::sitrep::ProtocolSupport::FallBackToTier2
 type SharedReady = Arc<tokio::sync::Mutex<Option<oneshot::Sender<Result<PluginReady, StartError>>>>>;
 
-/// Spawn the ExpectSitrep stdout reader.
+/// Spawn a tier-2 self-probe that, on a successful TCP connect to `local`,
+/// reports `PluginReady` (TCP-only) through the shared send-once sender.
+/// Shared by `ExpectSitrep`'s unknown-major fallback and `Auto`'s concurrent
+/// probe. `standdown` ends the probe early (without sending) when cancelled.
+fn spawn_shared_probe(local: SocketAddr, standdown: CancellationToken, shared: SharedReady) {
+    tokio::spawn(async move {
+        if let Some(addr) = crate::chain::poll_ready(local, standdown).await {
+            if let Some(tx) = shared.lock().await.take() {
+                let _ = tx.send(Ok(PluginReady {
+                    listen: addr,
+                    transports: crate::sitrep::Transports::TCP,
+                }));
+            }
+        }
+    });
+}
+
+/// Spawn the sitrep stdout reader.
 ///
-/// The reader is the readiness source: it parses `@sitrep` events and
-/// sends exactly one readiness result. On an unknown protocol major
-/// (`FallBackToTier2`) it hands readiness ownership to a self-probe task
-/// (the tier-2 strategy), sharing the single sender via [`SharedReady`]
-/// so at most one send ever happens. Non-event lines pass through to
-/// tracing as ordinary logs. On stdout EOF without ever sending, the
-/// sender drops unsent → the chain aggregator synthesizes a process-exit
-/// failure (the intended backstop).
+/// The reader parses `@sitrep` events and sends exactly one readiness result.
+/// On an unknown protocol major (`FallBackToTier2`) it hands readiness to a
+/// self-probe, sharing the single sender via [`SharedReady`] so at most one send
+/// ever happens. When `auto` is true ([`ReadinessMode::Auto`]) a concurrent
+/// self-probe is ALSO started up front and stood down on a supported `hello`, so
+/// a non-sitrep plugin (including one silent on stdout) is still readied by the
+/// probe. Non-event lines pass through to tracing as logs. On stdout EOF without
+/// ever sending, the sender drops unsent → the chain aggregator synthesizes a
+/// process-exit failure (the intended backstop).
 fn spawn_sitrep_stdout_reader(
     stdout: tokio::process::ChildStdout,
     plugin_name: String,
     local: SocketAddr,
     shutdown: CancellationToken,
     ready: oneshot::Sender<Result<PluginReady, StartError>>,
+    auto: bool,
 ) -> tokio::task::JoinHandle<()> {
     use crate::sitrep::{ProtocolSupport, SitrepEvent};
 
     let shared: SharedReady = Arc::new(tokio::sync::Mutex::new(Some(ready)));
     tokio::spawn(async move {
+        // Auto: run the self-probe concurrently from the start (mirrors the
+        // default `Probe` mode), sharing the send-once sender. A SUPPORTED
+        // `hello` cancels `probe_standdown` so the probe defers to sitrep;
+        // otherwise the probe readies the plugin (handles a non-sitrep plugin
+        // that is silent on stdout — there is no first line to classify on).
+        // `probe_standdown` is a child of `shutdown`, so chain shutdown stops it.
+        let probe_standdown = shutdown.child_token();
+        if auto {
+            spawn_shared_probe(local, probe_standdown.clone(), shared.clone());
+        }
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
         let mut handshake_ok = false;
@@ -335,6 +386,10 @@ fn spawn_sitrep_stdout_reader(
                         match crate::sitrep::protocol_support(&protocol) {
                             ProtocolSupport::Supported => {
                                 handshake_ok = true;
+                                // Auto: a real sitrep plugin — stand the probe
+                                // down so its richer `ready` wins. (No-op when
+                                // !auto: no probe was started with this token.)
+                                probe_standdown.cancel();
                                 tracing::debug!(plugin = %plugin_name, %protocol, "sitrep handshake");
                             }
                             ProtocolSupport::FallBackToTier2 => {
@@ -343,23 +398,15 @@ fn spawn_sitrep_stdout_reader(
                                     %protocol,
                                     "unknown sitrep protocol major; readiness falls back to probe"
                                 );
-                                // Hand readiness to a tier-2 self-probe,
-                                // sharing the single sender. The reader
-                                // continues only as a log passthrough (it
-                                // never sends readiness again).
-                                let probe_shared = shared.clone();
-                                let probe_local = local;
-                                let probe_shutdown = shutdown.clone();
-                                tokio::spawn(async move {
-                                    if let Some(addr) = crate::chain::poll_ready(probe_local, probe_shutdown).await {
-                                        if let Some(tx) = probe_shared.lock().await.take() {
-                                            let _ = tx.send(Ok(PluginReady {
-                                                listen: addr,
-                                                transports: crate::sitrep::Transports::TCP,
-                                            }));
-                                        }
-                                    }
-                                });
+                                // Hand readiness to a tier-2 self-probe, sharing
+                                // the single sender. In Auto the probe is already
+                                // running (do NOT cancel its standdown — unknown
+                                // major means the probe drives); in ExpectSitrep
+                                // start it now. The reader continues only as a log
+                                // passthrough (it never sends readiness again).
+                                if !auto {
+                                    spawn_shared_probe(local, shutdown.clone(), shared.clone());
+                                }
                                 // Drain the rest of stdout as logs so the
                                 // child's pipe never blocks; the probe task
                                 // owns readiness from here on.

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -465,6 +465,14 @@ fn spawn_sitrep_stdout_reader(
 /// Forward all remaining stdout lines to tracing as ordinary logs. Used
 /// after a `FallBackToTier2` handoff so the child's stdout pipe never
 /// blocks while the self-probe owns readiness.
+///
+/// The loop is unbounded by design and terminates on the **child's** stdout
+/// EOF — guaranteed when the child (and its tree) is reaped via `GroupedChild`
+/// / `kill_on_drop`, which closes the write end. This reads the child's pipe,
+/// not the host's, so it cannot reproduce the #197 runtime-drop hang (that was
+/// an orphan holding the *host's* stdio); and because it runs inside a detached
+/// `tokio::spawn`, runtime drop aborts it at the await point rather than
+/// blocking on it.
 async fn drain_remaining_logs(lines: &mut tokio::io::Lines<BufReader<tokio::process::ChildStdout>>, plugin_name: &str) {
     while let Ok(Some(line)) = lines.next_line().await {
         tracing::info!(plugin = %plugin_name, "{line}");

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -185,16 +185,15 @@ impl ChainPlugin for BinaryPlugin {
         cmd.stderr(Stdio::piped());
         cmd.kill_on_drop(true);
 
-        // On Windows, create a new process group so that graceful_stop can
-        // send CTRL_BREAK_EVENT targeted at this child's group (SIP003u).
-        #[cfg(windows)]
-        cmd.creation_flags(windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP.0);
-
-        let mut child = cmd
-            .spawn()
+        // Spawn as the root of a process-tree kill-group (Windows job object /
+        // Unix process group) with stdio handle hygiene, so a force-kill reaps the
+        // plugin's whole descendant tree and an orphaned grandchild can never hold
+        // the host's pipe handles (bindreams/hole#197). CREATE_NEW_PROCESS_GROUP
+        // (for graceful_stop's CTRL_BREAK) is set inside `GroupedChild::spawn`.
+        let mut gc = crate::proc_group::GroupedChild::spawn(&mut cmd)
             .map_err(|e| crate::Error::Chain(format!("failed to spawn '{}': {e}", self.path.display())))?;
 
-        if let (Some(sink), Some(pid)) = (&self.pid_sink, child.id()) {
+        if let (Some(sink), Some(pid)) = (&self.pid_sink, gc.child.id()) {
             sink(pid);
         }
 
@@ -202,7 +201,7 @@ impl ChainPlugin for BinaryPlugin {
         // readiness comes from a separate self-probe task; in ExpectSitrep
         // mode it parses sitrep events and IS the readiness source. Build
         // the right one per `self.readiness`.
-        let stdout = child.stdout.take().expect("stdout was piped");
+        let stdout = gc.child.stdout.take().expect("stdout was piped");
         let stdout_task = match self.readiness {
             ReadinessMode::Probe => {
                 // Tier-2: the stdout reader is a pure log passthrough; a
@@ -250,7 +249,7 @@ impl ChainPlugin for BinaryPlugin {
         };
 
         // Capture stderr
-        let stderr = child.stderr.take().expect("stderr was piped");
+        let stderr = gc.child.stderr.take().expect("stderr was piped");
         let plugin_name = self.name.clone();
         let stderr_task = tokio::spawn(async move {
             let reader = BufReader::new(stderr);
@@ -281,7 +280,7 @@ impl ChainPlugin for BinaryPlugin {
         // full two-channel rationale.
         let drain_timeout = std::time::Duration::from_secs(5);
         tokio::select! {
-            status = child.wait() => {
+            status = gc.child.wait() => {
                 let status = status?;
                 // Drain remaining log lines (tasks will EOF when child's pipes close)
                 let _ = tokio::time::timeout(
@@ -304,7 +303,9 @@ impl ChainPlugin for BinaryPlugin {
             }
             _ = shutdown.cancelled() => {
                 tracing::info!(plugin = %self.name, "shutting down");
-                shutdown::graceful_stop(&mut child, drain_timeout).await?;
+                // Force path force-kills the direct child; `gc` dropping at the
+                // end of `run` (or on task abort) reaps the whole tree.
+                shutdown::graceful_stop(&mut gc.child, drain_timeout).await?;
                 // Drain remaining log lines (tasks will EOF when child's pipes close)
                 let _ = tokio::time::timeout(
                     std::time::Duration::from_millis(100),

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -41,6 +41,11 @@ pub enum ReadinessMode {
     /// (better transports) is best-effort, not guaranteed. Prefer explicit
     /// `ExpectSitrep` when the plugin is known to speak sitrep AND authoritative
     /// transports matter (the bridge does).
+    ///
+    /// The concurrent probe is a TCP connect (as in `Probe`), so it cannot ready
+    /// a UDP-only listener; a UDP-only plugin must therefore speak sitrep. All
+    /// first-party UDP plugins (ex-ray/galoshes QUIC) do, so this is not a
+    /// limitation in practice.
     Auto,
 }
 

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -83,6 +83,12 @@ fn readiness_mode_defaults_to_probe() {
     assert_eq!(p.readiness_mode_for_test(), crate::binary::ReadinessMode::Probe);
 }
 
+#[skuld::test]
+fn readiness_mode_auto_is_selectable() {
+    let p = crate::BinaryPlugin::new("/nonexistent", None).readiness(crate::binary::ReadinessMode::Auto);
+    assert_eq!(p.readiness_mode_for_test(), crate::binary::ReadinessMode::Auto);
+}
+
 // GOTRACEBACK env test ================================================================================================
 
 #[skuld::test]

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -3,6 +3,7 @@ pub mod chain;
 pub mod counting;
 pub mod error;
 pub mod plugin;
+pub(crate) mod proc_group;
 pub mod shutdown;
 pub mod sip003;
 pub mod sitrep;

--- a/crates/garter/src/proc_group.rs
+++ b/crates/garter/src/proc_group.rs
@@ -1,0 +1,222 @@
+//! Cross-platform process-tree reaping for spawned plugins.
+//!
+//! garter force-kills a plugin on abrupt teardown (guard drop / drain-timeout).
+//! A plugin may spawn its own children (e.g. galoshes spawns ex-ray); killing
+//! only the direct child orphans those grandchildren. On Windows the orphan also
+//! inherits the host's stdout/stderr pipe handles, so the host's pipe-reader
+//! never EOFs and tokio's `Runtime::drop` blocks forever (bindreams/hole#197).
+//!
+//! [`GroupedChild`] fixes both, with no `#[cfg]` at any call site:
+//!
+//! - **Handle hygiene (Windows).** Before spawning, clear `HANDLE_FLAG_INHERIT`
+//!   on this process's own std handles so the child inherits only its own stdio.
+//!   This is the race-free fix for the hang: an orphan can never hold the host's
+//!   pipes. (Unix already guarantees this via `dup2` + `CLOEXEC`.)
+//! - **Tree-kill.** The plugin is spawned as the root of a kill-group whose whole
+//!   descendant tree dies as a unit: a Windows Job Object with
+//!   `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, or a Unix process group killed with
+//!   `kill(-pgid)`.
+//!
+//! **Root auto-detection.** Only the OUTERMOST garter spawn should create a
+//! kill-group: Windows jobs nest (a grandchild created inside the root's job
+//! joins it), but Unix process groups do not (a grandchild in its own group
+//! escapes the ancestor's `kill(-pgid)`). So a kill-group must be created exactly
+//! once, at the top. We detect "am I already inside a garter kill-group?" via the
+//! inherited `GARTER_IN_KILL_GROUP` env var: unset → we are the root (create the
+//! group, mark the child's env); set → we are nested (spawn normally; the child
+//! joins the ancestor's group). This needs no flag or wiring at call sites and
+//! composes to arbitrary depth.
+
+use std::io;
+use tokio::process::{Child, Command};
+
+/// Env var marking "this process is already inside a garter-managed kill-group."
+/// Inherited by every descendant; its presence makes a nested garter spawn skip
+/// creating a new kill-group (see the module docs).
+const IN_KILL_GROUP_ENV: &str = "GARTER_IN_KILL_GROUP";
+
+/// A spawned child whose entire descendant tree is reaped together when this
+/// guard is dropped or [`GroupedChild::kill_tree`]'d. See the module docs.
+pub(crate) struct GroupedChild {
+    pub(crate) child: Child,
+    group: imp::Group,
+}
+
+impl GroupedChild {
+    /// Spawn `cmd` with process-tree reaping and (on Windows) stdio handle
+    /// hygiene. The caller owns `cmd`'s stdio configuration (piped, etc.).
+    pub(crate) fn spawn(cmd: &mut Command) -> io::Result<Self> {
+        let is_root = std::env::var_os(IN_KILL_GROUP_ENV).is_none();
+        if is_root {
+            cmd.env(IN_KILL_GROUP_ENV, "1");
+        }
+        imp::spawn(cmd, is_root)
+    }
+}
+
+impl Drop for GroupedChild {
+    fn drop(&mut self) {
+        // Reap the tree synchronously here (the backstop for task abort /
+        // runtime drop, where graceful stop never ran) BEFORE `self.child`'s
+        // `kill_on_drop` runs — so an orphan can never linger holding a pipe.
+        self.group.kill();
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use super::*;
+    use windows::Win32::Foundation::{CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT};
+    use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
+    use windows::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+        TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
+
+    /// Owns the Job Object handle (root only). Dropping/killing it terminates
+    /// every process in the job (galoshes + ex-ray, which joined by inheritance).
+    pub(super) struct Group {
+        job: Option<HANDLE>,
+    }
+
+    // A Windows job-object HANDLE is a process-wide kernel handle; using it
+    // (TerminateJobObject / CloseHandle) from another thread is sound. The raw
+    // pointer in `HANDLE` is otherwise `!Send`, which would make the plugin's
+    // `run` future non-`Send` and unspawnable.
+    unsafe impl Send for Group {}
+
+    impl Group {
+        pub(super) fn kill(&mut self) {
+            if let Some(job) = self.job.take() {
+                // TerminateJobObject kills the whole tree synchronously; then we
+                // release the handle. (KILL_ON_JOB_CLOSE would also fire on the
+                // close, but terminating first avoids any runtime-drop ordering
+                // race with the host's I/O driver shutdown.)
+                unsafe {
+                    let _ = TerminateJobObject(job, 1);
+                    let _ = CloseHandle(job);
+                }
+            }
+        }
+    }
+
+    impl Drop for Group {
+        fn drop(&mut self) {
+            self.kill();
+        }
+    }
+
+    pub(super) fn spawn(cmd: &mut Command, is_root: bool) -> io::Result<GroupedChild> {
+        // Handle hygiene: a child must inherit only its own (piped) stdio, never
+        // this process's std handles. Best-effort — a missing/redirected std
+        // handle just means there's nothing to clear.
+        clear_std_handle_inheritance();
+
+        // CREATE_NEW_PROCESS_GROUP makes the child its own console group leader so
+        // graceful_stop's CTRL_BREAK targets it (unchanged behavior, both root and
+        // nested).
+        cmd.creation_flags(CREATE_NEW_PROCESS_GROUP.0);
+
+        let child = cmd.spawn()?;
+
+        let group = if is_root {
+            Group {
+                job: assign_to_kill_on_close_job(&child),
+            }
+        } else {
+            Group { job: None }
+        };
+        Ok(GroupedChild { child, group })
+    }
+
+    fn clear_std_handle_inheritance() {
+        for std_handle in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+            unsafe {
+                if let Ok(h) = GetStdHandle(std_handle) {
+                    if !h.is_invalid() {
+                        // dwmask is a raw u32; dwflags is HANDLE_FLAGS. Clearing
+                        // the INHERIT bit (mask = INHERIT, flags = 0).
+                        let _ = SetHandleInformation(h, HANDLE_FLAG_INHERIT.0, HANDLE_FLAGS(0));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Create a `KILL_ON_JOB_CLOSE` job and assign `child` to it. Returns the job
+    /// handle (held for the tree's lifetime) or `None` on failure (best-effort:
+    /// tree-reaping degrades to the direct child via `kill_on_drop`).
+    fn assign_to_kill_on_close_job(child: &Child) -> Option<HANDLE> {
+        let raw = child.raw_handle()?;
+        unsafe {
+            let job = CreateJobObjectW(None, windows::core::PCWSTR::null()).ok()?;
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let set = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(info).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if set.is_err() {
+                let _ = CloseHandle(job);
+                return None;
+            }
+            if AssignProcessToJobObject(job, HANDLE(raw)).is_err() {
+                let _ = CloseHandle(job);
+                return None;
+            }
+            Some(job)
+        }
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+
+    /// Holds the child's process-group id (root only). Killing it signals the
+    /// whole group — the plugin and every descendant that stayed in its group
+    /// (nested garter spawns deliberately do not create their own group).
+    pub(super) struct Group {
+        pgid: Option<libc::pid_t>,
+    }
+
+    impl Group {
+        pub(super) fn kill(&mut self) {
+            if let Some(pgid) = self.pgid.take() {
+                // Negative pid → signal the whole process group.
+                unsafe {
+                    let _ = libc::kill(-pgid, libc::SIGKILL);
+                }
+            }
+        }
+    }
+
+    impl Drop for Group {
+        fn drop(&mut self) {
+            self.kill();
+        }
+    }
+
+    pub(super) fn spawn(cmd: &mut Command, is_root: bool) -> io::Result<GroupedChild> {
+        // Unix already gives the child only its own stdio (dup2 + CLOEXEC), so no
+        // handle hygiene is needed. The root becomes a process-group leader so the
+        // whole tree can be killed with kill(-pgid); nested spawns inherit the
+        // root's group (so they are reaped by it, not orphaned).
+        if is_root {
+            cmd.process_group(0);
+        }
+        let child = cmd.spawn()?;
+        let group = if is_root {
+            // process_group(0) makes the child its own group leader, so pgid == pid.
+            Group {
+                pgid: child.id().map(|id| id as libc::pid_t),
+            }
+        } else {
+            Group { pgid: None }
+        };
+        Ok(GroupedChild { child, group })
+    }
+}

--- a/crates/garter/src/proc_group.rs
+++ b/crates/garter/src/proc_group.rs
@@ -26,6 +26,11 @@
 //! group, mark the child's env); set → we are nested (spawn normally; the child
 //! joins the ancestor's group). This needs no flag or wiring at call sites and
 //! composes to arbitrary depth.
+//!
+//! **`GARTER_IN_KILL_GROUP` is load-bearing: nothing outside garter may set it.**
+//! An external value would misclassify the outermost spawn as nested, skip the
+//! kill-group, and re-introduce the orphan/hang. Root detection is logged at
+//! `debug` so a misdetection is diagnosable.
 
 use std::io;
 use tokio::process::{Child, Command};
@@ -36,7 +41,7 @@ use tokio::process::{Child, Command};
 const IN_KILL_GROUP_ENV: &str = "GARTER_IN_KILL_GROUP";
 
 /// A spawned child whose entire descendant tree is reaped together when this
-/// guard is dropped or [`GroupedChild::kill_tree`]'d. See the module docs.
+/// guard is [`Drop`]ped. See the module docs.
 pub(crate) struct GroupedChild {
     pub(crate) child: Child,
     group: imp::Group,
@@ -49,6 +54,12 @@ impl GroupedChild {
         let is_root = std::env::var_os(IN_KILL_GROUP_ENV).is_none();
         if is_root {
             cmd.env(IN_KILL_GROUP_ENV, "1");
+            // Logged so a misdetection (e.g. an external GARTER_IN_KILL_GROUP that
+            // wrongly marks the outermost spawn as nested → no kill-group → the
+            // #197 orphan/hang returns) is visible at debug level.
+            tracing::debug!("proc_group: root spawn — creating a process-tree kill-group");
+        } else {
+            tracing::debug!("proc_group: nested spawn — joining the ancestor's kill-group");
         }
         imp::spawn(cmd, is_root)
     }
@@ -148,22 +159,34 @@ mod imp {
     /// handle (held for the tree's lifetime) or `None` on failure (best-effort:
     /// tree-reaping degrades to the direct child via `kill_on_drop`).
     fn assign_to_kill_on_close_job(child: &Child) -> Option<HANDLE> {
-        let raw = child.raw_handle()?;
+        // Every failure here degrades tree-reaping to just the direct child
+        // (`kill_on_drop`), which would re-orphan grandchildren — so log loudly.
+        let Some(raw) = child.raw_handle() else {
+            tracing::warn!("proc_group: child has no raw handle; process-tree reaping disabled");
+            return None;
+        };
         unsafe {
-            let job = CreateJobObjectW(None, windows::core::PCWSTR::null()).ok()?;
+            let job = match CreateJobObjectW(None, windows::core::PCWSTR::null()) {
+                Ok(j) => j,
+                Err(e) => {
+                    tracing::warn!(error = %e, "proc_group: CreateJobObjectW failed; process-tree reaping disabled");
+                    return None;
+                }
+            };
             let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
             info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-            let set = SetInformationJobObject(
+            if let Err(e) = SetInformationJobObject(
                 job,
                 JobObjectExtendedLimitInformation,
                 std::ptr::addr_of!(info).cast(),
                 std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-            );
-            if set.is_err() {
+            ) {
+                tracing::warn!(error = %e, "proc_group: SetInformationJobObject failed; process-tree reaping disabled");
                 let _ = CloseHandle(job);
                 return None;
             }
-            if AssignProcessToJobObject(job, HANDLE(raw)).is_err() {
+            if let Err(e) = AssignProcessToJobObject(job, HANDLE(raw)) {
+                tracing::warn!(error = %e, "proc_group: AssignProcessToJobObject failed; process-tree reaping disabled");
                 let _ = CloseHandle(job);
                 return None;
             }

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -790,9 +790,15 @@ async fn force_kill_reaps_descendant_tree() {
     let chain_local = chain_listener.local_addr().unwrap();
     drop(chain_listener);
 
-    // Per-test-process-unique pidfile (nextest runs each test in its own process).
-    let pidfile = std::env::temp_dir().join(format!("garter-treekill-{}.pid", std::process::id()));
-    let _ = std::fs::remove_file(&pidfile);
+    // Control channel: the grandchild dials back here on startup and holds the
+    // connection open. `accept()` => the grandchild is alive (deterministic
+    // readiness — no PID, no poll); a later read => EOF/reset the instant the
+    // grandchild is reaped (reuse-immune: a recycled PID cannot resurrect this
+    // specific TCP connection; and sleep-free: a broken tree-kill leaves the read
+    // blocked until the nextest per-test timeout — the sanctioned class-2
+    // failure-to-human bound for an external event that might never arrive).
+    let control_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let control_addr = control_listener.local_addr().unwrap();
 
     let (ready_tx, ready_rx) = oneshot::channel();
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -800,7 +806,7 @@ async fn force_kill_reaps_descendant_tree() {
         .add(Box::new(
             BinaryPlugin::new(&mock_path, None)
                 .readiness(garter::binary::ReadinessMode::ExpectSitrep)
-                .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", pidfile.to_str().unwrap()),
+                .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr.to_string()),
         ))
         .on_ready(ready_tx)
         .cancel_token(cancel.clone())
@@ -818,107 +824,42 @@ async fn force_kill_reaps_descendant_tree() {
         .await
         .expect("ready_tx dropped")
         .expect("mock-plugin should ready");
-    let grandchild_pid = read_pid_when_written(&pidfile).await;
-    assert!(
-        is_pid_alive(grandchild_pid),
-        "grandchild should be alive before teardown"
-    );
+
+    // The grandchild dials back on startup; accepting proves it is alive without
+    // a PID or a poll.
+    let (mut grandchild_conn, _) = control_listener
+        .accept()
+        .await
+        .expect("grandchild should dial the control channel");
 
     // Force-kill the chain. mock-plugin has no signal handler, so it dies on the
     // graceful signal; its grandchild is orphaned unless garter reaps the tree.
     cancel.cancel();
     let _ = chain.await;
 
-    let reaped = wait_pid_dead(grandchild_pid, Duration::from_secs(10)).await;
-    // Clean up on the failing path so a leaked grandchild can't hang this test
-    // process at runtime-drop (the #197 hang) or accumulate across runs. Confirm
-    // the kill landed so the inherited pipe is released before this test's
-    // runtime drops.
-    if !reaped {
-        force_kill_pid(grandchild_pid);
-        let _ = wait_pid_dead(grandchild_pid, Duration::from_secs(5)).await;
+    // The grandchild's connection closes the instant it is reaped. A clean exit
+    // EOFs (read => Ok(0)); a hard kill may RST the socket (ConnectionReset /
+    // ConnectionAborted). Either proves the grandchild died — reuse-immune,
+    // because only the grandchild's own process can hold this connection, and a
+    // recycled PID gets a different socket. The grandchild never writes, so any
+    // bytes read are a bug. If the tree-kill fails, the grandchild keeps the
+    // connection open and this read blocks until the nextest per-test timeout
+    // (the sanctioned class-2 bound) — at which point the inherited host pipe is
+    // still held, exactly the #197 leak this test guards against.
+    let mut buf = [0u8; 1];
+    match grandchild_conn.read(&mut buf).await {
+        Ok(0) => {} // clean EOF: the grandchild's socket closed on death.
+        Ok(n) => panic!("grandchild sent {n} unexpected byte(s); it must only hold the connection open"),
+        Err(e) => assert!(
+            matches!(
+                e.kind(),
+                std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+            ),
+            "force-killing the chain must reap the descendant tree; got unexpected control-conn error: {e:?}"
+        ),
     }
-    let _ = std::fs::remove_file(&pidfile);
+
     drop(echo_listener);
-
-    assert!(
-        reaped,
-        "force-killing the chain must reap the whole descendant tree (grandchild pid {grandchild_pid} survived)"
-    );
-}
-
-/// Block until `pidfile` holds a parseable PID (the grandchild writes it just
-/// after the parent readies). Sanctioned CLAUDE.md class-2 wait: an external
-/// subprocess produces the file; the budget is the failure-to-human bound.
-async fn read_pid_when_written(pidfile: &std::path::Path) -> u32 {
-    let start = std::time::Instant::now();
-    loop {
-        if let Ok(s) = std::fs::read_to_string(pidfile) {
-            if let Ok(pid) = s.trim().parse::<u32>() {
-                return pid;
-            }
-        }
-        assert!(
-            start.elapsed() < Duration::from_secs(10),
-            "grandchild pidfile not written within budget"
-        );
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-}
-
-/// Poll until `pid` is dead or `budget` elapses. Sanctioned class-2 wait: an
-/// external process exits; the budget is the failure-to-human bound.
-async fn wait_pid_dead(pid: u32, budget: Duration) -> bool {
-    let start = std::time::Instant::now();
-    while is_pid_alive(pid) {
-        if start.elapsed() >= budget {
-            return false;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    true
-}
-
-#[cfg(unix)]
-fn is_pid_alive(pid: u32) -> bool {
-    // kill(pid, 0): 0 → the process exists; ESRCH → it doesn't.
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(unix)]
-fn force_kill_pid(pid: u32) {
-    unsafe {
-        let _ = libc::kill(pid as libc::pid_t, libc::SIGKILL);
-    }
-}
-
-#[cfg(windows)]
-fn is_pid_alive(pid: u32) -> bool {
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-    // STILL_ACTIVE (259): the process has not exited.
-    const STILL_ACTIVE: u32 = 259;
-    unsafe {
-        let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
-            return false;
-        };
-        let mut code = 0u32;
-        let alive = GetExitCodeProcess(handle, &mut code).is_ok() && code == STILL_ACTIVE;
-        let _ = CloseHandle(handle);
-        alive
-    }
-}
-
-#[cfg(windows)]
-fn force_kill_pid(pid: u32) {
-    use windows::Win32::Foundation::CloseHandle;
-    use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
-    unsafe {
-        if let Ok(handle) = OpenProcess(PROCESS_TERMINATE, false, pid) {
-            let _ = TerminateProcess(handle, 1);
-            let _ = CloseHandle(handle);
-        }
-    }
 }
 
 // Install the workspace test subscriber + panic hook. See

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -568,6 +568,209 @@ async fn version_skew_falls_back_to_probe() {
     let _ = chain_task.await;
 }
 
+// ReadinessMode::Auto tests ===========================================================================================
+
+/// `Auto` readiness with a NON-sitrep, STDOUT-SILENT plugin: `MOCK_PLUGIN_NO_SITREP`
+/// prints nothing on stdout and loops on accept() (stdout never closes). `Auto`
+/// must ready it via the unconditional concurrent self-probe. (`ExpectSitrep`
+/// would hang; a "classify on first stdout line" design would also hang — this
+/// is the case that proves the probe is concurrent, not line-gated.)
+#[skuld::test]
+async fn auto_readies_silent_non_sitrep_plugin_via_probe() {
+    let mock_path = mock_plugin_path();
+
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    let echo_task = tokio::spawn(async move {
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut r, mut w) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut r, &mut w).await;
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::Auto)
+                .env("MOCK_PLUGIN_NO_SITREP", "1"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: echo_addr.ip().to_string(),
+        remote_port: echo_addr.port(),
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let chain_ready = ready_rx
+        .await
+        .expect("chain never signaled ready")
+        .expect("Auto must ready a silent non-sitrep plugin via the probe");
+    // The probe is TCP-connect only.
+    assert_eq!(chain_ready.transports, garter::Transports::TCP);
+    let mut client = TcpStream::connect(chain_ready.listen).await.expect("connect");
+    client.write_all(b"hello auto probe").await.unwrap();
+    let mut buf = [0u8; 1024];
+    let n = client.read(&mut buf).await.expect("read");
+    assert_eq!(&buf[..n], b"hello auto probe");
+
+    drop(client);
+    echo_task.abort();
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// `Auto` readiness with a sitrep plugin: the chain readies and relays. (Does
+/// not assert WHICH path won — sitrep vs probe on success is a best-effort
+/// race; both report the same listen address.)
+#[skuld::test]
+async fn auto_readies_sitrep_plugin() {
+    let mock_path = mock_plugin_path();
+
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    let echo_task = tokio::spawn(async move {
+        loop {
+            match echo_listener.accept().await {
+                Ok((stream, _)) => {
+                    tokio::spawn(async move {
+                        let (mut r, mut w) = tokio::io::split(stream);
+                        let _ = tokio::io::copy(&mut r, &mut w).await;
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None).readiness(garter::binary::ReadinessMode::Auto),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: echo_addr.ip().to_string(),
+        remote_port: echo_addr.port(),
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let chain_ready = ready_rx
+        .await
+        .expect("chain never signaled ready")
+        .expect("Auto should ready a sitrep plugin");
+    let mut client = TcpStream::connect(chain_ready.listen).await.expect("connect");
+    client.write_all(b"hello auto sitrep").await.unwrap();
+    let mut buf = [0u8; 1024];
+    let n = client.read(&mut buf).await.expect("read");
+    assert_eq!(&buf[..n], b"hello auto sitrep");
+
+    drop(client);
+    echo_task.abort();
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// `Auto` surfaces a typed `BindConflict` (the launcher's retry signal). This
+/// is DETERMINISTIC under Auto: on a bind conflict the port never binds, so the
+/// concurrent probe can never connect — only the sitrep `bind_conflict` fires.
+#[skuld::test]
+async fn auto_surfaces_bind_conflict() {
+    let mock_path = mock_plugin_path();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::Auto)
+                .env("MOCK_PLUGIN_FAIL", "bind_conflict"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    assert!(
+        matches!(outcome, Err(garter::StartError::BindConflict { .. })),
+        "Auto must surface BindConflict, got {outcome:?}"
+    );
+
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
+/// `Auto` surfaces a typed `Fatal` (a plugin that emits `fatal` then exits).
+/// Deterministic: the plugin exits before binding, so the probe can never connect.
+#[skuld::test]
+async fn auto_surfaces_fatal() {
+    let mock_path = mock_plugin_path();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::Auto)
+                .env("MOCK_PLUGIN_FAIL", "fatal"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    assert!(
+        matches!(outcome, Err(garter::StartError::Fatal { .. })),
+        "Auto must surface Fatal, got {outcome:?}"
+    );
+
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
 // Install the workspace test subscriber + panic hook. See
 // `crates/test-observability/` and bindreams/hole#301.
 hole_test_observability::register!();

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -771,6 +771,156 @@ async fn auto_surfaces_fatal() {
     let _ = chain_task.await;
 }
 
+// Process-tree reaping ================================================================================================
+
+/// Force-killing a chain must reap the plugin's WHOLE descendant tree, not just
+/// the direct child. mock-plugin (grandchild mode) spawns a long-lived grandchild
+/// that inherits its stdio (mimicking galoshes→ex-ray). After `cancel` + teardown
+/// the grandchild must be dead — otherwise it leaks (and on Windows, holding the
+/// inherited host pipe, hangs the host at runtime-drop; see bindreams/hole#197).
+#[skuld::test]
+async fn force_kill_reaps_descendant_tree() {
+    let mock_path = mock_plugin_path();
+
+    // SS_REMOTE target: mock-plugin parses it but never dials it before teardown.
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    // Per-test-process-unique pidfile (nextest runs each test in its own process).
+    let pidfile = std::env::temp_dir().join(format!("garter-treekill-{}.pid", std::process::id()));
+    let _ = std::fs::remove_file(&pidfile);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", pidfile.to_str().unwrap()),
+        ))
+        .on_ready(ready_tx)
+        .cancel_token(cancel.clone())
+        .drain_timeout(Duration::from_secs(3));
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: echo_addr.ip().to_string(),
+        remote_port: echo_addr.port(),
+        plugin_options: None,
+    };
+    let chain = tokio::spawn(async move { runner.run(env).await });
+
+    ready_rx
+        .await
+        .expect("ready_tx dropped")
+        .expect("mock-plugin should ready");
+    let grandchild_pid = read_pid_when_written(&pidfile).await;
+    assert!(
+        is_pid_alive(grandchild_pid),
+        "grandchild should be alive before teardown"
+    );
+
+    // Force-kill the chain. mock-plugin has no signal handler, so it dies on the
+    // graceful signal; its grandchild is orphaned unless garter reaps the tree.
+    cancel.cancel();
+    let _ = chain.await;
+
+    let reaped = wait_pid_dead(grandchild_pid, Duration::from_secs(10)).await;
+    // Clean up on the failing path so a leaked grandchild can't hang this test
+    // process at runtime-drop (the #197 hang) or accumulate across runs. Confirm
+    // the kill landed so the inherited pipe is released before this test's
+    // runtime drops.
+    if !reaped {
+        force_kill_pid(grandchild_pid);
+        let _ = wait_pid_dead(grandchild_pid, Duration::from_secs(5)).await;
+    }
+    let _ = std::fs::remove_file(&pidfile);
+    drop(echo_listener);
+
+    assert!(
+        reaped,
+        "force-killing the chain must reap the whole descendant tree (grandchild pid {grandchild_pid} survived)"
+    );
+}
+
+/// Block until `pidfile` holds a parseable PID (the grandchild writes it just
+/// after the parent readies). Sanctioned CLAUDE.md class-2 wait: an external
+/// subprocess produces the file; the budget is the failure-to-human bound.
+async fn read_pid_when_written(pidfile: &std::path::Path) -> u32 {
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(s) = std::fs::read_to_string(pidfile) {
+            if let Ok(pid) = s.trim().parse::<u32>() {
+                return pid;
+            }
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "grandchild pidfile not written within budget"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Poll until `pid` is dead or `budget` elapses. Sanctioned class-2 wait: an
+/// external process exits; the budget is the failure-to-human bound.
+async fn wait_pid_dead(pid: u32, budget: Duration) -> bool {
+    let start = std::time::Instant::now();
+    while is_pid_alive(pid) {
+        if start.elapsed() >= budget {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    true
+}
+
+#[cfg(unix)]
+fn is_pid_alive(pid: u32) -> bool {
+    // kill(pid, 0): 0 → the process exists; ESRCH → it doesn't.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(unix)]
+fn force_kill_pid(pid: u32) {
+    unsafe {
+        let _ = libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+fn is_pid_alive(pid: u32) -> bool {
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    // STILL_ACTIVE (259): the process has not exited.
+    const STILL_ACTIVE: u32 = 259;
+    unsafe {
+        let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+            return false;
+        };
+        let mut code = 0u32;
+        let alive = GetExitCodeProcess(handle, &mut code).is_ok() && code == STILL_ACTIVE;
+        let _ = CloseHandle(handle);
+        alive
+    }
+}
+
+#[cfg(windows)]
+fn force_kill_pid(pid: u32) {
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    unsafe {
+        if let Ok(handle) = OpenProcess(PROCESS_TERMINATE, false, pid) {
+            let _ = TerminateProcess(handle, 1);
+            let _ = CloseHandle(handle);
+        }
+    }
+}
+
 // Install the workspace test subscriber + panic hook. See
 // `crates/test-observability/` and bindreams/hole#301.
 hole_test_observability::register!();

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -32,6 +32,14 @@ fn first_failure_for_sentinel() -> bool {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Knob: MOCK_PLUGIN_SLEEP — "grandchild" mode (a garter process-tree-reaping
+    // test seam). Live forever, inheriting whatever stdio the parent gave us; do
+    // NOT read SIP003 env. Stands in for an inner plugin (e.g. galoshes's ex-ray)
+    // that a force-killed parent would otherwise orphan.
+    if std::env::var_os("MOCK_PLUGIN_SLEEP").is_some() {
+        std::future::pending::<()>().await;
+    }
+
     let local_host = std::env::var("SS_LOCAL_HOST")?;
     let local_port: u16 = std::env::var("SS_LOCAL_PORT")?.parse()?;
     let remote_host = std::env::var("SS_REMOTE_HOST")?;
@@ -139,6 +147,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         sitrep_enabled,
     );
+
+    // Knob: MOCK_PLUGIN_SPAWN_GRANDCHILD=<pidfile> — spawn a long-lived grandchild
+    // that INHERITS our stdio (default `Command` stdio), mimicking an inner plugin
+    // (galoshes→ex-ray) that, if orphaned, holds the host's stdout/stderr pipe.
+    // Record its PID so a test can verify a force-kill of the chain reaps the
+    // whole process tree. The grandchild gets MOCK_PLUGIN_SLEEP (so it short-
+    // circuits) and NOT this knob (so it does not recurse). std `Child` is not
+    // kill-on-drop, so letting it drop leaves the process running for the test.
+    if let Some(pidfile) = std::env::var_os("MOCK_PLUGIN_SPAWN_GRANDCHILD") {
+        let exe = std::env::current_exe()?;
+        let mut cmd = std::process::Command::new(exe);
+        cmd.env("MOCK_PLUGIN_SLEEP", "1")
+            .env_remove("MOCK_PLUGIN_SPAWN_GRANDCHILD");
+        // Put the grandchild in its OWN process group, mimicking how garter
+        // spawns plugins (e.g. galoshes→ex-ray): the parent's graceful
+        // CTRL_BREAK/SIGTERM then does NOT reach it, so only a process-TREE kill
+        // (Windows job object / Unix pgid kill) can reap it.
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            cmd.process_group(0);
+        }
+        let grandchild = cmd.spawn()?;
+        std::fs::write(&pidfile, grandchild.id().to_string())?;
+    }
 
     loop {
         let (inbound, peer) = listener.accept().await?;

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -36,7 +36,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // test seam). Live forever, inheriting whatever stdio the parent gave us; do
     // NOT read SIP003 env. Stands in for an inner plugin (e.g. galoshes's ex-ray)
     // that a force-killed parent would otherwise orphan.
+    //
+    // If MOCK_PLUGIN_GRANDCHILD_CALLBACK is set, first dial that loopback addr and
+    // HOLD the connection open for the process lifetime. The test accepts it to
+    // observe our liveness (deterministic readiness — no pidfile poll) and reads
+    // it to observe our death: the socket EOFs/resets the instant this process is
+    // reaped. That is reuse-immune (a recycled PID cannot resurrect this specific
+    // TCP connection) and needs no sleep. We never write to the socket — closing
+    // it is purely an exit signal.
     if std::env::var_os("MOCK_PLUGIN_SLEEP").is_some() {
+        let _callback = match std::env::var_os("MOCK_PLUGIN_GRANDCHILD_CALLBACK") {
+            Some(addr) => {
+                let addr = addr.to_str().expect("MOCK_PLUGIN_GRANDCHILD_CALLBACK is valid utf-8");
+                Some(
+                    TcpStream::connect(addr)
+                        .await
+                        .expect("grandchild dials the test callback"),
+                )
+            }
+            None => None,
+        };
         std::future::pending::<()>().await;
     }
 
@@ -148,17 +167,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sitrep_enabled,
     );
 
-    // Knob: MOCK_PLUGIN_SPAWN_GRANDCHILD=<pidfile> — spawn a long-lived grandchild
-    // that INHERITS our stdio (default `Command` stdio), mimicking an inner plugin
-    // (galoshes→ex-ray) that, if orphaned, holds the host's stdout/stderr pipe.
-    // Record its PID so a test can verify a force-kill of the chain reaps the
-    // whole process tree. The grandchild gets MOCK_PLUGIN_SLEEP (so it short-
-    // circuits) and NOT this knob (so it does not recurse). std `Child` is not
-    // kill-on-drop, so letting it drop leaves the process running for the test.
-    if let Some(pidfile) = std::env::var_os("MOCK_PLUGIN_SPAWN_GRANDCHILD") {
+    // Knob: MOCK_PLUGIN_SPAWN_GRANDCHILD=<callback_addr> — spawn a long-lived
+    // grandchild that INHERITS our stdio (default `Command` stdio), mimicking an
+    // inner plugin (galoshes→ex-ray) that, if orphaned, holds the host's
+    // stdout/stderr pipe. The grandchild dials <callback_addr> on startup and
+    // holds the connection, so a test can verify a force-kill of the chain reaps
+    // the whole process tree via the connection's liveness/EOF (reuse-immune, no
+    // PID poll). The grandchild gets MOCK_PLUGIN_SLEEP (so it short-circuits) plus
+    // the callback addr, and NOT this knob (so it does not recurse). std `Child`
+    // is not kill-on-drop, so letting it drop leaves the process running for the
+    // test.
+    if let Some(callback_addr) = std::env::var_os("MOCK_PLUGIN_SPAWN_GRANDCHILD") {
         let exe = std::env::current_exe()?;
         let mut cmd = std::process::Command::new(exe);
         cmd.env("MOCK_PLUGIN_SLEEP", "1")
+            .env("MOCK_PLUGIN_GRANDCHILD_CALLBACK", &callback_addr)
             .env_remove("MOCK_PLUGIN_SPAWN_GRANDCHILD");
         // Mimic how garter spawns a NESTED plugin (galoshes→ex-ray) so this
         // grandchild is reaped only by the root's process-tree kill, never by the
@@ -176,8 +199,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
         }
-        let grandchild = cmd.spawn()?;
-        std::fs::write(&pidfile, grandchild.id().to_string())?;
+        let _grandchild = cmd.spawn()?;
     }
 
     loop {

--- a/crates/mock-plugin/src/main.rs
+++ b/crates/mock-plugin/src/main.rs
@@ -160,20 +160,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = std::process::Command::new(exe);
         cmd.env("MOCK_PLUGIN_SLEEP", "1")
             .env_remove("MOCK_PLUGIN_SPAWN_GRANDCHILD");
-        // Put the grandchild in its OWN process group, mimicking how garter
-        // spawns plugins (e.g. galoshes→ex-ray): the parent's graceful
-        // CTRL_BREAK/SIGTERM then does NOT reach it, so only a process-TREE kill
-        // (Windows job object / Unix pgid kill) can reap it.
+        // Mimic how garter spawns a NESTED plugin (galoshes→ex-ray) so this
+        // grandchild is reaped only by the root's process-tree kill, never by the
+        // parent's graceful stop:
+        //  - Windows: give it its OWN console group (CREATE_NEW_PROCESS_GROUP,
+        //    exactly as garter spawns every plugin) so graceful_stop's CTRL_BREAK
+        //    to the parent's group can't reach it; it still joins the root's job
+        //    object by handle inheritance and is reaped that way.
+        //  - Unix: do NOT setpgid — inherit the parent's process group like a
+        //    nested ex-ray, so the root's kill(-pgid) reaps it. graceful_stop's
+        //    SIGTERM is PID-targeted, so it can't reach the grandchild anyway.
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt;
             const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
-        }
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            cmd.process_group(0);
         }
         let grandchild = cmd.spawn()?;
         std::fs::write(&pidfile, grandchild.id().to_string())?;

--- a/crates/plugin-e2e/src/roundtrip.rs
+++ b/crates/plugin-e2e/src/roundtrip.rs
@@ -36,9 +36,23 @@ pub enum Roundtrip {
     NotReachable(String),
 }
 
-/// Tunable timeouts. WS/QUIC cold-start needs generous values; the budgets are
-/// failure-to-human bounds for wedged subprocesses (CLAUDE.md sync-exception
-/// class 2), not intra-process synchronization.
+/// Tunable timeouts. Every budget here is a failure-to-human bound for a wedged
+/// *subprocess* (CLAUDE.md sync-exception class 2), NOT intra-process
+/// synchronization — so each must be generous enough to never fire on a
+/// legitimate-but-slow operation, only on a genuine hang.
+///
+/// The defaults are deliberately large because the data path crosses a plugin
+/// chain that extracts and execs a freshly-built `ex-ray` on first run. With
+/// **galoshes** on both ends, the server and client each extract their own
+/// embedded `ex-ray` concurrently, and a cold host scanning those binaries
+/// (Windows Defender on a just-built `ex-ray.exe`) can push the first
+/// roundtrip past a single-digit-second bound — the observed flake was a
+/// "read timed out" at ~5.9 s against a former 5 s `read_timeout`. These bounds
+/// are not a timing assumption: on a healthy host the roundtrip completes in
+/// milliseconds and the budget is never approached; on a true wedge the test
+/// still fails in bounded time. Do NOT tighten them to "make the suite faster"
+/// — a tight class-2 bound that flakes on cold-start is exactly the degenerate
+/// timing-assumption the invariant forbids.
 pub struct RoundtripConfig {
     pub ss_connect_timeout: Duration,
     pub read_timeout: Duration,
@@ -48,8 +62,8 @@ pub struct RoundtripConfig {
 impl Default for RoundtripConfig {
     fn default() -> Self {
         Self {
-            ss_connect_timeout: Duration::from_secs(5),
-            read_timeout: Duration::from_secs(5),
+            ss_connect_timeout: Duration::from_secs(20),
+            read_timeout: Duration::from_secs(20),
             ready_timeout: Duration::from_secs(30),
         }
     }

--- a/crates/plugin-e2e/src/ssserver.rs
+++ b/crates/plugin-e2e/src/ssserver.rs
@@ -1,21 +1,27 @@
 //! In-process shadowsocks server fixtures.
 //!
-//! Each helper spins up a real `shadowsocks_service::server::Server`
-//! bound to a loopback port the fixture allocates and binds in a single
-//! retry-wrapped operation via
-//! [`util::port_alloc::bind_ephemeral`] (the same allocate-and-bind
-//! retry pattern Hole's own loopback binders use). The returned
-//! [`JoinHandle`]s own the server loop and must be kept alive for the
-//! duration of the test that uses them.
+//! [`start_real_ss_server`] spins up a plain `shadowsocks_service::server::Server`
+//! on a HELD loopback port (no plugin). The `_with_plugin_*` helpers front a held
+//! ss-server with a SERVER-mode plugin chain via [`spawn_ss_with_plugin`] — a
+//! `garter::ChainRunner(Mode::Server)`, symmetric to the client-side
+//! [`crate::roundtrip::run_roundtrip`]. Readiness is inferred from the plugin's
+//! own sitrep `hello` ([`garter::ReadinessMode::Auto`]); the public port is
+//! pre-allocated and retried on the in-band `bind_conflict` signal. There is NO
+//! `shadowsocks-service` `PluginConfig` (its bind-and-drop rendezvous-port juggling
+//! is the #197 race; and it HANGS the test process on an assertion failure by
+//! leaving the plugin subprocess tree unreaped). The returned [`PluginServer`]
+//! must be kept alive for the duration of the test that uses it.
 
 use crate::certs::TestCerts;
 use base64::Engine as _;
-use shadowsocks::config::{Mode, ServerConfig};
+use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv, ReadinessMode, StartError};
+use shadowsocks::config::{Mode as SsMode, ServerConfig};
 use shadowsocks::crypto::CipherKind;
-use shadowsocks::plugin::PluginConfig;
 use shadowsocks_service::server::ServerBuilder as SsServerBuilder;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use util::port_alloc::{self, Protocols};
 
 pub const TEST_METHOD_STR: &str = "aes-256-gcm";
@@ -63,7 +69,7 @@ pub async fn start_real_ss_server(method: CipherKind, password: &str) -> (Socket
             let password = password.to_string();
             async move {
                 let mut svr_cfg = ServerConfig::new(("127.0.0.1", port), password, method).unwrap();
-                svr_cfg.set_mode(Mode::TcpAndUdp);
+                svr_cfg.set_mode(SsMode::TcpAndUdp);
                 SsServerBuilder::new(svr_cfg).build().await
             }
         },
@@ -81,15 +87,14 @@ pub async fn start_real_ss_server(method: CipherKind, password: &str) -> (Socket
     (addr, handle)
 }
 
-/// Spin up a real shadowsocks server with v2ray-plugin (websocket, no TLS)
-/// in front. Returns the public-facing socket address and the spawned
-/// server task handle. The plugin's public listen port is verified for
-/// `Protocols::TCP` only — WS is TCP per RFC 6455.
+/// Front a held ss-server with a SERVER-mode plugin (websocket, no TLS) and
+/// return the public address external clients connect to. The public port is
+/// allocated for `Protocols::TCP` only — WS is TCP per RFC 6455.
 pub async fn start_real_ss_server_with_plugin_ws(
     method: CipherKind,
     password: &str,
     plugin_path: &str,
-) -> (SocketAddr, JoinHandle<()>) {
+) -> (SocketAddr, PluginServer) {
     spawn_ss_with_plugin(
         method,
         password,
@@ -100,88 +105,160 @@ pub async fn start_real_ss_server_with_plugin_ws(
     .await
 }
 
-/// Spin up a real shadowsocks server with v2ray-plugin (websocket + TLS) in
-/// front. Same shape as [`start_real_ss_server_with_plugin_ws`] but with TLS
-/// enabled and the cert+key from `certs` mounted on the server side.
+/// Front a held ss-server with a SERVER-mode plugin (websocket + TLS). Same
+/// shape as [`start_real_ss_server_with_plugin_ws`] but with TLS enabled and the
+/// cert+key from `certs` mounted on the server side.
 pub async fn start_real_ss_server_with_plugin_ws_tls(
     method: CipherKind,
     password: &str,
     plugin_path: &str,
     certs: &TestCerts,
-) -> (SocketAddr, JoinHandle<()>) {
+) -> (SocketAddr, PluginServer) {
     let opts = format!("server;host=cloudfront.com;path=/;tls;{}", certs.plugin_opts_fragment());
     spawn_ss_with_plugin(method, password, Protocols::TCP, plugin_path, &opts).await
 }
 
-/// Spin up a real shadowsocks server with a QUIC-transport plugin in front.
-/// QUIC auto-enables TLS in `generateConfig`
-/// ([crates/ex-ray/config.go:133](../../ex-ray/config.go), the `case "quic"`
-/// arm sets `*tlsEnabled = true`), so the cert+key pair must still be supplied.
-/// The plugin's public listen port is verified for `Protocols::UDP` because
-/// QUIC runs over UDP.
+/// Front a held ss-server with a QUIC-transport SERVER-mode plugin. QUIC
+/// auto-enables TLS in `generateConfig`
+/// ([crates/ex-ray/config.go](../../ex-ray/config.go), the `case "quic"` arm
+/// sets `*tlsEnabled = true`), so the cert+key pair must still be supplied. The
+/// public port is allocated for `Protocols::UDP` because QUIC runs over UDP.
 ///
 /// Works with either the **galoshes** binary (which drives its embedded ex-ray)
-/// or a bare **ex-ray** / stock-v2ray-plugin binary: since bindreams/hole#421,
-/// ex-ray UDP-probes its inbound and reports `transports:["udp"]` for
-/// server+quic rather than rejecting it, so the standalone server path is fed
-/// directly by the QUIC interop tests in `plugin-e2e/tests/interop.rs`.
+/// or a bare **ex-ray** binary: since bindreams/hole#421, ex-ray UDP-probes its
+/// inbound and reports `transports:["udp"]` for server+quic.
 pub async fn start_real_ss_server_with_plugin_quic(
     method: CipherKind,
     password: &str,
     plugin_path: &str,
     certs: &TestCerts,
-) -> (SocketAddr, JoinHandle<()>) {
+) -> (SocketAddr, PluginServer) {
     let opts = format!("server;host=cloudfront.com;mode=quic;{}", certs.plugin_opts_fragment());
     spawn_ss_with_plugin(method, password, Protocols::UDP, plugin_path, &opts).await
 }
 
-/// Inner helper used by every `_with_plugin_*` variant. Allocates +
-/// binds the public port on the right [`Protocols`] for the plugin
-/// transport, builds a server-side `ServerConfig` with `PluginConfig`,
-/// and spawns the server loop.
+/// Keeps a plugin-fronted ss-server alive for a test's duration. Hold it for as
+/// long as the server must stay up.
 ///
-/// **Retry-asymmetry note.** `bind_ephemeral`'s retry catches
-/// `is_bind_race` errors that surface as `io::Error` from
-/// [`SsServerBuilder::build`]. For the plugin variants the public_port
-/// bind happens inside the **plugin subprocess**, after `build()`
-/// returns Ok — a public-port WSAEACCES surfaces as a `wait_for_port`
-/// timeout / connection refused, never as an `io::Error`. The wrapper
-/// here only catches races on the SS-side rendezvous loopback port
-/// that shadowsocks-rust's `Plugin::start` allocates synchronously
-/// (the long-standing #197 race class). Per-protocol correctness on
-/// the public port comes from the right `protocols` argument, not
-/// from the retry. The residual subprocess-bind TOCTOU is tracked in
-/// bindreams/hole#304. See bindreams/hole#285 §"Where the fix
-/// actually lands" for the rendezvous-port race class history.
+/// Cleanup: `Drop` cancels the chain's token (SIP003u graceful-stop signal).
+/// Final reaping of the galoshes/ex-ray subprocess is guaranteed by
+/// `BinaryPlugin`'s `kill_on_drop`: when this guard drops, the chain + ss-server
+/// `JoinHandle`s drop (detaching their tasks), and the suite's per-test `rt()`
+/// runtime is then dropped at the end of `block_on`, which drops those tasks'
+/// futures — dropping the chain's `tokio::process::Child` and killing the
+/// subprocess. nextest runs each test in its own process, so a `kill`-orphaned
+/// inner ex-ray (when graceful stop didn't run, e.g. on a test panic) is reaped
+/// by the OS when that per-test process exits — it does NOT block process exit
+/// (the load-bearing fail-fast property; see the #197 hang investigation).
+pub struct PluginServer {
+    cancel: CancellationToken,
+    _chain: JoinHandle<garter::Result<()>>,
+    _ss: JoinHandle<()>,
+}
+
+impl Drop for PluginServer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+/// Inner helper used by every `_with_plugin_*` variant: front a plain held
+/// ss-server with a single-plugin `ChainRunner(Mode::Server)` and return the
+/// public address. Symmetric to the client-side
+/// [`crate::roundtrip::run_roundtrip`]; readiness is inferred from the plugin's
+/// own sitrep `hello` ([`ReadinessMode::Auto`]).
+///
+/// The public port is PRE-ALLOCATED. ex-ray rejects port 0 (v2ray-core does not
+/// expose an OS-assigned bound port — see crates/ex-ray/main.go), so an ephemeral
+/// public listener is impossible. The narrow window between `free_port` releasing
+/// the probe socket and the plugin subprocess binding the port is closed by
+/// retrying on the in-band `StartError::BindConflict` signal with a fresh port —
+/// the same unbounded "no budget" discipline as `port_alloc::bind_ephemeral`
+/// (terminates only on ready or a non-race error; the nextest per-test timeout is
+/// the failure-to-human bound).
 async fn spawn_ss_with_plugin(
     method: CipherKind,
     password: &str,
     protocols: Protocols,
     plugin_path: &str,
     plugin_opts: &str,
-) -> (SocketAddr, JoinHandle<()>) {
-    let (port, server) = port_alloc::bind_ephemeral(IpAddr::V4(Ipv4Addr::LOCALHOST), protocols, |port| {
-        let password = password.to_string();
-        let plugin_path = plugin_path.to_string();
-        let plugin_opts = plugin_opts.to_string();
-        async move {
-            let mut svr_cfg = ServerConfig::new(("127.0.0.1", port), password, method).unwrap();
-            svr_cfg.set_mode(Mode::TcpAndUdp);
-            svr_cfg.set_plugin(PluginConfig {
-                plugin: plugin_path,
-                plugin_opts: Some(plugin_opts),
-                plugin_args: vec![],
-                plugin_mode: Mode::TcpAndUdp,
-            });
-            SsServerBuilder::new(svr_cfg).build().await
-        }
-    })
-    .await
-    .expect("spawn_ss_with_plugin: bind/build failed");
+) -> (SocketAddr, PluginServer) {
+    // Plain ss-server on a HELD loopback port (no plugin). The plugin chain
+    // forwards decapsulated traffic here; the port is held for the server's
+    // lifetime, so there is no bind-and-drop rendezvous race (the #197 class).
+    let (ss_addr, ss_handle) = start_real_ss_server(method, password).await;
 
-    let public_addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-    let handle = tokio::spawn(async move {
-        let _ = server.run().await;
-    });
-    (public_addr, handle)
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+
+        // Pre-allocate the public port. `free_port` (not `bind_ephemeral`)
+        // because the port must be returned to us so the plugin SUBPROCESS can
+        // bind it out-of-process — the documented exception to the bind_ephemeral
+        // rule (CONTRIBUTING.md#port-allocation / clippy.toml).
+        #[allow(clippy::disallowed_methods)]
+        let public_port = port_alloc::free_port(IpAddr::V4(Ipv4Addr::LOCALHOST), protocols)
+            .await
+            .expect("spawn_ss_with_plugin: allocate public port");
+
+        // Sanctioned: plugin-e2e is outside the bridge cancel chain (clippy.toml
+        // `CancellationToken::new` rule); this token owns the chain's whole life
+        // (mirrors roundtrip.rs).
+        #[allow(clippy::disallowed_methods)]
+        let cancel = CancellationToken::new();
+        let (ready_tx, ready_rx) = oneshot::channel();
+
+        let plugin = BinaryPlugin::new(plugin_path, Some(plugin_opts)).readiness(ReadinessMode::Auto);
+        let runner = ChainRunner::new()
+            .mode(Mode::Server)
+            .add(Box::new(plugin))
+            .cancel_token(cancel.clone())
+            .on_ready(ready_tx);
+        let env = PluginEnv {
+            local_host: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            local_port: ss_addr.port(),
+            remote_host: "127.0.0.1".to_string(),
+            remote_port: public_port,
+            plugin_options: None, // BinaryPlugin carries its own SS_PLUGIN_OPTIONS
+        };
+        let chain = tokio::spawn(async move { runner.run(env).await });
+
+        match ready_rx.await {
+            Ok(Ok(chain_ready)) => {
+                return (
+                    chain_ready.listen,
+                    PluginServer {
+                        cancel,
+                        _chain: chain,
+                        _ss: ss_handle,
+                    },
+                );
+            }
+            Ok(Err(StartError::BindConflict { addr, errno })) => {
+                // Adaptive milestone logging (mirrors port_alloc) so a stuck loop
+                // is visible without flooding the happy path.
+                if attempt == 1 || attempt.is_multiple_of(10) {
+                    tracing::info!(
+                        attempt,
+                        %addr,
+                        errno,
+                        "server plugin public-port bind conflict; retrying with a fresh port"
+                    );
+                }
+                cancel.cancel();
+                let _ = chain.await;
+                // retry with a fresh public_port
+            }
+            Ok(Err(StartError::Fatal { detail, errno })) => {
+                cancel.cancel();
+                let _ = chain.await;
+                panic!("server plugin failed to start: {detail} (errno={errno:?})");
+            }
+            Err(_recv) => {
+                cancel.cancel();
+                let outcome = chain.await;
+                panic!("server plugin exited before readiness: {outcome:?}");
+            }
+        }
+    }
 }

--- a/crates/plugin-e2e/src/util.rs
+++ b/crates/plugin-e2e/src/util.rs
@@ -2,9 +2,7 @@
 //! duplicated across `tests/*.rs`) so `interop.rs` and `roundtrip.rs` share one
 //! copy.
 
-use std::net::SocketAddr;
 use std::path::Path;
-use std::time::{Duration, Instant};
 
 /// One fresh tokio runtime per test body (the suites are `#[skuld::test]`
 /// sync fns that `block_on` their async work).
@@ -19,27 +17,4 @@ pub fn require_binary(path: &Path, remediation: &str) {
         path.is_file(),
         "plugin-e2e dependency missing at {path:?} — {remediation}"
     );
-}
-
-/// TCP-poll `addr` until it accepts a connection, bounded by `budget`.
-///
-/// Sanctioned CLAUDE.md sync-exception class 2: this waits on an out-of-process
-/// plugin subprocess binding its public TCP port; `budget` is the
-/// failure-to-human bound, not intra-process synchronization. The panic message
-/// includes the attempt count and last error for Windows-CI diagnosis.
-pub async fn wait_for_port(addr: SocketAddr, budget: Duration) {
-    let start = Instant::now();
-    let mut attempts = 0u32;
-    loop {
-        attempts += 1;
-        let err = match tokio::net::TcpStream::connect(addr).await {
-            Ok(_) => return,
-            Err(e) => e,
-        };
-        assert!(
-            start.elapsed() < budget,
-            "port {addr} not open within {budget:?} ({attempts} attempts; last error: {err})"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
 }

--- a/crates/plugin-e2e/tests/interop.rs
+++ b/crates/plugin-e2e/tests/interop.rs
@@ -41,8 +41,7 @@ use plugin_e2e::locators::{locate_ex_ray, locate_upstream_v2ray};
 use plugin_e2e::roundtrip::{run_roundtrip, Roundtrip, RoundtripConfig};
 use plugin_e2e::sentinel::start_fake_sentinel;
 use plugin_e2e::ssserver::{start_real_ss_server_with_plugin_ws, TEST_METHOD, TEST_PASSWORD};
-use plugin_e2e::util::{require_binary, rt, wait_for_port};
-use std::time::Duration;
+use plugin_e2e::util::{require_binary, rt};
 
 // Each skuld integration-test binary installs the observability ctor and
 // provides its own `fn main` (harness = false in Cargo.toml).
@@ -58,24 +57,20 @@ const PORT_ALLOC: skuld::Label;
 /// WS client opts mirror the server side minus the `server` flag.
 const WS_CLIENT_OPTS: &str = "host=cloudfront.com;path=/";
 
-/// The WS handshake adds latency on top of the raw TCP connect, so the
-/// generous defaults (5 s connect / 5 s read / 30 s ready) fit a cold start.
-fn ws_cfg() -> RoundtripConfig {
-    RoundtripConfig::default()
-}
-
 /// Drive one cross-implementation round-trip: a real SS server fronted by
 /// `server_plugin_path`, a client driven through `client_plugin_path`, and a
 /// fake sentinel. Asserts the `HEAD /` echoes back `HTTP/1.0 200 OK` →
 /// [`Roundtrip::Reachable`].
+///
+/// Readiness is deterministic: `start_real_ss_server_with_plugin_ws` returns
+/// only once the server plugin is live — ex-ray via its sitrep `ready`, and a
+/// non-sitrep stock plugin via `ReadinessMode::Auto`'s TCP probe (WS is TCP,
+/// so the probe observes the real public listener). There is therefore no
+/// `wait_for_port` poll before the client connects.
 fn assert_roundtrip(server_plugin_path: &str, client_plugin_path: &str) {
     rt().block_on(async {
         let (svr_addr, _svr) =
             start_real_ss_server_with_plugin_ws(TEST_METHOD, TEST_PASSWORD, server_plugin_path).await;
-        // The SS server's plugin binds its public port asynchronously; wait for
-        // it before the client connects (sanctioned class-2 external-subprocess
-        // startup wait).
-        wait_for_port(svr_addr, Duration::from_secs(7)).await;
 
         let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
 
@@ -87,7 +82,7 @@ fn assert_roundtrip(server_plugin_path: &str, client_plugin_path: &str) {
             TEST_METHOD,
             TEST_PASSWORD,
             sentinel,
-            &ws_cfg(),
+            &RoundtripConfig::default(),
         )
         .await;
         match outcome {
@@ -159,10 +154,15 @@ fn interop_stock_client_ex_ray_server() {
 /// signed by unknown authority". Production is unaffected (real CA-signed QUIC
 /// servers verify against the OS store with no custom cert). See bindreams/hole#421.
 ///
-/// The harness differs from `assert_roundtrip` because the public endpoint is
-/// UDP-only: there is no TCP `wait_for_port` (a TCP poll can't observe a UDP
-/// listener), so readiness is established by retrying the full roundtrip on a
-/// time budget.
+/// Like `assert_roundtrip`, readiness is deterministic via the launcher's
+/// sitrep `ready`: ex-ray UDP-probes its own QUIC inbound before reporting
+/// ready (bindreams/hole#421), so `start_real_ss_server_with_plugin_quic`
+/// returns only once the server is accepting. A single roundtrip therefore
+/// suffices — no retry, no time budget, no sleep. (A TCP `wait_for_port` would
+/// not work here regardless: the public endpoint is UDP-only and a TCP poll
+/// can't observe a UDP listener.) Every *active* QUIC test below uses ex-ray as
+/// the server; the lone stock-as-QUIC-server direction is `#[ignore]`d (#428),
+/// so `ReadinessMode::Auto`'s sitrep path always drives readiness here.
 #[cfg(not(target_os = "windows"))]
 mod quic {
     use super::{require_binary, rt, start_fake_sentinel, PORT_ALLOC};
@@ -170,12 +170,6 @@ mod quic {
     use plugin_e2e::locators::{locate_ex_ray, locate_upstream_v2ray};
     use plugin_e2e::roundtrip::{run_roundtrip, Roundtrip, RoundtripConfig};
     use plugin_e2e::ssserver::{start_real_ss_server_with_plugin_quic, TEST_METHOD, TEST_PASSWORD};
-    use std::time::{Duration, Instant};
-
-    /// Failure-to-human bound for the QUIC server's UDP listener becoming
-    /// reachable — the server plugin binds asynchronously after `build()`
-    /// returns, so the first roundtrip may race it; we retry until this elapses.
-    const QUIC_READY_BUDGET: Duration = Duration::from_secs(30);
 
     fn quic_client_opts(certs: &TestCerts) -> String {
         format!(
@@ -184,46 +178,34 @@ mod quic {
         )
     }
 
-    /// Drive one cross-implementation QUIC round-trip with a readiness retry
-    /// (sanctioned class-2 exception: out-of-process subprocess startup observed
-    /// via connect-success; `QUIC_READY_BUDGET` is the failure-to-human bound).
+    /// Drive one cross-implementation QUIC round-trip. Readiness is deterministic
+    /// (see the module doc): the launcher returns only after the server plugin's
+    /// sitrep `ready`, so a single roundtrip suffices with no readiness retry and
+    /// no sleep. A flake here would mean a real readiness gap in the launcher to
+    /// root-cause, not a reason to re-add timing.
     fn assert_quic_roundtrip(server_plugin_path: &str, client_plugin_path: &str) {
         rt().block_on(async {
             let certs = generate_test_certs();
             let (svr_addr, _svr) =
                 start_real_ss_server_with_plugin_quic(TEST_METHOD, TEST_PASSWORD, server_plugin_path, &certs).await;
             let opts = quic_client_opts(&certs);
-            let start = Instant::now();
-            loop {
-                // Fresh single-shot sentinel each attempt (it accepts one
-                // connection then exits, so it can't be reused across retries).
-                let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
-                match run_roundtrip(
-                    client_plugin_path,
-                    Some(&opts),
-                    &svr_addr.ip().to_string(),
-                    svr_addr.port(),
-                    TEST_METHOD,
-                    TEST_PASSWORD,
-                    sentinel,
-                    &RoundtripConfig::default(),
-                )
-                .await
-                {
-                    Roundtrip::Reachable { latency_ms } => {
-                        assert!(latency_ms >= 1, "latency_ms must be clamped to >= 1");
-                        return;
-                    }
-                    other => {
-                        assert!(
-                            start.elapsed() < QUIC_READY_BUDGET,
-                            "quic roundtrip server={server_plugin_path:?} client={client_plugin_path:?} \
-                             did not become reachable within {QUIC_READY_BUDGET:?}; last outcome: {other:?}"
-                        );
-                        // Server UDP listener still binding; brief backoff then retry.
-                        tokio::time::sleep(Duration::from_millis(200)).await;
-                    }
-                }
+            let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+            let outcome = run_roundtrip(
+                client_plugin_path,
+                Some(&opts),
+                &svr_addr.ip().to_string(),
+                svr_addr.port(),
+                TEST_METHOD,
+                TEST_PASSWORD,
+                sentinel,
+                &RoundtripConfig::default(),
+            )
+            .await;
+            match outcome {
+                Roundtrip::Reachable { latency_ms } => assert!(latency_ms >= 1, "latency_ms must be clamped to >= 1"),
+                other => panic!(
+                    "expected Reachable for quic server={server_plugin_path:?} client={client_plugin_path:?}, got {other:?}"
+                ),
             }
         });
     }

--- a/crates/plugin-e2e/tests/roundtrip.rs
+++ b/crates/plugin-e2e/tests/roundtrip.rs
@@ -4,15 +4,16 @@
 //! binary as the client plugin) → galoshes-client → (transport) →
 //! galoshes-server (fronting a real ss-server) → fake sentinel.
 //!
-//! **Linux-only (`#197`).** The galoshes-server fixture uses
-//! `shadowsocks-service`'s `PluginConfig`, whose bind-and-drop port allocation
-//! races galoshes' embedded yamux-server on Win+mac (bindreams/hole#197).
-//! Linux is where galoshes-server works today; relocation here is correct
-//! regardless of #197 (see #435). Re-enable on Win+mac once #197 lands.
+//! Plain **WS** runs on all platforms. **WS-TLS** and **QUIC** are gated off
+//! Windows (`#[cfg(not(target_os = "windows"))]`): both present a self-signed
+//! cert the client trusts via ex-ray's `AUTHORITY_VERIFY`, and v2ray-core's
+//! `getCertPool` drops custom certs on Windows — the same limitation that gates
+//! `interop.rs::mod quic`. macOS + Linux run all three. (bindreams/hole#197: the
+//! galoshes-server fixture is now the garter-based launcher in `ssserver.rs`,
+//! not `shadowsocks-service`'s `PluginConfig`; readiness is deterministic, so
+//! there is no `wait_for_port`.)
 
-// Unconditional: skuld's harness (`harness = false`) needs a `main` on every
-// platform. The tests themselves are `cfg(linux)` (see `mod linux` below); on
-// non-Linux this binary links and `skuld::run_all()` finds zero tests.
+// skuld's harness (`harness = false`) needs a `main` on every platform.
 hole_test_observability::register!();
 
 fn main() {
@@ -48,18 +49,20 @@ mod launcher_smoke {
     }
 }
 
-#[cfg(target_os = "linux")]
-mod linux {
-    use plugin_e2e::certs::{generate_test_certs, path_for_plugin_opts};
+mod roundtrips {
     use plugin_e2e::locators::locate_built_galoshes;
     use plugin_e2e::roundtrip::{run_roundtrip, Roundtrip, RoundtripConfig};
     use plugin_e2e::sentinel::start_fake_sentinel;
-    use plugin_e2e::ssserver::{
-        start_real_ss_server_with_plugin_quic, start_real_ss_server_with_plugin_ws,
-        start_real_ss_server_with_plugin_ws_tls, TEST_METHOD, TEST_PASSWORD,
-    };
-    use plugin_e2e::util::{require_binary, rt, wait_for_port};
-    use std::time::{Duration, Instant};
+    use plugin_e2e::ssserver::{start_real_ss_server_with_plugin_ws, TEST_METHOD, TEST_PASSWORD};
+    use plugin_e2e::util::{require_binary, rt};
+
+    // WS-TLS + QUIC present a self-signed cert; v2ray-core's getCertPool drops
+    // custom certs on Windows, so those two transports are gated off Windows (see
+    // the file header). These imports are used only by those gated tests.
+    #[cfg(not(target_os = "windows"))]
+    use plugin_e2e::certs::{generate_test_certs, path_for_plugin_opts};
+    #[cfg(not(target_os = "windows"))]
+    use plugin_e2e::ssserver::{start_real_ss_server_with_plugin_quic, start_real_ss_server_with_plugin_ws_tls};
 
     #[skuld::label]
     const PORT_ALLOC: skuld::Label;
@@ -70,13 +73,12 @@ mod linux {
         p.to_str().expect("galoshes path is valid utf-8").to_string()
     }
 
-    /// galoshes server↔client over websocket (the baseline "TCP" transport).
+    /// galoshes server↔client over websocket (the baseline TCP transport) — all platforms.
     #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
     fn galoshes_ws_roundtrip() {
         let g = require_galoshes();
         rt().block_on(async {
             let (svr, _h) = start_real_ss_server_with_plugin_ws(TEST_METHOD, TEST_PASSWORD, &g).await;
-            wait_for_port(svr, Duration::from_secs(10)).await;
             let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
             let outcome = run_roundtrip(
                 &g,
@@ -93,14 +95,14 @@ mod linux {
         });
     }
 
-    /// galoshes server↔client over websocket + TLS.
+    /// galoshes server↔client over websocket + TLS (off Windows — see file header).
+    #[cfg(not(target_os = "windows"))]
     #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
     fn galoshes_ws_tls_roundtrip() {
         let g = require_galoshes();
         rt().block_on(async {
             let certs = generate_test_certs();
             let (svr, _h) = start_real_ss_server_with_plugin_ws_tls(TEST_METHOD, TEST_PASSWORD, &g, &certs).await;
-            wait_for_port(svr, Duration::from_secs(10)).await;
             let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
             let opts = format!(
                 "host=cloudfront.com;path=/;tls;cert={}",
@@ -121,10 +123,12 @@ mod linux {
         });
     }
 
-    /// galoshes server↔client over QUIC (the path #421 unblocked for the
-    /// galoshes-fronted server). The public endpoint is UDP, so readiness is
-    /// established by retrying the whole roundtrip on a failure-to-human budget
-    /// (sanctioned class-2 exception).
+    /// galoshes server↔client over QUIC (the path #421 unblocked; off Windows —
+    /// see file header). Readiness is deterministic — the launcher returns only
+    /// after galoshes' sitrep `ready` — so a single roundtrip suffices, no
+    /// retry/sleep. (A flake here would mean a real readiness gap to root-cause,
+    /// not a reason to re-add timing.)
+    #[cfg(not(target_os = "windows"))]
     #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
     fn galoshes_quic_roundtrip() {
         let g = require_galoshes();
@@ -135,31 +139,19 @@ mod linux {
                 "host=cloudfront.com;mode=quic;cert={}",
                 path_for_plugin_opts(&certs.cert_path)
             );
-            let start = Instant::now();
-            loop {
-                let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
-                match run_roundtrip(
-                    &g,
-                    Some(&opts),
-                    &svr.ip().to_string(),
-                    svr.port(),
-                    TEST_METHOD,
-                    TEST_PASSWORD,
-                    sentinel,
-                    &RoundtripConfig::default(),
-                )
-                .await
-                {
-                    Roundtrip::Reachable { .. } => return,
-                    other => {
-                        assert!(
-                            start.elapsed() < Duration::from_secs(30),
-                            "quic not reachable in 30s; last: {other:?}"
-                        );
-                        tokio::time::sleep(Duration::from_millis(200)).await;
-                    }
-                }
-            }
+            let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+            let outcome = run_roundtrip(
+                &g,
+                Some(&opts),
+                &svr.ip().to_string(),
+                svr.port(),
+                TEST_METHOD,
+                TEST_PASSWORD,
+                sentinel,
+                &RoundtripConfig::default(),
+            )
+            .await;
+            assert!(matches!(outcome, Roundtrip::Reachable { .. }), "quic: {outcome:?}");
         });
     }
 }

--- a/crates/plugin-e2e/tests/roundtrip.rs
+++ b/crates/plugin-e2e/tests/roundtrip.rs
@@ -19,6 +19,35 @@ fn main() {
     skuld::run_all();
 }
 
+/// Focused launcher smoke check (all platforms): the garter-based fixture
+/// returns a LIVE, bound loopback public TCP address for a galoshes WS server —
+/// no `PluginConfig`, no `wait_for_port`. Isolates "did the launcher come up"
+/// from the full client roundtrip below.
+mod launcher_smoke {
+    use plugin_e2e::locators::locate_built_galoshes;
+    use plugin_e2e::ssserver::{start_real_ss_server_with_plugin_ws, TEST_METHOD, TEST_PASSWORD};
+    use plugin_e2e::util::{require_binary, rt};
+    use tokio::net::TcpStream;
+
+    #[skuld::test]
+    fn galoshes_ws_server_launcher_returns_live_public_addr() {
+        let g = locate_built_galoshes();
+        require_binary(&g, "run `cargo xtask galoshes`");
+        let g = g.to_str().expect("galoshes path is valid utf-8").to_string();
+        rt().block_on(async {
+            let (public, _server) = start_real_ss_server_with_plugin_ws(TEST_METHOD, TEST_PASSWORD, &g).await;
+            assert!(public.ip().is_loopback(), "public addr must be loopback: {public}");
+            assert_ne!(public.port(), 0, "public port must be concrete");
+            // The returned addr must be the REAL bound public port: a TCP connect
+            // to it must succeed (WS is TCP). Proves the launcher returned the
+            // plugin's actual listener, not a stale/garbage addr.
+            TcpStream::connect(public)
+                .await
+                .expect("public WS port must accept connections");
+        });
+    }
+}
+
 #[cfg(target_os = "linux")]
 mod linux {
     use plugin_e2e::certs::{generate_test_certs, path_for_plugin_opts};


### PR DESCRIPTION
Fixes #197.

## Problem

The galoshes **server-side** e2e tests failed on macOS (an internal port race in
`shadowsocks-service`'s `PluginConfig` rendezvous) and **hung the test process on
teardown** on Windows. Root cause of the hang: garter force-killed only the
direct plugin child (galoshes) and orphaned its grandchild (ex-ray), which on
Windows had inherited the host's stdout/stderr pipe handles — so the host's
pipe-reader never EOF'd and tokio's `Runtime::drop` blocked forever.

## Fix

**garter library hardening (also benefits production galoshes teardown):**

- **`proc_group.rs` (new): cross-platform process-tree reaping, no `#[cfg]` at
  call sites.** Windows clears `HANDLE_FLAG_INHERIT` on the host's std handles
  before spawn (the race-free fix for the hang — an orphan can never hold the
  host pipes) and assigns the root child to a Job Object with
  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; Unix uses `process_group(0)` +
  `kill(-pgid)`. Root vs. nested is auto-detected via an inherited
  `GARTER_IN_KILL_GROUP` env var (Windows jobs nest, Unix pgroups don't, so the
  kill-group is created exactly once at the outermost spawn).
- **`ReadinessMode::Auto`:** a plugin's readiness is inferred from its own sitrep
  `hello` — a concurrent TCP self-probe stands down when a supported `hello`
  arrives (sitrep drives readiness), and a silent/non-sitrep plugin readies via
  the probe. No caller argument needed.

**e2e fixture migration (the #197 race itself):**

- **`plugin-e2e/src/ssserver.rs`:** replaced the `shadowsocks-service`
  `PluginConfig` fixture with a `garter::ChainRunner(Mode::Server)` +
  `BinaryPlugin(ReadinessMode::Auto)` launcher. The public port is pre-allocated
  (ex-ray rejects port 0) and retried on the in-band `StartError::BindConflict`
  — the same unbounded "no budget" discipline as `bind_ephemeral`. No more
  bind-and-drop rendezvous race; readiness is deterministic.
- **`interop.rs` / `roundtrip.rs`:** dropped `wait_for_port` (readiness is now
  deterministic via the launcher's sitrep gate) and removed the QUIC interop
  sleep-retry loop in favor of a single-shot roundtrip (ex-ray emits sitrep
  `ready` only after UDP-probing its QUIC inbound, #421). Made `RoundtripConfig`'s
  default class-2 read/connect bounds generous (5s→20s) — a failure-to-human
  bound that only fires on a genuine hang, not the documented cold-start jitter.

## Tests

- `force_kill_reaps_descendant_tree` (garter) reproduces the #197 mechanism (a
  grandchild inheriting the parent's piped stdio) and verifies the whole tree is
  reaped — via a **control connection the grandchild dials back**, so readiness
  is `accept()` (deterministic, no poll) and death is `read()→EOF` (reuse-immune
  — a recycled PID can't resurrect the socket — and sleep-free).
- Four `auto_*` readiness tests, version-skew fallback, empty-transports, and
  bind-conflict/fatal surfacing.

## Local verification (Windows)

- plugin-e2e suite 5/5 + 6× forced cold-start of `galoshes_ws_roundtrip`
- garter + mock-plugin 104/104
- clippy `-D warnings` clean across garter/galoshes/mock-plugin/plugin-e2e/util
- garter version check passes

macOS/Linux (the WS-TLS/QUIC roundtrips and the original #197 macOS failure) are
gated off Windows and validated here on CI.

## Notes

- No `shadowsocks-service` `PluginConfig` in the server fixture anymore.
- Follow-up (separate PR, `azhukova/197-2`): un-orphan the bridge `DistHarness`
  server-side e2e tests onto the same launcher.
