### PR TITLE
fix(ui): dashboard wiring-fix batch from the GUI audit (#479)

### DIFF
--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+const saveConfigMock = vi.fn();
+const showToastMock = vi.fn();
+let mockConfig: { filters: { address: string; matching: string; action: string }[] } | null;
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+vi.mock("./toast", () => ({ showToast: (...args: unknown[]) => showToastMock(...args) }));
+vi.mock("./main", () => ({
+  get config() {
+    return mockConfig;
+  },
+  saveConfig: (...args: unknown[]) => saveConfigMock(...args),
+}));
+
+function scaffold() {
+  document.body.innerHTML = `
+    <table><tbody id="filter-tbody"></tbody></table>
+    <div id="filter-add-btn"></div>
+    <input id="test-input" type="text">
+    <div id="test-result"></div>`;
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
+  saveConfigMock.mockReset();
+  saveConfigMock.mockResolvedValue(undefined);
+  showToastMock.mockReset();
+  mockConfig = {
+    filters: [
+      { address: "*", matching: "wildcard", action: "proxy" },
+      { address: "a.example.com", matching: "exactly", action: "block" },
+      { address: "b.example.com", matching: "exactly", action: "bypass" },
+    ],
+  };
+  scaffold();
+  vi.resetModules();
+});
+
+/// Drain the persist chain: each persist is save (1 await) + reload
+/// (1 await); a fixed number of microtask turns covers N chained pairs
+/// because every mocked promise is already settled.
+async function flushPersist(turns = 8) {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+describe("reload_proxy_filters on mutation", () => {
+  it("deleting a rule saves and reloads the live proxy", async () => {
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+
+    document.querySelectorAll<HTMLElement>(".filter-del")[0]!.click(); // deletes rule index 1
+    await flushPersist();
+
+    expect(mockConfig!.filters).toHaveLength(2);
+    expect(saveConfigMock).toHaveBeenCalled();
+    expect(invokeMock).toHaveBeenCalledWith("reload_proxy_filters");
+  });
+
+  it("a reload failure is surfaced as a toast", async () => {
+    invokeMock.mockRejectedValueOnce("bridge gone");
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+
+    document.querySelectorAll<HTMLElement>(".filter-del")[0]!.click();
+    await flushPersist();
+
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("bridge gone"), "error");
+  });
+
+  it("two rapid mutations serialize: save,reload,save,reload in order", async () => {
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+
+    const order: string[] = [];
+    saveConfigMock.mockImplementation(async () => {
+      order.push("save");
+    });
+    invokeMock.mockImplementation(async (cmd: string) => {
+      order.push(cmd);
+    });
+
+    // Two synchronous back-to-back deletes (indices shift after the first).
+    document.querySelectorAll<HTMLElement>(".filter-del")[0]!.click();
+    document.querySelectorAll<HTMLElement>(".filter-del")[0]!.click();
+    await flushPersist(16);
+
+    expect(order).toEqual(["save", "reload_proxy_filters", "save", "reload_proxy_filters"]);
+    expect(mockConfig!.filters).toHaveLength(1);
+  });
+});

--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -94,3 +94,27 @@ describe("reload_proxy_filters on mutation", () => {
     expect(mockConfig!.filters).toHaveLength(1);
   });
 });
+
+describe("switching inline edits between cells", () => {
+  it("editing rule B while rule A is open commits A and opens a live editor on B", async () => {
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+
+    // Open edit on rule index 1 (first non-default), type a new address.
+    const cellA = document.querySelectorAll<HTMLElement>(".editable-addr")[0]!;
+    cellA.click();
+    const inputA = document.querySelector<HTMLInputElement>(".inline-input")!;
+    inputA.value = "a2.example.com";
+
+    // Click rule index 2's address cell.
+    document.querySelectorAll<HTMLElement>(".editable-addr")[1]!.click();
+
+    // A committed; B has a live (attached) editor.
+    expect(mockConfig!.filters[1].address).toBe("a2.example.com");
+    const inputB = document.querySelector<HTMLInputElement>(".inline-input");
+    expect(inputB).not.toBeNull();
+    expect(inputB!.isConnected).toBe(true);
+    expect(inputB!.closest("tr")!.dataset.index).toBe("2");
+  });
+});

--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -118,3 +118,37 @@ describe("switching inline edits between cells", () => {
     expect(inputB!.closest("tr")!.dataset.index).toBe("2");
   });
 });
+
+describe("background re-render during drag", () => {
+  it("cancels the drag, restores document state, and never saves a corrupted list", async () => {
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+    const before = mockConfig!.filters.map((r) => r.address);
+
+    // Begin a drag on the first non-default rule's handle. bubbles: true is
+    // required — the handler is delegated on the tbody. jsdom has no
+    // PointerEvent constructor; the handler only reads target/clientY,
+    // which MouseEvent provides.
+    const handle = document.querySelectorAll<HTMLElement>(".drag-handle")[1]!;
+    handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientY: 10 }));
+    expect(document.body.style.userSelect).toBe("none");
+
+    // A validation-changed style background reload re-renders mid-drag.
+    renderFilters();
+
+    // Drag state must be fully cancelled: userSelect restored…
+    expect(document.body.style.userSelect).toBe("");
+    // …no placeholder or lifted row left behind…
+    expect(document.querySelector(".drag-placeholder")).toBeNull();
+    // …and a later pointerup must not throw, reorder, or persist anything.
+    // (This asserts the *outcome* — whether the listener was removed or
+    // onDragEnd early-returns on null dragState, the corruption vector is
+    // closed either way.)
+    saveConfigMock.mockClear();
+    document.dispatchEvent(new MouseEvent("pointerup"));
+    await flushPersist();
+    expect(mockConfig!.filters.map((r) => r.address)).toEqual(before);
+    expect(saveConfigMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -152,3 +152,40 @@ describe("background re-render during drag", () => {
     expect(saveConfigMock).not.toHaveBeenCalled();
   });
 });
+
+describe("abandoning a new rule", () => {
+  it("clicking another cell while a new rule's address is empty removes the rule", async () => {
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+    const count = mockConfig!.filters.length;
+
+    document.getElementById("filter-add-btn")!.click(); // adds empty rule + opens editor
+    expect(mockConfig!.filters.length).toBe(count + 1);
+
+    // Abandon it by clicking an existing rule's address cell (sync commit path).
+    document.querySelectorAll<HTMLElement>(".editable-addr")[0]!.click();
+
+    expect(mockConfig!.filters.length).toBe(count);
+    expect(mockConfig!.filters.every((r) => r.address !== "")).toBe(true);
+  });
+
+  it("the editor opens on the correct rule even when the splice shifts indices", async () => {
+    const { initFilters, renderFilters } = await import("./filters");
+    initFilters();
+    renderFilters();
+
+    document.getElementById("filter-add-btn")!.click(); // empty rule appended, editor open on it
+    // Click rule 2's address cell ("b.example.com") — the empty rule is
+    // spliced out; index 2 stays valid (the splice removed a LATER row),
+    // and the editor must land on b.example.com's live row.
+    document.querySelectorAll<HTMLElement>(".editable-addr")[1]!.click();
+
+    const input = document.querySelector<HTMLInputElement>(".inline-input")!;
+    expect(input.isConnected).toBe(true);
+    const row = input.closest("tr")!;
+    expect(row.dataset.index).toBe("2");
+    expect(mockConfig!.filters[2].address).toBe("b.example.com");
+    expect(mockConfig!.filters.every((r) => r.address !== "")).toBe(true);
+  });
+});

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -220,7 +220,21 @@ export function renderFilters() {
  */
 function startAddressEdit(td: HTMLTableCellElement, index: number) {
   if (editingIndex === index) return; // Already editing this cell.
+
+  // Committing the previous edit re-renders the table, detaching `td`
+  // and possibly shifting `index` (an abandoned empty rule is spliced
+  // out). Capture the rule's identity, commit, then re-resolve both.
+  // Safe: this whole path is synchronous, so `config` cannot be
+  // reassigned between capture and re-resolution.
+  const rule = config?.filters[index];
   commitOrCancelEditing(); // Close any other active edit.
+  if (!rule || !config) return;
+  const liveIndex = config.filters.indexOf(rule);
+  if (liveIndex < 0) return; // rule was removed by the commit
+  const liveTd = tbody.querySelector<HTMLTableCellElement>(`tr[data-index="${liveIndex}"] .editable-addr`);
+  if (!liveTd) return;
+  td = liveTd;
+  index = liveIndex;
 
   editingIndex = index;
   const addrSpan = td.querySelector(".filter-addr");
@@ -384,7 +398,8 @@ let dragState: DragState | null = null;
 function startDrag(e: PointerEvent, row: HTMLTableRowElement, index: number) {
   e.preventDefault();
   closeDropdown();
-  commitOrCancelEditing();
+  // Any open edit was already committed by onTbodyPointerDown, which
+  // re-resolved `row`/`index` against the post-commit DOM.
 
   const rect = row.getBoundingClientRect();
   const tbodyRect = tbody.getBoundingClientRect();
@@ -783,7 +798,17 @@ function onTbodyPointerDown(e: PointerEvent) {
   const index = parseInt(tr.dataset.index ?? "", 10);
   if (Number.isNaN(index) || index <= 0) return; // Cannot drag default rule.
 
-  startDrag(e, tr, index);
+  // Commit any open edit FIRST (it re-renders), then re-resolve the row —
+  // same detached-node hazard as startAddressEdit.
+  const rule = config?.filters[index];
+  commitOrCancelEditing();
+  if (!rule || !config) return;
+  const liveIndex = config.filters.indexOf(rule);
+  if (liveIndex <= 0) return;
+  const liveRow = tbody.querySelector<HTMLTableRowElement>(`tr[data-index="${liveIndex}"]`);
+  if (!liveRow) return;
+
+  startDrag(e, liveRow, liveIndex);
 }
 
 /** Close dropdown when clicking outside. */

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -1,7 +1,9 @@
 // Filters section: filter rules table with in-place editing, drag reorder,
 // test filtering, add/delete rules.
 
+import { invoke } from "@tauri-apps/api/core";
 import { config, saveConfig } from "./main";
+import { showToast } from "./toast";
 import type { FilterRule } from "./types";
 
 // Constants ===========================================================================================================
@@ -44,6 +46,34 @@ let openDropdown: (HTMLDivElement & { _td?: HTMLTableCellElement }) | null = nul
 
 /** Index of the row being edited inline (address input), or -1. */
 let editingIndex = -1;
+
+// Persistence =========================================================================================================
+
+/// Persist the rule list, then push it to the running proxy.
+/// reload_proxy_filters is a no-op on the Rust side when disconnected;
+/// when connected, skipping it would leave live traffic on the old rules
+/// until the next reconnect with no indication in the UI.
+///
+/// Serialized through `persistChain`: callers fire-and-forget, and two
+/// rapid mutations must not interleave their save/reload pairs — the
+/// proxy must never be reloaded with an older snapshot than the last
+/// save. A reload that follows a FAILED save is harmless: save_config
+/// only replaces the Rust-side config on a successful disk write, so
+/// the reload pushes the unchanged old rules.
+let persistChain: Promise<void> = Promise.resolve();
+
+function persistFilters(): Promise<void> {
+  persistChain = persistChain.then(async () => {
+    await saveConfig();
+    try {
+      await invoke("reload_proxy_filters");
+    } catch (err) {
+      console.error("reload_proxy_filters failed:", err);
+      showToast(`Filters saved, but not applied to the running proxy: ${err}`, "error");
+    }
+  });
+  return persistChain;
+}
 
 // Rendering ===========================================================================================================
 
@@ -215,10 +245,10 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
     if (!newValue) {
       // Empty address — remove the rule (it was never valid).
       config?.filters.splice(index, 1);
-      saveConfig();
+      void persistFilters();
     } else if (newValue !== original) {
       if (config) config.filters[index].address = newValue;
-      saveConfig();
+      void persistFilters();
     }
     renderFilters();
   }
@@ -262,7 +292,7 @@ function commitOrCancelEditing() {
     const value = input.value.trim();
     if (value && value !== config.filters[index].address) {
       config.filters[index].address = value;
-      saveConfig();
+      void persistFilters();
     }
   }
   renderFilters();
@@ -319,7 +349,7 @@ function toggleDropdown(td: HTMLTableCellElement, index: number) {
       } else {
         config.filters[index].action = opt.value as FilterRule["action"];
       }
-      saveConfig();
+      void persistFilters();
       closeDropdown();
       renderFilters();
     });
@@ -518,7 +548,7 @@ function onDragEnd() {
       }
     }
     config.filters = newFilters;
-    saveConfig();
+    void persistFilters();
   }
 
   document.removeEventListener("pointermove", onDragMove);
@@ -566,7 +596,7 @@ function addRule() {
 function deleteRule(index: number) {
   if (index <= 0 || !config?.filters) return; // Cannot delete default rule.
   config.filters.splice(index, 1);
-  saveConfig();
+  void persistFilters();
   renderFilters();
 }
 

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -106,6 +106,8 @@ export function renderFilters() {
   if (!config) return;
   ensureDefaultRule();
 
+  commitPendingEdit();
+  cancelDrag();
   closeDropdown();
   editingIndex = -1;
   tbody.innerHTML = "";
@@ -296,8 +298,10 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
   });
 }
 
-/** If there's an active address edit, commit it synchronously. */
-function commitOrCancelEditing() {
+/// Commit a pending inline address edit WITHOUT re-rendering. Lets
+/// renderFilters() flush the edit before it wipes the tbody (calling the
+/// rendering variant from there would recurse).
+function commitPendingEdit() {
   if (editingIndex < 0) return;
   const index = editingIndex;
   const input = tbody.querySelector<HTMLInputElement>(".inline-input");
@@ -309,6 +313,12 @@ function commitOrCancelEditing() {
       void persistFilters();
     }
   }
+}
+
+/** If there's an active address edit, commit it synchronously. */
+function commitOrCancelEditing() {
+  if (editingIndex < 0) return;
+  commitPendingEdit();
   renderFilters();
 }
 
@@ -388,6 +398,21 @@ interface DragState {
 
 /** Active drag state, or null. */
 let dragState: DragState | null = null;
+
+/// Abandon an in-progress drag without applying a reorder. Called by
+/// renderFilters() when a background reload wipes the tbody mid-drag:
+/// finishing the drag against detached rows would throw before listener
+/// cleanup and then save a corrupted rule list on the next click. The
+/// lifted row's inline styles are not restored here — every caller wipes
+/// the tbody immediately after, discarding the row.
+function cancelDrag() {
+  if (!dragState) return;
+  dragState.placeholder.remove();
+  document.removeEventListener("pointermove", onDragMove);
+  document.removeEventListener("pointerup", onDragEnd);
+  document.body.style.userSelect = "";
+  dragState = null;
+}
 
 /**
  * Start dragging a row.

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -308,7 +308,11 @@ function commitPendingEdit() {
   editingIndex = -1; // Clear first so the blur handler becomes a no-op.
   if (input && config?.filters[index]) {
     const value = input.value.trim();
-    if (value && value !== config.filters[index].address) {
+    if (!value) {
+      // Empty address — the rule was never valid; drop it like commit() does.
+      config.filters.splice(index, 1);
+      void persistFilters();
+    } else if (value !== config.filters[index].address) {
       config.filters[index].address = value;
       void persistFilters();
     }

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -106,10 +106,14 @@ export function renderFilters() {
   if (!config) return;
   ensureDefaultRule();
 
+  // Flush a pending edit before wiping the tbody. This writes the open
+  // editor's value into the CURRENT config by row index — sound because
+  // every loadConfig caller today reloads a structurally identical
+  // filters array; a reload that reshapes the rules would need an
+  // identity-based commit instead.
   commitPendingEdit();
   cancelDrag();
   closeDropdown();
-  editingIndex = -1;
   tbody.innerHTML = "";
 
   for (let i = 0; i < config.filters.length; i++) {
@@ -242,7 +246,7 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
   const addrSpan = td.querySelector(".filter-addr");
   if (!addrSpan) return;
 
-  const original = addrSpan.textContent;
+  const original = addrSpan.textContent ?? "";
 
   const input = document.createElement("input");
   input.className = "inline-input";

--- a/ui/index.html
+++ b/ui/index.html
@@ -169,9 +169,9 @@
                     <div class="toggle" id="toggle-dns-intercept"></div>
                   </div>
                 </div>
-                <div class="setting-row setting-note">
-                  <span class="setting-label">Settings apply on reconnect. Edit the config file to change server list.</span>
-                </div>
+              </div>
+              <div class="setting-row setting-note">
+                <span class="setting-label">Settings apply on reconnect. Edit the config file to change the DNS server list.</span>
               </div>
             </div>
           </div>

--- a/ui/ip-display.test.ts
+++ b/ui/ip-display.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.fn();
+const showToastMock = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+vi.mock("./toast", () => ({ showToast: (...args: unknown[]) => showToastMock(...args) }));
 
 beforeEach(() => {
   invokeMock.mockReset();
+  showToastMock.mockReset();
   document.body.innerHTML = `
     <span id="ip-text"><span class="country-flag fi fis fi-xx" id="country-flag" title="Unknown"></span></span>
     <button id="copy-ip-btn"></button>
@@ -66,5 +69,36 @@ describe("copy button", () => {
     await updatePublicIp();
     document.getElementById("copy-ip-btn")!.click();
     expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("toasts success after a clipboard write", async () => {
+    invokeMock.mockResolvedValue({ ip: "203.0.113.7", country_code: "NL" });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { initIpDisplay, updatePublicIp } = await import("./ip-display");
+    initIpDisplay();
+    await updatePublicIp();
+
+    document.getElementById("copy-ip-btn")!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith("203.0.113.7");
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("copied"), "success");
+  });
+
+  it("toasts an error when the clipboard write fails", async () => {
+    invokeMock.mockResolvedValue({ ip: "203.0.113.7", country_code: "NL" });
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { initIpDisplay, updatePublicIp } = await import("./ip-display");
+    initIpDisplay();
+    await updatePublicIp();
+
+    document.getElementById("copy-ip-btn")!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("denied"), "error");
   });
 });

--- a/ui/ip-display.ts
+++ b/ui/ip-display.ts
@@ -3,6 +3,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { setCountryFlag } from "./country-flag";
+import { showToast } from "./toast";
 import type { PublicIpData } from "./types";
 
 let ipText: HTMLElement | null = null;
@@ -38,7 +39,11 @@ export async function updatePublicIp(): Promise<void> {
 
 function handleCopyIp(): void {
   if (!currentIp) return;
-  navigator.clipboard.writeText(currentIp).catch((err) => {
-    console.error("clipboard write failed:", err);
-  });
+  navigator.clipboard.writeText(currentIp).then(
+    () => showToast("IP address copied.", "success"),
+    (err) => {
+      console.error("clipboard write failed:", err);
+      showToast(`Copy failed: ${err}`, "error");
+    },
+  );
 }

--- a/ui/main.test.ts
+++ b/ui/main.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/// Records the interleaving of listen() registrations and invoke() calls
+/// so the test can assert listeners are registered before the first
+/// config fetch (the point where the UI becomes interactive).
+const callOrder: string[] = [];
+const invokeMock = vi.fn((cmd: string, _args?: unknown) => {
+  callOrder.push(`invoke:${cmd}`);
+  if (cmd === "get_config") return Promise.resolve({ servers: [], filters: [] });
+  if (cmd === "get_proxy_status") return Promise.resolve({ running: false });
+  if (cmd === "get_metrics")
+    return Promise.resolve({ bytes_in: 0, bytes_out: 0, speed_in_bps: 0, speed_out_bps: 0, uptime_secs: 0 });
+  if (cmd === "get_diagnostics") return Promise.resolve({});
+  return Promise.resolve(null);
+});
+const listenMock = vi.fn((event: string, _handler?: unknown) => {
+  callOrder.push(`listen:${event}`);
+  return Promise.resolve(() => {});
+});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: [string, unknown?]) => invokeMock(...a) }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: (...a: [string, unknown]) => listenMock(...a) }));
+vi.mock("@tauri-apps/plugin-log", () => ({
+  attachConsole: vi.fn().mockResolvedValue(undefined),
+  error: vi.fn().mockResolvedValue(undefined),
+  warn: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("overlayscrollbars", () => ({ OverlayScrollbars: vi.fn() }));
+vi.mock("flag-icons/css/flag-icons.min.css", () => ({}));
+vi.mock("overlayscrollbars/overlayscrollbars.css", () => ({}));
+vi.mock("./filters", () => ({ initFilters: vi.fn(), renderFilters: vi.fn() }));
+vi.mock("./import-summary", () => ({ postImportSummary: vi.fn().mockReturnValue(null) }));
+vi.mock("./sections", () => ({ initSections: vi.fn() }));
+vi.mock("./servers", () => ({
+  clearImportZoneHighlight: vi.fn(),
+  importFromDialog: vi.fn(),
+  initServers: vi.fn(),
+  renderServers: vi.fn(),
+  showImportFailureDialog: vi.fn(),
+}));
+vi.mock("./settings", () => ({ initSettings: vi.fn(), renderSettings: vi.fn() }));
+vi.mock("./sidebar", () => ({
+  initSidebar: vi.fn(),
+  updateDiagnostics: vi.fn(),
+  updateMetrics: vi.fn(),
+  updateProxyStatus: vi.fn().mockReturnValue({ state: "disconnected", changed: false }),
+  updatePublicIp: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./toast", () => ({ showToast: vi.fn() }));
+
+beforeEach(() => {
+  callOrder.length = 0;
+  vi.resetModules();
+});
+
+describe("init ordering", () => {
+  it("registers all event listeners before the first config fetch", async () => {
+    const { initDone } = await import("./main");
+    await initDone; // init's own promise — deterministic rendezvous, no polling
+
+    const firstConfig = callOrder.indexOf("invoke:get_config");
+    expect(firstConfig).toBeGreaterThan(-1);
+    for (const ev of ["import-requested", "tauri://drag-drop", "validation-changed"]) {
+      const idx = callOrder.indexOf(`listen:${ev}`);
+      expect(idx, `listener ${ev} must be registered before get_config`).toBeGreaterThan(-1);
+      expect(idx).toBeLessThan(firstConfig);
+    }
+  });
+});

--- a/ui/main.test.ts
+++ b/ui/main.test.ts
@@ -50,6 +50,13 @@ vi.mock("./toast", () => ({ showToast: vi.fn() }));
 
 beforeEach(() => {
   callOrder.length = 0;
+  // Clear call logs (not implementations) so per-test assertions don't
+  // match a previous test's invocations.
+  invokeMock.mockClear();
+  listenMock.mockClear();
+  // init() starts real polling intervals; stub so they don't keep
+  // firing in the worker after the test completes.
+  vi.stubGlobal("setInterval", vi.fn());
   vi.resetModules();
 });
 
@@ -65,5 +72,21 @@ describe("init ordering", () => {
       expect(idx, `listener ${ev} must be registered before get_config`).toBeGreaterThan(-1);
       expect(idx).toBeLessThan(firstConfig);
     }
+  });
+
+  it("a listener registration failure fails init loudly", async () => {
+    listenMock.mockImplementationOnce((event: string) => {
+      callOrder.push(`listen:${event}`);
+      return Promise.reject(new Error("capability missing"));
+    });
+    const { initDone } = await import("./main");
+    await initDone;
+
+    // init reported the failure through the ui-ready handshake…
+    const signal = invokeMock.mock.calls.find(([cmd]) => cmd === "signal_ui_ready");
+    expect(signal).toBeDefined();
+    expect((signal![1] as { result: { ok: boolean } }).result.ok).toBe(false);
+    // …and never proceeded to the config fetch.
+    expect(callOrder).not.toContain("invoke:get_config");
   });
 });

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -155,9 +155,9 @@ export async function runTestsBounded(ids: string[], maxInFlight: number) {
 
 // Event listeners =====================================================================================================
 
-function setupEventListeners() {
+function setupEventListeners(): Promise<unknown> {
   // File > Import menu action (tray emits () as payload — open dialog).
-  listen("import-requested", () => importFromDialog());
+  const importReady = listen("import-requested", () => importFromDialog());
 
   // WebView2 (Windows) shows the OS "forbidden" cursor on file drags
   // unless JS calls `preventDefault()` on the `dragover` event — even
@@ -174,7 +174,7 @@ function setupEventListeners() {
   // the user must acknowledge each), and aggregate any successes into
   // a single end-of-loop toast. Per-failure errors use blocking dialogs
   // (not auto-dismiss toasts) so they can't be missed.
-  listen<{ paths?: string[] }>("tauri://drag-drop", async (event) => {
+  const dropReady = listen<{ paths?: string[] }>("tauri://drag-drop", async (event) => {
     // A successful drop may not fire `dragleave` on the import zone —
     // remove the visual highlight unconditionally before processing
     // (the no-op case where the zone wasn't highlighted is harmless).
@@ -220,9 +220,15 @@ function setupEventListeners() {
 
   // Persisted validation changed (from `test_server` or
   // `mark_validated_by_proxy_start`). Pull fresh config and rerender.
-  listen<string>("validation-changed", async () => {
+  const validationReady = listen<string>("validation-changed", async () => {
     await loadConfig();
   });
+
+  // Joined so init() can await registration before the UI becomes
+  // interactive — an emit landing before listen() resolves is silently
+  // lost. Rejection is deliberately fatal to init: a dashboard without
+  // its listeners is broken in exactly the silent way this guards.
+  return Promise.all([importReady, dropReady, validationReady]);
 }
 
 // Initialization ======================================================================================================
@@ -310,6 +316,11 @@ async function init() {
     initSettings();
     initSidebar();
 
+    // Register Rust→JS event listeners BEFORE the first paint-driving
+    // fetches: the menu and drop targets are live from the first frame,
+    // and an emit before listen() resolves is dropped with no error.
+    await setupEventListeners();
+
     // Replace native scrollbars with fade-in/out overlay scrollbars.
     const main = document.querySelector<HTMLElement>(".main");
     if (main) {
@@ -334,9 +345,6 @@ async function init() {
     setInterval(pollProxyStatus, 5000);
     setInterval(pollMetrics, 1000);
     setInterval(pollDiagnostics, 5000);
-
-    // Wire up event listeners.
-    setupEventListeners();
 
     result = { ok: true, error: null };
   } catch (err) {
@@ -375,4 +383,7 @@ async function init() {
   }
 }
 
-init();
+// Test seam: init() never rejects (its body is fully try/caught and the
+// trailing signal_ui_ready failure is logged, not thrown), so awaiting
+// this is a plain rendezvous on startup completion.
+export const initDone = init();

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -4,7 +4,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { attachConsole, error as logError, warn as logWarn } from "@tauri-apps/plugin-log";
+import { error as logError, warn as logWarn } from "@tauri-apps/plugin-log";
 import "flag-icons/css/flag-icons.min.css";
 import { OverlayScrollbars } from "overlayscrollbars";
 import "overlayscrollbars/overlayscrollbars.css";
@@ -289,17 +289,10 @@ async function init() {
 
   let result: { ok: boolean; error: string | null };
   try {
-    // Mirror Rust log events into the JS console (the OPPOSITE direction
-    // from the relay above). Wrapped in try/catch so a future capability
-    // misconfiguration on `tauri-plugin-log` doesn't silently break the
-    // whole dashboard. The plugin is registered on the Rust side in
-    // main.rs with `.skip_logger()` so JS log events flow through
-    // `log` → `tracing-log::LogTracer` → `gui.log`.
-    try {
-      await attachConsole();
-    } catch (e) {
-      console.warn("attachConsole failed:", e);
-    }
+    // Rust→JS console mirroring is deliberately absent: main.rs registers
+    // tauri-plugin-log with .skip_logger(), which never constructs the
+    // Webview target that emits log://log events — attachConsole() would
+    // resolve and then receive nothing. Backend logs live in gui.log.
 
     window.addEventListener("error", (e) => {
       console.error(`window.error: ${e.message} at ${e.filename}:${e.lineno}:${e.colno}`);

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -58,6 +58,53 @@ describe("server test failure handling", () => {
     expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("bridge unreachable"), "error");
   });
 
+  it("a test settling after config lost its servers list does not throw", async () => {
+    let rejectTest!: (reason: unknown) => void;
+    invokeMock.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectTest = reject;
+      }),
+    );
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelector<HTMLButtonElement>(".srv-test")!.click();
+    await Promise.resolve();
+
+    // Config reloaded without a servers key while the card is still live.
+    mockConfig = {};
+    rejectTest("bridge unreachable");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The finally repaint falls back to "untested" instead of throwing.
+    expect(document.querySelector(".srv-status")!.className).toContain("untested");
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("bridge unreachable"), "error");
+  });
+
+  it("a test settling after its server was removed is a no-op repaint", async () => {
+    let rejectTest!: (reason: unknown) => void;
+    invokeMock.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectTest = reject;
+      }),
+    );
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelector<HTMLButtonElement>(".srv-test")!.click();
+    await Promise.resolve();
+
+    // Server deleted + re-render while the test is in flight.
+    (mockConfig as { servers: unknown[] }).servers = [];
+    renderServers();
+
+    rejectTest("bridge unreachable");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // No card to repaint — must not throw; the error still surfaces.
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("bridge unreachable"), "error");
+  });
+
   it("re-render during an in-flight test repaints the testing state", async () => {
     invokeMock.mockReturnValueOnce(new Promise(() => {}));
     const { renderServers } = await import("./servers");

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+const showToastMock = vi.fn();
+let mockConfig: Record<string, unknown> | null;
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ message: vi.fn(), open: vi.fn() }));
+vi.mock("./toast", () => ({ showToast: (...args: unknown[]) => showToastMock(...args) }));
+vi.mock("./sidebar", () => ({ updateDiagnostics: vi.fn() }));
+vi.mock("./main", () => ({
+  get config() {
+    return mockConfig;
+  },
+  loadConfig: vi.fn().mockResolvedValue(undefined),
+  saveConfig: vi.fn().mockResolvedValue(undefined),
+  runTestsBounded: vi.fn(),
+  TEST_CONCURRENCY: 5,
+}));
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  showToastMock.mockReset();
+  mockConfig = {
+    servers: [{ id: "srv-1", name: "S1", server: "1.2.3.4", server_port: 443, validation: null }],
+    selected_server: "srv-1",
+  };
+  document.body.innerHTML = `<div id="server-list"></div><div id="import-zone"></div>`;
+  vi.resetModules();
+});
+
+describe("server test failure handling", () => {
+  it("resets the dot and toasts when test_server rejects", async () => {
+    let rejectTest!: (reason: unknown) => void;
+    invokeMock.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectTest = reject;
+      }),
+    );
+    const { renderServers } = await import("./servers");
+    renderServers();
+
+    const btn = document.querySelector<HTMLButtonElement>(".srv-test")!;
+    btn.click();
+    await Promise.resolve();
+    // In flight: dot pulses, button disabled.
+    expect(document.querySelector(".srv-status")!.className).toContain("testing");
+    expect(btn.disabled).toBe(true);
+
+    rejectTest("bridge unreachable");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Dot restored from persisted state (null validation -> untested), error surfaced.
+    expect(document.querySelector(".srv-status")!.className).toContain("untested");
+    expect(document.querySelector(".srv-status")!.className).not.toContain("testing");
+    expect(document.querySelector<HTMLButtonElement>(".srv-test")!.disabled).toBe(false);
+    expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("bridge unreachable"), "error");
+  });
+
+  it("re-render during an in-flight test repaints the testing state", async () => {
+    invokeMock.mockReturnValueOnce(new Promise(() => {}));
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelector<HTMLButtonElement>(".srv-test")!.click();
+    await Promise.resolve();
+
+    renderServers(); // e.g. another server's validation-changed landed
+
+    expect(document.querySelector(".srv-status")!.className).toContain("testing");
+    expect(document.querySelector<HTMLButtonElement>(".srv-test")!.disabled).toBe(true);
+  });
+});

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -64,18 +64,54 @@ export function statusTooltipFor(v: ValidationState | null | undefined): string 
   return `${userMessageFor(v.outcome)} Tested ${formatRelativeTime(v.tested_at)}.`;
 }
 
-async function runServerTest(id: string, btn: HTMLButtonElement, status: HTMLElement) {
-  btn.disabled = true;
-  btn.classList.add("loading");
-  status.className = "srv-status testing";
+/// Entry IDs with a test_server invoke in flight. renderServers consults
+/// this so a mid-test rebuild repaints the in-flight state instead of
+/// silently reverting the card to its persisted dot.
+const testsInFlight = new Set<string>();
+
+/// Repaint one card's test button + status dot from the live DOM.
+/// Re-resolves by data-server-id because any re-render detaches the
+/// nodes a click handler captured.
+function setCardTesting(id: string, testing: boolean) {
+  // dataset comparison instead of an attribute selector: no dependency on
+  // CSS.escape (absent in the jsdom test environment) and no quoting rules.
+  let card: HTMLElement | null = null;
+  for (const child of serverList.children) {
+    if (child instanceof HTMLElement && child.dataset.serverId === id) {
+      card = child;
+      break;
+    }
+  }
+  if (!card) return;
+  const btn = card.querySelector<HTMLButtonElement>(".srv-test");
+  const dot = card.querySelector<HTMLElement>(".srv-status");
+  if (btn) {
+    btn.disabled = testing;
+    btn.classList.toggle("loading", testing);
+  }
+  if (dot) {
+    if (testing) {
+      dot.className = "srv-status testing";
+    } else {
+      const server = config?.servers.find((s) => s.id === id);
+      dot.className = `srv-status ${statusClassFor(server?.validation)}`;
+      dot.title = statusTooltipFor(server?.validation);
+    }
+  }
+}
+
+async function runServerTest(id: string) {
+  testsInFlight.add(id);
+  setCardTesting(id, true);
   try {
     await invoke("test_server", { entryId: id });
     // The validation-changed listener will rerender via loadConfig().
   } catch (err) {
     console.error("test_server failed:", err);
+    showToast(`Server test failed: ${err}`, "error");
   } finally {
-    btn.disabled = false;
-    btn.classList.remove("loading");
+    testsInFlight.delete(id);
+    setCardTesting(id, false);
   }
 }
 
@@ -138,7 +174,7 @@ export function renderServers() {
       testBtn.textContent = "Test";
       testBtn.addEventListener("click", (e) => {
         e.stopPropagation(); // do not trigger card selection
-        runServerTest(server.id, testBtn, statusDot);
+        runServerTest(server.id);
       });
       card.appendChild(testBtn);
 
@@ -159,6 +195,8 @@ export function renderServers() {
       });
 
       serverList.appendChild(card);
+
+      if (testsInFlight.has(server.id)) setCardTesting(server.id, true);
     }
   }
 }

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -93,7 +93,7 @@ function setCardTesting(id: string, testing: boolean) {
     if (testing) {
       dot.className = "srv-status testing";
     } else {
-      const server = config?.servers.find((s) => s.id === id);
+      const server = config?.servers?.find((s) => s.id === id);
       dot.className = `srv-status ${statusClassFor(server?.validation)}`;
       dot.title = statusTooltipFor(server?.validation);
     }
@@ -174,7 +174,7 @@ export function renderServers() {
       testBtn.textContent = "Test";
       testBtn.addEventListener("click", (e) => {
         e.stopPropagation(); // do not trigger card selection
-        runServerTest(server.id);
+        void runServerTest(server.id);
       });
       card.appendChild(testBtn);
 

--- a/ui/settings.test.ts
+++ b/ui/settings.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const saveConfigMock = vi.fn();
+let mockConfig: Record<string, unknown> | null;
+
+vi.mock("./main", () => ({
+  get config() {
+    return mockConfig;
+  },
+  saveConfig: (...args: unknown[]) => saveConfigMock(...args),
+}));
+
+function scaffold() {
+  document.body.innerHTML = `
+    <div id="toggle-start-on-login" class="toggle"></div>
+    <div id="toggle-proxy-server" class="toggle"></div>
+    <div id="proxy-nested">
+      <div id="toggle-socks5" class="toggle"></div>
+      <div id="toggle-http" class="toggle"></div>
+      <input id="input-port" type="text" value="4073">
+      <div class="setting-row" id="row-port-http" hidden>
+        <input id="input-port-http" type="text" value="4074">
+      </div>
+    </div>
+    <div class="custom-select-btn" id="select-on-startup"></div>
+    <div class="custom-select-menu" id="menu-on-startup"><div class="custom-select-opt" data-value="do-not-connect"></div></div>
+    <div class="custom-select-btn" id="select-theme"></div>
+    <div class="custom-select-menu" id="menu-theme"><div class="custom-select-opt" data-value="dark"></div></div>
+    <div id="toggle-dns-enabled" class="toggle"></div>
+    <div id="dns-nested">
+      <div class="custom-select-btn" id="select-dns-protocol"></div>
+      <div class="custom-select-menu" id="menu-dns-protocol"><div class="custom-select-opt" data-value="https"></div></div>
+      <div id="toggle-dns-intercept" class="toggle"></div>
+    </div>`;
+}
+
+beforeEach(() => {
+  saveConfigMock.mockReset();
+  saveConfigMock.mockResolvedValue(undefined);
+  mockConfig = { local_port: 4073, local_port_http: 4074, proxy_socks5: true, proxy_http: false };
+  // settings.ts calls window.matchMedia at module load; provide it if the
+  // jsdom build lacks one (the real implementation wins when present).
+  if (typeof window.matchMedia !== "function") {
+    Object.assign(window, {
+      matchMedia: () => ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    });
+  }
+  scaffold();
+  vi.resetModules();
+});
+
+function changePort(value: string) {
+  const input = document.getElementById("input-port") as HTMLInputElement;
+  input.value = value;
+  input.dispatchEvent(new Event("change"));
+}
+
+describe("port input validation", () => {
+  it("rejects trailing garbage and reverts the field", async () => {
+    const { initSettings } = await import("./settings");
+    initSettings();
+    changePort("8080abc");
+    expect(mockConfig!.local_port).toBe(4073);
+    expect((document.getElementById("input-port") as HTMLInputElement).value).toBe("4073");
+    expect(saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes accepted input back into the field", async () => {
+    const { initSettings } = await import("./settings");
+    initSettings();
+    changePort("0080");
+    expect(mockConfig!.local_port).toBe(80);
+    expect((document.getElementById("input-port") as HTMLInputElement).value).toBe("80");
+  });
+});
+
+describe("DNS controls with no config loaded", () => {
+  it("dns-enabled toggle does not flip its visual state when config is null", async () => {
+    mockConfig = null;
+    const { initSettings } = await import("./settings");
+    initSettings();
+    const el = document.getElementById("toggle-dns-enabled")!;
+    el.click();
+    expect(el.classList.contains("on")).toBe(false);
+  });
+
+  it("dns-intercept toggle does not flip its visual state when config is null", async () => {
+    mockConfig = null;
+    const { initSettings } = await import("./settings");
+    initSettings();
+    const el = document.getElementById("toggle-dns-intercept")!;
+    el.click();
+    expect(el.classList.contains("on")).toBe(false);
+  });
+});

--- a/ui/settings.test.ts
+++ b/ui/settings.test.ts
@@ -76,6 +76,17 @@ describe("port input validation", () => {
     expect(mockConfig!.local_port).toBe(80);
     expect((document.getElementById("input-port") as HTMLInputElement).value).toBe("80");
   });
+
+  it("rejects trailing garbage on the HTTP port and reverts", async () => {
+    const { initSettings } = await import("./settings");
+    initSettings();
+    const input = document.getElementById("input-port-http") as HTMLInputElement;
+    input.value = "9090xy";
+    input.dispatchEvent(new Event("change"));
+    expect(mockConfig!.local_port_http).toBe(4074);
+    expect(input.value).toBe("4074");
+    expect(saveConfigMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("DNS controls with no config loaded", () => {
@@ -95,5 +106,14 @@ describe("DNS controls with no config loaded", () => {
     const el = document.getElementById("toggle-dns-intercept")!;
     el.click();
     expect(el.classList.contains("on")).toBe(false);
+  });
+
+  it("dns protocol option does not flip selection when config is null", async () => {
+    mockConfig = null;
+    const { initSettings } = await import("./settings");
+    initSettings();
+    const opt = document.querySelector<HTMLElement>("#menu-dns-protocol .custom-select-opt")!;
+    opt.click();
+    expect(opt.classList.contains("selected")).toBe(false);
   });
 });

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -167,9 +167,13 @@ const rowPortHttp = document.getElementById("row-port-http")!;
 function wirePortInput() {
   portInput.addEventListener("change", () => {
     if (!config) return;
-    const parsed = parseInt(portInput.value, 10);
+    const raw = portInput.value.trim();
+    // Strict digits-only: parseInt would silently accept "8080abc" while
+    // the field keeps showing the unparsed text.
+    const parsed = /^\d+$/.test(raw) ? parseInt(raw, 10) : NaN;
     if (!Number.isNaN(parsed) && parsed > 0 && parsed <= 65535) {
       config.local_port = parsed;
+      portInput.value = String(parsed);
       saveConfig();
     } else {
       // Revert to current config value on invalid input.
@@ -182,9 +186,11 @@ function wirePortInput() {
 function wireHttpPortInput() {
   portHttpInput.addEventListener("change", () => {
     if (!config) return;
-    const parsed = parseInt(portHttpInput.value, 10);
+    const raw = portHttpInput.value.trim();
+    const parsed = /^\d+$/.test(raw) ? parseInt(raw, 10) : NaN;
     if (!Number.isNaN(parsed) && parsed > 0 && parsed <= 65535) {
       config.local_port_http = parsed;
+      portHttpInput.value = String(parsed);
       saveConfig();
     } else {
       portHttpInput.value = String(config.local_port_http ?? "");
@@ -271,6 +277,7 @@ export function initSettings() {
 function wireDnsControls() {
   const enabledEl = document.getElementById("toggle-dns-enabled")!;
   enabledEl.addEventListener("click", () => {
+    if (!config) return; // guard BEFORE the visual flip, like wireToggle
     const on = !enabledEl.classList.contains("on");
     enabledEl.classList.toggle("on", on);
     patchDns({ enabled: on });
@@ -278,6 +285,7 @@ function wireDnsControls() {
 
   const interceptEl = document.getElementById("toggle-dns-intercept")!;
   interceptEl.addEventListener("click", () => {
+    if (!config) return;
     const on = !interceptEl.classList.contains("on");
     interceptEl.classList.toggle("on", on);
     patchDns({ intercept_udp53: on });
@@ -297,6 +305,7 @@ function wireDnsControls() {
   for (const opt of menu.querySelectorAll<HTMLElement>(".custom-select-opt")) {
     opt.addEventListener("click", (e) => {
       e.stopPropagation();
+      if (!config) return;
       for (const o of menu.querySelectorAll(".custom-select-opt")) o.classList.remove("selected");
       opt.classList.add("selected");
       btn.textContent = opt.textContent;

--- a/ui/style.css
+++ b/ui/style.css
@@ -1092,9 +1092,23 @@ td.del-cell {
   padding: 0.3rem 0;
 }
 
+/* .setting-row's display:flex (author origin) overrides the UA's
+[hidden] { display: none } regardless of specificity — origin beats
+specificity. The attribute selector outspecifies the class, scoped to
+the rows that actually toggle `hidden`. */
+.setting-row[hidden] {
+  display: none;
+}
+
 .setting-label {
   color: var(--text-secondary);
   white-space: nowrap;
+}
+
+.setting-note .setting-label {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  white-space: normal;
 }
 
 .setting-control {

--- a/ui/toggle-flow.test.ts
+++ b/ui/toggle-flow.test.ts
@@ -192,3 +192,21 @@ describe("toggleFromIdle: outcome handling", () => {
     expect(h.state).toBe("disconnected");
   });
 });
+
+describe("mark_validated_by_proxy_start failure surfacing", () => {
+  it("toasts when the validation mark fails after a successful connect", async () => {
+    const h = makeHarness();
+    h.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "toggle_proxy") return Promise.resolve("running");
+      if (cmd === "mark_validated_by_proxy_start") return Promise.reject(new Error("config save failed"));
+      return Promise.resolve();
+    });
+    h.deps.getConfig = () => ({ selected_server: "srv-1" }) as never;
+
+    await toggleFromIdle(true, h.deps);
+
+    expect(h.showToast).toHaveBeenCalledWith(expect.stringContaining("config save failed"), "error");
+    // The connect itself still settled into `connected`.
+    expect(h.state).toBe("connected");
+  });
+});

--- a/ui/toggle-flow.test.ts
+++ b/ui/toggle-flow.test.ts
@@ -208,5 +208,8 @@ describe("mark_validated_by_proxy_start failure surfacing", () => {
     expect(h.showToast).toHaveBeenCalledWith(expect.stringContaining("config save failed"), "error");
     // The connect itself still settled into `connected`.
     expect(h.state).toBe("connected");
+    // The reload is scoped OUT of the mark's try: a failed mark must not
+    // trigger loadConfig (there is no new validation state to pick up).
+    expect(h.loadConfig).not.toHaveBeenCalled();
   });
 });

--- a/ui/toggle-flow.ts
+++ b/ui/toggle-flow.ts
@@ -101,9 +101,15 @@ export async function toggleFromIdle(goingToConnect: boolean, deps: ToggleDeps):
   if (goingToConnect && outcome === "running" && config?.selected_server) {
     try {
       await deps.invoke("mark_validated_by_proxy_start", { entryId: config.selected_server });
-      await deps.loadConfig();
     } catch (err) {
       console.error("mark_validated_by_proxy_start failed:", err);
+      // The connection itself succeeded — explain why the dot stays grey
+      // instead of leaving a silently unvalidated server. Scoped to the
+      // mark alone: loadConfig below never rejects (it catches and
+      // toasts internally), and this message would misdescribe it.
+      deps.showToast(`Connected, but couldn't record server validation: ${err}`, "error");
+      return;
     }
+    await deps.loadConfig();
   }
 }


### PR DESCRIPTION
Closes #479.

15 small frontend wiring defects from the release audit, one commit each plus a review-fix commit. Highlights: filter edits now reach the running proxy (reload_proxy_filters had zero call sites; persistence is serialized through a promise chain so rapid edits cannot reload stale rules), Tauri event listeners register before the UI becomes interactive (early drops/imports were silently lost), test_server failures reset the status dot instead of pulsing "testing" forever, and the filter table no longer corrupts rules when a background re-render lands mid-drag.

All changes are in ui/; no Rust changes. Each behavioral fix has a vitest (jsdom) regression test — new suites for servers, filters, settings, and main init-ordering. Verify: `npm test && npm run check`.