### PR TITLE
fix(dev): run dev mode unprivileged, sudo only the bridge (#452)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,19 @@ jobs:
         shell: bash
         run: cargo xtask run plugin-e2e-tests
 
+  # Unit tests for the dev/admin Python scripts (scripts/dev_tests.py). Runs
+  # `uv run` DIRECTLY (not via `cargo xtask run scripts-tests`) to avoid
+  # provisioning a Rust toolchain + compiling xtask just to shell out to
+  # Python. The tests are platform-agnostic, so one ubuntu runner suffices.
+  test-scripts:
+    name: Test scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+      - name: Run script tests
+        run: uv run scripts/dev_tests.py
 
   test-installer:
     name: Test installer (windows/amd64)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,38 +366,44 @@ cargo xtask run hole-dmg-tests   # mount + assert .app code signature is intact
 ### Running in dev mode
 
 Dev mode creates a **real TUN interface** and edits the routing table (the
-production bridge path), so it needs elevation:
+production bridge path), so the bridge needs elevation — but you run the command
+unprivileged:
 
 ```sh
-# Windows: from an elevated PowerShell
+# macOS: NO sudo
 cargo xtask run hole
 
-# macOS: build as your user first, then elevate to run
-cargo xtask build hole
-sudo cargo xtask run hole
+# Windows: from an elevated PowerShell
+cargo xtask run hole
 ```
+
+> **Do NOT `sudo cargo xtask run hole`.** dev.py refuses to run as root, but the
+> outer xtask build cascade runs first — so a sudo'd invocation leaves
+> root-owned files in `target/` before dev.py can bail (bindreams/hole#452).
+> Closing this sudo-invocation path structurally is tracked in #453.
 
 `cargo xtask run hole` launches `scripts/dev.py`, which builds the workspace,
 starts Vite, and launches bridge + GUI with multiplexed color-coded logs.
 Frontend changes hot-reload via Vite HMR; Rust changes need Ctrl+C and re-run.
 
-- **Why build first on macOS:** `run` invokes the build cascade before `run:`
-  steps; under `sudo` that would leave `target/` root-owned. Building unprivileged
-  first warms the cache so the elevated cascade is a no-op. (Windows UAC is
-  token-based — unaffected.)
-- On macOS `dev.py` detects `SUDO_USER` and drops privileges (setuid/setgid +
-  `extra_groups`) for the GUI/Vite so they read your real `~/Library`, while the
-  bridge inherits root.
+- **dev.py runs unprivileged and elevates only the bridge.** On macOS it
+  prompts for your sudo password once, then `sudo`s just `bridge grant-access` +
+  `bridge run`. Vite and the GUI run as you, reading your real `~/Library`. On
+  Windows everything inherits the already-elevated UAC token (token-based; no
+  identity change).
 - `dev.py` runs `hole bridge grant-access` (creates the `hole` group, adds your
   user) so the bridge exercises the production DACL/group path on every run. The
-  group is **not** removed on exit (same as production).
+  group is **not** removed on exit (same as production). The GUI needs the `hole`
+  group to open the IPC socket; the first run after `grant-access` creates the
+  group, so a one-time log out / log back in (or reboot) may be required.
 
 ### Manual workflow
 
-Separate terminals, more control. **Terminal 1 — bridge (elevated):**
+Separate terminals, more control. **Terminal 1 — bridge:** build and stage as
+your normal user; only `bridge grant-access` + `bridge run` need elevation.
 
 ```powershell
-# Windows (elevated PowerShell)
+# Windows (elevated PowerShell — UAC token-based, everything inherits it)
 cargo xtask build hole
 cargo xtask stage --profile debug --out-dir "$env:TEMP\hole-dev-manual"
 & "$env:TEMP\hole-dev-manual\hole.exe" bridge grant-access
@@ -406,11 +412,11 @@ cargo xtask stage --profile debug --out-dir "$env:TEMP\hole-dev-manual"
 ```
 
 ```sh
-# macOS (under sudo)
+# macOS — run as yourself; sudo only the two bridge commands
 cargo xtask build hole
 cargo xtask stage --profile debug --out-dir "$TMPDIR/hole-dev-manual"
-"$TMPDIR/hole-dev-manual/hole" bridge grant-access
-"$TMPDIR/hole-dev-manual/hole" bridge run \
+sudo "$TMPDIR/hole-dev-manual/hole" bridge grant-access
+sudo "$TMPDIR/hole-dev-manual/hole" bridge run \
     --socket-path "$TMPDIR/hole-dev.sock" --state-dir "$TMPDIR/hole-dev-state"
 ```
 
@@ -444,6 +450,8 @@ it. The canonical file list is [xtask/src/bindir.rs](xtask/src/bindir.rs).
 
 ### Notes
 
+- The unelevated GUI needs the `hole` group to open the IPC socket; `bridge grant-access` creates it and adds your user, so on a fresh machine a one-time
+  log out / log back in (or reboot) may be required before the GUI can connect.
 - Use absolute paths (e.g. `$TEMP`) for `--socket-path` to avoid Windows AF_UNIX
   path-length limits.
 - The dev binary shares `com.hole.app` with the installed build, so if an

--- a/build.yaml
+++ b/build.yaml
@@ -75,8 +75,10 @@ targets:
     # `cargo xtask run hole` launches dev mode via scripts/dev.py. dev.py
     # itself runs `cargo xtask build hole` internally, but the build cascade
     # above will have just executed it, so dev.py's own invocation no-ops via
-    # cargo's incremental cache. Cheap, no special handling needed. Requires
-    # elevation (sudo / Run As Administrator) — same precondition as today.
+    # cargo's incremental cache. Cheap, no special handling needed. dev.py
+    # itself runs unprivileged and elevates only the bridge — via sudo on
+    # POSIX (prompts for your password), inheriting the elevated token on
+    # Windows (#452).
     #
     # `--no-default-features` keeps Tauri's `cfg(dev) = true` so the webview
     # loads from the Vite dev server (`http://localhost:1420`) instead of
@@ -153,6 +155,19 @@ targets:
   # ===== Test targets =======================================================
   # `build:` compiles test binaries (--no-run); `run:` is the canonical local
   # nextest invocation. CI may diverge from it (see the header note above).
+
+  scripts-tests:
+    # Unit tests for the dev/admin Python scripts (scripts/dev_tests.py).
+    # Platforms wide-open (like prek/frontend-check) so a dev on ANY host can
+    # `cargo xtask run scripts-tests`; the tests are platform-agnostic
+    # (prefix_stream) or take the platform as a parameter (privilege helpers).
+    # CI pins its own runner (the test-scripts job runs `uv run` directly on
+    # ubuntu), so this `platforms:` only governs local host-applicability.
+    # Previously local-only; wiring it gives the tests CI coverage (#452).
+    # `run:`-only (no build cascade) — same shape as prek/frontend-check.
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    run: uv run scripts/dev_tests.py
 
   hole-tests:
     # `--no-default-features` matches the `hole` target's debug build: tests

--- a/crates/bridge/src/foreground.rs
+++ b/crates/bridge/src/foreground.rs
@@ -32,6 +32,12 @@ pub fn run(socket_path: &Path, state_dir: &Path, log_dir: &Path) -> Result<(), B
 /// (not lazily on first poll), so a caller that raises SIGTERM immediately
 /// after still observes it. Must be called within a Tokio runtime — it is,
 /// from `run_inner` and the test's `block_on`.
+// On non-unix the `#[cfg(unix)] let sigterm = …` line below is cfg'd out,
+// leaving a bare `async move` body, so clippy's `manual_async_fn` suggests
+// `async fn`. But on unix the function MUST stay `fn -> impl Future` so the
+// SIGTERM handler installs eagerly (before the future is first polled). Keep
+// one shape across platforms and silence the lint only where it misfires.
+#[cfg_attr(not(unix), allow(clippy::manual_async_fn))]
 fn shutdown_signal() -> impl std::future::Future<Output = ()> {
     #[cfg(unix)]
     let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate());

--- a/crates/bridge/src/foreground.rs
+++ b/crates/bridge/src/foreground.rs
@@ -23,6 +23,41 @@ pub fn run(socket_path: &Path, state_dir: &Path, log_dir: &Path) -> Result<(), B
     rt.block_on(run_inner(socket_path, state_dir, log_dir))
 }
 
+/// Resolve when a shutdown signal arrives: Ctrl+C (SIGINT) everywhere, or
+/// SIGTERM on Unix. dev.py terminates the bridge with SIGTERM (relayed
+/// through sudo); without a SIGTERM handler the bridge would die on the
+/// default disposition and leak routes/DNS (bindreams/hole#452).
+///
+/// Returns a future but installs the SIGTERM handler EAGERLY when called
+/// (not lazily on first poll), so a caller that raises SIGTERM immediately
+/// after still observes it. Must be called within a Tokio runtime — it is,
+/// from `run_inner` and the test's `block_on`.
+fn shutdown_signal() -> impl std::future::Future<Output = ()> {
+    #[cfg(unix)]
+    let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate());
+    async move {
+        #[cfg(unix)]
+        match sigterm {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => tracing::info!("shutdown signal (SIGINT) received"),
+                    _ = sigterm.recv() => tracing::info!("shutdown signal (SIGTERM) received"),
+                }
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to install SIGTERM handler; Ctrl+C only");
+                let _ = tokio::signal::ctrl_c().await;
+                tracing::info!("shutdown signal (SIGINT) received");
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!("shutdown signal (Ctrl+C) received");
+        }
+    }
+}
+
 async fn run_inner(socket_path: &Path, state_dir: &Path, log_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let proxy = std::sync::Arc::new(tokio::sync::Mutex::new(
         ProxyManager::new(ShadowsocksProxy::new(), SystemRouting::new(state_dir.to_path_buf()))
@@ -101,9 +136,7 @@ async fn run_inner(socket_path: &Path, state_dir: &Path, log_dir: &Path) -> Resu
                 tracing::error!(error = %e, "IPC server error");
             }
         }
-        _ = tokio::signal::ctrl_c() => {
-            tracing::info!("shutdown signal received");
-        }
+        _ = shutdown_signal() => {}
     }
 
     let mut pm = proxy_shutdown.lock().await;

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -207,3 +207,28 @@ fn foreground_run_accepts_ipc_and_shuts_down() {
         server_handle.await.expect("server task panicked");
     });
 }
+
+// dev.py's SIGTERM (relayed by sudo) must trigger graceful `pm.stop()`
+// instead of an ungraceful default-disposition kill that leaks routes/DNS
+// (bindreams/hole#452). `shutdown_signal()` installs the SIGTERM handler
+// SYNCHRONOUSLY when called (Step 3), so raising the signal immediately
+// after is non-fatal and is observed by the returned future — deterministic,
+// no spawn/poll race (a prior spawn+yield_now form raced and killed the test
+// process with SIGTERM's default disposition on iteration 0). macOS-gated to
+// match libc's dependency gating; test-hole's only POSIX hosts are macOS, and
+// nextest isolates each test in its own process so the raise can't disturb
+// siblings.
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn sigterm_resolves_shutdown_signal() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        // Installs the SIGTERM handler NOW (eager, not on first poll).
+        let fut = super::shutdown_signal();
+        // SAFETY: raising a signal to our own process is sound.
+        assert_eq!(unsafe { libc::raise(libc::SIGTERM) }, 0);
+        // Resolves on the delivered SIGTERM; bounded by the framework timeout
+        // (allowed external-event failure-bound), not a self-chosen sleep.
+        fut.await;
+    });
+}

--- a/scripts/_lib.py
+++ b/scripts/_lib.py
@@ -1,5 +1,4 @@
-"""Shared helpers for dev.py and network-reset.py — elevation detection
-and sudo user drop for POSIX split-privilege workflows.
+"""Shared helpers for dev.py and network-reset.py — elevation detection.
 
 Imported by both scripts as a plain sibling module. Python adds each
 script's own directory to sys.path at startup, so `import _lib` works
@@ -30,37 +29,3 @@ def require_elevation() -> None:
         if os.geteuid() != 0:
             print("ERROR: this script must run as root (use sudo).", file=sys.stderr)
             sys.exit(1)
-
-
-def sudo_target_user() -> tuple[int, int, str, str] | None:
-    """Return (uid, gid, username, home) of the invoking user if running
-    under `sudo` on POSIX, else None.
-
-    Returns None if:
-      - running on Windows (no equivalent concept — UAC preserves identity),
-      - SUDO_USER is unset (not running under sudo),
-      - SUDO_USER equals "root" (sudo -u root; no drop is meaningful),
-      - pwd.getpwnam cannot resolve SUDO_USER (NIS/LDAP lookup failure;
-        prints a warning and returns None so the caller falls back to
-        keeping the child at root rather than crashing).
-    """
-    if platform.system() == "Windows":
-        return None
-
-    user = os.environ.get("SUDO_USER")
-    if not user or user == "root":
-        return None
-
-    try:
-        import pwd
-
-        pw = pwd.getpwnam(user)
-    except KeyError:
-        print(
-            f"WARNING: SUDO_USER='{user}' could not be resolved via pwd.getpwnam. "
-            f"GUI will run as root; your real config will not be used.",
-            file=sys.stderr,
-        )
-        return None
-
-    return (pw.pw_uid, pw.pw_gid, user, pw.pw_dir)

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -50,7 +50,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 # `grp` is POSIX-only. dev.py is also invoked on Windows from an elevated
 # PowerShell, where `_lib.sudo_target_user()` returns None and `drop_kwargs`
@@ -344,7 +344,68 @@ def shutdown(
             t.join(timeout=5)
 
 
-# Privilege drop =======================================================================================================
+# Privilege model ======================================================================================================
+
+# Env vars worth preserving across the sudo boundary into the elevated bridge:
+# log filtering + backtraces. sudo scrubs the environment otherwise, silently
+# changing dev logging behavior. RUST_LOG/RUST_BACKTRACE/HOLE_BRIDGE_LOG are
+# not on sudo's default env blacklist, so `--preserve-env=<list>` passes them.
+SUDO_PRESERVE_ENV = ["RUST_LOG", "RUST_BACKTRACE", "HOLE_BRIDGE_LOG"]
+
+
+def elevation_action(system: str, euid: int | None) -> Literal["windows-require-admin", "posix-error-root", "posix-ok"]:
+    """How dev mode handles privilege on this host.
+
+    "windows-require-admin": Windows — require an already-elevated shell (UAC
+    token-based; nothing is dropped). "posix-error-root": POSIX as root —
+    refuse; dev mode runs unprivileged and elevates only the bridge, and
+    running as root re-poisons target/ (bindreams/hole#452). "posix-ok":
+    POSIX as a normal user — the supported path. `euid` is unused on Windows.
+    """
+    if system == "Windows":
+        return "windows-require-admin"
+    if euid == 0:
+        return "posix-error-root"
+    return "posix-ok"
+
+
+def sudo_prefix(system: str) -> list[str]:
+    """`["sudo"]` on POSIX, `[]` on Windows (already elevated; no sudo)."""
+    return [] if system == "Windows" else ["sudo"]
+
+
+def _elevated(elevate: list[str]) -> list[str]:
+    """sudo prefix with env preservation, or [] when not elevating."""
+    return [*elevate, f"--preserve-env={','.join(SUDO_PRESERVE_ENV)}"] if elevate else []
+
+
+def grant_access_argv(elevate: list[str], bridge_bin: str | os.PathLike[str]) -> list[str]:
+    """argv for `bridge grant-access`, sudo-prefixed on POSIX."""
+    return [*_elevated(elevate), str(bridge_bin), "bridge", "grant-access"]
+
+
+def bridge_argv(
+    elevate: list[str], bridge_bin: str | os.PathLike[str], socket_path: str | os.PathLike[str],
+    state_dir: str | os.PathLike[str]
+) -> list[str]:
+    """argv for `bridge run`, sudo-prefixed on POSIX."""
+    return [
+        *_elevated(elevate),
+        str(bridge_bin), "bridge", "run", "--socket-path",
+        str(socket_path), "--state-dir",
+        str(state_dir)
+    ]
+
+
+def missing_hole_group(hole_gid: int | None, current_gids: set[int]) -> bool:
+    """True if `hole` exists but the current process is not a member.
+
+    Pass `set(os.getgroups()) | {os.getgid(), os.getegid()}` as `current_gids`
+    — `os.getgroups()` omits the primary/effective gid on some systems, which
+    would falsely report a user whose primary group is `hole` as missing.
+    `hole_gid is None` means the group does not exist yet (nothing to check).
+    """
+    return hole_gid is not None and hole_gid not in current_gids
 
 
 def drop_kwargs(target: tuple[int, int, str, str] | None) -> dict:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -8,7 +8,7 @@ Builds the workspace, then runs three processes:
 
 USAGE:
   Windows: from an elevated PowerShell — `cargo xtask run hole`
-  macOS / Linux: `cargo xtask run hole`  (NO sudo)
+  macOS: `cargo xtask run hole`  (NO sudo)
 
 On POSIX dev.py runs as your user and elevates only the bridge
 (`bridge grant-access` + `bridge run`) via sudo, so target/ stays owned by
@@ -16,9 +16,8 @@ you. Do NOT run it under sudo — it refuses, and a sudo'd `cargo xtask run
 hole` leaves root-owned files in target/ — its outer build cascade runs as
 root before dev.py can refuse (bindreams/hole#452). Closing that
 sudo-invocation path structurally is tracked in #453. The dev GUI needs the
-`hole` group for the IPC
-socket; the first run after grant-access creates the group, so a one-time
-log-out/in may be required. On Windows, UAC is token-based so all three
+`hole` group for the IPC socket; the first run after grant-access creates the
+group, so a one-time log-out/in may be required. On Windows, UAC is token-based so all three
 inherit the elevated token without an identity change.
 
 The bridge binary and its sidecars (ex-ray, galoshes) are staged in a

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -6,14 +6,20 @@ Builds the workspace, then runs three processes:
   2. Bridge in foreground mode (REAL TUN + routing) — elevated
   3. GUI (Tauri webview loading from Vite) — unelevated on macOS
 
-REQUIRES ELEVATION:
-  Windows: run from an elevated PowerShell (`uv run scripts/dev.py`)
-  macOS:   `sudo uv run scripts/dev.py`
+USAGE:
+  Windows: from an elevated PowerShell — `cargo xtask run hole`
+  macOS / Linux: `cargo xtask run hole`  (NO sudo)
 
-On macOS, this script detects `SUDO_USER` and drops privileges for Vite
-and the GUI so they read your real ~/Library config, while the bridge
-inherits root. On Windows, UAC is token-based so all three inherit the
-elevated token without an identity change.
+On POSIX dev.py runs as your user and elevates only the bridge
+(`bridge grant-access` + `bridge run`) via sudo, so target/ stays owned by
+you. Do NOT run it under sudo — it refuses, and a sudo'd `cargo xtask run
+hole` leaves root-owned files in target/ — its outer build cascade runs as
+root before dev.py can refuse (bindreams/hole#452). Closing that
+sudo-invocation path structurally is tracked in #453. The dev GUI needs the
+`hole` group for the IPC
+socket; the first run after grant-access creates the group, so a one-time
+log-out/in may be required. On Windows, UAC is token-based so all three
+inherit the elevated token without an identity change.
 
 The bridge binary and its sidecars (ex-ray, galoshes) are staged in a
 per-pid subdirectory under the system temp dir (`$TMPDIR/hole-dev-<pid>/` or
@@ -41,6 +47,7 @@ from __future__ import annotations
 
 import atexit
 import os
+import platform
 import re
 import shutil
 import socket
@@ -52,10 +59,9 @@ import time
 from pathlib import Path
 from typing import Any, Literal
 
-# `grp` is POSIX-only. dev.py is also invoked on Windows from an elevated
-# PowerShell, where `_lib.sudo_target_user()` returns None and `drop_kwargs`
-# short-circuits before touching `grp`. Gate the import so module load
-# succeeds on Windows.
+# `grp` is POSIX-only. dev.py is also invoked on Windows, where the hole-group
+# gate in main() is skipped (guarded by `system != "Windows"`). Gate the import
+# so module load succeeds on Windows.
 if sys.platform != "win32":
     import grp
 
@@ -91,9 +97,9 @@ def resolve_tool(name: str) -> str:
     return path
 
 
-def ensure_node_modules(npm: str, target_user: tuple[int, int, str, str] | None) -> None:
+def ensure_node_modules(npm: str) -> None:
     """Run `npm install` unconditionally to keep `node_modules/` in sync with
-    `package-lock.json`.
+    `package-lock.json`. Runs as the invoking user — dev.py is unprivileged.
 
     Unconditional install is deliberate: a conditional skip-on-exists would
     silently miss dependency additions pulled from a new commit and leave Vite
@@ -101,27 +107,25 @@ def ensure_node_modules(npm: str, target_user: tuple[int, int, str, str] | None)
     dominated by cargo below; `--no-audit --no-fund` trims the output to a
     single line so dev.py's startup stays quiet on the happy path."""
     print(f"{BOLD}Syncing npm dependencies...{RESET}")
-    # Run as the invoking user so `node_modules/` is not owned by root.
     result = subprocess.run(
         [npm, "install", "--no-audit", "--no-fund"],
         stdout=sys.stdout,
         stderr=sys.stderr,
-        env=drop_env({**os.environ}, target_user),
-        **drop_kwargs(target_user),
     )
     if result.returncode != 0:
         sys.exit(result.returncode)
 
 
-def cargo_build(cargo: str, target_user: tuple[int, int, str, str] | None) -> None:
-    """Build the `hole` target via the orchestrator.
+def cargo_build(cargo: str) -> None:
+    """Build the `hole` target via the orchestrator, as the invoking user.
 
     `cargo xtask build hole` walks the build.yaml DAG: ex-ray → galoshes
     + wintun → cargo build (debug) → stage. The per-pid stage that follows in
     main() is dev.py-specific and stays separate.
 
-    Runs as the invoking user so `target/` and `.cache/` are not owned by root
-    on macOS-under-sudo.
+    The outer `cargo xtask run hole` cascade just ran this as this same user
+    (dev.py refuses to run as root upstream), so this is an incremental no-op
+    with consistent ownership — no root-owned artifacts.
     """
     print(f"{BOLD}Building hole (cargo xtask build hole)...{RESET}")
     result = subprocess.run(
@@ -131,8 +135,7 @@ def cargo_build(cargo: str, target_user: tuple[int, int, str, str] | None) -> No
         # HOLE_CRASH_DUMPS opts galoshes' xtask build into the dev-only
         # minidump feature (bindreams/hole#438), matching the hole target's
         # --features tombstone/crash-dumps. Never set in release/MSI builds.
-        env=drop_env({**os.environ, "HOLE_CRASH_DUMPS": "1"}, target_user),
-        **drop_kwargs(target_user),
+        env={**os.environ, "HOLE_CRASH_DUMPS": "1"},
     )
     if result.returncode != 0:
         sys.exit(result.returncode)
@@ -320,25 +323,33 @@ def terminate_tree(proc: subprocess.Popen) -> None:
 def shutdown(
     procs: list[subprocess.Popen],
     prefix_threads: list[threading.Thread] | None = None,
+    *,
+    bridge_proc: subprocess.Popen | None = None
 ) -> None:
     print(f"\n{BOLD}Shutting down...{RESET}")
+    # SIGTERM via killpg; sudo relays SIGTERM to the bridge, whose handler
+    # runs the graceful route/DNS teardown.
     for proc in procs:
         terminate_tree(proc)
     for proc in procs:
         try:
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
-            # Tree-kill already used SIGKILL on Windows; on POSIX fall
-            # back to per-process SIGKILL for any stragglers.
-            proc.kill()
-
-    # Drain the prefix_stream readers so any entry buffered in-flight
-    # (the bridge's panic before exit, in particular) gets flushed to the
-    # console. Each thread's natural exit happens quickly after its
-    # subprocess's stdout closes; the 5 s budget is the graceful-failure
-    # bound for the external readline returning (CLAUDE.md "external event
-    # with graceful failure bound" — the exception class for sync against
-    # an out-of-process I/O event).
+            if proc is bridge_proc:
+                # The bridge runs as root behind sudo (pty/monitor mode on
+                # sudo >= 1.9.14 puts it in its own session), so an
+                # unprivileged parent cannot reliably force-kill it: SIGKILL
+                # to the sudo wrapper does not reach the bridge and sudo
+                # cannot relay SIGKILL. The graceful SIGTERM above is the
+                # supported stop; if it didn't take, point at the recovery tool.
+                print(
+                    f"{YELLOW}The bridge did not exit within 10s and may still be running "
+                    f"as root with routing changes in place.\nRun `sudo scripts/network-reset.py` "
+                    f"to restore connectivity.{RESET}",
+                    file=sys.stderr,
+                )
+            else:
+                proc.kill()
     if prefix_threads is not None:
         for t in prefix_threads:
             t.join(timeout=5)
@@ -408,52 +419,6 @@ def missing_hole_group(hole_gid: int | None, current_gids: set[int]) -> bool:
     return hole_gid is not None and hole_gid not in current_gids
 
 
-def drop_kwargs(target: tuple[int, int, str, str] | None) -> dict:
-    """Return Popen kwargs that drop privileges to `target` on POSIX.
-
-    `extra_groups` contains only the `hole` group when it exists, not the
-    target user's full supplementary group list. The GUI needs `hole`
-    membership to open the production IPC socket (root:hole 0660 — see
-    `apply_socket_permissions` in `crates/bridge/src/ipc.rs`); no other
-    supplementary group gates anything dev.py's children touch. Passing
-    the full `os.getgrouplist` would also exceed macOS's NGROUPS_MAX
-    (16) on directory-managed accounts and crash subprocess with
-    `ValueError: too many groups`.
-
-    dev.py runs as root, so `setgroups([hole_gid])` succeeds even if the
-    target user is not yet listed in the `hole` group's member list —
-    the kernel honors root's setgroups regardless of on-disk
-    membership. This gives the GUI `hole` permissions on first launch
-    after `bridge grant-access` with no logout/login cycle.
-
-    The literal `"hole"` matches `crates/bridge/src/group.rs::GROUP_NAME`.
-    """
-    if target is None:
-        return {}
-    uid, gid, _user, _ = target
-    extra_groups: list[int] = []
-    try:
-        extra_groups.append(grp.getgrnam("hole").gr_gid)
-    except KeyError:
-        # Group not yet created (the first three privilege-drop calls
-        # happen before `bridge grant-access` creates the group).
-        pass
-    except OSError as e:
-        # macOS Directory Services unreachable — corporate machines can
-        # transiently lose LDAP. Drop the group rather than crash; the
-        # GUI will fall back to root-only IPC and surface its own error.
-        print(f"{YELLOW}warning: failed to look up 'hole' group: {e}{RESET}", file=sys.stderr)
-    return {"user": uid, "group": gid, "extra_groups": extra_groups}
-
-
-def drop_env(env: dict, target: tuple[int, int, str, str] | None) -> dict:
-    """Reset HOME/USER/LOGNAME in `env` to the target user."""
-    if target is None:
-        return env
-    _, _, user, home = target
-    return {**env, "HOME": home, "USER": user, "LOGNAME": user}
-
-
 # Main =================================================================================================================
 
 
@@ -463,14 +428,26 @@ def main() -> None:
         sys.exit(1)
     project_root = Path.cwd().resolve()
 
-    _lib.require_elevation()
-    target_user = _lib.sudo_target_user()  # (uid, gid, user, home) or None
+    system = platform.system()
+    euid = None if system == "Windows" else os.geteuid()
+    action = elevation_action(system, euid)
+    if action == "windows-require-admin":
+        _lib.require_elevation()  # elevated PowerShell (unchanged)
+    elif action == "posix-error-root":
+        print(
+            "ERROR: do not run dev mode as root / under sudo.\n"
+            "Run `cargo xtask run hole` (no sudo) — dev.py elevates only the\n"
+            "bridge itself. Running as root leaves root-owned files in target/.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    # else "posix-ok": proceed unprivileged.
 
     cargo = resolve_tool("cargo")
     npm = resolve_tool("npm")
 
-    ensure_node_modules(npm, target_user)
-    cargo_build(cargo, target_user)
+    ensure_node_modules(npm)
+    cargo_build(cargo)
 
     # Stage the runnable BINDIR (hole.exe + ex-ray.exe + wintun.dll on
     # Windows) in a per-pid subdir under TEMP. The contents and naming are
@@ -486,8 +463,6 @@ def main() -> None:
         [cargo, "xtask", "stage", "--profile", "debug", "--out-dir",
          str(dev_bin_dir)],
         cwd=project_root,
-        env=drop_env({**os.environ}, target_user),
-        **drop_kwargs(target_user),
     )
     if stage_result.returncode != 0:
         print(f"{YELLOW}cargo xtask stage failed (exit {stage_result.returncode}){RESET}")
@@ -501,12 +476,26 @@ def main() -> None:
     bridge_state_dir = Path(tempfile.gettempdir()) / "hole-dev" / "state"
     bridge_state_dir.mkdir(parents=True, exist_ok=True)
 
+    # Dev mode runs unprivileged; only the bridge needs root. Cache sudo
+    # credentials up-front so the back-to-back grant-access + bridge run calls
+    # don't each prompt (and so Vite's readiness wait can't straddle the cache).
+    elevate = sudo_prefix(system)
+    if elevate:
+        print(f"{BOLD}Dev mode needs root for the bridge — caching sudo credentials...{RESET}")
+        try:
+            if subprocess.run([*elevate, "-v"]).returncode != 0:
+                print(f"{YELLOW}sudo authentication failed{RESET}", file=sys.stderr)
+                sys.exit(1)
+        except FileNotFoundError:
+            print(f"{YELLOW}sudo not found on PATH; cannot elevate the bridge{RESET}", file=sys.stderr)
+            sys.exit(1)
+
     # Set up IPC access via the production path BEFORE starting the bridge
     # so that apply_socket_permissions picks up the hole group + user SID
     # from the very first socket bind.
     print(f"{BOLD}Granting IPC access (creates hole group, adds user)...{RESET}")
     grant_result = subprocess.run(
-        [str(bridge_bin), "bridge", "grant-access"],
+        grant_access_argv(elevate, bridge_bin),
         stdout=sys.stdout,
         stderr=sys.stderr,
     )
@@ -514,16 +503,35 @@ def main() -> None:
         print(f"{YELLOW}bridge grant-access failed (exit {grant_result.returncode}){RESET}")
         sys.exit(grant_result.returncode)
 
+    # The GUI must be in `hole` to open the IPC socket. If the group was just
+    # created (or the user hasn't re-logged in since), the running session
+    # lacks it. Check effective+real+supplementary gids.
+    if system != "Windows":
+        try:
+            hole_gid = grp.getgrnam("hole").gr_gid
+        except KeyError:
+            hole_gid = None
+        except OSError as e:  # macOS Directory Services transient failure
+            print(f"{YELLOW}warning: could not look up 'hole' group: {e}{RESET}", file=sys.stderr)
+            hole_gid = None
+        current_gids = set(os.getgroups()) | {os.getgid(), os.getegid()}
+        if missing_hole_group(hole_gid, current_gids):
+            print(
+                f"\n{YELLOW}Added you to the 'hole' group, but your current login session "
+                f"predates it,\nso the dashboard can't reach the bridge yet. Log out and back "
+                f"in (or reboot),\nthen run `cargo xtask run hole` again. One-time per machine. "
+                f"(`newgrp hole` may also work.){RESET}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     print(f"\n{BOLD}Starting dev environment...{RESET}")
     print(f"  Socket:    {socket_path}")
     print(f"  State dir: {bridge_state_dir}")
-    print(f"  {CYAN}[bridge]{RESET} {bridge_bin} → real TUN + routing (elevated)")
-    if target_user is not None:
-        print(f"  {MAGENTA}[client]{RESET} {built_bin} (GUI) → dropped to user '{target_user[2]}'")
-        print(f"  {YELLOW}[  vite]{RESET} npm run dev → port 1420 (dropped to user '{target_user[2]}')")
-    else:
-        print(f"  {MAGENTA}[client]{RESET} {built_bin} (GUI)")
-        print(f"  {YELLOW}[  vite]{RESET} npm run dev → port 1420")
+    sudo_note = "" if system == "Windows" else "sudo "
+    print(f"  {CYAN}[bridge]{RESET} {sudo_note}{bridge_bin} → real TUN + routing (elevated)")
+    print(f"  {MAGENTA}[client]{RESET} {built_bin} (GUI, as you)")
+    print(f"  {YELLOW}[  vite]{RESET} npm run dev → port 1420 (as you)")
     print(f"  Frontend changes hot-reload. Rust changes need Ctrl+C and re-run.")
     print()
 
@@ -532,53 +540,18 @@ def main() -> None:
     print_lock = threading.Lock()
     done = threading.Event()
 
+    # Initialized after the bridge Popen; declared here so the finally block is
+    # safe even if startup fails before the bridge starts.
+    bridge_proc: subprocess.Popen | None = None
+
     try:
-        # Start Vite first — GUI needs it listening before the webview opens.
-        # stdin=DEVNULL prevents child processes from accessing the parent console's stdin.
-        # Without this, Vite (via readline) puts the TTY into raw mode for keyboard shortcuts
-        # and doesn't restore it when terminated, leaving arrow keys broken.
-        vite_proc = subprocess.Popen(
-            [npm, "run", "dev"],
-            env=drop_env({**os.environ}, target_user),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            **drop_kwargs(target_user),
-            **new_process_group_kwargs(),
-        )
-        procs.append(vite_proc)
-        # Vite's output has no ISO timestamps; per-line emit avoids the
-        # buffer-never-flushes failure mode (see prefix_stream docstring).
-        t_vite = threading.Thread(
-            target=prefix_stream,
-            args=(vite_proc.stdout, "  vite", YELLOW, print_lock),
-            kwargs={"buffer_entries": False},
-            daemon=True,
-        )
-        t_vite.start()
-        prefix_threads.append(t_vite)
-        threading.Thread(target=wait_for_exit, args=(vite_proc, done), daemon=True).start()
-
-        if not wait_for_port(VITE_PORT, VITE_READY_TIMEOUT, vite_proc):
-            if vite_proc.poll() is not None:
-                print(f"{YELLOW}Vite exited with code {vite_proc.returncode}{RESET}")
-            else:
-                print(f"{YELLOW}Vite did not start on port {VITE_PORT} within {VITE_READY_TIMEOUT}s{RESET}")
-            sys.exit(1)  # finally block handles shutdown
-
-        # Start bridge (inherits elevated credentials).
+        # Start the bridge first so all sudo calls are back-to-back after the
+        # `sudo -v` preflight — Vite's readiness wait no longer straddles the
+        # credential cache. stdin=DEVNULL means an expired sudo timestamp gets
+        # EOF and exits non-zero (wait_for_socket then reports a clean failure)
+        # rather than hanging on a prompt.
         bridge_proc = subprocess.Popen(
-            [
-                str(bridge_bin),
-                "bridge",
-                "run",
-                "--socket-path",
-                str(socket_path),
-                "--state-dir",
-                str(bridge_state_dir),
-            ],
+            bridge_argv(elevate, bridge_bin, socket_path, bridge_state_dir),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -604,13 +577,51 @@ def main() -> None:
         # and can see a socket without the correct DACL/group yet.
         if not wait_for_socket(socket_path, bridge_proc, SOCKET_READY_TIMEOUT):
             if bridge_proc.poll() is not None:
-                print(f"{YELLOW}Bridge exited with code {bridge_proc.returncode}{RESET}")
+                print(
+                    f"{YELLOW}Bridge exited with code {bridge_proc.returncode} "
+                    f"(sudo credentials may have expired, or a restrictive sudoers "
+                    f"env_check/env_delete rejected --preserve-env){RESET}"
+                )
             else:
                 print(f"{YELLOW}Bridge did not bind socket within {SOCKET_READY_TIMEOUT}s{RESET}")
             sys.exit(1)
 
-        # Start GUI (dropped to target user on macOS under sudo).
-        gui_env = drop_env({**os.environ, "HOLE_BRIDGE_SOCKET": str(socket_path)}, target_user)
+        # Start Vite (after the bridge). GUI needs it listening before the
+        # webview opens. stdin=DEVNULL prevents child processes from accessing
+        # the parent console's stdin. Without this, Vite (via readline) puts the
+        # TTY into raw mode for keyboard shortcuts and doesn't restore it when
+        # terminated, leaving arrow keys broken.
+        vite_proc = subprocess.Popen(
+            [npm, "run", "dev"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            **new_process_group_kwargs(),
+        )
+        procs.append(vite_proc)
+        # Vite's output has no ISO timestamps; per-line emit avoids the
+        # buffer-never-flushes failure mode (see prefix_stream docstring).
+        t_vite = threading.Thread(
+            target=prefix_stream,
+            args=(vite_proc.stdout, "  vite", YELLOW, print_lock),
+            kwargs={"buffer_entries": False},
+            daemon=True,
+        )
+        t_vite.start()
+        prefix_threads.append(t_vite)
+        threading.Thread(target=wait_for_exit, args=(vite_proc, done), daemon=True).start()
+
+        if not wait_for_port(VITE_PORT, VITE_READY_TIMEOUT, vite_proc):
+            if vite_proc.poll() is not None:
+                print(f"{YELLOW}Vite exited with code {vite_proc.returncode}{RESET}")
+            else:
+                print(f"{YELLOW}Vite did not start on port {VITE_PORT} within {VITE_READY_TIMEOUT}s{RESET}")
+            sys.exit(1)  # finally block handles shutdown
+
+        # Start GUI (as the invoking user).
+        gui_env = {**os.environ, "HOLE_BRIDGE_SOCKET": str(socket_path)}
 
         # Enable remote inspection of the dashboard webview. The env var only
         # affects WebView2 (Windows) — WKWebView on macOS ignores it — but
@@ -639,7 +650,6 @@ def main() -> None:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
-            **drop_kwargs(target_user),
             **new_process_group_kwargs(),
         )
         procs.append(gui_proc)
@@ -674,7 +684,7 @@ def main() -> None:
     except KeyboardInterrupt:
         pass
     finally:
-        shutdown(procs, prefix_threads)
+        shutdown(procs, prefix_threads, bridge_proc=bridge_proc)
 
 
 if __name__ == "__main__":

--- a/scripts/dev_tests.py
+++ b/scripts/dev_tests.py
@@ -6,7 +6,7 @@
 """Unit tests for helpers in `dev.py`.
 
 Covers:
-- `drop_kwargs` (POSIX-only; skipped on Windows)
+- privilege-model helpers (elevation policy + sudo argv builders)
 - `prefix_stream` log multiplexing (platform-agnostic)
 
 Run with: `uv run scripts/dev_tests.py`
@@ -44,39 +44,70 @@ assert _spec and _spec.loader, "failed to locate scripts/dev.py"
 dev = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(dev)
 
-# drop_kwargs tests (POSIX-only) =======================================================================================
-
-posix_only = pytest.mark.skipif(sys.platform == "win32", reason="drop_kwargs is POSIX-only")
+# privilege-model helpers ==============================================================================================
 
 
-@posix_only
-def test_target_none_returns_empty():
-    assert dev.drop_kwargs(None) == {}
+def test_elevation_action_windows_requires_admin():
+    assert dev.elevation_action("Windows", None) == "windows-require-admin"
 
 
-@posix_only
-def test_hole_present_includes_hole_gid():
-    fake = types.SimpleNamespace(gr_gid=4242)
-    with mock.patch.object(dev.grp, "getgrnam", return_value=fake):
-        kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
-    assert kw == {"user": 501, "group": 20, "extra_groups": [4242]}
+def test_elevation_action_windows_ignores_euid():
+    assert dev.elevation_action("Windows", 0) == "windows-require-admin"
 
 
-@posix_only
-def test_hole_absent_returns_empty_list():
-    with mock.patch.object(dev.grp, "getgrnam", side_effect=KeyError("hole")):
-        kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
-    assert kw == {"user": 501, "group": 20, "extra_groups": []}
+def test_elevation_action_posix_root_is_error():
+    assert dev.elevation_action("Darwin", 0) == "posix-error-root"
+    assert dev.elevation_action("Linux", 0) == "posix-error-root"
 
 
-@posix_only
-def test_directory_services_failure_returns_empty_list(capsys):
-    with mock.patch.object(dev.grp, "getgrnam", side_effect=OSError("DS unreachable")):
-        kw = dev.drop_kwargs((501, 20, "alice", "/Users/alice"))
-    assert kw == {"user": 501, "group": 20, "extra_groups": []}
-    # Surface the failure to the user — silently dropping `hole` would
-    # leave the GUI confused without any breadcrumb.
-    assert "DS unreachable" in capsys.readouterr().err
+def test_elevation_action_posix_user_ok():
+    assert dev.elevation_action("Darwin", 501) == "posix-ok"
+
+
+def test_sudo_prefix_posix_is_sudo():
+    assert dev.sudo_prefix("Darwin") == ["sudo"]
+
+
+def test_sudo_prefix_windows_is_empty():
+    assert dev.sudo_prefix("Windows") == []
+
+
+def test_missing_hole_group_true_when_absent():
+    assert dev.missing_hole_group(4242, {20, 12, 80}) is True
+
+
+def test_missing_hole_group_false_when_present_as_supplementary():
+    assert dev.missing_hole_group(4242, {20, 4242, 80}) is False
+
+
+def test_missing_hole_group_false_when_group_absent():
+    assert dev.missing_hole_group(None, {20, 12}) is False
+
+
+def test_grant_access_argv_posix_prefixes_sudo_with_preserve_env():
+    argv = dev.grant_access_argv(["sudo"], "/tmp/hole-dev-1/hole")
+    assert argv == [
+        "sudo", "--preserve-env=RUST_LOG,RUST_BACKTRACE,HOLE_BRIDGE_LOG", "/tmp/hole-dev-1/hole", "bridge",
+        "grant-access"
+    ]
+
+
+def test_grant_access_argv_windows_no_sudo():
+    argv = dev.grant_access_argv([], "C:/hole/hole.exe")
+    assert argv == ["C:/hole/hole.exe", "bridge", "grant-access"]
+
+
+def test_bridge_argv_posix_prefixes_sudo_and_passes_paths():
+    argv = dev.bridge_argv(["sudo"], "/tmp/hole-dev-1/hole", "/tmp/x.sock", "/tmp/state")
+    assert argv == [
+        "sudo", "--preserve-env=RUST_LOG,RUST_BACKTRACE,HOLE_BRIDGE_LOG", "/tmp/hole-dev-1/hole", "bridge", "run",
+        "--socket-path", "/tmp/x.sock", "--state-dir", "/tmp/state"
+    ]
+
+
+def test_bridge_argv_windows_no_sudo():
+    argv = dev.bridge_argv([], "C:/hole/hole.exe", "P", "S")
+    assert argv == ["C:/hole/hole.exe", "bridge", "run", "--socket-path", "P", "--state-dir", "S"]
 
 
 # prefix_stream tests (platform-agnostic) ==============================================================================

--- a/scripts/dev_tests.py
+++ b/scripts/dev_tests.py
@@ -33,10 +33,9 @@ sys.path.insert(0, str(_SCRIPTS_DIR))
 # than `SimpleNamespace` so `sys.modules["_lib"]` matches its declared type.
 _lib_stub = types.ModuleType("_lib")
 # `setattr` bypasses ty's static attribute check (ModuleType has no
-# declared `require_elevation` / `sudo_target_user`); the attrs are
-# created dynamically and read from `dev.py` at module-load time.
+# declared `require_elevation`); the attr is created dynamically and read
+# from `dev.py` at module-load time.
 setattr(_lib_stub, "require_elevation", lambda: None)
-setattr(_lib_stub, "sudo_target_user", lambda: None)
 sys.modules.setdefault("_lib", _lib_stub)
 
 _spec = importlib.util.spec_from_file_location("dev", str(_SCRIPTS_DIR / "dev.py"))
@@ -108,6 +107,55 @@ def test_bridge_argv_posix_prefixes_sudo_and_passes_paths():
 def test_bridge_argv_windows_no_sudo():
     argv = dev.bridge_argv([], "C:/hole/hole.exe", "P", "S")
     assert argv == ["C:/hole/hole.exe", "bridge", "run", "--socket-path", "P", "--state-dir", "S"]
+
+
+def test_shutdown_does_not_kill_bridge_on_timeout(capsys):
+    import subprocess as _sp
+    killed = []
+
+    class _FakeProc:
+
+        def __init__(self, name):
+            self.name = name
+            self.pid = 4321
+
+        def wait(self, timeout: float | None = None):
+            raise _sp.TimeoutExpired(cmd=self.name, timeout=timeout or 0)
+
+        def kill(self):
+            killed.append(self.name)
+
+    bridge = _FakeProc("bridge")
+    vite = _FakeProc("vite")
+    with mock.patch.object(dev, "terminate_tree"):
+        dev.shutdown([vite, bridge], bridge_proc=bridge)
+    # Non-bridge procs are force-killed; the root bridge is NOT (SIGKILL to the
+    # sudo wrapper wouldn't reach it), and the user is told how to recover.
+    assert killed == ["vite"]
+    assert "network-reset.py" in capsys.readouterr().err
+
+
+def test_shutdown_graceful_exit_kills_nothing(capsys):
+    killed = []
+
+    class _FakeProc:
+
+        def __init__(self, name):
+            self.name = name
+            self.pid = 4321
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def kill(self):
+            killed.append(self.name)
+
+    bridge = _FakeProc("bridge")
+    vite = _FakeProc("vite")
+    with mock.patch.object(dev, "terminate_tree"):
+        dev.shutdown([vite, bridge], bridge_proc=bridge)
+    assert killed == []
+    assert "network-reset.py" not in capsys.readouterr().err
 
 
 # prefix_stream tests (platform-agnostic) ==============================================================================

--- a/scripts/dev_tests.py
+++ b/scripts/dev_tests.py
@@ -8,6 +8,7 @@
 Covers:
 - privilege-model helpers (elevation policy + sudo argv builders)
 - `prefix_stream` log multiplexing (platform-agnostic)
+- `shutdown()` teardown (bridge not killed on timeout / graceful exit)
 
 Run with: `uv run scripts/dev_tests.py`
 """


### PR DESCRIPTION
Closes #452.

## Problem

`sudo cargo xtask run hole` built the workspace as root, leaving `target/` (and `.cache/`) root-owned. dev.py then dropped privileges for its own `cargo xtask build hole`, which couldn't replace the root-owned artifacts and aborted with `Permission denied (os error 13)`.

## Fix

Invert `scripts/dev.py`: it runs as the invoking user and elevates **only** `bridge grant-access` + `bridge run` via `sudo` (with `--preserve-env` for `RUST_LOG`/`RUST_BACKTRACE`/`HOLE_BRIDGE_LOG`), so the build cascade never runs as root. dev.py refuses to run as root on POSIX; the dev GUI's `hole`-group membership is detected, with a one-time re-login instruction on first run.

The bridge now also shuts down gracefully on **SIGTERM** (it previously only handled SIGINT) — dev.py terminates it with SIGTERM, which `sudo` relays, so teardown restores routes/DNS across the new `sudo` boundary. Teardown no longer attempts a force-kill that, under modern sudo's pty mode, would miss the bridge and falsely report success; if the bridge doesn't exit it points at `scripts/network-reset.py`.

`scripts/dev_tests.py` now runs in CI via a new `test-scripts` job (it ran nowhere before). Windows is unchanged (UAC token-based).

## Out of scope — tracked in #453

`sudo cargo xtask run hole` still poisons `target/`: the outer xtask build cascade runs as root *before* dev.py can refuse. dev.py errors on root and the docs warn against `sudo`, but closing that path structurally (refusing to *build* under sudo) is #453.

## Verify

- `cargo xtask run hole` (no sudo): one sudo prompt, the dashboard appears, `find target .cache -user root` prints nothing, and `Ctrl+C` logs `shutdown signal (SIGTERM) received` then tears down cleanly (connectivity survives).
- CI: `test-scripts` (new), `test-hole` (includes the new `sigterm_resolves_shutdown_signal`), lint/clippy.

> Heads-up: add `test-scripts` to the branch-protection required checks so a future `dev_tests.py` regression can't merge green.
