### PR TITLE
fix(ui): keyboard accessibility for dashboard controls

### DIFF
--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mainMock: {
+  config: Record<string, unknown> | null;
+  saveConfig: ReturnType<typeof vi.fn<(...args: unknown[]) => void>>;
+} = {
+  config: null,
+  saveConfig: vi.fn<(...args: unknown[]) => void>(),
+};
+vi.mock("./main", () => ({
+  get config() {
+    return mainMock.config;
+  },
+  saveConfig: (...args: unknown[]) => mainMock.saveConfig(...args),
+}));
+
+function pressOn(el: Element, key: string) {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
+beforeEach(() => {
+  mainMock.saveConfig.mockClear();
+  mainMock.config = {
+    filters: [
+      { address: "*", matching: "wildcard", action: "proxy" },
+      { address: "example.com", matching: "exactly", action: "bypass" },
+      { address: "10.0.0.0/8", matching: "subnet", action: "block" },
+    ],
+  };
+  document.body.innerHTML = `
+    <table class="filters-tbl"><tbody id="filter-tbody"></tbody></table>
+    <button type="button" class="filter-add-row" id="filter-add-btn">+ Add rule</button>
+    <input id="test-input" type="text">
+    <div id="test-result"></div>
+  `;
+  vi.resetModules();
+});
+
+async function setup() {
+  const mod = await import("./filters");
+  mod.initFilters();
+  mod.renderFilters();
+  return mod;
+}
+
+function row(index: number): HTMLTableRowElement {
+  return document.querySelector(`tr[data-index="${index}"]`)!;
+}
+
+describe("filter row controls", () => {
+  it("delete is a labelled button on non-default rows; default row keeps the lock", async () => {
+    await setup();
+    const del = row(1).querySelector(".filter-del")!;
+    expect(del.tagName).toBe("BUTTON");
+    expect((del as HTMLButtonElement).type).toBe("button");
+    expect(del.getAttribute("aria-label")).toBe("Delete rule");
+    expect(row(0).querySelector(".filter-del")).toBeNull();
+    expect(row(0).querySelector(".filter-lock")).toBeTruthy();
+  });
+
+  it("matching/action cells contain expandable buttons on non-default rows only", async () => {
+    await setup();
+    for (const field of ["matching", "action"]) {
+      const cp = row(1).querySelector(`td[data-field="${field}"] .cp`)!;
+      expect(cp.tagName).toBe("BUTTON");
+      expect(cp.getAttribute("aria-haspopup")).toBe("listbox");
+      expect(cp.getAttribute("aria-expanded")).toBe("false");
+      expect(row(0).querySelector(`td[data-field="${field}"] .cp`)!.tagName).toBe("DIV");
+    }
+  });
+
+  it("address cell is an editable button on non-default rows only", async () => {
+    await setup();
+    expect(row(1).querySelector(".filter-addr")!.tagName).toBe("BUTTON");
+    expect(row(0).querySelector(".filter-addr")!.tagName).toBe("SPAN");
+  });
+});
+
+describe("filter delete", () => {
+  it("deletes the rule and restores focus to the delete button at the same position", async () => {
+    await setup();
+    const del1 = row(1).querySelector<HTMLElement>(".filter-del")!;
+    del1.focus();
+    del1.click();
+    expect((mainMock.config!.filters as { address: string }[]).map((f) => f.address)).toEqual(["*", "10.0.0.0/8"]);
+    const remaining = document.querySelectorAll<HTMLElement>(".filter-del");
+    expect(remaining).toHaveLength(1);
+    expect(document.activeElement).toBe(remaining[0]);
+  });
+
+  it("falls back to the add button when the last deletable rule goes", async () => {
+    mainMock.config!.filters = [
+      { address: "*", matching: "wildcard", action: "proxy" },
+      { address: "example.com", matching: "exactly", action: "bypass" },
+    ];
+    await setup();
+    const del = row(1).querySelector<HTMLElement>(".filter-del")!;
+    del.focus();
+    del.click();
+    expect(document.activeElement).toBe(document.getElementById("filter-add-btn"));
+  });
+});
+
+describe("filter dropdowns", () => {
+  it("opening sets aria-expanded, renders option buttons, focuses the selected one", async () => {
+    await setup();
+    const cp = row(1).querySelector<HTMLElement>('td[data-field="action"] .cp')!;
+    cp.click();
+    expect(cp.getAttribute("aria-expanded")).toBe("true");
+    const dropdown = row(1).querySelector(".inline-dropdown.open")!;
+    expect(dropdown.getAttribute("role")).toBe("listbox");
+    const opts = [...dropdown.querySelectorAll(".inline-dropdown-opt")];
+    expect(opts).toHaveLength(3);
+    for (const opt of opts) {
+      expect(opt.tagName).toBe("BUTTON");
+      expect(opt.getAttribute("role")).toBe("option");
+      expect(opt.getAttribute("tabindex")).toBe("-1");
+    }
+    expect(document.activeElement).toBe(dropdown.querySelector('[data-value="bypass"]'));
+  });
+
+  it("arrows rove, Escape closes and refocuses the cell button", async () => {
+    await setup();
+    const cp = row(1).querySelector<HTMLElement>('td[data-field="action"] .cp')!;
+    cp.click();
+    pressOn(document.activeElement!, "ArrowDown");
+    expect((document.activeElement as HTMLElement).dataset.value).toBe("block");
+    pressOn(document.activeElement!, "Escape");
+    expect(document.querySelector(".inline-dropdown")).toBeNull();
+    const cpAfter = row(1).querySelector<HTMLElement>('td[data-field="action"] .cp')!;
+    expect(document.activeElement).toBe(cpAfter);
+    expect(cpAfter.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("choosing an option updates config and restores focus to the rebuilt cell button", async () => {
+    await setup();
+    const cp = row(1).querySelector<HTMLElement>('td[data-field="action"] .cp')!;
+    cp.click();
+    (document.querySelector('.inline-dropdown-opt[data-value="block"]') as HTMLElement).click();
+    expect((mainMock.config!.filters as { action: string }[])[1].action).toBe("block");
+    expect(mainMock.saveConfig).toHaveBeenCalled();
+    const rebuilt = row(1).querySelector<HTMLElement>('td[data-field="action"] .cp')!;
+    expect(document.activeElement).toBe(rebuilt);
+    expect(rebuilt.textContent).toContain("Block");
+  });
+
+  it("ArrowDown on the closed cell button opens its dropdown", async () => {
+    await setup();
+    const cp = row(1).querySelector<HTMLElement>('td[data-field="matching"] .cp')!;
+    pressOn(cp, "ArrowDown");
+    expect(row(1).querySelector(".inline-dropdown.open")).toBeTruthy();
+  });
+});
+
+describe("address editing", () => {
+  it("clicking the address button swaps in a focused input; Enter commits and refocuses", async () => {
+    await setup();
+    const addr = row(1).querySelector<HTMLElement>(".filter-addr")!;
+    addr.focus();
+    addr.click();
+    const input = row(1).querySelector<HTMLInputElement>(".inline-input")!;
+    expect(document.activeElement).toBe(input);
+    input.value = "changed.example.com";
+    pressOn(input, "Enter");
+    expect((mainMock.config!.filters as { address: string }[])[1].address).toBe("changed.example.com");
+    const rebuilt = row(1).querySelector<HTMLElement>(".filter-addr")!;
+    expect(rebuilt.textContent).toBe("changed.example.com");
+    expect(document.activeElement).toBe(rebuilt);
+  });
+
+  it("add rule appends an empty rule and focuses its inline input", async () => {
+    await setup();
+    document.getElementById("filter-add-btn")!.click();
+    expect((mainMock.config!.filters as unknown[]).length).toBe(4);
+    const input = document.querySelector<HTMLInputElement>(".inline-input")!;
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -53,9 +53,18 @@ describe("filter row controls", () => {
     const del = row(1).querySelector(".filter-del")!;
     expect(del.tagName).toBe("BUTTON");
     expect((del as HTMLButtonElement).type).toBe("button");
-    expect(del.getAttribute("aria-label")).toBe("Delete rule");
+    // Each delete names its rule — N identical "Delete rule" entries are
+    // indistinguishable when browsing by button.
+    expect(del.getAttribute("aria-label")).toBe("Delete rule for example.com");
     expect(row(0).querySelector(".filter-del")).toBeNull();
     expect(row(0).querySelector(".filter-lock")).toBeTruthy();
+  });
+
+  it("decorative glyphs are hidden from the accessibility tree", async () => {
+    await setup();
+    expect(row(1).querySelector(".drag-handle")!.getAttribute("aria-hidden")).toBe("true");
+    expect(row(1).querySelector('td[data-field="matching"] .chev')!.getAttribute("aria-hidden")).toBe("true");
+    expect(row(1).querySelector('td[data-field="action"] .chev')!.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("matching/action cells contain expandable buttons on non-default rows only", async () => {
@@ -109,6 +118,7 @@ describe("filter dropdowns", () => {
     expect(cp.getAttribute("aria-expanded")).toBe("true");
     const dropdown = row(1).querySelector(".inline-dropdown.open")!;
     expect(dropdown.getAttribute("role")).toBe("listbox");
+    expect(dropdown.getAttribute("aria-label")).toBe("Action");
     const opts = [...dropdown.querySelectorAll(".inline-dropdown-opt")];
     expect(opts).toHaveLength(3);
     for (const opt of opts) {
@@ -174,6 +184,25 @@ describe("address editing", () => {
     expect((mainMock.config!.filters as unknown[]).length).toBe(4);
     const input = document.querySelector<HTMLInputElement>(".inline-input")!;
     expect(document.activeElement).toBe(input);
+  });
+
+  it("blur-commit after clicking a non-focusable area does not steal focus", async () => {
+    // Click-away dismissal: focus drops to <body> before the deferred
+    // commit runs. The edit must be saved, but focus must stay where the
+    // user put it — not jump back into the table.
+    vi.useFakeTimers();
+    try {
+      await setup();
+      row(1).querySelector<HTMLElement>(".filter-addr")!.click();
+      const input = row(1).querySelector<HTMLInputElement>(".inline-input")!;
+      input.value = "kept.example.com";
+      input.blur(); // fires the blur event and moves focus to <body>
+      vi.runAllTimers();
+      expect((mainMock.config!.filters as { address: string }[])[1].address).toBe("kept.example.com");
+      expect(document.activeElement).toBe(document.body);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("blur-commit does not steal focus from a control the user clicked", async () => {

--- a/ui/filters.test.ts
+++ b/ui/filters.test.ts
@@ -175,4 +175,58 @@ describe("address editing", () => {
     const input = document.querySelector<HTMLInputElement>(".inline-input")!;
     expect(document.activeElement).toBe(input);
   });
+
+  it("blur-commit does not steal focus from a control the user clicked", async () => {
+    // Mid-edit on row 1, the user clicks row 2's action cell: the click
+    // opens that cell's dropdown (focusing an option), then the deferred
+    // blur-commit fires and re-renders. Focus must stay with the user's
+    // target, not jump back to row 1's address button.
+    vi.useFakeTimers();
+    try {
+      await setup();
+      row(1).querySelector<HTMLElement>(".filter-addr")!.click();
+      const input = row(1).querySelector<HTMLInputElement>(".inline-input")!;
+      input.value = "edited.example.com";
+      input.dispatchEvent(new Event("blur"));
+      row(2).querySelector<HTMLElement>('td[data-field="action"] .cp')!.click();
+      vi.runAllTimers(); // deferred blur-commit: saves + re-renders
+      expect((mainMock.config!.filters as { address: string }[])[1].address).toBe("edited.example.com");
+      expect(document.activeElement).toBe(row(2).querySelector('td[data-field="action"] .cp'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("external re-renders", () => {
+  // Config reloads re-render the table at any moment; the focused control
+  // must survive the rebuild.
+  it("keeps focus on the same cell button across a re-render", async () => {
+    const mod = await setup();
+    row(1).querySelector<HTMLElement>('td[data-field="matching"] .cp')!.focus();
+    mod.renderFilters();
+    expect(document.activeElement).toBe(row(1).querySelector('td[data-field="matching"] .cp'));
+  });
+
+  it("keeps focus on the same delete button across a re-render", async () => {
+    const mod = await setup();
+    row(2).querySelector<HTMLElement>(".filter-del")!.focus();
+    mod.renderFilters();
+    expect(document.activeElement).toBe(row(2).querySelector(".filter-del"));
+  });
+
+  it("maps a focused address button back to the rebuilt address button", async () => {
+    const mod = await setup();
+    row(1).querySelector<HTMLElement>(".filter-addr")!.focus();
+    mod.renderFilters();
+    expect(document.activeElement).toBe(row(1).querySelector(".filter-addr"));
+  });
+
+  it("does not touch focus when it is outside the table", async () => {
+    const mod = await setup();
+    const outside = document.getElementById("filter-add-btn")!;
+    outside.focus();
+    mod.renderFilters();
+    expect(document.activeElement).toBe(outside);
+  });
 });

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -77,6 +77,27 @@ export function renderFilters() {
   if (!config) return;
   ensureDefaultRule();
 
+  // External re-renders (e.g. config reloads) destroy the focused control
+  // with the rest of the table; remember row + control so the rebuild can
+  // put focus back. A focused inline edit input or dropdown option maps
+  // back to the control that opened it. Captured before closeDropdown()
+  // below removes a focused option.
+  const active = document.activeElement;
+  let restoreSelector: string | null = null;
+  if (active instanceof HTMLElement && tbody.contains(active)) {
+    const index = active.closest("tr")?.dataset.index;
+    if (index !== undefined) {
+      if (active.closest(".filter-del")) {
+        restoreSelector = `tr[data-index="${index}"] .filter-del`;
+      } else if (active.closest(".editable-addr")) {
+        restoreSelector = `tr[data-index="${index}"] .filter-addr`;
+      } else {
+        const field = (active.closest("td") as HTMLTableCellElement | null)?.dataset.field;
+        if (field) restoreSelector = `tr[data-index="${index}"] td[data-field="${field}"] .cp`;
+      }
+    }
+  }
+
   closeDropdown();
   editingIndex = -1;
   tbody.innerHTML = "";
@@ -195,6 +216,8 @@ export function renderFilters() {
     tr.appendChild(tdDel);
     tbody.appendChild(tr);
   }
+
+  if (restoreSelector) tbody.querySelector<HTMLElement>(restoreSelector)?.focus();
 
   // Re-evaluate test filtering after render.
   evaluateTestFilter();

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -2,6 +2,7 @@
 // test filtering, add/delete rules.
 
 import { config, saveConfig } from "./main";
+import { menuKeydown } from "./menu-keys";
 import type { FilterRule } from "./types";
 
 // Constants ===========================================================================================================
@@ -100,10 +101,14 @@ export function renderFilters() {
     handle.textContent = "\u283F"; // ⠿ braille pattern dots-123456
     divAddr.appendChild(handle);
 
-    const addrSpan = document.createElement("span");
-    addrSpan.className = "filter-addr";
-    addrSpan.textContent = rule.address;
-    divAddr.appendChild(addrSpan);
+    // The address is a button on editable rows (activation starts the
+    // inline edit; startAddressEdit swaps exactly this node for the
+    // input, so the button must be the .filter-addr node itself).
+    const addrEl = document.createElement(isDefault ? "span" : "button");
+    if (addrEl instanceof HTMLButtonElement) addrEl.type = "button";
+    addrEl.className = "filter-addr";
+    addrEl.textContent = rule.address;
+    divAddr.appendChild(addrEl);
 
     tdAddr.appendChild(divAddr);
     tr.appendChild(tdAddr);
@@ -113,8 +118,14 @@ export function renderFilters() {
     tdMatch.className = isDefault ? "" : "editable-cell";
     tdMatch.dataset.field = "matching";
 
-    const divMatch = document.createElement("div");
+    const divMatch = document.createElement(isDefault ? "div" : "button");
     divMatch.className = "cp";
+    if (divMatch instanceof HTMLButtonElement) {
+      divMatch.type = "button";
+      divMatch.setAttribute("aria-haspopup", "listbox");
+      divMatch.setAttribute("aria-expanded", "false");
+      wireCellArrowOpen(divMatch, tdMatch, i);
+    }
 
     const matchSpan = document.createElement("span");
     matchSpan.className = "filter-match";
@@ -136,9 +147,15 @@ export function renderFilters() {
     tdAction.className = `${isDefault ? "action-cell" : "action-cell editable-cell"} ${rule.action}`;
     tdAction.dataset.field = "action";
 
-    const divAction = document.createElement("div");
+    const divAction = document.createElement(isDefault ? "div" : "button");
     divAction.className = "cp";
     divAction.textContent = actionLabel(rule.action);
+    if (divAction instanceof HTMLButtonElement) {
+      divAction.type = "button";
+      divAction.setAttribute("aria-haspopup", "listbox");
+      divAction.setAttribute("aria-expanded", "false");
+      wireCellArrowOpen(divAction, tdAction, i);
+    }
 
     if (!isDefault) {
       const chev = document.createElement("span");
@@ -155,10 +172,12 @@ export function renderFilters() {
     tdDel.className = "del-cell";
 
     if (!isDefault) {
-      const delSpan = document.createElement("span");
-      delSpan.className = "filter-del";
-      delSpan.textContent = "\u2715";
-      tdDel.appendChild(delSpan);
+      const delBtn = document.createElement("button");
+      delBtn.type = "button";
+      delBtn.className = "filter-del";
+      delBtn.textContent = "\u2715";
+      delBtn.setAttribute("aria-label", "Delete rule");
+      tdDel.appendChild(delBtn);
     } else {
       // Default wildcard rule — show a lock icon to indicate it cannot be deleted.
       // Inline monochrome SVG to match the UI icon style. Static literal (no
@@ -221,6 +240,7 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
       saveConfig();
     }
     renderFilters();
+    refocusAddrAfterEdit(index);
   }
 
   function cancel() {
@@ -231,6 +251,7 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
       config.filters.splice(index, 1);
     }
     renderFilters();
+    refocusAddrAfterEdit(index);
   }
 
   input.addEventListener("keydown", (e) => {
@@ -273,9 +294,26 @@ function commitOrCancelEditing() {
 /** Close the currently open dropdown. */
 function closeDropdown() {
   if (openDropdown) {
+    openDropdown._td?.querySelector(".cp")?.setAttribute("aria-expanded", "false");
     openDropdown.remove();
     openDropdown = null;
   }
+}
+
+/** Focus the dropdown-cell button of a row after a re-render. */
+function focusCellButton(index: number, field: string) {
+  tbody.querySelector<HTMLElement>(`tr[data-index="${index}"] td[data-field="${field}"] .cp`)?.focus();
+}
+
+/**
+ * Refocus an address button after an edit-triggered re-render — but only
+ * when the re-render actually dropped focus to <body>. Blur-commits caused
+ * by clicking another control must not steal focus back.
+ */
+function refocusAddrAfterEdit(index: number) {
+  if (document.activeElement !== document.body) return;
+  const addr = tbody.querySelector<HTMLElement>(`tr[data-index="${index}"] .filter-addr`);
+  (addr ?? addBtn).focus();
 }
 
 /**
@@ -303,15 +341,22 @@ function toggleDropdown(td: HTMLTableCellElement, index: number) {
 
   const dropdown = document.createElement("div") as HTMLDivElement & { _td?: HTMLTableCellElement };
   dropdown.className = "inline-dropdown open";
+  dropdown.setAttribute("role", "listbox");
   dropdown._td = td; // Tag so we can detect toggle clicks.
 
-  for (const opt of options) {
-    const div = document.createElement("div");
-    div.className = `inline-dropdown-opt${opt.value === currentValue ? " selected" : ""}`;
-    div.textContent = opt.label;
-    div.dataset.value = opt.value;
+  const cellBtn = td.querySelector<HTMLElement>(".cp");
 
-    div.addEventListener("click", (e) => {
+  for (const opt of options) {
+    const optBtn = document.createElement("button");
+    optBtn.type = "button";
+    optBtn.className = `inline-dropdown-opt${opt.value === currentValue ? " selected" : ""}`;
+    optBtn.setAttribute("role", "option");
+    optBtn.setAttribute("aria-selected", String(opt.value === currentValue));
+    optBtn.tabIndex = -1;
+    optBtn.textContent = opt.label;
+    optBtn.dataset.value = opt.value;
+
+    optBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       if (!config) return;
       if (field === "matching") {
@@ -322,13 +367,41 @@ function toggleDropdown(td: HTMLTableCellElement, index: number) {
       saveConfig();
       closeDropdown();
       renderFilters();
+      // The re-render rebuilt the row; keep keyboard users on the cell.
+      focusCellButton(index, field);
     });
 
-    dropdown.appendChild(div);
+    dropdown.appendChild(optBtn);
   }
+
+  dropdown.addEventListener("keydown", (e) => {
+    const opts = [...dropdown.querySelectorAll<HTMLElement>(".inline-dropdown-opt")];
+    menuKeydown(e, opts, () => {
+      closeDropdown();
+      cellBtn?.focus();
+    });
+  });
 
   td.appendChild(dropdown);
   openDropdown = dropdown;
+  cellBtn?.setAttribute("aria-expanded", "true");
+  (
+    dropdown.querySelector<HTMLElement>(".inline-dropdown-opt.selected") ??
+    dropdown.querySelector<HTMLElement>(".inline-dropdown-opt")
+  )?.focus();
+}
+
+/**
+ * Let ArrowDown/ArrowUp on a closed cell button open its dropdown,
+ * mirroring the settings dropdowns.
+ */
+function wireCellArrowOpen(btn: HTMLButtonElement, td: HTMLTableCellElement, index: number) {
+  btn.addEventListener("keydown", (e) => {
+    if ((e.key === "ArrowDown" || e.key === "ArrowUp") && openDropdown?._td !== td) {
+      e.preventDefault();
+      toggleDropdown(td, index);
+    }
+  });
 }
 
 // Drag reorder ========================================================================================================
@@ -565,9 +638,16 @@ function addRule() {
  */
 function deleteRule(index: number) {
   if (index <= 0 || !config?.filters) return; // Cannot delete default rule.
+  // The re-render destroys the focused delete button; remember whether
+  // focus was inside the table so keyboard users stay in place.
+  const hadFocusInTable = tbody.contains(document.activeElement);
   config.filters.splice(index, 1);
   saveConfig();
   renderFilters();
+  if (hadFocusInTable) {
+    const dels = tbody.querySelectorAll<HTMLElement>(".filter-del");
+    (dels[Math.min(index - 1, dels.length - 1)] ?? addBtn).focus();
+  }
 }
 
 // Test filtering ======================================================================================================
@@ -711,9 +791,11 @@ function onTbodyClick(e: MouseEvent) {
   const target = e.target as HTMLElement | null;
   if (!target) return;
 
-  // Delete button.
-  if (target.classList.contains("filter-del")) {
-    const tr = target.closest("tr");
+  // Delete button. closest() instead of an identity check so the button
+  // can gain child nodes without breaking delegation.
+  const delBtn = target.closest(".filter-del");
+  if (delBtn) {
+    const tr = delBtn.closest("tr");
     if (tr) deleteRule(parseInt(tr.dataset.index ?? "", 10));
     return;
   }

--- a/ui/filters.ts
+++ b/ui/filters.ts
@@ -120,6 +120,7 @@ export function renderFilters() {
     const handle = document.createElement("span");
     handle.className = "drag-handle";
     handle.textContent = "\u283F"; // ⠿ braille pattern dots-123456
+    handle.setAttribute("aria-hidden", "true"); // decorative; drag is pointer-only
     divAddr.appendChild(handle);
 
     // The address is a button on editable rows (activation starts the
@@ -157,6 +158,7 @@ export function renderFilters() {
       const chev = document.createElement("span");
       chev.className = "chev";
       chev.textContent = "\u25BE";
+      chev.setAttribute("aria-hidden", "true"); // decorative; keeps it out of the button's name
       divMatch.appendChild(chev);
     }
 
@@ -182,6 +184,7 @@ export function renderFilters() {
       const chev = document.createElement("span");
       chev.className = "chev";
       chev.textContent = "\u25BE";
+      chev.setAttribute("aria-hidden", "true"); // decorative; keeps it out of the button's name
       divAction.appendChild(chev);
     }
 
@@ -197,7 +200,7 @@ export function renderFilters() {
       delBtn.type = "button";
       delBtn.className = "filter-del";
       delBtn.textContent = "\u2715";
-      delBtn.setAttribute("aria-label", "Delete rule");
+      delBtn.setAttribute("aria-label", rule.address ? `Delete rule for ${rule.address}` : "Delete rule");
       tdDel.appendChild(delBtn);
     } else {
       // Default wildcard rule — show a lock icon to indicate it cannot be deleted.
@@ -217,7 +220,9 @@ export function renderFilters() {
     tbody.appendChild(tr);
   }
 
-  if (restoreSelector) tbody.querySelector<HTMLElement>(restoreSelector)?.focus();
+  // preventScroll: restoration preserves tab position invisibly — a
+  // background re-render must not yank the viewport to the element.
+  if (restoreSelector) tbody.querySelector<HTMLElement>(restoreSelector)?.focus({ preventScroll: true });
 
   // Re-evaluate test filtering after render.
   evaluateTestFilter();
@@ -251,6 +256,10 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
 
   function commit() {
     if (editingIndex !== index) return; // Already committed or cancelled.
+    // Refocus eligibility is decided BEFORE the re-render: only an edit
+    // ending with the input still focused (Enter/Escape) may move focus
+    // afterwards — a blur-commit from clicking elsewhere must not.
+    const shouldRefocus = document.activeElement === input;
     editingIndex = -1;
 
     const newValue = input.value.trim();
@@ -263,18 +272,19 @@ function startAddressEdit(td: HTMLTableCellElement, index: number) {
       saveConfig();
     }
     renderFilters();
-    refocusAddrAfterEdit(index);
+    refocusAddrAfterEdit(index, shouldRefocus);
   }
 
   function cancel() {
     if (editingIndex !== index) return;
+    const shouldRefocus = document.activeElement === input;
     editingIndex = -1;
     // If the original address was empty (new rule), remove it.
     if (!original && config?.filters[index]) {
       config.filters.splice(index, 1);
     }
     renderFilters();
-    refocusAddrAfterEdit(index);
+    refocusAddrAfterEdit(index, shouldRefocus);
   }
 
   input.addEventListener("keydown", (e) => {
@@ -329,11 +339,16 @@ function focusCellButton(index: number, field: string) {
 }
 
 /**
- * Refocus an address button after an edit-triggered re-render — but only
- * when the re-render actually dropped focus to <body>. Blur-commits caused
- * by clicking another control must not steal focus back.
+ * Refocus an address button after an edit-triggered re-render.
+ * @param {number} index - The edited rule's index.
+ * @param {boolean} shouldRefocus - Whether the input held focus when the
+ *   edit ended (captured before the re-render). False for blur-commits,
+ *   which must never steal focus from wherever the user clicked.
  */
-function refocusAddrAfterEdit(index: number) {
+function refocusAddrAfterEdit(index: number, shouldRefocus: boolean) {
+  if (!shouldRefocus) return;
+  // renderFilters' own focus capture usually restores the address button
+  // already; this fallback covers a removed row (cancelled new rule).
   if (document.activeElement !== document.body) return;
   const addr = tbody.querySelector<HTMLElement>(`tr[data-index="${index}"] .filter-addr`);
   (addr ?? addBtn).focus();
@@ -365,6 +380,7 @@ function toggleDropdown(td: HTMLTableCellElement, index: number) {
   const dropdown = document.createElement("div") as HTMLDivElement & { _td?: HTMLTableCellElement };
   dropdown.className = "inline-dropdown open";
   dropdown.setAttribute("role", "listbox");
+  dropdown.setAttribute("aria-label", field === "matching" ? "Matching" : "Action");
   dropdown._td = td; // Tag so we can detect toggle clicks.
 
   const cellBtn = td.querySelector<HTMLElement>(".cp");

--- a/ui/global.d.ts
+++ b/ui/global.d.ts
@@ -2,3 +2,10 @@
 // have no runtime type to declare, but TypeScript 6+ rejects them without an
 // explicit module declaration. Vite handles the actual CSS bundling.
 declare module "*.css";
+
+// Vite `?raw` asset imports (used by markup tests to assert on the
+// static index.html) have no ambient type without vite/client.
+declare module "*.html?raw" {
+  const content: string;
+  export default content;
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -14,7 +14,7 @@
       <!-- Servers section -->
       <div>
         <button type="button" class="section-hdr" id="section-servers-hdr" aria-expanded="true" aria-controls="section-servers-clip">
-          <span class="tri">&#x25BC;</span>
+          <span class="tri" aria-hidden="true">&#x25BC;</span>
           <span class="section-label">Servers</span>
         </button>
         <div class="section-clip" id="section-servers-clip">
@@ -30,7 +30,7 @@
       <!-- Filters section -->
       <div>
         <button type="button" class="section-hdr" id="section-filters-hdr" aria-expanded="true" aria-controls="section-filters-clip">
-          <span class="tri">&#x25BC;</span>
+          <span class="tri" aria-hidden="true">&#x25BC;</span>
           <span class="section-label">Filters</span>
         </button>
         <div class="section-clip" id="section-filters-clip">
@@ -70,7 +70,7 @@
       <!-- Settings section -->
       <div>
         <button type="button" class="section-hdr" id="section-settings-hdr" aria-expanded="true" aria-controls="section-settings-clip">
-          <span class="tri">&#x25BC;</span>
+          <span class="tri" aria-hidden="true">&#x25BC;</span>
           <span class="section-label">Settings</span>
         </button>
         <div class="section-clip" id="section-settings-clip">
@@ -86,7 +86,7 @@
                 <span class="setting-label" id="lbl-on-startup">On startup</span>
                 <div class="setting-control">
                   <div class="custom-select-wrap">
-                    <button type="button" class="custom-select-btn" id="select-on-startup" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-on-startup select-on-startup">Do not connect</button>
+                    <button type="button" class="custom-select-btn" id="select-on-startup" aria-haspopup="listbox" aria-controls="menu-on-startup" aria-expanded="false" aria-labelledby="lbl-on-startup select-on-startup">Do not connect</button>
                     <div class="custom-select-menu" id="menu-on-startup" role="listbox" aria-labelledby="lbl-on-startup">
                       <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="do-not-connect">Do not connect</button>
                       <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="restore-last-state">Restore last state</button>
@@ -99,7 +99,7 @@
                 <span class="setting-label" id="lbl-theme">Theme</span>
                 <div class="setting-control">
                   <div class="custom-select-wrap">
-                    <button type="button" class="custom-select-btn" id="select-theme" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-theme select-theme">Dark</button>
+                    <button type="button" class="custom-select-btn" id="select-theme" aria-haspopup="listbox" aria-controls="menu-theme" aria-expanded="false" aria-labelledby="lbl-theme select-theme">Dark</button>
                     <div class="custom-select-menu" id="menu-theme" role="listbox" aria-labelledby="lbl-theme">
                       <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="light">Light</button>
                       <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="dark">Dark</button>
@@ -153,7 +153,7 @@
                   <span class="setting-label" id="lbl-dns-protocol">Protocol</span>
                   <div class="setting-control">
                     <div class="custom-select-wrap">
-                      <button type="button" class="custom-select-btn" id="select-dns-protocol" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-dns-protocol select-dns-protocol">DNS over HTTPS</button>
+                      <button type="button" class="custom-select-btn" id="select-dns-protocol" aria-haspopup="listbox" aria-controls="menu-dns-protocol" aria-expanded="false" aria-labelledby="lbl-dns-protocol select-dns-protocol">DNS over HTTPS</button>
                       <div class="custom-select-menu" id="menu-dns-protocol" role="listbox" aria-labelledby="lbl-dns-protocol">
                         <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="plain-udp">Plain UDP</button>
                         <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="plain-tcp">Plain TCP</button>
@@ -184,7 +184,7 @@
     <div class="sidebar">
       <!-- Status header -->
       <div class="sb-header">
-        <button type="button" class="power-btn off" id="power-btn">
+        <button type="button" class="power-btn off" id="power-btn" aria-label="Toggle connection">
           <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
             <path d="M12 3v8"/>
             <path d="M5.6 6.6a9 9 0 1 0 12.8 0"/>

--- a/ui/index.html
+++ b/ui/index.html
@@ -13,27 +13,27 @@
 
       <!-- Servers section -->
       <div>
-        <div class="section-hdr" id="section-servers-hdr">
+        <button type="button" class="section-hdr" id="section-servers-hdr" aria-expanded="true" aria-controls="section-servers-clip">
           <span class="tri">&#x25BC;</span>
           <span class="section-label">Servers</span>
-        </div>
-        <div class="section-clip">
+        </button>
+        <div class="section-clip" id="section-servers-clip">
           <div class="section-body">
             <div class="server-list" id="server-list">
               <!-- Server cards rendered by JS -->
             </div>
-            <div class="add-zone" id="import-zone">+ Import servers from file</div>
+            <button type="button" class="add-zone" id="import-zone">+ Import servers from file</button>
           </div>
         </div>
       </div>
 
       <!-- Filters section -->
       <div>
-        <div class="section-hdr" id="section-filters-hdr">
+        <button type="button" class="section-hdr" id="section-filters-hdr" aria-expanded="true" aria-controls="section-filters-clip">
           <span class="tri">&#x25BC;</span>
           <span class="section-label">Filters</span>
-        </div>
-        <div class="section-clip">
+        </button>
+        <div class="section-clip" id="section-filters-clip">
           <div class="section-body">
             <table class="filters-tbl">
               <colgroup>
@@ -54,7 +54,7 @@
                 <!-- Filter rows rendered by JS -->
               </tbody>
             </table>
-            <div class="filter-add-row" id="filter-add-btn">+ Add rule</div>
+            <button type="button" class="filter-add-row" id="filter-add-btn">+ Add rule</button>
             <div class="test-filter">
               <div class="test-filter-label">Test filtering</div>
               <div class="test-filter-row">
@@ -69,63 +69,63 @@
 
       <!-- Settings section -->
       <div>
-        <div class="section-hdr" id="section-settings-hdr">
+        <button type="button" class="section-hdr" id="section-settings-hdr" aria-expanded="true" aria-controls="section-settings-clip">
           <span class="tri">&#x25BC;</span>
           <span class="section-label">Settings</span>
-        </div>
-        <div class="section-clip">
+        </button>
+        <div class="section-clip" id="section-settings-clip">
           <div class="section-body">
             <div class="settings-group">
               <div class="setting-row">
-                <span class="setting-label">Start Hole on login</span>
+                <span class="setting-label" id="lbl-start-on-login">Start Hole on login</span>
                 <div class="setting-control">
-                  <div class="toggle" id="toggle-start-on-login"></div>
+                  <button type="button" class="toggle" id="toggle-start-on-login" role="switch" aria-checked="false" aria-labelledby="lbl-start-on-login"></button>
                 </div>
               </div>
               <div class="setting-row">
-                <span class="setting-label">On startup</span>
+                <span class="setting-label" id="lbl-on-startup">On startup</span>
                 <div class="setting-control">
                   <div class="custom-select-wrap">
-                    <div class="custom-select-btn" id="select-on-startup">Do not connect</div>
-                    <div class="custom-select-menu" id="menu-on-startup">
-                      <div class="custom-select-opt selected" data-value="do-not-connect">Do not connect</div>
-                      <div class="custom-select-opt" data-value="restore-last-state">Restore last state</div>
-                      <div class="custom-select-opt" data-value="always-connect">Always connect</div>
+                    <button type="button" class="custom-select-btn" id="select-on-startup" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-on-startup select-on-startup">Do not connect</button>
+                    <div class="custom-select-menu" id="menu-on-startup" role="listbox" aria-labelledby="lbl-on-startup">
+                      <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="do-not-connect">Do not connect</button>
+                      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="restore-last-state">Restore last state</button>
+                      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="always-connect">Always connect</button>
                     </div>
                   </div>
                 </div>
               </div>
               <div class="setting-row">
-                <span class="setting-label">Theme</span>
+                <span class="setting-label" id="lbl-theme">Theme</span>
                 <div class="setting-control">
                   <div class="custom-select-wrap">
-                    <div class="custom-select-btn" id="select-theme">Dark</div>
-                    <div class="custom-select-menu" id="menu-theme">
-                      <div class="custom-select-opt" data-value="light">Light</div>
-                      <div class="custom-select-opt selected" data-value="dark">Dark</div>
-                      <div class="custom-select-opt" data-value="system">System</div>
+                    <button type="button" class="custom-select-btn" id="select-theme" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-theme select-theme">Dark</button>
+                    <div class="custom-select-menu" id="menu-theme" role="listbox" aria-labelledby="lbl-theme">
+                      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="light">Light</button>
+                      <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="dark">Dark</button>
+                      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="system">System</button>
                     </div>
                   </div>
                 </div>
               </div>
               <hr class="setting-divider">
               <div class="setting-row">
-                <span class="setting-label">Local proxy server</span>
+                <span class="setting-label" id="lbl-proxy-server">Local proxy server</span>
                 <div class="setting-control">
-                  <div class="toggle" id="toggle-proxy-server"></div>
+                  <button type="button" class="toggle" id="toggle-proxy-server" role="switch" aria-checked="false" aria-labelledby="lbl-proxy-server"></button>
                 </div>
               </div>
               <div class="setting-nested" id="proxy-nested">
                 <div class="setting-row">
-                  <span class="setting-label">SOCKS5</span>
+                  <span class="setting-label" id="lbl-socks5">SOCKS5</span>
                   <div class="setting-control">
-                    <div class="toggle" id="toggle-socks5"></div>
+                    <button type="button" class="toggle" id="toggle-socks5" role="switch" aria-checked="false" aria-labelledby="lbl-socks5"></button>
                   </div>
                 </div>
                 <div class="setting-row">
-                  <span class="setting-label">HTTP</span>
+                  <span class="setting-label" id="lbl-http">HTTP</span>
                   <div class="setting-control">
-                    <div class="toggle" id="toggle-http"></div>
+                    <button type="button" class="toggle" id="toggle-http" role="switch" aria-checked="false" aria-labelledby="lbl-http"></button>
                   </div>
                 </div>
                 <div class="setting-row">
@@ -143,30 +143,30 @@
               </div>
               <hr class="setting-divider">
               <div class="setting-row">
-                <span class="setting-label">DNS forwarder</span>
+                <span class="setting-label" id="lbl-dns-enabled">DNS forwarder</span>
                 <div class="setting-control">
-                  <div class="toggle" id="toggle-dns-enabled"></div>
+                  <button type="button" class="toggle" id="toggle-dns-enabled" role="switch" aria-checked="false" aria-labelledby="lbl-dns-enabled"></button>
                 </div>
               </div>
               <div class="setting-nested" id="dns-nested">
                 <div class="setting-row">
-                  <span class="setting-label">Protocol</span>
+                  <span class="setting-label" id="lbl-dns-protocol">Protocol</span>
                   <div class="setting-control">
                     <div class="custom-select-wrap">
-                      <div class="custom-select-btn" id="select-dns-protocol">DNS over HTTPS</div>
-                      <div class="custom-select-menu" id="menu-dns-protocol">
-                        <div class="custom-select-opt" data-value="plain-udp">Plain UDP</div>
-                        <div class="custom-select-opt" data-value="plain-tcp">Plain TCP</div>
-                        <div class="custom-select-opt" data-value="tls">DNS over TLS</div>
-                        <div class="custom-select-opt selected" data-value="https">DNS over HTTPS</div>
+                      <button type="button" class="custom-select-btn" id="select-dns-protocol" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-dns-protocol select-dns-protocol">DNS over HTTPS</button>
+                      <div class="custom-select-menu" id="menu-dns-protocol" role="listbox" aria-labelledby="lbl-dns-protocol">
+                        <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="plain-udp">Plain UDP</button>
+                        <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="plain-tcp">Plain TCP</button>
+                        <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="tls">DNS over TLS</button>
+                        <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="https">DNS over HTTPS</button>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div class="setting-row">
-                  <span class="setting-label">Intercept UDP/53 to other servers</span>
+                  <span class="setting-label" id="lbl-dns-intercept">Intercept UDP/53 to other servers</span>
                   <div class="setting-control">
-                    <div class="toggle" id="toggle-dns-intercept"></div>
+                    <button type="button" class="toggle" id="toggle-dns-intercept" role="switch" aria-checked="false" aria-labelledby="lbl-dns-intercept"></button>
                   </div>
                 </div>
                 <div class="setting-row setting-note">
@@ -194,7 +194,7 @@
           <div class="sb-status">You are <strong class="off" id="status-word">Disconnected</strong></div>
           <div class="sb-ip">
             <span class="ip-text" id="ip-text"><span class="country-flag fi fis fi-xx" id="country-flag" title="Unknown"></span> --</span>
-            <span class="copy-btn" id="copy-ip-btn" title="Copy to clipboard">&#x2398;</span>
+            <button type="button" class="copy-btn" id="copy-ip-btn" title="Copy to clipboard" aria-label="Copy IP address to clipboard">&#x2398;</button>
           </div>
         </div>
       </div>

--- a/ui/markup.test.ts
+++ b/ui/markup.test.ts
@@ -45,12 +45,13 @@ describe("custom select dropdowns", () => {
     { btn: "select-theme", menu: "menu-theme" },
     { btn: "select-dns-protocol", menu: "menu-dns-protocol" },
   ];
-  it.each(families)("$btn trigger is a labelled listbox button", ({ btn }) => {
+  it.each(families)("$btn trigger is a labelled listbox button", ({ btn, menu }) => {
     const el = byId(btn);
     expect(el.tagName).toBe("BUTTON");
     expect(el.getAttribute("type")).toBe("button");
     expect(el.getAttribute("aria-haspopup")).toBe("listbox");
     expect(el.getAttribute("aria-expanded")).toBe("false");
+    expect(el.getAttribute("aria-controls")).toBe(menu);
     assertLabelledBy(el);
   });
   it.each(families)("$menu options are focusable option buttons", ({ menu }) => {
@@ -83,6 +84,12 @@ describe("section headers", () => {
     // toggleSection finds the clip via nextElementSibling — pin the structure.
     expect(el.nextElementSibling).toBe(clip);
   });
+
+  it.each(ids)("%s hides its decorative triangle from the accessibility tree", (id) => {
+    // Without aria-hidden the ▼ glyph pollutes the button's accessible
+    // name ("▼ Servers").
+    expect(byId(id).querySelector(".tri")!.getAttribute("aria-hidden")).toBe("true");
+  });
 });
 
 describe("remaining controls", () => {
@@ -101,5 +108,8 @@ describe("remaining controls", () => {
     expect(el.tagName).toBe("BUTTON");
     expect(el.getAttribute("type")).toBe("button");
     expect(el.getAttribute("aria-label")).toBeTruthy();
+  });
+  it("power button has an accessible name (icon-only, SVG is aria-hidden)", () => {
+    expect(byId("power-btn").getAttribute("aria-label")).toBeTruthy();
   });
 });

--- a/ui/markup.test.ts
+++ b/ui/markup.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import html from "./index.html?raw";
+
+// Static-markup accessibility contract for issue #476: every interactive
+// control in index.html must be a real <button> (focusable, native
+// Enter/Space activation) carrying the ARIA state its pattern requires.
+const doc = new DOMParser().parseFromString(html, "text/html");
+
+function byId(id: string): HTMLElement {
+  const el = doc.getElementById(id);
+  if (!el) throw new Error(`#${id} missing from index.html`);
+  return el;
+}
+
+function assertLabelledBy(el: HTMLElement) {
+  const refs = el.getAttribute("aria-labelledby");
+  expect(refs, `${el.id} needs aria-labelledby`).toBeTruthy();
+  for (const ref of refs!.split(" ")) {
+    expect(doc.getElementById(ref), `#${ref} referenced by #${el.id}`).toBeTruthy();
+  }
+}
+
+describe("settings toggles", () => {
+  const ids = [
+    "toggle-start-on-login",
+    "toggle-proxy-server",
+    "toggle-socks5",
+    "toggle-http",
+    "toggle-dns-enabled",
+    "toggle-dns-intercept",
+  ];
+  it.each(ids)("%s is a labelled switch button", (id) => {
+    const el = byId(id);
+    expect(el.tagName).toBe("BUTTON");
+    expect(el.getAttribute("type")).toBe("button");
+    expect(el.getAttribute("role")).toBe("switch");
+    expect(el.getAttribute("aria-checked")).toBe("false");
+    assertLabelledBy(el);
+  });
+});
+
+describe("custom select dropdowns", () => {
+  const families = [
+    { btn: "select-on-startup", menu: "menu-on-startup" },
+    { btn: "select-theme", menu: "menu-theme" },
+    { btn: "select-dns-protocol", menu: "menu-dns-protocol" },
+  ];
+  it.each(families)("$btn trigger is a labelled listbox button", ({ btn }) => {
+    const el = byId(btn);
+    expect(el.tagName).toBe("BUTTON");
+    expect(el.getAttribute("type")).toBe("button");
+    expect(el.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(el.getAttribute("aria-expanded")).toBe("false");
+    assertLabelledBy(el);
+  });
+  it.each(families)("$menu options are focusable option buttons", ({ menu }) => {
+    const m = byId(menu);
+    expect(m.getAttribute("role")).toBe("listbox");
+    const opts = [...m.querySelectorAll(".custom-select-opt")];
+    expect(opts.length).toBeGreaterThan(1);
+    for (const opt of opts) {
+      expect(opt.tagName).toBe("BUTTON");
+      expect(opt.getAttribute("type")).toBe("button");
+      expect(opt.getAttribute("role")).toBe("option");
+      expect(opt.getAttribute("tabindex")).toBe("-1");
+      expect(["true", "false"]).toContain(opt.getAttribute("aria-selected"));
+    }
+    expect(opts.filter((o) => o.getAttribute("aria-selected") === "true")).toHaveLength(1);
+  });
+});
+
+describe("section headers", () => {
+  const ids = ["section-servers-hdr", "section-filters-hdr", "section-settings-hdr"];
+  it.each(ids)("%s is an expanded disclosure button controlling its clip", (id) => {
+    const el = byId(id);
+    expect(el.tagName).toBe("BUTTON");
+    expect(el.getAttribute("type")).toBe("button");
+    expect(el.getAttribute("aria-expanded")).toBe("true");
+    const clipId = el.getAttribute("aria-controls");
+    expect(clipId).toBeTruthy();
+    const clip = doc.getElementById(clipId!);
+    expect(clip?.classList.contains("section-clip")).toBe(true);
+    // toggleSection finds the clip via nextElementSibling — pin the structure.
+    expect(el.nextElementSibling).toBe(clip);
+  });
+});
+
+describe("remaining controls", () => {
+  it("import zone is a button", () => {
+    const el = byId("import-zone");
+    expect(el.tagName).toBe("BUTTON");
+    expect(el.getAttribute("type")).toBe("button");
+  });
+  it("filter add-rule is a button", () => {
+    const el = byId("filter-add-btn");
+    expect(el.tagName).toBe("BUTTON");
+    expect(el.getAttribute("type")).toBe("button");
+  });
+  it("copy-IP is a button with an accessible name", () => {
+    const el = byId("copy-ip-btn");
+    expect(el.tagName).toBe("BUTTON");
+    expect(el.getAttribute("type")).toBe("button");
+    expect(el.getAttribute("aria-label")).toBeTruthy();
+  });
+});

--- a/ui/menu-keys.test.ts
+++ b/ui/menu-keys.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { menuKeydown } from "./menu-keys";
+
+let options: HTMLElement[];
+let close: ReturnType<typeof vi.fn<() => void>>;
+
+function press(key: string): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+  (document.activeElement ?? document.body).dispatchEvent(e);
+  menuKeydown(e, options, close);
+  return e;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="menu">
+      <button type="button" tabindex="-1">One</button>
+      <button type="button" tabindex="-1">Two</button>
+      <button type="button" tabindex="-1">Three</button>
+    </div>
+  `;
+  options = [...document.querySelectorAll<HTMLElement>("#menu button")];
+  close = vi.fn<() => void>();
+});
+
+describe("menuKeydown", () => {
+  it("ArrowDown moves focus to the next option and stops at the last", () => {
+    options[0].focus();
+    press("ArrowDown");
+    expect(document.activeElement).toBe(options[1]);
+    press("ArrowDown");
+    press("ArrowDown");
+    expect(document.activeElement).toBe(options[2]);
+  });
+
+  it("ArrowUp moves focus to the previous option and stops at the first", () => {
+    options[2].focus();
+    press("ArrowUp");
+    expect(document.activeElement).toBe(options[1]);
+    press("ArrowUp");
+    press("ArrowUp");
+    expect(document.activeElement).toBe(options[0]);
+  });
+
+  it("Home and End jump to the first and last options", () => {
+    options[1].focus();
+    press("End");
+    expect(document.activeElement).toBe(options[2]);
+    press("Home");
+    expect(document.activeElement).toBe(options[0]);
+  });
+
+  it("arrow keys prevent default scrolling", () => {
+    options[0].focus();
+    expect(press("ArrowDown").defaultPrevented).toBe(true);
+    expect(press("ArrowUp").defaultPrevented).toBe(true);
+    expect(press("Home").defaultPrevented).toBe(true);
+    expect(press("End").defaultPrevented).toBe(true);
+  });
+
+  it("Escape closes (preventing default), Tab closes without preventing default", () => {
+    options[0].focus();
+    expect(press("Escape").defaultPrevented).toBe(true);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(press("Tab").defaultPrevented).toBe(false);
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores unrelated keys", () => {
+    options[0].focus();
+    press("a");
+    expect(document.activeElement).toBe(options[0]);
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/ui/menu-keys.ts
+++ b/ui/menu-keys.ts
@@ -1,0 +1,40 @@
+// Shared roving-focus keyboard handling for custom dropdown menus
+// (settings custom-selects and the filters table's inline dropdowns).
+// Options carry tabindex="-1" and receive focus programmatically.
+
+/**
+ * Handle a keydown inside an open menu.
+ * @param {KeyboardEvent} e - The keydown event.
+ * @param {HTMLElement[]} options - Menu options in display order.
+ * @param {Function} close - Closes the menu and returns focus to its
+ *   trigger. For Tab, the default action then moves focus onward from
+ *   the trigger, which is why Tab does not preventDefault.
+ */
+export function menuKeydown(e: KeyboardEvent, options: HTMLElement[], close: () => void): void {
+  const i = options.indexOf(document.activeElement as HTMLElement);
+  switch (e.key) {
+    case "ArrowDown":
+      e.preventDefault();
+      options[Math.min(i + 1, options.length - 1)]?.focus();
+      break;
+    case "ArrowUp":
+      e.preventDefault();
+      options[Math.max(i - 1, 0)]?.focus();
+      break;
+    case "Home":
+      e.preventDefault();
+      options[0]?.focus();
+      break;
+    case "End":
+      e.preventDefault();
+      options[options.length - 1]?.focus();
+      break;
+    case "Escape":
+      e.preventDefault();
+      close();
+      break;
+    case "Tab":
+      close();
+      break;
+  }
+}

--- a/ui/sections.test.ts
+++ b/ui/sections.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+// jsdom never fires transitionend on its own; tests dispatch it manually
+// on the clip to drive the cleanup handler (target check is `e.target ===
+// clip`, which a direct dispatch satisfies).
+beforeEach(() => {
+  document.body.innerHTML = `
+    <button type="button" class="section-hdr" id="hdr" aria-expanded="true" aria-controls="clip">
+      <span class="tri">▼</span>
+      <span class="section-label">Servers</span>
+    </button>
+    <div class="section-clip" id="clip"><div class="section-body">content</div></div>
+  `;
+});
+
+describe("section headers", () => {
+  it("click collapses: aria-expanded false, tri rotated, clip collapsed after transition", async () => {
+    const { initSections } = await import("./sections");
+    initSections();
+    const hdr = document.getElementById("hdr")!;
+    const clip = document.getElementById("clip")!;
+    hdr.click();
+    expect(hdr.getAttribute("aria-expanded")).toBe("false");
+    expect(hdr.querySelector(".tri")!.classList.contains("collapsed")).toBe(true);
+    clip.dispatchEvent(new Event("transitionend"));
+    expect(clip.classList.contains("collapsed")).toBe(true);
+  });
+
+  it("second click expands again", async () => {
+    const { initSections } = await import("./sections");
+    initSections();
+    const hdr = document.getElementById("hdr")!;
+    const clip = document.getElementById("clip")!;
+    hdr.click();
+    clip.dispatchEvent(new Event("transitionend"));
+    hdr.click();
+    expect(hdr.getAttribute("aria-expanded")).toBe("true");
+    expect(hdr.querySelector(".tri")!.classList.contains("collapsed")).toBe(false);
+    expect(clip.classList.contains("collapsed")).toBe(false);
+  });
+});

--- a/ui/sections.test.ts
+++ b/ui/sections.test.ts
@@ -38,4 +38,19 @@ describe("section headers", () => {
     expect(hdr.querySelector(".tri")!.classList.contains("collapsed")).toBe(false);
     expect(clip.classList.contains("collapsed")).toBe(false);
   });
+
+  it("collapse makes the clip inert so its controls leave the tab order; expand restores them", async () => {
+    // A collapsed clip is hidden via max-height: 0 + overflow: hidden only —
+    // without inert, the now-focusable buttons inside would remain tab stops
+    // while invisible.
+    const { initSections } = await import("./sections");
+    initSections();
+    const hdr = document.getElementById("hdr")!;
+    const clip = document.getElementById("clip")!;
+    hdr.click();
+    expect(clip.hasAttribute("inert")).toBe(true);
+    clip.dispatchEvent(new Event("transitionend"));
+    hdr.click();
+    expect(clip.hasAttribute("inert")).toBe(false);
+  });
 });

--- a/ui/sections.ts
+++ b/ui/sections.ts
@@ -36,6 +36,7 @@ function toggleSection(hdr: HTMLElement) {
     body.style.transform = "translateY(0)";
     body.style.opacity = "1";
     tri?.classList.remove("collapsed");
+    hdr.setAttribute("aria-expanded", "true");
 
     const cleanup = (e: Event) => {
       // Only react to the max-height transition (not child transitions).
@@ -63,6 +64,7 @@ function toggleSection(hdr: HTMLElement) {
     body.style.transform = "translateY(-100%)";
     body.style.opacity = "0";
     tri?.classList.add("collapsed");
+    hdr.setAttribute("aria-expanded", "false");
 
     const cleanup = (e: Event) => {
       if (e.target !== clip) return;

--- a/ui/sections.ts
+++ b/ui/sections.ts
@@ -20,6 +20,8 @@ function toggleSection(hdr: HTMLElement) {
   if (isCollapsed) {
     // Expand ----------------------------------------------------------------------------------------------------------
     clip.classList.remove("collapsed");
+    // Re-admit the section's controls to the tab order.
+    clip.removeAttribute("inert");
     clip.style.overflow = "hidden";
 
     const h = body.scrollHeight;
@@ -65,6 +67,9 @@ function toggleSection(hdr: HTMLElement) {
     body.style.opacity = "0";
     tri?.classList.add("collapsed");
     hdr.setAttribute("aria-expanded", "false");
+    // The clip is hidden via max-height: 0 + overflow: hidden, which does
+    // NOT remove its now-focusable buttons from the tab order — inert does.
+    clip.setAttribute("inert", "");
 
     const cleanup = (e: Event) => {
       if (e.target !== clip) return;

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mainMock: {
+  config: Record<string, unknown> | null;
+  saveConfig: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<void>>>;
+} = {
+  config: null,
+  saveConfig: vi.fn().mockResolvedValue(undefined),
+};
+const updateDiagnostics = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ message: vi.fn(), open: vi.fn() }));
+vi.mock("./main", () => ({
+  get config() {
+    return mainMock.config;
+  },
+  saveConfig: (...args: unknown[]) => mainMock.saveConfig(...args),
+  loadConfig: vi.fn(),
+  runTestsBounded: vi.fn(),
+  TEST_CONCURRENCY: 3,
+}));
+vi.mock("./sidebar", () => ({ updateDiagnostics: (...args: unknown[]) => updateDiagnostics(...args) }));
+vi.mock("./toast", () => ({ showToast: vi.fn() }));
+
+function server(id: string, name: string) {
+  return { id, name, server: `${id}.example.com`, server_port: 8388, validation: null };
+}
+
+beforeEach(() => {
+  mainMock.saveConfig.mockClear();
+  updateDiagnostics.mockClear();
+  mainMock.config = {
+    servers: [server("a", "Alpha"), server("b", "Beta"), server("c", "Gamma")],
+    selected_server: "a",
+  };
+  document.body.innerHTML = `
+    <div class="server-list" id="server-list"></div>
+    <button type="button" class="add-zone" id="import-zone">+ Import servers from file</button>
+  `;
+  vi.resetModules();
+});
+
+describe("server delete control", () => {
+  it("is a button with an accessible name", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const dels = document.querySelectorAll(".srv-del");
+    expect(dels).toHaveLength(3);
+    expect(dels[0].tagName).toBe("BUTTON");
+    expect((dels[0] as HTMLButtonElement).type).toBe("button");
+    expect(dels[0].getAttribute("aria-label")).toBe("Delete Alpha");
+  });
+
+  it("sits after the Test button in the card's tab order", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const card = document.querySelector(".srv")!;
+    const test = card.querySelector(".srv-test")!;
+    const del = card.querySelector(".srv-del")!;
+    // DOM order is tab order (no positive tabindex anywhere).
+    expect(test.compareDocumentPosition(del) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("deletes without triggering card selection", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const dels = document.querySelectorAll<HTMLElement>(".srv-del");
+    dels[1].click(); // delete Beta (not selected)
+    expect((mainMock.config!.servers as { id: string }[]).map((s) => s.id)).toEqual(["a", "c"]);
+    expect(mainMock.config!.selected_server).toBe("a");
+    // selectServer calls updateDiagnostics; deletion must not.
+    expect(updateDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it("moves focus to the delete button at the same position after deletion", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const dels = document.querySelectorAll<HTMLElement>(".srv-del");
+    dels[0].focus();
+    dels[0].click();
+    const after = document.querySelectorAll<HTMLElement>(".srv-del");
+    expect(after).toHaveLength(2);
+    expect(document.activeElement).toBe(after[0]);
+    expect(after[0].getAttribute("aria-label")).toBe("Delete Beta");
+  });
+
+  it("falls back to the import zone when the last server is deleted", async () => {
+    mainMock.config!.servers = [server("a", "Alpha")];
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const del = document.querySelector<HTMLElement>(".srv-del")!;
+    del.focus();
+    del.click();
+    expect(document.activeElement).toBe(document.getElementById("import-zone"));
+  });
+
+  it("does not steal focus when deletion happens with focus elsewhere", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const outside = document.getElementById("import-zone")!;
+    outside.focus();
+    document.querySelectorAll<HTMLElement>(".srv-del")[1].click();
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -8,8 +8,9 @@ const mainMock: {
   saveConfig: vi.fn().mockResolvedValue(undefined),
 };
 const updateDiagnostics = vi.fn();
+const invokeMock = vi.fn<(...args: unknown[]) => Promise<unknown>>();
 
-vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
 vi.mock("@tauri-apps/plugin-dialog", () => ({ message: vi.fn(), open: vi.fn() }));
 vi.mock("./main", () => ({
   get config() {
@@ -30,6 +31,8 @@ function server(id: string, name: string) {
 beforeEach(() => {
   mainMock.saveConfig.mockClear();
   updateDiagnostics.mockClear();
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
   mainMock.config = {
     servers: [server("a", "Alpha"), server("b", "Beta"), server("c", "Gamma")],
     selected_server: "a",
@@ -102,6 +105,74 @@ describe("server delete control", () => {
     outside.focus();
     document.querySelectorAll<HTMLElement>(".srv-del")[1].click();
     expect(document.activeElement).toBe(outside);
+  });
+});
+
+describe("server test button focus", () => {
+  // Disabling the focused button drops focus to <body> in real browsers
+  // (HTML focus-fixup rule). jsdom implements neither that nor blur() on a
+  // disabled element, so the tests emulate the drop by parking focus on a
+  // temporary input and removing it (removal does reset focus to <body>).
+  function emulateFocusFixupDrop() {
+    const park = document.createElement("input");
+    document.body.appendChild(park);
+    park.focus();
+    park.remove();
+    expect(document.activeElement).toBe(document.body);
+  }
+
+  function pendingTest(): (v: unknown) => void {
+    let resolve!: (v: unknown) => void;
+    invokeMock.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    return resolve;
+  }
+
+  it("returns focus to the Test button when the focus-fixup dropped it to body", async () => {
+    const resolveTest = pendingTest();
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const btn = document.querySelectorAll<HTMLElement>(".srv-test")[1];
+    btn.focus();
+    btn.click();
+    emulateFocusFixupDrop();
+    resolveTest(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.activeElement).toBe(document.querySelectorAll<HTMLElement>(".srv-test")[1]);
+  });
+
+  it("refocuses the rebuilt Test button when the list re-renders mid-test", async () => {
+    const resolveTest = pendingTest();
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const btn = document.querySelectorAll<HTMLElement>(".srv-test")[1];
+    btn.focus();
+    btn.click();
+    emulateFocusFixupDrop();
+    renderServers(); // validation-changed re-render destroys the old button
+    resolveTest(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.activeElement).toBe(document.querySelectorAll<HTMLElement>(".srv-test")[1]);
+  });
+
+  it("does not steal focus if the user moved on during the test", async () => {
+    const resolveTest = pendingTest();
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const btn = document.querySelectorAll<HTMLElement>(".srv-test")[1];
+    btn.focus();
+    btn.click();
+    const elsewhere = document.getElementById("import-zone")!;
+    elsewhere.focus();
+    resolveTest(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.activeElement).toBe(elsewhere);
   });
 });
 

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -104,3 +104,33 @@ describe("server delete control", () => {
     expect(document.activeElement).toBe(outside);
   });
 });
+
+describe("external re-renders", () => {
+  // validation-changed -> loadConfig -> renderServers rebuilds the list at
+  // any moment (e.g. a background server test finishing); the focused
+  // control must survive the rebuild.
+  it("keeps focus on the same server's Test button across a re-render", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelectorAll<HTMLElement>(".srv-test")[1].focus();
+    renderServers();
+    expect(document.activeElement).toBe(document.querySelectorAll<HTMLElement>(".srv-test")[1]);
+  });
+
+  it("keeps focus on the same server's delete button across a re-render", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelectorAll<HTMLElement>(".srv-del")[2].focus();
+    renderServers();
+    expect(document.activeElement).toBe(document.querySelectorAll<HTMLElement>(".srv-del")[2]);
+  });
+
+  it("does not touch focus when it is outside the list", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    const outside = document.getElementById("import-zone")!;
+    outside.focus();
+    renderServers();
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -142,19 +142,26 @@ export function renderServers() {
       });
       card.appendChild(testBtn);
 
-      const del = document.createElement("span");
+      const del = document.createElement("button");
+      del.type = "button";
       del.className = "srv-del";
       del.textContent = "\u2715";
+      del.setAttribute("aria-label", `Delete ${server.name}`);
       card.appendChild(del);
 
-      // Selection: click on card (but not the delete or test controls).
+      // Selection: click on the card. The Test and delete buttons stop
+      // propagation themselves; the status dot is inert but must not
+      // select either.
       card.addEventListener("click", (e) => {
-        if (e.target === del || e.target === testBtn || e.target === statusDot) return;
+        if (e.target === statusDot) return;
         selectServer(server.id);
       });
 
-      // Deletion: click on the X button.
-      del.addEventListener("click", () => {
+      // Deletion: click on the X button. Stop propagation so the card's
+      // selection handler never races the delete (keyboard activation
+      // synthesizes a bubbling click).
+      del.addEventListener("click", (e) => {
+        e.stopPropagation();
         deleteServer(server.id);
       });
 
@@ -179,12 +186,20 @@ async function selectServer(id: string) {
 /** Delete a server by ID — removes it from config, clears selection if needed, re-renders, saves. */
 async function deleteServer(id: string) {
   if (!config) return;
+  const idx = config.servers.findIndex((s) => s.id === id);
+  // The re-render destroys the focused delete button; remember whether
+  // focus was inside the list so we can keep a keyboard user in place.
+  const hadFocusInList = serverList.contains(document.activeElement);
   config.servers = config.servers.filter((s) => s.id !== id);
   if (config.selected_server === id) {
     // Auto-select the first remaining server, or null if none left.
     config.selected_server = config.servers.length > 0 ? config.servers[0].id : null;
   }
   renderServers();
+  if (hadFocusInList) {
+    const dels = serverList.querySelectorAll<HTMLElement>(".srv-del");
+    (dels[Math.min(idx, dels.length - 1)] ?? importZone).focus();
+  }
   await saveConfig();
 }
 

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -65,6 +65,9 @@ export function statusTooltipFor(v: ValidationState | null | undefined): string 
 }
 
 async function runServerTest(id: string, btn: HTMLButtonElement, status: HTMLElement) {
+  // Disabling the focused button drops focus to <body> (HTML focus-fixup
+  // rule); remember so focus can be restored once the test settles.
+  const hadFocus = document.activeElement === btn;
   btn.disabled = true;
   btn.classList.add("loading");
   status.className = "srv-status testing";
@@ -76,7 +79,24 @@ async function runServerTest(id: string, btn: HTMLButtonElement, status: HTMLEle
   } finally {
     btn.disabled = false;
     btn.classList.remove("loading");
+    // Restore only if focus is still orphaned — if the user moved on
+    // mid-test, leave them be. The validation-changed re-render may have
+    // replaced the card, so fall back to the rebuilt button.
+    if (hadFocus && (document.activeElement === document.body || document.activeElement === btn)) {
+      const target = btn.isConnected ? btn : findServerControl(id, ".srv-test");
+      target?.focus({ preventScroll: true });
+    }
   }
+}
+
+/** Find a control inside the rendered card of a given server, if any. */
+function findServerControl(serverId: string, selector: string): HTMLElement | null {
+  // Match by dataset rather than an interpolated attribute selector so
+  // the server id needs no CSS escaping.
+  for (const card of serverList.querySelectorAll<HTMLElement>(".srv")) {
+    if (card.dataset.serverId === serverId) return card.querySelector<HTMLElement>(selector);
+  }
+  return null;
 }
 
 // Rendering ===========================================================================================================
@@ -151,8 +171,7 @@ export function renderServers() {
       testBtn.type = "button";
       testBtn.className = "srv-test";
       testBtn.textContent = "Test";
-      testBtn.addEventListener("click", (e) => {
-        e.stopPropagation(); // do not trigger card selection
+      testBtn.addEventListener("click", () => {
         runServerTest(server.id, testBtn, statusDot);
       });
       card.appendChild(testBtn);
@@ -164,19 +183,17 @@ export function renderServers() {
       del.setAttribute("aria-label", `Delete ${server.name}`);
       card.appendChild(del);
 
-      // Selection: click on the card. The Test and delete buttons stop
-      // propagation themselves; the status dot is inert but must not
-      // select either.
+      // Selection: click on the card, ignoring its own controls and the
+      // inert status dot. Clicks bubble (no stopPropagation) so the
+      // document-level dropdown closers still see them.
       card.addEventListener("click", (e) => {
-        if (e.target === statusDot) return;
+        if ((e.target as HTMLElement | null)?.closest(".srv-test, .srv-del, .srv-status")) return;
         selectServer(server.id);
       });
 
-      // Deletion: click on the X button. Stop propagation so the card's
-      // selection handler never races the delete (keyboard activation
-      // synthesizes a bubbling click).
-      del.addEventListener("click", (e) => {
-        e.stopPropagation();
+      // Deletion: click on the X button (keyboard activation synthesizes a
+      // bubbling click; the card handler above ignores it via closest).
+      del.addEventListener("click", () => {
         deleteServer(server.id);
       });
 
@@ -185,14 +202,9 @@ export function renderServers() {
   }
 
   if (restore) {
-    // Match by dataset rather than an interpolated attribute selector so
-    // the server id needs no CSS escaping.
-    for (const card of serverList.querySelectorAll<HTMLElement>(".srv")) {
-      if (card.dataset.serverId === restore.serverId) {
-        card.querySelector<HTMLElement>(restore.selector)?.focus();
-        break;
-      }
-    }
+    // preventScroll: restoration preserves tab position invisibly — a
+    // background re-render must not yank the viewport to the element.
+    findServerControl(restore.serverId, restore.selector)?.focus({ preventScroll: true });
   }
 }
 

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -88,6 +88,21 @@ async function runServerTest(id: string, btn: HTMLButtonElement, status: HTMLEle
 export function renderServers() {
   if (!config) return;
 
+  // External re-renders (e.g. validation-changed -> loadConfig) destroy the
+  // focused control with the rest of the list; remember which server's
+  // button had focus so the rebuild can put it back.
+  const active = document.activeElement;
+  let restore: { serverId: string; selector: string } | null = null;
+  if (active instanceof HTMLElement && serverList.contains(active)) {
+    const serverId = (active.closest(".srv") as HTMLElement | null)?.dataset.serverId;
+    const selector = active.classList.contains("srv-test")
+      ? ".srv-test"
+      : active.classList.contains("srv-del")
+        ? ".srv-del"
+        : null;
+    if (serverId && selector) restore = { serverId, selector };
+  }
+
   serverList.innerHTML = "";
 
   const servers = config.servers || [];
@@ -166,6 +181,17 @@ export function renderServers() {
       });
 
       serverList.appendChild(card);
+    }
+  }
+
+  if (restore) {
+    // Match by dataset rather than an interpolated attribute selector so
+    // the server id needs no CSS escaping.
+    for (const card of serverList.querySelectorAll<HTMLElement>(".srv")) {
+      if (card.dataset.serverId === restore.serverId) {
+        card.querySelector<HTMLElement>(restore.selector)?.focus();
+        break;
+      }
     }
   }
 }

--- a/ui/settings.test.ts
+++ b/ui/settings.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// settings.ts captures `window.matchMedia(...)` at import time, but jsdom
+// does not implement matchMedia — stub the MediaQueryList surface the theme
+// code uses before the dynamic import runs.
+vi.stubGlobal(
+  "matchMedia",
+  (media: string): MediaQueryList =>
+    ({
+      media,
+      matches: false,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList,
+);
+
+const mainMock: {
+  config: Record<string, unknown> | null;
+  saveConfig: ReturnType<typeof vi.fn<(...args: unknown[]) => void>>;
+} = {
+  config: null,
+  saveConfig: vi.fn<(...args: unknown[]) => void>(),
+};
+vi.mock("./main", () => ({
+  get config() {
+    return mainMock.config;
+  },
+  saveConfig: (...args: unknown[]) => mainMock.saveConfig(...args),
+}));
+
+const SETTINGS_DOM = `
+  <span class="setting-label" id="lbl-start-on-login">Start Hole on login</span>
+  <button type="button" class="toggle" id="toggle-start-on-login" role="switch" aria-checked="false" aria-labelledby="lbl-start-on-login"></button>
+
+  <span class="setting-label" id="lbl-on-startup">On startup</span>
+  <div class="custom-select-wrap">
+    <button type="button" class="custom-select-btn" id="select-on-startup" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-on-startup select-on-startup">Do not connect</button>
+    <div class="custom-select-menu" id="menu-on-startup" role="listbox" aria-labelledby="lbl-on-startup">
+      <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="do-not-connect">Do not connect</button>
+      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="restore-last-state">Restore last state</button>
+      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="always-connect">Always connect</button>
+    </div>
+  </div>
+
+  <span class="setting-label" id="lbl-theme">Theme</span>
+  <div class="custom-select-wrap">
+    <button type="button" class="custom-select-btn" id="select-theme" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-theme select-theme">Dark</button>
+    <div class="custom-select-menu" id="menu-theme" role="listbox" aria-labelledby="lbl-theme">
+      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="light">Light</button>
+      <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="dark">Dark</button>
+      <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="system">System</button>
+    </div>
+  </div>
+
+  <span class="setting-label" id="lbl-proxy-server">Local proxy server</span>
+  <button type="button" class="toggle" id="toggle-proxy-server" role="switch" aria-checked="false" aria-labelledby="lbl-proxy-server"></button>
+  <div class="setting-nested" id="proxy-nested">
+    <span class="setting-label" id="lbl-socks5">SOCKS5</span>
+    <button type="button" class="toggle" id="toggle-socks5" role="switch" aria-checked="false" aria-labelledby="lbl-socks5"></button>
+    <span class="setting-label" id="lbl-http">HTTP</span>
+    <button type="button" class="toggle" id="toggle-http" role="switch" aria-checked="false" aria-labelledby="lbl-http"></button>
+    <input class="field-input" id="input-port" type="text" value="4073">
+    <div id="row-port-http" hidden>
+      <input class="field-input" id="input-port-http" type="text" value="4074">
+    </div>
+  </div>
+
+  <span class="setting-label" id="lbl-dns-enabled">DNS forwarder</span>
+  <button type="button" class="toggle" id="toggle-dns-enabled" role="switch" aria-checked="false" aria-labelledby="lbl-dns-enabled"></button>
+  <div class="setting-nested" id="dns-nested">
+      <span class="setting-label" id="lbl-dns-intercept">Intercept UDP/53 to other servers</span>
+    <span class="setting-label" id="lbl-dns-protocol">Protocol</span>
+    <div class="custom-select-wrap">
+      <button type="button" class="custom-select-btn" id="select-dns-protocol" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-dns-protocol select-dns-protocol">DNS over HTTPS</button>
+      <div class="custom-select-menu" id="menu-dns-protocol" role="listbox" aria-labelledby="lbl-dns-protocol">
+        <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="plain-udp">Plain UDP</button>
+        <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="plain-tcp">Plain TCP</button>
+        <button type="button" class="custom-select-opt" role="option" tabindex="-1" aria-selected="false" data-value="tls">DNS over TLS</button>
+        <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="https">DNS over HTTPS</button>
+      </div>
+    </div>
+    <button type="button" class="toggle" id="toggle-dns-intercept" role="switch" aria-checked="false" aria-labelledby="lbl-dns-intercept"></button>
+  </div>
+`;
+
+function freshConfig(): Record<string, unknown> {
+  return {
+    start_on_login: false,
+    proxy_server_enabled: true,
+    proxy_socks5: true,
+    proxy_http: false,
+    local_port: 4073,
+    local_port_http: 4074,
+    on_startup: "do_not_connect",
+    theme: "dark",
+    dns: { enabled: true, servers: ["1.1.1.1"], protocol: "https", intercept_udp53: true },
+  };
+}
+
+async function setup() {
+  const mod = await import("./settings");
+  mod.initSettings();
+  mod.renderSettings();
+  return mod;
+}
+
+beforeEach(() => {
+  mainMock.saveConfig.mockReset();
+  mainMock.config = freshConfig();
+  document.body.innerHTML = SETTINGS_DOM;
+  vi.resetModules();
+});
+
+describe("settings toggles", () => {
+  it("renderSettings syncs .on and aria-checked from config", async () => {
+    await setup();
+    const proxy = document.getElementById("toggle-proxy-server")!;
+    const login = document.getElementById("toggle-start-on-login")!;
+    expect(proxy.classList.contains("on")).toBe(true);
+    expect(proxy.getAttribute("aria-checked")).toBe("true");
+    expect(login.classList.contains("on")).toBe(false);
+    expect(login.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("click flips class, aria-checked, config, and saves", async () => {
+    await setup();
+    const login = document.getElementById("toggle-start-on-login")!;
+    login.click();
+    expect(login.classList.contains("on")).toBe(true);
+    expect(login.getAttribute("aria-checked")).toBe("true");
+    expect(mainMock.config!.start_on_login).toBe(true);
+    expect(mainMock.saveConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("proxy-server toggle drives nested muting", async () => {
+    await setup();
+    const proxy = document.getElementById("toggle-proxy-server")!;
+    const nested = document.getElementById("proxy-nested")!;
+    expect(nested.classList.contains("muted")).toBe(false);
+    proxy.click();
+    expect(mainMock.config!.proxy_server_enabled).toBe(false);
+    expect(nested.classList.contains("muted")).toBe(true);
+  });
+
+  it("DNS toggles patch config.dns and sync aria-checked", async () => {
+    await setup();
+    const enabled = document.getElementById("toggle-dns-enabled")!;
+    expect(enabled.getAttribute("aria-checked")).toBe("true");
+    enabled.click();
+    expect((mainMock.config!.dns as { enabled: boolean }).enabled).toBe(false);
+    expect(enabled.getAttribute("aria-checked")).toBe("false");
+    expect(document.getElementById("dns-nested")!.classList.contains("muted")).toBe(true);
+
+    const intercept = document.getElementById("toggle-dns-intercept")!;
+    intercept.click();
+    expect((mainMock.config!.dns as { intercept_udp53: boolean }).intercept_udp53).toBe(false);
+    expect(intercept.getAttribute("aria-checked")).toBe("false");
+  });
+});

--- a/ui/settings.test.ts
+++ b/ui/settings.test.ts
@@ -161,3 +161,108 @@ describe("settings toggles", () => {
     expect(intercept.getAttribute("aria-checked")).toBe("false");
   });
 });
+
+function pressOn(el: Element, key: string) {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
+describe("settings dropdowns", () => {
+  it("trigger click opens the menu, sets aria-expanded, focuses the selected option", async () => {
+    await setup();
+    const btn = document.getElementById("select-theme")!;
+    const menu = document.getElementById("menu-theme")!;
+    btn.click();
+    expect(menu.classList.contains("open")).toBe(true);
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement).toBe(menu.querySelector('[data-value="dark"]'));
+  });
+
+  it("ArrowDown on the closed trigger opens and focuses the selected option", async () => {
+    await setup();
+    const btn = document.getElementById("select-theme")!;
+    const menu = document.getElementById("menu-theme")!;
+    pressOn(btn, "ArrowDown");
+    expect(menu.classList.contains("open")).toBe(true);
+    expect(document.activeElement).toBe(menu.querySelector('[data-value="dark"]'));
+  });
+
+  it("arrows move focus between options; Escape closes and refocuses the trigger", async () => {
+    await setup();
+    const btn = document.getElementById("select-theme")!;
+    const menu = document.getElementById("menu-theme")!;
+    btn.click();
+    pressOn(document.activeElement!, "ArrowDown");
+    expect(document.activeElement).toBe(menu.querySelector('[data-value="system"]'));
+    pressOn(document.activeElement!, "ArrowUp");
+    pressOn(document.activeElement!, "ArrowUp");
+    expect(document.activeElement).toBe(menu.querySelector('[data-value="light"]'));
+    pressOn(document.activeElement!, "Escape");
+    expect(menu.classList.contains("open")).toBe(false);
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(btn);
+  });
+
+  it("option click selects: classes, aria-selected, button text, config, focus return", async () => {
+    await setup();
+    const btn = document.getElementById("select-theme")!;
+    const menu = document.getElementById("menu-theme")!;
+    btn.click();
+    (menu.querySelector('[data-value="light"]') as HTMLElement).click();
+    expect(mainMock.config!.theme).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light"); // applyTheme onChange ran
+    expect(btn.textContent).toBe("Light");
+    expect(menu.classList.contains("open")).toBe(false);
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    const light = menu.querySelector('[data-value="light"]')!;
+    const dark = menu.querySelector('[data-value="dark"]')!;
+    expect(light.classList.contains("selected")).toBe(true);
+    expect(light.getAttribute("aria-selected")).toBe("true");
+    expect(dark.getAttribute("aria-selected")).toBe("false");
+    expect(document.activeElement).toBe(btn);
+    expect(mainMock.saveConfig).toHaveBeenCalled();
+  });
+
+  it("DNS protocol dropdown goes through the same path and patches config.dns", async () => {
+    await setup();
+    const btn = document.getElementById("select-dns-protocol")!;
+    const menu = document.getElementById("menu-dns-protocol")!;
+    btn.click();
+    expect(document.activeElement).toBe(menu.querySelector('[data-value="https"]'));
+    (menu.querySelector('[data-value="plain-udp"]') as HTMLElement).click();
+    expect((mainMock.config!.dns as { protocol: string }).protocol).toBe("plain_udp");
+    expect(btn.textContent).toBe("Plain UDP");
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("opening one menu closes others and resets their trigger's aria-expanded", async () => {
+    await setup();
+    const themeBtn = document.getElementById("select-theme")!;
+    const themeMenu = document.getElementById("menu-theme")!;
+    const startBtn = document.getElementById("select-on-startup")!;
+    themeBtn.click();
+    startBtn.click();
+    expect(themeMenu.classList.contains("open")).toBe(false);
+    expect(themeBtn.getAttribute("aria-expanded")).toBe("false");
+    expect(document.getElementById("menu-on-startup")!.classList.contains("open")).toBe(true);
+  });
+
+  it("outside click closes menus without stealing focus", async () => {
+    await setup();
+    const btn = document.getElementById("select-theme")!;
+    const menu = document.getElementById("menu-theme")!;
+    btn.click();
+    document.body.click();
+    expect(menu.classList.contains("open")).toBe(false);
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).not.toBe(btn);
+  });
+
+  it("renderSettings syncs aria-selected from config", async () => {
+    mainMock.config!.theme = "system";
+    await setup();
+    const menu = document.getElementById("menu-theme")!;
+    expect(menu.querySelector('[data-value="system"]')!.getAttribute("aria-selected")).toBe("true");
+    expect(menu.querySelector('[data-value="dark"]')!.getAttribute("aria-selected")).toBe("false");
+    expect(document.getElementById("select-theme")!.textContent).toBe("System");
+  });
+});

--- a/ui/settings.test.ts
+++ b/ui/settings.test.ts
@@ -72,7 +72,6 @@ const SETTINGS_DOM = `
   <span class="setting-label" id="lbl-dns-enabled">DNS forwarder</span>
   <button type="button" class="toggle" id="toggle-dns-enabled" role="switch" aria-checked="false" aria-labelledby="lbl-dns-enabled"></button>
   <div class="setting-nested" id="dns-nested">
-      <span class="setting-label" id="lbl-dns-intercept">Intercept UDP/53 to other servers</span>
     <span class="setting-label" id="lbl-dns-protocol">Protocol</span>
     <div class="custom-select-wrap">
       <button type="button" class="custom-select-btn" id="select-dns-protocol" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="lbl-dns-protocol select-dns-protocol">DNS over HTTPS</button>
@@ -83,6 +82,7 @@ const SETTINGS_DOM = `
         <button type="button" class="custom-select-opt selected" role="option" tabindex="-1" aria-selected="true" data-value="https">DNS over HTTPS</button>
       </div>
     </div>
+    <span class="setting-label" id="lbl-dns-intercept">Intercept UDP/53 to other servers</span>
     <button type="button" class="toggle" id="toggle-dns-intercept" role="switch" aria-checked="false" aria-labelledby="lbl-dns-intercept"></button>
   </div>
 `;

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -321,9 +321,12 @@ export function initSettings() {
 }
 
 /**
- * Wire the DNS forwarder UI. The sub-setting group (`#dns-nested`) mirrors
- * the proxy-server muting pattern: when the enable toggle is off, the
- * nested controls are visually greyed.
+ * Wire the DNS forwarder controls (enable + intercept toggles and the
+ * protocol dropdown). All three persist through `patchDns` because they
+ * live in the nested `config.dns` object, not top-level config keys. The
+ * sub-setting group (`#dns-nested`) mirrors the proxy-server muting
+ * pattern: when the enable toggle is off, the nested controls are
+ * visually greyed.
  */
 function wireDnsControls() {
   wireToggle("toggle-dns-enabled", (on) => patchDns({ enabled: on }));

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -76,21 +76,24 @@ function patchDns(partial: Partial<DnsConfig>) {
 
 // Toggle component ====================================================================================================
 
+/** Apply toggle visual + ARIA state in one place. */
+function setToggleState(el: HTMLElement, on: boolean) {
+  el.classList.toggle("on", on);
+  el.setAttribute("aria-checked", String(on));
+}
+
 /**
- * Wire a toggle switch element.
- * @param {string} id        - Element ID of the `.toggle` div.
- * @param {string} configKey - Key in `config` to read/write (boolean).
- * @param {Function} [onToggle] - Optional callback after state changes.
+ * Wire a toggle switch button.
+ * @param {string} id - Element ID of the `.toggle` button.
+ * @param {Function} apply - Persists the new state (writes config and saves).
  */
-function wireToggle(id: string, configKey: string, onToggle?: (on: boolean) => void) {
+function wireToggle(id: string, apply: (on: boolean) => void) {
   const el = document.getElementById(id)!;
   el.addEventListener("click", () => {
     if (!config) return;
     const on = !el.classList.contains("on");
-    el.classList.toggle("on", on);
-    config[configKey] = on;
-    if (onToggle) onToggle(on);
-    saveConfig();
+    setToggleState(el, on);
+    apply(on);
   });
 }
 
@@ -234,16 +237,25 @@ function handleClickOutside() {
  */
 export function initSettings() {
   // Toggles.
-  wireToggle("toggle-start-on-login", "start_on_login");
-  wireToggle("toggle-proxy-server", "proxy_server_enabled", () => {
+  wireToggle("toggle-start-on-login", (on) => {
+    config!.start_on_login = on;
+    saveConfig();
+  });
+  wireToggle("toggle-proxy-server", (on) => {
+    config!.proxy_server_enabled = on;
     updateProxyMuting();
+    saveConfig();
   });
-  wireToggle("toggle-socks5", "proxy_socks5", () => {
+  wireToggle("toggle-socks5", (on) => {
+    config!.proxy_socks5 = on;
     updatePortConflictMarkers();
+    saveConfig();
   });
-  wireToggle("toggle-http", "proxy_http", () => {
+  wireToggle("toggle-http", (on) => {
+    config!.proxy_http = on;
     updateHttpPortVisibility();
     updatePortConflictMarkers();
+    saveConfig();
   });
 
   // Dropdowns.
@@ -269,19 +281,8 @@ export function initSettings() {
  * nested controls are visually greyed.
  */
 function wireDnsControls() {
-  const enabledEl = document.getElementById("toggle-dns-enabled")!;
-  enabledEl.addEventListener("click", () => {
-    const on = !enabledEl.classList.contains("on");
-    enabledEl.classList.toggle("on", on);
-    patchDns({ enabled: on });
-  });
-
-  const interceptEl = document.getElementById("toggle-dns-intercept")!;
-  interceptEl.addEventListener("click", () => {
-    const on = !interceptEl.classList.contains("on");
-    interceptEl.classList.toggle("on", on);
-    patchDns({ intercept_udp53: on });
-  });
+  wireToggle("toggle-dns-enabled", (on) => patchDns({ enabled: on }));
+  wireToggle("toggle-dns-intercept", (on) => patchDns({ intercept_udp53: on }));
 
   // DNS protocol dropdown — hand-wired (not via wireDropdown) because it
   // patches config.dns, not a top-level config key.
@@ -314,10 +315,10 @@ export function renderSettings() {
   if (!config) return;
 
   // Toggles.
-  document.getElementById("toggle-start-on-login")!.classList.toggle("on", !!config.start_on_login);
-  document.getElementById("toggle-proxy-server")!.classList.toggle("on", !!config.proxy_server_enabled);
-  document.getElementById("toggle-socks5")!.classList.toggle("on", !!config.proxy_socks5);
-  document.getElementById("toggle-http")!.classList.toggle("on", !!config.proxy_http);
+  setToggleState(document.getElementById("toggle-start-on-login")!, !!config.start_on_login);
+  setToggleState(document.getElementById("toggle-proxy-server")!, !!config.proxy_server_enabled);
+  setToggleState(document.getElementById("toggle-socks5")!, !!config.proxy_socks5);
+  setToggleState(document.getElementById("toggle-http")!, !!config.proxy_http);
 
   // Dropdowns.
   syncDropdown("select-on-startup", "menu-on-startup", config.on_startup ?? "do_not_connect");
@@ -334,8 +335,8 @@ export function renderSettings() {
 
   // DNS forwarder state.
   const dns = currentDns();
-  document.getElementById("toggle-dns-enabled")!.classList.toggle("on", dns.enabled);
-  document.getElementById("toggle-dns-intercept")!.classList.toggle("on", dns.intercept_udp53);
+  setToggleState(document.getElementById("toggle-dns-enabled")!, dns.enabled);
+  setToggleState(document.getElementById("toggle-dns-intercept")!, dns.intercept_udp53);
   syncDropdown("select-dns-protocol", "menu-dns-protocol", dns.protocol);
   updateDnsMuting();
 

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -1,6 +1,7 @@
 // Settings section: toggle switches, custom dropdowns, theme switching, proxy + DNS forwarder config.
 
 import { config, saveConfig } from "./main";
+import { menuKeydown } from "./menu-keys";
 import type { DnsConfig, DnsProtocol } from "./types";
 
 const DNS_DEFAULT: DnsConfig = {
@@ -118,45 +119,88 @@ function snakeToKebab(snake: string): string {
 }
 
 /**
- * Wire a custom dropdown.
- * @param {string} btnId     - Element ID of `.custom-select-btn`.
- * @param {string} menuId    - Element ID of `.custom-select-menu`.
- * @param {string} configKey - Key in `config` to read/write (string).
- * @param {Function} [onChange] - Optional callback after selection changes.
+ * Close every open dropdown menu, syncing its trigger's aria-expanded.
+ * The trigger button is the menu's previous sibling inside
+ * `.custom-select-wrap`.
+ * @param {Element} [except] - Menu to leave open.
  */
-function wireDropdown(btnId: string, menuId: string, configKey: string, onChange?: (value: string) => void) {
+function closeAllMenus(except?: Element) {
+  for (const m of document.querySelectorAll(".custom-select-menu.open")) {
+    if (m === except) continue;
+    m.classList.remove("open");
+    m.previousElementSibling?.setAttribute("aria-expanded", "false");
+  }
+}
+
+/**
+ * Wire a custom dropdown (trigger button + listbox menu of option buttons).
+ * Keyboard: Enter/Space/click toggles; ArrowDown/ArrowUp on the closed
+ * trigger opens; arrows/Home/End rove focus in the menu; Enter/Space picks
+ * the focused option (native button click); Escape/Tab closes.
+ * @param {string} btnId  - Element ID of the `.custom-select-btn` button.
+ * @param {string} menuId - Element ID of the `.custom-select-menu` listbox.
+ * @param {Function} apply - Persists the snake_case value (writes config and saves).
+ */
+function wireDropdown(btnId: string, menuId: string, apply: (value: string) => void) {
   const btn = document.getElementById(btnId)!;
   const menu = document.getElementById(menuId)!;
+  const options = [...menu.querySelectorAll<HTMLElement>(".custom-select-opt")];
+
+  const setOpen = (open: boolean) => {
+    menu.classList.toggle("open", open);
+    btn.setAttribute("aria-expanded", String(open));
+  };
+
+  const openAndFocus = () => {
+    closeAllMenus(menu);
+    setOpen(true);
+    (menu.querySelector<HTMLElement>(".custom-select-opt.selected") ?? options[0])?.focus();
+  };
+
+  const close = () => {
+    setOpen(false);
+    btn.focus();
+  };
 
   btn.addEventListener("click", (e) => {
     e.stopPropagation();
-    // Close any other open menus first.
-    for (const m of document.querySelectorAll(".custom-select-menu.open")) {
-      if (m !== menu) m.classList.remove("open");
+    if (menu.classList.contains("open")) {
+      // close() (not bare setOpen): focus may be on a now-hidden option.
+      close();
+    } else {
+      openAndFocus();
     }
-    menu.classList.toggle("open");
   });
 
-  for (const opt of menu.querySelectorAll<HTMLElement>(".custom-select-opt")) {
+  btn.addEventListener("keydown", (e) => {
+    if ((e.key === "ArrowDown" || e.key === "ArrowUp") && !menu.classList.contains("open")) {
+      e.preventDefault();
+      openAndFocus();
+    } else if (e.key === "Escape" && menu.classList.contains("open")) {
+      close();
+    }
+  });
+
+  menu.addEventListener("keydown", (e) => menuKeydown(e, options, close));
+
+  for (const opt of options) {
     opt.addEventListener("click", (e) => {
       e.stopPropagation();
       if (!config) return;
 
       // Update selected state.
-      for (const o of menu.querySelectorAll(".custom-select-opt")) {
+      for (const o of options) {
         o.classList.remove("selected");
+        o.setAttribute("aria-selected", "false");
       }
       opt.classList.add("selected");
+      opt.setAttribute("aria-selected", "true");
 
-      // Update button text and close menu.
+      // Update button text, close, and return focus to the trigger.
       btn.textContent = opt.textContent;
-      menu.classList.remove("open");
+      close();
 
-      // Update config.
-      const value = kebabToSnake(opt.dataset.value ?? "");
-      config[configKey] = value;
-      if (onChange) onChange(value);
-      saveConfig();
+      apply(kebabToSnake(opt.dataset.value ?? ""));
     });
   }
 }
@@ -223,11 +267,7 @@ function updatePortConflictMarkers() {
 // Click-outside handler ===============================================================================================
 
 function handleClickOutside() {
-  document.addEventListener("click", () => {
-    for (const menu of document.querySelectorAll(".custom-select-menu.open")) {
-      menu.classList.remove("open");
-    }
-  });
+  document.addEventListener("click", () => closeAllMenus());
 }
 
 // Public API ==========================================================================================================
@@ -259,9 +299,14 @@ export function initSettings() {
   });
 
   // Dropdowns.
-  wireDropdown("select-on-startup", "menu-on-startup", "on_startup");
-  wireDropdown("select-theme", "menu-theme", "theme", (value) => {
+  wireDropdown("select-on-startup", "menu-on-startup", (value) => {
+    config!.on_startup = value;
+    saveConfig();
+  });
+  wireDropdown("select-theme", "menu-theme", (value) => {
+    config!.theme = value;
     applyTheme(value);
+    saveConfig();
   });
 
   // Port inputs.
@@ -284,27 +329,11 @@ function wireDnsControls() {
   wireToggle("toggle-dns-enabled", (on) => patchDns({ enabled: on }));
   wireToggle("toggle-dns-intercept", (on) => patchDns({ intercept_udp53: on }));
 
-  // DNS protocol dropdown — hand-wired (not via wireDropdown) because it
-  // patches config.dns, not a top-level config key.
-  const btn = document.getElementById("select-dns-protocol")!;
-  const menu = document.getElementById("menu-dns-protocol")!;
-  btn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    for (const m of document.querySelectorAll(".custom-select-menu.open")) {
-      if (m !== menu) m.classList.remove("open");
-    }
-    menu.classList.toggle("open");
+  // The protocol dropdown patches config.dns rather than a top-level key;
+  // the apply callback absorbs that difference.
+  wireDropdown("select-dns-protocol", "menu-dns-protocol", (value) => {
+    patchDns({ protocol: value as DnsProtocol });
   });
-  for (const opt of menu.querySelectorAll<HTMLElement>(".custom-select-opt")) {
-    opt.addEventListener("click", (e) => {
-      e.stopPropagation();
-      for (const o of menu.querySelectorAll(".custom-select-opt")) o.classList.remove("selected");
-      opt.classList.add("selected");
-      btn.textContent = opt.textContent;
-      menu.classList.remove("open");
-      patchDns({ protocol: kebabToSnake(opt.dataset.value ?? "") as DnsProtocol });
-    });
-  }
 }
 
 /**
@@ -356,11 +385,9 @@ function syncDropdown(btnId: string, menuId: string, configVal: string) {
   const dataVal = snakeToKebab(configVal);
 
   for (const opt of menu.querySelectorAll<HTMLElement>(".custom-select-opt")) {
-    if (opt.dataset.value === dataVal) {
-      opt.classList.add("selected");
-      btn.textContent = opt.textContent;
-    } else {
-      opt.classList.remove("selected");
-    }
+    const selected = opt.dataset.value === dataVal;
+    opt.classList.toggle("selected", selected);
+    opt.setAttribute("aria-selected", String(selected));
+    if (selected) btn.textContent = opt.textContent;
   }
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -611,6 +611,10 @@ order. (0,2,0) > (0,1,0). */
 
 .section-clip.collapsed {
   max-height: 0;
+  /* Belt-and-braces with the inert attribute set by toggleSection:
+   * visibility removes descendants from the tab order on engines too old
+   * for inert. Set only once fully collapsed, so the slide-out animates. */
+  visibility: hidden;
 }
 
 .section-body {
@@ -1164,6 +1168,9 @@ td.del-cell {
 
 /* Settings: toggle switch -----  */
 .toggle {
+  /* Block like the div it replaced: an empty inline-block button adds the
+   * line-box strut below its baseline, growing every settings row. */
+  display: block;
   width: 36px;
   height: 20px;
   background: var(--toggle-track);

--- a/ui/style.css
+++ b/ui/style.css
@@ -127,6 +127,35 @@
   padding: 0;
 }
 
+/* Buttons: interactive controls are real <button>s for keyboard access
+ * (#476). Strip the UA chrome once here at type-selector specificity;
+ * per-class rules layer their own backgrounds/borders on top. */
+button {
+  appearance: none;
+  background: none;
+  border: none;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Inset the ring for controls inside clipped containers (dropdown menus,
+ * table cells) so overflow: hidden does not cut it off. */
+.custom-select-opt:focus-visible,
+.inline-dropdown-opt:focus-visible,
+.cp:focus-visible,
+.filter-addr:focus-visible,
+.filter-del:focus-visible,
+.toast-close:focus-visible {
+  outline-offset: -2px;
+}
+
 html,
 body {
   height: 100%;
@@ -355,6 +384,11 @@ order. (0,2,0) > (0,1,0). */
   color: var(--text-tertiary);
 }
 
+.sb-ip .copy-btn:focus-visible {
+  opacity: 1;
+  color: var(--text-tertiary);
+}
+
 .country-flag {
   /* Sizing (1em x 1em via .fi.fis) and background-image are owned by
    * flag-icons; only layout-affecting properties live here. */
@@ -533,6 +567,7 @@ order. (0,2,0) > (0,1,0). */
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  width: 100%;
   cursor: pointer;
   user-select: none;
   padding-bottom: 0.3rem;
@@ -551,6 +586,10 @@ order. (0,2,0) > (0,1,0). */
 }
 
 .section-hdr:hover .tri {
+  color: var(--text-tertiary);
+}
+
+.section-hdr:focus-visible .tri {
   color: var(--text-tertiary);
 }
 
@@ -720,6 +759,7 @@ order. (0,2,0) > (0,1,0). */
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  width: 100%;
   color: var(--text-faint);
   font-size: 0.75rem;
   cursor: pointer;
@@ -805,6 +845,10 @@ order. (0,2,0) > (0,1,0). */
   background: var(--bg-hover);
 }
 
+.filters-tbl tbody tr:focus-within {
+  background: var(--bg-hover);
+}
+
 .filters-tbl tbody tr.drag-placeholder:hover {
   background: transparent;
 }
@@ -815,6 +859,8 @@ order. (0,2,0) > (0,1,0). */
 
 /* Filter table: cell padding -----  */
 .cp {
+  display: block;
+  width: 100%;
   padding: 0.25rem 0.5rem;
   white-space: nowrap;
   overflow: hidden;
@@ -919,6 +965,13 @@ td.del-cell {
   position: relative;
 }
 
+/* The inline dropdown is an abs-positioned child of this (relative)
+ * cell; the td-level overflow:hidden would clip it. Ellipsis on these
+ * cells is owned by the inner .cp. */
+.filters-tbl tbody td.editable-cell {
+  overflow: visible;
+}
+
 .chev {
   display: none;
   color: var(--text-ghost);
@@ -975,6 +1028,8 @@ td.del-cell {
 }
 
 .inline-dropdown-opt {
+  display: block;
+  width: 100%;
   padding: 0.3rem 0.6rem;
   font-size: 0.75rem;
   color: var(--text-primary);
@@ -983,6 +1038,10 @@ td.del-cell {
 }
 
 .inline-dropdown-opt:hover {
+  background: var(--select-option-hover);
+}
+
+.inline-dropdown-opt:focus-visible {
   background: var(--select-option-hover);
 }
 
@@ -996,6 +1055,7 @@ td.del-cell {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  width: 100%;
   color: var(--text-faint);
   font-size: 0.75rem;
   cursor: pointer;
@@ -1150,7 +1210,6 @@ td.del-cell {
   font-size: 0.75rem;
   padding: 0.25rem 1.8rem 0.25rem 0.5rem;
   cursor: pointer;
-  outline: none;
   white-space: nowrap;
   user-select: none;
   position: relative;
@@ -1187,6 +1246,8 @@ td.del-cell {
 }
 
 .custom-select-opt {
+  display: block;
+  width: 100%;
   padding: 0.3rem 0.6rem;
   font-size: 0.75rem;
   color: var(--text-primary);
@@ -1195,6 +1256,10 @@ td.del-cell {
 }
 
 .custom-select-opt:hover {
+  background: var(--select-option-hover);
+}
+
+.custom-select-opt:focus-visible {
   background: var(--select-option-hover);
 }
 


### PR DESCRIPTION
Closes #476.

Every control from the issue is now a real `<button type="button">` with its pattern's ARIA state. Existing ids, classes, and state classes (`.on`/`.open`/`.selected`) are kept, so CSS and selector-based code keep working; native button semantics route Enter/Space through the existing click handlers.

- **Settings toggles:** `role="switch"` + `aria-checked`, synced wherever `.on` is toggled. The hand-wired DNS toggle/dropdown copies were folded into generalized `wireToggle`/`wireDropdown` taking an apply callback, so the ARIA logic exists once.
- **Dropdowns (settings ×3 + filter cells):** trigger `aria-haspopup`/`aria-expanded`/`aria-controls`, menu `role="listbox"`, option buttons `tabindex="-1"` with roving focus via the new `ui/menu-keys.ts` (arrows/Home/End/Escape/Tab). Focus returns to the trigger on select/Escape, but outside-click close never steals focus.
- **Section headers:** disclosure buttons with `aria-expanded`/`aria-controls`; collapsed clips get `inert` plus a `visibility: hidden` fallback — `max-height: 0` alone would leave invisible tab stops now that the content is focusable.
- **Focus survival:** both lists rebuild via `innerHTML` on every change (including background `validation-changed` re-renders), so `renderServers`/`renderFilters` capture and restore the focused control (`preventScroll`); delete/commit paths move focus explicitly (next delete button / rebuilt cell); blur-commits never steal focus (eligibility decided before the re-render).
- **CSS:** one `button {}` reset + `:focus-visible` rings (accent outline; inset inside clipped containers; opacity-reveal for the hover-hidden copy-IP; `tr:focus-within` row highlight).
- **Fixes that fell out of review:** the filter inline dropdown was clipped by the cell's `overflow: hidden` (`td.editable-cell` is now `overflow: visible`); the Test button's `disabled` dropped keyboard focus to `<body>` for the whole test; icon-only buttons got accessible names (including the power button) and decorative glyphs (▼ ▾ ⠿) are `aria-hidden`.

95 new vitest+jsdom tests on the branch (82 → 177, including the suites merged in from #482), with a static-markup contract test over `index.html?raw` that pins tags/ARIA for every converted control.

Main's #482 (dashboard wiring-fix batch) landed mid-flight and touched the same files; it is merged in, with its `runServerTest` rewrite (in-flight repaint), `persistFilters` chain, and identity-based edit re-resolution composed with the focus-restoration work rather than overwritten.

**Verify:** Tab-walk the dashboard — every toggle, dropdown, section header, import zone, filter cell, delete X, and copy-IP is focusable and operable; tab order follows the layout; collapsed sections are skipped. On macOS see question 1 below.

**Questions surfaced during review (not decided here):**
1. **macOS Tab behavior:** WKWebView skips `<button>`s on plain Tab unless system *Full Keyboard Access* is enabled (platform convention; Option+Tab always works; WebView2 unaffected). Worth one check on a default-config Mac — then either document FKA, or set the `AppleKeyboardUIMode` user default at startup.
2. **Muted sections:** nested proxy/DNS controls were always clickable-while-dimmed and are now also focusable-while-dimmed. Should muting set `disabled` instead (changes current mouse behavior)?
3. **Server row selection** remains mouse-only (not in the issue's enumerated list) — follow-up?
4. **Filter drag reorder** remains pointer-only — keyboard alternative as follow-up?
5. **Old WebKit floor:** macOS 10.13/10.14 (Tauri's default minimum) lacks `:focus-visible`, so focus rings are absent there; the `inert` gap is covered by the `visibility: hidden` fallback. Declare a `minimumSystemVersion`?
