### PR TITLE
fix(gui): prevent a stale UI save from dropping concurrently-imported servers (#504)

### DIFF
--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -90,12 +90,21 @@ pub fn get_config(state: State<AppState>) -> AppConfig {
     state.config.lock().unwrap().clone()
 }
 
+/// Apply a webview settings snapshot to `config`: merge the UI-owned portion by
+/// id (membership stays backend-owned, #504) then heal the selection so it
+/// always names a real server — a stale snapshot can name one deleted
+/// concurrently. Pure helper — `save_config` wraps it with the lock + persist.
+fn apply_ui_settings(config: &mut AppConfig, settings: crate::ui_settings::UiSettings) {
+    settings.apply(config);
+    auto_select_first_server(config);
+}
+
 #[tauri::command]
 pub fn save_config(state: State<AppState>, settings: crate::ui_settings::UiSettings) -> Result<(), String> {
     let mut current = state.config.lock().unwrap();
     // Apply to a copy so a failed save leaves in-memory state unchanged.
     let mut updated = current.clone();
-    settings.apply(&mut updated);
+    apply_ui_settings(&mut updated, settings);
     state.config_store.save(&updated).map_err(|e| {
         warn!(error = %e, path = %state.config_store.path().display(), "save_config: config save failed");
         e.to_string()

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -207,6 +207,20 @@ fn auto_select_first_server(config: &mut AppConfig) {
     }
 }
 
+/// Remove the server with `id` from `config` (matched by id) and heal the
+/// selection if it pointed at the removed entry. Returns whether an entry was
+/// actually removed.
+///
+/// Pure helper — no Tauri `State`, no `Mutex` — so it is unit-testable. The
+/// `#[tauri::command]` wrapper [`delete_server`] holds the lock and persists.
+fn remove_server(config: &mut AppConfig, id: &str) -> bool {
+    let before = config.servers.len();
+    config.servers.retain(|s| s.id != id);
+    let removed = config.servers.len() != before;
+    auto_select_first_server(config);
+    removed
+}
+
 /// Import servers from a config file path. Reads the file and parses it.
 ///
 /// Returns only the entries that were actually appended to the config —
@@ -237,6 +251,24 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
     })?;
 
     Ok(appended)
+}
+
+/// Delete the server with `entry_id` from the config (by id) and persist.
+///
+/// Membership is backend-owned (#504): removal is a dedicated by-id operation,
+/// like import is for addition — never a side effect of the wholesale
+/// `save_config`, which would drop servers imported concurrently. Idempotent:
+/// deleting an absent id persists the unchanged config and returns `Ok`.
+#[tauri::command]
+pub fn delete_server(state: State<AppState>, entry_id: String) -> Result<(), String> {
+    let mut cfg = state.config.lock().unwrap();
+    let removed = remove_server(&mut cfg, &entry_id);
+    state.config_store.save(&cfg).map_err(|e| {
+        warn!(error = %e, path = %state.config_store.path().display(), "delete_server: config save failed");
+        e.to_string()
+    })?;
+    info!(entry_id = %entry_id, removed, remaining = cfg.servers.len(), "delete_server");
+    Ok(())
 }
 
 /// Poll the proxy's status. The exchange itself commits the observation

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -270,13 +270,16 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
 /// deleting an absent id persists the unchanged config and returns `Ok`.
 #[tauri::command]
 pub fn delete_server(state: State<AppState>, entry_id: String) -> Result<(), String> {
-    let mut cfg = state.config.lock().unwrap();
-    let removed = remove_server(&mut cfg, &entry_id);
-    state.config_store.save(&cfg).map_err(|e| {
+    let mut current = state.config.lock().unwrap();
+    // Apply to a copy so a failed save leaves in-memory state unchanged.
+    let mut updated = current.clone();
+    let removed = remove_server(&mut updated, &entry_id);
+    state.config_store.save(&updated).map_err(|e| {
         warn!(error = %e, path = %state.config_store.path().display(), "delete_server: config save failed");
         e.to_string()
     })?;
-    info!(entry_id = %entry_id, removed, remaining = cfg.servers.len(), "delete_server");
+    *current = updated;
+    info!(entry_id = %entry_id, removed, remaining = current.servers.len(), "delete_server");
     Ok(())
 }
 

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -251,13 +251,16 @@ pub fn import_servers_from_file(state: State<AppState>, path: String) -> Result<
         warn!(path = %path, error = ?e, "import_servers_from_file: validate/parse failed");
     })?;
 
-    let mut config = state.config.lock().unwrap();
-    let (appended, _deduped) = apply_import(&mut config, parsed);
+    let mut current = state.config.lock().unwrap();
+    // Apply to a copy so a failed save leaves in-memory state unchanged.
+    let mut updated = current.clone();
+    let (appended, _deduped) = apply_import(&mut updated, parsed);
 
-    state.config_store.save(&config).map_err(|e| {
+    state.config_store.save(&updated).map_err(|e| {
         warn!(error = %e, path = %state.config_store.path().display(), "import_servers_from_file: config save failed");
         ImportFailure::SaveFailed
     })?;
+    *current = updated;
 
     Ok(appended)
 }

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -224,6 +224,54 @@ fn remove_server_missing_id_is_noop() {
     assert_eq!(config.selected_server.as_deref(), Some("a"));
 }
 
+// apply_ui_settings composition: merge by id + selection heal =========================================================
+
+fn ui_server_entry(id: &str) -> crate::ui_settings::UiServerEntry {
+    serde_json::from_value(serde_json::json!({
+        "id": id, "name": format!("Server {id}"), "server": "1.2.3.4",
+        "server_port": 8388, "method": "aes-256-gcm", "password": "pw",
+    }))
+    .unwrap()
+}
+
+fn default_ui_settings() -> crate::ui_settings::UiSettings {
+    serde_json::from_value(serde_json::json!({
+        "servers": [], "selected_server": null, "local_port": 4073,
+        "filters": [], "start_on_login": false, "on_startup": "restore_last_state",
+        "theme": "dark", "proxy_server_enabled": true, "proxy_socks5": true,
+        "proxy_http": false, "dns": AppConfig::default().dns, "local_port_http": 4074,
+        "diagnostic_plugin_tap": false
+    }))
+    .unwrap()
+}
+
+#[skuld::test]
+fn apply_ui_settings_drops_stale_selection_and_ignores_unknown() {
+    // Backend truth after a concurrent delete of "a": only "b" remains.
+    let mut current = AppConfig {
+        servers: vec![test_entry("b")],
+        selected_server: Some("b".to_string()),
+        ..Default::default()
+    };
+    // Stale webview snapshot still believes "a" exists and is selected.
+    let mut settings = default_ui_settings();
+    settings.servers = vec![ui_server_entry("a"), ui_server_entry("b")];
+    settings.selected_server = Some("a".to_string());
+
+    apply_ui_settings(&mut current, settings);
+
+    assert_eq!(
+        current.servers.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        ["b"],
+        "the unknown stale id 'a' must not be resurrected"
+    );
+    assert_eq!(
+        current.selected_server.as_deref(),
+        Some("b"),
+        "a selection naming the concurrently-deleted server is healed"
+    );
+}
+
 // get_metrics / get_diagnostics response mapping + public-IP parsing tests ============================================
 
 /// Verify that a Metrics BridgeResponse maps to the expected JSON.

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -156,6 +156,74 @@ fn auto_select_noop_on_empty_servers() {
     assert!(config.selected_server.is_none());
 }
 
+// remove_server tests =================================================================================================
+
+#[skuld::test]
+fn remove_server_removes_by_id() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b"), test_entry("c")],
+        selected_server: Some("b".to_string()),
+        ..Default::default()
+    };
+    let removed = remove_server(&mut config, "b");
+    assert!(removed);
+    assert_eq!(
+        config.servers.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        ["a", "c"]
+    );
+}
+
+#[skuld::test]
+fn remove_server_heals_selection_when_selected_removed() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b")],
+        selected_server: Some("a".to_string()),
+        ..Default::default()
+    };
+    remove_server(&mut config, "a");
+    assert_eq!(
+        config.selected_server.as_deref(),
+        Some("b"),
+        "selection heals to the first remaining server"
+    );
+}
+
+#[skuld::test]
+fn remove_server_keeps_selection_when_other_removed() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b")],
+        selected_server: Some("b".to_string()),
+        ..Default::default()
+    };
+    remove_server(&mut config, "a");
+    assert_eq!(config.selected_server.as_deref(), Some("b"));
+}
+
+#[skuld::test]
+fn remove_server_clears_selection_when_last_removed() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a")],
+        selected_server: Some("a".to_string()),
+        ..Default::default()
+    };
+    remove_server(&mut config, "a");
+    assert!(config.servers.is_empty());
+    assert!(config.selected_server.is_none());
+}
+
+#[skuld::test]
+fn remove_server_missing_id_is_noop() {
+    let mut config = AppConfig {
+        servers: vec![test_entry("a"), test_entry("b")],
+        selected_server: Some("a".to_string()),
+        ..Default::default()
+    };
+    let removed = remove_server(&mut config, "nonexistent");
+    assert!(!removed);
+    assert_eq!(config.servers.len(), 2);
+    assert_eq!(config.selected_server.as_deref(), Some("a"));
+}
+
 // get_metrics / get_diagnostics response mapping + public-IP parsing tests ============================================
 
 /// Verify that a Metrics BridgeResponse maps to the expected JSON.

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -120,6 +120,7 @@ fn launch_gui(show_dashboard: bool) {
             commands::get_config,
             commands::save_config,
             commands::import_servers_from_file,
+            commands::delete_server,
             commands::get_proxy_status,
             commands::get_metrics,
             commands::get_diagnostics,

--- a/crates/hole/src/ui_settings.rs
+++ b/crates/hole/src/ui_settings.rs
@@ -8,6 +8,7 @@
 
 use hole_common::config::{AppConfig, DnsConfig, FilterRule, ServerEntry, StartupBehavior, Theme};
 use serde::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -45,41 +46,52 @@ pub struct UiServerEntry {
 }
 
 impl UiSettings {
-    /// Replace the UI-owned portion of `current`, regrafting backend-owned
-    /// per-server validation by id (an entry edited under the same id keeps
-    /// its validation; a new id starts unvalidated).
+    /// Merge the UI-owned portion of the webview's snapshot into `current`.
+    ///
+    /// Membership is backend-owned (#504): additions flow through import,
+    /// removals through `delete_server`. This method therefore only updates
+    /// the UI-owned fields of servers that still exist (matched by id),
+    /// preserving backend-owned per-server `validation`. A member absent from
+    /// the payload is kept (it may have been imported after the snapshot); a
+    /// payload id absent from `current` is ignored (the UI cannot mint server
+    /// ids). `current`'s order is authoritative.
     ///
     /// Exhaustive struct literal on purpose: adding a field to `AppConfig`
     /// fails compilation here until its owner is decided.
     pub fn apply(self, current: &mut AppConfig) {
-        let servers: Vec<ServerEntry> = self
+        // Index the payload by id; first occurrence wins on duplicate ids.
+        let mut incoming: HashMap<String, UiServerEntry> = HashMap::new();
+        for s in self.servers {
+            incoming.entry(s.id.clone()).or_insert(s);
+        }
+
+        let servers: Vec<ServerEntry> = current
             .servers
-            .into_iter()
-            .map(|s| {
-                let validation = current
-                    .servers
-                    .iter()
-                    .find(|c| c.id == s.id)
-                    .and_then(|c| c.validation.clone());
-                ServerEntry {
-                    id: s.id,
-                    name: s.name,
-                    server: s.server,
-                    server_port: s.server_port,
-                    method: s.method,
-                    password: s.password,
-                    plugin: s.plugin,
-                    plugin_opts: s.plugin_opts,
-                    validation,
-                }
+            .iter()
+            .map(|c| match incoming.get(&c.id) {
+                Some(ui) => ServerEntry {
+                    id: c.id.clone(),
+                    name: ui.name.clone(),
+                    server: ui.server.clone(),
+                    server_port: ui.server_port,
+                    method: ui.method.clone(),
+                    password: ui.password.clone(),
+                    plugin: ui.plugin.clone(),
+                    plugin_opts: ui.plugin_opts.clone(),
+                    // Backend-owned — preserved.
+                    validation: c.validation.clone(),
+                },
+                None => c.clone(),
             })
             .collect();
+
         *current = AppConfig {
             // Backend-owned — preserved from in-memory state.
             enabled: current.enabled,
             elevation_prompt_shown: current.elevation_prompt_shown,
-            // UI-owned — replaced wholesale.
+            // Membership backend-owned; UI-owned fields merged by id above.
             servers,
+            // UI-owned — replaced wholesale.
             selected_server: self.selected_server,
             local_port: self.local_port,
             filters: self.filters,

--- a/crates/hole/src/ui_settings_tests.rs
+++ b/crates/hole/src/ui_settings_tests.rs
@@ -93,29 +93,102 @@ fn apply_preserves_backend_owned_fields() {
     assert!(current.elevation_prompt_shown);
 }
 
+// Membership is backend-owned (#504): apply merges UI-owned fields by id and
+// can neither add nor drop members.
+
 #[skuld::test]
-fn apply_regrafts_validation_by_id() {
+fn apply_keeps_servers_absent_from_payload() {
+    // Backend imported "c" after the webview took its snapshot; the stale
+    // save payload only knows "a" and "b". "c" must survive (#504).
     let mut current = AppConfig {
-        servers: vec![validated("a"), entry("b")],
+        servers: vec![entry("a"), entry("b"), entry("c")],
+        selected_server: Some("a".into()),
         ..Default::default()
     };
     let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
-    // UI kept "a" (edited its name), added "c", dropped "b".
-    settings.servers = vec![
-        UiServerEntry {
-            name: "Renamed".into(),
-            ..ui_entry("a")
-        },
-        ui_entry("c"),
-    ];
+    settings.servers = vec![ui_entry("a"), ui_entry("b")];
     settings.apply(&mut current);
-    assert_eq!(current.servers.len(), 2);
-    assert_eq!(current.servers[0].name, "Renamed");
+    assert_eq!(
+        current.servers.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        ["a", "b", "c"],
+        "a server absent from the stale payload must not be dropped; order preserved"
+    );
+}
+
+#[skuld::test]
+fn apply_ignores_payload_ids_absent_from_current() {
+    // The UI cannot mint server ids; a payload entry the backend never had
+    // (e.g. a server deleted concurrently) must not be resurrected.
+    let mut current = AppConfig {
+        servers: vec![entry("a")],
+        ..Default::default()
+    };
+    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    settings.servers = vec![ui_entry("a"), ui_entry("ghost")];
+    settings.apply(&mut current);
+    assert_eq!(
+        current.servers.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        ["a"],
+        "unknown payload id must be ignored"
+    );
+}
+
+#[skuld::test]
+fn apply_updates_ui_fields_by_id_keeping_validation() {
+    let mut current = AppConfig {
+        servers: vec![validated("a")],
+        ..Default::default()
+    };
+    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    settings.servers = vec![UiServerEntry {
+        name: "Renamed".into(),
+        ..ui_entry("a")
+    }];
+    settings.apply(&mut current);
+    assert_eq!(current.servers.len(), 1);
+    assert_eq!(current.servers[0].name, "Renamed", "UI-owned field updated by id");
     assert!(
         current.servers[0].validation.is_some(),
-        "validation survives an edit under the same id"
+        "backend-owned validation preserved"
     );
-    assert!(current.servers[1].validation.is_none(), "new entry starts unvalidated");
+}
+
+#[skuld::test]
+fn apply_duplicate_incoming_ids_update_single_member() {
+    // The UI should never send duplicate ids, but if it does, membership still
+    // comes from `current` (one member) and the first payload occurrence wins
+    // for its fields.
+    let mut current = AppConfig {
+        servers: vec![validated("a")],
+        ..Default::default()
+    };
+    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    settings.servers = vec![ui_entry("a"), ui_entry("a")];
+    settings.apply(&mut current);
+    assert_eq!(
+        current.servers.len(),
+        1,
+        "membership comes from current, not the payload"
+    );
+    assert!(current.servers[0].validation.is_some(), "validation preserved");
+}
+
+#[skuld::test]
+fn apply_keeps_current_order_ignoring_payload_order() {
+    // `current` order is authoritative; iterating the payload (as the old
+    // wholesale-replace did) would let a reordered snapshot reorder the list.
+    let mut current = AppConfig {
+        servers: vec![entry("a"), entry("b")],
+        ..Default::default()
+    };
+    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
+    settings.servers = vec![ui_entry("b"), ui_entry("a")]; // reversed
+    settings.apply(&mut current);
+    assert_eq!(
+        current.servers.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        ["a", "b"],
+        "payload order must not reorder the authoritative list"
+    );
 }
 
 #[skuld::test]
@@ -126,17 +199,4 @@ fn apply_replaces_ui_owned_fields() {
     let settings: UiSettings = serde_json::from_value(json).unwrap();
     settings.apply(&mut current);
     assert_eq!(current.local_port, 5555);
-}
-
-#[skuld::test]
-fn apply_first_match_wins_for_duplicate_incoming_ids() {
-    let mut current = AppConfig {
-        servers: vec![validated("a")],
-        ..Default::default()
-    };
-    let mut settings: UiSettings = serde_json::from_value(default_settings_json()).unwrap();
-    settings.servers = vec![ui_entry("a"), ui_entry("a")];
-    settings.apply(&mut current);
-    assert!(current.servers[0].validation.is_some());
-    assert!(current.servers[1].validation.is_some()); // both graft from the same current entry
 }

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mainMock: {
   config: Record<string, unknown> | null;
   saveConfig: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<void>>>;
+  loadConfig: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<void>>>;
 } = {
   config: null,
   saveConfig: vi.fn().mockResolvedValue(undefined),
+  loadConfig: vi.fn().mockResolvedValue(undefined),
 };
 const updateDiagnostics = vi.fn();
 const invokeMock = vi.fn<(...args: unknown[]) => Promise<unknown>>();
@@ -17,7 +19,7 @@ vi.mock("./main", () => ({
     return mainMock.config;
   },
   saveConfig: (...args: unknown[]) => mainMock.saveConfig(...args),
-  loadConfig: vi.fn(),
+  loadConfig: (...args: unknown[]) => mainMock.loadConfig(...args),
   runTestsBounded: vi.fn(),
   TEST_CONCURRENCY: 3,
 }));
@@ -31,6 +33,7 @@ function server(id: string, name: string) {
 
 beforeEach(() => {
   mainMock.saveConfig.mockClear();
+  mainMock.loadConfig.mockClear();
   updateDiagnostics.mockClear();
   invokeMock.mockReset();
   invokeMock.mockResolvedValue(undefined);
@@ -107,6 +110,37 @@ describe("server delete control", () => {
     outside.focus();
     document.querySelectorAll<HTMLElement>(".srv-del")[1].click();
     expect(document.activeElement).toBe(outside);
+  });
+
+  it("persists the deletion via delete_server, not a wholesale save", async () => {
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelectorAll<HTMLElement>(".srv-del")[1].click(); // delete Beta
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith("delete_server", { entryId: "b" }));
+    expect(mainMock.saveConfig).not.toHaveBeenCalled();
+    expect(mainMock.loadConfig).toHaveBeenCalled();
+  });
+
+  it("restores via loadConfig and toasts when delete_server fails", async () => {
+    invokeMock.mockRejectedValueOnce("backend exploded");
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelectorAll<HTMLElement>(".srv-del")[1].click();
+    await vi.waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("backend exploded"), "error"),
+    );
+    expect(mainMock.loadConfig).toHaveBeenCalled();
+  });
+
+  it("optimistically moves selection when the selected server is deleted", async () => {
+    // Fixture: "a" (Alpha) is selected; servers are [a, b, c].
+    const { renderServers } = await import("./servers");
+    renderServers();
+    document.querySelectorAll<HTMLElement>(".srv-del")[0].click(); // delete the selected "a"
+    // Synchronous (pre-await) optimistic update: selection moves to the first
+    // remaining server before the by-id delete + reload land.
+    expect(mainMock.config!.selected_server).toBe("b");
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith("delete_server", { entryId: "a" }));
   });
 });
 

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -67,9 +67,6 @@ export function statusTooltipFor(v: ValidationState | null | undefined): string 
 /// Entry IDs with a test_server invoke in flight. renderServers consults
 /// this so a mid-test rebuild repaints the in-flight state instead of
 /// silently reverting the card to its persisted dot.
-/// Entry IDs with a test_server invoke in flight. renderServers consults
-/// this so a mid-test rebuild repaints the in-flight state instead of
-/// silently reverting the card to its persisted dot.
 const testsInFlight = new Set<string>();
 
 /// Repaint one card's test button + status dot from the live DOM.

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -263,7 +263,12 @@ async function selectServer(id: string) {
   await saveConfig();
 }
 
-/** Delete a server by ID — removes it from config, clears selection if needed, re-renders, saves. */
+/** Delete a server by ID. Removal is a dedicated by-id backend op
+ * (`delete_server`), never a wholesale `save_config` — that would drop
+ * servers imported concurrently (#504). The optimistic local removal gives
+ * instant feedback; the trailing `loadConfig` reconciles with backend truth
+ * (concurrent imports, healed selection) and, on failure, restores the server
+ * the optimistic removal hid. */
 async function deleteServer(id: string) {
   if (!config) return;
   const idx = config.servers.findIndex((s) => s.id === id);
@@ -280,7 +285,16 @@ async function deleteServer(id: string) {
     const dels = serverList.querySelectorAll<HTMLElement>(".srv-del");
     (dels[Math.min(idx, dels.length - 1)] ?? importZone).focus();
   }
-  await saveConfig();
+  try {
+    await invoke("delete_server", { entryId: id });
+  } catch (err) {
+    console.error("delete_server failed:", err);
+    showToast(`Failed to delete server: ${err}`, "error");
+  }
+  // Reconcile with backend truth on both success and failure: a successful
+  // delete pulls in any concurrent import + the healed selection; a failed
+  // delete restores the server the optimistic removal hid.
+  await loadConfig();
 }
 
 // File import =========================================================================================================


### PR DESCRIPTION
## Problem

`save_config` → `UiSettings::apply` rebuilt `config.servers` **wholesale** from the webview's snapshot (regrafting only backend-owned `validation` by id, #462). Membership has two writers — backend `import_servers_from_file` (append-only) and the UI's delete (previously routed through the wholesale save) — so a `save_config` built from a snapshot taken *before* a concurrent import landed silently dropped the just-imported servers from disk and memory.

Repro: drop a JSON import onto the dashboard and toggle any setting before the post-import `loadConfig()` lands.

## Fix (approach A — membership is backend-owned, mutated only by id)

Membership now works like `validation` and `import` already do: backend-owned, mutated through dedicated by-id operations. `save_config` becomes structurally **incapable** of adding or removing a server.

- **`UiSettings::apply`** merges UI-owned fields into the authoritative `current.servers` *by id*: keeps members absent from the payload (a concurrent import survives), ignores payload ids absent from `current` (the UI can't mint server ids), preserves backend-owned `validation`, preserves `current` order. The exhaustive `AppConfig` struct-literal guard is kept.
- **New `delete_server(entry_id)` command** owns removal by id (pure `remove_server` helper + thin lock/persist wrapper, mirroring `apply_import`/`import_servers_from_file`). Clone-then-commit-on-success, so a failed persist leaves in-memory state unchanged.
- **`save_config`** routes through a pure `apply_ui_settings` helper that applies the merge and then heals `selected_server` (a stale snapshot can name a server deleted concurrently).
- **`ui/servers.ts`** `deleteServer` now optimistically removes locally for instant feedback, calls `delete_server`, then `loadConfig()` to reconcile (and to restore the server on failure) — no more wholesale save.

All config writers serialize on the single `state.config` mutex; the GUI is single-instance and the sole `config.json` writer, so by-id ops are linearizable and the lost-update is closed structurally.

## Testing

- `crates/hole` (Rust): new `apply_*` merge tests incl. the #504 regression (`apply_keeps_servers_absent_from_payload`), order-preservation, ignore-unknown-id, validation-regraft, duplicate-id; full `remove_server_*` matrix; `apply_ui_settings_drops_stale_selection_and_ignores_unknown`. Replaced the two obsolete wholesale-replace tests.
- `ui/servers.test.ts`: deletion persists via `delete_server` (not a wholesale save); failure path restores via `loadConfig` + toast; optimistic selection move.
- Local: `cargo fmt --check`, `cargo clippy --all-targets --no-default-features --features garter/test-utils -- -D warnings`, `cargo nextest run -p hole --no-default-features` (338 passed), `tsc --noEmit`, biome (changed files clean), `vitest run` (184 passed).

Closes #504.