### PR TITLE
fix(bridge): report real tunnel traffic in the metrics endpoint

### DIFF
--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -1,4 +1,4 @@
-use crate::proxy::{Proxy, ProxyError, RunningProxy};
+use crate::proxy::{Proxy, ProxyError, RunningProxy, TrafficTotals};
 use crate::proxy_manager::ProxyManager;
 use bytes::Bytes;
 use hole_common::protocol::{StatusResponse, ROUTE_STATUS};
@@ -80,6 +80,9 @@ impl RunningProxy for StubRunning {
             h.abort();
         }
         Ok(())
+    }
+    fn traffic_totals(&self) -> TrafficTotals {
+        TrafficTotals::default()
     }
 }
 

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -358,11 +358,13 @@ async fn handle_metrics<P: Proxy + 'static, R: Routing + 'static>(
     } else {
         None
     };
+    // Stopped → None → all four traffic fields zero.
+    let traffic = pm.sample_traffic().unwrap_or_default();
     Json(MetricsResponse {
-        bytes_in: 0,
-        bytes_out: 0,
-        speed_in_bps: 0,
-        speed_out_bps: 0,
+        bytes_in: traffic.totals.bytes_in,
+        bytes_out: traffic.totals.bytes_out,
+        speed_in_bps: traffic.speed_in_bps,
+        speed_out_bps: traffic.speed_out_bps,
         uptime_secs: pm.uptime_secs(),
         filter,
     })

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -358,7 +358,8 @@ async fn handle_metrics<P: Proxy + 'static, R: Routing + 'static>(
     } else {
         None
     };
-    // Stopped → None → all four traffic fields zero.
+    // Stopped or crashed (check_health cleared `running`) → None → all
+    // four traffic fields zero.
     let traffic = pm.sample_traffic().unwrap_or_default();
     Json(MetricsResponse {
         bytes_in: traffic.totals.bytes_in,

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -804,6 +804,8 @@ fn metrics_reports_traffic_totals_when_running() {
         let metrics = get_metrics(&mut client).await;
         assert_eq!(metrics.bytes_in, 0, "stopped bridge reports zero totals");
         assert_eq!(metrics.bytes_out, 0);
+        assert_eq!(metrics.speed_in_bps, 0, "stopped bridge reports zero speeds");
+        assert_eq!(metrics.speed_out_bps, 0);
 
         drop(client);
         handle.abort();
@@ -816,6 +818,7 @@ fn metrics_reports_speed_over_window() {
     rt().block_on(async {
         let path = test_socket_path("metrics-speed");
         let (pm, traffic) = mock_proxy_with_traffic();
+        let pm_for_shift = Arc::clone(&pm);
         let server = IpcServer::bind(&path, pm).unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
@@ -830,8 +833,15 @@ fn metrics_reports_speed_over_window() {
 
         // Plumbing-only assertion: bytes arriving between two polls must
         // surface as a nonzero speed. The exact rate math is unit-tested
-        // under a paused clock in proxy_manager_tests.rs.
+        // under a paused clock in proxy_manager_tests.rs. The 1ms rewind
+        // makes the second poll's `elapsed > 0` structural — without it,
+        // both polls landing on the same clock tick would hit the
+        // `elapsed.is_zero()` branch and return the previous (zero) speed.
         traffic.bytes_in.fetch_add(1_000_000_000, Ordering::SeqCst);
+        pm_for_shift
+            .lock()
+            .await
+            .shift_traffic_window_for_test(std::time::Duration::from_millis(1));
 
         let metrics = get_metrics(&mut client).await;
         assert!(metrics.speed_in_bps > 0, "speed_in_bps must reflect the byte delta");

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::proxy::{Proxy, ProxyError, RunningProxy};
+use crate::proxy::{Proxy, ProxyError, RunningProxy, TrafficTotals};
 use crate::proxy_manager::ProxyManager;
 use crate::socket::LocalStream;
 use bytes::Bytes;
@@ -11,7 +11,7 @@ use hyper_util::rt::TokioIo;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tun_engine::gateway::GatewayInfo;
@@ -20,8 +20,20 @@ use tun_engine::RoutingError;
 
 // MockProxy ===========================================================================================================
 
+/// Cumulative traffic counters shared between `MockProxy` and the
+/// `MockRunning` handles it issues. Tests clone the `Arc` out before
+/// handing the mock to `ProxyManager::new` and `fetch_add` to simulate
+/// tunnel traffic. Zeroed on every successful `start`, mirroring the
+/// fresh `FlowStat` a new shadowsocks `Server` creates.
+#[derive(Default)]
+struct MockTraffic {
+    bytes_in: AtomicU64,
+    bytes_out: AtomicU64,
+}
+
 struct MockProxy {
     fail_start: AtomicBool,
+    traffic: Arc<MockTraffic>,
     /// If Some, `start` awaits this gate before returning. Used to
     /// simulate a slow start so tests can race `POST /v1/cancel` against
     /// an in-flight `POST /v1/start`.
@@ -39,6 +51,7 @@ impl MockProxy {
     fn new() -> Self {
         Self {
             fail_start: AtomicBool::new(false),
+            traffic: Arc::new(MockTraffic::default()),
             start_gate: None,
             start_entered: std::sync::Mutex::new(None),
         }
@@ -47,16 +60,14 @@ impl MockProxy {
     fn failing() -> Self {
         Self {
             fail_start: AtomicBool::new(true),
-            start_gate: None,
-            start_entered: std::sync::Mutex::new(None),
+            ..Self::new()
         }
     }
 
     fn gated(gate: Arc<tokio::sync::Notify>) -> Self {
         Self {
-            fail_start: AtomicBool::new(false),
             start_gate: Some(gate),
-            start_entered: std::sync::Mutex::new(None),
+            ..Self::new()
         }
     }
 
@@ -81,16 +92,24 @@ impl Proxy for MockProxy {
         if self.fail_start.load(Ordering::SeqCst) {
             return Err(ProxyError::Runtime(io::Error::other("mock failure")));
         }
+        // Fresh session ⇒ fresh counters (production: a new Server
+        // creates a new FlowStat).
+        self.traffic.bytes_in.store(0, Ordering::SeqCst);
+        self.traffic.bytes_out.store(0, Ordering::SeqCst);
         let handle = tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
             Ok(())
         });
-        Ok(MockRunning { handle: Some(handle) })
+        Ok(MockRunning {
+            handle: Some(handle),
+            traffic: Arc::clone(&self.traffic),
+        })
     }
 }
 
 struct MockRunning {
     handle: Option<JoinHandle<io::Result<()>>>,
+    traffic: Arc<MockTraffic>,
 }
 
 impl RunningProxy for MockRunning {
@@ -102,6 +121,12 @@ impl RunningProxy for MockRunning {
             h.abort();
         }
         Ok(())
+    }
+    fn traffic_totals(&self) -> TrafficTotals {
+        TrafficTotals {
+            bytes_in: self.traffic.bytes_in.load(Ordering::SeqCst),
+            bytes_out: self.traffic.bytes_out.load(Ordering::SeqCst),
+        }
     }
 }
 
@@ -197,6 +222,16 @@ fn mock_proxy() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
     let state_dir = tempfile::tempdir().unwrap().keep();
     let routing = MockRouting::new(state_dir);
     Arc::new(Mutex::new(ProxyManager::new(MockProxy::new(), routing)))
+}
+
+/// `mock_proxy` variant that also hands back the mock's traffic counters
+/// so tests can simulate tunnel bytes.
+fn mock_proxy_with_traffic() -> (Arc<Mutex<ProxyManager<MockProxy, MockRouting>>>, Arc<MockTraffic>) {
+    let state_dir = tempfile::tempdir().unwrap().keep();
+    let routing = MockRouting::new(state_dir);
+    let mock = MockProxy::new();
+    let traffic = Arc::clone(&mock.traffic);
+    (Arc::new(Mutex::new(ProxyManager::new(mock, routing))), traffic)
 }
 
 fn failing_proxy() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
@@ -730,7 +765,7 @@ fn metrics_returns_uptime_when_running() {
         assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
 
         let metrics = get_metrics(&mut client).await;
-        // Traffic fields are still zero (not yet integrated)
+        // Running but idle: no traffic injected into the mock, so totals are 0.
         assert_eq!(metrics.bytes_in, 0);
         assert_eq!(metrics.bytes_out, 0);
         // uptime_secs should be >= 0 (may be 0 if < 1s elapsed, which is fine)
@@ -739,6 +774,69 @@ fn metrics_returns_uptime_when_running() {
         // Cleanup
         consume(post_stop(&mut client).await).await;
 
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn metrics_reports_traffic_totals_when_running() {
+    rt().block_on(async {
+        let path = test_socket_path("metrics-traffic");
+        let (pm, traffic) = mock_proxy_with_traffic();
+        let server = IpcServer::bind(&path, pm).unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
+
+        traffic.bytes_in.fetch_add(1_048_576, Ordering::SeqCst);
+        traffic.bytes_out.fetch_add(65_536, Ordering::SeqCst);
+
+        let metrics = get_metrics(&mut client).await;
+        assert_eq!(metrics.bytes_in, 1_048_576);
+        assert_eq!(metrics.bytes_out, 65_536);
+
+        consume(post_stop(&mut client).await).await;
+        let metrics = get_metrics(&mut client).await;
+        assert_eq!(metrics.bytes_in, 0, "stopped bridge reports zero totals");
+        assert_eq!(metrics.bytes_out, 0);
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn metrics_reports_speed_over_window() {
+    rt().block_on(async {
+        let path = test_socket_path("metrics-speed");
+        let (pm, traffic) = mock_proxy_with_traffic();
+        let server = IpcServer::bind(&path, pm).unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        assert_eq!(consume(post_start(&mut client, &sample_config()).await).await, 200);
+
+        // First poll establishes the rate window.
+        let first = get_metrics(&mut client).await;
+        assert_eq!(first.speed_in_bps, 0, "no window exists before the first poll");
+
+        // Plumbing-only assertion: bytes arriving between two polls must
+        // surface as a nonzero speed. The exact rate math is unit-tested
+        // under a paused clock in proxy_manager_tests.rs.
+        traffic.bytes_in.fetch_add(1_000_000_000, Ordering::SeqCst);
+
+        let metrics = get_metrics(&mut client).await;
+        assert!(metrics.speed_in_bps > 0, "speed_in_bps must reflect the byte delta");
+
+        consume(post_stop(&mut client).await).await;
         drop(client);
         handle.abort();
         let _ = handle.await;

--- a/crates/bridge/src/proxy.rs
+++ b/crates/bridge/src/proxy.rs
@@ -38,6 +38,17 @@ pub(crate) use config::resolve_plugin_path_inner;
 
 // Trait surface =======================================================================================================
 
+/// Cumulative tunnel-traffic byte totals since the running proxy started.
+///
+/// Wire bytes on the proxied connection (including cipher overhead) —
+/// what the tunnel actually carried. `bytes_in` = received from the
+/// remote (download), `bytes_out` = sent to it (upload).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TrafficTotals {
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+}
+
 /// A proxy tunnel implementation.
 ///
 /// Calling [`start`](Self::start) spawns a fresh running-proxy handle
@@ -70,6 +81,10 @@ pub trait Proxy: Send + Sync {
 pub trait RunningProxy: Send + Sync {
     /// Cheap, synchronous check: is the underlying task still running?
     fn is_alive(&self) -> bool;
+
+    /// Cheap, synchronous snapshot of cumulative tunnel-traffic totals
+    /// since this proxy started.
+    fn traffic_totals(&self) -> TrafficTotals;
 
     /// Graceful shutdown: abort the task and await its result so errors
     /// can be reported to the caller. Idempotent with respect to

--- a/crates/bridge/src/proxy/shadowsocks.rs
+++ b/crates/bridge/src/proxy/shadowsocks.rs
@@ -2,11 +2,13 @@
 // `RunningProxy` traits backed by `shadowsocks_service::local::Server`.
 
 use shadowsocks_service::config::Config;
+use shadowsocks_service::net::FlowStat;
 use std::io;
+use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, warn};
 
-use super::{Proxy, ProxyError, RunningProxy};
+use super::{Proxy, ProxyError, RunningProxy, TrafficTotals};
 
 /// Production `Proxy` implementation: spawns a `shadowsocks_service::local::Server`
 /// task on `start(config)` and returns a [`ShadowsocksRunning`] handle that
@@ -34,6 +36,11 @@ impl Proxy for ShadowsocksProxy {
             .await
             .map_err(ProxyError::Runtime)?;
         debug!("shadowsocks_service Server constructed");
+        // The balancer's ServiceContext is cloned from the same template
+        // as every local instance's, so they all share one Arc<FlowStat>
+        // (every proxied TCP stream / UDP association increments it).
+        // This is the only public handle to the server's traffic counters.
+        let flow_stat = server.server_balancer().context().flow_stat();
         debug!("spawning shadowsocks server.run() task");
         let handle = tokio::spawn(async move {
             // First log inside the spawned task: a gap between the
@@ -51,7 +58,10 @@ impl Proxy for ShadowsocksProxy {
             }
             result
         });
-        Ok(ShadowsocksRunning { handle: Some(handle) })
+        Ok(ShadowsocksRunning {
+            handle: Some(handle),
+            flow_stat,
+        })
     }
 }
 
@@ -74,6 +84,9 @@ impl Proxy for ShadowsocksProxy {
 /// is the ability to observe task-internal panics.
 pub struct ShadowsocksRunning {
     handle: Option<JoinHandle<io::Result<()>>>,
+    /// Shared with every local instance inside the running `Server` —
+    /// SOCKS5/HTTP listeners and UDP associations all increment it.
+    flow_stat: Arc<FlowStat>,
 }
 
 #[cfg(test)]
@@ -83,13 +96,23 @@ impl ShadowsocksRunning {
     /// listeners. Production code never reaches `ShadowsocksRunning`
     /// except through [`ShadowsocksProxy::start`].
     pub(crate) fn from_handle(handle: JoinHandle<io::Result<()>>) -> Self {
-        Self { handle: Some(handle) }
+        Self {
+            handle: Some(handle),
+            flow_stat: Arc::new(FlowStat::new()),
+        }
     }
 }
 
 impl RunningProxy for ShadowsocksRunning {
     fn is_alive(&self) -> bool {
         self.handle.as_ref().is_some_and(|h| !h.is_finished())
+    }
+
+    fn traffic_totals(&self) -> TrafficTotals {
+        TrafficTotals {
+            bytes_in: self.flow_stat.rx(),
+            bytes_out: self.flow_stat.tx(),
+        }
     }
 
     /// Graceful shutdown: aborts the task and awaits its result. Distinguishes

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -44,7 +44,9 @@ use tun_engine::gateway::GatewayInfo;
 use tun_engine::routing::{Routing, SystemRouting};
 
 use crate::dns::system::{Dns, DnsApplied, DnsError, SystemDns};
-use crate::proxy::{build_ss_config, Proxy, ProxyError, RunningProxy, ShadowsocksProxy, TUN_DEVICE_NAME};
+use crate::proxy::{
+    build_ss_config, Proxy, ProxyError, RunningProxy, ShadowsocksProxy, TrafficTotals, TUN_DEVICE_NAME,
+};
 
 /// Non-secret diagnostic view of a proxy-start event — suitable for
 /// YAML-shaped logging via `dump!`. Deliberately excludes password /
@@ -133,6 +135,33 @@ struct RunningState<P: Proxy, R: Routing, D: Dns> {
     udp_proxy_available: bool,
     /// Whether IPv6 bypass is available (from gateway info).
     ipv6_bypass_available: bool,
+    /// Rate window for [`ProxyManager::sample_traffic`]. `None` until the
+    /// first sample after start. Lives here so it structurally cannot
+    /// survive a stop/start cycle — the counters it derives deltas from
+    /// reset with the `Server`.
+    traffic_window: Option<TrafficWindow>,
+}
+
+/// Previous [`ProxyManager::sample_traffic`] observation.
+///
+/// `sampled_at` is a `tokio::time::Instant` (not std) so speed tests can
+/// drive the window deterministically with `tokio::time::pause`/`advance`
+/// instead of sleeping; outside a paused runtime it is the same monotonic
+/// clock.
+struct TrafficWindow {
+    sampled_at: tokio::time::Instant,
+    totals: TrafficTotals,
+    speed_in_bps: u64,
+    speed_out_bps: u64,
+}
+
+/// One traffic sample: cumulative totals plus speeds over the window
+/// since the previous sample.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TrafficMetrics {
+    pub totals: TrafficTotals,
+    pub speed_in_bps: u64,
+    pub speed_out_bps: u64,
 }
 
 // ProxyManager ========================================================================================================
@@ -216,6 +245,53 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 .checked_sub(by)
                 .expect("shift_started_at_for_test: arithmetic underflow");
         }
+    }
+
+    /// Sample cumulative tunnel-traffic totals and compute speeds over
+    /// the window since the previous sample. Each call advances the
+    /// window — the IPC metrics poll is the sampling event. `None` when
+    /// stopped; the first sample after a start reports 0 bps.
+    pub fn sample_traffic(&mut self) -> Option<TrafficMetrics> {
+        let running = self.running.as_mut()?;
+        let totals = running.proxy.traffic_totals();
+        let now = tokio::time::Instant::now();
+        let (speed_in_bps, speed_out_bps) = match &running.traffic_window {
+            None => (0, 0),
+            Some(w) => {
+                let elapsed = now.duration_since(w.sampled_at);
+                if elapsed.is_zero() {
+                    // Same-instant resample: nothing to divide by. Reuse
+                    // the previous speeds and keep the window so the next
+                    // real sample still has a usable base.
+                    return Some(TrafficMetrics {
+                        totals,
+                        speed_in_bps: w.speed_in_bps,
+                        speed_out_bps: w.speed_out_bps,
+                    });
+                }
+                // Counters are monotonic within one RunningState: same
+                // handle, fetch_add only, and the window dies with the state.
+                debug_assert!(
+                    totals.bytes_in >= w.totals.bytes_in && totals.bytes_out >= w.totals.bytes_out,
+                    "traffic counters must be monotonic within a running session"
+                );
+                (
+                    speed_bps(totals.bytes_in - w.totals.bytes_in, elapsed),
+                    speed_bps(totals.bytes_out - w.totals.bytes_out, elapsed),
+                )
+            }
+        };
+        running.traffic_window = Some(TrafficWindow {
+            sampled_at: now,
+            totals,
+            speed_in_bps,
+            speed_out_bps,
+        });
+        Some(TrafficMetrics {
+            totals,
+            speed_in_bps,
+            speed_out_bps,
+        })
     }
 
     pub fn last_error(&self) -> Option<&str> {
@@ -537,6 +613,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 started_at: Instant::now(),
                 udp_proxy_available,
                 ipv6_bypass_available: false,
+                traffic_window: None,
             });
         }
 
@@ -731,6 +808,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             started_at: Instant::now(),
             udp_proxy_available,
             ipv6_bypass_available: gw_info.ipv6_available,
+            traffic_window: None,
         })
     }
 
@@ -748,6 +826,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             started_at: _,
             udp_proxy_available: _,
             ipv6_bypass_available: _,
+            traffic_window: _,
         } = state;
 
         // 0. Restore system DNS FIRST (while routes + SS are still live
@@ -881,6 +960,16 @@ fn proxy_start_err_to_io_err(e: ProxyError) -> std::io::Error {
         ProxyError::Runtime(io) => io,
         other => std::io::Error::other(other.to_string()),
     }
+}
+
+// Traffic rate ========================================================================================================
+
+/// `bytes` over `elapsed` as bits per second. u128 intermediate so the
+/// multiply cannot overflow; saturates at u64::MAX.
+fn speed_bps(bytes: u64, elapsed: std::time::Duration) -> u64 {
+    let bits = bytes as u128 * 8 * 1_000_000_000;
+    let nanos = elapsed.as_nanos().max(1);
+    u64::try_from(bits / nanos).unwrap_or(u64::MAX)
 }
 
 // DNS resolution ======================================================================================================

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -294,6 +294,21 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         })
     }
 
+    /// Test seam: rewind the traffic window's `sampled_at` by `by`, making
+    /// the next sample's `elapsed > 0` a structural guarantee instead of a
+    /// bet on clock granularity. Callers rewind by a tiny duration (1ms) —
+    /// large rewinds can underflow past the `Instant` epoch (system boot).
+    /// No-op when not running or before the first sample.
+    #[cfg(test)]
+    pub fn shift_traffic_window_for_test(&mut self, by: std::time::Duration) {
+        if let Some(w) = self.running.as_mut().and_then(|r| r.traffic_window.as_mut()) {
+            w.sampled_at = w
+                .sampled_at
+                .checked_sub(by)
+                .expect("shift_traffic_window_for_test: rewound past the Instant epoch");
+        }
+    }
+
     pub fn last_error(&self) -> Option<&str> {
         self.last_error.as_deref()
     }

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -137,6 +137,86 @@ fn e2e_none_socks_only_roundtrip(
     rt().block_on(run_socks_only_e2e(dist, ss, http));
 }
 
+/// Metrics report tunnel traffic (#461): after a SOCKS5 roundtrip through
+/// a real ss-server, the FlowStat-backed metrics must show nonzero
+/// cumulative totals in both directions (wire bytes through the tunnel).
+/// A restart on a fresh port must reset the totals — a new `Server` means
+/// a new `FlowStat`.
+#[skuld::test(labels = [DIST_BIN])]
+fn e2e_metrics_report_tunnel_traffic(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_none)] ss: &SsServerHandle,
+    #[fixture(http_target_ipv4)] http: &HttpTarget,
+) {
+    rt().block_on(async {
+        let local_port = allocate_ephemeral_port(Protocols::TCP | Protocols::UDP).await;
+        let config_template = ProxyConfig {
+            server: entry_from(ss),
+            local_port,
+            tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4074,
+            diagnostic_plugin_tap: false,
+        };
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        let resp = harness
+            .send(BridgeRequest::Start {
+                config: config_template.clone(),
+            })
+            .await
+            .expect("send Start");
+        assert!(matches!(resp, BridgeResponse::Ack), "expected Ack, got {resp:?}");
+
+        assert_socks5_roundtrip(&mut harness, local_port, http.addr).await;
+
+        let resp = harness.send(BridgeRequest::Metrics).await.expect("send Metrics");
+        let BridgeResponse::Metrics {
+            bytes_in, bytes_out, ..
+        } = resp
+        else {
+            panic!("expected Metrics response, got {resp:?}");
+        };
+        assert!(bytes_in > 0, "roundtrip response must register as download, got 0");
+        assert!(bytes_out > 0, "roundtrip request must register as upload, got 0");
+
+        let resp = harness.send(BridgeRequest::Stop).await.expect("send Stop");
+        assert!(matches!(resp, BridgeResponse::Ack), "expected Ack, got {resp:?}");
+
+        // Restart on a fresh port: totals must reset (dns.enabled = false,
+        // so no forwarder self-test bytes — exactly zero before traffic).
+        let local_port2 = allocate_ephemeral_port(Protocols::TCP | Protocols::UDP).await;
+        let config2 = ProxyConfig {
+            local_port: local_port2,
+            ..config_template
+        };
+        let resp = harness
+            .send(BridgeRequest::Start { config: config2 })
+            .await
+            .expect("send Start 2");
+        assert!(matches!(resp, BridgeResponse::Ack), "expected Ack, got {resp:?}");
+
+        let resp = harness.send(BridgeRequest::Metrics).await.expect("send Metrics 2");
+        let BridgeResponse::Metrics {
+            bytes_in, bytes_out, ..
+        } = resp
+        else {
+            panic!("expected Metrics response, got {resp:?}");
+        };
+        assert_eq!(bytes_in, 0, "fresh session must start from zero totals");
+        assert_eq!(bytes_out, 0, "fresh session must start from zero totals");
+
+        let resp = harness.send(BridgeRequest::Stop).await.expect("send Stop 2");
+        assert!(matches!(resp, BridgeResponse::Ack), "expected Ack, got {resp:?}");
+    });
+}
+
 /// Test 2: SocksOnly mode with galoshes (websocket, no TLS).
 ///
 /// Linux-only: the galoshes *server* hits the #197 `PluginConfig` port race on

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -4,13 +4,13 @@
 #![allow(clippy::disallowed_methods)]
 
 use super::*;
-use crate::proxy::{Proxy, ProxyError, RunningProxy};
+use crate::proxy::{Proxy, ProxyError, RunningProxy, TrafficTotals};
 use hole_common::config::ServerEntry;
 use hole_common::protocol::ProxyConfig;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -36,6 +36,12 @@ struct MockProxyState {
     /// which local instances a start produced (e.g. the pure-VPN
     /// internal ephemeral SOCKS5 instance, #459).
     last_config: std::sync::Mutex<Option<shadowsocks_service::config::Config>>,
+    /// Cumulative traffic counters surfaced via `MockRunning::traffic_totals`.
+    /// Tests `fetch_add` to simulate tunnel traffic. Zeroed on every
+    /// successful `start`, mirroring the fresh `FlowStat` a new
+    /// shadowsocks `Server` creates.
+    bytes_in: AtomicU64,
+    bytes_out: AtomicU64,
 }
 
 struct MockProxy {
@@ -77,7 +83,7 @@ impl MockProxy {
         self
     }
 
-    fn start_calls_handle(&self) -> Arc<MockProxyState> {
+    fn state_handle(&self) -> Arc<MockProxyState> {
         Arc::clone(&self.state)
     }
 }
@@ -98,6 +104,10 @@ impl Proxy for MockProxy {
         if self.state.fail_start.load(Ordering::SeqCst) {
             return Err(ProxyError::Runtime(io::Error::other("mock start failure")));
         }
+        // Fresh session ⇒ fresh counters (production: a new Server
+        // creates a new FlowStat).
+        self.state.bytes_in.store(0, Ordering::SeqCst);
+        self.state.bytes_out.store(0, Ordering::SeqCst);
         // Spawn a long-sleeping task to simulate a running proxy so the
         // returned handle reports `is_alive()` realistically.
         let handle = tokio::spawn(async {
@@ -129,6 +139,13 @@ impl RunningProxy for MockRunning {
             h.abort();
         }
         Ok(())
+    }
+
+    fn traffic_totals(&self) -> TrafficTotals {
+        TrafficTotals {
+            bytes_in: self.state.bytes_in.load(Ordering::SeqCst),
+            bytes_out: self.state.bytes_out.load(Ordering::SeqCst),
+        }
     }
 }
 
@@ -378,7 +395,7 @@ fn start_when_running_returns_already_running() {
 fn reload_with_same_server_hot_swaps_rules() {
     rt().block_on(async {
         let backend = MockProxy::new();
-        let state = backend.start_calls_handle();
+        let state = backend.state_handle();
 
         let (mut pm, _dir) = new_manager(backend);
         pm.start(&test_config()).await.unwrap();
@@ -405,7 +422,7 @@ fn reload_with_same_server_hot_swaps_rules() {
 fn reload_with_different_server_restarts() {
     rt().block_on(async {
         let backend = MockProxy::new();
-        let state = backend.start_calls_handle();
+        let state = backend.state_handle();
 
         let (mut pm, _dir) = new_manager(backend);
         pm.start(&test_config()).await.unwrap();
@@ -440,7 +457,7 @@ fn start_failure_stays_stopped() {
 fn route_failure_rolls_back_proxy() {
     rt().block_on(async {
         let proxy = MockProxy::new();
-        let proxy_state = proxy.start_calls_handle();
+        let proxy_state = proxy.state_handle();
         let dir = tempfile::tempdir().unwrap();
         let routing = MockRouting::failing_install(dir.path().to_path_buf());
         let routing_state = routing.state();
@@ -464,7 +481,7 @@ fn route_failure_rolls_back_proxy() {
 fn check_health_detects_crashed_task() {
     rt().block_on(async {
         let proxy = MockProxy::new();
-        let state = proxy.start_calls_handle();
+        let state = proxy.state_handle();
 
         let (mut pm, _dir) = new_manager(proxy);
         pm.start(&test_config()).await.unwrap();
@@ -488,7 +505,7 @@ fn check_health_clears_active_config_so_reload_restarts() {
     // of starting a new proxy.
     rt().block_on(async {
         let proxy = MockProxy::new();
-        let state = proxy.start_calls_handle();
+        let state = proxy.state_handle();
 
         let (mut pm, _dir) = new_manager(proxy);
         pm.start(&test_config()).await.unwrap();
@@ -541,6 +558,100 @@ fn uptime_increases_while_running() {
         pm.stop().await.unwrap();
         // After stop, uptime should be 0
         assert_eq!(pm.uptime_secs(), 0);
+    });
+}
+
+// Traffic metrics =====================================================================================================
+
+#[skuld::test]
+fn sample_traffic_is_none_when_stopped() {
+    rt().block_on(async {
+        let (mut pm, _dir) = new_manager(MockProxy::new());
+        assert!(pm.sample_traffic().is_none());
+    });
+}
+
+#[skuld::test]
+fn sample_traffic_reports_cumulative_totals() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let state = proxy.state_handle();
+        let (mut pm, _dir) = new_manager(proxy);
+        pm.start(&test_config()).await.unwrap();
+
+        state.bytes_in.fetch_add(1_048_576, Ordering::SeqCst);
+        state.bytes_out.fetch_add(65_536, Ordering::SeqCst);
+
+        let m = pm.sample_traffic().expect("running");
+        assert_eq!(m.totals.bytes_in, 1_048_576);
+        assert_eq!(m.totals.bytes_out, 65_536);
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
+fn sample_traffic_speed_is_zero_on_first_sample() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let state = proxy.state_handle();
+        let (mut pm, _dir) = new_manager(proxy);
+        pm.start(&test_config()).await.unwrap();
+        state.bytes_in.fetch_add(10_000, Ordering::SeqCst);
+
+        let m = pm.sample_traffic().expect("running");
+        assert_eq!(m.speed_in_bps, 0, "no window exists before the first sample");
+        assert_eq!(m.speed_out_bps, 0);
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
+async fn sample_traffic_computes_speed_over_window() {
+    // Current-thread runtime (skuld async) + paused clock: the window's
+    // tokio::time::Instant advances exactly 1s, so the speeds are exact.
+    tokio::time::pause();
+    let proxy = MockProxy::new();
+    let state = proxy.state_handle();
+    let (mut pm, _dir) = new_manager(proxy);
+    pm.start(&test_config()).await.unwrap();
+    let _ = pm.sample_traffic().expect("running"); // establish the window at totals (0, 0)
+
+    state.bytes_in.fetch_add(1_000_000, Ordering::SeqCst);
+    state.bytes_out.fetch_add(500_000, Ordering::SeqCst);
+    tokio::time::advance(Duration::from_secs(1)).await;
+
+    let m = pm.sample_traffic().expect("running");
+    assert_eq!(m.speed_in_bps, 8_000_000, "1_000_000 bytes over exactly 1s");
+    assert_eq!(m.speed_out_bps, 4_000_000);
+
+    pm.stop().await.unwrap();
+}
+
+#[skuld::test]
+fn sample_traffic_resets_on_restart() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let state = proxy.state_handle();
+        let (mut pm, _dir) = new_manager(proxy);
+        pm.start(&test_config()).await.unwrap();
+        let _ = pm.sample_traffic().expect("running");
+        state.bytes_in.fetch_add(1_000, Ordering::SeqCst);
+        pm.stop().await.unwrap();
+
+        // MockProxy::start zeroes the counters, mirroring the fresh
+        // FlowStat a new shadowsocks Server creates.
+        pm.start(&test_config()).await.unwrap();
+        let m = pm.sample_traffic().expect("running");
+        assert_eq!(m.totals, TrafficTotals::default(), "fresh session inherits no totals");
+        assert_eq!(
+            (m.speed_in_bps, m.speed_out_bps),
+            (0, 0),
+            "fresh session inherits no window"
+        );
+
+        pm.stop().await.unwrap();
     });
 }
 
@@ -860,7 +971,7 @@ fn start_cancellable_dropped_future_runs_guards() {
 fn pure_vpn_start_binds_internal_ephemeral_socks5() {
     rt().block_on(async {
         let proxy = MockProxy::new();
-        let state = proxy.start_calls_handle();
+        let state = proxy.state_handle();
         let (mut pm, _dir) = new_manager(proxy);
         let mut config = test_config();
         config.proxy_socks5 = false;
@@ -924,7 +1035,7 @@ fn reload_creates_fresh_uncancellable_token() {
     // reload path still works after the cancellation refactor.
     rt().block_on(async {
         let proxy = MockProxy::new();
-        let state = proxy.start_calls_handle();
+        let state = proxy.state_handle();
 
         let (mut pm, _dir) = new_manager(proxy);
         pm.start(&test_config()).await.unwrap();
@@ -945,7 +1056,7 @@ fn reload_creates_fresh_uncancellable_token() {
 fn reload_when_not_running_starts() {
     rt().block_on(async {
         let proxy = MockProxy::new();
-        let state = proxy.start_calls_handle();
+        let state = proxy.state_handle();
 
         let (mut pm, _dir) = new_manager(proxy);
         assert_eq!(pm.state(), ProxyState::Stopped);

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -274,18 +274,34 @@ components:
           type: integer
           format: uint64
           minimum: 0
+          description: >-
+            Cumulative bytes received through the tunnel since the proxy
+            started — wire bytes on the proxied connection, including
+            cipher overhead. Includes DNS-forwarder queries carried over
+            the tunnel; bypass-routed traffic is not counted. Resets on
+            every start. 0 when stopped.
         bytes_out:
           type: integer
           format: uint64
           minimum: 0
+          description: >-
+            Cumulative bytes sent through the tunnel since the proxy
+            started. Same accounting rules as bytes_in.
         speed_in_bps:
           type: integer
           format: uint64
           minimum: 0
+          description: >-
+            Download speed in bits per second, averaged over the window
+            since the previous /v1/metrics call. 0 on the first poll
+            after a start and when stopped.
         speed_out_bps:
           type: integer
           format: uint64
           minimum: 0
+          description: >-
+            Upload speed in bits per second. Same windowing as
+            speed_in_bps.
         uptime_secs:
           type: integer
           format: uint64


### PR DESCRIPTION
Fixes #461.

The bridge's `GET /v1/metrics` handler hardcoded all four traffic fields to zero — the entire GUI chain (poll → Tauri command → bridge client → IPC → sidebar/graph/stats) was correctly wired but starved of data.

## Counting layer

Totals come from shadowsocks-service's built-in `FlowStat` (every proxied TCP stream and UDP association already increments it), captured at start via the public chain `Server::server_balancer() → PingBalancer::context() → ServiceContext::flow_stat()` and surfaced through a new `RunningProxy::traffic_totals()` trait method, preserving the bridge test-isolation seam.

This deliberately deviates from the issue's hint of wrapping `copy_bidirectional` in the TUN endpoints: that layer only exists in Full mode. SocksOnly traffic, Full-mode direct-listener clients, and DNS-forwarder queries all flow through ss-local only — endpoint counters would leave SocksOnly users at zero forever. The ss-local `FlowStat` is the one choke point every proxied byte crosses in every mode.

## Semantics (documented in openapi.yaml)

- Totals are **tunnel traffic**: wire bytes on the proxied connection, including cipher overhead (same accounting as shadowsocks-android).
- **DNS over the tunnel counts**, including the start-time forwarder self-test probe (a few hundred bytes) — DNS the tunnel carries is tunnel traffic.
- **Bypass-routed traffic does not count** — it is traffic excluded from the VPN; counting it would make "Downloaded" ≈ whole-machine traffic in Full mode while meaning something different in SocksOnly. Flagging for veto: if you want bypass in the totals, it needs endpoint-level counters and arguably its own wire fields/UI rows.
- Totals reset on every start (fresh `Server` → fresh `FlowStat`); filter-only hot-swap reload keeps them, matching uptime behavior.
- `speed_*_bps` is **bits per second** over the window since the previous metrics poll, computed on demand in `ProxyManager::sample_traffic` (no background sampler). The window lives in `RunningState`, so it structurally cannot survive a stop/start cycle. First poll after start reports 0 bps.

## Verification

- Unit: `sample_traffic_*` in proxy_manager_tests (totals passthrough, first-sample zero, **exact** speed math under `tokio::time::pause`/`advance`, restart reset), `metrics_*` IPC tests with injectable mock counters (totals, speeds, stopped → zeros).
- Integration: `e2e_metrics_report_tunnel_traffic` — real bridge subprocess + real ss-server + SOCKS5 roundtrip → nonzero `bytes_in`/`bytes_out` over IPC; restart on a fresh port → exactly zero totals.
- Adversarial review verified against the vendored shadowsocks-service 1.24 source: the captured `Arc<FlowStat>` is the one every listener increments (incl. across the pure-VPN `bind_ephemeral` retry path), direction mapping rx=download / tx=upload holds on TCP+HTTP+UDP paths, and nothing increments it when idle (single-server config never spawns balancer probes).
- `cargo fmt`, `cargo xtask run clippy-hole`, hole-bridge suite 481 passing locally (2 TUN tests require elevation and run in CI), hole-common 176, UI vitest 177.

No schema or GUI changes — the wire fields and the whole UI consumer chain already existed.
