### PR TITLE
fix(config): accurate save errors, leak-safe messages, atomic + robust writes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -577,10 +577,16 @@ not show toasts** (toasts are per-call-site so a tight loop can't flood the UI).
 user-visible failures with `showToast(message, kind)` from
 [`ui/toast.ts`](ui/toast.ts) (caps at 5 visible). **Errors containing filesystem
 paths or other PII must be redacted before reaching a toast** — the detail still
-lands in `gui.log`. The `config.save` path in
-[`commands.rs`](crates/hole/src/commands.rs) is canonical: the raw `io::Error`
-holds the config-file path (PII on Windows), so the toast string is generic and
-the path is recorded only in `gui.log`.
+lands in `gui.log`. Two mechanisms are sanctioned. **(1) A PII/content-free error
+type + `warn!` with the path to `gui.log`:** `ConfigError`
+([`config.rs`](crates/common/src/config.rs)) carries the failing operation and the
+OS error, never the path, and its `Parse` variant surfaces only a category plus
+line/column — never the raw `serde_json` message (which can echo a password).
+`save_config` ([`commands.rs`](crates/hole/src/commands.rs)) logs the path via
+`warn!` and shows the path-free message in the toast. **(2) A detail-free
+structured wire variant + `warn!`** when the detail itself could carry
+content/PII: `import_servers_from_file` returns `ImportFailure::SaveFailed` /
+`CorruptedJson` (no fields) and logs the full error.
 
 ### Logging directives (HOLE_BRIDGE_LOG)
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -35,6 +35,7 @@ time = { version = "0.3", features = ["serde-well-known", "formatting"] }
 tokio = { version = "1", features = ["rt", "macros", "time", "net"] }
 yaml_serde = "0.10"
 nu-ansi-term = "0.50"
+tempfile = "3"
 tombstone = { path = "../tombstone" }
 util = { path = "../util" }
 
@@ -58,6 +59,5 @@ yaml_serde = "0.10"
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }
 log = "0.4"
-tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }
 garter = { path = "../garter" }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -9,10 +9,36 @@ use time::OffsetDateTime;
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
-    #[error("failed to read config: {0}")]
-    Read(#[from] std::io::Error),
-    #[error("failed to parse config: {0}")]
-    Parse(#[from] serde_json::Error),
+    #[error("failed to read config file: {source}")]
+    Read { source: std::io::Error },
+    // Carries only content-safe scalars (category + position), NOT the
+    // `serde_json::Error`: its `Display` echoes a fragment of the input near the
+    // error, which for a config can include a password (see commands_tests.rs).
+    // Dropping the source makes a content leak structurally impossible (even via
+    // `Debug`), while classify() + line/column keep the message actionable.
+    #[error("failed to parse config file: {kind} (line {line}, column {column})")]
+    Parse {
+        kind: &'static str,
+        line: usize,
+        column: usize,
+    },
+    #[error("failed to serialize config: {source}")]
+    Serialize { source: serde_json::Error },
+    #[error("failed to create config directory: {source}")]
+    CreateDir { source: std::io::Error },
+    #[error("failed to write config file: {source}")]
+    Write { source: std::io::Error },
+}
+
+/// Content-safe label for a `serde_json` parse failure (never echoes the input).
+fn parse_kind(e: &serde_json::Error) -> &'static str {
+    use serde_json::error::Category;
+    match e.classify() {
+        Category::Io => "I/O error",
+        Category::Syntax => "syntax error",
+        Category::Data => "data error",
+        Category::Eof => "unexpected end of input",
+    }
 }
 
 // Types ===============================================================================================================
@@ -266,51 +292,62 @@ pub fn is_valid_plugin_name(name: &str) -> bool {
 impl AppConfig {
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
         match std::fs::read_to_string(path) {
-            Ok(contents) => Ok(serde_json::from_str(&contents)?),
+            Ok(contents) => serde_json::from_str(&contents).map_err(|e| ConfigError::Parse {
+                kind: parse_kind(&e),
+                line: e.line(),
+                column: e.column(),
+            }),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
-            Err(e) => Err(ConfigError::Read(e)),
+            Err(source) => Err(ConfigError::Read { source }),
         }
     }
 
     pub fn save(&self, path: &Path) -> Result<(), ConfigError> {
-        let json = serde_json::to_string_pretty(self)?;
+        use std::io::Write;
 
-        #[cfg(target_os = "macos")]
-        {
-            use std::fs::{DirBuilder, OpenOptions, Permissions};
-            use std::io::Write;
-            use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+        let json = serde_json::to_string_pretty(self).map_err(|source| ConfigError::Serialize { source })?;
 
-            // Only the leaf directory (e.g. `hole/`) is created by us — ancestor directories
-            // like `~/Library/Application Support/` are system-managed and already exist.
-            if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
-                DirBuilder::new().recursive(true).mode(0o700).create(parent)?;
-                std::fs::set_permissions(parent, Permissions::from_mode(0o700))?;
-            }
-            // Restrict config file permissions on macOS — the config contains plaintext
-            // passwords and must not be world-readable (default umask 0022 yields 0644).
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(path)?;
-            file.set_permissions(Permissions::from_mode(0o600))?;
-            file.write_all(json.as_bytes())?;
+        // The directory that will hold the config — and the atomic-rename temp.
+        // The rename is only atomic within one filesystem, so the temp must be
+        // created in this same directory.
+        let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
+        if let Some(parent) = dir {
+            ensure_config_dir(parent)?;
         }
+        let temp_dir = dir.unwrap_or_else(|| Path::new("."));
 
-        #[cfg(target_os = "windows")]
-        {
-            if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
-                std::fs::create_dir_all(parent)?;
+        // Atomic write: a fresh temp file in the target directory, fully written
+        // and synced, then renamed over the target. A crash or partial write can
+        // never leave a truncated/corrupt config in place.
+        let mut tmp = tempfile::Builder::new()
+            .prefix(".config")
+            .suffix(".tmp")
+            .tempfile_in(temp_dir)
+            .map_err(|source| ConfigError::Write { source })?;
+        tmp.write_all(json.as_bytes())
+            .map_err(|source| ConfigError::Write { source })?;
+        // tempfile creates the temp 0600 on unix (O_EXCL + restrictive mode), and
+        // rename preserves the mode — so the persisted config keeps its plaintext
+        // passwords at 0600, never the umask-default 0644. The 0600 invariant is
+        // guarded by `save_creates_file_with_owner_only_permissions`.
+        tmp.as_file()
+            .sync_all()
+            .map_err(|source| ConfigError::Write { source })?;
+        // persist() renames the temp over `path`. rename does NOT follow a target
+        // symlink (it replaces the link itself), so there is no target-symlink
+        // TOCTOU; the temp's random O_EXCL name in the 0700 dir is unguessable.
+        tmp.persist(path).map_err(|e| ConfigError::Write { source: e.error })?;
+
+        // Best-effort: fsync the directory so the rename is durable across power
+        // loss. The atomic property (no truncated/partial config is ever visible)
+        // already holds without this; only crash-durability of the *rename* needs
+        // it, and a failure here must not fail an otherwise-successful save. Unix
+        // only — Windows has no portable directory fsync.
+        #[cfg(unix)]
+        if let Some(parent) = dir {
+            if let Err(e) = std::fs::File::open(parent).and_then(|d| d.sync_all()) {
+                tracing::warn!(error = %e, "could not fsync config directory; rename may not survive power loss");
             }
-            std::fs::write(path, json)?;
-        }
-
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
-            let _ = json;
-            compile_error!("save() is not implemented for this platform");
         }
 
         Ok(())
@@ -320,6 +357,41 @@ impl AppConfig {
         let id = self.selected_server.as_ref()?;
         self.servers.iter().find(|s| &s.id == id)
     }
+}
+
+/// Create the config's leaf directory (e.g. `hole/`). Ancestors like
+/// `~/Library/Application Support/` are system-managed and already exist.
+#[cfg(target_os = "macos")]
+fn ensure_config_dir(parent: &Path) -> Result<(), ConfigError> {
+    use std::fs::{DirBuilder, Permissions};
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(parent)
+        .map_err(|source| ConfigError::CreateDir { source })?;
+    // Best-effort hardening of a *pre-existing* directory. The 0600 config file
+    // is the load-bearing protection for its plaintext passwords; a directory we
+    // don't own (e.g. left root-owned by an earlier privileged run) can't be
+    // chmod'd by us, but that must not abort the save — if the directory is
+    // genuinely unwritable the temp-file create fails with an accurate write
+    // error instead of a spurious permission error here.
+    if let Err(source) = std::fs::set_permissions(parent, Permissions::from_mode(0o700)) {
+        tracing::warn!(error = %source, dir = %parent.display(),
+            "could not tighten config directory permissions; continuing");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn ensure_config_dir(parent: &Path) -> Result<(), ConfigError> {
+    std::fs::create_dir_all(parent).map_err(|source| ConfigError::CreateDir { source })
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn ensure_config_dir(_parent: &Path) -> Result<(), ConfigError> {
+    compile_error!("save() is not implemented for this platform");
 }
 
 #[cfg(test)]

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -13,7 +13,7 @@ pub enum ConfigError {
     Read { source: std::io::Error },
     // Carries only content-safe scalars (category + position), NOT the
     // `serde_json::Error`: its `Display` echoes a fragment of the input near the
-    // error, which for a config can include a password (see commands_tests.rs).
+    // error, which for a config can include a password (see config_tests.rs).
     // Dropping the source makes a content leak structurally impossible (even via
     // `Debug`), while classify() + line/column keep the message actionable.
     #[error("failed to parse config file: {kind} (line {line}, column {column})")]

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -44,6 +44,85 @@ fn load_corrupt_json_returns_error(#[fixture(temp_dir)] dir: &Path) {
     assert!(err.to_string().contains("parse"));
 }
 
+// Error labeling + redaction ------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn save_to_directory_path_reports_write_error(#[fixture(temp_dir)] dir: &Path) {
+    // A path that is itself a directory can't be written as a file: the atomic
+    // rename (persist) fails. macOS/Windows differ in the OS error, but both
+    // land on the Write variant.
+    let path = dir.join("config-as-dir");
+    std::fs::create_dir_all(&path).unwrap();
+
+    let msg = AppConfig::default().save(&path).unwrap_err().to_string();
+
+    assert!(
+        msg.contains("write"),
+        "save failure should read as a write error, got: {msg}"
+    );
+    assert!(
+        !msg.contains("read"),
+        "save failure must not be mislabeled as a read error, got: {msg}"
+    );
+}
+
+#[skuld::test]
+fn save_error_does_not_leak_path(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config-as-dir");
+    std::fs::create_dir_all(&path).unwrap();
+
+    let msg = AppConfig::default().save(&path).unwrap_err().to_string();
+
+    assert!(
+        !msg.contains(&*dir.to_string_lossy()),
+        "config error Display leaked the path: {msg}"
+    );
+}
+
+#[skuld::test]
+fn load_error_does_not_leak_content(#[fixture(temp_dir)] dir: &Path) {
+    // serde_json's Display echoes a fragment of the input near the parse error,
+    // which for a real config can include a password. The Parse variant must
+    // surface category + line/column only, never the raw serde message.
+    let path = dir.join("config.json");
+    std::fs::write(&path, r#"{"local_port": "PLAINTEXT_SECRET_VALUE"}"#).unwrap();
+
+    let msg = AppConfig::load(&path).unwrap_err().to_string();
+
+    assert!(
+        msg.contains("parse"),
+        "load of bad config should be a parse error, got: {msg}"
+    );
+    assert!(
+        !msg.contains("PLAINTEXT_SECRET_VALUE"),
+        "parse error leaked config content: {msg}"
+    );
+}
+
+#[skuld::test]
+fn config_error_labels_match_operation() {
+    use std::io::{Error as IoError, ErrorKind};
+    let io = || IoError::from(ErrorKind::PermissionDenied);
+    let serde = || serde_json::from_str::<i32>("nope").unwrap_err();
+
+    assert!(ConfigError::Read { source: io() }.to_string().contains("read"));
+    assert!(ConfigError::Parse {
+        kind: "syntax error",
+        line: 1,
+        column: 1
+    }
+    .to_string()
+    .contains("parse"));
+    assert!(ConfigError::Serialize { source: serde() }
+        .to_string()
+        .contains("serialize"));
+    assert!(ConfigError::CreateDir { source: io() }
+        .to_string()
+        .contains("create config directory"));
+    let write = ConfigError::Write { source: io() }.to_string();
+    assert!(write.contains("write") && !write.contains("read"), "{write}");
+}
+
 #[skuld::test]
 fn save_creates_parent_dirs(#[fixture(temp_dir)] dir: &Path) {
     let path = dir.join("nested").join("deep").join("config.json");

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -217,9 +217,9 @@ fn auto_select_first_server(config: &mut AppConfig) {
 ///
 /// Logging: emits `info!` at entry and through [`apply_import`]'s summary;
 /// emits `warn!` on validate/parse failure and on config-save failure. The
-/// save-failure path returns `ImportFailure::SaveFailed` (no detail in
-/// the wire form) because the underlying `io::Error` includes the
-/// config-file path (PII on Windows); the full detail still lands in
+/// save-failure path returns `ImportFailure::SaveFailed` (no detail in the
+/// wire form) — the structured wire variant is deliberately detail-free; the
+/// full `ConfigError` (path- and content-free) plus the config path land in
 /// `gui.log` via `warn!`.
 #[tauri::command]
 pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<Vec<ServerEntry>, ImportFailure> {

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -49,9 +49,10 @@ pub enum ImportFailure {
     /// show — it never echoes file content (covered by tests in
     /// `import_tests.rs` and `commands_tests.rs`).
     InvalidValue { detail: String },
-    /// Config save to disk failed. No detail — the underlying
-    /// `io::Error` Display includes the config-file path (PII on
-    /// Windows). The full detail lands in `gui.log` via `warn!`.
+    /// Config save to disk failed. The wire form stays detail-free on
+    /// purpose; the full `ConfigError` (whose Display is path- and
+    /// content-free) plus the config path is recorded in `gui.log` via
+    /// `warn!`.
     SaveFailed,
 }
 
@@ -95,7 +96,10 @@ pub fn save_config(state: State<AppState>, mut config: AppConfig) -> Result<(), 
     // The frontend doesn't know about elevation_prompt_shown — preserve the
     // in-memory value so a save from the Settings UI doesn't reset it.
     config.elevation_prompt_shown = current.elevation_prompt_shown;
-    config.save(&state.config_path).map_err(|e| e.to_string())?;
+    config.save(&state.config_path).map_err(|e| {
+        warn!(error = %e, path = %state.config_path.display(), "save_config: config save failed");
+        e.to_string()
+    })?;
     *current = config;
     Ok(())
 }
@@ -228,7 +232,7 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
     let (appended, _deduped) = apply_import(&mut config, parsed);
 
     config.save(&state.config_path).map_err(|e| {
-        warn!(error = %e, "import_servers_from_file: config save failed");
+        warn!(error = %e, path = %state.config_path.display(), "import_servers_from_file: config save failed");
         ImportFailure::SaveFailed
     })?;
 
@@ -408,7 +412,10 @@ pub async fn test_server(state: State<'_, AppState>, entry_id: String) -> Result
                 tested_at: OffsetDateTime::now_utc(),
                 outcome: outcome.clone(),
             });
-            cfg.save(&state.config_path).map_err(|e| e.to_string())?;
+            cfg.save(&state.config_path).map_err(|e| {
+                warn!(error = %e, path = %state.config_path.display(), "test_server: persist validation failed");
+                e.to_string()
+            })?;
         }
     }
 
@@ -456,7 +463,10 @@ pub fn mark_validated_by_proxy_start(state: State<AppState>, entry_id: String) -
                 },
             });
         }
-        cfg.save(&state.config_path).map_err(|e| e.to_string())?;
+        cfg.save(&state.config_path).map_err(|e| {
+            warn!(error = %e, path = %state.config_path.display(), "mark_validated_by_proxy_start: persist failed");
+            e.to_string()
+        })?;
     }
     Ok(())
 }

--- a/crates/hole/src/elevation.rs
+++ b/crates/hole/src/elevation.rs
@@ -62,7 +62,7 @@ pub async fn prompt_elevation(app: &AppHandle, request: BridgeRequest) -> bool {
         let mut config = state.config.lock().unwrap();
         config.elevation_prompt_shown = true;
         if let Err(e) = config.save(&state.config_path) {
-            warn!(error = %e, "failed to persist elevation_prompt_shown");
+            warn!(error = %e, path = %state.config_path.display(), "failed to persist elevation_prompt_shown");
         }
     }
 

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -22,9 +22,24 @@ pub struct AppState {
     test_locks: tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
+/// Load the persisted config, falling back to defaults on any error. A
+/// corrupt/unreadable config must not crash startup, but — unlike a bare
+/// `unwrap_or_default()` — the failure is recorded in `gui.log` so it is not
+/// silently masked (and overwritten on the next save). The user-facing
+/// "Failed to load settings" modal (#481) builds on this.
+fn load_config_or_default(path: &std::path::Path) -> AppConfig {
+    match AppConfig::load(path) {
+        Ok(config) => config,
+        Err(e) => {
+            warn!(error = %e, path = %path.display(), "failed to load config; starting with defaults");
+            AppConfig::default()
+        }
+    }
+}
+
 impl AppState {
     pub fn new(config_path: PathBuf, app_handle: tauri::AppHandle) -> Self {
-        let config = AppConfig::load(&config_path).unwrap_or_default();
+        let config = load_config_or_default(&config_path);
         Self {
             config_path,
             config: Mutex::new(config),
@@ -106,3 +121,7 @@ fn resolve_bridge_socket_path() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(hole_common::protocol::default_bridge_socket_path)
 }
+
+#[cfg(test)]
+#[path = "state_tests.rs"]
+mod state_tests;

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -1,0 +1,33 @@
+use super::load_config_or_default;
+use hole_common::config::AppConfig;
+use skuld::temp_dir;
+use std::path::Path;
+
+#[skuld::test]
+fn load_config_or_default_falls_back_on_corrupt_file(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    std::fs::write(&path, "{ this is not valid json").unwrap();
+
+    let config = load_config_or_default(&path);
+
+    assert_eq!(
+        config,
+        AppConfig::default(),
+        "a corrupt config must fall back to defaults, not panic or propagate"
+    );
+}
+
+#[skuld::test]
+fn load_config_or_default_reads_a_valid_file(#[fixture(temp_dir)] dir: &Path) {
+    // Use a NON-default value so this can't pass by accidentally falling back.
+    let path = dir.join("config.json");
+    let saved = AppConfig {
+        local_port: 5555,
+        ..AppConfig::default()
+    };
+    saved.save(&path).unwrap();
+
+    let config = load_config_or_default(&path);
+
+    assert_eq!(config.local_port, 5555);
+}

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -195,7 +195,9 @@ fn revert_proxy_state(app: &AppHandle, enabled: bool) {
     {
         let mut config = state.config.lock().unwrap();
         config.enabled = enabled;
-        config.save(&state.config_path).ok();
+        if let Err(e) = config.save(&state.config_path) {
+            warn!(error = %e, path = %state.config_path.display(), "revert_proxy_state: persist failed");
+        }
     }
     set_tray_icon(app, enabled);
     rebuild_tray_menu(app);
@@ -235,7 +237,9 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<ToggleO
             });
         }
         config.enabled = enabled;
-        config.save(&state.config_path).ok();
+        if let Err(e) = config.save(&state.config_path) {
+            warn!(error = %e, path = %state.config_path.display(), "set_proxy_enabled: persist failed");
+        }
         build_proxy_config(&config)
     };
 


### PR DESCRIPTION
Fixes the dev-mode toast `Failed to save config: failed to read config: Operation not permitted (os error 1)`.

## Root cause

`ConfigError::Read(#[from] std::io::Error)` was the blanket `?` target for **every** io error, so all of `save()`'s write-side failures were mislabeled "read". The trigger: `save()` unconditionally `chmod`'d the config dir (`set_permissions(parent, 0o700)`), which returns EPERM on a dir left **root-owned** by earlier privileged dev runs.

## Changes

- **Accurate errors** — `ConfigError` split into `Read`/`Parse`/`Serialize`/`CreateDir`/`Write`; every `?` mapped explicitly (`#[from]` removed).
- **Leak-safe messages** — `Display` carries the operation + OS error, never the path. `Parse` carries only a category + line/column (never the raw `serde_json` message, which can echo a password). `save_config` logs the path to `gui.log` and shows the path-free message in the toast.
- **Atomic + robust save** — write a `0600` temp in the target dir → `sync_all` → rename (`tempfile::persist`), with a best-effort parent-dir fsync (unix). The directory `chmod` is now best-effort: a dir we can't `chmod` no longer aborts the save, and a genuinely unwritable dir surfaces an accurate `Write` error at the real failing op.
- **No silent failures** — every `config.save`/`load` site logs `warn!(error, path)`; the two `tray` `.ok()` swallows and the `state` `unwrap_or_default()` are replaced with logged variants.
- **Docs** — corrected CONTRIBUTING "Console relay and toasts" and the `SaveFailed`/import doc comments (the `io::Error`-carries-the-path claim was false).

## Tests

4 new in `config_tests.rs` (write-error labeling, no path leak, no content leak, per-operation labels) + 2 in `state_tests.rs`. Existing macOS permission tests still pass under the rename-replace approach (`413 passed, 0 failed`; clippy clean).

## Not in this PR

The startup **"Failed to load settings" modal** (Exit / Reset to defaults) — tracked in #481; this PR's accurate messages are its prerequisite. The dir-chmod-failure recovery path is verified by manual reproduction + the accurate-write-error test (a faithful auto-test needs a root-owned dir, infeasible on the CI runners).

Closes #480. Refs #481.
