### PR TITLE
fix(tray): resync Start at Login checkmark and surface autostart errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,6 +265,19 @@ the original message. Registration is RAII (`register` → guard). The dispatche
 is installed at ctor time, so consumers just `register()`. Current consumer:
 `BridgeChildLogSource` dumps each live `DistHarness` child's `bridge.log` (#303).
 
+### Tray menu rebuild contract
+
+All tray menu commits go through `tray::rebuild_tray_menu`, which dispatches
+the whole rebuild — state reads included — to the main thread
+(`run_on_main_thread` executes inline when already there). A raw `set_menu`
+from a worker thread reads state early and commits the menu later through the
+event-loop queue, so a stale menu can overwrite a newer one (the #473 desync).
+Enforcement is in [`clippy.toml`](clippy.toml) (`TrayIcon::set_menu` is
+disallowed; the one commit point inside `rebuild_tray_menu` carries a per-site
+`#[allow]`). Corollary: `sync_menu_state` is main-thread-only — menu-item
+setters dispatch-and-block from any other thread, so calling it from a worker
+while holding a lock deadlocks the app.
+
 ## Workspace layout
 
 Each publishable member declares a release group in

--- a/clippy.toml
+++ b/clippy.toml
@@ -169,3 +169,16 @@ reason = "Non-atomic: pairing with `set_icon` flickers (per tauri docs) and `(fa
 [[disallowed-methods]]
 path = "tray_icon::TrayIcon::set_icon_as_template"
 reason = "Reached via `with_inner_tray_icon`; same non-atomic footgun as the tauri-level form. Use `tauri::tray::TrayIcon::set_icon_with_as_template(icon, true)`. See bindreams/hole#469."
+
+# Tray menu rebuild ordering -------------------------------------------------------------------------------------------
+#
+# All tray menu commits must go through `tray::rebuild_tray_menu`, which
+# dispatches the whole rebuild (state reads included) to the main thread.
+# A raw `set_menu` from a worker thread reads state early and commits the
+# menu later through the event-loop queue, so a stale menu can overwrite a
+# newer one — the bindreams/hole#473 desync. The sanctioned commit point
+# inside `rebuild_tray_menu` carries a per-site `#[allow]`.
+
+[[disallowed-methods]]
+path = "tauri::tray::TrayIcon::set_menu"
+reason = "Menu commits must go through `tray::rebuild_tray_menu` so rebuilds stay ordered on the main thread and cannot commit stale state. The sanctioned commit site inside `rebuild_tray_menu` carries a per-site `#[allow]`. See bindreams/hole#473."

--- a/crates/hole/capabilities/default.json
+++ b/crates/hole/capabilities/default.json
@@ -3,9 +3,6 @@
   "windows": ["settings"],
   "permissions": [
     "core:default",
-    "autostart:allow-enable",
-    "autostart:allow-disable",
-    "autostart:allow-is-enabled",
     "dialog:allow-open",
     "dialog:allow-message",
     "dialog:allow-save",

--- a/crates/hole/src/autostart.rs
+++ b/crates/hole/src/autostart.rs
@@ -1,0 +1,66 @@
+// "Start at Login" toggle logic for the tray menu, extracted from tray.rs so
+// the decision logic is unit-testable (the tray handler itself needs a full
+// Tauri app context).
+
+use tauri_plugin_autostart::{AutoLaunchManager, Error};
+
+/// Seam over the autostart plugin so [`toggle`] is testable without a Tauri app.
+pub trait Autostart {
+    fn is_enabled(&self) -> Result<bool, Error>;
+    fn enable(&self) -> Result<(), Error>;
+    fn disable(&self) -> Result<(), Error>;
+}
+
+impl Autostart for AutoLaunchManager {
+    fn is_enabled(&self) -> Result<bool, Error> {
+        AutoLaunchManager::is_enabled(self)
+    }
+
+    fn enable(&self) -> Result<(), Error> {
+        AutoLaunchManager::enable(self)
+    }
+
+    fn disable(&self) -> Result<(), Error> {
+        AutoLaunchManager::disable(self)
+    }
+}
+
+/// Which step of the toggle failed. The Display form may embed filesystem
+/// paths (auto-launch's "app path doesn't exist: <exe path>") and must only
+/// reach gui.log; dialogs use [`ToggleError::user_message`].
+#[derive(Debug, thiserror::Error)]
+pub enum ToggleError {
+    #[error("failed to check autostart state: {0}")]
+    Check(#[source] Error),
+    #[error("failed to enable autostart: {0}")]
+    Enable(#[source] Error),
+    #[error("failed to disable autostart: {0}")]
+    Disable(#[source] Error),
+}
+
+impl ToggleError {
+    /// PII-free message for the error dialog; the full detail lands in gui.log.
+    pub fn user_message(&self) -> &'static str {
+        match self {
+            ToggleError::Check(_) => "Could not check whether Start at Login is enabled. See gui.log for details.",
+            ToggleError::Enable(_) => "Failed to enable Start at Login. See gui.log for details.",
+            ToggleError::Disable(_) => "Failed to disable Start at Login. See gui.log for details.",
+        }
+    }
+}
+
+/// Flip the OS autostart registration to the opposite of its current state.
+/// Returns the new state on success.
+pub fn toggle(autostart: &impl Autostart) -> Result<bool, ToggleError> {
+    if autostart.is_enabled().map_err(ToggleError::Check)? {
+        autostart.disable().map_err(ToggleError::Disable)?;
+        Ok(false)
+    } else {
+        autostart.enable().map_err(ToggleError::Enable)?;
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+#[path = "autostart_tests.rs"]
+mod autostart_tests;

--- a/crates/hole/src/autostart_tests.rs
+++ b/crates/hole/src/autostart_tests.rs
@@ -1,0 +1,115 @@
+use super::*;
+use std::cell::{Cell, RefCell};
+
+/// Mock with single-use pre-loaded results. A call with no loaded result
+/// panics, so "this method must not be called" is asserted by omission and
+/// double-calls fail loudly.
+struct FakeAutostart {
+    is_enabled_result: RefCell<Option<Result<bool, Error>>>,
+    enable_result: RefCell<Option<Result<(), Error>>>,
+    disable_result: RefCell<Option<Result<(), Error>>>,
+    enable_calls: Cell<usize>,
+    disable_calls: Cell<usize>,
+}
+
+impl FakeAutostart {
+    fn new(
+        is_enabled: Result<bool, Error>,
+        enable: Option<Result<(), Error>>,
+        disable: Option<Result<(), Error>>,
+    ) -> Self {
+        Self {
+            is_enabled_result: RefCell::new(Some(is_enabled)),
+            enable_result: RefCell::new(enable),
+            disable_result: RefCell::new(disable),
+            enable_calls: Cell::new(0),
+            disable_calls: Cell::new(0),
+        }
+    }
+}
+
+impl Autostart for FakeAutostart {
+    fn is_enabled(&self) -> Result<bool, Error> {
+        self.is_enabled_result
+            .borrow_mut()
+            .take()
+            .expect("unexpected is_enabled call")
+    }
+
+    fn enable(&self) -> Result<(), Error> {
+        self.enable_calls.set(self.enable_calls.get() + 1);
+        self.enable_result.borrow_mut().take().expect("unexpected enable call")
+    }
+
+    fn disable(&self) -> Result<(), Error> {
+        self.disable_calls.set(self.disable_calls.get() + 1);
+        self.disable_result
+            .borrow_mut()
+            .take()
+            .expect("unexpected disable call")
+    }
+}
+
+#[skuld::test]
+fn toggle_enables_when_disabled() {
+    let fake = FakeAutostart::new(Ok(false), Some(Ok(())), None);
+    let result = toggle(&fake);
+    assert!(matches!(result, Ok(true)));
+    assert_eq!(fake.enable_calls.get(), 1);
+    assert_eq!(fake.disable_calls.get(), 0);
+}
+
+#[skuld::test]
+fn toggle_disables_when_enabled() {
+    let fake = FakeAutostart::new(Ok(true), None, Some(Ok(())));
+    let result = toggle(&fake);
+    assert!(matches!(result, Ok(false)));
+    assert_eq!(fake.enable_calls.get(), 0);
+    assert_eq!(fake.disable_calls.get(), 1);
+}
+
+#[skuld::test]
+fn check_failure_skips_toggle() {
+    let fake = FakeAutostart::new(Err(Error::Anyhow("registry denied".into())), None, None);
+    let result = toggle(&fake);
+    assert!(matches!(result, Err(ToggleError::Check(_))));
+    assert_eq!(fake.enable_calls.get(), 0);
+    assert_eq!(fake.disable_calls.get(), 0);
+}
+
+#[skuld::test]
+fn enable_failure_is_reported() {
+    let fake = FakeAutostart::new(Ok(false), Some(Err(Error::Anyhow("plist write failed".into()))), None);
+    assert!(matches!(toggle(&fake), Err(ToggleError::Enable(_))));
+}
+
+#[skuld::test]
+fn disable_failure_is_reported() {
+    let fake = FakeAutostart::new(Ok(true), None, Some(Err(Error::Anyhow("plist remove failed".into()))));
+    assert!(matches!(toggle(&fake), Err(ToggleError::Disable(_))));
+}
+
+#[skuld::test]
+fn user_message_is_pii_free_while_log_detail_keeps_the_path() {
+    // auto-launch's AppPathDoesntExist embeds the full executable path; the
+    // plugin stringifies it into Error::Anyhow. The dialog string must not
+    // leak it, the gui.log string must keep it.
+    let underlying = "app path doesn't exist: /Users/jdoe/Applications/Hole.app";
+    for (err, op_word) in [
+        (ToggleError::Check(Error::Anyhow(underlying.into())), "check"),
+        (ToggleError::Enable(Error::Anyhow(underlying.into())), "enable"),
+        (ToggleError::Disable(Error::Anyhow(underlying.into())), "disable"),
+    ] {
+        let dialog = err.user_message();
+        assert!(!dialog.contains("/Users/jdoe"), "dialog leaks path: {dialog}");
+        assert!(dialog.contains("Start at Login"), "dialog lacks context: {dialog}");
+        assert!(dialog.contains("gui.log"), "dialog lacks log pointer: {dialog}");
+        assert!(
+            dialog.to_lowercase().contains(op_word),
+            "dialog does not say which operation failed: {dialog}"
+        );
+
+        let log_line = format!("{err}");
+        assert!(log_line.contains(underlying), "log line lost detail: {log_line}");
+    }
+}

--- a/crates/hole/src/autostart_tests.rs
+++ b/crates/hole/src/autostart_tests.rs
@@ -81,12 +81,16 @@ fn check_failure_skips_toggle() {
 fn enable_failure_is_reported() {
     let fake = FakeAutostart::new(Ok(false), Some(Err(Error::Anyhow("plist write failed".into()))), None);
     assert!(matches!(toggle(&fake), Err(ToggleError::Enable(_))));
+    assert_eq!(fake.enable_calls.get(), 1);
+    assert_eq!(fake.disable_calls.get(), 0);
 }
 
 #[skuld::test]
 fn disable_failure_is_reported() {
     let fake = FakeAutostart::new(Ok(true), None, Some(Err(Error::Anyhow("plist remove failed".into()))));
     assert!(matches!(toggle(&fake), Err(ToggleError::Disable(_))));
+    assert_eq!(fake.enable_calls.get(), 0);
+    assert_eq!(fake.disable_calls.get(), 1);
 }
 
 #[skuld::test]

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -148,21 +148,11 @@ fn launch_gui(show_dashboard: bool) {
             // support; this cleans those up after a few days). Non-
             // blocking; failures are logged at `warn` only.
             orphan_sweep::spawn_default();
-            hole::update::start_update_checker(app.handle().clone(), |app, info| {
-                // Rebuild tray menu to include the "Install Update" item.
-                if let Some(tray_icon) = app.tray_by_id("main") {
-                    let enabled = app.state::<AppState>().config.lock().unwrap().enabled;
-                    match tray::build_tray_menu(app, Some(info), enabled) {
-                        Ok(menu) => {
-                            // Re-sync checkbox state from config before applying new menu.
-                            tray::sync_menu_state(app, &menu);
-                            tray_icon.set_menu(Some(menu)).ok();
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, "failed to rebuild tray menu with update");
-                        }
-                    }
-                }
+            hole::update::start_update_checker(app.handle().clone(), |app, _info| {
+                // Rebuild the tray menu to include the "Install Update" item.
+                // `UpdateState` is already populated when this fires; the
+                // rebuild reads the info from it on the main thread.
+                tray::rebuild_tray_menu(app);
             });
             Ok(())
         })

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -4,6 +4,7 @@
 // the regular GUI functions appear unused to clippy.
 #![cfg_attr(test, allow(dead_code))]
 
+mod autostart;
 mod bridge_client;
 #[macro_use]
 mod cli_log;
@@ -46,6 +47,12 @@ fn main() {
         None => launch_gui(cli.show_dashboard),
     }
 }
+
+// Install the workspace test subscriber + panic hook. The dev-dep
+// is gated on cfg(test) because it isn't linked in non-test builds.
+// See `crates/test-observability/` and bindreams/hole#301.
+#[cfg(test)]
+hole_test_observability::register!();
 
 #[cfg(test)]
 fn main() {

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -120,8 +120,17 @@ pub fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>) {
     if let Some(item) = menu.get(ID_AUTOSTART) {
         if let Some(check) = item.as_check_menuitem() {
             use tauri_plugin_autostart::ManagerExt;
-            let is_enabled = app.autolaunch().is_enabled().unwrap_or(false);
-            check.set_checked(is_enabled).ok();
+            let is_enabled = match app.autolaunch().is_enabled() {
+                Ok(enabled) => enabled,
+                Err(e) => {
+                    // Unreadable state renders as unchecked; detail to gui.log.
+                    warn!(error = %e, "failed to check autostart state during menu sync");
+                    false
+                }
+            };
+            if let Err(e) = check.set_checked(is_enabled) {
+                warn!(error = %e, "failed to sync autostart checkmark");
+            }
         }
     }
 }
@@ -169,18 +178,34 @@ pub fn set_tray_icon(app: &AppHandle, enabled: bool) {
 /// Rebuild the tray menu to sync state with the current config.
 ///
 /// Preserves the "Install Update" item if an update is available.
+///
+/// The whole rebuild (state reads included) is dispatched to the main
+/// thread: worker-thread callers would otherwise read autostart/config
+/// state on one thread and commit the menu later via a queued
+/// `set_menu`, letting a stale menu overwrite a newer one (#473).
+/// `run_on_main_thread` executes inline when already on the main thread.
 pub fn rebuild_tray_menu(app: &AppHandle) {
-    if let Some(tray) = app.tray_by_id("main") {
-        let update_state = app.state::<hole::update::UpdateState>();
+    let handle = app.clone();
+    let dispatched = app.run_on_main_thread(move || {
+        let Some(tray) = handle.tray_by_id("main") else {
+            warn!("tray not found, skipping menu rebuild");
+            return;
+        };
+        let update_state = handle.state::<hole::update::UpdateState>();
         let update_info = update_state.rx.borrow().clone();
-        let enabled = app.state::<AppState>().config.lock().unwrap().enabled;
-        match build_tray_menu(app, update_info.as_ref(), enabled) {
+        let enabled = handle.state::<AppState>().config.lock().unwrap().enabled;
+        match build_tray_menu(&handle, update_info.as_ref(), enabled) {
             Ok(menu) => {
-                sync_menu_state(app, &menu);
-                tray.set_menu(Some(menu)).ok();
+                sync_menu_state(&handle, &menu);
+                if let Err(e) = tray.set_menu(Some(menu)) {
+                    warn!(error = %e, "failed to set tray menu");
+                }
             }
             Err(e) => warn!(error = %e, "failed to rebuild tray menu"),
         }
+    });
+    if let Err(e) = dispatched {
+        warn!(error = %e, "failed to dispatch tray menu rebuild");
     }
 }
 
@@ -378,19 +403,26 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
         ID_AUTOSTART => {
             info!("tray: autostart toggled");
             use tauri_plugin_autostart::ManagerExt;
-            let autostart = app.autolaunch();
-            match autostart.is_enabled() {
-                Ok(true) => {
-                    if let Err(e) = autostart.disable() {
-                        error!("failed to disable autostart: {e}");
-                    }
+            let result = crate::autostart::toggle(&*app.autolaunch());
+            // muda flipped the checkmark before this handler ran; rebuilding
+            // re-syncs it from the real autostart state — required on failure,
+            // and on success too when the menu was stale.
+            rebuild_tray_menu(app);
+            match result {
+                Ok(enabled) => info!("autostart {}", if enabled { "enabled" } else { "disabled" }),
+                Err(e) => {
+                    // Full detail (may embed the executable path) goes to
+                    // gui.log; the dialog gets the PII-free summary.
+                    error!("{e}");
+                    let message = e.user_message();
+                    let app_handle = app.clone();
+                    // spawn_blocking: blocking_show must not run on the main
+                    // thread and would park a core async worker if spawned.
+                    tauri::async_runtime::spawn_blocking(move || {
+                        use tauri_plugin_dialog::DialogExt;
+                        app_handle.dialog().message(message).title("Error").blocking_show();
+                    });
                 }
-                Ok(false) => {
-                    if let Err(e) = autostart.enable() {
-                        error!("failed to enable autostart: {e}");
-                    }
-                }
-                Err(e) => error!("failed to check autostart: {e}"),
             }
         }
         ID_SETTINGS => {

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -51,7 +51,7 @@ const ID_COLLECT_LOGS: &str = "window_collect_logs";
 // Tray creation =======================================================================================================
 
 /// Build the tray menu, optionally including an "Install Update" item.
-pub fn build_tray_menu(
+fn build_tray_menu(
     app: &AppHandle,
     update: Option<&hole::update::UpdateInfo>,
     enabled: bool,
@@ -95,15 +95,17 @@ pub fn build_tray_menu(
     }
 }
 
-/// Sync tray menu item text and checkbox states from the current config.
-pub fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>) {
-    let state = app.state::<AppState>();
-    let config = state.config.lock().unwrap();
-
+/// Sync tray menu item text and checkbox states from the given proxy state
+/// and the OS autostart registration.
+///
+/// Must run on the main thread: the menu-item setters dispatch to the main
+/// thread and block when called from anywhere else, so a caller holding a
+/// lock here can deadlock the app.
+fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>, enabled: bool) {
     // Sync status text
     if let Some(item) = menu.get(ID_STATUS) {
         if let Some(menu_item) = item.as_menuitem() {
-            let text = if config.enabled { "Connected" } else { "Disconnected" };
+            let text = if enabled { "Connected" } else { "Disconnected" };
             menu_item.set_text(text).ok();
         }
     }
@@ -111,7 +113,7 @@ pub fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>) {
     // Sync connect/disconnect text
     if let Some(item) = menu.get(ID_CONNECT) {
         if let Some(menu_item) = item.as_menuitem() {
-            let text = if config.enabled { "Disconnect" } else { "Connect" };
+            let text = if enabled { "Disconnect" } else { "Connect" };
             menu_item.set_text(text).ok();
         }
     }
@@ -157,7 +159,7 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
 
     let tray = builder.build(app)?;
 
-    sync_menu_state(app.handle(), &menu);
+    sync_menu_state(app.handle(), &menu, enabled);
 
     Ok(tray)
 }
@@ -196,7 +198,10 @@ pub fn rebuild_tray_menu(app: &AppHandle) {
         let enabled = handle.state::<AppState>().config.lock().unwrap().enabled;
         match build_tray_menu(&handle, update_info.as_ref(), enabled) {
             Ok(menu) => {
-                sync_menu_state(&handle, &menu);
+                sync_menu_state(&handle, &menu, enabled);
+                // Sanctioned `set_menu` site: the one ordered commit point
+                // (clippy.toml bans it everywhere else).
+                #[allow(clippy::disallowed_methods)]
                 if let Err(e) = tray.set_menu(Some(menu)) {
                     warn!(error = %e, "failed to set tray menu");
                 }
@@ -394,8 +399,12 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
                         info!("tray: start was cancelled externally");
                     }
                     Err(msg) => {
-                        use tauri_plugin_dialog::DialogExt;
-                        app_handle.dialog().message(msg).title("Error").blocking_show();
+                        // blocking_show would park a core async worker here;
+                        // use the blocking pool.
+                        tauri::async_runtime::spawn_blocking(move || {
+                            use tauri_plugin_dialog::DialogExt;
+                            app_handle.dialog().message(msg).title("Error").blocking_show();
+                        });
                     }
                 }
             });

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -1,3 +1,3 @@
-//! Tray tests require a full Tauri app context.
-//! The Start-at-Login toggle logic is unit-tested in autostart_tests.rs;
-//! see E2E tests in tests/webdriver/ for the rest of the tray behavior.
+//! The tray handler glue (menu events, rebuilds, dialogs) requires a full
+//! Tauri app context and has no automated coverage at any level; the
+//! Start-at-Login toggle logic is unit-tested in autostart_tests.rs.

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -1,2 +1,3 @@
 //! Tray tests require a full Tauri app context.
-//! See E2E tests in tests/webdriver/ for tray behavior coverage.
+//! The Start-at-Login toggle logic is unit-tested in autostart_tests.rs;
+//! see E2E tests in tests/webdriver/ for the rest of the tray behavior.


### PR DESCRIPTION
Closes #473.

muda auto-toggles the Start-at-Login `CheckMenuItem` before the `ID_AUTOSTART` handler runs, and the handler only `error!`-logged failures of `is_enabled()`/`enable()`/`disable()` — so a failed registration left the checkmark showing the opposite of reality with no user feedback until an unrelated menu rebuild.

- Extract the toggle decision into `autostart.rs` behind an `Autostart` trait seam, unit-tested: enable/disable/check failure paths, call-count discipline, and the PII boundary (dialog text stays generic; the full error — which can embed the executable path — lands only in gui.log).
- The handler now always rebuilds the tray menu after a toggle, re-syncing the checkmark from `is_enabled()`; this covers all three failure arms and the success-with-stale-menu case.
- `rebuild_tray_menu` dispatches its whole body (state reads included) through `run_on_main_thread`, totally ordering rebuilds — a worker-side rebuild could otherwise commit a stale menu over a newer one, reintroducing the desync. The update-found callback now uses this path too (its old hand-rolled rebuild both bypassed the ordering and could deadlock the main thread once the rebuild closure takes the config lock there). `TrayIcon::set_menu` is now clippy-banned outside the one sanctioned commit point; contract documented in CONTRIBUTING.
- `sync_menu_state` no longer holds the config lock across menu-item setters (they dispatch-and-block cross-thread), no longer swallows `is_enabled`/`set_checked` errors, and is documented main-thread-only.
- Failure dialogs run via `spawn_blocking` (`blocking_show` is forbidden on the main thread and would park a core async worker if spawned); the `ID_CONNECT` error dialog is converted to the same pattern.
- Removed the dead `autostart:*` capability grants (no ui/ code invokes the plugin), making the tray the only autostart writer.
- Added the missing `#[cfg(test)] hole_test_observability::register!()` to the bin test binary (CONTRIBUTING requires it once per binary; `main.rs` lacked it).

Dialog wording follows the existing `ImportFailure` precedent ("… See gui.log for details.").