### PR TITLE
fix(gui): quarantine corrupt config.json to a .bak instead of silently resetting it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,19 @@ installed service `C:\ProgramData\hole\state\` / `/var/db/hole/state/`;
 If in-bridge recovery can't run, [`scripts/network-reset.py`](scripts/network-reset.py)
 performs equivalent cleanup from outside.
 
+### Config corruption recovery
+
+`ConfigStore` ([crates/common/src/config_store.rs](crates/common/src/config_store.rs))
+is the only door to `config.json` — `AppConfig::save` is clippy-disallowed
+elsewhere, and there is no other loader. On load, a corrupt or unreadable file
+is quarantined to a timestamped sibling (`config.json.<ts>Z.bak`) before
+defaults are used, and the user gets a native dialog naming the backup. If
+quarantine fails (e.g. unwritable directory), saving is blocked for the whole
+session (`ConfigError::SaveBlocked`) so the corrupt file is never overwritten —
+the original data-loss bug (#467) was a save clobbering a file that had failed
+to parse. Saves are atomic (sibling temp file + rename) so a crash mid-save
+cannot produce a corrupt config.
+
 ### Native-crash observability (tombstone)
 
 Native faults (SIGSEGV/access-violation, stack overflow, SIGABRT/`abort()`,

--- a/clippy.toml
+++ b/clippy.toml
@@ -169,3 +169,15 @@ reason = "Non-atomic: pairing with `set_icon` flickers (per tauri docs) and `(fa
 [[disallowed-methods]]
 path = "tray_icon::TrayIcon::set_icon_as_template"
 reason = "Reached via `with_inner_tray_icon`; same non-atomic footgun as the tauri-level form. Use `tauri::tray::TrayIcon::set_icon_with_as_template(icon, true)`. See bindreams/hole#469."
+
+# Config persistence — enforce the ConfigStore seam --------------------------------------------------------------------
+#
+# `ConfigStore` (crates/common/src/config_store.rs) quarantines a corrupt
+# config.json at load and blocks saves for the session when quarantine
+# fails. A direct `AppConfig::save` bypasses the `save_blocked` gate and
+# can overwrite the very file #467 preserves. `ConfigStore::save` and the
+# `AppConfig::save` unit tests carry sanctioned `#[allow]`s.
+
+[[disallowed-methods]]
+path = "hole_common::config::AppConfig::save"
+reason = "Go through `ConfigStore::save` — direct saves bypass the #467 save_blocked gate and can destroy a quarantine-pending config.json. See bindreams/hole#467."

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -31,7 +31,7 @@ tracing-log = "0.2"
 tracing-appender = "0.2"
 file-rotate = "0.8"
 os_pipe = "1"
-time = { version = "0.3", features = ["serde-well-known", "formatting"] }
+time = { version = "0.3", features = ["serde-well-known", "formatting", "macros"] }
 tokio = { version = "1", features = ["rt", "macros", "time", "net"] }
 yaml_serde = "0.10"
 nu-ansi-term = "0.50"

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -266,13 +266,8 @@ pub fn is_valid_plugin_name(name: &str) -> bool {
 // Methods =============================================================================================================
 
 impl AppConfig {
-    pub fn load(path: &Path) -> Result<Self, ConfigError> {
-        match std::fs::read_to_string(path) {
-            Ok(contents) => Ok(serde_json::from_str(&contents)?),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
-            Err(e) => Err(ConfigError::Read(e)),
-        }
-    }
+    // Loading lives in `ConfigStore::load` (crate::config_store) — it
+    // quarantines corrupt files instead of returning an error to discard.
 
     /// Serialize and write atomically: write a sibling temp file, then rename
     /// it over `path`. A crash mid-write leaves the old config intact — a

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -274,8 +274,15 @@ impl AppConfig {
         }
     }
 
+    /// Serialize and write atomically: write a sibling temp file, then rename
+    /// it over `path`. A crash mid-write leaves the old config intact — a
+    /// truncate-in-place write here is how #467 corruption happened.
     pub fn save(&self, path: &Path) -> Result<(), ConfigError> {
         let json = serde_json::to_string_pretty(self)?;
+        // Dot-prefixed so it can't collide with the `config.json.*.bak`
+        // quarantine namespace; a stale one (crash between write and rename)
+        // is overwritten by the next save and never loaded.
+        let tmp = path.with_file_name(".config.json.tmp");
 
         #[cfg(target_os = "macos")]
         {
@@ -291,30 +298,37 @@ impl AppConfig {
             }
             // Restrict config file permissions on macOS — the config contains plaintext
             // passwords and must not be world-readable (default umask 0022 yields 0644).
+            // The temp file carries the mode; rename preserves it.
             let mut file = OpenOptions::new()
                 .write(true)
                 .create(true)
                 .truncate(true)
                 .mode(0o600)
-                .open(path)?;
+                .open(&tmp)?;
             file.set_permissions(Permissions::from_mode(0o600))?;
             file.write_all(json.as_bytes())?;
+            file.sync_all()?;
         }
 
         #[cfg(target_os = "windows")]
         {
+            use std::io::Write;
             if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::write(path, json)?;
+            let mut file = std::fs::File::create(&tmp)?;
+            file.write_all(json.as_bytes())?;
+            file.sync_all()?;
         }
 
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         {
-            let _ = json;
+            let _ = (json, &tmp);
             compile_error!("save() is not implemented for this platform");
         }
 
+        // Atomic replace on both platforms (Windows: MOVEFILE_REPLACE_EXISTING).
+        std::fs::rename(&tmp, path)?;
         Ok(())
     }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -13,6 +13,8 @@ pub enum ConfigError {
     Read(#[from] std::io::Error),
     #[error("failed to parse config: {0}")]
     Parse(#[from] serde_json::Error),
+    #[error("config saving is disabled: the corrupt config file could not be backed up at startup")]
+    SaveBlocked,
 }
 
 // Types ===============================================================================================================

--- a/crates/common/src/config_store.rs
+++ b/crates/common/src/config_store.rs
@@ -8,9 +8,11 @@
 //! used, and if quarantine fails, saving is blocked for the session.
 
 use crate::config::{AppConfig, ConfigError};
+use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
+use tracing::{error, warn};
 
 /// What happened when the config file could not be loaded.
 #[derive(Debug)]
@@ -40,16 +42,46 @@ impl ConfigStore {
     /// timestamp in the backup name; production passes
     /// `OffsetDateTime::now_utc()`.
     pub fn load(path: PathBuf, now: OffsetDateTime) -> (Self, AppConfig, Option<ConfigRecovery>) {
-        let _ = now;
-        let config = AppConfig::load(&path).unwrap_or_default();
-        (
-            Self {
-                path,
-                save_blocked: false,
+        let (config, recovery) = match fs::read_to_string(&path) {
+            Ok(contents) => match serde_json::from_str(&contents) {
+                Ok(config) => (config, None),
+                Err(e) => {
+                    let backup = quarantine(&path, Some(&contents), now);
+                    let recovery = ConfigRecovery {
+                        path: path.clone(),
+                        error: e.into(),
+                        backup,
+                    };
+                    (AppConfig::default(), Some(recovery))
+                }
             },
-            config,
-            None,
-        )
+            Err(e) if e.kind() == io::ErrorKind::NotFound => (AppConfig::default(), None),
+            Err(e) => {
+                let backup = quarantine(&path, None, now);
+                let recovery = ConfigRecovery {
+                    path: path.clone(),
+                    error: ConfigError::Read(e),
+                    backup,
+                };
+                (AppConfig::default(), Some(recovery))
+            }
+        };
+
+        if let Some(r) = &recovery {
+            match &r.backup {
+                Ok(bak) => error!(
+                    path = %r.path.display(), error = %r.error, backup = %bak.display(),
+                    "config file unreadable; quarantined to backup, starting with defaults"
+                ),
+                Err(bak_err) => error!(
+                    path = %r.path.display(), error = %r.error, backup_error = %bak_err,
+                    "config file unreadable and backup failed; saving disabled for this session"
+                ),
+            }
+        }
+
+        let save_blocked = matches!(&recovery, Some(r) if r.backup.is_err());
+        (Self { path, save_blocked }, config, recovery)
     }
 
     pub fn path(&self) -> &Path {
@@ -67,6 +99,99 @@ impl ConfigStore {
         }
         config.save(&self.path)
     }
+}
+
+/// Timestamp embedded in backup names. Dashes instead of colons — colons are
+/// invalid in Windows file names.
+const BACKUP_TS_FORMAT: &[time::format_description::BorrowedFormatItem<'static>] =
+    time::macros::format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]Z");
+
+fn backup_path(path: &Path, now: OffsetDateTime, counter: u32) -> PathBuf {
+    debug_assert!(path.file_name().is_some(), "config path must name a file: {path:?}");
+    let ts = now.format(BACKUP_TS_FORMAT).expect("static format, in-range timestamp");
+    let name = path.file_name().unwrap_or_default().to_string_lossy();
+    let suffix = if counter == 1 {
+        String::new()
+    } else {
+        format!("-{counter}")
+    };
+    path.with_file_name(format!("{name}.{ts}{suffix}.bak"))
+}
+
+/// Move the file at `path` aside to a timestamped sibling `.bak`.
+///
+/// Prefers an atomic `rename`: one step, and it preserves the original
+/// file's permissions (the config holds plaintext passwords; macOS `save()`
+/// enforces 0600). If rename fails and the contents are known (the file was
+/// readable but unparsable), falls back to writing a fresh backup and
+/// best-effort removing the original — on Windows a file held open by
+/// another process refuses the rename but still allows new siblings.
+fn quarantine(path: &Path, contents: Option<&str>, now: OffsetDateTime) -> Result<PathBuf, io::Error> {
+    // The exists()-probe → rename pair is not atomic, and on unix a rename
+    // would silently overwrite an existing destination — the probe is what
+    // protects older backups. That is sound because nothing else creates
+    // `config.json.*.bak` siblings: the webview engine shares this directory
+    // but never writes backup-named files, and the single-instance lock
+    // (held before setup) makes Hole itself sequential. `exists()` mapping
+    // stat errors to `false` is the safe direction — the rename/create_new
+    // below is authoritative and fails cleanly.
+    let mut counter = 1;
+    let bak = loop {
+        let candidate = backup_path(path, now, counter);
+        if !candidate.exists() {
+            break candidate;
+        }
+        counter += 1;
+    };
+
+    let rename_err = match fs::rename(path, &bak) {
+        Ok(()) => return Ok(bak),
+        Err(e) => e,
+    };
+    let Some(contents) = contents else {
+        return Err(rename_err);
+    };
+    warn!(error = %rename_err, "rename to backup failed; attempting copy fallback");
+
+    // `create_new` is an atomic claim of the name, so this loop is race-free.
+    loop {
+        let candidate = backup_path(path, now, counter);
+        match open_create_new(&candidate) {
+            Ok(mut file) => {
+                use std::io::Write;
+                if let Err(e) = file.write_all(contents.as_bytes()) {
+                    let _ = fs::remove_file(&candidate);
+                    return Err(e);
+                }
+                if let Err(e) = fs::remove_file(path) {
+                    warn!(
+                        path = %path.display(), error = %e,
+                        "backed up corrupt config by copy, but could not remove the original; \
+                         it may be re-quarantined on next start"
+                    );
+                }
+                return Ok(candidate);
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => counter += 1,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// The backup holds plaintext passwords — match `save()`'s 0600 on unix.
+#[cfg(unix)]
+fn open_create_new(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_create_new(path: &Path) -> io::Result<fs::File> {
+    fs::OpenOptions::new().write(true).create_new(true).open(path)
 }
 
 #[cfg(test)]

--- a/crates/common/src/config_store.rs
+++ b/crates/common/src/config_store.rs
@@ -97,6 +97,8 @@ impl ConfigStore {
         if self.save_blocked {
             return Err(ConfigError::SaveBlocked);
         }
+        // The clippy ban routes everyone else here; this is the seam itself.
+        #[allow(clippy::disallowed_methods)]
         config.save(&self.path)
     }
 }

--- a/crates/common/src/config_store.rs
+++ b/crates/common/src/config_store.rs
@@ -1,0 +1,74 @@
+//! Load-time quarantine and gated saving for the GUI config file (#467).
+//!
+//! `AppConfig::load` used to map a missing file to defaults and anything else
+//! to an error — which the GUI discarded (`unwrap_or_default`), so the next
+//! save overwrote the corrupt file, destroying the user's servers and
+//! passwords. `ConfigStore` makes that impossible: a corrupt/unreadable
+//! `config.json` is quarantined to a timestamped `.bak` before defaults are
+//! used, and if quarantine fails, saving is blocked for the session.
+
+use crate::config::{AppConfig, ConfigError};
+use std::io;
+use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
+
+/// What happened when the config file could not be loaded.
+#[derive(Debug)]
+pub struct ConfigRecovery {
+    /// The config file that failed to load.
+    pub path: PathBuf,
+    /// Why it failed.
+    pub error: ConfigError,
+    /// Where the file was quarantined, or the error that prevented it.
+    pub backup: Result<PathBuf, io::Error>,
+}
+
+/// Owns the config path and the load-time recovery state. All GUI saves go
+/// through [`ConfigStore::save`] so a failed quarantine blocks destructive
+/// writes for the whole session.
+pub struct ConfigStore {
+    path: PathBuf,
+    /// Set when quarantine failed: the corrupt file is still at `path` and
+    /// writing would destroy it.
+    save_blocked: bool,
+}
+
+impl ConfigStore {
+    /// Load `path`, quarantining a corrupt/unreadable file to a `.bak`.
+    ///
+    /// Missing file → defaults, no recovery (first launch). `now` becomes the
+    /// timestamp in the backup name; production passes
+    /// `OffsetDateTime::now_utc()`.
+    pub fn load(path: PathBuf, now: OffsetDateTime) -> (Self, AppConfig, Option<ConfigRecovery>) {
+        let _ = now;
+        let config = AppConfig::load(&path).unwrap_or_default();
+        (
+            Self {
+                path,
+                save_blocked: false,
+            },
+            config,
+            None,
+        )
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Save `config`, unless a failed quarantine blocked saving.
+    ///
+    /// Not a synchronization point: concurrent saves are serialized by the
+    /// caller — every GUI site holds the `AppState::config` mutex across
+    /// this call.
+    pub fn save(&self, config: &AppConfig) -> Result<(), ConfigError> {
+        if self.save_blocked {
+            return Err(ConfigError::SaveBlocked);
+        }
+        config.save(&self.path)
+    }
+}
+
+#[cfg(test)]
+#[path = "config_store_tests.rs"]
+mod config_store_tests;

--- a/crates/common/src/config_store_tests.rs
+++ b/crates/common/src/config_store_tests.rs
@@ -1,0 +1,51 @@
+use super::*;
+use crate::config::ServerEntry;
+use skuld::temp_dir;
+use std::path::Path;
+use time::macros::datetime;
+
+const NOW: time::OffsetDateTime = datetime!(2026-06-10 14:23:05 UTC);
+
+#[skuld::test]
+fn load_valid_file_returns_config_and_no_recovery(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    let original = AppConfig {
+        servers: vec![ServerEntry::default_placeholder()],
+        local_port: 5555,
+        ..Default::default()
+    };
+    original.save(&path).unwrap();
+
+    let (store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, original);
+    assert!(recovery.is_none());
+    assert_eq!(store.path(), path);
+    // No stray backup or temp files.
+    assert_eq!(std::fs::read_dir(dir).unwrap().count(), 1);
+}
+
+#[skuld::test]
+fn load_missing_file_returns_defaults_and_no_recovery(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+
+    let (_store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, AppConfig::default());
+    assert!(recovery.is_none());
+    assert!(!path.exists());
+    assert_eq!(std::fs::read_dir(dir).unwrap().count(), 0);
+}
+
+#[skuld::test]
+fn save_roundtrips_through_store(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    let (store, mut config, _) = ConfigStore::load(path.clone(), NOW);
+
+    config.local_port = 6666;
+    store.save(&config).unwrap();
+
+    let (_, reloaded, recovery) = ConfigStore::load(path, NOW);
+    assert_eq!(reloaded, config);
+    assert!(recovery.is_none());
+}

--- a/crates/common/src/config_store_tests.rs
+++ b/crates/common/src/config_store_tests.rs
@@ -6,6 +6,8 @@ use time::macros::datetime;
 
 const NOW: time::OffsetDateTime = datetime!(2026-06-10 14:23:05 UTC);
 
+// Direct `AppConfig::save` for test setup — sanctioned; see clippy.toml.
+#[allow(clippy::disallowed_methods)]
 #[skuld::test]
 fn load_valid_file_returns_config_and_no_recovery(#[fixture(temp_dir)] dir: &Path) {
     let path = dir.join("config.json");
@@ -116,6 +118,8 @@ fn save_works_after_successful_quarantine(#[fixture(temp_dir)] dir: &Path) {
 
 /// rename(2) preserves the inode, so the 0600 mode `save()` sets on macOS
 /// must survive quarantine — the backup holds plaintext passwords.
+// Direct `AppConfig::save` for test setup — sanctioned; see clippy.toml.
+#[allow(clippy::disallowed_methods)]
 #[cfg(unix)]
 #[skuld::test]
 fn quarantine_preserves_file_permissions(#[fixture(temp_dir)] dir: &Path) {

--- a/crates/common/src/config_store_tests.rs
+++ b/crates/common/src/config_store_tests.rs
@@ -49,3 +49,225 @@ fn save_roundtrips_through_store(#[fixture(temp_dir)] dir: &Path) {
     assert_eq!(reloaded, config);
     assert!(recovery.is_none());
 }
+
+const GARBAGE: &str = "not json at all {{{";
+
+#[skuld::test]
+fn corrupt_json_is_quarantined_to_timestamped_bak(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+
+    let (_store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, AppConfig::default());
+    let recovery = recovery.expect("corrupt file must produce a recovery");
+    assert!(matches!(recovery.error, ConfigError::Parse(_)));
+    assert_eq!(recovery.path, path);
+
+    let bak = recovery.backup.expect("backup must succeed");
+    assert_eq!(bak, dir.join("config.json.2026-06-10T14-23-05Z.bak"));
+    assert!(!path.exists(), "original must be moved away");
+    assert_eq!(std::fs::read_to_string(&bak).unwrap(), GARBAGE);
+}
+
+/// An empty file is not valid JSON — it must be quarantined, not silently
+/// replaced (truncation is the classic crash-mid-save corruption shape).
+#[skuld::test]
+fn empty_file_is_quarantined(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    std::fs::write(&path, "").unwrap();
+
+    let (_store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, AppConfig::default());
+    let recovery = recovery.expect("empty file must produce a recovery");
+    assert!(matches!(recovery.error, ConfigError::Parse(_)));
+    assert!(recovery.backup.is_ok());
+    assert!(!path.exists());
+}
+
+#[skuld::test]
+fn backup_name_collision_appends_counter(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+    let occupied = dir.join("config.json.2026-06-10T14-23-05Z.bak");
+    std::fs::write(&occupied, "older backup").unwrap();
+
+    let (_store, _config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    let bak = recovery.unwrap().backup.unwrap();
+    assert_eq!(bak, dir.join("config.json.2026-06-10T14-23-05Z-2.bak"));
+    assert_eq!(std::fs::read_to_string(&bak).unwrap(), GARBAGE);
+    assert_eq!(std::fs::read_to_string(&occupied).unwrap(), "older backup");
+}
+
+#[skuld::test]
+fn save_works_after_successful_quarantine(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+
+    let (store, config, _recovery) = ConfigStore::load(path.clone(), NOW);
+    store.save(&config).unwrap();
+
+    let (_, reloaded, recovery) = ConfigStore::load(path, NOW);
+    assert_eq!(reloaded, config);
+    assert!(recovery.is_none());
+}
+
+/// rename(2) preserves the inode, so the 0600 mode `save()` sets on macOS
+/// must survive quarantine — the backup holds plaintext passwords.
+#[cfg(unix)]
+#[skuld::test]
+fn quarantine_preserves_file_permissions(#[fixture(temp_dir)] dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join("config.json");
+    AppConfig::default().save(&path).unwrap(); // 0600 on macOS
+    std::fs::write(&path, GARBAGE).unwrap(); // truncating write keeps mode
+
+    let (_store, _config, recovery) = ConfigStore::load(path, NOW);
+
+    let bak = recovery.unwrap().backup.unwrap();
+    let mode = std::fs::metadata(&bak).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600);
+}
+
+/// Restores a directory's permissions on drop, so a failing assert can't
+/// leave the temp dir undeletable.
+#[cfg(unix)]
+struct RestorePerms<'a> {
+    path: &'a Path,
+    mode: u32,
+}
+
+#[cfg(unix)]
+impl Drop for RestorePerms<'_> {
+    fn drop(&mut self) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(self.path, std::fs::Permissions::from_mode(self.mode));
+    }
+}
+
+/// An unreadable (not missing) file is a Read error and must be quarantined
+/// the same way — rename does not require read permission.
+/// CI runs as a non-root user, so 0o000 genuinely denies; under root the
+/// read would succeed and flip the error branch, failing this test loudly.
+#[cfg(unix)]
+#[skuld::test]
+fn unreadable_file_is_quarantined_via_rename(#[fixture(temp_dir)] dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let (store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, AppConfig::default());
+    let recovery = recovery.expect("unreadable file must produce a recovery");
+    assert!(matches!(recovery.error, ConfigError::Read(_)));
+    let bak = recovery.backup.expect("rename does not need read permission");
+    assert!(!path.exists());
+
+    // Quarantine preserved the mode; relax it to inspect the contents.
+    std::fs::set_permissions(&bak, std::fs::Permissions::from_mode(0o600)).unwrap();
+    assert_eq!(std::fs::read_to_string(&bak).unwrap(), GARBAGE);
+
+    // Saving is allowed — the backup succeeded.
+    store.save(&AppConfig::default()).unwrap();
+}
+
+/// `chflags uchg` makes rename/unlink of the file fail while still allowing
+/// new sibling files — exactly the "rename refused, copy fallback" shape.
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn rename_refused_falls_back_to_copying_contents(#[fixture(temp_dir)] dir: &Path) {
+    struct ClearUchg<'a>(&'a Path);
+    impl Drop for ClearUchg<'_> {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("/usr/bin/chflags")
+                .arg("nouchg")
+                .arg(self.0)
+                .status();
+        }
+    }
+
+    let path = dir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+    let status = std::process::Command::new("/usr/bin/chflags")
+        .arg("uchg")
+        .arg(&path)
+        .status()
+        .unwrap();
+    assert!(status.success(), "chflags uchg failed");
+    let _guard = ClearUchg(&path);
+
+    let (store, _config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    let recovery = recovery.unwrap();
+    let bak = recovery.backup.expect("copy fallback must succeed");
+    assert_eq!(std::fs::read_to_string(&bak).unwrap(), GARBAGE);
+    // remove_file on a uchg file fails; the original stays behind (re-quarantined
+    // on next start — safe, the contents are already backed up).
+    assert!(path.exists());
+
+    // Backup succeeded → the store allows saving; the OS then refuses to open
+    // the uchg file for write, deterministically (EPERM → ConfigError::Read).
+    assert!(matches!(store.save(&AppConfig::default()), Err(ConfigError::Read(_))));
+}
+
+/// Windows shape of the same fallback: a file held open without
+/// FILE_SHARE_DELETE refuses rename/delete but allows new siblings.
+#[cfg(windows)]
+#[skuld::test]
+fn rename_refused_falls_back_to_copying_contents(#[fixture(temp_dir)] dir: &Path) {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_SHARE_READ: u32 = 0x1;
+
+    let path = dir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+    // Hold the file open for the duration of load: reads allowed, rename and
+    // delete refused (no FILE_SHARE_DELETE), sibling create_new allowed.
+    let _holder = std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ)
+        .open(&path)
+        .unwrap();
+
+    let (_store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, AppConfig::default());
+    let recovery = recovery.unwrap();
+    let bak = recovery.backup.expect("copy fallback must succeed");
+    assert_eq!(std::fs::read_to_string(&bak).unwrap(), GARBAGE);
+    // remove_file is refused while the holder is open; the original stays
+    // behind (re-quarantined on next start — safe, contents already backed up).
+    assert!(path.exists());
+}
+
+/// When the directory refuses both rename and new files, nothing can preserve
+/// the data — so saves must be blocked for the session.
+/// (Non-root only, like `unreadable_file_is_quarantined_via_rename`.)
+#[cfg(unix)]
+#[skuld::test]
+fn backup_failure_blocks_saving(#[fixture(temp_dir)] dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let subdir = dir.join("conf");
+    std::fs::create_dir(&subdir).unwrap();
+    let path = subdir.join("config.json");
+    std::fs::write(&path, GARBAGE).unwrap();
+    std::fs::set_permissions(&subdir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let guard = RestorePerms {
+        path: &subdir,
+        mode: 0o755,
+    };
+
+    let (store, config, recovery) = ConfigStore::load(path.clone(), NOW);
+
+    assert_eq!(config, AppConfig::default());
+    let recovery = recovery.unwrap();
+    recovery.backup.expect_err("backup cannot succeed in a read-only dir");
+
+    assert!(matches!(store.save(&config), Err(ConfigError::SaveBlocked)));
+    drop(guard);
+    // The corrupt original is untouched — neither quarantined nor overwritten.
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), GARBAGE);
+}

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -514,3 +514,32 @@ fn plugin_name_shell_metacharacters_rejected() {
     assert!(!is_valid_plugin_name("evil(1)"));
     assert!(!is_valid_plugin_name("evil{1}"));
 }
+
+#[skuld::test]
+fn save_replaces_existing_file_and_leaves_no_temp(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    AppConfig::default().save(&path).unwrap();
+    let changed = AppConfig {
+        local_port: 7777,
+        ..Default::default()
+    };
+    changed.save(&path).unwrap();
+
+    // Exactly one file in the dir: no .tmp leftovers.
+    let entries: Vec<_> = std::fs::read_dir(dir).unwrap().collect();
+    assert_eq!(entries.len(), 1);
+    let on_disk: AppConfig = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(on_disk, changed);
+}
+
+/// The temp file becomes config.json via rename, so it must carry the final
+/// 0600 mode from the moment it has contents (plaintext passwords).
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn save_writes_with_owner_only_permissions(#[fixture(temp_dir)] dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join("config.json");
+    AppConfig::default().save(&path).unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600);
+}

--- a/crates/common/src/config_tests.rs
+++ b/crates/common/src/config_tests.rs
@@ -1,10 +1,23 @@
+// This module tests `AppConfig::save` itself — the clippy ban exists to route
+// production callers through `ConfigStore::save`.
+#![allow(clippy::disallowed_methods)]
+
 use super::*;
 use skuld::temp_dir;
 use std::path::Path;
 
+/// Load via the production loader (`ConfigStore`), asserting a clean load —
+/// `AppConfig::load` was removed in #467 (quarantine made it production-dead).
+fn load(path: &Path) -> AppConfig {
+    let now = time::macros::datetime!(2026-06-10 14:23:05 UTC);
+    let (_, config, recovery) = crate::config_store::ConfigStore::load(path.to_path_buf(), now);
+    assert!(recovery.is_none(), "unexpected recovery: {recovery:?}");
+    config
+}
+
 #[skuld::test]
 fn load_nonexistent_returns_defaults(#[fixture(temp_dir)] dir: &Path) {
-    let config = AppConfig::load(&dir.join("nonexistent.json")).unwrap();
+    let config = load(&dir.join("nonexistent.json"));
     assert_eq!(config.local_port, 4073);
     assert!(config.servers.is_empty());
     assert!(!config.enabled);
@@ -32,17 +45,12 @@ fn load_valid_json_roundtrips(#[fixture(temp_dir)] dir: &Path) {
         ..Default::default()
     };
     original.save(&path).unwrap();
-    let loaded = AppConfig::load(&path).unwrap();
+    let loaded = load(&path);
     assert_eq!(original, loaded);
 }
 
-#[skuld::test]
-fn load_corrupt_json_returns_error(#[fixture(temp_dir)] dir: &Path) {
-    let path = dir.join("bad.json");
-    std::fs::write(&path, "not json at all {{{").unwrap();
-    let err = AppConfig::load(&path).unwrap_err();
-    assert!(err.to_string().contains("parse"));
-}
+// Corrupt-input behavior now lives in `config_store_tests.rs`
+// (`corrupt_json_is_quarantined_to_timestamped_bak` and friends).
 
 #[skuld::test]
 fn save_creates_parent_dirs(#[fixture(temp_dir)] dir: &Path) {
@@ -56,7 +64,7 @@ fn save_then_load_is_identity(#[fixture(temp_dir)] dir: &Path) {
     let path = dir.join("config.json");
     let config = AppConfig::default();
     config.save(&path).unwrap();
-    let loaded = AppConfig::load(&path).unwrap();
+    let loaded = load(&path);
     assert_eq!(config, loaded);
 }
 
@@ -154,7 +162,7 @@ fn elevation_prompt_shown_roundtrips(#[fixture(temp_dir)] dir: &Path) {
     };
     config.save(&path).unwrap();
 
-    let loaded = AppConfig::load(&path).unwrap();
+    let loaded = load(&path);
     assert!(loaded.elevation_prompt_shown);
 }
 
@@ -348,7 +356,7 @@ fn new_config_fields_roundtrip(#[fixture(temp_dir)] dir: &Path) {
         ..Default::default()
     };
     config.save(&path).unwrap();
-    let loaded = AppConfig::load(&path).unwrap();
+    let loaded = load(&path);
     assert_eq!(config.filters, loaded.filters);
     assert_eq!(config.start_on_login, loaded.start_on_login);
     assert_eq!(config.on_startup, loaded.on_startup);
@@ -419,7 +427,7 @@ fn dns_config_roundtrips_via_json(#[fixture(temp_dir)] dir: &Path) {
         ..Default::default()
     };
     config.save(&path).unwrap();
-    let loaded = AppConfig::load(&path).unwrap();
+    let loaded = load(&path);
     assert_eq!(config.dns, loaded.dns);
 }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod config_store;
 pub mod import;
 pub mod logging;
 pub mod paths;

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -95,7 +95,7 @@ pub fn save_config(state: State<AppState>, mut config: AppConfig) -> Result<(), 
     // The frontend doesn't know about elevation_prompt_shown — preserve the
     // in-memory value so a save from the Settings UI doesn't reset it.
     config.elevation_prompt_shown = current.elevation_prompt_shown;
-    config.save(&state.config_path).map_err(|e| e.to_string())?;
+    state.config_store.save(&config).map_err(|e| e.to_string())?;
     *current = config;
     Ok(())
 }
@@ -227,7 +227,7 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
     let mut config = state.config.lock().unwrap();
     let (appended, _deduped) = apply_import(&mut config, parsed);
 
-    config.save(&state.config_path).map_err(|e| {
+    state.config_store.save(&config).map_err(|e| {
         warn!(error = %e, "import_servers_from_file: config save failed");
         ImportFailure::SaveFailed
     })?;
@@ -408,7 +408,7 @@ pub async fn test_server(state: State<'_, AppState>, entry_id: String) -> Result
                 tested_at: OffsetDateTime::now_utc(),
                 outcome: outcome.clone(),
             });
-            cfg.save(&state.config_path).map_err(|e| e.to_string())?;
+            state.config_store.save(&cfg).map_err(|e| e.to_string())?;
         }
     }
 
@@ -456,7 +456,7 @@ pub fn mark_validated_by_proxy_start(state: State<AppState>, entry_id: String) -
                 },
             });
         }
-        cfg.save(&state.config_path).map_err(|e| e.to_string())?;
+        state.config_store.save(&cfg).map_err(|e| e.to_string())?;
     }
     Ok(())
 }

--- a/crates/hole/src/config_recovery.rs
+++ b/crates/hole/src/config_recovery.rs
@@ -1,0 +1,31 @@
+//! User-facing messaging for config quarantine (#467).
+
+use hole_common::config_store::ConfigRecovery;
+
+/// Kind-neutral: covers both corruption (parse) and unreadable (IO) branches.
+pub const RECOVERY_DIALOG_TITLE: &str = "Settings could not be loaded";
+
+/// Native-dialog body for a config-recovery event. Paths are allowed here:
+/// this is a local native dialog, not a toast (CONTRIBUTING.md "Console relay
+/// and toasts"); the user needs to know where the backup is. The underlying
+/// parse/IO error text stays in `gui.log`.
+pub fn recovery_dialog_message(recovery: &ConfigRecovery) -> String {
+    match &recovery.backup {
+        Ok(bak) => format!(
+            "Hole could not read its settings file, so it is starting with default settings.\n\n\
+             The old file was backed up to:\n{}",
+            bak.display()
+        ),
+        Err(_) => format!(
+            "Hole could not read its settings file, so it is starting with default settings.\n\n\
+             Backing up the old file also failed, so saving settings is disabled until Hole \
+             restarts — otherwise the old file would be overwritten. Move or delete it to fix \
+             this:\n{}",
+            recovery.path.display()
+        ),
+    }
+}
+
+#[cfg(test)]
+#[path = "config_recovery_tests.rs"]
+mod config_recovery_tests;

--- a/crates/hole/src/config_recovery_tests.rs
+++ b/crates/hole/src/config_recovery_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+use hole_common::config::ConfigError;
+use std::path::PathBuf;
+
+fn recovery(backup: Result<PathBuf, std::io::Error>) -> ConfigRecovery {
+    ConfigRecovery {
+        path: PathBuf::from("/cfg/config.json"),
+        error: ConfigError::Read(std::io::Error::other("boom")),
+        backup,
+    }
+}
+
+#[skuld::test]
+fn message_with_backup_names_the_backup_file() {
+    let msg = recovery_dialog_message(&recovery(Ok(PathBuf::from(
+        "/cfg/config.json.2026-06-10T14-23-05Z.bak",
+    ))));
+    assert!(msg.contains("default settings"));
+    assert!(msg.contains("/cfg/config.json.2026-06-10T14-23-05Z.bak"));
+}
+
+#[skuld::test]
+fn message_without_backup_says_saving_is_disabled_and_names_the_original() {
+    let msg = recovery_dialog_message(&recovery(Err(std::io::Error::other("denied"))));
+    assert!(msg.contains("default settings"));
+    assert!(msg.contains("disabled"));
+    assert!(msg.contains("/cfg/config.json"));
+    // The raw error text stays in gui.log, not the dialog.
+    assert!(!msg.contains("denied"));
+    assert!(!msg.contains("boom"));
+}

--- a/crates/hole/src/elevation.rs
+++ b/crates/hole/src/elevation.rs
@@ -61,7 +61,7 @@ pub async fn prompt_elevation(app: &AppHandle, request: BridgeRequest) -> bool {
     {
         let mut config = state.config.lock().unwrap();
         config.elevation_prompt_shown = true;
-        if let Err(e) = config.save(&state.config_path) {
+        if let Err(e) = state.config_store.save(&config) {
             warn!(error = %e, "failed to persist elevation_prompt_shown");
         }
     }

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bridge_client;
 #[macro_use]
 pub mod cli_log;
 pub mod commands;
+pub mod config_recovery;
 pub mod elevation;
 pub mod logging;
 pub mod path_management;

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -128,7 +128,19 @@ fn launch_gui(show_dashboard: bool) {
             // Manage shared state here (instead of pre-`.setup()`) so that
             // `AppState` has access to a real `tauri::AppHandle` for emitting
             // events from commands like `test_server`.
-            app.manage(AppState::new(config_path.clone(), app.handle().clone()));
+            let (config_store, config, recovery) =
+                hole_common::config_store::ConfigStore::load(config_path.clone(), time::OffsetDateTime::now_utc());
+            app.manage(AppState::new(config_store, config, app.handle().clone()));
+            if let Some(recovery) = recovery {
+                // Non-blocking: `blocking_show` must not run on the main
+                // thread, and setup must not stall the event loop.
+                use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+                app.dialog()
+                    .message(hole::config_recovery::recovery_dialog_message(&recovery))
+                    .title(hole::config_recovery::RECOVERY_DIALOG_TITLE)
+                    .kind(MessageDialogKind::Error)
+                    .show(|_| {});
+            }
             app.manage(hole::update::UpdateState::default());
             tray::create_tray(app)?;
             platform::on_setup(app)?;

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -2,6 +2,7 @@
 
 use crate::bridge_client::{BridgeClient, ClientError};
 use hole_common::config::AppConfig;
+use hole_common::config_store::ConfigStore;
 use hole_common::protocol::{BridgeRequest, BridgeResponse};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -10,7 +11,7 @@ use tracing::warn;
 
 /// Shared application state managed by Tauri.
 pub struct AppState {
-    pub config_path: PathBuf,
+    pub config_store: ConfigStore,
     pub config: Mutex<AppConfig>,
     /// Tauri app handle, used by commands that need to emit events
     /// (currently `test_server` → `validation-changed`).
@@ -23,10 +24,9 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(config_path: PathBuf, app_handle: tauri::AppHandle) -> Self {
-        let config = AppConfig::load(&config_path).unwrap_or_default();
+    pub fn new(config_store: ConfigStore, config: AppConfig, app_handle: tauri::AppHandle) -> Self {
         Self {
-            config_path,
+            config_store,
             config: Mutex::new(config),
             app_handle,
             bridge: tokio::sync::Mutex::new(None),

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -197,7 +197,7 @@ fn revert_proxy_state(app: &AppHandle, enabled: bool) {
     {
         let mut config = state.config.lock().unwrap();
         config.enabled = enabled;
-        config.save(&state.config_path).ok();
+        state.config_store.save(&config).ok();
     }
     set_tray_icon(app, enabled);
     rebuild_tray_menu(app);
@@ -237,7 +237,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<ToggleO
             });
         }
         config.enabled = enabled;
-        config.save(&state.config_path).ok();
+        state.config_store.save(&config).ok();
         build_proxy_config(&config)
     };
 


### PR DESCRIPTION
Closes #467.

`AppState::new` discarded `AppConfig::load` errors (`unwrap_or_default`), so a corrupt `config.json` silently became defaults and the next save destroyed it. Now:

- A corrupt/unreadable config is quarantined to `config.json.<timestamp>Z.bak` (atomic rename; copy fallback when the rename is refused — tested on macOS via `chflags uchg` and on Windows via a no-`FILE_SHARE_DELETE` open).
- A native dialog tells the user what happened and where the backup is.
- If quarantine itself fails, saving is disabled for the session (`ConfigError::SaveBlocked`) so the corrupt file can never be overwritten.
- All GUI saves go through the new `ConfigStore` seam (`hole-common`); `AppConfig::save` is clippy-disallowed outside it and `AppConfig::load` is gone.

**Scope notes** (each is an isolated commit — easy to drop if unwanted):
- `fix(config): write config.json atomically via temp-file rename` — truncate-in-place `save()` was the likeliest *source* of the corruption #467 recovers from; included as prevention.
- A valid-JSON-but-foreign object (e.g. `{}`) still loads as defaults without quarantine: `#[serde(default)]` back-compat makes it indistinguishable from a legit old config. Distinguishing would need schema versioning — flagging rather than including.

Local verification: full workspace tests pass except the 9 known-environmental hole-bridge failures on this machine (#485); clippy `--all-targets -D warnings` clean; the new clippy seam lint verified to reject a raw `AppConfig::save` canary.