### PR TITLE
fix(tray): keep macOS template flag on icon updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -677,6 +677,13 @@ generated raster icons**. `TrayState::Disabled` currently aliases `Enabled` (the
 enum is preserved for a future variant). `.cache/icons/icon.ico` is bound by the
 MSI as `ARPPRODUCTICON` so Add/Remove Programs matches the app icon (#359).
 
+The macOS tray icon is a [template image]: alpha-only shape, RGB=0, inverted by
+the OS to match the menu bar. Runtime icon updates must use
+`set_icon_with_as_template(icon, true)` — `TrayIcon::set_icon` hardcodes
+`icon_is_template=false` (tray-icon 0.23.1) and turns the icon solid black on
+the first state change; `set_icon`/`set_icon_as_template` (tauri and inner
+`tray_icon` layers) are clippy-banned (#469).
+
 ## Emergency network reset
 
 If routing gets into a bad state during development:
@@ -688,3 +695,5 @@ python scripts/network-reset.py         # Windows (run as Administrator)
 
 It reads the bridge's route-state file and tears down the exact leaked routes
 (reaping plugins by name and stopping ETW sessions as a last resort).
+
+[template image]: https://developer.apple.com/documentation/appkit/nsimage/1520017-template

--- a/clippy.toml
+++ b/clippy.toml
@@ -136,3 +136,36 @@ allow-invalid = true
 [[disallowed-methods]]
 path = "tokio_util::sync::CancellationToken::new"
 reason = "In `crates/bridge/src/`, fresh tokens shadow the cooperative-cancellation chain rooted at `ipc.rs::handle_start`. Use the propagated `cancel: &CancellationToken` parameter (or `cancel.child_token()` for phase isolation). Sanctioned production sites: `ipc.rs::handle_start`, `dispatcher.rs::Dispatcher::new`, `proxy_manager.rs::ProxyManager::start`, `server_test.rs`. Test files use module-level `#![allow]`. See bindreams/hole#397."
+
+# macOS tray template flag ---------------------------------------------------------------------------------------------
+#
+# On macOS, `TrayIcon::set_icon` applies the NSImage with
+# `icon_is_template=false` hardcoded (tray-icon 0.23.1), silently dropping
+# the template flag set at tray build time. Hole's tray icon bytes are
+# RGB=0 with an alpha-only shape (crates/hole/build.rs), so a non-template
+# icon renders solid black — invisible on a dark menu bar and frozen on
+# highlight. Icon updates must go through `set_icon_with_as_template(icon,
+# true)`; its non-macOS fallback calls `set_icon` inside the tauri crate,
+# which clippy does not lint, so the ban cannot misfire there. The
+# underlying `tray_icon::TrayIcon` methods are banned too: they are
+# reachable via `with_inner_tray_icon` without naming any banned tauri
+# path. `set_icon_as_template` (both layers) is the non-atomic sibling —
+# tauri's own docs call the `set_icon` + `set_icon_as_template` sequence
+# out for visible flicker, and `(false)` clears the live flag outright.
+# See bindreams/hole#469.
+
+[[disallowed-methods]]
+path = "tauri::tray::TrayIcon::set_icon"
+reason = "On macOS this resets the NSImage template flag, rendering the alpha-only tray icon solid black. Use `set_icon_with_as_template(icon, true)` — atomic on macOS, falls back to `set_icon` elsewhere. See bindreams/hole#469."
+
+[[disallowed-methods]]
+path = "tray_icon::TrayIcon::set_icon"
+reason = "Reached via `with_inner_tray_icon`; hardcodes icon_is_template=false on macOS (tray-icon 0.23.1). Use `tauri::tray::TrayIcon::set_icon_with_as_template(icon, true)`. See bindreams/hole#469."
+
+[[disallowed-methods]]
+path = "tauri::tray::TrayIcon::set_icon_as_template"
+reason = "Non-atomic: pairing with `set_icon` flickers (per tauri docs) and `(false)` clears the template flag live. Use `set_icon_with_as_template(icon, true)`. See bindreams/hole#469."
+
+[[disallowed-methods]]
+path = "tray_icon::TrayIcon::set_icon_as_template"
+reason = "Reached via `with_inner_tray_icon`; same non-atomic footgun as the tauri-level form. Use `tauri::tray::TrayIcon::set_icon_with_as_template(icon, true)`. See bindreams/hole#469."

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -156,7 +156,9 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
 /// Update the tray icon to reflect the given enabled/disabled state.
 pub fn set_tray_icon(app: &AppHandle, enabled: bool) {
     if let Some(tray) = app.tray_by_id("main") {
-        if let Err(e) = tray.set_icon(Some(tray_icons::tray_image(enabled.into()))) {
+        // `true` mirrors the build-time `icon_as_template(true)`; on
+        // non-macOS this falls back to plain `set_icon` (see #469).
+        if let Err(e) = tray.set_icon_with_as_template(Some(tray_icons::tray_image(enabled.into())), true) {
             warn!(error = %e, "failed to set tray icon");
         }
     }


### PR DESCRIPTION
Closes #469.

On macOS, `TrayIcon::set_icon` hardcodes `icon_is_template=false` (tray-icon 0.23.1), so the first state change after connect/disconnect/cancel/error dropped the template flag set at tray build time — the alpha-only icon rendered solid black on a dark menu bar and stopped inverting on highlight. `set_tray_icon` now uses `set_icon_with_as_template(icon, true)`, which applies icon + flag atomically on macOS and falls back to plain `set_icon` on other platforms.

`TrayIcon` cannot be constructed outside a live Tauri app (no unit-test seam; `tray_tests.rs`), so the regression guard is structural: clippy `disallowed-methods` bans on `set_icon` and `set_icon_as_template` at both the tauri and inner `tray_icon` layers — the inner layer is reachable via `with_inner_tray_icon` without naming any tauri path. Each ban was watched fail RED against a real call site (the original bug for the first; a temporary probe for the other three) before going GREEN. CONTRIBUTING.md's Icons section now documents the invariant.

Verify: `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — GREEN on this branch, RED at `tray.rs:159` with the fix reverted.

Known not lint-enforceable: a future `set_icon_with_as_template(icon, false)` call. The single call site owns the `true` today; say the word if you'd rather route updates through a wrapper that hardcodes it.