### PR TITLE
fix(gui): public IP reflects the active tunnel (#464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,7 +3033,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tun-engine",
- "ureq",
  "util",
  "webpki-roots",
  "windows 0.62.2",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -46,7 +46,6 @@ http-body-util = "0.1"
 http = "1"
 bytes = "1"
 tower = { version = "0.5", features = ["util"] }
-ureq = { version = "3", features = ["json"] }
 tempfile = "3"
 # Filter engine dependencies. All except `lru` and `tls-parser` are already
 # pulled in transitively via shadowsocks-service; promoted to direct deps so

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -10,16 +10,15 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use hole_common::protocol::{
-    DiagnosticsResponse, EmptyResponse, ErrorResponse, MetricsResponse, ProxyConfig, PublicIpResponse, StatusResponse,
-    TestServerRequest, TestServerResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
-    ROUTE_PUBLIC_IP, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    DiagnosticsResponse, EmptyResponse, ErrorResponse, MetricsResponse, ProxyConfig, StatusResponse, TestServerRequest,
+    TestServerResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START,
+    ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
@@ -46,17 +45,13 @@ pub struct StartCancelState {
     pub pending: bool,
 }
 
-/// Shared state for IPC handlers, holding the proxy manager, IP cache, and
-/// the start-cancellation handoff struct.
+/// Shared state for IPC handlers, holding the proxy manager and the
+/// start-cancellation handoff struct.
 pub struct IpcState<P: Proxy, R: Routing> {
     pub proxy: Arc<Mutex<ProxyManager<P, R>>>,
-    pub ip_cache: Arc<tokio::sync::Mutex<Option<(PublicIpResponse, Instant)>>>,
     // std::sync::Mutex — never held across .await. See StartCancelState docs.
     pub start_cancel: Arc<std::sync::Mutex<StartCancelState>>,
 }
-
-/// IP cache time-to-live.
-const IP_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 
 // Server ==============================================================================================================
 
@@ -90,7 +85,6 @@ impl IpcServer {
 
         let state = Arc::new(IpcState {
             proxy,
-            ip_cache: Arc::new(tokio::sync::Mutex::new(None)),
             start_cancel: Arc::new(std::sync::Mutex::new(StartCancelState::default())),
         });
         let router = build_router(state);
@@ -198,7 +192,6 @@ fn build_router<P: Proxy + 'static, R: Routing + 'static>(state: Arc<IpcState<P,
         .route(ROUTE_RELOAD, axum::routing::post(handle_reload::<P, R>))
         .route(ROUTE_METRICS, axum::routing::get(handle_metrics::<P, R>))
         .route(ROUTE_DIAGNOSTICS, axum::routing::get(handle_diagnostics::<P, R>))
-        .route(ROUTE_PUBLIC_IP, axum::routing::get(handle_public_ip::<P, R>))
         .route(ROUTE_TEST_SERVER, axum::routing::post(handle_test_server::<P, R>))
         .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
         .with_state(state)
@@ -425,62 +418,6 @@ async fn handle_test_server<P: Proxy + 'static, R: Routing + 'static>(
     let cfg = TestConfig::production();
     let outcome = run_server_test(&req.entry, &cfg).await;
     Json(TestServerResponse { outcome })
-}
-
-async fn handle_public_ip<P: Proxy + 'static, R: Routing + 'static>(
-    State(state): State<Arc<IpcState<P, R>>>,
-) -> Result<Json<PublicIpResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Check cache first.
-    {
-        let cache = state.ip_cache.lock().await;
-        if let Some((ref cached, instant)) = *cache {
-            if instant.elapsed() < IP_CACHE_TTL {
-                return Ok(Json(cached.clone()));
-            }
-        }
-    }
-
-    // Cache miss or expired — fetch from external service.
-    // ureq is blocking, so run in a blocking thread.
-    let result = tokio::task::spawn_blocking(|| -> Result<PublicIpResponse, String> {
-        let agent = ureq::Agent::new_with_defaults();
-        let body: serde_json::Value = agent
-            .get("https://ipinfo.io/json")
-            .call()
-            .map_err(|e| format!("IP lookup failed: {e}"))?
-            .body_mut()
-            .read_json()
-            .map_err(|e| format!("parse error: {e}"))?;
-
-        let ip = body["ip"]
-            .as_str()
-            .ok_or_else(|| "missing 'ip' field".to_string())?
-            .to_string();
-        let country_code = body["country"]
-            .as_str()
-            .ok_or_else(|| "missing 'country' field".to_string())?
-            .to_string();
-
-        Ok(PublicIpResponse { ip, country_code })
-    })
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                message: format!("task join error: {e}"),
-            }),
-        )
-    })?
-    .map_err(|e| (StatusCode::BAD_GATEWAY, Json(ErrorResponse { message: e })))?;
-
-    // Update cache.
-    {
-        let mut cache = state.ip_cache.lock().await;
-        *cache = Some((result.clone(), Instant::now()));
-    }
-
-    Ok(Json(result))
 }
 
 // Security ============================================================================================================

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -983,9 +983,6 @@ fn diagnostics_bridge_error_after_failed_start() {
 // (line ~363). A thread-local `set_default` capture could be added now
 // that the global subscriber level-rejects noisy third-party events.
 
-// No public_ip handler test: it makes a live HTTP call to ipinfo.io that
-// can't be mocked without an HTTP-client seam.
-
 // Cancel tests ========================================================================================================
 
 /// Extract the `message` field from a 500 `ErrorResponse`.

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -31,9 +31,9 @@
 use crate::socket::LocalStream;
 use bytes::Bytes;
 use hole_common::protocol::{
-    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, PublicIpResponse,
-    StatusResponse, TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
-    ROUTE_PUBLIC_IP, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, StatusResponse,
+    TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START,
+    ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -620,19 +620,6 @@ impl BridgeIpcClient {
                         network: diag.network,
                         vpn_server: diag.vpn_server,
                         internet: diag.internet,
-                    })
-                } else {
-                    parse_bridge_error(resp).await
-                }
-            }
-            BridgeRequest::PublicIp => {
-                let resp = self.http_get(ROUTE_PUBLIC_IP).await?;
-                if resp.status().is_success() {
-                    let body = read_body(resp).await?;
-                    let pip: PublicIpResponse = serde_json::from_slice(&body)?;
-                    Ok(BridgeResponse::PublicIp {
-                        ip: pip.ip,
-                        country_code: pip.country_code,
                     })
                 } else {
                     parse_bridge_error(resp).await

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -125,18 +125,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/DiagnosticsResponse"
 
-  /v1/public-ip:
-    get:
-      summary: Get public IP address
-      operationId: getPublicIp
-      responses:
-        "200":
-          description: Current public IP and country
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PublicIpResponse"
-
   /v1/test-server:
     post:
       summary: Run a one-shot shadowsocks client test against a server entry
@@ -351,17 +339,6 @@ components:
             Bridge always returns "unknown". The GUI computes this dot from
             the selected ServerEntry's persisted validation state and
             ignores this field.
-
-    PublicIpResponse:
-      type: object
-      required:
-        - ip
-        - country_code
-      properties:
-        ip:
-          type: string
-        country_code:
-          type: string
 
     # Documentation-only schemas (not code-generated; hand-written in Rust)
     ProxyConfig:

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -1,6 +1,6 @@
 //! Generates Rust types and route constants from the OpenAPI spec at `api/openapi.yaml`.
 //!
-//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `PublicIpResponse`, `InvalidFilter`, `FilterMetrics`.
+//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `InvalidFilter`, `FilterMetrics`.
 //! Generated constants: one `ROUTE_*` const per `/v1/*` path in `api/openapi.yaml` (e.g. `ROUTE_STATUS`, `ROUTE_START`, `ROUTE_STOP`, `ROUTE_CANCEL`, `ROUTE_RELOAD`, …).
 //!
 //! The remaining schemas — including `ProxyConfig`, `ServerEntry`, `ValidationState`,
@@ -25,7 +25,6 @@ fn main() {
         "EmptyResponse",
         "MetricsResponse",
         "DiagnosticsResponse",
-        "PublicIpResponse",
         "InvalidFilter",
         "FilterMetrics",
     ];

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -47,7 +47,6 @@ pub enum BridgeRequest {
     },
     Metrics,
     Diagnostics,
-    PublicIp,
     TestServer {
         entry: ServerEntry,
     },
@@ -89,10 +88,6 @@ pub enum BridgeResponse {
         network: String,
         vpn_server: String,
         internet: String,
-    },
-    PublicIp {
-        ip: String,
-        country_code: String,
     },
     TestServerResult {
         outcome: ServerTestOutcome,

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -238,21 +238,9 @@ fn diagnostics_response_roundtrips() {
 }
 
 #[skuld::test]
-fn public_ip_response_roundtrips() {
-    let resp = PublicIpResponse {
-        ip: "185.0.0.42".to_string(),
-        country_code: "DE".to_string(),
-    };
-    let json = serde_json::to_string(&resp).unwrap();
-    let parsed: PublicIpResponse = serde_json::from_str(&json).unwrap();
-    assert_eq!(resp, parsed);
-}
-
-#[skuld::test]
 fn route_constants_for_new_endpoints_exist() {
     assert_eq!(ROUTE_METRICS, "/v1/metrics");
     assert_eq!(ROUTE_DIAGNOSTICS, "/v1/diagnostics");
-    assert_eq!(ROUTE_PUBLIC_IP, "/v1/public-ip");
 }
 
 // Protocol variant roundtrips -----------------------------------------------------------------------------------------
@@ -268,14 +256,6 @@ fn bridge_request_metrics_roundtrips() {
 #[skuld::test]
 fn bridge_request_diagnostics_roundtrips() {
     let req = BridgeRequest::Diagnostics;
-    let json = serde_json::to_string(&req).unwrap();
-    let parsed: BridgeRequest = serde_json::from_str(&json).unwrap();
-    assert_eq!(req, parsed);
-}
-
-#[skuld::test]
-fn bridge_request_public_ip_roundtrips() {
-    let req = BridgeRequest::PublicIp;
     let json = serde_json::to_string(&req).unwrap();
     let parsed: BridgeRequest = serde_json::from_str(&json).unwrap();
     assert_eq!(req, parsed);
@@ -304,17 +284,6 @@ fn bridge_response_diagnostics_roundtrips() {
         network: "error".to_string(),
         vpn_server: "unknown".to_string(),
         internet: "unknown".to_string(),
-    };
-    let json = serde_json::to_string(&resp).unwrap();
-    let parsed: BridgeResponse = serde_json::from_str(&json).unwrap();
-    assert_eq!(resp, parsed);
-}
-
-#[skuld::test]
-fn bridge_response_public_ip_roundtrips() {
-    let resp = BridgeResponse::PublicIp {
-        ip: "1.2.3.4".to_string(),
-        country_code: "US".to_string(),
     };
     let json = serde_json::to_string(&resp).unwrap();
     let parsed: BridgeResponse = serde_json::from_str(&json).unwrap();

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -2,9 +2,9 @@
 
 use bytes::Bytes;
 use hole_common::protocol::{
-    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, PublicIpResponse,
-    StatusResponse, TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
-    ROUTE_PUBLIC_IP, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, StatusResponse,
+    TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START,
+    ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -159,20 +159,6 @@ impl BridgeClient {
                         network: diag.network,
                         vpn_server: diag.vpn_server,
                         internet: diag.internet,
-                    })
-                } else {
-                    parse_bridge_error(resp).await
-                }
-            }
-            BridgeRequest::PublicIp => {
-                let resp = self.http_get(ROUTE_PUBLIC_IP).await?;
-                if resp.status().is_success() {
-                    let body = read_body(resp).await?;
-                    let pip: PublicIpResponse =
-                        serde_json::from_slice(&body).map_err(|e| ClientError::Protocol(e.to_string()))?;
-                    Ok(BridgeResponse::PublicIp {
-                        ip: pip.ip,
-                        country_code: pip.country_code,
                     })
                 } else {
                     parse_bridge_error(resp).await

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -1,8 +1,7 @@
 use super::*;
 use axum::Json;
 use hole_common::protocol::{
-    BridgeRequest, BridgeResponse, DiagnosticsResponse, EmptyResponse, MetricsResponse, PublicIpResponse,
-    StatusResponse,
+    BridgeRequest, BridgeResponse, DiagnosticsResponse, EmptyResponse, MetricsResponse, StatusResponse,
 };
 use hyper::body::Incoming;
 use std::path::PathBuf;
@@ -73,15 +72,6 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     network: "ok".to_string(),
                     vpn_server: "ok".to_string(),
                     internet: "ok".to_string(),
-                })
-            }),
-        )
-        .route(
-            hole_common::protocol::ROUTE_PUBLIC_IP,
-            axum::routing::get(|| async {
-                Json(PublicIpResponse {
-                    ip: "203.0.113.42".to_string(),
-                    country_code: "DE".to_string(),
                 })
             }),
         );
@@ -403,25 +393,6 @@ fn send_diagnostics_returns_response() {
                 network: "ok".to_string(),
                 vpn_server: "ok".to_string(),
                 internet: "ok".to_string(),
-            }
-        );
-    });
-}
-
-#[skuld::test]
-fn send_public_ip_returns_response() {
-    rt().block_on(async {
-        let path = test_socket_path("publicip");
-        let _mock = spawn_mock_bridge(&path).await;
-
-        let mut client = BridgeClient::connect(&path).await.unwrap();
-        let resp = client.send(BridgeRequest::PublicIp).await.unwrap();
-
-        assert_eq!(
-            resp,
-            BridgeResponse::PublicIp {
-                ip: "203.0.113.42".to_string(),
-                country_code: "DE".to_string(),
             }
         );
     });

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -699,7 +699,6 @@ fn send_bridge_request(request: hole_common::protocol::BridgeRequest) -> i32 {
         Ok(BridgeResponse::Status { .. }) => 0,
         Ok(BridgeResponse::Metrics { .. }) => 0,
         Ok(BridgeResponse::Diagnostics { .. }) => 0,
-        Ok(BridgeResponse::PublicIp { .. }) => 0,
         Ok(BridgeResponse::TestServerResult { .. }) => 0,
         Ok(BridgeResponse::Error { message }) => {
             cli_log!(error, "bridge error: {message}");

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -357,17 +357,6 @@ fn map_diagnostics_response(result: Result<BridgeResponse, ClientError>) -> serd
     }
 }
 
-/// Try to extract a public IP response from the bridge result.
-/// Returns `Some(json)` on success, `None` if fallback is needed.
-fn map_public_ip_bridge_response(result: Result<BridgeResponse, ClientError>) -> Option<serde_json::Value> {
-    match result {
-        Ok(BridgeResponse::PublicIp { ip, country_code }) => {
-            Some(serde_json::json!({ "ip": ip, "country_code": country_code }))
-        }
-        _ => None,
-    }
-}
-
 // Tauri commands ======================================================================================================
 
 #[tauri::command]
@@ -483,33 +472,44 @@ pub fn mark_validated_by_proxy_start(state: State<AppState>, entry_id: String) -
     Ok(())
 }
 
-#[tauri::command]
-pub async fn get_public_ip(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
-    // Try bridge first (fetches through VPN when connected)
-    if let Some(json) = map_public_ip_bridge_response(state.bridge_send(BridgeRequest::PublicIp).await) {
-        return Ok(json);
+/// Map Cloudflare's `/cdn-cgi/trace` `key=value` body to the badge's shape.
+/// `ip=` is the source IP Cloudflare's edge sees — the VPN exit when
+/// connected, the ISP otherwise; `loc=` is its 2-letter country. Absent
+/// fields fall back to display placeholders.
+fn parse_cf_trace(body: &str) -> serde_json::Value {
+    let mut ip = "unknown";
+    let mut country = "??";
+    for line in body.lines() {
+        if let Some(v) = line.strip_prefix("ip=") {
+            ip = v;
+        } else if let Some(v) = line.strip_prefix("loc=") {
+            country = v;
+        }
     }
+    serde_json::json!({ "ip": ip, "country_code": country })
+}
 
-    // Bridge unreachable — fetch directly (shows ISP IP)
-    let result = tokio::task::spawn_blocking(|| {
-        // ureq v3 API: Agent-based, not free functions.
-        let agent = ureq::Agent::new_with_defaults();
-        let body: serde_json::Value = agent
-            .get("https://ipinfo.io/json")
+#[tauri::command]
+pub async fn get_public_ip() -> Result<serde_json::Value, String> {
+    // Routing is a system-wide split-default (all traffic → TUN when
+    // connected), so a direct fetch already reflects the active egress — VPN
+    // exit when connected, ISP otherwise — with no bridge round-trip.
+    // Cloudflare's trace echoes the source IP + country with no per-IP daily
+    // cap. ureq is blocking, so run it on a blocking thread.
+    tokio::task::spawn_blocking(|| {
+        // www host avoids the apex 301 → www redirect round-trip.
+        let body = ureq::get("https://www.cloudflare.com/cdn-cgi/trace")
             .call()
             .map_err(|e| format!("IP lookup failed: {e}"))?
-            .body_mut()
-            .read_json()
-            .map_err(|e| format!("parse error: {e}"))?;
-        Ok::<_, String>(serde_json::json!({
-            "ip": body["ip"].as_str().unwrap_or("unknown"),
-            "country_code": body["country"].as_str().unwrap_or("??"),
-        }))
+            .into_body()
+            .with_config()
+            .limit(64 * 1024)
+            .read_to_string()
+            .map_err(|e| format!("read error: {e}"))?;
+        Ok::<_, String>(parse_cf_trace(&body))
     })
     .await
-    .map_err(|e| format!("task join error: {e}"))?;
-
-    result
+    .map_err(|e| format!("task join error: {e}"))?
 }
 
 /// Build a `ProxyConfig` from the currently selected server in app config.

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -259,6 +259,22 @@ fn parse_cf_trace_falls_back_when_fields_absent() {
     assert_eq!(out["country_code"], "??");
 }
 
+/// CRLF line endings: `str::lines()` strips the trailing `\r`.
+#[skuld::test]
+fn parse_cf_trace_handles_crlf() {
+    let out = parse_cf_trace("ip=203.0.113.42\r\nloc=DE\r\n");
+    assert_eq!(out["ip"], "203.0.113.42");
+    assert_eq!(out["country_code"], "DE");
+}
+
+/// Present-but-empty fields stay empty; the UI renders its own placeholder.
+#[skuld::test]
+fn parse_cf_trace_present_but_empty_fields() {
+    let out = parse_cf_trace("ip=\nloc=\n");
+    assert_eq!(out["ip"], "");
+    assert_eq!(out["country_code"], "");
+}
+
 // validate_and_read_import tests ======================================================================================
 
 const VALID_SERVER_JSON: &str = r#"{"server":"1.2.3.4","server_port":8388,"password":"pw","method":"aes-256-gcm"}"#;

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -156,7 +156,7 @@ fn auto_select_noop_on_empty_servers() {
     assert!(config.selected_server.is_none());
 }
 
-// get_metrics / get_diagnostics / get_public_ip response mapping tests ================================================
+// get_metrics / get_diagnostics response mapping + public-IP parsing tests ============================================
 
 /// Verify that a Metrics BridgeResponse maps to the expected JSON.
 #[skuld::test]
@@ -242,33 +242,21 @@ fn get_diagnostics_unexpected_response_falls_back() {
     assert_eq!(json["bridge"], "unknown");
 }
 
-/// Verify that a PublicIp BridgeResponse maps to the expected JSON.
+/// `parse_cf_trace` pulls `ip=` / `loc=` out of Cloudflare's trace body.
 #[skuld::test]
-fn get_public_ip_bridge_success_returns_json() {
-    let resp: Result<BridgeResponse, ClientError> = Ok(BridgeResponse::PublicIp {
-        ip: "203.0.113.42".into(),
-        country_code: "DE".into(),
-    });
-    let json = map_public_ip_bridge_response(resp).expect("should return Some for PublicIp");
-    assert_eq!(json["ip"], "203.0.113.42");
-    assert_eq!(json["country_code"], "DE");
+fn parse_cf_trace_extracts_ip_and_country() {
+    let body = "fl=123abc\nh=cloudflare.com\nip=203.0.113.42\nts=1700000000.1\nvisit_scheme=https\nloc=DE\ncolo=FRA\n";
+    let out = parse_cf_trace(body);
+    assert_eq!(out["ip"], "203.0.113.42");
+    assert_eq!(out["country_code"], "DE");
 }
 
-/// Verify that a failed PublicIp bridge request returns None (triggers fallback).
+/// Absent fields fall back to the display placeholders.
 #[skuld::test]
-fn get_public_ip_bridge_failure_returns_none() {
-    let err: Result<BridgeResponse, ClientError> = Err(ClientError::Connection(std::io::Error::new(
-        std::io::ErrorKind::ConnectionRefused,
-        "bridge unreachable",
-    )));
-    assert!(map_public_ip_bridge_response(err).is_none());
-}
-
-/// Verify that an unexpected BridgeResponse for PublicIp returns None.
-#[skuld::test]
-fn get_public_ip_unexpected_response_returns_none() {
-    let resp: Result<BridgeResponse, ClientError> = Ok(BridgeResponse::Ack);
-    assert!(map_public_ip_bridge_response(resp).is_none());
+fn parse_cf_trace_falls_back_when_fields_absent() {
+    let out = parse_cf_trace("fl=123abc\nh=cloudflare.com\ncolo=FRA\n");
+    assert_eq!(out["ip"], "unknown");
+    assert_eq!(out["country_code"], "??");
 }
 
 // validate_and_read_import tests ======================================================================================

--- a/ui/country-flag.test.ts
+++ b/ui/country-flag.test.ts
@@ -68,7 +68,7 @@ describe("setCountryFlag", () => {
     expect(el.classList.contains("fi-xx")).toBe(true);
   });
 
-  // Backend always sends a string (ipinfo.io fallback coerces to "??");
+  // Backend always sends a string (the IP fetch coerces a missing country to "??");
   // null/undefined is defense-in-depth.
   // biome-ignore lint/suspicious/noExplicitAny: cast through to test the runtime guard
   it("null / undefined: same as '??'", () => {

--- a/ui/ip-display.test.ts
+++ b/ui/ip-display.test.ts
@@ -18,6 +18,10 @@ beforeEach(() => {
 afterEach(() => {
   // jsdom adds a clipboard mock to navigator that persists across tests.
   delete (navigator as { clipboard?: unknown }).clipboard;
+  // The auto-refresh test stubs setInterval/clearInterval and overrides
+  // document.hidden; vitest does not auto-unstub, so restore both here.
+  vi.unstubAllGlobals();
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
 });
 
 describe("updatePublicIp", () => {
@@ -124,5 +128,36 @@ describe("copy button", () => {
     await Promise.resolve();
 
     expect(showToastMock).toHaveBeenCalledWith(expect.stringContaining("denied"), "error");
+  });
+});
+
+describe("startPublicIpAutoRefresh", () => {
+  it("polls every 60s while visible, pauses when hidden, resumes on return", async () => {
+    const setIntervalMock = vi.fn().mockReturnValue(777);
+    const clearIntervalMock = vi.fn();
+    vi.stubGlobal("setInterval", setIntervalMock);
+    vi.stubGlobal("clearInterval", clearIntervalMock);
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    invokeMock.mockResolvedValue({ ip: "1.2.3.4", country_code: "DE" });
+
+    const { initIpDisplay, startPublicIpAutoRefresh } = await import("./ip-display");
+    initIpDisplay();
+    startPublicIpAutoRefresh();
+
+    // Visible at start → one 60s interval, no immediate fetch (init owns the first).
+    expect(setIntervalMock).toHaveBeenCalledTimes(1);
+    expect(setIntervalMock.mock.calls[0][1]).toBe(60000);
+
+    // Hidden → interval cleared.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(clearIntervalMock).toHaveBeenCalledWith(777);
+
+    // Visible again → immediate refresh + a fresh interval.
+    invokeMock.mockClear();
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(invokeMock).toHaveBeenCalledWith("get_public_ip");
+    expect(setIntervalMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/ip-display.test.ts
+++ b/ui/ip-display.test.ts
@@ -42,6 +42,30 @@ describe("updatePublicIp", () => {
     expect(flag.title).toBe("Unknown");
     expect(document.getElementById("ip-text")!.textContent).toContain("unknown");
   });
+
+  it("replaces a stale IP with '--' and clears the copyable value when the fetch fails", async () => {
+    // A good fetch populates the badge + currentIp...
+    invokeMock.mockResolvedValueOnce({ ip: "1.2.3.4", country_code: "DE" });
+    const { initIpDisplay, updatePublicIp } = await import("./ip-display");
+    initIpDisplay();
+    await updatePublicIp();
+    expect(document.getElementById("ip-text")!.textContent).toContain("1.2.3.4");
+
+    // ...a failing fetch must NOT keep it — show the placeholder instead.
+    invokeMock.mockRejectedValueOnce(new Error("fetch failed"));
+    await updatePublicIp();
+    const flag = document.getElementById("country-flag")!;
+    expect(flag.classList.contains("fi-xx")).toBe(true);
+    const text = document.getElementById("ip-text")!.textContent!;
+    expect(text).toContain("--");
+    expect(text).not.toContain("1.2.3.4");
+
+    // currentIp was cleared → copy is a no-op.
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    document.getElementById("copy-ip-btn")!.click();
+    expect(writeText).not.toHaveBeenCalled();
+  });
 });
 
 describe("copy button", () => {

--- a/ui/ip-display.ts
+++ b/ui/ip-display.ts
@@ -34,6 +34,14 @@ export async function updatePublicIp(): Promise<void> {
     }
   } catch (err) {
     console.error("get_public_ip failed:", err);
+    // Never keep a possibly pre-VPN value on failure (#464): clear the
+    // copyable IP and show a placeholder distinct from the empty-success
+    // "unknown".
+    currentIp = "";
+    if (countryFlag) setCountryFlag(countryFlag, "");
+    if (ipText && countryFlag) {
+      ipText.replaceChildren(countryFlag, document.createTextNode(" --"));
+    }
   }
 }
 

--- a/ui/ip-display.ts
+++ b/ui/ip-display.ts
@@ -19,6 +19,39 @@ export function initIpDisplay(): void {
   copyIpBtn?.addEventListener("click", handleCopyIp);
 }
 
+const PUBLIC_IP_REFRESH_MS = 60_000;
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+function startRefreshTimer(): void {
+  if (refreshTimer === null) refreshTimer = setInterval(updatePublicIp, PUBLIC_IP_REFRESH_MS);
+}
+
+function stopRefreshTimer(): void {
+  if (refreshTimer !== null) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+/**
+ * Refresh the public IP every 60s while the dashboard is visible; pause when
+ * minimized or closed to the tray so we never poll in the background (#464).
+ * The initial fetch is owned by init(); this only fetches on a hidden→visible
+ * return. Call once at startup.
+ */
+export function startPublicIpAutoRefresh(): void {
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      stopRefreshTimer();
+    } else {
+      void updatePublicIp();
+      startRefreshTimer();
+    }
+  });
+  if (document.hidden) stopRefreshTimer();
+  else startRefreshTimer();
+}
+
 /** Refetch the public IP via Tauri and repaint the badge + address. */
 export async function updatePublicIp(): Promise<void> {
   try {

--- a/ui/main.test.ts
+++ b/ui/main.test.ts
@@ -47,6 +47,7 @@ vi.mock("./sidebar", () => ({
   updateMetrics: vi.fn(),
   updateProxyStatus: vi.fn().mockReturnValue({ state: "disconnected", changed: false }),
   updatePublicIp: vi.fn().mockResolvedValue(undefined),
+  startPublicIpAutoRefresh: vi.fn(),
 }));
 vi.mock("./toast", () => ({ showToast: vi.fn() }));
 
@@ -76,6 +77,16 @@ describe("init ordering", () => {
       expect(idx, `listener ${ev} must be registered before get_config`).toBeGreaterThan(-1);
       expect(idx).toBeLessThan(firstConfig);
     }
+  });
+
+  it("starts the visibility-gated public-IP refresh during init", async () => {
+    const sidebar = await import("./sidebar");
+    // The mock persists across tests; clear prior tests' init calls so the
+    // count reflects this init only.
+    vi.mocked(sidebar.startPublicIpAutoRefresh).mockClear();
+    const { initDone } = await import("./main");
+    await initDone;
+    expect(sidebar.startPublicIpAutoRefresh).toHaveBeenCalledTimes(1);
   });
 
   it("sends only UI-owned keys and strips server validation on save", async () => {

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -22,6 +22,7 @@ import { initSettings, renderSettings } from "./settings";
 import {
   applyProxyStateObservation,
   initSidebar,
+  startPublicIpAutoRefresh,
   updateDiagnostics,
   updateMetrics,
   updateProxyStatus,
@@ -385,6 +386,9 @@ async function init() {
     setInterval(pollProxyStatus, 5000);
     setInterval(pollMetrics, 1000);
     setInterval(pollDiagnostics, 5000);
+    // Public IP refreshes every 60s while the dashboard is visible, paused
+    // when minimized/hidden to the tray (#464).
+    startPublicIpAutoRefresh();
 
     result = { ok: true, error: null };
   } catch (err) {

--- a/ui/sidebar.ts
+++ b/ui/sidebar.ts
@@ -5,7 +5,7 @@
 
 import { initDiagnostics, updateDiagnostics } from "./diagnostics";
 import { initGraph, pushGraphData, renderGraph } from "./graph";
-import { initIpDisplay, updatePublicIp } from "./ip-display";
+import { initIpDisplay, startPublicIpAutoRefresh, updatePublicIp } from "./ip-display";
 import { applyProxyStateObservation, getConnectionState, initPowerButton, updateProxyStatus } from "./power-button";
 import { initStats, updateStats } from "./stats";
 import type { Metrics } from "./types";
@@ -29,4 +29,11 @@ export function initSidebar(): void {
 }
 
 // Public re-exports for main.ts and other consumers.
-export { applyProxyStateObservation, getConnectionState, updateDiagnostics, updatePublicIp, updateProxyStatus };
+export {
+  applyProxyStateObservation,
+  getConnectionState,
+  startPublicIpAutoRefresh,
+  updateDiagnostics,
+  updatePublicIp,
+  updateProxyStatus,
+};


### PR DESCRIPTION
Closes #464.

The public IP is derived state of the active network egress. The GUI fetched
it through the bridge, which cached the result for 60s and never invalidated
it — so a pre-connect ISP IP was shown for up to 60s after connecting.

Routing is a system-wide split-default (`0.0.0.0/1` + `128.0.0.0/1` and `::/1` +
`8000::/1` via TUN, only the SS server bypassed), so any process's fetch is
already tunneled when connected; the bridge round-trip added nothing but the
stale cache. This change:

- fetches the public IP directly from the GUI via Cloudflare's `/cdn-cgi/trace`
  endpoint (no bridge round-trip, no cache → always reflects the current
  egress; Cloudflare has no per-IP daily cap and is already the default DoH
  resolver);
- deletes the now-unused bridge public-IP endpoint (protocol variants, route,
  handler, cache, client/CLI/harness arms, and the bridge crate's `ureq` dep);
- shows `"--"` on fetch failure instead of keeping a stale value;
- refreshes the badge every 60s while the dashboard is visible, paused when
  minimized/hidden to the tray.