### PR TITLE
feat(xtask): elevated flag for build/run steps with privilege normalization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,33 @@ jobs:
         shell: bash
         run: cargo xtask run plugin-e2e-tests
 
+  # Orchestrator (xtask) tests, incl. the privilege EFFECT tests (labels root /
+  # windows_elevated). `cargo xtask run xtask-tests` builds the nextest archive
+  # unprivileged, then runs it elevated (the target's `run:` block is `elevated:
+  # true`): POSIX self-elevates via passwordless `sudo -n`; the Windows runner is
+  # already elevated. Running for real is the point — the drop/de-elevate effect
+  # tests fail loudly here if privilege normalization is broken.
+  test-xtask:
+    name: Test xtask (${{ matrix.os }}/${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: linux,   arch: amd64, runner: ubuntu-latest }
+          - { os: darwin,  arch: arm64, runner: macos-latest }
+          - { os: windows, arch: amd64, runner: windows-latest }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-build
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Run xtask tests (elevated)
+        run: cargo xtask run xtask-tests
+
   # Unit tests for the dev/admin Python scripts (scripts/dev_tests.py). Runs
   # `uv run` DIRECTLY (not via `cargo xtask run scripts-tests`) to avoid
   # provisioning a Rust toolchain + compiling xtask just to shell out to

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -346,6 +346,16 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+      # Hosted Windows runners are elevated but expose no UAC-split linked token,
+      # so the linked-token de-elevation effect tests (label `windows_elevated`)
+      # have nothing to de-elevate to and can't run here — exclude them (they're
+      # validated on an interactive elevated Windows session). The quoter and the
+      # pure decision tests still run natively. POSIX legs run everything,
+      # including the `root` drop test (the elevated run supplies root + SUDO_USER).
+      - name: Exclude linked-token effect tests on hosted Windows
+        if: matrix.os == 'windows'
+        shell: bash
+        run: echo "SKULD_LABELS=!windows_elevated" >> "$GITHUB_ENV"
       - name: Run xtask tests (elevated)
         run: cargo xtask run xtask-tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,6 +334,16 @@ cargo xtask run hole         # dev mode (= build hole + scripts/dev.py)
 cargo xtask run hole-tests   # canonical local nextest invocation
 ```
 
+### The `elevated:` flag
+
+Any `build.yaml` step may declare `elevated: <bool>` (default `false`), per-step
+or as a `run:`/`build:` block default (`{ elevated: <bool>, steps: [...] }`). The
+orchestrator normalizes each step to its declared privilege — dropping root for
+`false` (so `sudo cargo xtask …` never leaves root-owned artifacts), obtaining it
+for `true` (sudo on macOS/Linux, a one-time UAC prompt on Windows). `elevated: true` is rejected on `build:` steps. When running as root with no invoking user
+(a container / root shell), set `HOLE_BUILD_USER=<user>` to designate the drop
+target; under `CI` with root and no such user, the step hard-fails.
+
 ### Tauri dev/prod feature toggle
 
 The `hole` crate defaults to `tauri/custom-protocol` (**production mode**:
@@ -377,10 +387,13 @@ cargo xtask run hole
 cargo xtask run hole
 ```
 
-> **Do NOT `sudo cargo xtask run hole`.** dev.py refuses to run as root, but the
-> outer xtask build cascade runs first — so a sudo'd invocation leaves
-> root-owned files in `target/` before dev.py can bail (bindreams/hole#452).
-> Closing this sudo-invocation path structurally is tracked in #453.
+> **You can now `sudo cargo xtask run hole` safely** (though it's unnecessary):
+> the `elevated:` flag normalizes every build/run step back to your user when
+> invoked as root, so the cascade leaves no root-owned files in `target/` and
+> dev.py runs as you (it self-sudoes only the bridge). This structurally closes
+> the sudo-invocation path that used to strand root-owned artifacts
+> (bindreams/hole#452, #453). Plain `cargo xtask run hole` remains the
+> recommended form.
 
 `cargo xtask run hole` launches `scripts/dev.py`, which builds the workspace,
 starts Vite, and launches bridge + GUI with multiplexed color-coded logs.
@@ -457,7 +470,8 @@ it. The canonical file list is [xtask/src/bindir.rs](xtask/src/bindir.rs).
 - The dev binary shares `com.hole.app` with the installed build, so if an
   installed `hole.exe` is running, dev launches forward to it and the dev GUI
   won't appear — quit the installed Hole first.
-- If a dev crash breaks routing, run `scripts/network-reset.py` (elevated).
+- If a dev crash breaks routing, run `cargo xtask run network-reset` (it obtains
+  root itself — no manual `sudo` / elevated PowerShell).
 - First `cargo xtask deps` is slow (compiles ex-ray, downloads wintun);
   subsequent runs are near-instant (Go build cache + sha256-sentineled download).
 
@@ -682,8 +696,7 @@ MSI as `ARPPRODUCTICON` so Add/Remove Programs matches the app icon (#359).
 If routing gets into a bad state during development:
 
 ```sh
-sudo python scripts/network-reset.py    # macOS
-python scripts/network-reset.py         # Windows (run as Administrator)
+cargo xtask run network-reset    # obtains root itself (sudo / UAC); all platforms
 ```
 
 It reads the bridge's route-state file and tears down the exact leaked routes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9534,6 +9534,8 @@ dependencies = [
  "flate2",
  "glob",
  "indexmap 2.14.0",
+ "libc",
+ "nix 0.31.2",
  "petgraph",
  "serde",
  "serde_yml",
@@ -9542,6 +9544,7 @@ dependencies = [
  "tar",
  "tempfile",
  "ureq",
+ "windows 0.62.2",
  "xtask-lib",
  "zip",
 ]

--- a/build.yaml
+++ b/build.yaml
@@ -13,6 +13,18 @@
 # `process: [...]` for direct subprocess spawn (no shell). Per-step
 # `environment:` appends to inherited env. CWD is repo root.
 #
+# `elevated:` selects the privilege a step runs at. Two forms: per-step
+# (`bash: ...` + `elevated: true`) or a block default `{ elevated: true, steps:
+# [...] }` that every step inherits (a per-step `elevated:` still wins). Legal on
+# `run:` only — `elevated:` on a `build:` step (per-step or block default) is a
+# parse error: builds must never write `target/` or `~/.cargo` as root. At
+# execution each step is normalized to its declared privilege: an unelevated
+# invocation self-elevates `elevated: true` steps (passwordless `sudo` on POSIX;
+# the inherited elevated token on Windows), and an elevated invocation drops
+# `elevated: false` steps back to the invoking user — so `sudo cargo xtask run X`
+# leaves no root-owned build output. Semantics and the cross-platform mechanism
+# live in xtask/src/privilege.rs; user-facing summary in CONTRIBUTING.md.
+#
 # Two phases per target:
 #   build:  produce the artifact this target is named after. May depend on
 #           other targets' builds (`depends:` chains them).
@@ -243,6 +255,30 @@ targets:
     build: cargo nextest run --no-run -p mock-plugin
     run: cargo nextest run -p mock-plugin
 
+  xtask-tests:
+    # Orchestrator tests incl. the privilege EFFECT tests (labels root / windows_elevated).
+    # Build (unprivileged) ARCHIVES the test binaries; run (elevated) executes the archive —
+    # no recompile-as-root, no ~/.cargo writes. POSIX self-elevates via passwordless sudo;
+    # Windows runs as-is (runner already elevated) and de-elevates elevated:false steps.
+    # pre-create target/debug (skuld writes its coordination DB at
+    # <ws>/target/debug/.skuld.db, mirroring ci.yaml test-garter's mkdir) and
+    # target/nextest (nextest does not create the --archive-file parent dir). NO
+    # --workspace-remap: build and run happen on the SAME machine at the SAME
+    # path (repo root — run_step sets CWD to repo_root, and sudo_wrap preserves
+    # it), so the archive's recorded workspace path resolves as-is. (The CI
+    # archive jobs remap only because they download the artifact onto a fresh
+    # checkout; here there is no relocation, and a Git-Bash `$PWD` would be a
+    # `/c/...` path nextest rejects on Windows.)
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build:
+      - mkdir -p target/debug target/nextest
+      - cargo nextest archive --package xtask --archive-file target/nextest/xtask-tests.tar.zst
+    run:
+      elevated: true
+      steps:
+        - cargo nextest run --archive-file target/nextest/xtask-tests.tar.zst
+
   # ===== Lint & check targets ==============================================
   # No build phase; the tool's incremental cache is the build. Each is a
   # first-class runnable invoked via `cargo xtask run <name>`, replacing the
@@ -291,3 +327,18 @@ targets:
       - npm ci --no-audit --no-fund
       - npm run check
       - npm test
+
+  # ===== Admin / maintenance targets =======================================
+  # Privileged maintenance runnables. Their `run:` block carries `elevated:
+  # true`, so `cargo xtask run <name>` self-elevates (see the `elevated:` note
+  # in the header).
+
+  network-reset:
+    # Tears down stray hole network state (TUN adapter, routes, DNS) left by a
+    # crashed bridge. Explicit platforms — windows is amd64-only repo-wide;
+    # network-reset.py is arch-agnostic.
+    platforms: [windows/amd64, darwin/amd64, darwin/arm64]
+    run:
+      elevated: true
+      steps:
+        - uv run scripts/network-reset.py

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -40,6 +40,30 @@ serde_yml = "0.0.12"
 indexmap = { version = "2", features = ["serde"] }
 petgraph = "0.8"
 
+# Privilege normalization (`elevated:` flag, bindreams/hole#453). POSIX uses nix
+# for typed User/Uid/Gid (feature `user`) and libc for the actual syscalls
+# (setgroups/getgrouplist absent from nix on apple_targets, so libc is uniform
+# across linux + macos).
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["user"] }
+libc = "0.2"
+
+# Windows privilege control: elevation detection + UAC self-elevation
+# (ShellExecuteEx runas) + linked-token de-elevation (CreateProcessWithTokenW)
+# + Job-Object reaping + pipe stdio. Version matches the workspace (0.62).
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_System_JobObjects",
+    "Win32_System_Console",
+    "Win32_System_Pipes",
+    "Win32_Storage_FileSystem",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
 [dev-dependencies]
 skuld = { workspace = true }
 tempfile = "3"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -60,6 +60,11 @@ windows = { version = "0.62", features = [
     "Win32_System_Console",
     "Win32_System_Pipes",
     "Win32_Storage_FileSystem",
+    # ShellExecuteExW + SHELLEXECUTEINFOW (UAC self-elevation) are gated behind
+    # Win32_System_Registry (the struct carries an HKEY); SystemServices supplies
+    # SECURITY_MANDATORY_HIGH_RID for the de-elevated child's integrity check.
+    "Win32_System_Registry",
+    "Win32_System_SystemServices",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -57,7 +57,6 @@ windows = { version = "0.62", features = [
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_System_JobObjects",
-    "Win32_System_Console",
     "Win32_System_Pipes",
     "Win32_Storage_FileSystem",
     # ShellExecuteExW + SHELLEXECUTEINFOW (UAC self-elevation) are gated behind

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::manifest::{Manifest, Platform};
 use crate::orchestrate::{execute, execute_run, relocate_self_if_windows, render_list, Plan};
+use crate::privilege::Readiness;
 
 pub mod bindir;
 pub mod ex_ray;
@@ -277,12 +278,13 @@ pub fn run_build(target: Option<String>, all: bool) -> Result<()> {
     relocate_self_if_windows()?;
 
     let (manifest, repo_root) = load_manifest()?;
-    let host = Platform::host().ok_or_else(|| {
+    let host_platform = Platform::host().ok_or_else(|| {
         anyhow!(
             "host platform not in the known set (windows/darwin/linux × amd64/arm64); \
              cannot orchestrate"
         )
     })?;
+    let host = privilege::Host::detect();
     let plan = Plan::new(&manifest)?;
 
     let roots: Vec<&str> = match (target, all) {
@@ -293,7 +295,7 @@ pub fn run_build(target: Option<String>, all: bool) -> Result<()> {
         (None, true) => plan
             .target_names()
             .into_iter()
-            .filter(|name| manifest.get(name).map(|t| t.applies_to(host)).unwrap_or(false))
+            .filter(|name| manifest.get(name).map(|t| t.applies_to(host_platform)).unwrap_or(false))
             .collect(),
         (Some(_), true) => unreachable!("clap rejects --all with a positional target"),
         (None, false) => {
@@ -302,12 +304,17 @@ pub fn run_build(target: Option<String>, all: bool) -> Result<()> {
     };
 
     if roots.is_empty() {
-        println!("xtask: no targets apply to host platform {host}");
+        println!("xtask: no targets apply to host platform {host_platform}");
         return Ok(());
     }
 
-    let order = plan.order_for(&roots, host)?;
-    execute(&plan, &order, &repo_root)
+    let order = plan.order_for(&roots, host_platform)?;
+    // Build steps can never be elevated (the manifest parse guard rejects
+    // `elevated: true` on `build:`), so `any_elevated_ahead` is false.
+    if let Readiness::ElevatedChildExited(code) = privilege::ensure_can_elevate(&host, false)? {
+        std::process::exit(code);
+    }
+    execute(&plan, &order, &repo_root, &host)
 }
 
 pub fn run_run(target: String) -> Result<()> {
@@ -317,14 +324,27 @@ pub fn run_run(target: String) -> Result<()> {
     relocate_self_if_windows()?;
 
     let (manifest, repo_root) = load_manifest()?;
-    let host = Platform::host().ok_or_else(|| {
+    let host_platform = Platform::host().ok_or_else(|| {
         anyhow!(
             "host platform not in the known set (windows/darwin/linux × amd64/arm64); \
              cannot orchestrate"
         )
     })?;
+    let host = privilege::Host::detect();
     let plan = Plan::new(&manifest)?;
-    execute_run(&plan, &target, host, &repo_root)
+    // Only the target's OWN run steps can be elevated. Build steps are
+    // structurally never elevated (the parse guard), so scanning the dependency
+    // cascade would be dead computation — and recomputing `order_for` here would
+    // move validation ahead of `execute_run`'s pinned error messages. Compute
+    // solely from the target's run steps; if the target is unknown, `execute_run`
+    // emits the canonical "unknown target" error.
+    let any_elevated = manifest
+        .get(&target)
+        .is_some_and(|t| t.run.iter().any(crate::manifest::Step::is_elevated));
+    if let Readiness::ElevatedChildExited(code) = privilege::ensure_can_elevate(&host, any_elevated)? {
+        std::process::exit(code);
+    }
+    execute_run(&plan, &target, host_platform, &repo_root, &host)
 }
 
 pub fn run_list() -> Result<()> {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -17,6 +17,7 @@ pub mod galoshes;
 pub mod golangci_lint;
 pub mod manifest;
 pub mod orchestrate;
+pub mod privilege;
 pub mod stage;
 pub mod test_binaries;
 pub mod upstream_v2ray;
@@ -31,6 +32,9 @@ mod manifest_tests;
 #[cfg(test)]
 #[path = "orchestrate_tests.rs"]
 mod orchestrate_tests;
+#[cfg(test)]
+#[path = "privilege_tests.rs"]
+mod privilege_tests;
 #[cfg(test)]
 #[path = "stage_tests.rs"]
 mod stage_tests;

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use indexmap::IndexMap;
+use serde::de::value::MapAccessDeserializer;
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
@@ -172,10 +173,12 @@ pub enum Step {
     Bash {
         command: String,
         environment: HashMap<String, String>,
+        elevated: bool,
     },
     Process {
         args: Vec<String>,
         environment: HashMap<String, String>,
+        elevated: bool,
     },
 }
 
@@ -185,24 +188,6 @@ pub enum Step {
 //   - bare string         ↔ { bash: <string> }
 //   - { bash: <string> }  ↔ { bash: { command: <string> } }
 // Symmetric collapse for `process:` (bare list ↔ { process: { args: [...] } }).
-
-// `deny_unknown_fields` only applies to struct-shaped variants and structs;
-// it's a no-op on untagged enums themselves.
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum StepRaw {
-    Bare(String),
-    Tagged(TaggedStepRaw),
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-enum TaggedStepRaw {
-    #[serde(rename = "bash")]
-    Bash(BashRaw),
-    #[serde(rename = "process")]
-    Process(ProcessRaw),
-}
 
 #[derive(Deserialize)]
 #[serde(untagged)]
@@ -226,34 +211,100 @@ enum ProcessRaw {
     },
 }
 
-impl From<StepRaw> for Step {
-    fn from(raw: StepRaw) -> Self {
-        match raw {
-            StepRaw::Bare(command) => Step::Bash {
-                command,
-                environment: HashMap::new(),
-            },
-            StepRaw::Tagged(TaggedStepRaw::Bash(BashRaw::Short(command))) => Step::Bash {
-                command,
-                environment: HashMap::new(),
-            },
-            StepRaw::Tagged(TaggedStepRaw::Bash(BashRaw::Full { command, environment })) => {
-                Step::Bash { command, environment }
+// A raw step is a `bash:` or `process:` kind, optionally carrying an `elevated:`
+// sibling key. Hand-rolled `Deserialize` (rather than untagged enum) so the
+// `elevated:` flag can ride alongside `bash:`/`process:` in the same mapping and
+// produce clear "both keys"/"unknown field" errors.
+struct StepRaw {
+    kind: StepKindRaw,
+    elevated: Option<bool>,
+}
+enum StepKindRaw {
+    Bash(BashRaw),
+    Process(ProcessRaw),
+}
+
+impl<'de> Deserialize<'de> for StepRaw {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = StepRaw;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a bash string, or a `{ bash|process: ..., elevated?: <bool> }` mapping")
             }
-            StepRaw::Tagged(TaggedStepRaw::Process(ProcessRaw::Args(args))) => Step::Process {
-                args,
-                environment: HashMap::new(),
-            },
-            StepRaw::Tagged(TaggedStepRaw::Process(ProcessRaw::Full { args, environment })) => {
-                Step::Process { args, environment }
+            fn visit_str<E: de::Error>(self, s: &str) -> std::result::Result<Self::Value, E> {
+                Ok(StepRaw {
+                    kind: StepKindRaw::Bash(BashRaw::Short(s.to_owned())),
+                    elevated: None,
+                })
+            }
+            fn visit_string<E: de::Error>(self, s: String) -> std::result::Result<Self::Value, E> {
+                self.visit_str(&s)
+            }
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> std::result::Result<Self::Value, A::Error> {
+                let mut kind: Option<StepKindRaw> = None;
+                let mut elevated: Option<bool> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "bash" => {
+                            if kind.is_some() {
+                                return Err(de::Error::custom("step has both `bash:` and `process:`"));
+                            }
+                            kind = Some(StepKindRaw::Bash(map.next_value()?));
+                        }
+                        "process" => {
+                            if kind.is_some() {
+                                return Err(de::Error::custom("step has both `bash:` and `process:`"));
+                            }
+                            kind = Some(StepKindRaw::Process(map.next_value()?));
+                        }
+                        "elevated" => {
+                            if elevated.is_some() {
+                                return Err(de::Error::duplicate_field("elevated"));
+                            }
+                            elevated = Some(map.next_value()?);
+                        }
+                        other => return Err(de::Error::unknown_field(other, &["bash", "process", "elevated"])),
+                    }
+                }
+                let kind = kind.ok_or_else(|| de::Error::custom("step needs a `bash:` or `process:` key"))?;
+                Ok(StepRaw { kind, elevated })
             }
         }
+        d.deserialize_any(V)
     }
 }
 
-impl<'de> Deserialize<'de> for Step {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
-        StepRaw::deserialize(d).map(Step::from)
+impl Step {
+    fn from_raw(kind: StepKindRaw, elevated: bool) -> Self {
+        match kind {
+            StepKindRaw::Bash(BashRaw::Short(command)) => Step::Bash {
+                command,
+                environment: HashMap::new(),
+                elevated,
+            },
+            StepKindRaw::Bash(BashRaw::Full { command, environment }) => Step::Bash {
+                command,
+                environment,
+                elevated,
+            },
+            StepKindRaw::Process(ProcessRaw::Args(args)) => Step::Process {
+                args,
+                environment: HashMap::new(),
+                elevated,
+            },
+            StepKindRaw::Process(ProcessRaw::Full { args, environment }) => Step::Process {
+                args,
+                environment,
+                elevated,
+            },
+        }
+    }
+    /// Whether this step runs elevated after `elevated:` resolution.
+    pub fn is_elevated(&self) -> bool {
+        match self {
+            Step::Bash { elevated, .. } | Step::Process { elevated, .. } => *elevated,
+        }
     }
 }
 
@@ -317,19 +368,88 @@ impl DependsRaw {
     }
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
+// `build:`/`run:` accept a single step, a list of steps, or a
+// `{ elevated: <bool>, steps: [...] }` block carrying a per-block `elevated`
+// default. The block form shares its mapping shape with a tagged single step
+// (`{ bash: ... }`), so a clean untagged enum can't disambiguate; we hand-roll
+// a Visitor and branch on the presence of a `steps:` key.
 enum BuildRaw {
-    One(StepRaw),
-    Many(Vec<StepRaw>),
+    Steps {
+        block_elevated: Option<bool>,
+        steps: Vec<StepRaw>,
+    },
 }
 
 impl BuildRaw {
     fn into_steps(self) -> Vec<Step> {
-        match self {
-            BuildRaw::One(s) => vec![Step::from(s)],
-            BuildRaw::Many(v) => v.into_iter().map(Step::from).collect(),
+        let BuildRaw::Steps { block_elevated, steps } = self;
+        steps
+            .into_iter()
+            .map(|r| {
+                let elevated = r.elevated.or(block_elevated).unwrap_or(false);
+                Step::from_raw(r.kind, elevated)
+            })
+            .collect()
+    }
+}
+
+impl<'de> Deserialize<'de> for BuildRaw {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = BuildRaw;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a step, a list of steps, or a `{ elevated: <bool>, steps: [...] }` block")
+            }
+            fn visit_str<E: de::Error>(self, s: &str) -> std::result::Result<Self::Value, E> {
+                Ok(BuildRaw::Steps {
+                    block_elevated: None,
+                    steps: vec![StepRaw {
+                        kind: StepKindRaw::Bash(BashRaw::Short(s.to_owned())),
+                        elevated: None,
+                    }],
+                })
+            }
+            fn visit_string<E: de::Error>(self, s: String) -> std::result::Result<Self::Value, E> {
+                self.visit_str(&s)
+            }
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error> {
+                let mut steps = Vec::new();
+                while let Some(s) = seq.next_element::<StepRaw>()? {
+                    steps.push(s);
+                }
+                Ok(BuildRaw::Steps {
+                    block_elevated: None,
+                    steps,
+                })
+            }
+            fn visit_map<A: MapAccess<'de>>(self, map: A) -> std::result::Result<Self::Value, A::Error> {
+                // Buffer the map so we can branch on a `steps:` key, then re-deserialize.
+                let value = serde_yml::Value::deserialize(MapAccessDeserializer::new(map))?;
+                let is_block = value.as_mapping().map(|m| m.contains_key("steps")).unwrap_or(false);
+                if is_block {
+                    #[derive(Deserialize)]
+                    #[serde(deny_unknown_fields)]
+                    struct BlockRaw {
+                        #[serde(default)]
+                        elevated: Option<bool>,
+                        steps: Vec<StepRaw>,
+                    }
+                    let b = BlockRaw::deserialize(value).map_err(de::Error::custom)?;
+                    Ok(BuildRaw::Steps {
+                        block_elevated: b.elevated,
+                        steps: b.steps,
+                    })
+                } else {
+                    let step = StepRaw::deserialize(value).map_err(de::Error::custom)?;
+                    Ok(BuildRaw::Steps {
+                        block_elevated: None,
+                        steps: vec![step],
+                    })
+                }
+            }
         }
+        d.deserialize_any(V)
     }
 }
 
@@ -455,6 +575,14 @@ impl Manifest {
             let platforms = t.platforms.into_vec().with_context(|| format!("in target {name:?}"))?;
             let build = t.build.map(BuildRaw::into_steps).unwrap_or_default();
             let run = t.run.map(BuildRaw::into_steps).unwrap_or_default();
+
+            if let Some(i) = build.iter().position(Step::is_elevated) {
+                return Err(anyhow!(
+                    "target {name:?}: build step #{} is `elevated: true`; build steps cannot be \
+                     elevated (build artifacts must stay unprivileged)",
+                    i + 1
+                ));
+            }
 
             // Reject platform duplicates inside one target — silent dedup would
             // hide a real authoring mistake.

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -915,6 +915,24 @@ targets:
 }
 
 #[skuld::test]
+fn elevated_true_on_single_mapping_build_step_is_rejected() {
+    // The single-mapping build form (one tagged step as the value, not a list)
+    // must hit the same guard as the list and `{elevated, steps}` block forms.
+    let err = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    build:
+      bash: "compile"
+      elevated: true
+"#,
+    )
+    .unwrap_err();
+    assert!(format!("{err:#}").contains("elevated"));
+}
+
+#[skuld::test]
 fn elevated_true_build_block_default_is_rejected() {
     let err = parse("targets:\n  foo:\n    platforms: windows/amd64\n    build:\n      elevated: true\n      steps:\n        - \"compile\"\n").unwrap_err();
     assert!(format!("{err:#}").contains("elevated"));

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -949,3 +949,39 @@ fn block_form_run_equals_list_form_when_unelevated() {
     let list = parse("targets:\n  foo:\n    platforms: windows/amd64\n    run:\n      - \"echo hi\"\n").unwrap();
     assert_eq!(block.get("foo").unwrap().run, list.get("foo").unwrap().run);
 }
+
+#[skuld::test]
+fn network_reset_target_is_elevated() {
+    let m = Manifest::parse(include_str!("../../build.yaml")).unwrap();
+    let t = m.get("network-reset").expect("network-reset missing");
+    assert_eq!(t.run.len(), 1);
+    assert!(t.run[0].is_elevated());
+    assert!(t.build.is_empty());
+}
+#[skuld::test]
+fn hole_run_and_build_stay_unprivileged() {
+    // #452 (PR #455) merged: dev.py runs UNPRIVILEGED and self-sudoes only the
+    // bridge. So `hole` stays fully unprivileged — #453's contribution to the
+    // sudo-invocation path is the build-step DROP normalization (a `sudo cargo
+    // xtask run hole` drops every step back to the invoking user), NOT elevating
+    // the run step. Pin that we do NOT re-elevate hole (dev.py refuses to run as
+    // root; elevating it would be a regression).
+    let m = Manifest::parse(include_str!("../../build.yaml")).unwrap();
+    let h = m.get("hole").unwrap();
+    assert!(
+        h.run.iter().all(|s| !s.is_elevated()),
+        "hole run (dev.py) must stay unprivileged post-#452"
+    );
+    assert!(
+        h.build.iter().all(|s| !s.is_elevated()),
+        "hole build must stay unprivileged"
+    );
+}
+#[skuld::test]
+fn xtask_tests_target_runs_elevated_via_archive() {
+    let m = Manifest::parse(include_str!("../../build.yaml")).unwrap();
+    let t = m.get("xtask-tests").unwrap();
+    assert!(t.run.iter().all(Step::is_elevated));
+    assert!(t.build.iter().all(|s| !s.is_elevated()));
+    assert!(t.has_run());
+}

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -28,6 +28,7 @@ targets:
         vec![Step::Bash {
             command: "echo hi".to_string(),
             environment: HashMap::new(),
+            elevated: false,
         }]
     );
 }
@@ -117,6 +118,7 @@ targets:
         vec![Step::Bash {
             command: "echo hi".to_string(),
             environment: HashMap::new(),
+            elevated: false,
         }]
     );
 }
@@ -151,6 +153,7 @@ targets:
         Step::Bash {
             command: "echo a".to_string(),
             environment: HashMap::new(),
+            elevated: false,
         }
     );
     assert_eq!(
@@ -158,6 +161,7 @@ targets:
         Step::Bash {
             command: "echo b".to_string(),
             environment: HashMap::new(),
+            elevated: false,
         }
     );
     let mut env_kv = HashMap::new();
@@ -167,6 +171,7 @@ targets:
         Step::Bash {
             command: "echo c".to_string(),
             environment: env_kv,
+            elevated: false,
         }
     );
 
@@ -176,6 +181,7 @@ targets:
         Step::Process {
             args: vec!["cargo".to_string(), "build".to_string()],
             environment: HashMap::new(),
+            elevated: false,
         }
     );
     let mut env_goos = HashMap::new();
@@ -185,6 +191,7 @@ targets:
         Step::Process {
             args: vec!["go".to_string(), "build".to_string()],
             environment: env_goos,
+            elevated: false,
         }
     );
 }
@@ -404,6 +411,7 @@ targets:
         Step::Bash {
             command: "echo a".to_string(),
             environment: HashMap::new(),
+            elevated: false,
         }
     );
     let mut env_kv = HashMap::new();
@@ -413,6 +421,7 @@ targets:
         Step::Bash {
             command: "echo c".to_string(),
             environment: env_kv,
+            elevated: false,
         }
     );
     let mut env_goos = HashMap::new();
@@ -422,6 +431,7 @@ targets:
         Step::Process {
             args: vec!["go".to_string(), "build".to_string()],
             environment: env_goos,
+            elevated: false,
         }
     );
 }
@@ -630,6 +640,7 @@ fn clippy_hole_target_shape() {
         vec![Step::Bash {
             command: "cargo clippy --workspace --all-targets --no-default-features -- -D warnings".to_string(),
             environment: HashMap::new(),
+            elevated: false,
         }]
     );
     assert_eq!(t.depends, Vec::<String>::new());
@@ -654,6 +665,7 @@ fn prek_target_shape() {
         vec![Step::Bash {
             command: "prek run --all-files --show-diff-on-failure".to_string(),
             environment: env,
+            elevated: false,
         }]
     );
 }
@@ -672,14 +684,17 @@ fn frontend_check_target_shape() {
             Step::Bash {
                 command: "npm ci --no-audit --no-fund".to_string(),
                 environment: HashMap::new(),
+                elevated: false,
             },
             Step::Bash {
                 command: "npm run check".to_string(),
                 environment: HashMap::new(),
+                elevated: false,
             },
             Step::Bash {
                 command: "npm test".to_string(),
                 environment: HashMap::new(),
+                elevated: false,
             },
         ]
     );
@@ -712,10 +727,12 @@ fn frontend_build_target_shape() {
             Step::Bash {
                 command: "npm ci --no-audit --no-fund".to_string(),
                 environment: HashMap::new(),
+                elevated: false,
             },
             Step::Bash {
                 command: "npm run build".to_string(),
                 environment: HashMap::new(),
+                elevated: false,
             },
         ],
     );
@@ -806,4 +823,129 @@ fn tests_targets_run_matches_build_minus_no_run() {
         assert!(build_cmd.contains("--no-run"), "{name:?} build must contain --no-run");
         assert!(!run_cmd.contains("--no-run"), "{name:?} run must not contain --no-run");
     }
+}
+
+#[skuld::test]
+fn step_elevated_defaults_false() {
+    let m = parse("targets:\n  foo:\n    platforms: windows/amd64\n    run: echo hi\n").unwrap();
+    assert!(matches!(
+        m.get("foo").unwrap().run[0],
+        Step::Bash { elevated: false, .. }
+    ));
+}
+
+#[skuld::test]
+fn per_step_elevated_override() {
+    let m = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    run:
+      - "plain"
+      - bash: "rooty"
+        elevated: true
+"#,
+    )
+    .unwrap();
+    let r = &m.get("foo").unwrap().run;
+    assert!(matches!(r[0], Step::Bash { elevated: false, .. }));
+    assert!(matches!(r[1], Step::Bash { elevated: true, .. }));
+}
+
+#[skuld::test]
+fn block_default_elevated_applies_to_all_steps() {
+    let m = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    run:
+      elevated: true
+      steps:
+        - "a"
+        - process: ["b"]
+"#,
+    )
+    .unwrap();
+    let r = &m.get("foo").unwrap().run;
+    assert!(matches!(r[0], Step::Bash { elevated: true, .. }));
+    assert!(matches!(r[1], Step::Process { elevated: true, .. }));
+}
+
+#[skuld::test]
+fn per_step_override_beats_block_default() {
+    let m = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    run:
+      elevated: true
+      steps:
+        - bash: "still-root"
+        - bash: "explicitly-not"
+          elevated: false
+"#,
+    )
+    .unwrap();
+    let r = &m.get("foo").unwrap().run;
+    assert!(matches!(r[0], Step::Bash { elevated: true, .. }));
+    assert!(matches!(r[1], Step::Bash { elevated: false, .. }));
+}
+
+#[skuld::test]
+fn elevated_true_on_build_step_is_rejected() {
+    let err = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    build:
+      - bash: "compile"
+        elevated: true
+"#,
+    )
+    .unwrap_err();
+    let m = format!("{err:#}");
+    assert!(
+        m.contains("foo") && m.contains("build") && m.contains("elevated"),
+        "got: {m}"
+    );
+}
+
+#[skuld::test]
+fn elevated_true_build_block_default_is_rejected() {
+    let err = parse("targets:\n  foo:\n    platforms: windows/amd64\n    build:\n      elevated: true\n      steps:\n        - \"compile\"\n").unwrap_err();
+    assert!(format!("{err:#}").contains("elevated"));
+}
+
+#[skuld::test]
+fn elevated_true_per_step_override_in_build_block_is_rejected() {
+    // Block default false, but a per-step override flips it true → the guard
+    // (which checks resolved `is_elevated()`) must still reject it. Pins the
+    // resolution-order → guard interaction against a future refactor.
+    let err = parse(
+        r#"
+targets:
+  foo:
+    platforms: windows/amd64
+    build:
+      elevated: false
+      steps:
+        - bash: "compile"
+          elevated: true
+"#,
+    )
+    .unwrap_err();
+    assert!(format!("{err:#}").contains("elevated"));
+}
+
+#[skuld::test]
+fn block_form_run_equals_list_form_when_unelevated() {
+    let block =
+        parse("targets:\n  foo:\n    platforms: windows/amd64\n    run:\n      steps:\n        - \"echo hi\"\n")
+            .unwrap();
+    let list = parse("targets:\n  foo:\n    platforms: windows/amd64\n    run:\n      - \"echo hi\"\n").unwrap();
+    assert_eq!(block.get("foo").unwrap().run, list.get("foo").unwrap().run);
 }

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -291,7 +291,9 @@ fn relocate_self_windows() -> Result<()> {
 /// (the build driver) propagates that via fail-fast.
 pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
     match step {
-        Step::Bash { command, environment } => {
+        Step::Bash {
+            command, environment, ..
+        } => {
             let mut cmd = Command::new(resolve_bash()?);
             // `-e` so multi-line bash heredocs fail fast on the first error,
             // matching the driver's overall fail-fast contract.
@@ -301,7 +303,7 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
             }
             run(cmd, &format!("bash step: {command}"))
         }
-        Step::Process { args, environment } => {
+        Step::Process { args, environment, .. } => {
             let (program, rest) = args
                 .split_first()
                 .ok_or_else(|| anyhow!("process step has empty args list"))?;

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -19,7 +19,7 @@ use std::io;
 use std::path::Path;
 #[cfg(windows)]
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use anyhow::{anyhow, bail, Context, Result};
 use petgraph::algo::{tarjan_scc, toposort};
@@ -28,6 +28,7 @@ use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 
 use crate::manifest::{Manifest, Platform, Step};
+use crate::privilege::{self, Groups, Host, Privilege};
 
 // ===== Plan ==========================================================================================================
 
@@ -284,13 +285,21 @@ fn relocate_self_windows() -> Result<()> {
 
 // ===== Step execution ================================================================================================
 
-/// Execute one [`Step`] from the given working directory.
+/// Execute one [`Step`] from the given working directory, normalized to its
+/// declared privilege relative to `host`.
 ///
-/// CWD is always `repo_root`. The step inherits stdio. On non-zero exit this
-/// returns `Err` with a message naming the step and exit code; the caller
-/// (the build driver) propagates that via fail-fast.
-pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
-    match step {
+/// CWD is always `repo_root`. The step inherits stdio. Spawning, privilege
+/// drop/elevate, and exit-status mapping all live in the privilege layer
+/// ([`privilege::run_command`]); on non-zero exit it returns `Err` naming the
+/// step and exit code, which the caller (the build driver) propagates via
+/// fail-fast.
+pub fn run_step(step: &Step, repo_root: &Path, host: &Host) -> Result<()> {
+    let target = if step.is_elevated() {
+        Privilege::Elevated
+    } else {
+        Privilege::Unprivileged
+    };
+    let (cmd, label) = match step {
         Step::Bash {
             command, environment, ..
         } => {
@@ -301,7 +310,7 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
             for (k, v) in environment {
                 cmd.env(k, v);
             }
-            run(cmd, &format!("bash step: {command}"))
+            (cmd, format!("bash step: {command}"))
         }
         Step::Process { args, environment, .. } => {
             let (program, rest) = args
@@ -312,9 +321,10 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
             for (k, v) in environment {
                 cmd.env(k, v);
             }
-            run(cmd, &format!("process step: {}", args.join(" ")))
+            (cmd, format!("process step: {}", args.join(" ")))
         }
-    }
+    };
+    privilege::run_command(host, target, cmd, &Groups::Full, &label)
 }
 
 /// Pick the bash interpreter to invoke for `bash:` steps.
@@ -362,23 +372,18 @@ fn resolve_bash() -> Result<OsString> {
     }
 }
 
-fn run(mut cmd: Command, label: &str) -> Result<()> {
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-    let status = cmd.status().with_context(|| format!("spawning {label}"))?;
-    if !status.success() {
-        return Err(anyhow!("{label} failed: exit status {status}"));
-    }
-    Ok(())
-}
-
 // ===== Build driver ==================================================================================================
 
 /// Execute every target in `order` (already toposorted). Each target's
 /// `build:` steps run in declaration order; first failure aborts the whole
-/// invocation.
-pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path) -> Result<()> {
+/// invocation. Steps run at their declared privilege relative to `host`.
+pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path, host: &Host) -> Result<()> {
+    run_build_cascade(plan, order, repo_root, host)
+}
+
+/// Run the `build:` steps of every target in `order` (already toposorted), in
+/// declaration order, fail-fast. Shared by [`execute`] and [`execute_run`].
+fn run_build_cascade(plan: &Plan<'_>, order: &[&str], repo_root: &Path, host: &Host) -> Result<()> {
     for name in order {
         let target = plan
             .manifest
@@ -391,7 +396,7 @@ pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path) -> Result<()> 
         }
         println!("xtask: ==== building target {name} ====");
         for step in &target.build {
-            run_step(step, repo_root).with_context(|| format!("while building target {name}"))?;
+            run_step(step, repo_root, host).with_context(|| format!("while building target {name}"))?;
         }
     }
     Ok(())
@@ -400,8 +405,9 @@ pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path) -> Result<()> 
 /// Run a target's `run:` steps after the full build cascade for that target.
 ///
 /// The cascade order matches `cargo xtask build <target>`: every transitive
-/// build dep applicable to `host`, in topological order, then the target's
-/// own `build:` steps. Once that succeeds, the target's `run:` steps execute.
+/// build dep applicable to `host_platform`, in topological order, then the
+/// target's own `build:` steps. Once that succeeds, the target's `run:` steps
+/// execute. Every step runs at its declared privilege relative to `host`.
 ///
 /// Errors:
 /// - `unknown target: {name:?}` if `target_name` isn't declared.
@@ -409,10 +415,16 @@ pub fn execute(plan: &Plan<'_>, order: &[&str], repo_root: &Path) -> Result<()> 
 ///   empty. Checked before any platform-applicability work — running a
 ///   target without `run:` is a manifest error, not a host-specific issue.
 /// - The platform-applicability message from [`Plan::order_for`] if the
-///   target doesn't apply to `host`.
+///   target doesn't apply to `host_platform`.
 /// - Any step's failure aborts the cascade with `while building target X` or
 ///   `while running target X` context.
-pub fn execute_run(plan: &Plan<'_>, target_name: &str, host: Platform, repo_root: &Path) -> Result<()> {
+pub fn execute_run(
+    plan: &Plan<'_>,
+    target_name: &str,
+    host_platform: Platform,
+    repo_root: &Path,
+    host: &Host,
+) -> Result<()> {
     let target = plan
         .manifest
         .get(target_name)
@@ -420,12 +432,12 @@ pub fn execute_run(plan: &Plan<'_>, target_name: &str, host: Platform, repo_root
     if target.run.is_empty() {
         bail!("target {target_name:?} has no run steps defined");
     }
-    let order = plan.order_for(&[target_name], host)?;
-    execute(plan, &order, repo_root)?;
+    let order = plan.order_for(&[target_name], host_platform)?;
+    run_build_cascade(plan, &order, repo_root, host)?;
 
     println!("xtask: ==== running target {target_name} ====");
     for step in &target.run {
-        run_step(step, repo_root).with_context(|| format!("while running target {target_name}"))?;
+        run_step(step, repo_root, host).with_context(|| format!("while running target {target_name}"))?;
     }
     Ok(())
 }

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -292,6 +292,7 @@ fn run_step_bash_succeeds_on_zero_exit() {
     let step = Step::Bash {
         command: "true".to_string(),
         environment: Default::default(),
+        elevated: false,
     };
     run_step(&step, dir.path()).unwrap();
 }
@@ -302,6 +303,7 @@ fn run_step_bash_fails_on_nonzero_exit() {
     let step = Step::Bash {
         command: "exit 7".to_string(),
         environment: Default::default(),
+        elevated: false,
     };
     let err = run_step(&step, dir.path()).unwrap_err();
     let msg = format!("{err:#}");
@@ -318,6 +320,7 @@ fn run_step_bash_environment_overrides_inherited() {
     let step = Step::Bash {
         command: r#"[ "$HOLE_TEST_VAR" = "set-from-step" ]"#.to_string(),
         environment: env,
+        elevated: false,
     };
     run_step(&step, dir.path()).unwrap();
 }
@@ -331,6 +334,7 @@ fn run_step_process_fails_on_nonzero_exit() {
     let step = Step::Process {
         args: vec!["cargo".to_string(), "this-subcommand-does-not-exist".to_string()],
         environment: Default::default(),
+        elevated: false,
     };
     let err = run_step(&step, dir.path()).unwrap_err();
     let msg = format!("{err:#}");
@@ -343,6 +347,7 @@ fn run_step_process_empty_args_errors() {
     let step = Step::Process {
         args: vec![],
         environment: Default::default(),
+        elevated: false,
     };
     let err = run_step(&step, dir.path()).unwrap_err();
     let msg = format!("{err:#}");

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -294,7 +294,7 @@ fn run_step_bash_succeeds_on_zero_exit() {
         environment: Default::default(),
         elevated: false,
     };
-    run_step(&step, dir.path()).unwrap();
+    run_step(&step, dir.path(), &unprivileged_host()).unwrap();
 }
 
 #[skuld::test]
@@ -305,7 +305,7 @@ fn run_step_bash_fails_on_nonzero_exit() {
         environment: Default::default(),
         elevated: false,
     };
-    let err = run_step(&step, dir.path()).unwrap_err();
+    let err = run_step(&step, dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("exit"), "expected exit-status error, got: {msg}");
 }
@@ -322,7 +322,7 @@ fn run_step_bash_environment_overrides_inherited() {
         environment: env,
         elevated: false,
     };
-    run_step(&step, dir.path()).unwrap();
+    run_step(&step, dir.path(), &unprivileged_host()).unwrap();
 }
 
 #[skuld::test]
@@ -336,7 +336,7 @@ fn run_step_process_fails_on_nonzero_exit() {
         environment: Default::default(),
         elevated: false,
     };
-    let err = run_step(&step, dir.path()).unwrap_err();
+    let err = run_step(&step, dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("exit"), "expected exit-status error, got: {msg}");
 }
@@ -349,7 +349,7 @@ fn run_step_process_empty_args_errors() {
         environment: Default::default(),
         elevated: false,
     };
-    let err = run_step(&step, dir.path()).unwrap_err();
+    let err = run_step(&step, dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("empty"), "expected empty-args error, got: {msg}");
 }
@@ -366,6 +366,35 @@ fn host_platform() -> Platform {
     // the real host so we don't accidentally encode the test host into the
     // manifest's platform set.
     Platform::host().expect("test host must be in the known platform set")
+}
+
+/// A non-elevated `Host` constructed directly so step-execution tests never
+/// touch real privilege state. `Posix` strategy keeps `plan` on the run-as-is
+/// branch for unelevated steps; tests here never declare `elevated: true`.
+fn unprivileged_host() -> crate::privilege::Host {
+    crate::privilege::Host {
+        elevated: false,
+        invoking_user: None,
+        is_ci: false,
+        has_tty: false,
+        strategy: crate::privilege::ElevateStrategy::Posix,
+    }
+}
+
+#[skuld::test]
+fn unelevated_run_executes_normally_through_privilege_layer() {
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("ran");
+    let marker_str = marker.to_string_lossy().replace('\\', "/");
+    let yaml = format!(
+        "targets:\n  foo:\n    platforms: {host}\n    run:\n      - bash: 'touch \"{m}\"'\n",
+        host = host_yaml(),
+        m = marker_str
+    );
+    let m = Manifest::parse(&yaml).unwrap();
+    let plan = Plan::new(&m).unwrap();
+    execute_run(&plan, "foo", host_platform(), dir.path(), &unprivileged_host()).unwrap();
+    assert!(marker.exists());
 }
 
 fn host_yaml() -> String {
@@ -398,7 +427,7 @@ targets:
     );
     let m = Manifest::parse(&yaml).unwrap();
     let plan = Plan::new(&m).unwrap();
-    execute_run(&plan, "foo", host_platform(), dir.path()).unwrap();
+    execute_run(&plan, "foo", host_platform(), dir.path(), &unprivileged_host()).unwrap();
     // Sentinel must be on disk after run_run returns.
     assert!(sentinel.exists(), "expected build to have created sentinel");
 }
@@ -440,7 +469,7 @@ targets:
     );
     let m = Manifest::parse(&yaml).unwrap();
     let plan = Plan::new(&m).unwrap();
-    execute_run(&plan, "child", host_platform(), dir.path()).unwrap();
+    execute_run(&plan, "child", host_platform(), dir.path(), &unprivileged_host()).unwrap();
 
     assert!(child_marker.exists(), "child's run: must have executed");
     assert!(
@@ -464,7 +493,7 @@ targets:
     ));
     let plan = Plan::new(&m).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    let err = execute_run(&plan, "build-only", host_platform(), dir.path()).unwrap_err();
+    let err = execute_run(&plan, "build-only", host_platform(), dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
         msg.contains(r#"target "build-only" has no run steps defined"#),
@@ -484,7 +513,7 @@ targets:
     ));
     let plan = Plan::new(&m).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    let err = execute_run(&plan, "nonexistent", host_platform(), dir.path()).unwrap_err();
+    let err = execute_run(&plan, "nonexistent", host_platform(), dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
         msg.contains(r#"unknown target: "nonexistent""#),
@@ -515,7 +544,7 @@ targets:
     let m = Manifest::parse(&yaml).unwrap();
     let plan = Plan::new(&m).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    let err = execute_run(&plan, "off-host", host, dir.path()).unwrap_err();
+    let err = execute_run(&plan, "off-host", host, dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
         msg.contains("does not apply to host platform") && msg.contains("off-host"),
@@ -547,7 +576,7 @@ targets:
     );
     let m = Manifest::parse(&yaml).unwrap();
     let plan = Plan::new(&m).unwrap();
-    let err = execute_run(&plan, "foo", host_platform(), dir.path()).unwrap_err();
+    let err = execute_run(&plan, "foo", host_platform(), dir.path(), &unprivileged_host()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
         msg.contains("building target") && msg.contains("foo"),

--- a/xtask/src/privilege.rs
+++ b/xtask/src/privilege.rs
@@ -22,7 +22,7 @@ mod posix;
 pub(crate) mod win_quote;
 #[cfg(windows)]
 #[path = "privilege/windows.rs"]
-mod windows;
+pub(crate) mod windows;
 
 /// The privilege a step is *declared* to run at — independent of the ambient.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/xtask/src/privilege.rs
+++ b/xtask/src/privilege.rs
@@ -1,0 +1,202 @@
+//! Cross-platform process privilege control.
+//!
+//! Reusable by the build orchestrator (per-step `elevated:`) and the future
+//! Rust dev supervisor (bindreams/hole#454). Operates only on
+//! [`std::process::Command`] + the plain types below; it knows nothing about
+//! `build.yaml` or [`crate::manifest::Step`]. All platform code lives in the
+//! `posix`/`windows` submodules; signatures here are platform-neutral.
+//!
+//! The pure decision core is [`Host::plan`] — no side effects, no privileges,
+//! exhaustively unit-tested on every OS via the [`ElevateStrategy`] data field.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Result;
+
+#[cfg(unix)]
+#[path = "privilege/posix.rs"]
+mod posix;
+#[cfg(windows)]
+#[path = "privilege/win_quote.rs"]
+mod win_quote;
+#[cfg(windows)]
+#[path = "privilege/windows.rs"]
+mod windows;
+
+/// The privilege a step is *declared* to run at — independent of the ambient.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Privilege {
+    Unprivileged,
+    Elevated,
+}
+
+/// How this platform *gains* privilege when unprivileged work needs root/admin.
+/// Stored as data (set by [`Host::detect`]) so [`Host::plan`] is pure and both
+/// branches are testable on any host.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ElevateStrategy {
+    /// POSIX: prefix the child with `sudo`.
+    Posix,
+    /// Windows: re-launch the whole process via UAC.
+    Windows,
+}
+
+/// The user a privileged process drops down to. The variant matches the host by
+/// construction in [`Host::detect`]; [`Host::plan`] only checks `is_some()`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InvokingUser {
+    Posix {
+        name: String,
+        uid: u32,
+        gid: u32,
+        home: PathBuf,
+    },
+    /// Windows: a linked (limited) token is available to de-elevate a child.
+    WindowsLinkedToken,
+}
+
+/// Supplementary-group policy for a POSIX drop (ignored on Windows).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Groups {
+    Full,
+    Only(Vec<String>),
+}
+
+/// Ambient privilege facts, resolved once. `detect()` in production; construct
+/// directly in tests.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Host {
+    pub elevated: bool,
+    pub invoking_user: Option<InvokingUser>,
+    pub is_ci: bool,
+    /// POSIX-only signal (Windows never prompts on a TTY — UAC is GUI).
+    pub has_tty: bool,
+    pub strategy: ElevateStrategy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Transition {
+    RunAsIs,
+    DropTo(InvokingUser),
+    ElevateChild,       // POSIX: sudo prefix
+    SelfElevateProcess, // Windows: UAC re-launch (handled up front)
+    WarnVacuous(String),
+    HardFail(String),
+}
+
+/// Outcome of the up-front readiness pass (acted on at the CLI boundary).
+#[derive(Debug)]
+pub enum Readiness {
+    Proceed,
+    /// Windows only: we re-launched elevated; child exited with this code.
+    ElevatedChildExited(i32),
+}
+
+impl Host {
+    pub fn detect() -> Self {
+        let is_ci = std::env::var_os("CI").is_some();
+        #[cfg(unix)]
+        {
+            posix::detect(is_ci)
+        }
+        #[cfg(windows)]
+        {
+            windows::detect(is_ci)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Host {
+                elevated: false,
+                invoking_user: None,
+                is_ci,
+                has_tty: false,
+                strategy: ElevateStrategy::Posix,
+            }
+        }
+    }
+
+    /// Pure decision. No side effects, no privileges.
+    pub fn plan(&self, target: Privilege) -> Transition {
+        match (target, self.elevated) {
+            (Privilege::Unprivileged, false) => Transition::RunAsIs,
+            (Privilege::Unprivileged, true) => match &self.invoking_user {
+                Some(user) => Transition::DropTo(user.clone()),
+                None if self.is_ci => Transition::HardFail(
+                    "running elevated under CI with no invoking user to drop to \
+                     (set HOLE_BUILD_USER=<user> to designate a drop target)"
+                        .into(),
+                ),
+                None => Transition::WarnVacuous(
+                    "running elevated with no unprivileged user to honor; proceeding \
+                     as-is (set HOLE_BUILD_USER=<user> to drop)"
+                        .into(),
+                ),
+            },
+            (Privilege::Elevated, true) => Transition::RunAsIs,
+            (Privilege::Elevated, false) => match self.strategy {
+                ElevateStrategy::Posix => Transition::ElevateChild,
+                ElevateStrategy::Windows => Transition::SelfElevateProcess,
+            },
+        }
+    }
+}
+
+/// Up-front, process-level. If `any_elevated_ahead` and we are not elevated:
+/// POSIX primes sudo credentials (see posix.rs); Windows self-elevates the
+/// whole process via UAC and reports the child's exit code.
+pub fn ensure_can_elevate(host: &Host, any_elevated_ahead: bool) -> Result<Readiness> {
+    if !any_elevated_ahead || host.elevated {
+        return Ok(Readiness::Proceed);
+    }
+    #[cfg(unix)]
+    {
+        posix::prime_sudo(host)?;
+        Ok(Readiness::Proceed)
+    }
+    #[cfg(windows)]
+    {
+        windows::self_elevate()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        anyhow::bail!("privilege elevation unsupported on this platform")
+    }
+}
+
+/// Spawn `cmd` at `target` privilege relative to `host`, inheriting stdio, wait.
+pub fn run_command(host: &Host, target: Privilege, cmd: Command, groups: &Groups, label: &str) -> Result<()> {
+    let transition = host.plan(target);
+    #[cfg(unix)]
+    {
+        posix::run_command(transition, cmd, groups, label)
+    }
+    #[cfg(windows)]
+    {
+        let _ = groups;
+        windows::run_command(transition, cmd, label)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (transition, cmd, groups, label);
+        anyhow::bail!("unsupported platform")
+    }
+}
+
+/// Spawn `cmd` inheriting stdio and map a non-zero exit to an error. Shared by
+/// both effect layers for the run-as-is / drop / elevate-child paths
+/// (cross-platform — the name carries no POSIX semantics).
+// Effect-layer callers (posix/windows `run_command`) land in Tasks 4/5; until
+// then this is unused but must compile (mirrors `win_quote.rs`'s allow).
+#[allow(dead_code)]
+pub(crate) fn run_inherit(mut cmd: Command, label: &str) -> Result<()> {
+    use std::process::Stdio;
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    let status = cmd.status().map_err(|e| anyhow::anyhow!("spawning {label}: {e}"))?;
+    if !status.success() {
+        return Err(anyhow::anyhow!("{label} failed: exit status {status}"));
+    }
+    Ok(())
+}

--- a/xtask/src/privilege.rs
+++ b/xtask/src/privilege.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 
 #[cfg(unix)]
 #[path = "privilege/posix.rs"]
-mod posix;
+pub(crate) mod posix;
 #[cfg(windows)]
 #[path = "privilege/win_quote.rs"]
 pub(crate) mod win_quote;

--- a/xtask/src/privilege.rs
+++ b/xtask/src/privilege.rs
@@ -120,16 +120,29 @@ impl Host {
     pub fn plan(&self, target: Privilege) -> Transition {
         match (target, self.elevated) {
             (Privilege::Unprivileged, false) => Transition::RunAsIs,
-            (Privilege::Unprivileged, true) => match &self.invoking_user {
-                Some(user) => Transition::DropTo(user.clone()),
-                None if self.is_ci => Transition::HardFail(
+            (Privilege::Unprivileged, true) => match (&self.invoking_user, self.strategy) {
+                (Some(user), _) => Transition::DropTo(user.clone()),
+                // POSIX root with no drop target. The CI hard-fail is a dormant
+                // tripwire: a root *container* job in CI would leave root-owned
+                // artifacts, so refuse. Off-CI, warn and proceed.
+                (None, ElevateStrategy::Posix) if self.is_ci => Transition::HardFail(
                     "running elevated under CI with no invoking user to drop to \
                      (set HOLE_BUILD_USER=<user> to designate a drop target)"
                         .into(),
                 ),
-                None => Transition::WarnVacuous(
+                (None, ElevateStrategy::Posix) => Transition::WarnVacuous(
                     "running elevated with no unprivileged user to honor; proceeding \
                      as-is (set HOLE_BUILD_USER=<user> to drop)"
+                        .into(),
+                ),
+                // Windows with no UAC-split linked token to de-elevate to (e.g. a
+                // hosted CI runner whose elevated token has no linked sibling).
+                // Windows has no root-owned-file hazard, so de-elevation is
+                // best-effort — proceed as-is. Deliberately NOT a CI hard-fail:
+                // the tripwire is POSIX-only.
+                (None, ElevateStrategy::Windows) => Transition::WarnVacuous(
+                    "elevated with no linked token to de-elevate to; running the step \
+                     as-is (best-effort de-elevation)"
                         .into(),
                 ),
             },

--- a/xtask/src/privilege.rs
+++ b/xtask/src/privilege.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 mod posix;
 #[cfg(windows)]
 #[path = "privilege/win_quote.rs"]
-mod win_quote;
+pub(crate) mod win_quote;
 #[cfg(windows)]
 #[path = "privilege/windows.rs"]
 mod windows;

--- a/xtask/src/privilege.rs
+++ b/xtask/src/privilege.rs
@@ -186,9 +186,6 @@ pub fn run_command(host: &Host, target: Privilege, cmd: Command, groups: &Groups
 /// Spawn `cmd` inheriting stdio and map a non-zero exit to an error. Shared by
 /// both effect layers for the run-as-is / drop / elevate-child paths
 /// (cross-platform — the name carries no POSIX semantics).
-// Effect-layer callers (posix/windows `run_command`) land in Tasks 4/5; until
-// then this is unused but must compile (mirrors `win_quote.rs`'s allow).
-#[allow(dead_code)]
 pub(crate) fn run_inherit(mut cmd: Command, label: &str) -> Result<()> {
     use std::process::Stdio;
     cmd.stdin(Stdio::null())

--- a/xtask/src/privilege/posix.rs
+++ b/xtask/src/privilege/posix.rs
@@ -106,13 +106,24 @@ fn drop_to(mut cmd: Command, user: &InvokingUser, groups: &Groups) -> Result<Com
         bail!("internal: non-POSIX InvokingUser");
     };
     let (uid, gid) = (*uid, *gid);
-    let group_gids: Vec<libc::gid_t> = match groups {
+    let mut group_gids: Vec<libc::gid_t> = match groups {
         Groups::Full => getgrouplist(name, gid)?,
         Groups::Only(names) => names
             .iter()
             .map(|g| group_gid(g).ok_or_else(|| anyhow!("group {g:?} not found (getgrnam)")))
             .collect::<Result<_>>()?,
     };
+    // macOS enforces NGROUPS_MAX (16) in setgroups(2): a longer list fails with
+    // EINVAL (os error 22) — which is exactly how a many-group user's drop blew
+    // up on the macOS CI runner. Cap to the OS limit (a no-op under Linux's much
+    // larger limit). The primary gid is set separately via setgid below, and
+    // supplementary membership beyond the cap is resolved dynamically by the OS
+    // (opendirectoryd on macOS) the same way it is for a normal interactive login.
+    let ngroups_max = match unsafe { libc::sysconf(libc::_SC_NGROUPS_MAX) } {
+        n if n > 0 => n as usize,
+        _ => 16,
+    };
+    group_gids.truncate(ngroups_max);
     cmd.env("HOME", home).env("USER", name).env("LOGNAME", name);
     // SAFETY: runs in the forked child pre-exec; no allocation (group_gids moved
     // in, read-only), only async-signal-safe syscalls in setgroups→setgid→setuid order.

--- a/xtask/src/privilege/posix.rs
+++ b/xtask/src/privilege/posix.rs
@@ -22,11 +22,10 @@ pub(super) fn detect(is_ci: bool) -> Host {
     }
 }
 
-/// The drop target: HOLE_BUILD_USER (explicit override) else SUDO_USER.
-/// Extends `scripts/_lib.py::sudo_target_user` (which reads only SUDO_USER) with
-/// the HOLE_BUILD_USER escape hatch; the `=="root"` / unresolvable → none rules
-/// match it. Note `HOLE_BUILD_USER=root` resolves to None (no drop) — intended:
-/// it's the documented way to assert "no unprivileged user to honor."
+/// The drop target: HOLE_BUILD_USER (explicit override) else SUDO_USER. A value
+/// of `"root"` or one that does not resolve (a `getpwnam` miss, warned) yields
+/// None — no drop. Note `HOLE_BUILD_USER=root` resolves to None (no drop) —
+/// intended: it's the documented way to assert "no unprivileged user to honor."
 fn resolve_invoking_user() -> Option<InvokingUser> {
     let name = std::env::var("HOLE_BUILD_USER")
         .ok()
@@ -157,7 +156,7 @@ fn getgrouplist(name: &str, gid: u32) -> Result<Vec<libc::gid_t>> {
     }
 }
 
-fn group_gid(name: &str) -> Option<libc::gid_t> {
+pub(crate) fn group_gid(name: &str) -> Option<libc::gid_t> {
     let c = CString::new(name).ok()?;
     // SAFETY: getgrnam returns a pointer into static storage or null.
     let p = unsafe { libc::getgrnam(c.as_ptr()) };

--- a/xtask/src/privilege/posix.rs
+++ b/xtask/src/privilege/posix.rs
@@ -1,14 +1,205 @@
 //! POSIX privilege effect layer. See `privilege.rs` for the public API.
-use crate::privilege::{Groups, Host, Transition};
-use anyhow::Result;
+use std::ffi::CString;
+use std::io;
+use std::os::unix::process::CommandExt as _;
 use std::process::Command;
 
-pub(super) fn detect(_is_ci: bool) -> Host {
-    unimplemented!("Task 4")
+use anyhow::{anyhow, bail, Context, Result};
+use nix::unistd::User;
+
+use crate::privilege::{ElevateStrategy, Groups, Host, InvokingUser, Transition};
+
+pub(super) fn detect(is_ci: bool) -> Host {
+    // SAFETY: geteuid/isatty have no preconditions and never fail.
+    let elevated = unsafe { libc::geteuid() } == 0;
+    let has_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } == 1;
+    Host {
+        elevated,
+        invoking_user: resolve_invoking_user(),
+        is_ci,
+        has_tty,
+        strategy: ElevateStrategy::Posix,
+    }
 }
-pub(super) fn prime_sudo(_host: &Host) -> Result<()> {
-    unimplemented!("Task 4")
+
+/// The drop target: HOLE_BUILD_USER (explicit override) else SUDO_USER.
+/// Extends `scripts/_lib.py::sudo_target_user` (which reads only SUDO_USER) with
+/// the HOLE_BUILD_USER escape hatch; the `=="root"` / unresolvable → none rules
+/// match it. Note `HOLE_BUILD_USER=root` resolves to None (no drop) — intended:
+/// it's the documented way to assert "no unprivileged user to honor."
+fn resolve_invoking_user() -> Option<InvokingUser> {
+    let name = std::env::var("HOLE_BUILD_USER")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("SUDO_USER").ok())?;
+    if name == "root" {
+        return None;
+    }
+    match User::from_name(&name) {
+        Ok(Some(u)) => Some(InvokingUser::Posix {
+            name: u.name,
+            uid: u.uid.as_raw(),
+            gid: u.gid.as_raw(),
+            // `nix::User::dir` is already a `PathBuf`; bind it through `home: PathBuf`.
+            home: u.dir,
+        }),
+        Ok(None) | Err(_) => {
+            eprintln!("xtask: warning: invoking user {name:?} could not be resolved (getpwnam); running as-is");
+            None
+        }
+    }
 }
-pub(super) fn run_command(_t: Transition, _cmd: Command, _g: &Groups, _label: &str) -> Result<()> {
-    unimplemented!("Task 4")
+
+/// Prime sudo so per-step `sudo -n` succeeds. Probe `sudo -n true` (passwordless
+/// CI or cached cred); else interactive `sudo -v` if a TTY; else hard fail.
+/// NEVER a blind `sudo -v` (it fails on macOS with no TTY).
+///
+/// `sudo -v` and the later per-step `sudo -n` share sudo's credential timestamp.
+/// xtask runs both from the same process tree / controlling tty, so the cache
+/// applies regardless of sudoers `timestamp_type` (tty/ppid/global). If a site
+/// runs sudoers with an exotic per-tty scope AND xtask's children somehow ran on
+/// a different tty, the per-step `sudo -n` would re-fail loudly (not silently
+/// elevate) — acceptable per the contract.
+pub(super) fn prime_sudo(host: &Host) -> Result<()> {
+    if Command::new("sudo")
+        .args(["-n", "true"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+    if host.has_tty
+        && Command::new("sudo")
+            .arg("-v")
+            .status()
+            .context("running `sudo -v`")?
+            .success()
+    {
+        return Ok(());
+    }
+    bail!(
+        "a step needs root but sudo credentials are unavailable and there is no TTY to prompt. \
+         Re-run the whole command elevated (e.g. under `sudo`)."
+    )
+}
+
+pub(super) fn run_command(transition: Transition, cmd: Command, groups: &Groups, label: &str) -> Result<()> {
+    match transition {
+        Transition::RunAsIs => crate::privilege::run_inherit(cmd, label),
+        Transition::WarnVacuous(why) => {
+            eprintln!("xtask: warning: {why}");
+            crate::privilege::run_inherit(cmd, label)
+        }
+        Transition::HardFail(why) => Err(anyhow!("{label}: {why}")),
+        Transition::DropTo(user) => crate::privilege::run_inherit(drop_to(cmd, &user, groups)?, label),
+        Transition::ElevateChild => crate::privilege::run_inherit(sudo_wrap(cmd), label),
+        Transition::SelfElevateProcess => Err(anyhow!(
+            "{label}: internal: SelfElevateProcess is not a POSIX transition"
+        )),
+    }
+}
+
+/// Configure `cmd` to drop to `user` in the forked child. Groups precomputed in
+/// the parent; the closure does only async-signal-safe libc syscalls.
+fn drop_to(mut cmd: Command, user: &InvokingUser, groups: &Groups) -> Result<Command> {
+    let InvokingUser::Posix { name, uid, gid, home } = user else {
+        bail!("internal: non-POSIX InvokingUser");
+    };
+    let (uid, gid) = (*uid, *gid);
+    let group_gids: Vec<libc::gid_t> = match groups {
+        Groups::Full => getgrouplist(name, gid)?,
+        Groups::Only(names) => names
+            .iter()
+            .map(|g| group_gid(g).ok_or_else(|| anyhow!("group {g:?} not found (getgrnam)")))
+            .collect::<Result<_>>()?,
+    };
+    cmd.env("HOME", home).env("USER", name).env("LOGNAME", name);
+    // SAFETY: runs in the forked child pre-exec; no allocation (group_gids moved
+    // in, read-only), only async-signal-safe syscalls in setgroups→setgid→setuid order.
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::setgroups(group_gids.len() as _, group_gids.as_ptr()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::setgid(gid as libc::gid_t) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::setuid(uid as libc::uid_t) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    Ok(cmd)
+}
+
+/// libc::getgrouplist with NGROUPS-aware growth (nix omits it on apple_targets).
+fn getgrouplist(name: &str, gid: u32) -> Result<Vec<libc::gid_t>> {
+    let c = CString::new(name).context("username has interior NUL")?;
+    let mut ngroups: libc::c_int = 32;
+    loop {
+        let mut buf = vec![0 as libc::gid_t; ngroups as usize];
+        let mut n = ngroups;
+        // SAFETY: buf has `n` slots; getgrouplist writes ≤ n and updates n to the needed count.
+        let rc = unsafe { libc::getgrouplist(c.as_ptr(), gid as _, buf.as_mut_ptr() as *mut _, &mut n) };
+        if rc >= 0 {
+            buf.truncate(n as usize);
+            return Ok(buf);
+        }
+        // rc < 0: buffer too small. The `+1` makes growth UNCONDITIONALLY
+        // monotone — that, not the assert, is what guarantees termination
+        // (no arbitrary cap, no infinite spin) even if a broken libc fails to
+        // update `n`. The debug_assert just documents/checks the normal
+        // contract ("n holds the needed size") in dev builds.
+        debug_assert!(n > ngroups, "getgrouplist should report the needed size on overflow");
+        ngroups = n.max(ngroups + 1);
+    }
+}
+
+fn group_gid(name: &str) -> Option<libc::gid_t> {
+    let c = CString::new(name).ok()?;
+    // SAFETY: getgrnam returns a pointer into static storage or null.
+    let p = unsafe { libc::getgrnam(c.as_ptr()) };
+    if p.is_null() {
+        None
+    } else {
+        Some(unsafe { (*p).gr_gid })
+    }
+}
+
+/// Wrap `cmd` to run elevated via sudo, non-interactively, preserving PATH/HOME
+/// past secure_path. ALL `KEY=VALUE` assignments precede the program (env treats
+/// trailing assignments as program args). No `--` (macOS BSD env rejects it).
+fn sudo_wrap(cmd: Command) -> Command {
+    let mut sudo = Command::new("sudo");
+    sudo.arg("-n")
+        .arg("--preserve-env=PATH,HOME,SKULD_LABELS,CI")
+        .arg("env");
+    // Assignments first: PATH/HOME (defeat secure_path) + the step's own env overrides.
+    let kv = |k: &std::ffi::OsStr, v: &std::ffi::OsStr| {
+        let mut s = k.to_os_string();
+        s.push("=");
+        s.push(v);
+        s
+    };
+    sudo.arg(kv(
+        std::ffi::OsStr::new("PATH"),
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    sudo.arg(kv(
+        std::ffi::OsStr::new("HOME"),
+        &std::env::var_os("HOME").unwrap_or_default(),
+    ));
+    for (k, v) in cmd.get_envs() {
+        if let Some(v) = v {
+            sudo.arg(kv(k, v));
+        }
+    }
+    // Then program + args (program is resolved by PATH; never an option token).
+    sudo.arg(cmd.get_program()).args(cmd.get_args());
+    if let Some(d) = cmd.get_current_dir() {
+        sudo.current_dir(d);
+    }
+    sudo
 }

--- a/xtask/src/privilege/posix.rs
+++ b/xtask/src/privilege/posix.rs
@@ -1,0 +1,14 @@
+//! POSIX privilege effect layer. See `privilege.rs` for the public API.
+use crate::privilege::{Groups, Host, Transition};
+use anyhow::Result;
+use std::process::Command;
+
+pub(super) fn detect(_is_ci: bool) -> Host {
+    unimplemented!("Task 4")
+}
+pub(super) fn prime_sudo(_host: &Host) -> Result<()> {
+    unimplemented!("Task 4")
+}
+pub(super) fn run_command(_t: Transition, _cmd: Command, _g: &Groups, _label: &str) -> Result<()> {
+    unimplemented!("Task 4")
+}

--- a/xtask/src/privilege/win_quote.rs
+++ b/xtask/src/privilege/win_quote.rs
@@ -2,9 +2,10 @@
 //! implementation in `crates/hole/src/setup.rs::quote_arg`).
 //!
 //! Used to build the `lpParameters` string for `ShellExecuteExW` and the
-//! `lpCommandLine` for `CreateProcessWithTokenW`. In debug builds,
-//! [`join_command_line`] round-trips every result through the real
-//! `CommandLineToArgvW` API to verify correctness.
+//! `lpCommandLine` for `CreateProcessWithTokenW`. A unit test in
+//! `privilege_tests.rs` verifies round-trip correctness by feeding
+//! [`join_command_line`]'s output back through the real `CommandLineToArgvW`
+//! API.
 
 /// Quote a single argument per the MSDN `CommandLineToArgvW` specification:
 /// backslashes are doubled only when they immediately precede a `"`, trailing

--- a/xtask/src/privilege/win_quote.rs
+++ b/xtask/src/privilege/win_quote.rs
@@ -1,0 +1,9 @@
+//! CommandLineToArgvW-compatible argument quoting (mirrors the tested
+//! implementation in `crates/hole/src/setup.rs::quote_arg`). Filled in Task 5.
+#![allow(dead_code)]
+pub(super) fn quote_arg(_arg: &str) -> String {
+    unimplemented!("Task 5")
+}
+pub(super) fn join_command_line(_argv: &[String]) -> String {
+    unimplemented!("Task 5")
+}

--- a/xtask/src/privilege/win_quote.rs
+++ b/xtask/src/privilege/win_quote.rs
@@ -1,9 +1,91 @@
-//! CommandLineToArgvW-compatible argument quoting (mirrors the tested
-//! implementation in `crates/hole/src/setup.rs::quote_arg`). Filled in Task 5.
-#![allow(dead_code)]
-pub(super) fn quote_arg(_arg: &str) -> String {
-    unimplemented!("Task 5")
+//! `CommandLineToArgvW`-compatible argument quoting (mirrors the tested
+//! implementation in `crates/hole/src/setup.rs::quote_arg`).
+//!
+//! Used to build the `lpParameters` string for `ShellExecuteExW` and the
+//! `lpCommandLine` for `CreateProcessWithTokenW`. In debug builds,
+//! [`join_command_line`] round-trips every result through the real
+//! `CommandLineToArgvW` API to verify correctness.
+
+/// Quote a single argument per the MSDN `CommandLineToArgvW` specification:
+/// backslashes are doubled only when they immediately precede a `"`, trailing
+/// backslashes are doubled (they precede the closing quote), and the quote
+/// itself is escaped with a backslash.
+pub(super) fn quote_arg(arg: &str) -> String {
+    if !arg.is_empty() && !arg.contains([' ', '\t', '"']) {
+        return arg.to_string();
+    }
+
+    let mut quoted = String::with_capacity(arg.len() + 2);
+    quoted.push('"');
+
+    let mut backslash_count: usize = 0;
+    for ch in arg.chars() {
+        match ch {
+            '\\' => backslash_count += 1,
+            '"' => {
+                // Double the backslashes preceding this quote, then escape the quote itself.
+                for _ in 0..(backslash_count * 2 + 1) {
+                    quoted.push('\\');
+                }
+                quoted.push('"');
+                backslash_count = 0;
+            }
+            _ => {
+                for _ in 0..backslash_count {
+                    quoted.push('\\');
+                }
+                quoted.push(ch);
+                backslash_count = 0;
+            }
+        }
+    }
+
+    // Double trailing backslashes (they precede the closing quote).
+    for _ in 0..(backslash_count * 2) {
+        quoted.push('\\');
+    }
+    quoted.push('"');
+
+    quoted
 }
-pub(super) fn join_command_line(_argv: &[String]) -> String {
-    unimplemented!("Task 5")
+
+/// Join an argument slice into a single command-line string with
+/// `CommandLineToArgvW`-compatible quoting. Correctness is verified by the
+/// [`cmdline_roundtrips`]-based unit test in `privilege_tests.rs`, which feeds
+/// the result back through the real `CommandLineToArgvW` API.
+pub(crate) fn join_command_line(argv: &[String]) -> String {
+    argv.iter().map(|a| quote_arg(a)).collect::<Vec<_>>().join(" ")
+}
+
+/// Parse `cmdline` back through `CommandLineToArgvW` and check it matches
+/// `expected`. Test-only: exercised by the quoter round-trip unit test.
+#[cfg(test)]
+pub(crate) fn cmdline_roundtrips(cmdline: &str, expected: &[String]) -> bool {
+    use windows::core::HSTRING;
+    use windows::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows::Win32::UI::Shell::CommandLineToArgvW;
+
+    // CommandLineToArgvW expects a full command line with argv[0]. An empty
+    // cmdline (no args) parses to just argv[0], i.e. zero parsed args.
+    let full = format!("xtask.exe {cmdline}");
+    let wide = HSTRING::from(full.as_str());
+
+    let mut argc: i32 = 0;
+    // SAFETY: `wide` outlives the call; argv is freed via LocalFree below.
+    let argv = unsafe { CommandLineToArgvW(&wide, &mut argc) };
+    if argv.is_null() {
+        return false;
+    }
+
+    let parsed: Vec<String> = (0..argc as isize)
+        .map(|i| unsafe { (*argv.offset(i)).to_string().unwrap() })
+        .collect();
+
+    // SAFETY: `argv` was allocated by CommandLineToArgvW via LocalAlloc.
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(argv as *mut _)));
+    }
+
+    let parsed_args = &parsed[1..]; // skip argv[0]
+    parsed_args.len() == expected.len() && parsed_args.iter().zip(expected).all(|(got, exp)| got == exp)
 }

--- a/xtask/src/privilege/windows.rs
+++ b/xtask/src/privilege/windows.rs
@@ -4,18 +4,33 @@
 //! `WaitForSingleObject(.., INFINITE)` awaits an external child exit (the
 //! sanctioned exception to the no-timeout rule), never a self-sync timer.
 
+use std::ffi::{c_void, OsStr};
+use std::io::Read as _;
 use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::FromRawHandle as _;
 use std::process::Command;
 
-use anyhow::{anyhow, bail, Result};
-use windows::core::PCWSTR;
-use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0};
+use anyhow::{anyhow, bail, Context, Result};
+use windows::core::{PCWSTR, PWSTR};
+use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, HANDLE, WAIT_OBJECT_0};
 use windows::Win32::Security::{
-    GetTokenInformation, TokenElevation, TokenLinkedToken, TOKEN_DUPLICATE, TOKEN_ELEVATION, TOKEN_LINKED_TOKEN,
+    GetSidSubAuthority, GetSidSubAuthorityCount, GetTokenInformation, TokenElevation, TokenIntegrityLevel,
+    TokenLinkedToken, SECURITY_ATTRIBUTES, TOKEN_DUPLICATE, TOKEN_ELEVATION, TOKEN_LINKED_TOKEN, TOKEN_MANDATORY_LABEL,
     TOKEN_QUERY,
 };
+use windows::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows::Win32::System::Pipes::CreatePipe;
+use windows::Win32::System::SystemServices::SECURITY_MANDATORY_HIGH_RID;
 use windows::Win32::System::Threading::{
-    GetCurrentProcess, GetExitCodeProcess, OpenProcessToken, WaitForSingleObject, INFINITE,
+    CreateProcessWithTokenW, GetCurrentProcess, GetExitCodeProcess, OpenProcessToken, ResumeThread, TerminateProcess,
+    WaitForSingleObject, CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, INFINITE,
+    LOGON_WITH_PROFILE, PROCESS_INFORMATION, STARTF_USESTDHANDLES, STARTUPINFOW,
 };
 use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
 use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
@@ -148,6 +163,468 @@ pub(super) fn self_elevate() -> Result<Readiness> {
     }
 }
 
-pub(super) fn run_command(_t: Transition, _cmd: Command, _label: &str) -> Result<()> {
-    unimplemented!("Task 5c")
+pub(super) fn run_command(transition: Transition, mut cmd: Command, label: &str) -> Result<()> {
+    match transition {
+        Transition::RunAsIs => crate::privilege::run_inherit(cmd, label),
+        Transition::WarnVacuous(why) => {
+            eprintln!("xtask: warning: {why}");
+            crate::privilege::run_inherit(cmd, label)
+        }
+        Transition::HardFail(why) => Err(anyhow!("{label}: {why}")),
+        Transition::DropTo(_) => de_elevate(&mut cmd, label)
+            .map(|_| ())
+            .with_context(|| format!("de-elevating {label}")),
+        Transition::ElevateChild => Err(anyhow!("{label}: internal: ElevateChild is not a Windows transition")),
+        Transition::SelfElevateProcess => Err(anyhow!(
+            "{label}: internal: SelfElevateProcess must be handled up front"
+        )),
+    }
+}
+
+/// One anonymous pipe whose child-facing WRITE end is inheritable (the child's
+/// stdout/stderr) and whose parent-facing READ end is not.
+struct InheritablePipe {
+    /// Parent's read end (the relay reads from here). Not inheritable.
+    parent: OwnedHandle,
+    /// Child's write end. Inheritable; closed by the parent once relays start.
+    child: OwnedHandle,
+}
+
+/// A `SECURITY_ATTRIBUTES` requesting an inheritable handle.
+fn inheritable_sa() -> SECURITY_ATTRIBUTES {
+    SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: std::ptr::null_mut(),
+        bInheritHandle: true.into(),
+    }
+}
+
+/// Create an anonymous pipe whose WRITE end (the child's stdout/stderr) is
+/// inheritable and whose READ end (the parent's relay) is not.
+///
+/// `CreatePipe` marks BOTH ends inheritable (the `SECURITY_ATTRIBUTES` applies
+/// to both), so we clear the inherit flag on the parent read end — otherwise the
+/// child would inherit a copy and the relay's read would never EOF.
+fn make_pipe() -> Result<InheritablePipe> {
+    let sa = inheritable_sa();
+    let mut read = HANDLE::default();
+    let mut write = HANDLE::default();
+    // SAFETY: out-params are valid; both handles are wrapped in guards below.
+    unsafe { CreatePipe(&mut read, &mut write, Some(&sa), 0).context("CreatePipe")? };
+    let (parent, child) = (OwnedHandle(read), OwnedHandle(write));
+    clear_inherit(&parent).context("clearing inherit flag on the parent pipe read end")?;
+    Ok(InheritablePipe { parent, child })
+}
+
+/// Clear `HANDLE_FLAG_INHERIT` so the child does not inherit this handle.
+fn clear_inherit(h: &OwnedHandle) -> Result<()> {
+    use windows::Win32::Foundation::{SetHandleInformation, HANDLE_FLAGS, HANDLE_FLAG_INHERIT};
+    // SAFETY: `h` is a live handle owned by the guard.
+    unsafe { SetHandleInformation(h.0, HANDLE_FLAG_INHERIT.0, HANDLE_FLAGS(0))? };
+    Ok(())
+}
+
+/// An inheritable handle to the `NUL` device opened for reading — the child's
+/// stdin. `CreateProcessWithTokenW` requires a real handle when
+/// `STARTF_USESTDHANDLES` is set; a null stdin would otherwise be inherited.
+fn nul_stdin() -> Result<OwnedHandle> {
+    let sa = inheritable_sa();
+    let name = wide(OsStr::new("NUL"));
+    // SAFETY: `name` outlives the call; the returned handle is owned by the guard.
+    let h = unsafe {
+        CreateFileW(
+            PCWSTR(name.as_ptr()),
+            GENERIC_READ.0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            Some(&sa),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+        .context("opening NUL for the de-elevated child's stdin")?
+    };
+    Ok(OwnedHandle(h))
+}
+
+/// Read the PE `Machine` field of `exe` and assert it is a 64-bit machine.
+///
+/// `CreateProcessWithTokenW` has a documented WOW64 bug: launching a 32-bit
+/// child silently drops the inherited std handles, so the relay pipes would
+/// never receive output. We check the exe FILE's PE header before launch (the
+/// running-process `IsWow64Process2` API cannot be used pre-creation). The repo
+/// is amd64-only, but an arm64 child is equally valid; both are accepted, only
+/// `i386`/`THUMB`/etc. are rejected.
+fn assert_child_is_64bit(exe: &std::path::Path) -> Result<()> {
+    use std::io::{Read, Seek, SeekFrom};
+    const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
+    const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
+
+    let mut f = std::fs::File::open(exe).with_context(|| format!("opening child exe {}", exe.display()))?;
+    // DOS header: e_lfanew (offset of the PE header) lives at 0x3C.
+    f.seek(SeekFrom::Start(0x3C)).context("seeking to e_lfanew")?;
+    let mut lfanew = [0u8; 4];
+    f.read_exact(&mut lfanew).context("reading e_lfanew")?;
+    let pe_off = u32::from_le_bytes(lfanew) as u64;
+    // PE header: 4-byte "PE\0\0" signature, then the COFF header whose first
+    // field (2 bytes) is Machine.
+    f.seek(SeekFrom::Start(pe_off + 4))
+        .context("seeking to the COFF Machine field")?;
+    let mut machine = [0u8; 2];
+    f.read_exact(&mut machine).context("reading the PE Machine field")?;
+    let machine = u16::from_le_bytes(machine);
+    match machine {
+        IMAGE_FILE_MACHINE_AMD64 | IMAGE_FILE_MACHINE_ARM64 => Ok(()),
+        other => bail!(
+            "child exe {} is not 64-bit (PE Machine = {other:#06x}); CreateProcessWithTokenW \
+             silently drops a 32-bit child's std handles (WOW64 bug)",
+            exe.display()
+        ),
+    }
+}
+
+/// Build a UTF-16, double-NUL-terminated environment block = the current
+/// process env merged with `cmd`'s overrides (`None` value = removal).
+///
+/// `CreateProcessWithTokenW` with `lpEnvironment = NULL` would inherit the
+/// *elevated* xtask env, dropping per-step `environment:` overrides. We pass an
+/// explicit block built from our env (the elevated process's env, which is what
+/// the dropped child should see) overlaid with the step's overrides.
+fn build_env_block(cmd: &Command) -> Vec<u16> {
+    use std::collections::BTreeMap;
+    use std::ffi::OsString;
+
+    let mut env: BTreeMap<OsString, OsString> = std::env::vars_os().collect();
+    for (k, v) in cmd.get_envs() {
+        match v {
+            Some(v) => {
+                env.insert(k.to_os_string(), v.to_os_string());
+            }
+            None => {
+                env.remove(k);
+            }
+        }
+    }
+
+    let mut block: Vec<u16> = Vec::new();
+    for (k, v) in &env {
+        block.extend(k.encode_wide());
+        block.push(b'=' as u16);
+        block.extend(v.encode_wide());
+        block.push(0);
+    }
+    // A trailing NUL terminates the block (double-NUL after the last entry).
+    block.push(0);
+    block
+}
+
+/// `true` iff `token`'s integrity level is at or above High (i.e. NOT dropped).
+/// Used to assert the de-elevated child really lost its elevation before resume.
+fn token_is_high_or_above(token: HANDLE) -> Result<bool> {
+    // SAFETY: two-call GetTokenInformation pattern; the buffer is sized by the
+    // first call's `ret`, and the SID pointer is read only while the buffer lives.
+    unsafe {
+        let mut ret = 0u32;
+        // First call sizes the buffer (expected to fail with insufficient buffer).
+        let _ = GetTokenInformation(token, TokenIntegrityLevel, None, 0, &mut ret);
+        if ret == 0 {
+            bail!("GetTokenInformation(TokenIntegrityLevel) returned a zero size");
+        }
+        let mut buf = vec![0u8; ret as usize];
+        GetTokenInformation(
+            token,
+            TokenIntegrityLevel,
+            Some(buf.as_mut_ptr() as *mut c_void),
+            ret,
+            &mut ret,
+        )
+        .context("GetTokenInformation(TokenIntegrityLevel)")?;
+        let label = &*(buf.as_ptr() as *const TOKEN_MANDATORY_LABEL);
+        let sid = label.Label.Sid;
+        let count_ptr = GetSidSubAuthorityCount(sid);
+        if count_ptr.is_null() || *count_ptr == 0 {
+            bail!("integrity-level SID has no sub-authorities");
+        }
+        let last = (*count_ptr as u32) - 1;
+        let rid = *GetSidSubAuthority(sid, last);
+        Ok(rid >= SECURITY_MANDATORY_HIGH_RID as u32)
+    }
+}
+
+/// Reaping job, mirroring `crates/garter/src/proc_group.rs`: a
+/// `KILL_ON_JOB_CLOSE` Job Object whose membership is reaped when the handle
+/// closes. Closing it before joining the relays reaps a pipe-holding grandchild
+/// so the relays can EOF (the #197 lesson).
+fn create_kill_on_close_job() -> Result<OwnedHandle> {
+    // SAFETY: standard job creation; the handle is owned by the guard.
+    unsafe {
+        let job = CreateJobObjectW(None, PCWSTR::null()).context("CreateJobObjectW")?;
+        let job = OwnedHandle(job);
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        SetInformationJobObject(
+            job.0,
+            JobObjectExtendedLimitInformation,
+            std::ptr::addr_of!(info).cast(),
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+        .context("SetInformationJobObject")?;
+        Ok(job)
+    }
+}
+
+/// De-elevate `cmd` onto the invoking user's linked token. Returns the
+/// `ResumeThread` previous suspend count (`1` proves `CREATE_SUSPENDED` was
+/// honored) so the suspend-rendezvous test can assert it.
+///
+/// Loud-fails EVERY branch: there is no path that resumes or runs an elevated
+/// child. See the module docs and the 9-step sequence in the implementation.
+fn de_elevate(cmd: &mut Command, label: &str) -> Result<u32> {
+    // 1. Resolve program + args and assert the child is 64-bit (WOW64 stdio bug).
+    let program = std::path::PathBuf::from(cmd.get_program());
+    let exe = which_exe(&program).with_context(|| format!("resolving child program {program:?}"))?;
+    assert_child_is_64bit(&exe)?;
+
+    let mut argv: Vec<String> = vec![exe.to_string_lossy().into_owned()];
+    for a in cmd.get_args() {
+        argv.push(a.to_string_lossy().into_owned());
+    }
+    let cmdline = super::win_quote::join_command_line(&argv);
+    let mut cmdline_w = wide(OsStr::new(&cmdline));
+
+    let cwd = cmd.get_current_dir().map(|p| wide(p.as_os_str()));
+
+    // 2. Three dedicated inheritable pipes + an inheritable NUL stdin.
+    let stdin = nul_stdin()?;
+    let out = make_pipe()?;
+    let err = make_pipe()?;
+
+    // 3. Env block: our env overlaid with the step's overrides.
+    let mut env_block = build_env_block(cmd);
+
+    // 4. CreateProcessWithTokenW(CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP | CREATE_UNICODE_ENVIRONMENT).
+    let linked = linked_token().context("obtaining the invoking user's linked token")?;
+    let si = STARTUPINFOW {
+        cb: std::mem::size_of::<STARTUPINFOW>() as u32,
+        dwFlags: STARTF_USESTDHANDLES,
+        hStdInput: stdin.0,
+        hStdOutput: out.child.0,
+        hStdError: err.child.0,
+        ..Default::default()
+    };
+    let mut pi = PROCESS_INFORMATION::default();
+    let cwd_ptr = cwd.as_ref().map(|c| PCWSTR(c.as_ptr())).unwrap_or_else(PCWSTR::null);
+    // SAFETY: all pointers (cmdline, env, cwd, si, pi) outlive the call; the
+    // returned process/thread handles are wrapped in guards immediately.
+    unsafe {
+        CreateProcessWithTokenW(
+            linked.0,
+            LOGON_WITH_PROFILE,
+            PCWSTR::null(),
+            Some(PWSTR(cmdline_w.as_mut_ptr())),
+            CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP | CREATE_UNICODE_ENVIRONMENT,
+            Some(env_block.as_mut_ptr() as *const c_void),
+            cwd_ptr,
+            &si,
+            &mut pi,
+        )
+        .context("CreateProcessWithTokenW")?;
+    }
+    let proc = OwnedHandle(pi.hProcess);
+    let thread = OwnedHandle(pi.hThread);
+
+    // The child holds its own inheritable copies of the std handles now; the
+    // job + IL checks happen in the suspended window before any code runs.
+    let resume_count = run_suspended_child(&proc, &thread, label, out, err)?;
+    Ok(resume_count)
+}
+
+/// Test-only entry point: de-elevate `cmd` and return the `ResumeThread`
+/// previous suspend count (`1` proves `CREATE_SUSPENDED` was honored). The
+/// suspend-rendezvous effect test asserts this is `1`.
+#[cfg(test)]
+pub(crate) fn de_elevate_for_test(cmd: &mut Command, label: &str) -> Result<u32> {
+    de_elevate(cmd, label)
+}
+
+/// The suspended-window sequence (steps 5-9). Split out so `de_elevate`'s
+/// pipe/handle guards drop in the right order and every early return reaps the
+/// suspended child.
+fn run_suspended_child(
+    proc: &OwnedHandle,
+    thread: &OwnedHandle,
+    label: &str,
+    out: InheritablePipe,
+    err: InheritablePipe,
+) -> Result<u32> {
+    // 5. Assert the child's integrity level dropped below High. If not, this is
+    //    NOT a de-elevated child — terminate and hard-fail (never resume it).
+    let child_high = {
+        let mut ctoken = HANDLE::default();
+        // SAFETY: query the suspended child's token; guard closes it.
+        let r = unsafe { OpenProcessToken(proc.0, TOKEN_QUERY, &mut ctoken) };
+        match r {
+            Ok(()) => {
+                let _g = OwnedHandle(ctoken);
+                token_is_high_or_above(ctoken)
+            }
+            Err(e) => Err(anyhow!("OpenProcessToken on the suspended child failed: {e}")),
+        }
+    };
+    let child_high = match child_high {
+        Ok(v) => v,
+        Err(e) => {
+            terminate(proc);
+            return Err(e.context("checking the suspended child's integrity level"));
+        }
+    };
+    if child_high {
+        terminate(proc);
+        bail!("{label}: de-elevated child is still at High integrity (token did not drop); refusing to resume");
+    }
+
+    // 6. Reaping job; assign the suspended child. Failure → terminate + hard-fail
+    //    (a child outside the job could escape reaping — never run it elevated-adjacent).
+    let job = match create_kill_on_close_job() {
+        Ok(j) => j,
+        Err(e) => {
+            terminate(proc);
+            return Err(e);
+        }
+    };
+    // SAFETY: both handles are live; assigning a suspended child to an empty job
+    // succeeds under the nested-job rules.
+    if let Err(e) = unsafe { AssignProcessToJobObject(job.0, proc.0) } {
+        terminate(proc);
+        return Err(anyhow!(
+            "AssignProcessToJobObject failed: {e}; refusing to run the child outside its reaping job"
+        ));
+    }
+
+    // 7. Spawn relay threads reading the parent ends; hand the child-side write
+    //    ends to be closed so EOF can propagate once the child (and any
+    //    grandchild) releases them.
+    let out_relay = spawn_relay(out.parent, RelayTarget::Stdout);
+    let err_relay = spawn_relay(err.parent, RelayTarget::Stderr);
+    drop(out.child); // close our copy of the child-side write ends
+    drop(err.child);
+
+    // 8. Resume. The previous suspend count MUST be 1 — proof CREATE_SUSPENDED
+    //    was honored through seclogon (0 = ignored → the child already ran). The
+    //    last mutation before waiting.
+    // SAFETY: `thread` is the live primary thread handle from CreateProcess.
+    let prev = unsafe { ResumeThread(thread.0) };
+    if prev != 1 {
+        // The child may already be running (CREATE_SUSPENDED ignored). Reap via
+        // the job and hard-fail — we cannot prove it de-elevated correctly.
+        drop(job);
+        let _ = out_relay.join();
+        let _ = err_relay.join();
+        bail!(
+            "{label}: ResumeThread returned previous suspend count {prev}, expected 1; \
+             CREATE_SUSPENDED was not honored — refusing to trust this child"
+        );
+    }
+
+    // 9. Wait for exit, read the code, THEN close the job BEFORE joining relays
+    //    (a pipe-holding grandchild would otherwise hang the relay join — the
+    //    proc_group.rs #197 lesson), then join.
+    // SAFETY: `proc` is the live child process handle; INFINITE awaits its exit.
+    let code = unsafe {
+        if WaitForSingleObject(proc.0, INFINITE) != WAIT_OBJECT_0 {
+            // Reap and join before surfacing the error so no relay/grandchild lingers.
+            drop(job);
+            let _ = out_relay.join();
+            let _ = err_relay.join();
+            bail!("{label}: waiting on the de-elevated child failed");
+        }
+        let mut code = 0u32;
+        GetExitCodeProcess(proc.0, &mut code).context("GetExitCodeProcess")?;
+        code
+    };
+
+    drop(job); // reap stragglers + release their write ends → relays EOF
+    let _ = out_relay.join();
+    let _ = err_relay.join();
+
+    if code != 0 {
+        bail!("{label} failed: exit code {code}");
+    }
+    Ok(prev)
+}
+
+/// Force-terminate a suspended/misbehaving child. Best-effort; used only on
+/// hard-fail paths where the child must never run.
+fn terminate(proc: &OwnedHandle) {
+    // SAFETY: `proc` is a live process handle; terminating it is sound.
+    unsafe {
+        let _ = TerminateProcess(proc.0, 1);
+    }
+}
+
+/// Which parent stream a relay copies its pipe into.
+enum RelayTarget {
+    Stdout,
+    Stderr,
+}
+
+/// Spawn a thread that copies the pipe `read_end` byte-for-byte into the
+/// parent's real stdout/stderr until EOF, then returns. Takes ownership of the
+/// handle (closed when the wrapping `File` drops).
+fn spawn_relay(read_end: OwnedHandle, target: RelayTarget) -> std::thread::JoinHandle<()> {
+    // Take the raw handle out of the guard so the File owns it (no double-close).
+    // Send it as an integer — a raw `*mut c_void` is `!Send`, but a pipe HANDLE
+    // is a process-wide kernel handle that is sound to use from another thread.
+    let raw = read_end.0 .0 as isize;
+    std::mem::forget(read_end);
+    std::thread::spawn(move || {
+        // SAFETY: `raw` is a valid pipe read handle whose ownership we took above.
+        let mut file = unsafe { std::fs::File::from_raw_handle(raw as *mut c_void) };
+        let mut buf = [0u8; 8192];
+        loop {
+            match file.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    use std::io::Write as _;
+                    let written = match target {
+                        RelayTarget::Stdout => std::io::stdout().write_all(&buf[..n]),
+                        RelayTarget::Stderr => std::io::stderr().write_all(&buf[..n]),
+                    };
+                    if written.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Resolve a program name to an absolute executable path. An absolute/relative
+/// path with a separator is used as-is (with a `.exe` fallback); a bare name is
+/// searched on `PATH`.
+fn which_exe(program: &std::path::Path) -> Result<std::path::PathBuf> {
+    if program.components().count() > 1 || program.is_absolute() {
+        if program.is_file() {
+            return Ok(program.to_path_buf());
+        }
+        let with_exe = program.with_extension("exe");
+        if with_exe.is_file() {
+            return Ok(with_exe);
+        }
+        bail!("program path {program:?} does not exist (tried {with_exe:?})");
+    }
+    // Bare name: search PATH, honoring PATHEXT for the .exe extension.
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    for dir in std::env::split_paths(&path) {
+        for ext in ["", "exe", "EXE"] {
+            let cand = if ext.is_empty() {
+                dir.join(program)
+            } else {
+                dir.join(program).with_extension(ext)
+            };
+            if cand.is_file() {
+                return Ok(cand);
+            }
+        }
+    }
+    bail!("could not find {program:?} on PATH")
 }

--- a/xtask/src/privilege/windows.rs
+++ b/xtask/src/privilege/windows.rs
@@ -1,14 +1,93 @@
 //! Windows privilege effect layer. See `privilege.rs` for the public API.
-use crate::privilege::{Host, Readiness, Transition};
-use anyhow::Result;
+//!
+//! All Windows handles use the inline RAII [`OwnedHandle`] guard.
+//! `WaitForSingleObject(.., INFINITE)` awaits an external child exit (the
+//! sanctioned exception to the no-timeout rule), never a self-sync timer.
+
 use std::process::Command;
 
-pub(super) fn detect(_is_ci: bool) -> Host {
-    unimplemented!("Task 5")
+use anyhow::Result;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::Security::{
+    GetTokenInformation, TokenElevation, TokenLinkedToken, TOKEN_DUPLICATE, TOKEN_ELEVATION, TOKEN_LINKED_TOKEN,
+    TOKEN_QUERY,
+};
+use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+use crate::privilege::{ElevateStrategy, Host, InvokingUser, Readiness, Transition};
+
+/// RAII close-on-drop for a HANDLE.
+pub(super) struct OwnedHandle(pub HANDLE);
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if !self.0.is_invalid() {
+            // SAFETY: the handle was returned by a successful Win32 call and is
+            // owned by this guard; closing it exactly once on drop is sound.
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
 }
+
+pub(super) fn detect(is_ci: bool) -> Host {
+    let elevated = is_elevated().unwrap_or(false);
+    let invoking_user = if elevated && linked_token().is_ok() {
+        Some(InvokingUser::WindowsLinkedToken)
+    } else {
+        None
+    };
+    Host {
+        elevated,
+        invoking_user,
+        is_ci,
+        has_tty: false,
+        strategy: ElevateStrategy::Windows,
+    }
+}
+
+fn is_elevated() -> Result<bool> {
+    // SAFETY: standard token-query; handle closed by guard.
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)?;
+        let _g = OwnedHandle(token);
+        let mut e = TOKEN_ELEVATION::default();
+        let mut ret = 0u32;
+        GetTokenInformation(
+            token,
+            TokenElevation,
+            Some(&mut e as *mut _ as *mut _),
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut ret,
+        )?;
+        Ok(e.TokenIsElevated != 0)
+    }
+}
+
+/// The user's limited (medium-IL) linked primary-ready token. Caller owns it.
+pub(super) fn linked_token() -> Result<OwnedHandle> {
+    // SAFETY: query our token, then its linked token (elevated→limited needs no SeTcb).
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY | TOKEN_DUPLICATE, &mut token)?;
+        let _g = OwnedHandle(token);
+        let mut linked = TOKEN_LINKED_TOKEN::default();
+        let mut ret = 0u32;
+        GetTokenInformation(
+            token,
+            TokenLinkedToken,
+            Some(&mut linked as *mut _ as *mut _),
+            std::mem::size_of::<TOKEN_LINKED_TOKEN>() as u32,
+            &mut ret,
+        )?;
+        Ok(OwnedHandle(linked.LinkedToken))
+    }
+}
+
 pub(super) fn self_elevate() -> Result<Readiness> {
-    unimplemented!("Task 5")
+    unimplemented!("Task 5b")
 }
 pub(super) fn run_command(_t: Transition, _cmd: Command, _label: &str) -> Result<()> {
-    unimplemented!("Task 5")
+    unimplemented!("Task 5c")
 }

--- a/xtask/src/privilege/windows.rs
+++ b/xtask/src/privilege/windows.rs
@@ -259,18 +259,38 @@ fn assert_child_is_64bit(exe: &std::path::Path) -> Result<()> {
     const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
     const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
 
+    // Read a too-short file as a hard error rather than reading garbage: a
+    // truncated/non-PE file would otherwise yield an arbitrary `Machine` value.
+    let short = |what: &str| format!("child exe {} is too short to be a PE image ({what})", exe.display());
+
     let mut f = std::fs::File::open(exe).with_context(|| format!("opening child exe {}", exe.display()))?;
-    // DOS header: e_lfanew (offset of the PE header) lives at 0x3C.
+    // DOS header: "MZ" magic at offset 0, then e_lfanew (PE header offset) at 0x3C.
+    let mut dos = [0u8; 2];
+    f.read_exact(&mut dos).map_err(|_| anyhow!(short("no DOS header")))?;
+    if &dos != b"MZ" {
+        bail!(
+            "child exe {} is not a PE image (missing \"MZ\" DOS signature)",
+            exe.display()
+        );
+    }
     f.seek(SeekFrom::Start(0x3C)).context("seeking to e_lfanew")?;
     let mut lfanew = [0u8; 4];
-    f.read_exact(&mut lfanew).context("reading e_lfanew")?;
+    f.read_exact(&mut lfanew).map_err(|_| anyhow!(short("no e_lfanew")))?;
     let pe_off = u32::from_le_bytes(lfanew) as u64;
     // PE header: 4-byte "PE\0\0" signature, then the COFF header whose first
     // field (2 bytes) is Machine.
-    f.seek(SeekFrom::Start(pe_off + 4))
-        .context("seeking to the COFF Machine field")?;
+    f.seek(SeekFrom::Start(pe_off)).context("seeking to the PE signature")?;
+    let mut sig = [0u8; 4];
+    f.read_exact(&mut sig).map_err(|_| anyhow!(short("no PE signature")))?;
+    if &sig != b"PE\0\0" {
+        bail!(
+            "child exe {} is not a PE image (missing \"PE\\0\\0\" signature at e_lfanew)",
+            exe.display()
+        );
+    }
     let mut machine = [0u8; 2];
-    f.read_exact(&mut machine).context("reading the PE Machine field")?;
+    f.read_exact(&mut machine)
+        .map_err(|_| anyhow!(short("no COFF Machine field")))?;
     let machine = u16::from_le_bytes(machine);
     match machine {
         IMAGE_FILE_MACHINE_AMD64 | IMAGE_FILE_MACHINE_ARM64 => Ok(()),

--- a/xtask/src/privilege/windows.rs
+++ b/xtask/src/privilege/windows.rs
@@ -4,17 +4,34 @@
 //! `WaitForSingleObject(.., INFINITE)` awaits an external child exit (the
 //! sanctioned exception to the no-timeout rule), never a self-sync timer.
 
+use std::os::windows::ffi::OsStrExt;
 use std::process::Command;
 
-use anyhow::Result;
-use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use anyhow::{anyhow, bail, Result};
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0};
 use windows::Win32::Security::{
     GetTokenInformation, TokenElevation, TokenLinkedToken, TOKEN_DUPLICATE, TOKEN_ELEVATION, TOKEN_LINKED_TOKEN,
     TOKEN_QUERY,
 };
-use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+use windows::Win32::System::Threading::{
+    GetCurrentProcess, GetExitCodeProcess, OpenProcessToken, WaitForSingleObject, INFINITE,
+};
+use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
+use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
 use crate::privilege::{ElevateStrategy, Host, InvokingUser, Readiness, Transition};
+
+/// `ERROR_CANCELLED` (1223) as an `HRESULT` (`0x800704C7`) — the code
+/// `ShellExecuteExW` surfaces when the user declines the UAC prompt.
+/// `WIN32_ERROR` has no `to_hresult()` in windows-rs 0.62, so we compare against
+/// the literal (matching `crates/hole/src/setup.rs`).
+const ERROR_CANCELLED_HRESULT: windows::core::HRESULT = windows::core::HRESULT(0x800704C7_u32 as i32);
+
+/// UTF-16, NUL-terminated, for a `PCWSTR`/`PWSTR` arg.
+fn wide(s: &std::ffi::OsStr) -> Vec<u16> {
+    s.encode_wide().chain(std::iter::once(0)).collect()
+}
 
 /// RAII close-on-drop for a HANDLE.
 pub(super) struct OwnedHandle(pub HANDLE);
@@ -85,9 +102,52 @@ pub(super) fn linked_token() -> Result<OwnedHandle> {
     }
 }
 
+/// Re-launch this whole xtask process elevated via UAC (`ShellExecuteEx`
+/// `runas`), wait for it, and report its exit code. `SW_SHOWNORMAL` (not
+/// `SW_HIDE`) so the elevated console is visible — xtask is interactive build
+/// tooling, unlike the hidden bridge installer. A declined prompt
+/// (`ERROR_CANCELLED`) is a clear, non-generic error.
 pub(super) fn self_elevate() -> Result<Readiness> {
-    unimplemented!("Task 5b")
+    let exe = std::env::current_exe()?;
+    let exe_w = wide(exe.as_os_str());
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let params = super::win_quote::join_command_line(&argv);
+    let params_w = wide(std::ffi::OsStr::new(&params));
+    let verb_w = wide(std::ffi::OsStr::new("runas"));
+    // SAFETY: `info` is fully initialized with the correct `cbSize`; the `wide`
+    // buffers outlive the call, keeping the PCWSTR pointers valid.
+    // SEE_MASK_NOCLOSEPROCESS asks for a process handle in `info.hProcess`,
+    // which the guard closes below.
+    unsafe {
+        let mut info = SHELLEXECUTEINFOW {
+            cbSize: std::mem::size_of::<SHELLEXECUTEINFOW>() as u32,
+            fMask: SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC,
+            lpVerb: PCWSTR(verb_w.as_ptr()),
+            lpFile: PCWSTR(exe_w.as_ptr()),
+            lpParameters: PCWSTR(params_w.as_ptr()),
+            nShow: SW_SHOWNORMAL.0,
+            ..Default::default()
+        };
+        ShellExecuteExW(&mut info).map_err(|e| {
+            if e.code() == ERROR_CANCELLED_HRESULT {
+                anyhow!("UAC elevation was declined")
+            } else {
+                anyhow!("UAC elevation (ShellExecuteEx runas) failed: {e}")
+            }
+        })?;
+        let child = OwnedHandle(info.hProcess);
+        if child.0.is_invalid() {
+            bail!("ShellExecuteEx did not return a process handle for the elevated xtask child");
+        }
+        if WaitForSingleObject(child.0, INFINITE) != WAIT_OBJECT_0 {
+            bail!("waiting on the elevated xtask child failed");
+        }
+        let mut code = 0u32;
+        GetExitCodeProcess(child.0, &mut code)?;
+        Ok(Readiness::ElevatedChildExited(code as i32))
+    }
 }
+
 pub(super) fn run_command(_t: Transition, _cmd: Command, _label: &str) -> Result<()> {
     unimplemented!("Task 5c")
 }

--- a/xtask/src/privilege/windows.rs
+++ b/xtask/src/privilege/windows.rs
@@ -1,0 +1,14 @@
+//! Windows privilege effect layer. See `privilege.rs` for the public API.
+use crate::privilege::{Host, Readiness, Transition};
+use anyhow::Result;
+use std::process::Command;
+
+pub(super) fn detect(_is_ci: bool) -> Host {
+    unimplemented!("Task 5")
+}
+pub(super) fn self_elevate() -> Result<Readiness> {
+    unimplemented!("Task 5")
+}
+pub(super) fn run_command(_t: Transition, _cmd: Command, _label: &str) -> Result<()> {
+    unimplemented!("Task 5")
+}

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -89,3 +89,45 @@ fn ci_tripwire_requires_all_three_conditions() {
         Transition::WarnVacuous(_)
     ));
 }
+
+// Effect test: actually drop and read back the child uid. Needs root; labeled
+// `root`, runs by default (CI supplies root via the elevated xtask-tests
+// target). Opt out locally with SKULD_LABELS="!root". Does NOT use skuld's
+// `requires` (that marks the trial ignored — a green-build skip); asserts root
+// and fails LOUDLY instead.
+#[cfg(unix)]
+#[skuld::label]
+const ROOT: skuld::Label;
+
+#[cfg(unix)]
+#[skuld::test(labels = [ROOT])]
+fn drop_actually_changes_uid() {
+    use crate::privilege::{Groups, Host, InvokingUser, Privilege, Transition};
+    use std::process::Command;
+
+    // SAFETY: geteuid is always safe.
+    assert_eq!(
+        unsafe { libc::geteuid() },
+        0,
+        "this test requires root. Run the elevated `xtask-tests` target (CI does this), \
+         or opt out locally with SKULD_LABELS=\"!root\"."
+    );
+
+    let host = Host::detect();
+    let uid = match &host.invoking_user {
+        Some(InvokingUser::Posix { uid, .. }) => *uid,
+        _ => panic!(
+            "no invoking user resolved: set SUDO_USER or HOLE_BUILD_USER (the elevated \
+             xtask-tests target runs under sudo, which sets SUDO_USER)"
+        ),
+    };
+    assert!(matches!(host.plan(Privilege::Unprivileged), Transition::DropTo(_)));
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("uid.txt");
+    let mut cmd = Command::new("bash");
+    cmd.arg("-c").arg(format!("id -u > {}", out.display()));
+    crate::privilege::run_command(&host, Privilege::Unprivileged, cmd, &Groups::Full, "id -u").unwrap();
+    let got: u32 = std::fs::read_to_string(&out).unwrap().trim().parse().unwrap();
+    assert_eq!(got, uid, "child did not drop to the invoking user's uid");
+}

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -123,12 +123,29 @@ fn drop_actually_changes_uid() {
     };
     assert!(matches!(host.plan(Privilege::Unprivileged), Transition::DropTo(_)));
 
-    let dir = tempfile::tempdir().unwrap();
-    let out = dir.path().join("uid.txt");
+    // The DROPPED (unprivileged) child must be able to write the output. A
+    // `tempfile::tempdir()` is created by this root process at 0700 — and under
+    // sudo the platform temp dir can be root-owned 0700 (macOS `/var/folders`),
+    // untraversable by the dropped user. Use a pre-created world-writable file
+    // in `/tmp` (1777 + sticky on both Linux and macOS): the dropped child can
+    // truncate+write an existing 0666 file there with only directory traversal.
+    use std::os::unix::fs::PermissionsExt;
+    let out = std::path::PathBuf::from(format!("/tmp/hole-xtask-drop-{}.txt", std::process::id()));
+    std::fs::write(&out, "").unwrap();
+    std::fs::set_permissions(&out, std::fs::Permissions::from_mode(0o666)).unwrap();
+
     let mut cmd = Command::new("bash");
     cmd.arg("-c").arg(format!("id -u > {}", out.display()));
-    crate::privilege::run_command(&host, Privilege::Unprivileged, cmd, &Groups::Full, "id -u").unwrap();
-    let got: u32 = std::fs::read_to_string(&out).unwrap().trim().parse().unwrap();
+    let result = crate::privilege::run_command(&host, Privilege::Unprivileged, cmd, &Groups::Full, "id -u");
+    let contents = std::fs::read_to_string(&out).ok();
+    let _ = std::fs::remove_file(&out);
+
+    result.unwrap();
+    let got: u32 = contents
+        .expect("dropped child produced no output")
+        .trim()
+        .parse()
+        .unwrap();
     assert_eq!(got, uid, "child did not drop to the invoking user's uid");
 }
 

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -132,6 +132,49 @@ fn drop_actually_changes_uid() {
     assert_eq!(got, uid, "child did not drop to the invoking user's uid");
 }
 
+// Unit test for the getgrnam-backed `group_gid` (the resolution path used by
+// `Groups::Only`). Portable and root-free: resolve our own real primary gid,
+// look up its group name via getgrgid, then assert group_gid(name) round-trips
+// back to that gid. The negative lookup runs unconditionally.
+#[cfg(unix)]
+#[skuld::test]
+fn group_gid_resolves_own_primary_group_and_misses_unknown() {
+    use crate::privilege::posix::group_gid;
+    use std::ffi::CStr;
+
+    // SAFETY: getgid never fails and has no preconditions.
+    let gid = unsafe { libc::getgid() };
+    // SAFETY: getgrgid returns a pointer into static storage or null; we read
+    // gr_name only while the (non-null) record is valid, before any other libc
+    // call that could clobber the static buffer.
+    let name: Option<String> = unsafe {
+        let grp = libc::getgrgid(gid);
+        if grp.is_null() {
+            None
+        } else {
+            CStr::from_ptr((*grp).gr_name).to_str().ok().map(str::to_owned)
+        }
+    };
+
+    // If the environment can resolve our primary group's name, the getgrnam
+    // path must agree on the gid. (Some minimal containers lack a name for the
+    // primary gid; tolerate that — it is not the unit under test.)
+    if let Some(name) = name {
+        assert_eq!(
+            group_gid(&name),
+            Some(gid),
+            "group_gid({name:?}) must round-trip to the primary gid {gid}"
+        );
+    }
+
+    // The not-found path is unconditional.
+    assert_eq!(
+        group_gid("hole-no-such-group-zzzzz"),
+        None,
+        "a nonexistent group name must resolve to None"
+    );
+}
+
 // ===== Windows quoter ================================================================================================
 
 // The CommandLineToArgvW quoter must round-trip exactly: every arg we quote and

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -1,0 +1,1 @@
+// Tests added in Tasks 2/4/5.

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -90,6 +90,16 @@ fn ci_tripwire_requires_all_three_conditions() {
     ));
 }
 
+#[skuld::test]
+fn windows_elevated_no_linked_token_warns_not_hard_fails_even_under_ci() {
+    // GitHub-hosted Windows runners are elevated but expose no UAC-split linked
+    // token, so there is nothing to de-elevate to. Windows has no root-owned-file
+    // hazard, so this must NOT trip the (POSIX-only) CI hard-fail — it warns and
+    // runs the step as-is. Regression guard for the Windows-CI breakage.
+    let h = host(true, None, true, false, ElevateStrategy::Windows);
+    assert!(matches!(h.plan(Privilege::Unprivileged), Transition::WarnVacuous(_)));
+}
+
 // Effect test: actually drop and read back the child uid. Needs root; labeled
 // `root`, runs by default (CI supplies root via the elevated xtask-tests
 // target). Opt out locally with SKULD_LABELS="!root". Does NOT use skuld's

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -131,3 +131,42 @@ fn drop_actually_changes_uid() {
     let got: u32 = std::fs::read_to_string(&out).unwrap().trim().parse().unwrap();
     assert_eq!(got, uid, "child did not drop to the invoking user's uid");
 }
+
+// ===== Windows quoter ================================================================================================
+
+// The CommandLineToArgvW quoter must round-trip exactly: every arg we quote and
+// join must parse back to the identical argv. Verified against the real Win32
+// parser (runs on Windows only).
+#[cfg(windows)]
+#[skuld::test]
+fn quoter_roundtrips_through_commandlinetoargvw() {
+    use crate::privilege::win_quote::{cmdline_roundtrips, join_command_line};
+
+    let cases: Vec<Vec<String>> = vec![
+        vec![],
+        vec!["plain".into()],
+        vec!["a".into(), "b".into(), "c".into()],
+        vec!["has spaces".into()],
+        vec!["a\ttab".into()],
+        vec!["embedded\"quote".into()],
+        vec!["trailing\\".into()],
+        vec!["two\\\\".into()],
+        vec!["C:\\Program Files\\x\\".into()],
+        vec!["quote\\\"and\\back".into()],
+        vec![
+            "build".into(),
+            "--target".into(),
+            "C:\\Program Files\\hole\\".into(),
+            "with space".into(),
+        ],
+        vec!["".into(), "after-empty".into()],
+    ];
+
+    for argv in &cases {
+        let cmdline = join_command_line(argv);
+        assert!(
+            cmdline_roundtrips(&cmdline, argv),
+            "argv {argv:?} did not round-trip; produced cmdline {cmdline:?}"
+        );
+    }
+}

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -1,1 +1,91 @@
-// Tests added in Tasks 2/4/5.
+use std::path::PathBuf;
+
+use crate::privilege::{ElevateStrategy, Host, InvokingUser, Privilege, Transition};
+
+fn user() -> InvokingUser {
+    InvokingUser::Posix {
+        name: "alice".into(),
+        uid: 501,
+        gid: 20,
+        home: PathBuf::from("/Users/alice"),
+    }
+}
+fn host(elevated: bool, u: Option<InvokingUser>, is_ci: bool, has_tty: bool, strategy: ElevateStrategy) -> Host {
+    Host {
+        elevated,
+        invoking_user: u,
+        is_ci,
+        has_tty,
+        strategy,
+    }
+}
+
+#[skuld::test]
+fn unprivileged_target_unprivileged_runs_as_is() {
+    for s in [ElevateStrategy::Posix, ElevateStrategy::Windows] {
+        assert_eq!(
+            host(false, None, false, true, s).plan(Privilege::Unprivileged),
+            Transition::RunAsIs
+        );
+    }
+}
+
+#[skuld::test]
+fn elevated_host_unprivileged_target_drops_to_user() {
+    let h = host(true, Some(user()), false, true, ElevateStrategy::Posix);
+    assert_eq!(h.plan(Privilege::Unprivileged), Transition::DropTo(user()));
+}
+
+#[skuld::test]
+fn elevated_host_no_user_warns_vacuous_off_ci() {
+    let h = host(true, None, false, true, ElevateStrategy::Posix);
+    match h.plan(Privilege::Unprivileged) {
+        Transition::WarnVacuous(m) => assert!(m.contains("HOLE_BUILD_USER")),
+        o => panic!("expected WarnVacuous, got {o:?}"),
+    }
+}
+
+#[skuld::test]
+fn elevated_host_no_user_hard_fails_under_ci() {
+    let h = host(true, None, true, false, ElevateStrategy::Posix);
+    match h.plan(Privilege::Unprivileged) {
+        Transition::HardFail(m) => assert!(m.contains("CI") && m.contains("HOLE_BUILD_USER")),
+        o => panic!("expected HardFail, got {o:?}"),
+    }
+}
+
+#[skuld::test]
+fn elevated_target_elevated_host_runs_as_is() {
+    for s in [ElevateStrategy::Posix, ElevateStrategy::Windows] {
+        assert_eq!(
+            host(true, Some(user()), false, true, s).plan(Privilege::Elevated),
+            Transition::RunAsIs
+        );
+    }
+}
+
+#[skuld::test]
+fn elevated_target_unprivileged_host_gains_privilege_per_strategy() {
+    assert_eq!(
+        host(false, None, false, true, ElevateStrategy::Posix).plan(Privilege::Elevated),
+        Transition::ElevateChild
+    );
+    assert_eq!(
+        host(false, None, false, true, ElevateStrategy::Windows).plan(Privilege::Elevated),
+        Transition::SelfElevateProcess
+    );
+}
+
+#[skuld::test]
+fn ci_tripwire_requires_all_three_conditions() {
+    // CI + elevated + user present → DropTo (a user to honor exists).
+    assert_eq!(
+        host(true, Some(user()), true, false, ElevateStrategy::Posix).plan(Privilege::Unprivileged),
+        Transition::DropTo(user())
+    );
+    // Not CI + elevated + no user → WarnVacuous, not HardFail.
+    assert!(matches!(
+        host(true, None, false, false, ElevateStrategy::Posix).plan(Privilege::Unprivileged),
+        Transition::WarnVacuous(_)
+    ));
+}

--- a/xtask/src/privilege_tests.rs
+++ b/xtask/src/privilege_tests.rs
@@ -170,3 +170,94 @@ fn quoter_roundtrips_through_commandlinetoargvw() {
         );
     }
 }
+
+// ===== Windows de-elevation effect tests =============================================================================
+
+// These EFFECT tests need an ELEVATED process to exercise linked-token
+// de-elevation. Labeled `windows_elevated`, they run by default (the elevated
+// CI runner / `xtask-tests` target supplies elevation). Opt out locally with
+// SKULD_LABELS="!windows_elevated". They do NOT use skuld's `requires` (which
+// would mark the trial ignored — a green-build skip); they assert elevation and
+// fail LOUDLY otherwise.
+#[cfg(windows)]
+#[skuld::label]
+const WINDOWS_ELEVATED: skuld::Label;
+
+#[cfg(windows)]
+fn require_elevated() {
+    let host = crate::privilege::Host::detect();
+    assert!(
+        host.elevated,
+        "this test requires an elevated process (to obtain the linked token for de-elevation). \
+         Run via the elevated `xtask-tests` target / the elevated CI runner, or opt out locally \
+         with SKULD_LABELS=\"!windows_elevated\"."
+    );
+    assert!(
+        host.invoking_user.is_some(),
+        "elevated but no linked token available — cannot de-elevate. The runner must have \
+         EnableLUA=1 with a linked (limited) token."
+    );
+}
+
+// Drop effect: a child launched via the Unprivileged transition must land at
+// Medium integrity, not High. We assert on the locale-independent integrity SID
+// in `whoami /groups`: S-1-16-8192 (Medium) present, S-1-16-12288 (High) absent.
+#[cfg(windows)]
+#[skuld::test(labels = [WINDOWS_ELEVATED])]
+fn de_elevate_drops_child_integrity_below_high() {
+    use crate::privilege::{Groups, Host, Privilege};
+    use std::process::Command;
+
+    require_elevated();
+    let host = Host::detect();
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("groups.txt");
+    // cmd's `>` redirect writes the file directly (not through our relay pipes),
+    // proving the child ran AND letting us inspect its integrity SID.
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/C").arg(format!("whoami /groups > \"{}\"", out.display()));
+    crate::privilege::run_command(&host, Privilege::Unprivileged, cmd, &Groups::Full, "whoami /groups").unwrap();
+
+    let groups = std::fs::read_to_string(&out).expect("child did not write its groups file");
+    assert!(
+        groups.contains("S-1-16-8192"),
+        "de-elevated child is not at Medium integrity (no S-1-16-8192 in whoami /groups):\n{groups}"
+    );
+    assert!(
+        !groups.contains("S-1-16-12288"),
+        "de-elevated child is still at High integrity (S-1-16-12288 present):\n{groups}"
+    );
+}
+
+// Suspend rendezvous: prove CREATE_SUSPENDED survives the seclogon round-trip.
+// The proof is race-free — `ResumeThread` returns the thread's PREVIOUS suspend
+// count, which is 1 for a CREATE_SUSPENDED thread and 0 if the flag was ignored.
+// There is no byte-peek and no timing. We additionally confirm stdio works by
+// reading a post-resume sentinel the child wrote to a file.
+#[cfg(windows)]
+#[skuld::test(labels = [WINDOWS_ELEVATED])]
+fn de_elevate_creates_child_suspended() {
+    use std::process::Command;
+
+    require_elevated();
+
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel = dir.path().join("ran.txt");
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/C").arg(format!("echo resumed > \"{}\"", sentinel.display()));
+
+    let resume_count = crate::privilege::windows::de_elevate_for_test(&mut cmd, "suspend-proof").unwrap();
+    assert_eq!(
+        resume_count, 1,
+        "ResumeThread returned previous suspend count {resume_count}, expected 1; \
+         CREATE_SUSPENDED was not honored through seclogon"
+    );
+
+    // Stdio/exec actually worked: the child ran to completion past the resume.
+    let body = std::fs::read_to_string(&sentinel).expect("child did not write its sentinel file");
+    assert!(
+        body.contains("resumed"),
+        "sentinel file had unexpected content: {body:?}"
+    );
+}


### PR DESCRIPTION
Implements #453: declarative per-step `elevated: <bool>` in `build.yaml`, with a reusable cross-platform `privilege` API that normalizes every build/run step to its declared privilege.

## What it does
- **Schema:** `elevated: <bool>` per-step and as a `run:`/`build:` block default (`{ elevated, steps }`); resolves outward (step → block → global `false`); `elevated: true` is rejected on `build:` steps (build artifacts stay unprivileged by construction).
- **`privilege` API** (`xtask/src/privilege*`): a pure `Host::plan` decision core (`(ambient, declared) → Transition`, exhaustively unit-tested on every OS via a platform-strategy data field) + thin POSIX/Windows effect layers. Built library-grade for reuse by the future Rust dev supervisor (#454) — e.g. `Groups::Only(["hole"])` is carved out for it.
- **POSIX:** drops root via a `pre_exec` `setgroups→setgid→setuid` child (raw `libc` — `nix` omits the group calls on macOS; groups precomputed in the parent for async-signal-safety, and **capped to `NGROUPS_MAX`** since macOS `setgroups` rejects >16). Elevates via `sudo -n` preserving `PATH`/`HOME`/`SKULD_LABELS`/`CI` past `secure_path` (assignments before the program, no `--`); primes once up front (`sudo -n true`, else interactive `sudo -v` on a TTY, else hard-fail).
- **Windows:** self-elevates the whole process via UAC (`ShellExecuteEx runas`) when an elevated step is reachable; de-elevates `elevated:false` steps via the linked token with `CreateProcessWithTokenW(CREATE_SUSPENDED)` → integrity-check → Job-Object assign → `ResumeThread` (prev-count `== 1` proves suspension), raw separate stdio pipes relayed to the parent, Job-Object reaping (the `crates/garter/src/proc_group.rs` pattern), 64-bit guard for the WOW64 `CreateProcessWithTokenW` stdio bug. No SYSTEM impersonation — only `SeImpersonate`. Every failure path is loud; no path runs an elevated child when de-elevation was requested.
- **First consumer:** new `network-reset` target (`elevated: true`) — `cargo xtask run network-reset` obtains root itself.
- **Tests run for real:** new `xtask-tests` target (nextest archive — the elevated run executes prebuilt binaries, so no recompile-as-root / `~/.cargo` pollution) + a `test-xtask` CI matrix (linux/macos/windows) runs the suite **elevated**, so the privilege effect tests execute and fail loudly (never skip).

## Reconciliation with #452 (merged mid-development)
#452 (PR #455) landed first and inverted dev.py (unprivileged, self-sudoes only the bridge; dev.py refuses to run as root). So **`hole` is intentionally left unchanged** — flipping it to `elevated: true` would regress that. #453's contribution to the sudo-invocation path is the **build/run drop-normalization**: `sudo cargo xtask run hole` now drops every step back to the invoking user (no root-owned `target/`). That's exactly what #455's CONTRIBUTING note deferred to #453; this PR updates that note. A test pins that `hole` stays unprivileged.

## Platform realities worth a reviewer's eye
- **The CI hard-fail tripwire is POSIX-only.** GitHub-hosted **Windows runners run elevated but expose no UAC-split linked token**, so de-elevation there is best-effort and the step runs as-is (Windows has no root-owned-file hazard). A POSIX root container in CI with no `SUDO_USER` still hard-fails (the original dormant tripwire).
- **The linked-token de-elevation effect tests** (label `windows_elevated`) need an interactive elevated Windows session (a real linked token), which hosted runners lack — they're excluded on the Windows CI leg (the quoter + pure decision tests still run there) and validated on a real elevated Windows desktop. The full `de_elevate` path is compile-verified for the MSVC target (cargo-xwin) and runtime-validated interactively.

## Follow-up (not in this PR)
- `win_quote::quote_arg` intentionally mirrors the private `crates/hole/src/setup.rs::quote_arg`; deduping means a cross-crate extraction into `util` touching the security-sensitive `hole` setup path — out of scope here.

Out of scope: the Rust dev-supervisor port (#454), which reuses this API.