### PR TITLE
fix(gui): reveal an already-open dashboard instead of a no-op rebuild

### DIFF
--- a/crates/hole/capabilities/default.json
+++ b/crates/hole/capabilities/default.json
@@ -1,6 +1,6 @@
 {
   "identifier": "default",
-  "windows": ["settings"],
+  "windows": ["dashboard-*"],
   "permissions": [
     "core:default",
     "dialog:allow-open",

--- a/crates/hole/src/dashboard.rs
+++ b/crates/hole/src/dashboard.rs
@@ -1,0 +1,64 @@
+//! Tracks the single dashboard window's identity so the tray, menu, and
+//! single-instance paths can reveal a live window or build a fresh one
+//! without racing Tauri's destroy-on-close teardown (#466).
+
+use std::sync::Mutex;
+
+/// At most one dashboard window is open at a time. Each built window gets a
+/// unique, monotonic label (`dashboard-{n}`) so a new window never collides
+/// with a still-closing one. Tauri-managed; the `Mutex` only satisfies `Sync`
+/// (all access is on the main thread).
+pub(crate) struct DashboardWindow {
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    /// Generation of the live dashboard, or `None` when none is open.
+    current: Option<u64>,
+    /// Next generation to hand out.
+    next: u64,
+}
+
+impl DashboardWindow {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner { current: None, next: 0 }),
+        }
+    }
+
+    /// Label of the live dashboard, or `None` if none is open.
+    pub(crate) fn current_label(&self) -> Option<String> {
+        self.inner.lock().unwrap().current.map(label_for)
+    }
+
+    /// Allocate a fresh generation, mark it the current dashboard, and return
+    /// `(generation, label)`. On build failure the caller calls
+    /// [`forget`](Self::forget) with `generation`.
+    pub(crate) fn allocate(&self) -> (u64, String) {
+        let mut inner = self.inner.lock().unwrap();
+        let generation = inner.next;
+        inner.next += 1;
+        inner.current = Some(generation);
+        (generation, label_for(generation))
+    }
+
+    /// The window of `generation` is going away. Clears the current dashboard
+    /// iff it still points at `generation`, so a stale window's close can
+    /// never forget a newer dashboard.
+    pub(crate) fn forget(&self, generation: u64) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.current == Some(generation) {
+            inner.current = None;
+        }
+    }
+}
+
+/// Window label for a dashboard generation. Must match the capability glob
+/// `dashboard-*` in `capabilities/default.json`.
+fn label_for(generation: u64) -> String {
+    format!("dashboard-{generation}")
+}
+
+#[cfg(test)]
+#[path = "dashboard_tests.rs"]
+mod dashboard_tests;

--- a/crates/hole/src/dashboard_tests.rs
+++ b/crates/hole/src/dashboard_tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+#[skuld::test]
+fn dashboard_none_initially() {
+    let dash = DashboardWindow::new();
+    assert_eq!(dash.current_label(), None);
+}
+
+#[skuld::test]
+fn dashboard_allocate_marks_current_and_labels_from_zero() {
+    let dash = DashboardWindow::new();
+    let (generation, label) = dash.allocate();
+    assert_eq!(generation, 0);
+    assert_eq!(label, "dashboard-0");
+    assert_eq!(dash.current_label(), Some("dashboard-0".to_string()));
+}
+
+#[skuld::test]
+fn dashboard_allocate_hands_out_unique_generations() {
+    let dash = DashboardWindow::new();
+    let (g0, l0) = dash.allocate();
+    let (g1, l1) = dash.allocate();
+    assert_ne!(g0, g1);
+    assert_ne!(l0, l1);
+    assert_eq!(l1, "dashboard-1");
+    // `current` tracks the latest allocation.
+    assert_eq!(dash.current_label(), Some("dashboard-1".to_string()));
+}
+
+#[skuld::test]
+fn dashboard_forget_current_clears_it() {
+    let dash = DashboardWindow::new();
+    let (generation, _) = dash.allocate();
+    dash.forget(generation);
+    assert_eq!(dash.current_label(), None);
+}
+
+#[skuld::test]
+fn dashboard_forget_stale_generation_leaves_current_intact() {
+    let dash = DashboardWindow::new();
+    let (g0, _) = dash.allocate(); // generation 0 becomes current
+    dash.forget(g0); // 0 closes -> current None
+    let _ = dash.allocate(); // generation 1 becomes current
+
+    // A late close for the already-gone generation 0 must not touch gen 1.
+    dash.forget(g0);
+    assert_eq!(dash.current_label(), Some("dashboard-1".to_string()));
+}
+
+#[skuld::test]
+fn dashboard_close_then_reopen_during_teardown_keeps_new_window() {
+    // The race: close A (forget its generation), then a concurrent open()
+    // builds B with a fresh label while A is still tearing down. B must win.
+    let dash = DashboardWindow::new();
+    let (a, _) = dash.allocate(); // A live
+    dash.forget(a); // user clicks X on A -> current None
+    let (_b, b_label) = dash.allocate(); // open() during A's teardown builds B
+    assert_eq!(b_label, "dashboard-1");
+    assert_eq!(dash.current_label(), Some("dashboard-1".to_string()));
+}

--- a/crates/hole/src/dashboard_tests.rs
+++ b/crates/hole/src/dashboard_tests.rs
@@ -58,3 +58,27 @@ fn dashboard_close_then_reopen_during_teardown_keeps_new_window() {
     assert_eq!(b_label, "dashboard-1");
     assert_eq!(dash.current_label(), Some("dashboard-1".to_string()));
 }
+
+#[skuld::test]
+fn dashboard_forget_unallocated_generation_is_noop() {
+    let dash = DashboardWindow::new();
+    dash.forget(0);
+    assert_eq!(dash.current_label(), None);
+}
+
+#[skuld::test]
+fn dashboard_double_forget_current_is_idempotent() {
+    let dash = DashboardWindow::new();
+    let (g, _) = dash.allocate();
+    dash.forget(g);
+    dash.forget(g);
+    assert_eq!(dash.current_label(), None);
+}
+
+#[skuld::test]
+fn dashboard_label_matches_capability_glob_prefix() {
+    // Labels must match the `dashboard-*` glob in capabilities/default.json.
+    assert_eq!(label_for(0), "dashboard-0");
+    assert_eq!(label_for(42), "dashboard-42");
+    assert!(label_for(7).starts_with("dashboard-"));
+}

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -10,6 +10,7 @@ mod bridge_client;
 mod cli_log;
 mod cli;
 mod commands;
+mod dashboard;
 mod elevation;
 mod log_collector;
 mod logging;
@@ -152,6 +153,7 @@ fn launch_gui(show_dashboard: bool) {
             }
             app.manage(hole::update::UpdateState::default());
             app.manage(tray::TransitionSlot::new());
+            app.manage(dashboard::DashboardWindow::new());
             tray::create_tray(app)?;
             // Tray + webview follow the ProxyStateCell; the reconciler's
             // immediate first tick is the startup resync against the

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -564,14 +564,14 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
 // Window event handler ================================================================================================
 
 /// Handle events from the settings window menu bar. See `handle_tray_event` for why this is separate.
-fn handle_window_menu_event(app: &AppHandle, event: MenuEvent) {
+fn handle_window_menu_event(window: &tauri::Window, event: MenuEvent) {
+    let app = window.app_handle();
     match event.id().as_ref() {
         ID_WINDOW_IMPORT => {
             info!("menu: import requested");
             use tauri::Emitter;
-            if let Some(w) = app.get_webview_window("settings") {
-                w.emit("import-requested", ()).ok();
-            }
+            // Emit to the menu's own window — no label lookup needed.
+            window.emit("import-requested", ()).ok();
         }
         ID_WINDOW_EXIT => {
             info!("menu: exit requested");
@@ -842,20 +842,38 @@ async fn handle_check_for_updates(app: AppHandle) {
     }
 }
 
+/// Reveal the dashboard if one is open, otherwise build a fresh one. Called
+/// by the tray click, the tray "Dashboard…" item, `--show-dashboard`, and the
+/// single-instance callback.
 pub(crate) fn open_settings_window(app: &AppHandle) {
-    // Always rebuild the dashboard fresh rather than reusing an open window:
-    // with windows destroyed (not hidden) on close, a
-    // `get_webview_window()`/`show()` reuse path can race the window teardown
-    // (the wry runtime clears the window inner before Tauri's manager removes
-    // the entry, so `get_webview_window` returns `Some` but `show()` silently
-    // no-ops) and the user sees nothing happen. Cold-start (~200–500 ms) is
-    // acceptable for an infrequently-opened panel.
-    //
-    // The per-window menu listener registered below is stored in a
-    // `HashMap<String, ...>` keyed by window label inside Tauri's
-    // `MenuManager`, so rebuilding with the same label "settings" replaces
-    // the prior entry — no menu handler leaks across rebuilds.
-    let mut builder = WebviewWindowBuilder::new(app, "settings", WebviewUrl::default())
+    let dashboard = app.state::<crate::dashboard::DashboardWindow>();
+    if let Some(label) = dashboard.current_label() {
+        if let Some(window) = app.get_webview_window(&label) {
+            reveal(&window);
+            #[cfg(target_os = "macos")]
+            crate::platform::show_dock_icon(app);
+            return;
+        }
+        // `current` named a window that no longer exists; build a fresh one.
+        // `allocate` below overwrites the stale generation.
+    }
+    build_dashboard(app, &dashboard);
+}
+
+/// Bring an existing dashboard to the foreground. Best-effort: the window is
+/// known to exist and these calls are cosmetic.
+fn reveal(window: &tauri::WebviewWindow) {
+    let _ = window.unminimize();
+    let _ = window.show();
+    let _ = window.set_focus();
+}
+
+/// Build a fresh dashboard window with a unique label and wire its close
+/// handler.
+fn build_dashboard(app: &AppHandle, dashboard: &crate::dashboard::DashboardWindow) {
+    let (generation, label) = dashboard.allocate();
+
+    let mut builder = WebviewWindowBuilder::new(app, &label, WebviewUrl::default())
         .title("Hole Dashboard")
         .inner_size(800.0, 600.0)
         .min_inner_size(800.0, 200.0)
@@ -908,17 +926,29 @@ pub(crate) fn open_settings_window(app: &AppHandle) {
         };
 
         builder = builder.menu(menu).on_menu_event(|window, event| {
-            handle_window_menu_event(window.app_handle(), event);
+            handle_window_menu_event(window, event);
         });
     }
 
     match builder.build() {
-        Ok(_window) => {
+        Ok(window) => {
+            // Stop tracking this generation on close; don't prevent the close,
+            // so the webview is destroyed and freed. The generation tag stops a
+            // late close from forgetting a newer dashboard.
+            let close_handle = app.clone();
+            window.on_window_event(move |event| {
+                if let tauri::WindowEvent::CloseRequested { .. } = event {
+                    close_handle
+                        .state::<crate::dashboard::DashboardWindow>()
+                        .forget(generation);
+                }
+            });
             #[cfg(target_os = "macos")]
             crate::platform::show_dock_icon(app);
         }
         Err(e) => {
             error!(error = %e, "failed to open settings window");
+            dashboard.forget(generation);
         }
     }
 }

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -563,7 +563,7 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
 
 // Window event handler ================================================================================================
 
-/// Handle events from the settings window menu bar. See `handle_tray_event` for why this is separate.
+/// Handle events from the dashboard window menu bar. See `handle_tray_event` for why this is separate.
 fn handle_window_menu_event(window: &tauri::Window, event: MenuEvent) {
     let app = window.app_handle();
     match event.id().as_ref() {
@@ -947,7 +947,7 @@ fn build_dashboard(app: &AppHandle, dashboard: &crate::dashboard::DashboardWindo
             crate::platform::show_dock_icon(app);
         }
         Err(e) => {
-            error!(error = %e, "failed to open settings window");
+            error!(error = %e, "failed to open dashboard window");
             dashboard.forget(generation);
         }
     }


### PR DESCRIPTION
Closes #466.

Tray click, the tray "Dashboard…" item, a second `hole` launch, and `--show-dashboard` did nothing when the dashboard was already open: `open_settings_window` rebuilt a window with the fixed label `settings`, Tauri rejected the duplicate (`WebviewLabelAlreadyExists`), and the error was only logged — never revealed.

## Approach

Track the live dashboard's identity in a `Mutex`-guarded `DashboardWindow` (a monotonic generation). Each built window gets a unique label `dashboard-{n}`, so a freshly-opened window never collides with a still-closing one. `open_settings_window` reveals the live window (`unminimize` + `show` + `set_focus`) when one is tracked, else builds a fresh one. A per-window `CloseRequested` handler drops the generation without preventing the close, so destroy-on-close (no resident webview) is preserved. Capability widened `["settings"]` → `["dashboard-*"]`.

Race-free without any timing: a close clears the tracked generation *before* Tauri's teardown limbo, and the generation tag stops a stale close from forgetting a newer window. `handle_run_event` is untouched. (Hide-on-close was rejected — it keeps the webview resident in RAM for an always-on tray VPN.)

## Testing

- `DashboardWindow` generation/forget logic is unit-tested, including the close-then-reopen-during-teardown race (9 `dashboard_*` tests).
- `cargo nextest run -p hole --no-default-features`: 329 passed; clippy + fmt clean.
- The Tauri glue (reveal side-effects, capability ACL) isn't unit-testable (the mock runtime models neither visibility/focus nor ACLs). Manual checklist:
  - [ ] minimized → tray left-click restores + focuses
  - [ ] buried → tray "Dashboard…" comes to front
  - [ ] second `hole` launch reveals (no duplicate window, no error)
  - [ ] dashboard IPC works under the new label (server list loads; File → Import works)
  - [ ] close → reopen rebuilds (cold start ⇒ webview was freed on close)
  - [ ] Tray → Exit and File → Exit still clean (#144 unaffected)