### PR TITLE
fix(gui): bridge status is the single owner of proxy state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,11 +296,21 @@ the whole rebuild — state reads included — to the main thread
 (`run_on_main_thread` executes inline when already there). A raw `set_menu`
 from a worker thread reads state early and commits the menu later through the
 event-loop queue, so a stale menu can overwrite a newer one (the #473 desync).
-Enforcement is in [`clippy.toml`](clippy.toml) (`TrayIcon::set_menu` is
-disallowed; the one commit point inside `rebuild_tray_menu` carries a per-site
-`#[allow]`). Corollary: `sync_menu_state` is main-thread-only — menu-item
-setters dispatch-and-block from any other thread, so calling it from a worker
-while holding a lock deadlocks the app.
+The tray **icon** is committed inside the same ordered closure for the same
+reason (the #492 stale-icon class). Enforcement is in
+[`clippy.toml`](clippy.toml) (`TrayIcon::set_menu` is disallowed; the one
+commit point inside `rebuild_tray_menu` carries a per-site `#[allow]`).
+Corollary: `sync_autostart_state` is main-thread-only — menu-item setters
+dispatch-and-block from any other thread, so calling it from a worker while
+holding a lock deadlocks the app.
+
+The rebuild renders from the runtime truth, never from persisted config
+(#462): proxy state comes from `AppState`'s `ProxyStateCell` (fed by every
+bridge exchange, inside the client lock) plus the in-flight `TransitionSlot`
+target; status/connect text is baked into the menu at build time. Persisted
+`config.enabled` is a write-only record of the last honored intent (the
+designated input for a future `StartupBehavior::RestoreLastState` consumer),
+with `tray::persist_intended_enabled` as its sole writer.
 
 ## Workspace layout
 

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -239,55 +239,67 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
     Ok(appended)
 }
 
+/// Poll the proxy's status. The exchange itself commits the observation
+/// to the `ProxyStateCell` (inside `BridgeLink::send`); the returned
+/// `running` + `state_seq` come from the committed cell so the frontend
+/// can apply observations monotonically (#462). The remaining fields are
+/// cosmetics from the raw response.
+///
+/// On `PermissionDenied` the cell is NOT committed (a DACL-gated Status
+/// says nothing about the tunnel), so `running` reports the last
+/// committed value while `error` carries the failure — stale truth beats
+/// flapping to false. Every other error arm commits false, so cell and
+/// cosmetics agree.
 #[tauri::command]
 pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
-    match state.bridge_send(BridgeRequest::Status).await {
+    let result = state.bridge_send(BridgeRequest::Status).await;
+    let snap = state.proxy_snapshot();
+    let mut json = match result {
         Ok(BridgeResponse::Status {
-            running,
+            running: _,
             uptime_secs,
             error,
             invalid_filters,
             udp_proxy_available,
             ipv6_bypass_available,
-        }) => Ok(serde_json::json!({
-            "running": running,
+        }) => serde_json::json!({
             "uptime_secs": uptime_secs,
             "error": error,
             "invalid_filters": invalid_filters,
             "udp_proxy_available": udp_proxy_available,
             "ipv6_bypass_available": ipv6_bypass_available,
-        })),
+        }),
         Ok(BridgeResponse::Error { message }) => {
             warn!(error = %message, "bridge returned error for status");
-            Ok(serde_json::json!({
-                "running": false,
+            serde_json::json!({
                 "uptime_secs": 0,
                 "error": message,
                 "invalid_filters": [],
                 "udp_proxy_available": true,
                 "ipv6_bypass_available": true,
-            }))
+            })
         }
-        Ok(_) => Ok(serde_json::json!({
-            "running": false,
+        Ok(_) => serde_json::json!({
             "uptime_secs": 0,
             "error": "unexpected response from bridge",
             "invalid_filters": [],
             "udp_proxy_available": true,
             "ipv6_bypass_available": true,
-        })),
+        }),
         Err(e) => {
             // Bridge not running or unreachable — not an error for the frontend
-            Ok(serde_json::json!({
-                "running": false,
+            serde_json::json!({
                 "uptime_secs": 0,
                 "error": format!("bridge unreachable: {e}"),
                 "invalid_filters": [],
                 "udp_proxy_available": true,
                 "ipv6_bypass_available": true,
-            }))
+            })
         }
-    }
+    };
+    json["running"] = serde_json::json!(snap.running);
+    json["state_seq"] = serde_json::json!(snap.seq);
+    Ok(json)
 }
 
 // Response mappers (extracted for testability) ========================================================================
@@ -529,13 +541,16 @@ pub fn build_proxy_config(config: &AppConfig) -> Option<ProxyConfig> {
 
 /// Reload the proxy's filter rules from the current config. If the proxy
 /// is not running, this is a no-op (changes apply on next start).
+///
+/// The running check rides the same client-lock acquisition as the
+/// Reload (`BridgeLink::reload_if_running`), so it cannot go stale
+/// against a concurrent Start/Stop: a reload landing during an in-flight
+/// Start queues behind it and applies iff that Start succeeded, and a
+/// stopped proxy is never reloaded — bridge-side `reload` would START it.
 #[tauri::command]
 pub async fn reload_proxy_filters(state: State<'_, AppState>) -> Result<(), String> {
     let config = {
         let app_config = state.config.lock().unwrap();
-        if !app_config.enabled {
-            return Ok(()); // Not running, changes apply on next start.
-        }
         build_proxy_config(&app_config)
     };
 
@@ -543,11 +558,7 @@ pub async fn reload_proxy_filters(state: State<'_, AppState>) -> Result<(), Stri
         return Ok(()); // No server selected.
     };
 
-    state
-        .bridge_send(BridgeRequest::Reload { config: proxy_config })
-        .await
-        .map(|_| ())
-        .map_err(|e| e.to_string())
+    state.link.reload_if_running(proxy_config).await.map(|_| ())
 }
 
 #[cfg(test)]

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -91,16 +91,16 @@ pub fn get_config(state: State<AppState>) -> AppConfig {
 }
 
 #[tauri::command]
-pub fn save_config(state: State<AppState>, mut config: AppConfig) -> Result<(), String> {
+pub fn save_config(state: State<AppState>, settings: crate::ui_settings::UiSettings) -> Result<(), String> {
     let mut current = state.config.lock().unwrap();
-    // The frontend doesn't know about elevation_prompt_shown — preserve the
-    // in-memory value so a save from the Settings UI doesn't reset it.
-    config.elevation_prompt_shown = current.elevation_prompt_shown;
-    state.config_store.save(&config).map_err(|e| {
+    // Apply to a copy so a failed save leaves in-memory state unchanged.
+    let mut updated = current.clone();
+    settings.apply(&mut updated);
+    state.config_store.save(&updated).map_err(|e| {
         warn!(error = %e, path = %state.config_store.path().display(), "save_config: config save failed");
         e.to_string()
     })?;
-    *current = config;
+    *current = updated;
     Ok(())
 }
 

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -93,39 +93,10 @@ fn build_proxy_config_master_toggle_on_passes_listener_flags() {
 
 // save_config preservation tests ======================================================================================
 
-/// Verify that merging a frontend config (elevation_prompt_shown=false) with
-/// an in-memory config (elevation_prompt_shown=true) preserves the flag.
-///
-/// This mirrors the logic in `save_config`: re-inject the in-memory
-/// `elevation_prompt_shown` before saving, because the frontend doesn't
-/// know about the field and always sends `false`.
-#[skuld::test]
-fn save_config_preserves_elevation_prompt_shown() {
-    // Simulate in-memory state where the dialog has been shown
-    let in_memory = AppConfig {
-        elevation_prompt_shown: true,
-        ..Default::default()
-    };
-
-    // Simulate what the frontend sends (doesn't know about the field)
-    let mut from_frontend = AppConfig {
-        local_port: 5555, // user changed the port
-        elevation_prompt_shown: false,
-        ..Default::default()
-    };
-
-    // Apply the same logic as save_config
-    from_frontend.elevation_prompt_shown = in_memory.elevation_prompt_shown;
-
-    assert!(
-        from_frontend.elevation_prompt_shown,
-        "elevation_prompt_shown should be preserved from in-memory state"
-    );
-    assert_eq!(
-        from_frontend.local_port, 5555,
-        "other fields should keep frontend values"
-    );
-}
+// Backend-owned-field preservation across a save lives in
+// `ui_settings_tests.rs` (`apply_preserves_backend_owned_fields`): the
+// wire type makes those fields unrepresentable and `UiSettings::apply`
+// carries the preservation.
 
 // auto_select_first_server tests ======================================================================================
 

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -10,6 +10,7 @@ pub mod setup;
 pub mod state;
 pub mod tray_icons;
 pub mod ui_ready;
+pub mod ui_settings;
 pub mod update;
 pub mod version;
 

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -127,7 +127,8 @@ fn launch_gui(show_dashboard: bool) {
             commands::test_server,
             commands::mark_validated_by_proxy_start,
             commands::reload_proxy_filters,
-            tray::toggle_proxy,
+            tray::start_proxy,
+            tray::stop_proxy,
             tray::cancel_proxy,
             ui_ready::signal_ui_ready,
             ui_ready::wait_ui_ready,
@@ -150,7 +151,13 @@ fn launch_gui(show_dashboard: bool) {
                     .show(|_| {});
             }
             app.manage(hole::update::UpdateState::default());
+            app.manage(tray::TransitionSlot::new());
             tray::create_tray(app)?;
+            // Tray + webview follow the ProxyStateCell; the reconciler's
+            // immediate first tick is the startup resync against the
+            // bridge's actual state (#462).
+            tray::spawn_proxy_state_sync(app.handle());
+            tray::spawn_status_reconciler(app.handle());
             platform::on_setup(app)?;
             if show_dashboard {
                 tray::open_settings_window(app.handle());

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -20,6 +20,7 @@ mod setup;
 mod state;
 mod tray;
 mod ui_ready;
+mod ui_settings;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -3,7 +3,7 @@
 use crate::bridge_client::{BridgeClient, ClientError};
 use hole_common::config::AppConfig;
 use hole_common::config_store::ConfigStore;
-use hole_common::protocol::{BridgeRequest, BridgeResponse};
+use hole_common::protocol::{BridgeRequest, BridgeResponse, CANCELLED_MESSAGE};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -16,7 +16,7 @@ pub struct AppState {
     /// Tauri app handle, used by commands that need to emit events
     /// (currently `test_server` → `validation-changed`).
     pub app_handle: tauri::AppHandle,
-    bridge: tokio::sync::Mutex<Option<BridgeClient>>,
+    pub(crate) link: BridgeLink,
     /// Per-entry test serialization. Acquired for the entire duration of a
     /// `test_server` call so a slower test cannot overwrite a faster newer
     /// one. Different entries do NOT contend.
@@ -32,7 +32,7 @@ impl AppState {
             config_store,
             config: Mutex::new(config),
             app_handle,
-            bridge: tokio::sync::Mutex::new(None),
+            link: BridgeLink::new(resolve_bridge_socket_path()),
             test_locks: tokio::sync::Mutex::new(HashMap::new()),
         }
     }
@@ -49,16 +49,85 @@ impl AppState {
             .clone()
     }
 
-    /// Send a request to the bridge, lazily connecting on first use.
-    /// On connection failure, clears the cached client so the next call reconnects.
     pub async fn bridge_send(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
-        let mut guard = self.bridge.lock().await;
+        self.link.send(req).await
+    }
 
+    pub async fn bridge_send_oneshot(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
+        self.link.send_oneshot(req).await
+    }
+
+    pub fn proxy_snapshot(&self) -> ProxySnapshot {
+        self.link.cell().snapshot()
+    }
+
+    pub fn subscribe_proxy_state(&self) -> tokio::sync::watch::Receiver<ProxySnapshot> {
+        self.link.cell().subscribe()
+    }
+}
+
+/// Resolve the bridge socket path from `HOLE_BRIDGE_SOCKET` or the
+/// platform default. Read once at `AppState` construction; tests inject
+/// per-test paths directly into `BridgeLink::new` instead (the env var is
+/// process-global and skuld tests may share a process).
+fn resolve_bridge_socket_path() -> PathBuf {
+    std::env::var("HOLE_BRIDGE_SOCKET")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(hole_common::protocol::default_bridge_socket_path)
+}
+
+// BridgeLink ==========================================================================================================
+
+/// The GUI's bridge channel plus the runtime-state cell it feeds (#462).
+///
+/// All pooled requests flow through `send`, which commits what the
+/// exchange revealed about `running` (see `observed_running`) BEFORE
+/// releasing the client lock — commit order therefore equals bridge
+/// processing order, with no separate synchronization.
+pub struct BridgeLink {
+    socket_path: PathBuf,
+    client: tokio::sync::Mutex<Option<BridgeClient>>,
+    cell: ProxyStateCell,
+}
+
+impl BridgeLink {
+    pub fn new(socket_path: PathBuf) -> Self {
+        Self {
+            socket_path,
+            client: tokio::sync::Mutex::new(None),
+            cell: ProxyStateCell::new(),
+        }
+    }
+
+    pub fn cell(&self) -> &ProxyStateCell {
+        &self.cell
+    }
+
+    /// Send a request to the bridge, lazily connecting on first use.
+    /// On connection failure, clears the cached client so the next call
+    /// reconnects.
+    pub async fn send(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
+        let kind = ReqKind::of(&req);
+        let mut guard = self.client.lock().await;
+        let result = Self::send_locked(&mut guard, &self.socket_path, req).await;
+        if let Some(running) = observed_running(kind, &result) {
+            self.cell.commit(running);
+        }
+        result
+    }
+
+    /// The transport body, operating on the already-held client guard so
+    /// every exit path stays inside the lock until the caller has
+    /// committed its observation.
+    async fn send_locked(
+        guard: &mut Option<BridgeClient>,
+        socket_path: &std::path::Path,
+        req: BridgeRequest,
+    ) -> Result<BridgeResponse, ClientError> {
         // Lazy connect
         if guard.is_none() {
-            let connect_result = BridgeClient::connect(&resolve_bridge_socket_path()).await;
-
-            match connect_result {
+            match BridgeClient::connect(socket_path).await {
                 Ok(client) => *guard = Some(client),
                 Err(e) => {
                     warn!(error = %e, "failed to connect to bridge");
@@ -85,27 +154,173 @@ impl AppState {
     }
 
     /// Send a request over a fresh, single-use bridge connection that
-    /// bypasses the pooled `BridgeClient`. This exists specifically so
+    /// bypasses the pooled client. This exists specifically so
     /// `BridgeRequest::Cancel` can race an in-flight request on the main
-    /// connection: `bridge_send` holds `self.bridge.lock().await` for the
-    /// entire duration of each request, which would otherwise block a
-    /// concurrent cancel until the request it is trying to cancel finishes.
+    /// connection: `send` holds the client lock for the entire duration of
+    /// each request, which would otherwise block a concurrent cancel until
+    /// the request it is trying to cancel finishes.
+    ///
+    /// Deliberately never commits an observation: the raced Start's own
+    /// outcome carries the truth.
     ///
     /// Unix-domain-socket connect latency is sub-millisecond, so the
     /// per-call overhead is negligible. Use sparingly — the pooled client
     /// is still the right choice for normal request traffic.
-    pub async fn bridge_send_oneshot(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
-        let mut client = BridgeClient::connect(&resolve_bridge_socket_path()).await?;
+    pub async fn send_oneshot(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
+        let mut client = BridgeClient::connect(&self.socket_path).await?;
         client.send(req).await
+    }
+
+    /// Send Reload iff the proxy is running, decided at the linearization
+    /// point: Status and Reload ride ONE client-lock acquisition, so the
+    /// check cannot go stale against a concurrent Start/Stop (they queue
+    /// behind this lock). The check is load-bearing: bridge-side `reload`
+    /// on a stopped proxy STARTS it, so an unguarded Reload queued behind
+    /// a failed Start would resurrect the tunnel.
+    ///
+    /// Returns Ok(false) when skipped (not running), Ok(true) on a
+    /// successful reload.
+    pub async fn reload_if_running(&self, config: hole_common::protocol::ProxyConfig) -> Result<bool, String> {
+        let mut guard = self.client.lock().await;
+        let status = Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Status).await;
+        if let Some(running) = observed_running(ReqKind::Status, &status) {
+            self.cell.commit(running);
+        }
+        if !matches!(status, Ok(BridgeResponse::Status { running: true, .. })) {
+            return Ok(false); // Not running; changes apply on next start.
+        }
+        match Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Reload { config }).await {
+            Ok(BridgeResponse::Ack) => Ok(true),
+            Ok(BridgeResponse::Error { message }) => Err(message),
+            Ok(_) => Err("unexpected response from bridge".into()),
+            Err(e) => Err(e.to_string()),
+        }
     }
 }
 
-/// Resolve the bridge socket path from `HOLE_BRIDGE_SOCKET` or the
-/// platform default. Extracted so `bridge_send` and `bridge_send_oneshot`
-/// stay in sync.
-fn resolve_bridge_socket_path() -> PathBuf {
-    std::env::var("HOLE_BRIDGE_SOCKET")
-        .ok()
-        .map(PathBuf::from)
-        .unwrap_or_else(hole_common::protocol::default_bridge_socket_path)
+// Proxy runtime state =================================================================================================
+
+/// A versioned observation of the proxy's runtime state. `seq` increases
+/// only when `running` changes; consumers (tray watcher, webview) discard
+/// observations whose seq is not newer than the last applied, which makes
+/// application monotone across the unordered event/poll channels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct ProxySnapshot {
+    pub seq: u64,
+    pub running: bool,
 }
+
+/// Single owner of the GUI's view of "is the proxy running" (#462).
+pub struct ProxyStateCell {
+    tx: tokio::sync::watch::Sender<ProxySnapshot>,
+}
+
+impl Default for ProxyStateCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProxyStateCell {
+    pub fn new() -> Self {
+        let (tx, _) = tokio::sync::watch::channel(ProxySnapshot { seq: 0, running: false });
+        Self { tx }
+    }
+
+    /// Commit an observed running state. Bumps `seq` (and wakes watchers)
+    /// only when the value actually changes.
+    pub fn commit(&self, running: bool) {
+        self.tx.send_if_modified(|snap| {
+            if snap.running == running {
+                return false;
+            }
+            *snap = ProxySnapshot {
+                seq: snap.seq + 1,
+                running,
+            };
+            true
+        });
+    }
+
+    pub fn snapshot(&self) -> ProxySnapshot {
+        *self.tx.borrow()
+    }
+
+    pub fn subscribe(&self) -> tokio::sync::watch::Receiver<ProxySnapshot> {
+        self.tx.subscribe()
+    }
+}
+
+/// Which request kinds reveal the proxy's running state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReqKind {
+    Status,
+    Start,
+    Stop,
+    Other,
+}
+
+impl ReqKind {
+    fn of(req: &BridgeRequest) -> Self {
+        match req {
+            BridgeRequest::Status => Self::Status,
+            BridgeRequest::Start { .. } => Self::Start,
+            BridgeRequest::Stop => Self::Stop,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// The bridge's Start-error taxonomy, classified in exactly one place —
+/// both the runtime-truth axis (`observed_running`) and the user-outcome
+/// axis (`tray::outcome_for_start_response`) consume this; the string
+/// literals must never appear anywhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StartErrorKind {
+    Cancelled,
+    AlreadyRunning,
+    Other,
+}
+
+pub(crate) fn classify_start_error(message: &str) -> StartErrorKind {
+    if message == CANCELLED_MESSAGE {
+        StartErrorKind::Cancelled
+    } else if message.contains("already running") {
+        StartErrorKind::AlreadyRunning
+    } else {
+        StartErrorKind::Other
+    }
+}
+
+/// What a completed bridge exchange proves about `running`, if anything.
+///
+/// - Stop+Error commits nothing: the bridge takes the running slot before
+///   teardown (`ProxyManager::stop`), so its own Status already reports
+///   false — the caller follows up with a Status instead of guessing.
+/// - PermissionDenied commits nothing: a connect-phase DACL rejection
+///   says nothing about the tunnel.
+/// - Transport errors on tracked kinds commit false: an unreachable
+///   bridge tunnels nothing (the mapping `get_proxy_status` always used).
+pub(crate) fn observed_running(kind: ReqKind, result: &Result<BridgeResponse, ClientError>) -> Option<bool> {
+    use ReqKind::*;
+    match (kind, result) {
+        (Other, _) => None,
+        (_, Err(ClientError::PermissionDenied)) => None,
+        (_, Err(_)) => Some(false),
+        (Status, Ok(BridgeResponse::Status { running, .. })) => Some(*running),
+        (Start, Ok(BridgeResponse::Ack)) => Some(true),
+        (Start, Ok(BridgeResponse::Error { message })) => match classify_start_error(message) {
+            StartErrorKind::Cancelled => Some(false),
+            // A failed start is rolled back bridge-side.
+            StartErrorKind::Other => Some(false),
+            StartErrorKind::AlreadyRunning => Some(true),
+        },
+        (Stop, Ok(BridgeResponse::Ack)) => Some(false),
+        (Stop, Ok(BridgeResponse::Error { .. })) => None,
+        (_, Ok(_)) => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "state_tests.rs"]
+mod state_tests;

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -1,0 +1,336 @@
+use super::*;
+use crate::bridge_client::ClientError;
+use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE};
+
+// ProxyStateCell ======================================================================================================
+
+#[skuld::test]
+fn cell_bumps_seq_only_on_change() {
+    let cell = ProxyStateCell::new();
+    assert_eq!(cell.snapshot(), ProxySnapshot { seq: 0, running: false });
+    cell.commit(false);
+    assert_eq!(cell.snapshot().seq, 0, "no-change commit must not bump seq");
+    cell.commit(true);
+    assert_eq!(cell.snapshot(), ProxySnapshot { seq: 1, running: true });
+    cell.commit(false);
+    assert_eq!(cell.snapshot(), ProxySnapshot { seq: 2, running: false });
+}
+
+#[skuld::test]
+async fn cell_wakes_watchers_only_on_change() {
+    let cell = ProxyStateCell::new();
+    let mut rx = cell.subscribe();
+    cell.commit(false); // no change
+    assert!(!rx.has_changed().unwrap());
+    cell.commit(true);
+    assert!(rx.has_changed().unwrap());
+    assert_eq!(*rx.borrow_and_update(), ProxySnapshot { seq: 1, running: true });
+}
+
+// observed_running ====================================================================================================
+
+fn status_resp(running: bool) -> BridgeResponse {
+    BridgeResponse::Status {
+        running,
+        uptime_secs: 0,
+        error: None,
+        invalid_filters: vec![],
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
+    }
+}
+
+fn err_resp(msg: &str) -> BridgeResponse {
+    BridgeResponse::Error { message: msg.into() }
+}
+
+fn transport_err() -> ClientError {
+    ClientError::Connection(std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused"))
+}
+
+#[skuld::test]
+fn observed_running_rules() {
+    use ReqKind::*;
+    // (kind, result, expected) — owned Results, only ever borrowed:
+    // BridgeResponse/ClientError are not Clone.
+    let table: Vec<(ReqKind, Result<BridgeResponse, ClientError>, Option<bool>)> = vec![
+        (Status, Ok(status_resp(true)), Some(true)),
+        (Status, Ok(status_resp(false)), Some(false)),
+        (Start, Ok(BridgeResponse::Ack), Some(true)),
+        (Start, Ok(err_resp(CANCELLED_MESSAGE)), Some(false)),
+        (Start, Ok(err_resp("proxy already running")), Some(true)),
+        (Start, Ok(err_resp("plugin failed")), Some(false)),
+        (Stop, Ok(BridgeResponse::Ack), Some(false)),
+        (Stop, Ok(err_resp("teardown failed")), None),
+        (Start, Err(ClientError::PermissionDenied), None),
+        (Stop, Err(ClientError::PermissionDenied), None),
+        (Status, Err(transport_err()), Some(false)),
+        (Start, Err(transport_err()), Some(false)),
+        (Stop, Err(transport_err()), Some(false)),
+        (Other, Ok(BridgeResponse::Ack), None),
+        (Other, Err(transport_err()), None),
+    ];
+    for (kind, result, expected) in &table {
+        assert_eq!(observed_running(*kind, result), *expected, "{kind:?} / {result:?}");
+    }
+}
+
+#[skuld::test]
+fn start_error_classification() {
+    assert_eq!(classify_start_error(CANCELLED_MESSAGE), StartErrorKind::Cancelled);
+    assert_eq!(
+        classify_start_error("proxy already running"),
+        StartErrorKind::AlreadyRunning
+    );
+    assert_eq!(classify_start_error("plugin failed"), StartErrorKind::Other);
+}
+
+// BridgeLink ==========================================================================================================
+
+use axum::routing::{get, post};
+use axum::Json;
+use hole_common::protocol::{EmptyResponse, StatusResponse, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS};
+use hyper::body::Incoming;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+fn test_socket_path(suffix: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("hole-link-test-{}-{suffix}.sock", std::process::id()))
+}
+
+fn test_proxy_config() -> hole_common::protocol::ProxyConfig {
+    hole_common::protocol::ProxyConfig {
+        server: hole_common::config::ServerEntry {
+            id: "id".into(),
+            name: "S".into(),
+            server: "1.2.3.4".into(),
+            server_port: 8388,
+            method: "aes-256-gcm".into(),
+            password: "pw".into(),
+            plugin: None,
+            plugin_opts: None,
+            validation: None,
+        },
+        local_port: 4073,
+        tunnel_mode: hole_common::protocol::TunnelMode::Full,
+        filters: Vec::new(),
+        dns: hole_common::config::DnsConfig {
+            enabled: false,
+            ..hole_common::config::DnsConfig::default()
+        },
+        proxy_socks5: true,
+        proxy_http: false,
+        local_port_http: 4074,
+        diagnostic_plugin_tap: false,
+    }
+}
+
+fn status_response(running: bool) -> StatusResponse {
+    StatusResponse {
+        running,
+        uptime_secs: 0,
+        error: None,
+        invalid_filters: Vec::new(),
+        udp_proxy_available: true,
+        ipv6_bypass_available: true,
+    }
+}
+
+/// Serve `router` on `path`, accepting connections in a loop (BridgeLink
+/// reconnects after transport errors, and `send_oneshot` always dials
+/// fresh). Each connection is served on its own task so a parked handler
+/// cannot block later accepts.
+async fn serve_router(path: &std::path::Path, router: axum::Router) -> tokio::task::JoinHandle<()> {
+    let listener = hole_bridge::socket::LocalListener::bind(path).unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok(stream) = listener.accept().await else { return };
+            let io = hyper_util::rt::TokioIo::new(stream);
+            let router = router.clone();
+            let service = hyper::service::service_fn(move |req: http::Request<Incoming>| {
+                let router = router.clone();
+                async move {
+                    use tower::ServiceExt;
+                    let resp = router.oneshot(req.map(axum::body::Body::new)).await.unwrap();
+                    Ok::<_, std::convert::Infallible>(resp)
+                }
+            });
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    })
+}
+
+#[skuld::test]
+async fn start_ack_commits_true() {
+    let path = test_socket_path("start-ack");
+    let router = axum::Router::new().route(ROUTE_START, post(|| async { Json(EmptyResponse {}) }));
+    let _mock = serve_router(&path, router).await;
+
+    let link = BridgeLink::new(path);
+    assert!(!link.cell().snapshot().running);
+    let resp = link
+        .send(BridgeRequest::Start {
+            config: test_proxy_config(),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(resp, BridgeResponse::Ack));
+    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+}
+
+#[skuld::test]
+async fn transport_error_commits_false() {
+    let path = test_socket_path("dead");
+    let _ = std::fs::remove_file(&path);
+    let link = BridgeLink::new(path);
+    link.cell().commit(true); // pretend we believed it was running
+    let _ = link.send(BridgeRequest::Status).await.unwrap_err();
+    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 2, running: false });
+}
+
+#[skuld::test]
+async fn oneshot_never_commits() {
+    let path = test_socket_path("oneshot");
+    let router = axum::Router::new().route(
+        hole_common::protocol::ROUTE_CANCEL,
+        post(|| async { Json(EmptyResponse {}) }),
+    );
+    let _mock = serve_router(&path, router).await;
+
+    let link = BridgeLink::new(path);
+    link.cell().commit(true);
+    link.send_oneshot(BridgeRequest::Cancel).await.unwrap();
+    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+}
+
+#[skuld::test]
+async fn untracked_requests_never_commit() {
+    let path = test_socket_path("untracked");
+    let router = axum::Router::new().route(
+        hole_common::protocol::ROUTE_METRICS,
+        get(|| async {
+            Json(hole_common::protocol::MetricsResponse {
+                bytes_in: 0,
+                bytes_out: 0,
+                speed_in_bps: 0,
+                speed_out_bps: 0,
+                uptime_secs: 0,
+                filter: None,
+            })
+        }),
+    );
+    let _mock = serve_router(&path, router).await;
+
+    let link = BridgeLink::new(path);
+    link.send(BridgeRequest::Metrics).await.unwrap();
+    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 0, running: false });
+}
+
+/// The ordering guarantee under test is the CLIENT-LOCK serialization:
+/// there is exactly one pooled connection; task B waits on the
+/// tokio::sync::Mutex around the client, not on a second connection.
+#[skuld::test]
+async fn concurrent_requests_commit_in_bridge_order() {
+    let path = test_socket_path("order");
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let (entered2, release2) = (entered.clone(), release.clone());
+    let router = axum::Router::new()
+        .route(
+            ROUTE_START,
+            post(move || {
+                let (entered, release) = (entered2.clone(), release2.clone());
+                async move {
+                    entered.notify_one();
+                    release.notified().await;
+                    Json(EmptyResponse {})
+                }
+            }),
+        )
+        .route(ROUTE_STATUS, get(|| async { Json(status_response(true)) }));
+    let _mock = serve_router(&path, router).await;
+
+    let link = Arc::new(BridgeLink::new(path));
+    let a = tokio::spawn({
+        let link = link.clone();
+        async move {
+            link.send(BridgeRequest::Start {
+                config: test_proxy_config(),
+            })
+            .await
+        }
+    });
+    // Rendezvous: A's Start has reached the mock, so A holds the client
+    // lock before B is spawned.
+    entered.notified().await;
+    let b = tokio::spawn({
+        let link = link.clone();
+        async move { link.send(BridgeRequest::Status).await }
+    });
+    release.notify_one();
+
+    let a = a.await.unwrap().unwrap();
+    let b = b.await.unwrap().unwrap();
+    assert!(matches!(a, BridgeResponse::Ack));
+    assert!(matches!(b, BridgeResponse::Status { running: true, .. }));
+    // Start committed true (seq 1); the queued Status confirmed true (no bump).
+    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+}
+
+#[skuld::test]
+async fn reload_if_running_skips_when_stopped() {
+    let path = test_socket_path("reload-stopped");
+    let reloads = Arc::new(AtomicUsize::new(0));
+    let reloads2 = reloads.clone();
+    let router = axum::Router::new()
+        .route(ROUTE_STATUS, get(|| async { Json(status_response(false)) }))
+        .route(
+            ROUTE_RELOAD,
+            post(move || {
+                let reloads = reloads2.clone();
+                async move {
+                    reloads.fetch_add(1, Ordering::SeqCst);
+                    Json(EmptyResponse {})
+                }
+            }),
+        );
+    let _mock = serve_router(&path, router).await;
+
+    let link = BridgeLink::new(path);
+    let reloaded = link.reload_if_running(test_proxy_config()).await.unwrap();
+    assert!(!reloaded);
+    // The resurrection guard: bridge-side `reload` on a stopped proxy
+    // STARTS it, so the Reload must never have been sent.
+    assert_eq!(reloads.load(Ordering::SeqCst), 0);
+}
+
+#[skuld::test]
+async fn reload_if_running_reloads_when_running() {
+    let path = test_socket_path("reload-running");
+    let reloads = Arc::new(AtomicUsize::new(0));
+    let reloads2 = reloads.clone();
+    let router = axum::Router::new()
+        .route(ROUTE_STATUS, get(|| async { Json(status_response(true)) }))
+        .route(
+            ROUTE_RELOAD,
+            post(move || {
+                let reloads = reloads2.clone();
+                async move {
+                    reloads.fetch_add(1, Ordering::SeqCst);
+                    Json(EmptyResponse {})
+                }
+            }),
+        );
+    let _mock = serve_router(&path, router).await;
+
+    let link = BridgeLink::new(path);
+    let reloaded = link.reload_if_running(test_proxy_config()).await.unwrap();
+    assert!(reloaded);
+    assert_eq!(reloads.load(Ordering::SeqCst), 1);
+    // The Status leg committed the observation.
+    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+}

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -3,7 +3,7 @@
 use crate::commands::build_proxy_config;
 use crate::state::AppState;
 use hole::tray_icons;
-use hole_common::protocol::{BridgeRequest, BridgeResponse, CANCELLED_MESSAGE};
+use hole_common::protocol::{BridgeRequest, BridgeResponse};
 use serde::Serialize;
 use tauri::menu::{CheckMenuItem, MenuEvent, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
@@ -29,11 +29,105 @@ pub enum ToggleOutcome {
     Cancelled,
 }
 
+/// Marks a connect/disconnect operation as in flight. One transition at a
+/// time: a concurrent opposite toggle is rejected instead of queuing a
+/// contradictory Start/Stop behind the bridge lock (a user's cancel must
+/// not be overtaken by a queued second Start). The target also drives the
+/// tray's Connecting…/Disconnecting… rendering. Tauri-managed state,
+/// registered in `main.rs` setup.
+pub(crate) struct TransitionSlot {
+    target: std::sync::Mutex<Option<bool>>,
+}
+
+impl TransitionSlot {
+    pub(crate) fn new() -> Self {
+        Self {
+            target: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Claim the slot for a transition toward `target`. False if another
+    /// transition is already in flight.
+    pub(crate) fn try_begin(&self, target: bool) -> bool {
+        let mut slot = self.target.lock().unwrap();
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(target);
+        true
+    }
+
+    pub(crate) fn end(&self) {
+        *self.target.lock().unwrap() = None;
+    }
+
+    pub(crate) fn target(&self) -> Option<bool> {
+        *self.target.lock().unwrap()
+    }
+}
+
+/// Decision derived from a Start/Stop exchange. Pure — the dialog and
+/// elevation glue in `set_proxy_enabled` interprets `NeedsElevation`.
+pub(crate) enum StartDecision {
+    Outcome(ToggleOutcome),
+    NeedsElevation,
+    Fail(String),
+}
+
+pub(crate) fn outcome_for_start_response(
+    result: &Result<BridgeResponse, crate::bridge_client::ClientError>,
+) -> StartDecision {
+    use crate::state::{classify_start_error, StartErrorKind};
+    match result {
+        Ok(BridgeResponse::Ack) => StartDecision::Outcome(ToggleOutcome::Running),
+        Ok(BridgeResponse::Error { message }) => match classify_start_error(message) {
+            StartErrorKind::Cancelled => StartDecision::Outcome(ToggleOutcome::Cancelled),
+            StartErrorKind::AlreadyRunning => StartDecision::Outcome(ToggleOutcome::Running),
+            StartErrorKind::Other => StartDecision::Fail(format!("Bridge error: {message}")),
+        },
+        Ok(_) => StartDecision::Fail("Unexpected response from bridge".into()),
+        Err(crate::bridge_client::ClientError::PermissionDenied) => StartDecision::NeedsElevation,
+        Err(e) => StartDecision::Fail(format!("Failed to connect to bridge: {e}")),
+    }
+}
+
+pub(crate) fn outcome_for_stop_response(
+    result: &Result<BridgeResponse, crate::bridge_client::ClientError>,
+) -> StartDecision {
+    match result {
+        Ok(BridgeResponse::Ack) => StartDecision::Outcome(ToggleOutcome::Stopped),
+        Ok(BridgeResponse::Error { message }) => StartDecision::Fail(format!("Bridge error: {message}")),
+        Ok(_) => StartDecision::Fail("Unexpected response from bridge".into()),
+        Err(crate::bridge_client::ClientError::PermissionDenied) => StartDecision::NeedsElevation,
+        Err(e) => StartDecision::Fail(format!("Failed to connect to bridge: {e}")),
+    }
+}
+
+/// Sole writer of persisted `config.enabled` (#462): records the last user
+/// intent the bridge honored, as input for a future
+/// `StartupBehavior::RestoreLastState`. Nothing reads it at runtime —
+/// display and direction come from the `ProxyStateCell`.
+pub(crate) fn persist_intended_enabled(
+    config: &std::sync::Mutex<hole_common::config::AppConfig>,
+    store: &hole_common::config_store::ConfigStore,
+    enabled: bool,
+) {
+    let mut config = config.lock().unwrap();
+    if config.enabled == enabled {
+        return;
+    }
+    config.enabled = enabled;
+    if let Err(e) = store.save(&config) {
+        warn!(error = %e, path = %store.path().display(), "failed to persist intended enabled state");
+    }
+}
+
 // Menu IDs ============================================================================================================
 
 // Tray menu -----------------------------------------------------------------------------------------------------------
 const ID_STATUS: &str = "status";
 const ID_CONNECT: &str = "connect";
+const ID_DISCONNECT: &str = "disconnect";
 const ID_AUTOSTART: &str = "autostart";
 const ID_SETTINGS: &str = "settings";
 const ID_EXIT: &str = "exit";
@@ -51,16 +145,33 @@ const ID_COLLECT_LOGS: &str = "window_collect_logs";
 // Tray creation =======================================================================================================
 
 /// Build the tray menu, optionally including an "Install Update" item.
+///
+/// `running` is the bridge's actual state (from the `ProxyStateCell`,
+/// never persisted config — #462); `transition` is an in-flight
+/// connect/disconnect target, rendered as Connecting…/Disconnecting…
+/// with the action item disabled.
 fn build_tray_menu(
     app: &AppHandle,
     update: Option<&hole::update::UpdateInfo>,
-    enabled: bool,
+    running: bool,
+    transition: Option<bool>,
 ) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
-    let status_text = if enabled { "Connected" } else { "Disconnected" };
-    let connect_text = if enabled { "Disconnect" } else { "Connect" };
+    let status_text = match (transition, running) {
+        (Some(true), _) => "Connecting...",
+        (Some(false), _) => "Disconnecting...",
+        (None, true) => "Connected",
+        (None, false) => "Disconnected",
+    };
+    // The action item carries the intent its label displays: a click
+    // dispatches on the item ID, with no state read at click time.
+    let (action_id, action_text) = if running {
+        (ID_DISCONNECT, "Disconnect")
+    } else {
+        (ID_CONNECT, "Connect")
+    };
 
     let status = MenuItem::with_id(app, ID_STATUS, status_text, false, None::<&str>)?;
-    let connect = MenuItem::with_id(app, ID_CONNECT, connect_text, true, None::<&str>)?;
+    let connect = MenuItem::with_id(app, action_id, action_text, transition.is_none(), None::<&str>)?;
     let autostart = CheckMenuItem::with_id(app, ID_AUTOSTART, "Start at Login", true, false, None::<&str>)?;
     let settings = MenuItem::with_id(app, ID_SETTINGS, "Dashboard...", true, None::<&str>)?;
     let sep1 = PredefinedMenuItem::separator(app)?;
@@ -95,30 +206,13 @@ fn build_tray_menu(
     }
 }
 
-/// Sync tray menu item text and checkbox states from the given proxy state
-/// and the OS autostart registration.
+/// Sync the autostart checkbox from the OS autostart registration. Status
+/// and connect/disconnect text are baked into the menu at build time.
 ///
 /// Must run on the main thread: the menu-item setters dispatch to the main
 /// thread and block when called from anywhere else, so a caller holding a
 /// lock here can deadlock the app.
-fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>, enabled: bool) {
-    // Sync status text
-    if let Some(item) = menu.get(ID_STATUS) {
-        if let Some(menu_item) = item.as_menuitem() {
-            let text = if enabled { "Connected" } else { "Disconnected" };
-            menu_item.set_text(text).ok();
-        }
-    }
-
-    // Sync connect/disconnect text
-    if let Some(item) = menu.get(ID_CONNECT) {
-        if let Some(menu_item) = item.as_menuitem() {
-            let text = if enabled { "Disconnect" } else { "Connect" };
-            menu_item.set_text(text).ok();
-        }
-    }
-
-    // Sync autostart checkbox
+fn sync_autostart_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>) {
     if let Some(item) = menu.get(ID_AUTOSTART) {
         if let Some(check) = item.as_check_menuitem() {
             use tauri_plugin_autostart::ManagerExt;
@@ -138,10 +232,15 @@ fn sync_menu_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>, enable
 }
 
 /// Create and register the system tray icon with its menu.
+///
+/// Renders from the `ProxyStateCell` (false until the first Status lands),
+/// never from persisted config — a relaunch can no longer show "Connected"
+/// over no tunnel (#462); the status reconciler's immediate first tick
+/// corrects the genuine bridge-survived-a-GUI-crash case.
 pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
-    let enabled = app.state::<AppState>().config.lock().unwrap().enabled;
-    let menu = build_tray_menu(app.handle(), None, enabled)?;
-    let icon = tray_icons::tray_image(enabled.into());
+    let running = app.state::<AppState>().proxy_snapshot().running;
+    let menu = build_tray_menu(app.handle(), None, running, None)?;
+    let icon = tray_icons::tray_image(running.into());
 
     #[allow(unused_mut)]
     let mut builder = TrayIconBuilder::with_id("main")
@@ -159,32 +258,23 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
 
     let tray = builder.build(app)?;
 
-    sync_menu_state(app.handle(), &menu, enabled);
+    sync_autostart_state(app.handle(), &menu);
 
     Ok(tray)
 }
 
-/// Update the tray icon to reflect the given enabled/disabled state.
-pub fn set_tray_icon(app: &AppHandle, enabled: bool) {
-    if let Some(tray) = app.tray_by_id("main") {
-        // `true` mirrors the build-time `icon_as_template(true)`; on
-        // non-macOS this falls back to plain `set_icon` (see #469).
-        if let Err(e) = tray.set_icon_with_as_template(Some(tray_icons::tray_image(enabled.into())), true) {
-            warn!(error = %e, "failed to set tray icon");
-        }
-    }
-}
-
 // Proxy state management ==============================================================================================
 
-/// Rebuild the tray menu to sync state with the current config.
+/// Rebuild the tray menu and icon to sync with the actual proxy state.
 ///
 /// Preserves the "Install Update" item if an update is available.
 ///
 /// The whole rebuild (state reads included) is dispatched to the main
-/// thread: worker-thread callers would otherwise read autostart/config
-/// state on one thread and commit the menu later via a queued
-/// `set_menu`, letting a stale menu overwrite a newer one (#473).
+/// thread: worker-thread callers would otherwise read state on one
+/// thread and commit the menu later via a queued `set_menu`, letting a
+/// stale menu overwrite a newer one (#473). The icon is committed inside
+/// the same ordered closure for the same reason (#492 — a worker-thread
+/// read paired with a queued `set_icon` can commit a stale icon).
 /// `run_on_main_thread` executes inline when already on the main thread.
 pub fn rebuild_tray_menu(app: &AppHandle) {
     let handle = app.clone();
@@ -195,10 +285,11 @@ pub fn rebuild_tray_menu(app: &AppHandle) {
         };
         let update_state = handle.state::<hole::update::UpdateState>();
         let update_info = update_state.rx.borrow().clone();
-        let enabled = handle.state::<AppState>().config.lock().unwrap().enabled;
-        match build_tray_menu(&handle, update_info.as_ref(), enabled) {
+        let snap = handle.state::<AppState>().proxy_snapshot();
+        let transition = handle.state::<TransitionSlot>().target();
+        match build_tray_menu(&handle, update_info.as_ref(), snap.running, transition) {
             Ok(menu) => {
-                sync_menu_state(&handle, &menu, enabled);
+                sync_autostart_state(&handle, &menu);
                 // Sanctioned `set_menu` site: the one ordered commit point
                 // (clippy.toml bans it everywhere else).
                 #[allow(clippy::disallowed_methods)]
@@ -208,6 +299,11 @@ pub fn rebuild_tray_menu(app: &AppHandle) {
             }
             Err(e) => warn!(error = %e, "failed to rebuild tray menu"),
         }
+        // `true` mirrors the build-time `icon_as_template(true)`; on
+        // non-macOS this falls back to plain `set_icon` (see #469).
+        if let Err(e) = tray.set_icon_with_as_template(Some(tray_icons::tray_image(snap.running.into())), true) {
+            warn!(error = %e, "failed to set tray icon");
+        }
     });
     if let Err(e) = dispatched {
         warn!(error = %e, "failed to dispatch tray menu rebuild");
@@ -215,147 +311,141 @@ pub fn rebuild_tray_menu(app: &AppHandle) {
 }
 
 /// Send a best-effort Stop to the bridge and exit the application.
+///
+/// Persisted `config.enabled` is deliberately untouched: it is the
+/// write-only record of the last honored intent (the future
+/// `RestoreLastState` input), and the tray renders from bridge Status at
+/// the next launch, never from that flag (#462).
 async fn exit_app(app: AppHandle) {
     let state = app.state::<AppState>();
     let _ = state.bridge_send(BridgeRequest::Stop).await;
     app.exit(0);
 }
 
-/// Revert config.enabled and sync the tray icon + menu.
-fn revert_proxy_state(app: &AppHandle, enabled: bool) {
-    let state = app.state::<AppState>();
-    {
-        let mut config = state.config.lock().unwrap();
-        config.enabled = enabled;
-        if let Err(e) = state.config_store.save(&config) {
-            warn!(error = %e, path = %state.config_store.path().display(), "revert_proxy_state: persist failed");
+/// RAII transition marker: registers the target so the tray renders
+/// Connecting…/Disconnecting… (action item disabled), and a concurrent
+/// opposite toggle is rejected instead of queuing a contradictory
+/// Start/Stop behind the bridge lock (a user's cancel must not be
+/// overtaken by a queued second Start).
+struct TransitionGuard {
+    app: AppHandle,
+}
+
+impl TransitionGuard {
+    fn begin(app: &AppHandle, target: bool) -> Option<Self> {
+        if !app.state::<TransitionSlot>().try_begin(target) {
+            return None;
         }
+        let guard = Self { app: app.clone() };
+        rebuild_tray_menu(&guard.app);
+        Some(guard)
     }
-    set_tray_icon(app, enabled);
-    rebuild_tray_menu(app);
+}
+
+impl Drop for TransitionGuard {
+    fn drop(&mut self) {
+        self.app.state::<TransitionSlot>().end();
+        rebuild_tray_menu(&self.app);
+    }
+}
+
+/// Elevation bypasses the pooled bridge channel, so on success confirm
+/// the actual state via a tracked Status instead of assuming: the commit
+/// (inside `BridgeLink::send`) is what updates the tray and the webview.
+async fn elevate_and_confirm(
+    app: &AppHandle,
+    request: BridgeRequest,
+    assumed: ToggleOutcome,
+) -> Result<ToggleOutcome, String> {
+    if crate::elevation::prompt_elevation(app, request).await {
+        let _ = app.state::<AppState>().bridge_send(BridgeRequest::Status).await;
+        Ok(assumed)
+    } else {
+        Err("Elevation was denied or failed".into())
+    }
 }
 
 /// Set the proxy to the given enabled state. Returns a `ToggleOutcome`
 /// describing whether the proxy ended up Running, Stopped, or the Start
-/// was Cancelled before it could complete (only when `enabled == true`).
+/// was Cancelled before it could complete (only when `enable == true`).
 ///
-/// On bridge errors that are NOT a cancellation, reverts config + tray
-/// state and returns an error message. On `Cancelled`, reverts config
-/// back to `false` — the optimistic `config.enabled = true` flip is
-/// rolled back so the persisted state matches reality.
-/// Used by both the tray Enable checkbox and the frontend toggle button.
-pub async fn set_proxy_enabled(app: &AppHandle, enabled: bool) -> Result<ToggleOutcome, String> {
+/// There is no optimistic state flip and no revert: the bridge exchange
+/// itself commits the observed truth to the `ProxyStateCell` (inside the
+/// client lock), the state-sync watcher repaints the tray and notifies
+/// the webview, and persisted `config.enabled` records only an intent
+/// the bridge actually honored. On failure, one follow-up Status commits
+/// reality — a failed Disconnect can no longer re-assert "Connected"
+/// over a stopped tunnel.
+/// Used by the tray menu items and the `start_proxy`/`stop_proxy`
+/// commands.
+pub async fn set_proxy_enabled(app: &AppHandle, enable: bool) -> Result<ToggleOutcome, String> {
     let state = app.state::<AppState>();
 
     // Bridge install gate: if the user is trying to enable the proxy and
     // the bridge isn't installed yet, prompt for installation BEFORE
-    // flipping any config state. Cancelling here leaves `config.enabled`
-    // untouched (no rollback needed).
-    if enabled
+    // anything else.
+    if enable
         && crate::setup::bridge_install_status() == crate::setup::BridgeInstallStatus::NotInstalled
         && !crate::setup::prompt_bridge_install(app.clone()).await
     {
         return Err("The Hole bridge must be installed to connect.".into());
     }
 
-    let proxy_config = {
-        let mut config = state.config.lock().unwrap();
-        if config.enabled == enabled {
-            // Already in the desired state (concurrent toggle).
-            return Ok(if enabled {
-                ToggleOutcome::Running
-            } else {
-                ToggleOutcome::Stopped
-            });
-        }
-        config.enabled = enabled;
-        if let Err(e) = state.config_store.save(&config) {
-            warn!(error = %e, path = %state.config_store.path().display(), "set_proxy_enabled: persist failed");
-        }
-        build_proxy_config(&config)
+    let Some(_transition) = TransitionGuard::begin(app, enable) else {
+        return Err("Another connect or disconnect is already in progress.".into());
     };
 
-    set_tray_icon(app, enabled);
-
-    let result: Result<ToggleOutcome, String> = if enabled {
+    let result: Result<ToggleOutcome, String> = if enable {
+        let proxy_config = {
+            let config = state.config.lock().unwrap();
+            build_proxy_config(&config)
+        };
         let Some(proxy_config) = proxy_config else {
-            revert_proxy_state(app, false);
             return Err("No server is selected. Open the Dashboard and select a server before connecting.".into());
         };
 
         let request = BridgeRequest::Start { config: proxy_config };
-        match state.bridge_send(request.clone()).await {
-            Ok(BridgeResponse::Ack) => {
-                info!("proxy started");
-                Ok(ToggleOutcome::Running)
+        let response = state.bridge_send(request.clone()).await;
+        match outcome_for_start_response(&response) {
+            StartDecision::Outcome(outcome) => {
+                info!(?outcome, "proxy start settled");
+                Ok(outcome)
             }
-            Ok(BridgeResponse::Error { message }) if message == CANCELLED_MESSAGE => {
-                info!("proxy start cancelled");
-                Ok(ToggleOutcome::Cancelled)
-            }
-            Ok(BridgeResponse::Error { message }) if message.contains("already running") => {
-                info!("proxy already running");
-                Ok(ToggleOutcome::Running)
-            }
-            Ok(BridgeResponse::Error { message }) => {
-                error!("bridge error: {message}");
-                Err(format!("Bridge error: {message}"))
-            }
-            Ok(_) => {
-                warn!("unexpected response from bridge");
-                Err("Unexpected response from bridge".into())
-            }
-            Err(crate::bridge_client::ClientError::PermissionDenied) => {
-                if crate::elevation::prompt_elevation(app, request).await {
-                    Ok(ToggleOutcome::Running)
-                } else {
-                    Err("Elevation was denied or failed".into())
-                }
-            }
-            Err(e) => {
-                error!("failed to send start: {e}");
-                Err(format!("Failed to connect to bridge: {e}"))
+            StartDecision::NeedsElevation => elevate_and_confirm(app, request, ToggleOutcome::Running).await,
+            StartDecision::Fail(msg) => {
+                error!("proxy start failed: {msg}");
+                Err(msg)
             }
         }
     } else {
         let request = BridgeRequest::Stop;
-        match state.bridge_send(request.clone()).await {
-            Ok(BridgeResponse::Ack) => {
-                info!("proxy stopped");
-                Ok(ToggleOutcome::Stopped)
+        let response = state.bridge_send(request.clone()).await;
+        match outcome_for_stop_response(&response) {
+            StartDecision::Outcome(outcome) => {
+                info!(?outcome, "proxy stop settled");
+                Ok(outcome)
             }
-            Ok(BridgeResponse::Error { message }) => {
-                error!("bridge error: {message}");
-                Err(format!("Bridge error: {message}"))
-            }
-            Ok(_) => {
-                warn!("unexpected response from bridge");
-                Err("Unexpected response from bridge".into())
-            }
-            Err(crate::bridge_client::ClientError::PermissionDenied) => {
-                if crate::elevation::prompt_elevation(app, request).await {
-                    Ok(ToggleOutcome::Stopped)
-                } else {
-                    Err("Elevation was denied or failed".into())
-                }
-            }
-            Err(e) => {
-                error!("failed to send stop: {e}");
-                Err(format!("Failed to connect to bridge: {e}"))
+            StartDecision::NeedsElevation => elevate_and_confirm(app, request, ToggleOutcome::Stopped).await,
+            StartDecision::Fail(msg) => {
+                error!("proxy stop failed: {msg}");
+                Err(msg)
             }
         }
     };
 
     match &result {
-        Ok(ToggleOutcome::Running | ToggleOutcome::Stopped) => rebuild_tray_menu(app),
-        Ok(ToggleOutcome::Cancelled) => {
-            // The user cancelled the Start. Roll back the optimistic
-            // `config.enabled = true` flip so persisted state matches
-            // reality, and rebuild the menu with enabled=false.
-            debug_assert!(enabled, "Cancelled outcome only possible on Start");
-            revert_proxy_state(app, false);
+        Ok(outcome) => {
+            persist_intended_enabled(
+                &state.config,
+                &state.config_store,
+                matches!(outcome, ToggleOutcome::Running),
+            );
         }
-        Err(_) => revert_proxy_state(app, !enabled),
+        Err(_) => {
+            // The failed exchange may have committed nothing (Stop+Error)
+            // or a pessimistic false; one linearized Status commits truth.
+            let _ = state.bridge_send(BridgeRequest::Status).await;
+        }
     }
 
     result
@@ -386,20 +476,20 @@ fn handle_tray_icon_event(tray: &TrayIcon, event: TrayIconEvent) {
 /// also invoke the window's handler (and vice versa), causing actions to fire twice.
 fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
     match event.id().as_ref() {
-        ID_CONNECT => {
-            info!("tray: connect toggled");
+        // The clicked item's ID carries the user's intent — the intent the
+        // displayed label offered, not a flip of any state read now (#462).
+        id @ (ID_CONNECT | ID_DISCONNECT) => {
+            let enable = id == ID_CONNECT;
+            info!(enable, "tray: connect/disconnect clicked");
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move {
-                let state = app_handle.state::<AppState>();
-                let enabled = !state.config.lock().unwrap().enabled;
-                match set_proxy_enabled(&app_handle, enabled).await {
-                    Ok(ToggleOutcome::Running) | Ok(ToggleOutcome::Stopped) => { /* menu already rebuilt */ }
+                match set_proxy_enabled(&app_handle, enable).await {
+                    Ok(ToggleOutcome::Running) | Ok(ToggleOutcome::Stopped) => { /* watcher repaints */ }
                     Ok(ToggleOutcome::Cancelled) => {
                         // Tray never initiates Cancel itself, so this is an
                         // observer effect: the frontend cancelled while the
                         // tray-triggered Start was still in flight. The
-                        // config has already been reverted by
-                        // set_proxy_enabled. Nothing to do here.
+                        // cancelled exchange already committed not-running.
                         info!("tray: start was cancelled externally");
                     }
                     Err(msg) => {
@@ -822,17 +912,26 @@ pub(crate) fn open_settings_window(app: &AppHandle) {
 
 // Tauri commands ======================================================================================================
 
-/// Toggle the proxy on/off. Returns a `ToggleOutcome` describing the
-/// resulting state (Running / Stopped / Cancelled). The frontend
-/// distinguishes the three cases in its connection state machine.
+/// Start the proxy. The caller transmits explicit intent — direction is
+/// decided by the state the user SAW, never re-derived backend-side from
+/// possibly-stale state (#462); the bridge's idempotence ("already
+/// running" → Running) absorbs a stale view instead of inverting the
+/// user's intent. Returns a `ToggleOutcome` (Running / Stopped /
+/// Cancelled); the frontend distinguishes the three cases in its
+/// connection state machine.
 #[tauri::command]
-pub async fn toggle_proxy(app: AppHandle, state: tauri::State<'_, AppState>) -> Result<ToggleOutcome, String> {
-    let enabled = !state.config.lock().unwrap().enabled;
-    set_proxy_enabled(&app, enabled).await
+pub async fn start_proxy(app: AppHandle) -> Result<ToggleOutcome, String> {
+    set_proxy_enabled(&app, true).await
+}
+
+/// Stop the proxy. See [`start_proxy`].
+#[tauri::command]
+pub async fn stop_proxy(app: AppHandle) -> Result<ToggleOutcome, String> {
+    set_proxy_enabled(&app, false).await
 }
 
 /// Cancel an in-flight proxy start. Uses `bridge_send_oneshot` so the
-/// cancel can race an in-flight `toggle_proxy` on the main pooled
+/// cancel can race an in-flight `start_proxy` on the main pooled
 /// bridge connection. Always returns `Ok(())` on a successful bridge
 /// round-trip — the bridge's `/v1/cancel` route is idempotent.
 #[tauri::command]
@@ -848,6 +947,54 @@ pub async fn cancel_proxy(state: tauri::State<'_, AppState>) -> Result<(), Strin
             Err(format!("Failed to cancel: {e}"))
         }
     }
+}
+
+// Proxy state sync ====================================================================================================
+
+/// Forward every committed proxy-state change to the tray and the
+/// webview. Single sequential consumer of the `ProxyStateCell` watch
+/// channel, so emit order equals commit order; the rebuild re-reads the
+/// cell inside its main-thread closure, so the last queued rebuild always
+/// renders the newest state.
+pub fn spawn_proxy_state_sync(app: &AppHandle) {
+    use tauri::Emitter;
+    let app = app.clone();
+    let mut rx = app.state::<AppState>().subscribe_proxy_state();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            if rx.changed().await.is_err() {
+                return; // cell dropped — app teardown
+            }
+            let snap = *rx.borrow_and_update();
+            rebuild_tray_menu(&app);
+            if let Err(e) = app.emit("proxy-state-changed", snap) {
+                warn!(error = %e, "failed to emit proxy-state-changed");
+            }
+        }
+    });
+}
+
+/// Keep the GUI's view of the bridge honest when the dashboard is closed
+/// (no webview poll): an external stop, a bridge crash, or `hole proxy
+/// stop` must reach the tray (#462).
+///
+/// Sanctioned timing exception (CONTRIBUTING.md test-invariants, the
+/// "external process whose state changes out-of-band" class): this polls
+/// a SEPARATE PROCESS for presentation reconciliation — the same class as
+/// the webview's 5s status poll — and synchronizes nothing in-process
+/// (`BridgeLink::send` commits synchronously; no code waits on this
+/// loop). The immediate first tick doubles as the startup reconcile.
+pub fn spawn_status_reconciler(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(5));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tick.tick().await;
+            // Result irrelevant: the commit happens inside send.
+            let _ = app.state::<AppState>().bridge_send(BridgeRequest::Status).await;
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -351,15 +351,19 @@ impl Drop for TransitionGuard {
 
 /// Elevation bypasses the pooled bridge channel, so on success confirm
 /// the actual state via a tracked Status instead of assuming: the commit
-/// (inside `BridgeLink::send`) is what updates the tray and the webview.
-async fn elevate_and_confirm(
-    app: &AppHandle,
-    request: BridgeRequest,
-    assumed: ToggleOutcome,
-) -> Result<ToggleOutcome, String> {
+/// (inside `BridgeLink::send`) updates the tray and the webview, and the
+/// returned outcome — which the caller persists as the last honored
+/// intent — is derived from that confirmed snapshot, never from the
+/// elevated helper's claim of success.
+async fn elevate_and_confirm(app: &AppHandle, request: BridgeRequest) -> Result<ToggleOutcome, String> {
     if crate::elevation::prompt_elevation(app, request).await {
-        let _ = app.state::<AppState>().bridge_send(BridgeRequest::Status).await;
-        Ok(assumed)
+        let state = app.state::<AppState>();
+        let _ = state.bridge_send(BridgeRequest::Status).await;
+        Ok(if state.proxy_snapshot().running {
+            ToggleOutcome::Running
+        } else {
+            ToggleOutcome::Stopped
+        })
     } else {
         Err("Elevation was denied or failed".into())
     }
@@ -391,27 +395,36 @@ pub async fn set_proxy_enabled(app: &AppHandle, enable: bool) -> Result<ToggleOu
         return Err("The Hole bridge must be installed to connect.".into());
     }
 
+    // Resolve the start payload BEFORE claiming the transition slot — a
+    // request that cannot proceed must not flash "Connecting..." in the
+    // tray.
+    let proxy_config = if enable {
+        let config = state.config.lock().unwrap();
+        match build_proxy_config(&config) {
+            Some(pc) => Some(pc),
+            None => {
+                return Err("No server is selected. Open the Dashboard and select a server before connecting.".into())
+            }
+        }
+    } else {
+        None
+    };
+
     let Some(_transition) = TransitionGuard::begin(app, enable) else {
         return Err("Another connect or disconnect is already in progress.".into());
     };
 
     let result: Result<ToggleOutcome, String> = if enable {
-        let proxy_config = {
-            let config = state.config.lock().unwrap();
-            build_proxy_config(&config)
+        let request = BridgeRequest::Start {
+            config: proxy_config.expect("built above for the enable path"),
         };
-        let Some(proxy_config) = proxy_config else {
-            return Err("No server is selected. Open the Dashboard and select a server before connecting.".into());
-        };
-
-        let request = BridgeRequest::Start { config: proxy_config };
         let response = state.bridge_send(request.clone()).await;
         match outcome_for_start_response(&response) {
             StartDecision::Outcome(outcome) => {
                 info!(?outcome, "proxy start settled");
                 Ok(outcome)
             }
-            StartDecision::NeedsElevation => elevate_and_confirm(app, request, ToggleOutcome::Running).await,
+            StartDecision::NeedsElevation => elevate_and_confirm(app, request).await,
             StartDecision::Fail(msg) => {
                 error!("proxy start failed: {msg}");
                 Err(msg)
@@ -425,7 +438,7 @@ pub async fn set_proxy_enabled(app: &AppHandle, enable: bool) -> Result<ToggleOu
                 info!(?outcome, "proxy stop settled");
                 Ok(outcome)
             }
-            StartDecision::NeedsElevation => elevate_and_confirm(app, request, ToggleOutcome::Stopped).await,
+            StartDecision::NeedsElevation => elevate_and_confirm(app, request).await,
             StartDecision::Fail(msg) => {
                 error!("proxy stop failed: {msg}");
                 Err(msg)

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -1,3 +1,105 @@
-//! The tray handler glue (menu events, rebuilds, dialogs) requires a full
-//! Tauri app context and has no automated coverage at any level; the
-//! Start-at-Login toggle logic is unit-tested in autostart_tests.rs.
+//! Unit tests for the tray's pure decision logic (outcome mapping, the
+//! intended-enabled persist rule). The remaining handler glue (menu
+//! events, rebuilds, dialogs) requires a full Tauri app context and has
+//! no automated coverage; the Start-at-Login toggle logic is unit-tested
+//! in autostart_tests.rs.
+
+use super::*;
+use crate::bridge_client::ClientError;
+use hole_common::config_store::ConfigStore;
+use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE};
+use skuld::temp_dir;
+use std::path::Path;
+use std::sync::Mutex;
+
+#[skuld::test]
+fn transition_slot_rejects_concurrent_and_clears() {
+    let t = TransitionSlot::new();
+    assert_eq!(t.target(), None);
+    assert!(t.try_begin(true));
+    assert_eq!(t.target(), Some(true));
+    assert!(
+        !t.try_begin(false),
+        "second toggle while one is in flight must be rejected"
+    );
+    t.end();
+    assert_eq!(t.target(), None);
+    assert!(t.try_begin(false));
+}
+
+fn err_resp(msg: &str) -> BridgeResponse {
+    BridgeResponse::Error { message: msg.into() }
+}
+
+fn transport_err() -> ClientError {
+    ClientError::Connection(std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused"))
+}
+
+#[skuld::test]
+fn start_response_outcomes() {
+    use StartDecision::*;
+    assert!(matches!(
+        outcome_for_start_response(&Ok(BridgeResponse::Ack)),
+        Outcome(ToggleOutcome::Running)
+    ));
+    assert!(matches!(
+        outcome_for_start_response(&Ok(err_resp(CANCELLED_MESSAGE))),
+        Outcome(ToggleOutcome::Cancelled)
+    ));
+    assert!(matches!(
+        outcome_for_start_response(&Ok(err_resp("proxy already running"))),
+        Outcome(ToggleOutcome::Running)
+    ));
+    assert!(matches!(outcome_for_start_response(&Ok(err_resp("boom"))), Fail(_)));
+    assert!(matches!(
+        outcome_for_start_response(&Ok(BridgeResponse::Ack)),
+        Outcome(ToggleOutcome::Running)
+    ));
+    assert!(matches!(
+        outcome_for_start_response(&Err(ClientError::PermissionDenied)),
+        NeedsElevation
+    ));
+    assert!(matches!(outcome_for_start_response(&Err(transport_err())), Fail(_)));
+}
+
+#[skuld::test]
+fn stop_response_outcomes() {
+    use StartDecision::*;
+    assert!(matches!(
+        outcome_for_stop_response(&Ok(BridgeResponse::Ack)),
+        Outcome(ToggleOutcome::Stopped)
+    ));
+    assert!(matches!(
+        outcome_for_stop_response(&Ok(err_resp("teardown failed"))),
+        Fail(_)
+    ));
+    assert!(matches!(
+        outcome_for_stop_response(&Err(ClientError::PermissionDenied)),
+        NeedsElevation
+    ));
+    assert!(matches!(outcome_for_stop_response(&Err(transport_err())), Fail(_)));
+}
+
+#[skuld::test]
+fn persist_intended_enabled_writes_only_on_change(#[fixture(temp_dir)] dir: &Path) {
+    let path = dir.join("config.json");
+    let (store, config, _) = ConfigStore::load(path.clone(), time::OffsetDateTime::UNIX_EPOCH);
+    let config = Mutex::new(config);
+
+    persist_intended_enabled(&config, &store, true);
+    assert!(config.lock().unwrap().enabled);
+    let (_, reloaded, _) = ConfigStore::load(path.clone(), time::OffsetDateTime::UNIX_EPOCH);
+    assert!(reloaded.enabled, "the change must reach the disk");
+
+    // Unchanged value → no write: delete the file, call with the same
+    // value, assert it was NOT recreated.
+    std::fs::remove_file(&path).unwrap();
+    persist_intended_enabled(&config, &store, true);
+    assert!(!path.exists(), "no-op persist must not touch the disk");
+
+    // …and a CHANGED value after the delete does write again.
+    persist_intended_enabled(&config, &store, false);
+    assert!(path.exists());
+    let (_, reloaded, _) = ConfigStore::load(path, time::OffsetDateTime::UNIX_EPOCH);
+    assert!(!reloaded.enabled);
+}

--- a/crates/hole/src/ui_settings.rs
+++ b/crates/hole/src/ui_settings.rs
@@ -1,0 +1,101 @@
+//! The settings payload the webview is allowed to persist (#462).
+//!
+//! Backend-owned state (`enabled`, `elevation_prompt_shown`,
+//! `servers[].validation`) is structurally absent from these types: the
+//! webview cannot clobber what it cannot express. `deny_unknown_fields`
+//! turns a frontend that tries into a loud deserialize error instead of a
+//! silent drop.
+
+use hole_common::config::{AppConfig, DnsConfig, FilterRule, ServerEntry, StartupBehavior, Theme};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UiSettings {
+    pub servers: Vec<UiServerEntry>,
+    pub selected_server: Option<String>,
+    pub local_port: u16,
+    pub filters: Vec<FilterRule>,
+    pub start_on_login: bool,
+    pub on_startup: StartupBehavior,
+    pub theme: Theme,
+    pub proxy_server_enabled: bool,
+    pub proxy_socks5: bool,
+    pub proxy_http: bool,
+    pub dns: DnsConfig,
+    pub local_port_http: u16,
+    pub diagnostic_plugin_tap: bool,
+}
+
+/// `ServerEntry` minus the backend-owned `validation`. `deny_unknown_fields`
+/// does not recurse, so this type carries its own.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UiServerEntry {
+    pub id: String,
+    pub name: String,
+    pub server: String,
+    pub server_port: u16,
+    pub method: String,
+    pub password: String,
+    #[serde(default)]
+    pub plugin: Option<String>,
+    #[serde(default)]
+    pub plugin_opts: Option<String>,
+}
+
+impl UiSettings {
+    /// Replace the UI-owned portion of `current`, regrafting backend-owned
+    /// per-server validation by id (an entry edited under the same id keeps
+    /// its validation; a new id starts unvalidated).
+    ///
+    /// Exhaustive struct literal on purpose: adding a field to `AppConfig`
+    /// fails compilation here until its owner is decided.
+    pub fn apply(self, current: &mut AppConfig) {
+        let servers: Vec<ServerEntry> = self
+            .servers
+            .into_iter()
+            .map(|s| {
+                let validation = current
+                    .servers
+                    .iter()
+                    .find(|c| c.id == s.id)
+                    .and_then(|c| c.validation.clone());
+                ServerEntry {
+                    id: s.id,
+                    name: s.name,
+                    server: s.server,
+                    server_port: s.server_port,
+                    method: s.method,
+                    password: s.password,
+                    plugin: s.plugin,
+                    plugin_opts: s.plugin_opts,
+                    validation,
+                }
+            })
+            .collect();
+        *current = AppConfig {
+            // Backend-owned — preserved from in-memory state.
+            enabled: current.enabled,
+            elevation_prompt_shown: current.elevation_prompt_shown,
+            // UI-owned — replaced wholesale.
+            servers,
+            selected_server: self.selected_server,
+            local_port: self.local_port,
+            filters: self.filters,
+            start_on_login: self.start_on_login,
+            on_startup: self.on_startup,
+            theme: self.theme,
+            proxy_server_enabled: self.proxy_server_enabled,
+            proxy_socks5: self.proxy_socks5,
+            proxy_http: self.proxy_http,
+            dns: self.dns,
+            local_port_http: self.local_port_http,
+            diagnostic_plugin_tap: self.diagnostic_plugin_tap,
+        };
+    }
+}
+
+#[cfg(test)]
+#[path = "ui_settings_tests.rs"]
+mod ui_settings_tests;

--- a/crates/hole/src/ui_settings_tests.rs
+++ b/crates/hole/src/ui_settings_tests.rs
@@ -1,0 +1,142 @@
+use super::*;
+use hole_common::config::{AppConfig, ServerEntry, ValidationState};
+use hole_common::protocol::ServerTestOutcome;
+use time::OffsetDateTime;
+
+fn entry(id: &str) -> ServerEntry {
+    ServerEntry {
+        id: id.into(),
+        name: format!("Server {id}"),
+        server: "1.2.3.4".into(),
+        server_port: 8388,
+        method: "aes-256-gcm".into(),
+        password: "pw".into(),
+        plugin: None,
+        plugin_opts: None,
+        validation: None,
+    }
+}
+
+fn validated(id: &str) -> ServerEntry {
+    ServerEntry {
+        validation: Some(ValidationState {
+            tested_at: OffsetDateTime::UNIX_EPOCH,
+            outcome: ServerTestOutcome::Reachable { latency_ms: 42 },
+        }),
+        ..entry(id)
+    }
+}
+
+fn ui_entry(id: &str) -> UiServerEntry {
+    serde_json::from_value(serde_json::json!({
+        "id": id, "name": format!("Server {id}"), "server": "1.2.3.4",
+        "server_port": 8388, "method": "aes-256-gcm", "password": "pw",
+    }))
+    .unwrap()
+}
+
+fn default_settings_json() -> serde_json::Value {
+    serde_json::json!({
+        "servers": [], "selected_server": null, "local_port": 4073,
+        "filters": [], "start_on_login": false, "on_startup": "restore_last_state",
+        "theme": "dark", "proxy_server_enabled": true, "proxy_socks5": true,
+        "proxy_http": false, "dns": AppConfig::default().dns, "local_port_http": 4074,
+        "diagnostic_plugin_tap": false
+    })
+}
+
+// The defect-1 regression (#462): backend-owned fields are unrepresentable
+// on the wire — a frontend that sends them must fail loudly, not be
+// silently merged or ignored.
+#[skuld::test]
+fn deserialize_rejects_enabled_key() {
+    let mut json = default_settings_json();
+    json["enabled"] = serde_json::json!(true);
+    let err = serde_json::from_value::<UiSettings>(json).unwrap_err();
+    assert!(err.to_string().contains("enabled"), "got: {err}");
+}
+
+#[skuld::test]
+fn deserialize_rejects_elevation_prompt_shown_key() {
+    let mut json = default_settings_json();
+    json["elevation_prompt_shown"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<UiSettings>(json).is_err());
+}
+
+// Relies on UiServerEntry's OWN deny_unknown_fields — the attribute does
+// not recurse from UiSettings. Dropping it there would make `validation`
+// silently *ignored* instead of rejected, and this test would catch that.
+#[skuld::test]
+fn deserialize_rejects_server_validation_key() {
+    let mut json = default_settings_json();
+    json["servers"] = serde_json::json!([{
+        "id": "a", "name": "A", "server": "1.2.3.4", "server_port": 8388,
+        "method": "aes-256-gcm", "password": "pw",
+        "validation": {
+            "tested_at": "2026-01-01T00:00:00Z",
+            "outcome": { "kind": "reachable", "latency_ms": 1 }
+        }
+    }]);
+    assert!(serde_json::from_value::<UiSettings>(json).is_err());
+}
+
+#[skuld::test]
+fn apply_preserves_backend_owned_fields() {
+    let mut current = AppConfig {
+        enabled: true,
+        elevation_prompt_shown: true,
+        ..Default::default()
+    };
+    let settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    settings.apply(&mut current);
+    assert!(current.enabled, "stale UI save must not clobber backend-owned enabled");
+    assert!(current.elevation_prompt_shown);
+}
+
+#[skuld::test]
+fn apply_regrafts_validation_by_id() {
+    let mut current = AppConfig {
+        servers: vec![validated("a"), entry("b")],
+        ..Default::default()
+    };
+    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    // UI kept "a" (edited its name), added "c", dropped "b".
+    settings.servers = vec![
+        UiServerEntry {
+            name: "Renamed".into(),
+            ..ui_entry("a")
+        },
+        ui_entry("c"),
+    ];
+    settings.apply(&mut current);
+    assert_eq!(current.servers.len(), 2);
+    assert_eq!(current.servers[0].name, "Renamed");
+    assert!(
+        current.servers[0].validation.is_some(),
+        "validation survives an edit under the same id"
+    );
+    assert!(current.servers[1].validation.is_none(), "new entry starts unvalidated");
+}
+
+#[skuld::test]
+fn apply_replaces_ui_owned_fields() {
+    let mut current = AppConfig::default();
+    let mut json = default_settings_json();
+    json["local_port"] = serde_json::json!(5555);
+    let settings: UiSettings = serde_json::from_value(json).unwrap();
+    settings.apply(&mut current);
+    assert_eq!(current.local_port, 5555);
+}
+
+#[skuld::test]
+fn apply_first_match_wins_for_duplicate_incoming_ids() {
+    let mut current = AppConfig {
+        servers: vec![validated("a")],
+        ..Default::default()
+    };
+    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    settings.servers = vec![ui_entry("a"), ui_entry("a")];
+    settings.apply(&mut current);
+    assert!(current.servers[0].validation.is_some());
+    assert!(current.servers[1].validation.is_some()); // both graft from the same current entry
+}

--- a/ui/diagnostics.test.ts
+++ b/ui/diagnostics.test.ts
@@ -36,6 +36,8 @@ function makeServerWithValidation(validation: Server["validation"]): Config {
     proxy_http: false,
     on_startup: "disconnected",
     theme: "dark",
+    dns: { enabled: true, servers: ["1.1.1.1"], protocol: "https", intercept_udp53: true },
+    diagnostic_plugin_tap: false,
   };
 }
 

--- a/ui/main.test.ts
+++ b/ui/main.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 /// so the test can assert listeners are registered before the first
 /// config fetch (the point where the UI becomes interactive).
 const callOrder: string[] = [];
-const invokeMock = vi.fn((cmd: string, _args?: unknown) => {
+const defaultInvokeImpl = (cmd: string, _args?: unknown) => {
   callOrder.push(`invoke:${cmd}`);
   if (cmd === "get_config") return Promise.resolve({ servers: [], filters: [] });
   if (cmd === "get_proxy_status") return Promise.resolve({ running: false });
@@ -12,7 +12,8 @@ const invokeMock = vi.fn((cmd: string, _args?: unknown) => {
     return Promise.resolve({ bytes_in: 0, bytes_out: 0, speed_in_bps: 0, speed_out_bps: 0, uptime_secs: 0 });
   if (cmd === "get_diagnostics") return Promise.resolve({});
   return Promise.resolve(null);
-});
+};
+const invokeMock = vi.fn(defaultInvokeImpl);
 const listenMock = vi.fn((event: string, _handler?: unknown) => {
   callOrder.push(`listen:${event}`);
   return Promise.resolve(() => {});
@@ -50,9 +51,11 @@ vi.mock("./toast", () => ({ showToast: vi.fn() }));
 
 beforeEach(() => {
   callOrder.length = 0;
-  // Clear call logs (not implementations) so per-test assertions don't
-  // match a previous test's invocations.
-  invokeMock.mockClear();
+  // Reset to the default implementation (a test may substitute its own)
+  // and clear call logs so per-test assertions don't match a previous
+  // test's invocations.
+  invokeMock.mockReset();
+  invokeMock.mockImplementation(defaultInvokeImpl);
   listenMock.mockClear();
   // init() starts real polling intervals; stub so they don't keep
   // firing in the worker after the test completes.
@@ -71,6 +74,71 @@ describe("init ordering", () => {
       const idx = callOrder.indexOf(`listen:${ev}`);
       expect(idx, `listener ${ev} must be registered before get_config`).toBeGreaterThan(-1);
       expect(idx).toBeLessThan(firstConfig);
+    }
+  });
+
+  it("sends only UI-owned keys and strips server validation on save", async () => {
+    invokeMock.mockImplementation((cmd: string, _args?: unknown) => {
+      callOrder.push(`invoke:${cmd}`);
+      if (cmd === "get_config")
+        return Promise.resolve({
+          servers: [
+            {
+              id: "a",
+              name: "A",
+              server: "1.2.3.4",
+              server_port: 8388,
+              method: "aes-256-gcm",
+              password: "pw",
+              validation: { tested_at: "2026-01-01T00:00:00Z", outcome: { kind: "reachable", latency_ms: 5 } },
+            },
+          ],
+          selected_server: "a",
+          filters: [],
+          local_port: 4073,
+          local_port_http: 4074,
+          start_on_login: false,
+          proxy_server_enabled: true,
+          proxy_socks5: true,
+          proxy_http: false,
+          on_startup: "restore_last_state",
+          theme: "dark",
+          dns: { enabled: true, servers: ["1.1.1.1"], protocol: "https", intercept_udp53: true },
+          diagnostic_plugin_tap: false,
+          // Backend-owned fields present in the snapshot — must NOT round-trip.
+          enabled: true,
+          elevation_prompt_shown: true,
+        });
+      if (cmd === "get_proxy_status") return Promise.resolve({ running: false });
+      if (cmd === "get_metrics")
+        return Promise.resolve({ bytes_in: 0, bytes_out: 0, speed_in_bps: 0, speed_out_bps: 0, uptime_secs: 0 });
+      if (cmd === "get_diagnostics") return Promise.resolve({});
+      return Promise.resolve(null);
+    });
+    const { initDone, saveConfig } = await import("./main");
+    await initDone;
+    await saveConfig();
+
+    const call = invokeMock.mock.calls.find(([cmd]) => cmd === "save_config");
+    expect(call).toBeDefined();
+    const { settings } = call![1] as { settings: Record<string, unknown> };
+    expect(Object.keys(settings).sort()).toEqual([
+      "diagnostic_plugin_tap",
+      "dns",
+      "filters",
+      "local_port",
+      "local_port_http",
+      "on_startup",
+      "proxy_http",
+      "proxy_server_enabled",
+      "proxy_socks5",
+      "selected_server",
+      "servers",
+      "start_on_login",
+      "theme",
+    ]);
+    for (const s of settings.servers as Record<string, unknown>[]) {
+      expect(s).not.toHaveProperty("validation");
     }
   });
 

--- a/ui/main.test.ts
+++ b/ui/main.test.ts
@@ -7,7 +7,7 @@ const callOrder: string[] = [];
 const defaultInvokeImpl = (cmd: string, _args?: unknown) => {
   callOrder.push(`invoke:${cmd}`);
   if (cmd === "get_config") return Promise.resolve({ servers: [], filters: [] });
-  if (cmd === "get_proxy_status") return Promise.resolve({ running: false });
+  if (cmd === "get_proxy_status") return Promise.resolve({ running: false, state_seq: 0 });
   if (cmd === "get_metrics")
     return Promise.resolve({ bytes_in: 0, bytes_out: 0, speed_in_bps: 0, speed_out_bps: 0, uptime_secs: 0 });
   if (cmd === "get_diagnostics") return Promise.resolve({});
@@ -110,7 +110,7 @@ describe("init ordering", () => {
           enabled: true,
           elevation_prompt_shown: true,
         });
-      if (cmd === "get_proxy_status") return Promise.resolve({ running: false });
+      if (cmd === "get_proxy_status") return Promise.resolve({ running: false, state_seq: 0 });
       if (cmd === "get_metrics")
         return Promise.resolve({ bytes_in: 0, bytes_out: 0, speed_in_bps: 0, speed_out_bps: 0, uptime_secs: 0 });
       if (cmd === "get_diagnostics") return Promise.resolve({});

--- a/ui/main.test.ts
+++ b/ui/main.test.ts
@@ -41,6 +41,7 @@ vi.mock("./servers", () => ({
 }));
 vi.mock("./settings", () => ({ initSettings: vi.fn(), renderSettings: vi.fn() }));
 vi.mock("./sidebar", () => ({
+  applyProxyStateObservation: vi.fn().mockReturnValue({ state: "disconnected", changed: false }),
   initSidebar: vi.fn(),
   updateDiagnostics: vi.fn(),
   updateMetrics: vi.fn(),
@@ -70,7 +71,7 @@ describe("init ordering", () => {
 
     const firstConfig = callOrder.indexOf("invoke:get_config");
     expect(firstConfig).toBeGreaterThan(-1);
-    for (const ev of ["import-requested", "tauri://drag-drop", "validation-changed"]) {
+    for (const ev of ["import-requested", "tauri://drag-drop", "validation-changed", "proxy-state-changed"]) {
       const idx = callOrder.indexOf(`listen:${ev}`);
       expect(idx, `listener ${ev} must be registered before get_config`).toBeGreaterThan(-1);
       expect(idx).toBeLessThan(firstConfig);

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -19,7 +19,14 @@ import {
   showImportFailureDialog,
 } from "./servers";
 import { initSettings, renderSettings } from "./settings";
-import { initSidebar, updateDiagnostics, updateMetrics, updateProxyStatus, updatePublicIp } from "./sidebar";
+import {
+  applyProxyStateObservation,
+  initSidebar,
+  updateDiagnostics,
+  updateMetrics,
+  updateProxyStatus,
+  updatePublicIp,
+} from "./sidebar";
 import { showToast } from "./toast";
 import type { Config, DiagnosticsData, Metrics, ProxyStatus, Server, UiSettings } from "./types";
 
@@ -254,11 +261,21 @@ function setupEventListeners(): Promise<unknown> {
     await loadConfig();
   });
 
+  // Tray- or backend-initiated proxy state changes reach the power
+  // button immediately instead of waiting for the 5s poll (#462). Routed
+  // through the same seq-monotone, IDLE-guarded application as the poll.
+  const proxyStateReady = listen<{ seq: number; running: boolean }>("proxy-state-changed", (event) => {
+    const result = applyProxyStateObservation(event.payload.seq, event.payload.running);
+    if (result.changed) {
+      updatePublicIp();
+    }
+  });
+
   // Joined so init() can await registration before the UI becomes
   // interactive — an emit landing before listen() resolves is silently
   // lost. Rejection is deliberately fatal to init: a dashboard without
   // its listeners is broken in exactly the silent way this guards.
-  return Promise.all([importReady, dropReady, validationReady]);
+  return Promise.all([importReady, dropReady, validationReady, proxyStateReady]);
 }
 
 // Initialization ======================================================================================================

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -21,7 +21,7 @@ import {
 import { initSettings, renderSettings } from "./settings";
 import { initSidebar, updateDiagnostics, updateMetrics, updateProxyStatus, updatePublicIp } from "./sidebar";
 import { showToast } from "./toast";
-import type { Config, DiagnosticsData, Metrics, ProxyStatus, Server } from "./types";
+import type { Config, DiagnosticsData, Metrics, ProxyStatus, Server, UiSettings } from "./types";
 
 /// Maximum number of concurrent server tests during bulk auto-test (e.g.
 /// after a JSON import). 50 concurrent plugin processes is non-trivial
@@ -68,11 +68,41 @@ export async function loadConfig() {
   }
 }
 
-/** Save the current config to the backend. */
+/// Strip backend-owned fields before persisting: the wire type rejects
+/// unknown keys, so sending `validation` (or any future backend-owned
+/// field) fails loudly instead of silently clobbering. See #462.
+function toUiSettings(c: Config): UiSettings {
+  return {
+    servers: c.servers.map(({ id, name, server, server_port, method, password, plugin, plugin_opts }) => ({
+      id,
+      name,
+      server,
+      server_port,
+      method,
+      password,
+      plugin,
+      plugin_opts,
+    })),
+    selected_server: c.selected_server,
+    local_port: c.local_port,
+    filters: c.filters,
+    start_on_login: c.start_on_login,
+    on_startup: c.on_startup,
+    theme: c.theme,
+    proxy_server_enabled: c.proxy_server_enabled,
+    proxy_socks5: c.proxy_socks5,
+    proxy_http: c.proxy_http,
+    dns: c.dns,
+    local_port_http: c.local_port_http,
+    diagnostic_plugin_tap: c.diagnostic_plugin_tap,
+  };
+}
+
+/** Save the current config's UI-owned settings to the backend. */
 export async function saveConfig() {
   if (!config) return;
   try {
-    await invoke("save_config", { config });
+    await invoke("save_config", { settings: toUiSettings(config) });
     dirty = false;
   } catch (err) {
     console.error("saveConfig failed:", err);

--- a/ui/power-button.test.ts
+++ b/ui/power-button.test.ts
@@ -45,7 +45,7 @@ describe("power-button state machine", () => {
   it("updateProxyStatus writes through when current state is idle", async () => {
     const { initPowerButton, updateProxyStatus, getConnectionState } = await import("./power-button");
     initPowerButton();
-    const { state, changed } = updateProxyStatus({ running: true });
+    const { state, changed } = updateProxyStatus({ running: true, state_seq: 1 });
     expect(state).toBe("connected");
     expect(changed).toBe(true);
     expect(getConnectionState()).toBe("connected");
@@ -58,59 +58,111 @@ describe("power-button state machine", () => {
     document.getElementById("power-btn")!.click();
     await Promise.resolve();
     // Now in `connecting`.
-    const { changed } = updateProxyStatus({ running: true });
+    const { changed } = updateProxyStatus({ running: true, state_seq: 1 });
     expect(changed).toBe(false);
     expect(getConnectionState()).toBe("connecting");
   });
 
+  it("drops out-of-order observations (#462: poll and event interleave arbitrarily)", async () => {
+    const { initPowerButton, applyProxyStateObservation, getConnectionState } = await import("./power-button");
+    initPowerButton();
+    applyProxyStateObservation(2, true);
+    expect(getConnectionState()).toBe("connected");
+    // A poll response computed before the seq-2 commit arrives late:
+    applyProxyStateObservation(1, false);
+    expect(getConnectionState()).toBe("connected");
+  });
+
+  it("event and poll share the seq gate", async () => {
+    const { initPowerButton, applyProxyStateObservation, updateProxyStatus, getConnectionState } = await import(
+      "./power-button"
+    );
+    initPowerButton();
+    applyProxyStateObservation(3, true); // proxy-state-changed event
+    expect(getConnectionState()).toBe("connected");
+    const { changed } = updateProxyStatus({ running: false, state_seq: 2 }); // stale poll
+    expect(changed).toBe(false);
+    expect(getConnectionState()).toBe("connected");
+  });
+
+  it("a same-seq re-observation does not clobber a failure cue", async () => {
+    // After a failed stop the component shows `disconnection-failed`
+    // while the bridge still reports the same (seq, running=true)
+    // observation. The seq gate keeps the failure cue visible until the
+    // state actually CHANGES (a new seq), instead of repainting it to
+    // plain `connected` on the next 5s poll.
+    let rejectStop!: (reason: unknown) => void;
+    const stopPromise = new Promise<never>((_, reject) => {
+      rejectStop = reject;
+    });
+    const { initPowerButton, applyProxyStateObservation, getConnectionState } = await import("./power-button");
+    initPowerButton();
+    applyProxyStateObservation(3, true);
+    expect(getConnectionState()).toBe("connected");
+
+    invokeMock.mockReturnValueOnce(stopPromise);
+    document.getElementById("power-btn")!.click();
+    await Promise.resolve();
+    expect(getConnectionState()).toBe("disconnecting");
+    rejectStop("teardown wedged");
+    await stopPromise.catch(() => {});
+    await Promise.resolve();
+    expect(getConnectionState()).toBe("disconnection-failed");
+
+    // The next poll re-reports the unchanged truth (still seq 3, still
+    // running) — it must not erase the failure cue.
+    applyProxyStateObservation(3, true);
+    expect(getConnectionState()).toBe("disconnection-failed");
+  });
+
   it("click from `connection-failed` starts a fresh connect (retry path)", async () => {
     // `connection-failed` has no public setter — it is only ever reached
-    // by a `toggle_proxy` rejection on the connect path (the catch arm in
+    // by a `start_proxy` rejection on the connect path (the catch arm in
     // toggleFromIdle: disconnected → connecting → connection-failed). So
     // we drive the genuine failure first, then exercise the retry click,
     // rather than synthesizing the state with a back-door setter that
     // would bypass the production transition.
     //
-    // First click: toggle_proxy rejects → the component lands in
+    // First click: start_proxy rejects → the component lands in
     // `connection-failed`. We hold the rejecting promise ourselves so we
     // can await its settlement deterministically (no timeout-bounded poll).
-    let rejectToggle!: (reason: unknown) => void;
-    const firstToggle = new Promise<never>((_, reject) => {
-      rejectToggle = reject;
+    let rejectStart!: (reason: unknown) => void;
+    const firstStart = new Promise<never>((_, reject) => {
+      rejectStart = reject;
     });
-    invokeMock.mockReturnValueOnce(firstToggle);
+    invokeMock.mockReturnValueOnce(firstStart);
     const { initPowerButton, getConnectionState } = await import("./power-button");
     initPowerButton();
     document.getElementById("power-btn")!.click();
     // Synchronous prelude ran: setState("connecting"), then parked on the
-    // `await invoke("toggle_proxy")`.
+    // `await invoke("start_proxy")`.
     await Promise.resolve();
     expect(getConnectionState()).toBe("connecting");
 
-    // Reject the in-flight toggle_proxy and wait for the production catch
+    // Reject the in-flight start_proxy and wait for the production catch
     // arm (which is registered ahead of this awaited continuation) to run
     // setState("connection-failed"). Awaiting the same settled promise is
     // a deterministic rendezvous, not a sleep.
-    rejectToggle("connect failed");
-    await firstToggle.catch(() => {});
+    rejectStart("connect failed");
+    await firstStart.catch(() => {});
     await Promise.resolve();
     expect(getConnectionState()).toBe("connection-failed");
 
-    // The first toggle_proxy attempt happened and failed; clear the call
+    // The first start_proxy attempt happened and failed; clear the call
     // log so the retry assertion sees only the retry's invoke.
     invokeMock.mockReset();
     // Retry click: `connection-failed` is an idle state with
     // `isEffectivelyOn` false → goingToConnect is true → a fresh Start is
-    // attempted. The second toggle_proxy never resolves so the component
+    // attempted. The second start_proxy never resolves so the component
     // parks in `connecting`.
     invokeMock.mockReturnValue(new Promise(() => {}));
     document.getElementById("power-btn")!.click();
     await Promise.resolve();
 
     expect(getConnectionState()).toBe("connecting");
-    // The retry fired toggle_proxy (a fresh connect), not cancel_proxy.
-    const toggleCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "toggle_proxy");
-    expect(toggleCalls).toHaveLength(1);
+    // The retry fired start_proxy (a fresh connect), not cancel_proxy.
+    const startCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "start_proxy");
+    expect(startCalls).toHaveLength(1);
     const cancelCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "cancel_proxy");
     expect(cancelCalls).toHaveLength(0);
   });
@@ -123,7 +175,7 @@ describe("power-button state machine", () => {
     const { initPowerButton, updateProxyStatus, getConnectionState } = await import("./power-button");
     initPowerButton();
     // Drive to connected first via polling.
-    updateProxyStatus({ running: true });
+    updateProxyStatus({ running: true, state_seq: 1 });
     expect(getConnectionState()).toBe("connected");
     document.getElementById("power-btn")!.click();
     await Promise.resolve();

--- a/ui/power-button.ts
+++ b/ui/power-button.ts
@@ -41,7 +41,7 @@ async function handlePowerClick(): Promise<void> {
     return;
   }
 
-  // Click during connecting → fire cancel. The original toggle_proxy
+  // Click during connecting → fire cancel. The original start_proxy
   // promise is still pending in toggleFromIdle(); `cancel_proxy`
   // races it on a fresh bridge connection so it does not block behind
   // the in-flight start.
@@ -75,32 +75,55 @@ export function initPowerButton(): void {
   powerBtn?.addEventListener("click", handlePowerClick);
 }
 
+/// The seq of the newest applied observation. Observations arrive on two
+/// unordered channels (the 5s poll and `proxy-state-changed` events);
+/// applying them monotonically by the backend's commit seq means an
+/// out-of-order arrival can never render an older state (#462).
+let lastAppliedSeq = -1;
+
 /**
- * Update the connection state from a periodic proxy status poll.
+ * Apply a `(seq, running)` observation from either the periodic status
+ * poll or a `proxy-state-changed` event.
+ *
+ * An observation whose seq is not newer than the last applied one is
+ * dropped — including a re-observation of the unchanged truth, which
+ * keeps a `connection-failed`/`disconnection-failed` cue visible until
+ * the state actually changes instead of repainting it on the next poll.
  *
  * Only overwrites `currentState` when the current state is IDLE.
  * Transition states (`connecting`/`cancelling`/`disconnecting`) are
  * short-lived, carry their own owning IPC promise in `handlePowerClick`,
- * and must not be clobbered by a poll landing mid-transition. A poll
- * that arrives during a transition is a no-op for state purposes.
+ * and must not be clobbered by an observation landing mid-transition.
  *
- * Returns `{ state, changed }` where `changed` is true iff this poll
- * itself caused a state change (not including click-driven transitions
- * that were applied between polls). `main.ts` uses this to know when to
- * refresh the public IP. The click handler owns the `connecting →
- * connected` emission of `mark_validated_by_proxy_start`, so the poll
- * does not need to track previous state.
+ * Returns `{ state, changed }` where `changed` is true iff this
+ * observation itself caused a state change (not including click-driven
+ * transitions applied between observations). `main.ts` uses this to know
+ * when to refresh the public IP. The click handler owns the `connecting
+ * → connected` emission of `mark_validated_by_proxy_start`, so
+ * observations do not need to track previous state.
  */
-export function updateProxyStatus(status: ProxyStatus): { state: ConnectionState; changed: boolean } {
+export function applyProxyStateObservation(
+  seq: number,
+  running: boolean,
+): { state: ConnectionState; changed: boolean } {
+  if (seq <= lastAppliedSeq) {
+    return { state: currentState, changed: false };
+  }
+  lastAppliedSeq = seq;
   if (!IDLE_STATES.has(currentState)) {
     return { state: currentState, changed: false };
   }
-  const polled = stateForPolledRunning(!!status.running);
+  const polled = stateForPolledRunning(running);
   if (polled === currentState) {
     return { state: currentState, changed: false };
   }
   setState(polled);
   return { state: currentState, changed: true };
+}
+
+/** Update the connection state from a periodic proxy status poll. */
+export function updateProxyStatus(status: ProxyStatus): { state: ConnectionState; changed: boolean } {
+  return applyProxyStateObservation(status.state_seq, !!status.running);
 }
 
 /** Returns the current connection state. */

--- a/ui/sidebar.ts
+++ b/ui/sidebar.ts
@@ -6,7 +6,7 @@
 import { initDiagnostics, updateDiagnostics } from "./diagnostics";
 import { initGraph, pushGraphData, renderGraph } from "./graph";
 import { initIpDisplay, updatePublicIp } from "./ip-display";
-import { getConnectionState, initPowerButton, updateProxyStatus } from "./power-button";
+import { applyProxyStateObservation, getConnectionState, initPowerButton, updateProxyStatus } from "./power-button";
 import { initStats, updateStats } from "./stats";
 import type { Metrics } from "./types";
 import { initVersion } from "./version";
@@ -29,4 +29,4 @@ export function initSidebar(): void {
 }
 
 // Public re-exports for main.ts and other consumers.
-export { getConnectionState, updateDiagnostics, updatePublicIp, updateProxyStatus };
+export { applyProxyStateObservation, getConnectionState, updateDiagnostics, updatePublicIp, updateProxyStatus };

--- a/ui/toggle-failure.test.ts
+++ b/ui/toggle-failure.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for the pure toggle_proxy failure-message helper.
+// Unit tests for the pure start/stop-proxy failure-message helper.
 // ToggleFailure is a single { error: unknown } interface;
 // toggleFailureToast stringifies non-string rejections defensively
 // (no [object Object]).

--- a/ui/toggle-failure.ts
+++ b/ui/toggle-failure.ts
@@ -1,11 +1,11 @@
-// Pure helper: format the toast message for a `toggle_proxy` failure.
+// Pure helper: format the toast message for a `start_proxy`/`stop_proxy` failure.
 // Extracted so the message shape is unit-testable without DOM/Tauri-
 // mock plumbing. Surfaces real bridge failures to the user instead of
 // only logging to console.
 
 import type { ToastKind } from "./toast";
 
-/// A toggle_proxy IPC failure. The bridge's wire format is
+/// A start_proxy/stop_proxy IPC failure. The bridge's wire format is
 /// `Result<_, String>`; `error` is typed `unknown` for the defensive
 /// `String()` conversion below — a future shape change shouldn't
 /// silently fall back to "[object Object]" in the user's face.
@@ -18,7 +18,7 @@ export interface ToastSpec {
   kind: ToastKind;
 }
 
-/// Compute the toast message for a `toggle_proxy` failure. Stringifies
+/// Compute the toast message for a `start_proxy`/`stop_proxy` failure. Stringifies
 /// non-string rejections defensively.
 export function toggleFailureToast(failure: ToggleFailure): ToastSpec {
   return {

--- a/ui/toggle-flow.test.ts
+++ b/ui/toggle-flow.test.ts
@@ -1,8 +1,9 @@
-// Unit tests for the extracted toggle-flow module. The key invariant
-// tested here is that `toggleFromIdle` schedules NO client-side timer:
-// the UI stays in `connecting`/`disconnecting` until the bridge IPC
-// returns; the user's Cancel button (`cancel_proxy`) is the only escape
-// hatch.
+// Unit tests for the extracted toggle-flow module. The key invariants
+// tested here: `toggleFromIdle` schedules NO client-side timer (the UI
+// stays in `connecting`/`disconnecting` until the bridge IPC returns;
+// the user's Cancel button (`cancel_proxy`) is the only escape hatch),
+// and the user's direction is transmitted as explicit start/stop intent
+// on the wire (#462).
 //
 // Sync-invariant note (CLAUDE.md §"Synchronization invariant"): this
 // test uses `vi.useFakeTimers()` + `vi.getTimerCount()` to assert the
@@ -61,16 +62,16 @@ afterEach(() => {
 });
 
 describe("toggleFromIdle: client-side timer absence (regression for #397 sub-bug C)", () => {
-  it("schedules NO timers and fires no cancel_proxy while toggle_proxy is pending", async () => {
-    // toggle_proxy resolves never (slow-but-working bridge start). The
+  it("schedules NO timers and fires no cancel_proxy while start_proxy is pending", async () => {
+    // start_proxy resolves never (slow-but-working bridge start). The
     // UI must stay in `connecting` and schedule no timer.
     const h = makeHarness();
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return new Promise(() => {});
+      if (cmd === "start_proxy") return new Promise(() => {});
       return Promise.resolve();
     });
 
-    // Kick off the toggle. We deliberately don't await — toggle_proxy
+    // Kick off the toggle. We deliberately don't await — start_proxy
     // never resolves. The promise hangs in the background; we observe
     // side effects.
     void toggleFromIdle(true, h.deps);
@@ -84,7 +85,7 @@ describe("toggleFromIdle: client-side timer absence (regression for #397 sub-bug
     // this immediately.
     expect(vi.getTimerCount()).toBe(0);
 
-    // The in-flight toggle_proxy promise never resolves, so no further
+    // The in-flight start_proxy promise never resolves, so no further
     // setState/showToast/invoke side effects can fire from this code
     // path. State and toast surface should match the prelude.
     expect(h.state).toBe("connecting");
@@ -95,7 +96,7 @@ describe("toggleFromIdle: client-side timer absence (regression for #397 sub-bug
     const h = makeHarness();
     h.state = "connected";
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return new Promise(() => {});
+      if (cmd === "stop_proxy") return new Promise(() => {});
       return Promise.resolve();
     });
 
@@ -112,12 +113,15 @@ describe("toggleFromIdle: outcome handling", () => {
   it("transitions to `connected` on a Running outcome", async () => {
     const h = makeHarness();
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return Promise.resolve("running");
+      if (cmd === "start_proxy") return Promise.resolve("running");
       return Promise.resolve();
     });
     await toggleFromIdle(true, h.deps);
     expect(h.state).toBe("connected");
     expect(h.updatePublicIp).toHaveBeenCalled();
+    // Explicit intent on the wire (#462): the direction the user chose,
+    // not a directionless toggle the backend has to re-derive.
+    expect(h.invoke).toHaveBeenCalledWith("start_proxy");
   });
 
   it("transitions to `disconnected` on a Cancelled outcome (bridge-side cancel)", async () => {
@@ -127,7 +131,7 @@ describe("toggleFromIdle: outcome handling", () => {
     // `cancelling`, but the settled idle state is Disconnected.
     const h = makeHarness();
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return Promise.resolve("cancelled");
+      if (cmd === "start_proxy") return Promise.resolve("cancelled");
       return Promise.resolve();
     });
     await toggleFromIdle(true, h.deps);
@@ -137,7 +141,7 @@ describe("toggleFromIdle: outcome handling", () => {
   it("surfaces a bridge error via toast + transitions to `connection-failed`", async () => {
     const h = makeHarness();
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return Promise.reject("forwarder self-test failed");
+      if (cmd === "start_proxy") return Promise.reject("forwarder self-test failed");
       return Promise.resolve();
     });
     await toggleFromIdle(true, h.deps);
@@ -149,12 +153,13 @@ describe("toggleFromIdle: outcome handling", () => {
     const h = makeHarness();
     h.state = "connected";
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return Promise.reject("teardown wedged");
+      if (cmd === "stop_proxy") return Promise.reject("teardown wedged");
       return Promise.resolve();
     });
     await toggleFromIdle(false, h.deps);
     expect(h.state).toBe("disconnection-failed");
     expect(h.showToast).toHaveBeenCalledWith("teardown wedged", "error");
+    expect(h.invoke).toHaveBeenCalledWith("stop_proxy");
   });
 
   it("fires follow-up stop when Cancel raced with a successful Start", async () => {
@@ -163,14 +168,14 @@ describe("toggleFromIdle: outcome handling", () => {
     // === "running", and fires a follow-up Stop to honor the user's
     // cancel intent.
     const h = makeHarness();
-    let toggleCalls = 0;
+    const proxyCalls: string[] = [];
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") {
-        toggleCalls++;
-        // First call (the Start) returns Running after the user
-        // clicked Cancel (test simulates this by mutating state below).
-        // Second call (the follow-up Stop) returns Stopped.
-        return Promise.resolve(toggleCalls === 1 ? "running" : "stopped");
+      if (cmd === "start_proxy" || cmd === "stop_proxy") {
+        proxyCalls.push(cmd);
+        // The Start returns Running after the user clicked Cancel (the
+        // test simulates this by mutating state below); the follow-up
+        // Stop returns Stopped.
+        return Promise.resolve(cmd === "start_proxy" ? "running" : "stopped");
       }
       return Promise.resolve();
     });
@@ -186,8 +191,9 @@ describe("toggleFromIdle: outcome handling", () => {
     h.deps.setState("cancelling");
     await togglePromise;
 
-    // The follow-up Stop was fired (two toggle_proxy calls total).
-    expect(toggleCalls).toBe(2);
+    // The follow-up carries explicit STOP intent (#462) — the backend
+    // must not be left to derive direction from its own state.
+    expect(proxyCalls).toEqual(["start_proxy", "stop_proxy"]);
     // Final state honors the user's cancel intent: Stopped → disconnected.
     expect(h.state).toBe("disconnected");
   });
@@ -197,7 +203,7 @@ describe("mark_validated_by_proxy_start failure surfacing", () => {
   it("toasts when the validation mark fails after a successful connect", async () => {
     const h = makeHarness();
     h.invoke.mockImplementation((cmd: string) => {
-      if (cmd === "toggle_proxy") return Promise.resolve("running");
+      if (cmd === "start_proxy") return Promise.resolve("running");
       if (cmd === "mark_validated_by_proxy_start") return Promise.reject(new Error("config save failed"));
       return Promise.resolve();
     });

--- a/ui/toggle-flow.ts
+++ b/ui/toggle-flow.ts
@@ -44,7 +44,9 @@ export interface ToggleDeps {
   loadConfig(): Promise<void>;
 }
 
-/// Issue `toggle_proxy` and apply the resulting state transition.
+/// Issue `start_proxy`/`stop_proxy` — explicit intent on the wire, so
+/// the backend never re-derives direction from its own possibly-stale
+/// state (#462) — and apply the resulting state transition.
 ///
 /// The UI stays in `connecting`/`disconnecting` until the bridge IPC
 /// returns. There is no client-side timeout: the bridge supports
@@ -56,11 +58,12 @@ export interface ToggleDeps {
 export async function toggleFromIdle(goingToConnect: boolean, deps: ToggleDeps): Promise<void> {
   deps.setState(goingToConnect ? "connecting" : "disconnecting");
 
+  const command = goingToConnect ? "start_proxy" : "stop_proxy";
   let outcome: ToggleOutcome;
   try {
-    outcome = await deps.invoke<ToggleOutcome>("toggle_proxy");
+    outcome = await deps.invoke<ToggleOutcome>(command);
   } catch (error) {
-    console.error("toggle_proxy failed:", error);
+    console.error(`${command} failed:`, error);
     const spec = toggleFailureToast({ error });
     deps.showToast(spec.message, spec.kind);
     deps.setState(goingToConnect ? "connection-failed" : "disconnection-failed");
@@ -76,7 +79,7 @@ export async function toggleFromIdle(goingToConnect: boolean, deps: ToggleDeps):
     console.info("cancel raced with successful start — firing follow-up stop");
     deps.setState("disconnecting");
     try {
-      const stopOutcome = await deps.invoke<ToggleOutcome>("toggle_proxy");
+      const stopOutcome = await deps.invoke<ToggleOutcome>("stop_proxy");
       deps.setState(stateForToggleOutcome(stopOutcome));
     } catch (err) {
       console.error("follow-up stop failed:", err);

--- a/ui/types.ts
+++ b/ui/types.ts
@@ -71,8 +71,36 @@ export interface Config {
   proxy_http: boolean;
   on_startup: string;
   theme: string;
-  dns?: DnsConfig;
+  // Required: `get_config` always returns it (AppConfig has no skip
+  // attribute), and `toUiSettings` must always send it — the backend
+  // rejects a missing field.
+  dns: DnsConfig;
+  diagnostic_plugin_tap: boolean;
   [key: string]: unknown;
+}
+
+/// `Server` minus the backend-owned `validation`. Mirrors the Rust
+/// `UiServerEntry` in `crates/hole/src/ui_settings.rs`.
+export type UiServer = Omit<Server, "validation">;
+
+/// The settings payload `save_config` accepts. Mirrors the Rust
+/// `UiSettings` (#462): backend-owned state (`enabled`,
+/// `elevation_prompt_shown`, `servers[].validation`) is not part of the
+/// wire type, and the backend rejects unknown keys — send exactly this.
+export interface UiSettings {
+  servers: UiServer[];
+  selected_server: string | null;
+  local_port: number;
+  filters: FilterRule[];
+  start_on_login: boolean;
+  on_startup: string;
+  theme: string;
+  proxy_server_enabled: boolean;
+  proxy_socks5: boolean;
+  proxy_http: boolean;
+  dns: DnsConfig;
+  local_port_http: number;
+  diagnostic_plugin_tap: boolean;
 }
 
 export interface ProxyStatus {

--- a/ui/types.ts
+++ b/ui/types.ts
@@ -105,6 +105,10 @@ export interface UiSettings {
 
 export interface ProxyStatus {
   running: boolean;
+  /// Commit seq of the backend's ProxyStateCell at response time. The
+  /// frontend applies observations monotonically by this value; see
+  /// `applyProxyStateObservation` in `ui/power-button.ts` (#462).
+  state_seq: number;
 }
 
 export interface Metrics {


### PR DESCRIPTION
Fixes #462.

Three defects shared one root cause: `config.enabled` had no single owner and no start/stop intent was ever transmitted. This PR makes the bridge's actual status the only runtime truth and demotes persisted `enabled` to a write-only record of the last honored intent.

## What changed

**Defect 1 — `save_config` clobber.** The webview no longer round-trips backend-owned state. `save_config` takes a `UiSettings` wire type (`deny_unknown_fields` on it *and* on `UiServerEntry`) on which `enabled`, `elevation_prompt_shown`, and `servers[].validation` are unrepresentable; sending them is a loud deserialize error, not a silent merge. `UiSettings::apply` regrafts per-server `validation` by id (concurrent `test_server` writes survive a stale save) and builds the new `AppConfig` via an exhaustive struct literal, so adding a config field fails compilation until its owner is decided. The frontend sends an explicit pick-list (`toUiSettings`).

**Defect 2 — directionless `toggle_proxy`.** Replaced by `start_proxy`/`stop_proxy`: direction is decided by the state the user *saw* and transmitted explicitly (webview: `goingToConnect`; tray: the clicked menu item's ID — `ID_CONNECT`/`ID_DISCONNECT` baked at render time). The bridge's "already running" idempotence absorbs a stale view instead of inverting the user's intent. A `TransitionSlot` (one transition in flight) rejects a concurrent opposite toggle, so a user's cancel can't be overtaken by a queued second Start, and renders Connecting…/Disconnecting… in the tray with the action item disabled.

**Defect 3 — tray never reconciled with the bridge.** New `BridgeLink` owns the pooled client plus a seq-versioned `ProxyStateCell` (tokio watch). Every pooled exchange commits what it revealed about `running` (pure `observed_running`) **before releasing the client lock**, so commit order equals bridge order — no benign-race arguments. A single watcher task forwards each change to the tray (menu **and icon** committed inside the sanctioned main-thread closure) and to the webview via a new `proxy-state-changed` event; the webview applies observations seq-monotonically (shared gate for the event and the 5s poll, `state_seq` added to `get_proxy_status`). A 5s backend Status reconciler (immediate first tick = startup resync) keeps the tray honest with the dashboard closed. `set_proxy_enabled` lost its optimistic flip and the `revert_proxy_state(!enabled)` wedge: on failure one linearized Status commits reality, so a failed Disconnect can no longer re-assert "Connected", and quit-while-connected relaunches render Disconnected. `exit_app` deliberately leaves persisted `enabled` untouched. `reload_proxy_filters` now decides at the linearization point (`reload_if_running`: Status + Reload under one lock acquisition) — load-bearing because bridge-side reload on a stopped proxy *starts* it.

## Cross-references

- Likely fixes the #492 class: the icon is now committed inside the same ordered main-thread rebuild closure as the menu, reading state inside the closure. Closing #492 left to you.
- Follow-ups filed, deliberately out of scope here: #504 (server-membership lost-update vs concurrent import), #505 (bridge reload-when-stopped auto-start semantic), #506 (`StartupBehavior` has no consumer — persisted `enabled` is now the ready-made `RestoreLastState` input; implementing the consumer is your scope call, surfaced per review).

## Behavior notes

- Tray icon flips on the actual outcome, not optimistically at click; the in-flight feedback is the Connecting…/Disconnecting… status text + disabled action item.
- After a failed stop, the "Disconnect failed" cue persists until the state actually changes (seq gate) instead of being repainted to "Connected" by the next poll.
- A `PermissionDenied` Status leaves `running` at the last committed value (a DACL-gated probe says nothing about the tunnel) while `error` carries the failure.
- After a successful elevation, the persisted intent derives from a confirmed Status snapshot, never from the elevated helper's claim.

## Verification

Unit (all TDD, failing-first): wire-type rejection + apply regraft (`ui_settings_tests`), `observed_running` table + cell monotonicity + commit-in-bridge-order interleave + reload resurrection guard against a mock axum bridge over per-test socket paths (`state_tests`), outcome mappers + sole-writer persist rule + transition slot (`tray_tests`), explicit-intent transmission + payload key-set + seq gate + listener registration (vitest). Suites: 320 Rust (hole) + 178 hole-common, 181 vitest, clippy/tsc/biome clean.

Manual script (not unit-testable — real tray/webview/elevation):
1. Connect via tray with dashboard open → power button flips immediately (event, not 5s poll).
2. Connect via tray → change any setting → power click **stops** (defect-1 repro).
3. Exit while connected → relaunch → tray shows Disconnected.
4. Stop the bridge service externally with dashboard closed → tray flips Disconnected within ~5s.
5. Wedge the bridge, click Disconnect → tray does not re-assert Connected; webview shows a persistent "Disconnect failed".
6. Tray click during an in-flight webview connect → rejected with "already in progress".
