### PR TITLE
fix: make the Local proxy server master toggle disable listeners (#459)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,10 @@ before editing; the sections linked below are the authoritative source.
   forwarder self-test gates the whole connection. →
   [CONTRIBUTING.md#dns-forwarder](CONTRIBUTING.md#dns-forwarder)
 - **Listener selection invariants.** `build_ss_config` rejects
-  `TunnelRequiresSocks5` / `NoListenersEnabled` / `DuplicateListenerPort`
-  up-front. →
+  `TunnelRequiresSocks5` (full + HTTP-only) / `NoListenersEnabled`
+  (socks-only + none) / `DuplicateListenerPort` up-front; full mode with
+  no listeners is the pure-VPN start (internal SOCKS5 data plane on an
+  ephemeral port). →
   [CONTRIBUTING.md#listener-selection-invariants](CONTRIBUTING.md#listener-selection-invariants)
 - **Bridge trait seam.** All OS-mutating bridge I/O routes through the `Proxy`,
   `Routing`, and `Dns` traits so tests can mock it. →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,11 +105,22 @@ touching routes, system DNS, or the wintun adapter. Guarded by
 `LocalInstanceConfig`s and rejects three combinations up-front (surfaced as
 `BridgeResponse::Error`):
 
-1. `Full && !proxy_socks5` → `TunnelRequiresSocks5` (the TUN dispatcher hands
-   captured traffic to the SOCKS5 listener; without it Full-mode flows vanish).
-1. `!proxy_socks5 && !proxy_http` → `NoListenersEnabled`.
+1. `Full && !proxy_socks5 && proxy_http` → `TunnelRequiresSocks5` (the TUN
+   data plane either rides the user-facing SOCKS5 listener, or — pure-VPN —
+   an internal one on an ephemeral port; a mixed user-facing-HTTP +
+   internal-SOCKS5 split is rejected so the fixed HTTP port never sits
+   inside `bind_ephemeral`'s unbounded retry loop).
+1. `SocksOnly && !proxy_socks5 && !proxy_http` → `NoListenersEnabled`.
 1. `proxy_socks5 && proxy_http && local_port == local_port_http` →
    `DuplicateListenerPort`.
+
+`Full && !proxy_socks5 && !proxy_http` is the **pure-VPN** configuration —
+what the GUI sends when the "Local proxy server" master toggle is off
+(`build_proxy_config` gates both flags on `proxy_server_enabled`, #459):
+`build_ss_config` emits a single SOCKS5 instance on a caller-supplied
+ephemeral loopback port (`proxy_manager::start_inner` allocates it via
+`port_alloc::bind_ephemeral`), the TUN dispatcher and DNS forwarder dial
+that port, and nothing is bound on `local_port` / `local_port_http`.
 
 The HTTP listener's `Mode` is always `TcpOnly` (HTTP CONNECT is TCP-only,
 RFC 7231 §4.3.6); the SOCKS5 listener's is always `TcpAndUdp`.

--- a/crates/bridge/src/proxy.rs
+++ b/crates/bridge/src/proxy.rs
@@ -29,7 +29,7 @@ pub mod config;
 pub mod plugin;
 pub mod shadowsocks;
 
-pub use config::{build_ss_config, ProxyError, TUN_DEVICE_NAME, TUN_SUBNET};
+pub use config::{build_ss_config, validate_proxy_config, ProxyError, TUN_DEVICE_NAME, TUN_SUBNET};
 pub use shadowsocks::{ShadowsocksProxy, ShadowsocksRunning};
 
 // Used by `server_test.rs` + `proxy_tests.rs`. Kept crate-private so

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -57,12 +57,16 @@ pub enum ProxyError {
     /// unknown), preserved for `bridge.log` diagnostics.
     #[error("plugin bind conflict on {addr} (errno {errno})")]
     BindRace { errno: i32, addr: SocketAddr },
-    /// `tunnel_mode == Full` requires the SOCKS5 listener, because the
-    /// TUN dispatcher hands captured traffic to it on `local_port`.
-    #[error("tunnel_mode=full requires the SOCKS5 listener; enable proxy_socks5 or switch to tunnel_mode=socks-only")]
+    /// `tunnel_mode == Full` with the HTTP listener enabled requires the
+    /// user-facing SOCKS5 listener: the TUN data plane either rides the
+    /// user-facing SOCKS5 listener on `local_port`, or — when no
+    /// user-facing listener is requested at all (pure-VPN, #459) — an
+    /// internal one on an ephemeral port. A mixed user-facing-HTTP +
+    /// internal-SOCKS5 split is rejected.
+    #[error("tunnel_mode=full with proxy_http requires the SOCKS5 listener; enable proxy_socks5, or disable proxy_http for a pure-VPN start, or switch to tunnel_mode=socks-only")]
     TunnelRequiresSocks5,
-    /// Both `proxy_socks5` and `proxy_http` are false — there is
-    /// nothing to listen on.
+    /// SocksOnly mode with both `proxy_socks5` and `proxy_http` false —
+    /// there is nothing to listen on and no TUN to serve.
     #[error("no local listeners enabled: at least one of proxy_socks5 / proxy_http must be true")]
     NoListenersEnabled,
     /// Both listeners enabled with identical ports. Each listener needs
@@ -134,15 +138,28 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 /// * **HTTP CONNECT** (`proxy_http`): `127.0.0.1:{local_port_http}`,
 ///   always `TcpOnly` (HTTP CONNECT is TCP-only by RFC 7231 §4.3.6).
 ///
+/// # Pure-VPN starts (#459)
+///
+/// `Full && !proxy_socks5 && !proxy_http` is the pure-VPN configuration
+/// (the GUI's "Local proxy server" master toggle off): no user-facing
+/// listeners, but the TUN data plane still rides an SS SOCKS5 instance.
+/// The caller allocates an ephemeral loopback port (via
+/// `port_alloc::bind_ephemeral`) and passes it as `internal_socks5_port`;
+/// a single SOCKS5 instance is emitted there instead of `local_port`,
+/// so nothing is bound on the user-configured ports.
+/// `internal_socks5_port` must be `Some` exactly on that path — see the
+/// `debug_assert!`s.
+///
 /// # Validation
 ///
-/// Rejected configurations (returns `ProxyError`):
+/// Rejected configurations (returns `ProxyError`, see
+/// [`validate_proxy_config`]):
 ///
-/// 1. `tunnel_mode == Full && !proxy_socks5` — the TUN dispatcher needs
-///    the SOCKS5 listener to exist on `local_port`
+/// 1. `tunnel_mode == Full && !proxy_socks5 && proxy_http` — a mixed
+///    user-facing-HTTP + internal-SOCKS5 split
 ///    (`TunnelRequiresSocks5`).
-/// 2. `!proxy_socks5 && !proxy_http` — nothing to listen on
-///    (`NoListenersEnabled`).
+/// 2. `tunnel_mode == SocksOnly && !proxy_socks5 && !proxy_http` —
+///    nothing to listen on and no TUN to serve (`NoListenersEnabled`).
 /// 3. `proxy_socks5 && proxy_http && local_port == local_port_http` —
 ///    each listener needs its own port (`DuplicateListenerPort`).
 /// 4. Port `0` on an enabled listener (`InvalidListenerPort`).
@@ -157,19 +174,30 @@ pub const TUN_DEVICE_NAME: &str = "hole-tun";
 ///
 /// When `plugin_local` is `None`, the original server address is used as-is
 /// (no plugin, or plugin management is handled elsewhere).
-pub fn build_ss_config(config: &ProxyConfig, plugin_local: Option<SocketAddr>) -> Result<Config, ProxyError> {
-    validate_listeners(config)?;
+pub fn build_ss_config(
+    config: &ProxyConfig,
+    plugin_local: Option<SocketAddr>,
+    internal_socks5_port: Option<u16>,
+) -> Result<Config, ProxyError> {
+    validate_proxy_config(config)?;
+
+    let full = config.tunnel_mode == hole_common::protocol::TunnelMode::Full;
+    // Contract with proxy_manager::start_inner: the internal port exists
+    // exactly when this is a Full-mode pure-VPN start. Production code
+    // structurally upholds this (start_inner's pure-VPN branch always
+    // passes Some); the asserts document the contract for future callers.
+    debug_assert!(
+        internal_socks5_port.is_none() || (full && !config.proxy_socks5),
+        "internal_socks5_port is only meaningful for a Full-mode pure-VPN start"
+    );
+    debug_assert!(
+        !full || config.proxy_socks5 || internal_socks5_port.is_some(),
+        "a Full-mode pure-VPN start must supply internal_socks5_port"
+    );
 
     let entry = &config.server;
 
-    // Validate plugin name (format check, not known-plugin check).
-    if let Some(ref p) = entry.plugin {
-        if !is_valid_plugin_name(p) {
-            return Err(ProxyError::InvalidPluginName(p.clone()));
-        }
-    }
-
-    // Parse cipher method
+    // Parse cipher method (validated by `validate_proxy_config` above).
     let method = entry
         .method
         .parse()
@@ -192,10 +220,17 @@ pub fn build_ss_config(config: &ProxyConfig, plugin_local: Option<SocketAddr>) -
         .server
         .push(ServerInstanceConfig::with_server_config(server_config));
 
-    if config.proxy_socks5 {
+    // User-facing SOCKS5 listener, or — on a Full-mode pure-VPN start —
+    // the internal data-plane instance on the caller-allocated port.
+    let socks5_port = if config.proxy_socks5 {
+        Some(config.local_port)
+    } else {
+        internal_socks5_port
+    };
+    if let Some(port) = socks5_port {
         ss_config.local.push(build_local_instance(
             ProtocolType::Socks,
-            loopback(config.local_port),
+            loopback(port),
             Mode::TcpAndUdp,
         ));
     }
@@ -212,11 +247,40 @@ pub fn build_ss_config(config: &ProxyConfig, plugin_local: Option<SocketAddr>) -
     Ok(ss_config)
 }
 
+/// Typed, side-effect-free validation of everything [`build_ss_config`]
+/// checks: listener invariants, plugin-name format, cipher method.
+/// `proxy_manager::start_inner` runs this before the Full-mode preamble
+/// when the config can only be built later (pure-VPN: the internal
+/// SOCKS5 port arrives from `bind_ephemeral`), so rejects stay fast and
+/// typed.
+pub fn validate_proxy_config(config: &ProxyConfig) -> Result<(), ProxyError> {
+    validate_listeners(config)?;
+    if let Some(ref p) = config.server.plugin {
+        if !is_valid_plugin_name(p) {
+            return Err(ProxyError::InvalidPluginName(p.clone()));
+        }
+    }
+    config
+        .server
+        .method
+        .parse::<shadowsocks::crypto::CipherKind>()
+        .map_err(|_| ProxyError::InvalidMethod(config.server.method.clone()))?;
+    Ok(())
+}
+
 fn validate_listeners(config: &ProxyConfig) -> Result<(), ProxyError> {
-    if config.tunnel_mode == hole_common::protocol::TunnelMode::Full && !config.proxy_socks5 {
+    let full = config.tunnel_mode == hole_common::protocol::TunnelMode::Full;
+    // Full mode with NO user-facing listeners is the pure-VPN
+    // configuration (GUI "Local proxy server" master toggle off): the
+    // TUN data plane binds an internal SOCKS5 instance on an ephemeral
+    // port instead (proxy_manager::start_inner). The mixed split —
+    // user-facing HTTP with an internal SOCKS5 — is rejected: the fixed
+    // HTTP port must not live inside bind_ephemeral's unbounded retry
+    // loop (a genuine conflict on a fixed port must surface, not spin).
+    if full && !config.proxy_socks5 && config.proxy_http {
         return Err(ProxyError::TunnelRequiresSocks5);
     }
-    if !config.proxy_socks5 && !config.proxy_http {
+    if !full && !config.proxy_socks5 && !config.proxy_http {
         return Err(ProxyError::NoListenersEnabled);
     }
     if config.proxy_socks5 && config.local_port == 0 {

--- a/crates/bridge/src/proxy/config_tests.rs
+++ b/crates/bridge/src/proxy/config_tests.rs
@@ -41,7 +41,7 @@ fn sample_config() -> ProxyConfig {
 fn config_with_plugin_local_overrides_server_address() {
     let cfg = sample_config();
     let plugin_local: std::net::SocketAddr = "127.0.0.1:54321".parse().unwrap();
-    let ss_config = build_ss_config(&cfg, Some(plugin_local)).unwrap();
+    let ss_config = build_ss_config(&cfg, Some(plugin_local), None).unwrap();
 
     // Server address should be the plugin's local address, not the original server.
     let svr = &ss_config.server[0].config;
@@ -56,7 +56,7 @@ fn config_with_plugin_local_overrides_server_address() {
 #[skuld::test]
 fn config_without_plugin_local_uses_original_server() {
     let cfg = sample_config();
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
 
     let svr = &ss_config.server[0].config;
     match svr.addr() {
@@ -73,7 +73,7 @@ fn config_with_plugin_local_has_no_plugin_config() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("v2ray-plugin".into());
     let plugin_local: std::net::SocketAddr = "127.0.0.1:54321".parse().unwrap();
-    let ss_config = build_ss_config(&cfg, Some(plugin_local)).unwrap();
+    let ss_config = build_ss_config(&cfg, Some(plugin_local), None).unwrap();
 
     // No PluginConfig should be set — Garter manages the plugin lifecycle.
     let svr = &ss_config.server[0].config;
@@ -85,7 +85,7 @@ fn config_with_plugin_local_has_no_plugin_config() {
 #[skuld::test]
 fn socks5_only_produces_one_socks_local() {
     let cfg = sample_config();
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
 
     assert_eq!(ss_config.local.len(), 1);
     let local = &ss_config.local[0].config;
@@ -103,7 +103,7 @@ fn http_only_produces_one_http_local() {
     cfg.proxy_socks5 = false;
     cfg.proxy_http = true;
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
 
     assert_eq!(ss_config.local.len(), 1);
     let local = &ss_config.local[0].config;
@@ -121,7 +121,7 @@ fn both_enabled_produces_two_locals() {
     let mut cfg = sample_config();
     cfg.proxy_http = true;
     cfg.local_port_http = 4074;
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
 
     assert_eq!(ss_config.local.len(), 2);
     let socks = &ss_config.local[0].config;
@@ -145,7 +145,7 @@ fn http_listener_is_tcp_only_in_full_mode() {
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::Full;
     cfg.proxy_http = true;
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
     let http = ss_config
         .local
         .iter()
@@ -160,7 +160,7 @@ fn socks5_full_mode_is_tcp_and_udp() {
     // use UDP ASSOCIATE.
     let cfg = sample_config();
     assert_eq!(cfg.tunnel_mode, hole_common::protocol::TunnelMode::Full);
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
     let socks = &ss_config.local[0].config;
     assert!(matches!(socks.mode, Mode::TcpAndUdp));
 }
@@ -172,7 +172,7 @@ fn socks5_socks_only_mode_is_tcp_and_udp() {
     // DNS forwarder's UDP path), so the SOCKS5 listener is TcpAndUdp.
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let ss_config = build_ss_config(&cfg, None).unwrap();
+    let ss_config = build_ss_config(&cfg, None, None).unwrap();
     let socks = &ss_config.local[0].config;
     assert!(matches!(socks.mode, Mode::TcpAndUdp));
 }
@@ -185,7 +185,7 @@ fn full_mode_without_socks5_errors() {
     cfg.proxy_socks5 = false;
     cfg.proxy_http = true;
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::Full;
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(
         matches!(err, ProxyError::TunnelRequiresSocks5),
         "expected TunnelRequiresSocks5, got {err:?}"
@@ -198,7 +198,7 @@ fn no_listeners_enabled_errors() {
     cfg.proxy_socks5 = false;
     cfg.proxy_http = false;
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(
         matches!(err, ProxyError::NoListenersEnabled),
         "expected NoListenersEnabled, got {err:?}"
@@ -210,7 +210,7 @@ fn same_port_errors() {
     let mut cfg = sample_config();
     cfg.proxy_http = true;
     cfg.local_port_http = cfg.local_port;
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     match err {
         ProxyError::DuplicateListenerPort { port } => assert_eq!(port, cfg.local_port),
         other => panic!("expected DuplicateListenerPort, got {other:?}"),
@@ -221,7 +221,7 @@ fn same_port_errors() {
 fn port_zero_errors_socks5() {
     let mut cfg = sample_config();
     cfg.local_port = 0;
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     match err {
         ProxyError::InvalidListenerPort { field } => assert_eq!(field, "local_port"),
         other => panic!("expected InvalidListenerPort(local_port), got {other:?}"),
@@ -233,9 +233,45 @@ fn port_zero_errors_http() {
     let mut cfg = sample_config();
     cfg.proxy_http = true;
     cfg.local_port_http = 0;
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     match err {
         ProxyError::InvalidListenerPort { field } => assert_eq!(field, "local_port_http"),
         other => panic!("expected InvalidListenerPort(local_port_http), got {other:?}"),
     }
+}
+
+// Pure-VPN (#459) -----------------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn full_mode_pure_vpn_binds_internal_socks5_only() {
+    let mut cfg = sample_config();
+    cfg.proxy_socks5 = false;
+    cfg.proxy_http = false;
+    let ss_config = build_ss_config(&cfg, None, Some(54321)).unwrap();
+
+    assert_eq!(ss_config.local.len(), 1, "exactly one internal SOCKS5 instance");
+    let socks = &ss_config.local[0].config;
+    assert!(matches!(socks.mode, Mode::TcpAndUdp));
+    let addr = socks.addr.as_ref().expect("local must have addr");
+    match addr {
+        ServerAddr::SocketAddr(s) => {
+            assert_eq!(s.ip(), std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+            assert_eq!(s.port(), 54321);
+        }
+        other => panic!("expected SocketAddr, got {other:?}"),
+    }
+}
+
+#[skuld::test]
+fn full_mode_pure_vpn_ignores_configured_ports() {
+    // With both user-facing listeners off, the configured ports are inert:
+    // port checks are flag-conditioned and the internal instance uses the
+    // caller-allocated port.
+    let mut cfg = sample_config();
+    cfg.proxy_socks5 = false;
+    cfg.proxy_http = false;
+    cfg.local_port = 0;
+    cfg.local_port_http = 0;
+    let ss_config = build_ss_config(&cfg, None, Some(54321)).unwrap();
+    assert_eq!(ss_config.local.len(), 1);
 }

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -460,7 +460,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // Build shadowsocks config. When a plugin chain is running,
         // point ss-service at the chain's local port.
         let plugin_local = plugin_chain.as_ref().map(|c| c.local_addr());
-        let ss_config = build_ss_config(config, plugin_local)?;
+        let ss_config = build_ss_config(config, plugin_local, None)?;
 
         // SocksOnly mode: skip everything routing-related (wintun preload,
         // DNS resolution, gateway detection, route installation). Just start

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -32,8 +32,9 @@
 // to mock state happens via `Arc` clones captured before the mock is
 // handed to `new`. A getter would recreate an encapsulation smell.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::time::Instant;
+use util::port_alloc;
 
 use dump::{dump, DeriveDump};
 use hole_common::protocol::{ProxyConfig, TunnelMode};
@@ -459,8 +460,20 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
 
         // Build shadowsocks config. When a plugin chain is running,
         // point ss-service at the chain's local port.
+        //
+        // Pure-VPN starts (Full mode, no user-facing listeners, #459)
+        // cannot build the config yet — the internal SOCKS5 port is
+        // allocated by bind_ephemeral in phase 2 — so run the same
+        // typed validation now to keep rejects fast and typed, before
+        // any Full-mode preamble work.
         let plugin_local = plugin_chain.as_ref().map(|c| c.local_addr());
-        let ss_config = build_ss_config(config, plugin_local, None)?;
+        let pure_vpn = matches!(config.tunnel_mode, TunnelMode::Full) && !config.proxy_socks5;
+        let ss_config = if pure_vpn {
+            crate::proxy::validate_proxy_config(config)?;
+            None
+        } else {
+            Some(build_ss_config(config, plugin_local, None)?)
+        };
 
         // SocksOnly mode: skip everything routing-related (wintun preload,
         // DNS resolution, gateway detection, route installation). Just start
@@ -468,6 +481,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // local instance, so `shadowsocks-service::local::Server::new` will
         // only bind the SOCKS5 listener.
         if matches!(config.tunnel_mode, TunnelMode::SocksOnly) {
+            let ss_config = ss_config.expect("SocksOnly start always has a prebuilt ss_config");
             debug!(local_count = ss_config.local.len(), "calling proxy.start");
             // Phase 2 (SocksOnly): race proxy.start against cancel.
             let running_proxy = tokio::select! {
@@ -568,10 +582,38 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // Phase 2 (Full mode): start the SS SOCKS5 proxy, racing the
         // start future against cancel. Drop on Running aborts the SS
         // task on cancel via P::Running::drop.
-        let running_proxy = tokio::select! {
-            biased;
-            _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
-            r = proxy.start(ss_config) => r?,
+        //
+        // The TUN data plane rides the user-facing SOCKS5 listener when
+        // it is enabled. On a pure-VPN start (no user-facing listeners,
+        // #459) the internal SOCKS5 instance binds an ephemeral loopback
+        // port instead, so nothing is bound on the user-configured
+        // ports. TCP+UDP: the SOCKS5 instance is always TcpAndUdp.
+        let (socks5_port, running_proxy) = if let Some(ss_config) = ss_config {
+            let running = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
+                r = proxy.start(ss_config) => r?,
+            };
+            (config.local_port, running)
+        } else {
+            let bind = port_alloc::bind_ephemeral(
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                port_alloc::Protocols::TCP | port_alloc::Protocols::UDP,
+                |port| async move {
+                    let ss_config =
+                        build_ss_config(config, plugin_local, Some(port)).map_err(proxy_start_err_to_io_err)?;
+                    proxy.start(ss_config).await.map_err(proxy_start_err_to_io_err)
+                },
+            );
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
+                r = bind => match r {
+                    Ok((port, running)) => (port, running),
+                    Err(_) if cancel.is_cancelled() => return Err(ProxyError::Cancelled),
+                    Err(e) => return Err(ProxyError::Runtime(e)),
+                },
+            }
         };
 
         // Phase 3: build the in-TUN DNS endpoint + forwarder. Err on the
@@ -581,7 +623,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         let (local_dns_endpoint, forwarder) = tokio::select! {
             biased;
             _ = cancel.cancelled() => return Err(ProxyError::Cancelled),
-            r = build_local_dns(&config.dns, config.local_port, gw_info.ipv6_available, cancel.clone()) => r?,
+            r = build_local_dns(&config.dns, socks5_port, gw_info.ipv6_available, cancel.clone()) => r?,
         };
 
         // Phase 4: blocking forwarder self-test gate. Runs synchronously
@@ -613,7 +655,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         #[cfg(not(test))]
         let dispatcher = {
             let d = crate::dispatcher::Dispatcher::new(
-                config.local_port,
+                socks5_port,
                 gw_info.interface_index,
                 gw_info.ipv6_available,
                 config.server.plugin.clone(),
@@ -819,6 +861,25 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 self.ipv6_bypass_available = true;
             }
         }
+    }
+}
+
+// Pure-VPN ephemeral bind =============================================================================================
+
+/// Map errors from a pure-VPN ephemeral bind attempt into `io::Error`
+/// for [`port_alloc::bind_ephemeral`]'s retry classification.
+/// `Runtime` unwraps to its `io::Error` so a genuine listener bind race
+/// (`AddrInUse` from shadowsocks-service's in-process bind) is
+/// classified by `is_bind_race` and retried on a fresh port; every
+/// other variant is deterministic for a given config (validation,
+/// cipher, plugin name) and becomes a non-retryable
+/// `io::Error::other`. The IPC layer surfaces `ProxyError` to clients
+/// as a message string, so wrapping the round-trip in
+/// `ProxyError::Runtime` preserves the user-visible text.
+fn proxy_start_err_to_io_err(e: ProxyError) -> std::io::Error {
+    match e {
+        ProxyError::Runtime(io) => io,
+        other => std::io::Error::other(other.to_string()),
     }
 }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -911,10 +911,9 @@ fn pure_vpn_start_cancellable_during_proxy_start() {
         let err = pm.start_cancellable(&config, token).await.unwrap_err();
         assert!(matches!(err, ProxyError::Cancelled), "expected Cancelled, got {err:?}");
         assert_eq!(pm.state(), ProxyState::Stopped);
-
-        // The gate is still held — release it so the spawned mock task
-        // can drop cleanly.
-        gate.notify_one();
+        // No gate release needed: the cancel drops the parked
+        // `proxy.start` future before it passes the gate, so the mock's
+        // sleeper task is never spawned.
     });
 }
 
@@ -1579,6 +1578,45 @@ mod self_test {
                 "last_error should mention the self-test failure; got {:?}",
                 pm.last_error()
             );
+        });
+    }
+
+    /// Pure-VPN (#459): the resolved ephemeral port — not
+    /// `config.local_port` — must be what `build_local_dns` (and
+    /// `Dispatcher::new`) receive. The regression mode is a swap back to
+    /// `config.local_port` at a consumer call site, which would make the
+    /// forwarder's `Socks5Connector` dial the configured port. Detect it
+    /// by listening on `config.local_port` for the duration of a pure-VPN
+    /// start with the forwarder enabled and asserting zero connection
+    /// attempts. (The start itself fails at the self-test gate either
+    /// way — MockProxy binds nothing — which also guarantees every
+    /// connector dial has completed before the assertion runs.)
+    #[skuld::test]
+    fn pure_vpn_start_never_dials_the_configured_port() {
+        rt().block_on(async {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let configured_port = listener.local_addr().unwrap().port();
+
+            let (mut pm, _dir) = new_manager(MockProxy::new());
+            let mut cfg = test_config();
+            cfg.proxy_socks5 = false;
+            cfg.proxy_http = false;
+            cfg.local_port = configured_port;
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec!["127.0.0.1".parse().unwrap()];
+
+            let err = pm.start_cancellable(&cfg, CancellationToken::new()).await.unwrap_err();
+            assert!(
+                matches!(err, ProxyError::ForwarderSelfTestFailed { .. }),
+                "expected ForwarderSelfTestFailed, got {err:?}"
+            );
+
+            match listener.accept() {
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {} // nothing dialed local_port
+                Ok((_, peer)) => panic!("pure-VPN start dialed the configured local_port (from {peer})"),
+                Err(e) => panic!("unexpected accept error: {e}"),
+            }
         });
     }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -32,6 +32,10 @@ struct MockProxyState {
     /// If true, `MockRunning::is_alive` returns false — used to simulate
     /// a crashed ss task for `check_health_detects_crashed_task`.
     crashed: AtomicBool,
+    /// Last shadowsocks Config passed to `start` — lets tests assert
+    /// which local instances a start produced (e.g. the pure-VPN
+    /// internal ephemeral SOCKS5 instance, #459).
+    last_config: std::sync::Mutex<Option<shadowsocks_service::config::Config>>,
 }
 
 struct MockProxy {
@@ -81,7 +85,8 @@ impl MockProxy {
 impl Proxy for MockProxy {
     type Running = MockRunning;
 
-    async fn start(&self, _config: shadowsocks_service::config::Config) -> Result<MockRunning, ProxyError> {
+    async fn start(&self, config: shadowsocks_service::config::Config) -> Result<MockRunning, ProxyError> {
+        *self.state.last_config.lock().unwrap() = Some(config);
         // Fire entered signal BEFORE awaiting the gate.
         if let Some(tx) = self.start_entered.lock().unwrap().take() {
             let _ = tx.send(());
@@ -845,6 +850,70 @@ fn start_cancellable_dropped_future_runs_guards() {
             "routing.install never ran, so teardown should not have either"
         );
 
+        gate.notify_one();
+    });
+}
+
+// Pure-VPN (#459) =====================================================================================================
+
+#[skuld::test]
+fn pure_vpn_start_binds_internal_ephemeral_socks5() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let state = proxy.start_calls_handle();
+        let (mut pm, _dir) = new_manager(proxy);
+        let mut config = test_config();
+        config.proxy_socks5 = false;
+        config.proxy_http = false;
+
+        pm.start(&config).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+
+        {
+            let guard = state.last_config.lock().unwrap();
+            let ss_config = guard.as_ref().expect("proxy.start captured a config");
+            assert_eq!(ss_config.local.len(), 1, "exactly one internal SOCKS5 instance");
+            let addr = ss_config.local[0].config.addr.as_ref().expect("local must have addr");
+            let sock = match addr {
+                shadowsocks::config::ServerAddr::SocketAddr(s) => *s,
+                other => panic!("expected SocketAddr, got {other:?}"),
+            };
+            assert_eq!(sock.ip(), std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+            assert_ne!(sock.port(), 0, "ephemeral port must be resolved, not 0");
+            assert_ne!(sock.port(), config.local_port, "configured port must stay unused");
+        }
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
+fn pure_vpn_start_cancellable_during_proxy_start() {
+    rt().block_on(async {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let proxy = MockProxy::with_start_gate(gate.clone()).with_entered_signal(entered_tx);
+        let (mut pm, _dir) = new_manager(proxy);
+        let mut config = test_config();
+        config.proxy_socks5 = false;
+        config.proxy_http = false;
+        let token = CancellationToken::new();
+
+        // Fire the cancel once `proxy.start(...)` is *known* to be parked
+        // on the gate (inside the bind_ephemeral op). Deterministic — no
+        // sleep.
+        let cancel_clone = token.clone();
+        tokio::spawn(async move {
+            entered_rx.await.expect("MockProxy::start never entered");
+            cancel_clone.cancel();
+        });
+
+        let err = pm.start_cancellable(&config, token).await.unwrap_err();
+        assert!(matches!(err, ProxyError::Cancelled), "expected Cancelled, got {err:?}");
+        assert_eq!(pm.state(), ProxyState::Stopped);
+
+        // The gate is still held — release it so the spawned mock task
+        // can drop cleanly.
         gate.notify_one();
     });
 }

--- a/crates/bridge/src/proxy_tests.rs
+++ b/crates/bridge/src/proxy_tests.rs
@@ -39,13 +39,13 @@ fn sample_config() -> ProxyConfig {
 
 #[skuld::test]
 fn builds_one_server_entry() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     assert_eq!(ss.server.len(), 1);
 }
 
 #[skuld::test]
 fn server_has_correct_address() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     let srv = &ss.server[0].config;
     assert_eq!(srv.addr().host(), "1.2.3.4");
     assert_eq!(srv.addr().port(), 8388);
@@ -53,13 +53,13 @@ fn server_has_correct_address() {
 
 #[skuld::test]
 fn server_has_correct_password() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     assert_eq!(ss.server[0].config.password(), "secret");
 }
 
 #[skuld::test]
 fn server_has_correct_method() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     let method = ss.server[0].config.method();
     assert_eq!(method.to_string(), "aes-256-gcm");
 }
@@ -68,7 +68,7 @@ fn server_has_correct_method() {
 fn invalid_method_returns_error() {
     let mut cfg = sample_config();
     cfg.server.method = "definitely-not-a-cipher".to_string();
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(matches!(err, ProxyError::InvalidMethod(_)));
 }
 
@@ -76,19 +76,19 @@ fn invalid_method_returns_error() {
 
 #[skuld::test]
 fn creates_one_local_instance() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     assert_eq!(ss.local.len(), 1, "only SOCKS5 local, no TUN");
 }
 
 #[skuld::test]
 fn local_is_socks5() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     assert_eq!(ss.local[0].config.protocol.as_str(), "socks");
 }
 
 #[skuld::test]
 fn full_mode_socks5_is_tcp_and_udp() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     let mode = ss.local[0].config.mode;
     // Mode doesn't impl PartialEq; use Debug string comparison.
     assert_eq!(format!("{mode:?}"), "TcpAndUdp");
@@ -99,14 +99,14 @@ fn socks_only_mode_socks5_is_tcp_and_udp() {
     // Post-#250: SocksOnly listener also exposes UDP-ASSOCIATE.
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     let mode = ss.local[0].config.mode;
     assert_eq!(format!("{mode:?}"), "TcpAndUdp");
 }
 
 #[skuld::test]
 fn socks5_binds_to_localhost_on_configured_port() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     let addr = ss.local[0].config.addr.as_ref().unwrap();
     assert_eq!(addr.host(), "127.0.0.1");
     assert_eq!(addr.port(), 4073);
@@ -116,7 +116,7 @@ fn socks5_binds_to_localhost_on_configured_port() {
 fn socks5_uses_custom_port() {
     let mut cfg = sample_config();
     cfg.local_port = 9999;
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     let addr = ss.local[0].config.addr.as_ref().unwrap();
     assert_eq!(addr.port(), 9999);
 }
@@ -127,7 +127,7 @@ fn socks5_uses_custom_port() {
 fn socks_only_mode_creates_exactly_one_local() {
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     assert_eq!(ss.local.len(), 1, "SocksOnly must skip the TUN local entirely");
 }
 
@@ -135,7 +135,7 @@ fn socks_only_mode_creates_exactly_one_local() {
 fn socks_only_mode_only_local_is_socks5() {
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     assert_eq!(ss.local[0].config.protocol.as_str(), "socks");
 }
 
@@ -144,7 +144,7 @@ fn socks_only_mode_binds_socks5_to_configured_port() {
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
     cfg.local_port = 12345;
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     let addr = ss.local[0].config.addr.as_ref().unwrap();
     assert_eq!(addr.host(), "127.0.0.1");
     assert_eq!(addr.port(), 12345);
@@ -154,7 +154,7 @@ fn socks_only_mode_binds_socks5_to_configured_port() {
 fn socks_only_mode_has_no_tun_local() {
     let mut cfg = sample_config();
     cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     for local in &ss.local {
         assert_ne!(
             local.config.protocol.as_str(),
@@ -169,7 +169,7 @@ fn socks_only_mode_has_no_tun_local() {
 
 #[skuld::test]
 fn no_plugin_when_absent() {
-    let ss = build_ss_config(&sample_config(), None).unwrap();
+    let ss = build_ss_config(&sample_config(), None, None).unwrap();
     assert!(ss.server[0].config.plugin().is_none());
 }
 
@@ -181,7 +181,7 @@ fn no_plugin_config_even_when_plugin_name_present() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("v2ray-plugin".to_string());
     cfg.server.plugin_opts = Some("tls;host=example.com".to_string());
-    let ss = build_ss_config(&cfg, None).unwrap();
+    let ss = build_ss_config(&cfg, None, None).unwrap();
     assert!(ss.server[0].config.plugin().is_none());
 }
 
@@ -191,7 +191,7 @@ fn no_plugin_config_even_when_plugin_name_present() {
 fn plugin_name_with_forward_slash_rejected() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("/usr/bin/evil".to_string());
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(matches!(err, ProxyError::InvalidPluginName(_)));
 }
 
@@ -199,7 +199,7 @@ fn plugin_name_with_forward_slash_rejected() {
 fn plugin_name_with_backslash_rejected() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("..\\evil".to_string());
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(matches!(err, ProxyError::InvalidPluginName(_)));
 }
 
@@ -207,7 +207,7 @@ fn plugin_name_with_backslash_rejected() {
 fn plugin_name_with_null_byte_rejected() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("evil\0".to_string());
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(matches!(err, ProxyError::InvalidPluginName(_)));
 }
 
@@ -215,7 +215,7 @@ fn plugin_name_with_null_byte_rejected() {
 fn plugin_name_empty_rejected() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("".to_string());
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(matches!(err, ProxyError::InvalidPluginName(_)));
 }
 
@@ -223,7 +223,7 @@ fn plugin_name_empty_rejected() {
 fn plugin_name_with_space_rejected() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("evil plugin".to_string());
-    let err = build_ss_config(&cfg, None).unwrap_err();
+    let err = build_ss_config(&cfg, None, None).unwrap_err();
     assert!(matches!(err, ProxyError::InvalidPluginName(_)));
 }
 
@@ -231,7 +231,7 @@ fn plugin_name_with_space_rejected() {
 fn plugin_name_bare_name_accepted() {
     let mut cfg = sample_config();
     cfg.server.plugin = Some("v2ray-plugin".to_string());
-    assert!(build_ss_config(&cfg, None).is_ok());
+    assert!(build_ss_config(&cfg, None, None).is_ok());
 }
 
 // Plugin path resolution tests ========================================================================================

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -353,12 +353,15 @@ components:
       description: |
         Hand-written in protocol.rs — included here for spec completeness.
 
-        At least one of `proxy_socks5` / `proxy_http` must be true. When
-        `tunnel_mode == full`, `proxy_socks5` must be true (the TUN
-        dispatcher hands captured traffic to the SOCKS5 listener on
-        `local_port`). If both listeners are enabled, `local_port` and
-        `local_port_http` must differ. Any violation makes the bridge
-        reject `BridgeRequest::Start` with `BridgeResponse::Error`.
+        Listener rules: in `tunnel_mode == full`, disabling `proxy_socks5`
+        requires `proxy_http` to be disabled too — that combination is a
+        valid "pure-VPN" start where the bridge binds its internal SOCKS5
+        data plane on an ephemeral loopback port and nothing listens on
+        `local_port` / `local_port_http`. In `tunnel_mode == socks-only`,
+        at least one of `proxy_socks5` / `proxy_http` must be true. If
+        both listeners are enabled, `local_port` and `local_port_http`
+        must differ. Any violation makes the bridge reject
+        `BridgeRequest::Start` with `BridgeResponse::Error`.
       required:
         - server
         - local_port
@@ -378,8 +381,9 @@ components:
           type: boolean
           default: true
           description: |
-            Whether to bind a SOCKS5 listener on 127.0.0.1:{local_port}.
-            Must be true when tunnel_mode == full.
+            Whether to bind a user-facing SOCKS5 listener on
+            127.0.0.1:{local_port}. In tunnel_mode == full, false is only
+            valid together with proxy_http == false (pure-VPN start).
         proxy_http:
           type: boolean
           default: false

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -135,6 +135,13 @@ pub struct AppConfig {
     pub start_on_login: bool,
     pub on_startup: StartupBehavior,
     pub theme: Theme,
+    /// Master switch for the user-facing local proxy listeners
+    /// ("Local proxy server" in settings). When false,
+    /// `build_proxy_config` zeroes `proxy_socks5` / `proxy_http` in the
+    /// outgoing `ProxyConfig` and the bridge runs a pure-VPN start: the
+    /// TUN data plane binds an internal ephemeral SOCKS5 instance and
+    /// nothing listens on `local_port` / `local_port_http`. The nested
+    /// toggles keep their persisted values for re-enable.
     pub proxy_server_enabled: bool,
     pub proxy_socks5: bool,
     pub proxy_http: bool,

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -140,11 +140,14 @@ pub struct ProxyConfig {
     /// the forwarder on upgrade.
     #[serde(default)]
     pub dns: crate::config::DnsConfig,
-    /// Whether to bind a SOCKS5 listener on `127.0.0.1:{local_port}`.
-    /// Defaults to `true` so older clients that omit the field keep their
-    /// existing behaviour. Required when `tunnel_mode == Full` (the TUN
-    /// dispatcher in `hole_bridge::dispatcher` hands captured traffic to
-    /// this listener).
+    /// Whether to bind a user-facing SOCKS5 listener on
+    /// `127.0.0.1:{local_port}`. Defaults to `true` so older clients that
+    /// omit the field keep their existing behaviour. In
+    /// `tunnel_mode == Full`, `false` is only valid together with
+    /// `proxy_http == false` — the pure-VPN start (#459), where the TUN
+    /// data plane binds an internal SOCKS5 instance on an ephemeral
+    /// loopback port and nothing listens on `local_port`; `false` with
+    /// `proxy_http == true` is rejected (`TunnelRequiresSocks5`).
     #[serde(default = "proxy_config_defaults::proxy_socks5")]
     pub proxy_socks5: bool,
     /// Whether to bind an HTTP CONNECT listener on

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -61,9 +61,11 @@ pub(crate) enum ProxyAction {
         /// `--local-port` when both listeners are enabled.
         #[arg(long, default_value_t = 4074)]
         local_port_http: u16,
-        /// Disable the SOCKS5 listener (default: enabled). Incompatible
-        /// with `--tunnel-mode full`, since the TUN dispatcher hands
-        /// captured traffic to the SOCKS5 listener.
+        /// Disable the user-facing SOCKS5 listener (default: enabled).
+        /// With `--tunnel-mode full` this requires `--http` to be off
+        /// too (a pure-VPN start: the TUN data plane binds an internal
+        /// SOCKS5 listener on an ephemeral port; nothing listens on
+        /// `--local-port`).
         #[arg(long)]
         no_socks5: bool,
         /// Enable the HTTP CONNECT listener (default: disabled). HTTP

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -494,6 +494,13 @@ pub async fn get_public_ip(state: State<'_, AppState>) -> Result<serde_json::Val
 ///
 /// Always requests [`TunnelMode::Full`]; `TunnelMode::SocksOnly` is reachable
 /// via `hole proxy start --tunnel-mode socks-only` and direct IPC.
+///
+/// The "Local proxy server" master toggle (`proxy_server_enabled`) gates
+/// both listener flags: with it off, the bridge receives
+/// `proxy_socks5 = proxy_http = false` and runs a pure-VPN start — the
+/// TUN data plane binds an internal ephemeral SOCKS5 instance and
+/// nothing listens on `local_port` / `local_port_http` (#459). The
+/// nested toggles keep their persisted values for re-enable.
 pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
     let selected_id = config.selected_server.as_ref()?;
     let entry = config.servers.iter().find(|s| &s.id == selected_id)?;
@@ -503,8 +510,8 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
         tunnel_mode: hole_common::protocol::TunnelMode::Full,
         filters: config.filters.clone(),
         dns: config.dns.clone(),
-        proxy_socks5: config.proxy_socks5,
-        proxy_http: config.proxy_http,
+        proxy_socks5: config.proxy_socks5 && config.proxy_server_enabled,
+        proxy_http: config.proxy_http && config.proxy_server_enabled,
         local_port_http: config.local_port_http,
         diagnostic_plugin_tap: config.diagnostic_plugin_tap,
     })

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -59,6 +59,38 @@ fn build_proxy_config_invalid_selection() {
     assert!(build_proxy_config(&config).is_none());
 }
 
+#[skuld::test]
+fn build_proxy_config_master_toggle_off_disables_listeners() {
+    let config = AppConfig {
+        servers: vec![test_entry("a")],
+        selected_server: Some("a".to_string()),
+        proxy_server_enabled: false,
+        proxy_socks5: true,
+        proxy_http: true,
+        ..Default::default()
+    };
+
+    let pc = build_proxy_config(&config).expect("should return Some");
+    assert!(!pc.proxy_socks5, "master toggle off must disable the SOCKS5 listener");
+    assert!(!pc.proxy_http, "master toggle off must disable the HTTP listener");
+}
+
+#[skuld::test]
+fn build_proxy_config_master_toggle_on_passes_listener_flags() {
+    let config = AppConfig {
+        servers: vec![test_entry("a")],
+        selected_server: Some("a".to_string()),
+        proxy_server_enabled: true,
+        proxy_socks5: true,
+        proxy_http: true,
+        ..Default::default()
+    };
+
+    let pc = build_proxy_config(&config).expect("should return Some");
+    assert!(pc.proxy_socks5);
+    assert!(pc.proxy_http);
+}
+
 // save_config preservation tests ======================================================================================
 
 /// Verify that merging a frontend config (elevation_prompt_shown=false) with


### PR DESCRIPTION
Closes #459.

The "Local proxy server" master toggle persisted `proxy_server_enabled` but no backend code read it — listeners were always bound from `proxy_socks5`/`proxy_http` alone.

Gating the flags in `build_proxy_config` alone would have broken every connect: GUI starts always request full tunnel mode, and the full-mode TUN data plane rides the local SOCKS5 listener (the dispatcher and the DNS forwarder's `Socks5Connector` dial it), enforced as `TunnelRequiresSocks5`. So the fix has two halves:

- **Bridge: pure-VPN starts.** Full mode with `!proxy_socks5 && !proxy_http` is now valid: the internal SOCKS5 data plane binds an ephemeral loopback port via `port_alloc::bind_ephemeral` (the plugin-handoff pattern), threaded to the dispatcher and DNS forwarder. Nothing listens on `local_port`/`local_port_http`. The mixed split (`!proxy_socks5 && proxy_http`) stays rejected so the fixed HTTP port never sits inside `bind_ephemeral`'s unbounded retry loop.
- **GUI gate.** `build_proxy_config` gates both listener flags on `proxy_server_enabled`. Applies on the next connect (flipping the toggle has never sent a bridge request, and still doesn't); a filter-edit reload while connected takes the existing structural-change restart path.

Also intended: `hole proxy start --no-socks5 --tunnel-mode full` (without `--http`) was rejected, and is now a pure-VPN start. No wire change — `ProxyConfig` fields and serde defaults are unchanged, so older clients keep today's behavior.

Verification: new tests pin the pure-VPN `build_ss_config` emission, the master-toggle gating, pure-VPN start/cancel in `proxy_manager`, and that a pure-VPN start never dials the configured port (the last proven discriminating by mutating the consumer call site). `cargo test --workspace`, clippy, and vitest green locally. The `Dispatcher::new` port argument is unreachable under `#[cfg(test)]` (test builds skip dispatcher construction), so its threading is covered by the never-dials test on the DNS side plus review.