### PR TITLE
fix(installer): ship the galoshes plugin in the Windows MSI and macOS DMG

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,7 +413,7 @@ jobs:
         shell: pwsh
         run: |
           $binDir = "C:\Program Files\hole\bin"
-          foreach ($f in @("hole.exe", "ex-ray.exe", "wintun.dll")) {
+          foreach ($f in @("hole.exe", "ex-ray.exe", "galoshes.exe", "wintun.dll")) {
             if (!(Test-Path "$binDir\$f")) { throw "$f not found" }
           }
           $svc = Get-Service -Name HoleBridge -ErrorAction SilentlyContinue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -496,11 +496,14 @@ npm run dev &                                     # Vite on port 1420
 HOLE_BRIDGE_SOCKET=$TMPDIR/hole-dev.sock target/debug/hole
 ```
 
-`cargo xtask stage` populates a BINDIR (`hole` + `ex-ray` sidecar + `wintun.dll`
-on Windows) matching the installed `Program Files\hole\bin\`. The bridge must be
+`cargo xtask stage` populates a BINDIR (`hole` + the `ex-ray` and `galoshes`
+plugin sidecars + `NOTICES.md` + per-platform debug symbols + `wintun.dll` on
+Windows) matching the installed `Program Files\hole\bin\`. The bridge must be
 staged out of the cargo target dir because the running bridge file-locks its own
-exe; the `ex-ray` sidecar must be a sibling so `resolve_plugin_path_inner` finds
-it. The canonical file list is [xtask/src/bindir.rs](xtask/src/bindir.rs).
+exe; the plugin sidecars must be siblings so `resolve_plugin_path_inner` finds
+them. The canonical file list (the single source of truth, per-OS) is
+[`bindir_dest_names`](xtask/src/bindir.rs); the installer manifests are checked
+against it by conformance tests (`cargo xtask bindir-names`).
 
 ### Flags
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9581,6 +9581,7 @@ dependencies = [
  "indexmap 2.14.0",
  "petgraph",
  "serde",
+ "serde_json",
  "serde_yml",
  "sha2 0.11.0",
  "skuld",

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -100,3 +100,4 @@ xtask-lib = { path = "../../xtask-lib" }
 resvg = "0.47"
 png = "0.18"
 ico = "0.5"
+serde_json = "1"

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -30,21 +30,33 @@ fn main() {
     // lives in `cargo xtask deps`, not here — this build.rs is
     // compile-time metadata only.
 
-    ensure_external_bin_stub(&repo_root);
+    println!("cargo:rerun-if-changed=tauri.conf.json");
+    ensure_external_bin_stubs(&repo_root);
     tauri_build::build();
 }
 
-/// Ensure the `externalBin` stub exists so `tauri_build::build()` passes
-/// validation even when `cargo xtask deps` has not been run yet.
-/// The real binary is built by `cargo xtask deps`.
-fn ensure_external_bin_stub(repo_root: &Path) {
+/// Stub every `externalBin` sidecar so `tauri_build::build()` passes
+/// validation even when `cargo xtask deps` has not been run yet. The stub
+/// list derives from `tauri.conf.json`'s `bundle.externalBin`, so a new
+/// sidecar entry can never desync from its stub. Each entry `<base>` resolves
+/// to `<repo>/<base>-<target>{suffix}`, mirroring what Tauri's bundler reads.
+/// The real binaries are built by `cargo xtask deps`.
+fn ensure_external_bin_stubs(repo_root: &Path) {
     let target = std::env::var("TARGET").unwrap();
     let suffix = if target.contains("windows") { ".exe" } else { "" };
-    let path = repo_root.join(".cache/ex-ray").join(format!("ex-ray-{target}{suffix}"));
-    if !path.exists() {
-        std::fs::create_dir_all(path.parent().unwrap()).expect("failed to create .cache/ex-ray/");
-        std::fs::File::create(&path).expect("failed to create ex-ray stub");
-        println!("cargo:warning=created empty ex-ray stub — run `cargo xtask deps` for a real build");
+    let conf = std::fs::read_to_string("tauri.conf.json").expect("failed to read tauri.conf.json");
+    let conf: serde_json::Value = serde_json::from_str(&conf).expect("failed to parse tauri.conf.json");
+    let entries = conf["bundle"]["externalBin"]
+        .as_array()
+        .expect("tauri.conf.json bundle.externalBin must be an array");
+    for entry in entries {
+        let base = entry.as_str().expect("externalBin entry must be a string");
+        let path = repo_root.join(format!("{base}-{target}{suffix}"));
+        if !path.exists() {
+            std::fs::create_dir_all(path.parent().unwrap()).expect("failed to create sidecar cache dir");
+            std::fs::File::create(&path).expect("failed to create sidecar stub");
+            println!("cargo:warning=created empty {base} stub — run `cargo xtask deps` for a real build");
+        }
     }
 }
 

--- a/crates/hole/tauri.conf.json
+++ b/crates/hole/tauri.conf.json
@@ -31,6 +31,9 @@
       ".cache/ex-ray/ex-ray",
       ".cache/galoshes/galoshes"
     ],
+    "resources": {
+      "../../NOTICES.md": "NOTICES.md"
+    },
     "icon": [
       ".cache/icons/32x32.png",
       ".cache/icons/128x128.png",

--- a/crates/hole/tauri.conf.json
+++ b/crates/hole/tauri.conf.json
@@ -28,7 +28,8 @@
       "signingIdentity": "-"
     },
     "externalBin": [
-      ".cache/ex-ray/ex-ray"
+      ".cache/ex-ray/ex-ray",
+      ".cache/galoshes/galoshes"
     ],
     "icon": [
       ".cache/icons/32x32.png",

--- a/dmg-installer/tests/test_dmg_signing.py
+++ b/dmg-installer/tests/test_dmg_signing.py
@@ -79,3 +79,9 @@ def test_galoshes_sidecar_present_and_signed(installed_app: Path) -> None:
         f"galoshes sidecar still carries the linker-applied ad-hoc signature "
         f"— Tauri's codesign step did not re-sign it:\n{output}"
     )
+
+
+def test_notices_present_in_bundle(installed_app: Path) -> None:
+    """Apache-2.0 §4(d): the NOTICE file must ship with the bundle (#512)."""
+    notices = installed_app / "Contents" / "Resources" / "NOTICES.md"
+    assert notices.exists(), "NOTICES.md missing from the .app bundle"

--- a/dmg-installer/tests/test_dmg_signing.py
+++ b/dmg-installer/tests/test_dmg_signing.py
@@ -68,3 +68,14 @@ def test_sidecar_has_real_signature(installed_app: Path) -> None:
     assert "linker-signed" not in output, (
         f"ex-ray sidecar still carries the linker-applied ad-hoc signature:\n{output}"
     )
+
+
+def test_galoshes_sidecar_present_and_signed(installed_app: Path) -> None:
+    """galoshes must ship inside Hole.app and be re-signed by Tauri (#512)."""
+    galoshes = installed_app / "Contents" / "MacOS" / "galoshes"
+    assert galoshes.exists(), "galoshes sidecar missing from the .app bundle (externalBin not bundled?)"
+    output = _codesign_dv(galoshes)
+    assert "linker-signed" not in output, (
+        f"galoshes sidecar still carries the linker-applied ad-hoc signature "
+        f"— Tauri's codesign step did not re-sign it:\n{output}"
+    )

--- a/msi-installer/src/msi_installer/hole.wxs
+++ b/msi-installer/src/msi_installer/hole.wxs
@@ -146,6 +146,12 @@
       <Component Id="ExRay" Guid="7E1F2A3B-4C5D-4E6F-8A9B-0C1D2E3F4A5B">
         <File Id="ex_ray.exe" Source="!(bindpath.BinDir)\ex-ray.exe" KeyPath="yes" />
       </Component>
+      <!-- galoshes.exe — first-party YAMUX/UDP-capable SIP003 plugin. Built by
+           `cargo xtask galoshes`, staged by xtask::bindir alongside ex-ray.
+           A component's GUID must change whenever its KeyPath file changes. -->
+      <Component Id="Galoshes" Guid="E09260EA-F450-4090-91D9-41B38DFC54E2">
+        <File Id="galoshes.exe" Source="!(bindpath.BinDir)\galoshes.exe" KeyPath="yes" />
+      </Component>
       <Component Id="WintunDll" Guid="C3D4E5F6-A7B8-9012-CDEF-123456789012">
         <File Id="wintun.dll" Source="!(bindpath.BinDir)\wintun.dll" KeyPath="yes" />
       </Component>

--- a/msi-installer/tests/conftest.py
+++ b/msi-installer/tests/conftest.py
@@ -1,5 +1,7 @@
 """Shared fixtures and constants for installer tests."""
 
+import json
+import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -11,6 +13,26 @@ import msi_installer
 NS = {"wix": "http://wixtoolset.org/schemas/v4/wxs"}
 WXS_PATH = msi_installer.WXS_PATH
 REPO_ROOT = msi_installer._find_repo_root()
+
+
+def canonical_windows_bindir() -> set[str]:
+    """Canonical Windows BINDIR filenames, from the single source of truth.
+
+    Runs `cargo xtask bindir-names` so the installer manifest is checked
+    against `bindir::bindir_dest_names`, not a hand-restated copy. Hard-depends
+    on cargo (the `test-installer` lane installs Rust and runs `cargo xtask
+    deps` before pytest); `check=True` surfaces a missing toolchain loudly
+    rather than silently skipping.
+    """
+    out = subprocess.run(
+        ["cargo", "xtask", "bindir-names", "--os", "windows"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return set(json.loads(out.stdout))
+
 
 # XML fixtures =========================================================================================================
 

--- a/msi-installer/tests/test_hole_msi.py
+++ b/msi-installer/tests/test_hole_msi.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 import msi_installer
-from conftest import NS, WXS_PATH
+from conftest import NS, WXS_PATH, canonical_windows_bindir
 
 pytestmark = [
     pytest.mark.skipif(platform.system() != "Windows", reason="Windows-only (needs WiX + msiexec)"),
@@ -26,14 +26,15 @@ pytestmark = [
 
 @pytest.fixture(scope="session")
 def staged_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create a staging directory with non-zero dummy binaries.
+    """Stage exactly the canonical Windows BINDIR set as non-zero dummies.
 
-    Non-zero so the embedded cabinet actually contains data and the
-    relocated-extract test has files to find post-extraction.
+    Derived from `cargo xtask bindir-names` (the single source of truth) so the
+    build->package->extract round-trip is a true conformance run, not a
+    hand-maintained list that can drift (#512). Non-zero bytes so the embedded
+    cabinet has data and the relocated-extract test finds files post-extraction.
     """
     d = tmp_path_factory.mktemp("stage")
-    # Mirror the bindir layout from `cargo xtask stage` (hole.exe + hole.pdb + ex-ray.exe + wintun.dll + NOTICES.md).
-    for name in ("hole.exe", "hole.pdb", "ex-ray.exe", "wintun.dll", "NOTICES.md"):
+    for name in sorted(canonical_windows_bindir()):
         (d / name).write_bytes(b"x" * 1024)
     return d
 
@@ -339,9 +340,16 @@ def test_msi_admin_extract_works_when_separated_from_build_dir(
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
-    payload_files = {"hole.exe", "hole.pdb", "ex-ray.exe", "wintun.dll", "NOTICES.md"}
-    extracted = {p.name for p in extract_dir.rglob("*") if p.is_file() and p.name in payload_files}
-    assert extracted == payload_files, (f"MSI extracted but expected payload missing: got {extracted}")
+    # Derive the expected payload from the source of truth, and compare the
+    # FULL extracted set (no `if p.name in payload_files` pre-filter, which
+    # made the old assertion self-fulfilling). Subset, not equality: `msiexec
+    # /a` also writes its own files (the relocated .msi, MSI metadata), so
+    # exact equality on the whole tree is fragile. Exact-equality of the
+    # manifest <File> set is guarded by test_hole_wxs.py::test_wxs_files_
+    # match_canonical_bindir; this is the real-artifact presence backstop.
+    payload_files = canonical_windows_bindir()
+    extracted = {p.name for p in extract_dir.rglob("*") if p.is_file()}
+    assert payload_files <= extracted, (f"MSI payload missing expected files: {payload_files - extracted}")
 
 
 # UI property + dialog tests ===========================================================================================

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -625,10 +625,16 @@ def test_notices_md_component_exists(package: ET.Element) -> None:
 
 
 def _wxs_bindir_file_basenames(package: ET.Element) -> set[str]:
-    """Basenames of every <File> sourced from the BinDir bindpath."""
+    """Basenames of every <File> sourced from the BinDir bindpath.
+
+    Captures only the last path segment so a future nested Source
+    (`...BinDir)\\sub\\x.exe`) still compares against the flat
+    bindir_dest_names. The staged BINDIR is flat (stage.rs rejects
+    separators in dest_name), so today every match is already a basename.
+    """
     names: set[str] = set()
     for f in package.iter(f"{{{NS['wix']}}}File"):
-        m = re.search(r"!\(bindpath\.BinDir\)\\(.+)$", f.get("Source", ""))
+        m = re.search(r"!\(bindpath\.BinDir\)\\([^\\]+)$", f.get("Source", ""))
         if m:
             names.add(m.group(1))
     return names

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -6,7 +6,7 @@ Parse the WiX source (hole.wxs) and verify structural correctness without buildi
 import re
 import xml.etree.ElementTree as ET
 
-from conftest import NS
+from conftest import NS, canonical_windows_bindir
 
 # Known bind path variables passed via `-bindpath` to `wix build`.
 KNOWN_BINDPATHS = {"BinDir", "IconDir", "LicenseDir"}
@@ -615,6 +615,45 @@ def test_notices_md_component_exists(package: ET.Element) -> None:
     assert file_elem is not None, "NoticesMd component must contain <File Id='NOTICES.md'>"
     source = file_elem.get("Source", "")
     assert "!(bindpath.BinDir)" in source, (f"NOTICES.md File Source must resolve via BinDir bindpath; got '{source}'")
+
+
+# BINDIR conformance tests =============================================================================================
+#
+# Guards the staging->packaging boundary: every file `cargo xtask stage` puts
+# in BINDIR must have a <File> in hole.wxs, or WiX silently drops it from the
+# MSI. This is exactly how galoshes went missing (#512).
+
+
+def _wxs_bindir_file_basenames(package: ET.Element) -> set[str]:
+    """Basenames of every <File> sourced from the BinDir bindpath."""
+    names: set[str] = set()
+    for f in package.iter(f"{{{NS['wix']}}}File"):
+        m = re.search(r"!\(bindpath\.BinDir\)\\(.+)$", f.get("Source", ""))
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def test_wxs_files_match_canonical_bindir(package: ET.Element) -> None:
+    """hole.wxs <File> set must equal the canonical Windows bindir_files()."""
+    expected = canonical_windows_bindir()
+    actual = _wxs_bindir_file_basenames(package)
+    assert actual == expected, (
+        "hole.wxs <File> set diverges from bindir_files(): "
+        f"missing={expected - actual}, extra={actual - expected}"
+    )
+
+
+def test_galoshes_component_exists(package: ET.Element) -> None:
+    """galoshes.exe must ship in the MSI (#512)."""
+    comp = _find_component(package, "Galoshes")
+    assert comp is not None, "Component 'Galoshes' is required to ship the galoshes plugin"
+    file_elem = next(
+        (f for f in comp.iter(f"{{{NS['wix']}}}File") if f.get("Id") == "galoshes.exe"),
+        None,
+    )
+    assert file_elem is not None, "Galoshes component must contain <File Id='galoshes.exe'>"
+    assert "!(bindpath.BinDir)" in file_elem.get("Source", "")
 
 
 # Sticky-preference tests ==============================================================================================

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -36,6 +36,7 @@ tar = "0.4"
 
 # `cargo xtask build|test|list` (build.yaml manifest + DAG orchestration).
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yml = "0.0.12"
 indexmap = { version = "2", features = ["serde"] }
 petgraph = "0.8"

--- a/xtask/src/bindir.rs
+++ b/xtask/src/bindir.rs
@@ -107,17 +107,18 @@ pub fn plugin_sidecar_names() -> &'static [&'static str] {
     &["ex-ray", "galoshes"]
 }
 
-/// The host OS as a manifest [`Os`]. Panics on an unsupported host — the same
-/// platforms `bindir_files` already supports.
-fn host_os() -> Os {
-    Os::host().expect("bindir_files runs only on supported hosts")
+/// The host OS as a manifest [`Os`], or an error on a host outside the
+/// supported set (windows/darwin/linux) — the same platforms `bindir_files`
+/// already supports.
+fn host_os() -> Result<Os> {
+    Os::host().ok_or_else(|| anyhow!("host OS is not one of windows/darwin/linux; cannot resolve BINDIR"))
 }
 
 /// Resolve the canonical BINDIR file list for the host platform and given
 /// profile. The *set* and order come from [`bindir_dest_names`]; this fn maps
 /// each name to its host source path.
 pub fn bindir_files(profile: Profile, repo_root: &Path) -> Result<Vec<BindirFile>> {
-    let host = host_os();
+    let host = host_os()?;
     let target_dir = repo_root.join("target").join(profile.dir_name());
 
     // ex-ray is built per-target-triple into `.cache/ex-ray/ex-ray-<triple>{.exe}`;

--- a/xtask/src/bindir.rs
+++ b/xtask/src/bindir.rs
@@ -1,9 +1,11 @@
 //! The canonical list of files that comprise a runnable hole BINDIR.
 //!
-//! **This is the single source of truth.** Adding a new file that must sit
-//! next to `hole.exe` is one line in `bindir_files()` below — both
-//! dev-console and `msi-installer/src/msi_installer/__init__.py:stage_files()` call into
-//! this via `cargo xtask stage`, so they pick it up automatically.
+//! **This is the single source of truth.** The *set* of files lives in
+//! [`bindir_dest_names`]; [`bindir_files`] resolves each to its host source
+//! path. dev-console and `msi-installer/src/msi_installer/__init__.py:stage_files()`
+//! stage via `cargo xtask stage`, and the installer-manifest conformance
+//! tests (WiX, Tauri) derive their expected payload from `bindir_dest_names`
+//! (via `cargo xtask bindir-names`) so the manifests cannot silently drift.
 //!
 //! See issue #143 for the motivation.
 
@@ -11,6 +13,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
+use crate::manifest::Os;
 use crate::Profile;
 
 /// Source kind for a BINDIR entry. Files use hard-link-then-copy;
@@ -63,80 +66,87 @@ impl BindirFile {
     }
 }
 
-/// Return the canonical BINDIR file list for the host platform and given profile.
+/// On-disk filenames that must sit next to the bridge binary on `os`, in
+/// staging order. **Single source of truth for the BINDIR payload.** Pure:
+/// no disk access, callable for any `os` from any host — so the installer
+/// conformance tests (`cargo xtask bindir-names`) and [`bindir_files`] share
+/// one definition of what ships.
 ///
-/// **Edit this function to add or remove BINDIR files.** The accompanying
-/// regression test in `bindir_tests.rs` asserts the exact filenames per
-/// platform — it will fail loudly if this list changes, forcing the change
-/// to be acknowledged.
+/// Add or remove a BINDIR file here. `bindir_tests.rs` asserts the exact set
+/// per OS, and the WiX / Tauri conformance tests fail loudly if a manifest
+/// stops covering it.
+pub fn bindir_dest_names(os: Os) -> Vec<String> {
+    let exe = if os == Os::Windows { ".exe" } else { "" };
+    let mut names = vec![format!("hole{exe}")];
+    // Debug symbols, staged alongside the binary so panic backtraces resolve
+    // frame names + line numbers (else `<unknown>`; see #393). The workspace
+    // `[profile.release] debug = "limited"` + `split-debuginfo = "packed"`
+    // produce a portable PDB/dSYM for this purpose.
+    match os {
+        Os::Windows => names.push("hole.pdb".to_string()),
+        Os::Darwin => names.push("hole.dSYM".to_string()),
+        Os::Linux => {}
+    }
+    names.push(format!("ex-ray{exe}"));
+    names.push(format!("galoshes{exe}"));
+    // wintun.dll — Windows-only DLL loaded by the bridge's TUN path.
+    if os == Os::Windows {
+        names.push("wintun.dll".to_string());
+    }
+    // NOTICES.md — Apache-2.0 §4(d) attribution for the bundled galoshes/garter
+    // components; the installer license dialog shows only GPL-3.0 text, so the
+    // NOTICE file must accompany the binaries on disk.
+    names.push("NOTICES.md".to_string());
+    names
+}
+
+/// SIP003 plugin sidecar binaries (no extension) that every installer must
+/// ship next to the bridge so `resolve_plugin_path` finds them. Subset of
+/// [`bindir_dest_names`]; drives the macOS `externalBin` conformance check.
+pub fn plugin_sidecar_names() -> &'static [&'static str] {
+    &["ex-ray", "galoshes"]
+}
+
+/// The host OS as a manifest [`Os`]. Panics on an unsupported host — the same
+/// platforms `bindir_files` already supports.
+fn host_os() -> Os {
+    Os::host().expect("bindir_files runs only on supported hosts")
+}
+
+/// Resolve the canonical BINDIR file list for the host platform and given
+/// profile. The *set* and order come from [`bindir_dest_names`]; this fn maps
+/// each name to its host source path.
 pub fn bindir_files(profile: Profile, repo_root: &Path) -> Result<Vec<BindirFile>> {
-    let mut files = Vec::new();
-    let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
+    let host = host_os();
+    let target_dir = repo_root.join("target").join(profile.dir_name());
 
-    // 1. hole binary — this IS the bridge + GUI executable. Built by `cargo build`.
-    let hole_name = format!("hole{exe_suffix}");
-    let hole_src = repo_root.join("target").join(profile.dir_name()).join(&hole_name);
-    files.push(BindirFile::new(hole_src, hole_name));
-
-    // 1a. Debug symbols for `hole` — staged alongside the binary so panic
-    //     backtraces in dev (dev-console) and production (the MSI)
-    //     resolve frame names and line numbers. Without these, the panic
-    //     hook at `crates/common/src/logging.rs::install_panic_hook` renders
-    //     every frame as `<unknown>`.
-    //
-    //     The workspace `[profile.release].debug = "limited"` guarantees the
-    //     PDB/dSYM exists for release builds (cargo's default is `false`).
-    //     Debug builds already emit full debug info.
-    #[cfg(target_os = "windows")]
-    {
-        // MSVC emits the binary's PDB next to the .exe.
-        let pdb_src = repo_root.join("target").join(profile.dir_name()).join("hole.pdb");
-        files.push(BindirFile::new(pdb_src, "hole.pdb".to_string()));
-    }
-    #[cfg(target_os = "macos")]
-    {
-        // Cargo's macOS `split-debuginfo = "unpacked"` (release default)
-        // emits a `.dSYM` bundle at the same level as the binary.
-        let dsym_src = repo_root.join("target").join(profile.dir_name()).join("hole.dSYM");
-        files.push(BindirFile::directory(dsym_src, "hole.dSYM".to_string()));
-    }
-
-    // 2. ex-ray sidecar. Built by `cargo xtask ex-ray` into
-    //    `.cache/ex-ray/ex-ray-<target-triple>{.exe}`. The
-    //    target-triple varies (`x86_64-pc-windows-msvc`, `aarch64-apple-darwin`,
-    //    etc.) so we glob and assert exactly one match.
-    let ex_ray_glob_pattern = if cfg!(windows) {
+    // ex-ray is built per-target-triple into `.cache/ex-ray/ex-ray-<triple>{.exe}`;
+    // the triple varies, so glob + assert exactly one match.
+    let ex_ray_glob = if host == Os::Windows {
         ".cache/ex-ray/ex-ray-*.exe"
     } else {
         ".cache/ex-ray/ex-ray-*"
     };
-    let ex_ray_src = unique_glob_match(repo_root, ex_ray_glob_pattern)?;
-    let ex_ray_dest = format!("ex-ray{exe_suffix}");
-    files.push(BindirFile::new(ex_ray_src, ex_ray_dest));
 
-    // 3. galoshes sidecar. Built by `cargo xtask galoshes` into
-    //    `target/release/galoshes{.exe}` (the unified workspace target dir
-    //    now that galoshes is a regular workspace member at `crates/galoshes/`).
-    let galoshes_name = format!("galoshes{exe_suffix}");
-    let galoshes_src = repo_root.join("target").join("release").join(&galoshes_name);
-    files.push(BindirFile::new(galoshes_src, galoshes_name));
-
-    // 4. wintun.dll — Windows-only. Downloaded by `cargo xtask wintun` into
-    //    `.cache/wintun/wintun.dll`. Not a sidecar binary; loaded as a DLL by
-    //    the bridge's TUN code path. See crates/bridge/src/wintun.rs.
-    #[cfg(target_os = "windows")]
-    {
-        let wintun_src = repo_root.join(".cache").join("wintun").join("wintun.dll");
-        files.push(BindirFile::new(wintun_src, "wintun.dll".to_string()));
+    let mut files = Vec::new();
+    for name in bindir_dest_names(host) {
+        let file = match name.as_str() {
+            // hole binary — the bridge + GUI executable, built by `cargo build`.
+            "hole" | "hole.exe" => BindirFile::new(target_dir.join(&name), name),
+            // MSVC emits the PDB next to the .exe.
+            "hole.pdb" => BindirFile::new(target_dir.join("hole.pdb"), name),
+            // macOS `split-debuginfo = "packed"` emits a self-contained `.dSYM` bundle.
+            "hole.dSYM" => BindirFile::directory(target_dir.join("hole.dSYM"), name),
+            "ex-ray" | "ex-ray.exe" => BindirFile::new(unique_glob_match(repo_root, ex_ray_glob)?, name),
+            // galoshes is a workspace member, built into the unified `target/release/`.
+            "galoshes" | "galoshes.exe" => BindirFile::new(repo_root.join("target").join("release").join(&name), name),
+            // wintun.dll — downloaded by `cargo xtask wintun` into `.cache/wintun/`.
+            "wintun.dll" => BindirFile::new(repo_root.join(".cache").join("wintun").join("wintun.dll"), name),
+            "NOTICES.md" => BindirFile::new(repo_root.join("NOTICES.md"), name),
+            other => return Err(anyhow!("BINDIR name {other:?} has no source mapping in bindir_files")),
+        };
+        files.push(file);
     }
-
-    // 5. NOTICES.md — Apache-2.0 attribution for galoshes/garter components
-    //    that the GPL-3.0 binary distribution bundles. Apache-2.0 §4(d)
-    //    requires the NOTICE file to be preserved in derivative works; since
-    //    the installer's license dialog only shows GPL-3.0 text, the file
-    //    must accompany the binaries on disk.
-    let notices_src = repo_root.join("NOTICES.md");
-    files.push(BindirFile::new(notices_src, "NOTICES.md".to_string()));
 
     Ok(files)
 }

--- a/xtask/src/bindir_tests.rs
+++ b/xtask/src/bindir_tests.rs
@@ -1,6 +1,37 @@
 use crate::bindir::*;
+use crate::manifest::Os;
 use crate::Profile;
 use std::fs;
+
+#[skuld::test]
+fn dest_names_per_os_are_exact() {
+    // Exact-equality is intentional: adding a BINDIR file forces an update
+    // here AND in every installer manifest (caught by the conformance tests).
+    assert_eq!(
+        bindir_dest_names(Os::Windows),
+        vec![
+            "hole.exe",
+            "hole.pdb",
+            "ex-ray.exe",
+            "galoshes.exe",
+            "wintun.dll",
+            "NOTICES.md"
+        ]
+    );
+    assert_eq!(
+        bindir_dest_names(Os::Darwin),
+        vec!["hole", "hole.dSYM", "ex-ray", "galoshes", "NOTICES.md"]
+    );
+    assert_eq!(
+        bindir_dest_names(Os::Linux),
+        vec!["hole", "ex-ray", "galoshes", "NOTICES.md"]
+    );
+}
+
+#[skuld::test]
+fn plugin_sidecars_are_ex_ray_and_galoshes() {
+    assert_eq!(plugin_sidecar_names(), &["ex-ray", "galoshes"]);
+}
 
 /// Build a fake repo layout in a tempdir that satisfies `bindir_files()` so we
 /// can call it without depending on the real `target/` and `.cache/`.

--- a/xtask/src/bindir_tests.rs
+++ b/xtask/src/bindir_tests.rs
@@ -33,6 +33,14 @@ fn plugin_sidecars_are_ex_ray_and_galoshes() {
     assert_eq!(plugin_sidecar_names(), &["ex-ray", "galoshes"]);
 }
 
+#[skuld::test]
+fn bindir_names_command_emits_json_for_os() {
+    let json = crate::render_bindir_names(Os::Windows);
+    let parsed: Vec<String> = serde_json::from_str(&json).unwrap();
+    assert!(parsed.contains(&"galoshes.exe".to_string()));
+    assert_eq!(parsed, bindir_dest_names(Os::Windows));
+}
+
 /// Build a fake repo layout in a tempdir that satisfies `bindir_files()` so we
 /// can call it without depending on the real `target/` and `.cache/`.
 fn fake_repo() -> tempfile::TempDir {

--- a/xtask/src/ex_ray.rs
+++ b/xtask/src/ex_ray.rs
@@ -14,44 +14,9 @@ use anyhow::{anyhow, bail, Context, Result};
 /// Returns the platform-specific output filename matching what shadowsocks-rust
 /// expects and what `crates/galoshes/build.rs` reads via
 /// `ex-ray-{TARGET}{ext}`. The trailing `.exe` is included on Windows.
-///
-/// Supports every target triple in the workspace CI matrix (Hole's
-/// Windows/macOS release set plus the ex-Galoshes Linux / Windows-arm64
-/// test matrix).
-pub fn output_name() -> &'static str {
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    {
-        "ex-ray-x86_64-pc-windows-msvc.exe"
-    }
-    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-    {
-        "ex-ray-aarch64-pc-windows-msvc.exe"
-    }
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
-        "ex-ray-aarch64-apple-darwin"
-    }
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    {
-        "ex-ray-x86_64-apple-darwin"
-    }
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    {
-        "ex-ray-x86_64-unknown-linux-gnu"
-    }
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    {
-        "ex-ray-aarch64-unknown-linux-gnu"
-    }
-    #[cfg(not(any(
-        all(target_os = "windows", target_arch = "x86_64"),
-        all(target_os = "windows", target_arch = "aarch64"),
-        all(target_os = "macos", target_arch = "aarch64"),
-        all(target_os = "macos", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "aarch64"),
-    )))]
-    compile_error!("unsupported platform for ex-ray sidecar");
+pub fn output_name() -> String {
+    let exe = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    format!("ex-ray-{}{exe}", crate::target::host_target_triple())
 }
 
 /// Build (or rebuild) the ex-ray binary for the host platform.

--- a/xtask/src/external_bin_tests.rs
+++ b/xtask/src/external_bin_tests.rs
@@ -1,0 +1,38 @@
+//! Conformance: the Tauri bundle must ship every plugin sidecar.
+
+use crate::bindir::plugin_sidecar_names;
+
+/// Basenames of `crates/hole/tauri.conf.json`'s `bundle.externalBin` entries.
+fn external_bin_basenames() -> Vec<String> {
+    let root = crate::repo_root().expect("repo root");
+    let text = std::fs::read_to_string(root.join("crates/hole/tauri.conf.json")).expect("read tauri.conf.json");
+    let conf: serde_json::Value = serde_json::from_str(&text).expect("parse tauri.conf.json");
+    conf["bundle"]["externalBin"]
+        .as_array()
+        .expect("bundle.externalBin array")
+        .iter()
+        .map(|e| {
+            e.as_str()
+                .expect("externalBin entry is a string")
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_string()
+        })
+        .collect()
+}
+
+#[skuld::test]
+fn external_bin_covers_every_plugin_sidecar() {
+    // Tauri's bundler ships only `externalBin` sidecars into Contents/MacOS/,
+    // so every plugin binary must be listed there or the macOS DMG can't run
+    // it (this is how galoshes was missing from the DMG — #512).
+    let external = external_bin_basenames();
+    for sidecar in plugin_sidecar_names() {
+        assert!(
+            external.contains(&sidecar.to_string()),
+            "tauri.conf.json externalBin is missing plugin sidecar {sidecar:?} — the macOS DMG \
+             would not ship it (#512). Have: {external:?}"
+        );
+    }
+}

--- a/xtask/src/galoshes.rs
+++ b/xtask/src/galoshes.rs
@@ -3,7 +3,8 @@
 //! (written to `<repo>/.cache/ex-ray/`, where galoshes's `build.rs` picks
 //! it up).
 //!
-//! Output: `<repo>/target/release/galoshes{.exe}`.
+//! Output: `<repo>/target/release/galoshes{.exe}`, plus a Tauri-sidecar copy
+//! at `<repo>/.cache/galoshes/galoshes-<triple>{.exe}` for the macOS DMG.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -46,5 +47,22 @@ pub fn build(repo_root: &Path) -> Result<PathBuf> {
         return Err(anyhow!("galoshes binary not found at {} after build", binary.display()));
     }
 
+    // Also stage a Tauri-sidecar copy at `.cache/galoshes/galoshes-<triple>`.
+    // `npx tauri build` (the macOS DMG path) bundles `externalBin` entries by
+    // appending the host triple, mirroring how ex-ray lands in `.cache/ex-ray/`.
+    let cache_dir = repo_root.join(".cache").join("galoshes");
+    std::fs::create_dir_all(&cache_dir).with_context(|| format!("failed to create {}", cache_dir.display()))?;
+    let sidecar = cache_dir.join(cache_sidecar_name());
+    std::fs::copy(&binary, &sidecar)
+        .with_context(|| format!("failed to stage galoshes sidecar to {}", sidecar.display()))?;
+
     Ok(binary)
+}
+
+/// Tauri-sidecar filename: `galoshes-<triple>{.exe}`. Tauri's bundler appends
+/// the host triple to each `externalBin` path, so the macOS DMG needs galoshes
+/// at `.cache/galoshes/galoshes-<triple>` to bundle it into `Contents/MacOS/`.
+pub fn cache_sidecar_name() -> String {
+    let exe = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    format!("galoshes-{}{exe}", crate::target::host_target_triple())
 }

--- a/xtask/src/galoshes_tests.rs
+++ b/xtask/src/galoshes_tests.rs
@@ -1,0 +1,11 @@
+use crate::galoshes::cache_sidecar_name;
+use crate::target::host_target_triple;
+
+#[skuld::test]
+fn cache_sidecar_name_matches_host_triple() {
+    // Must match exactly what Tauri appends to the externalBin path, or the
+    // macOS DMG bundles nothing. Assert the full name, not just a prefix.
+    let exe = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    let expected = format!("galoshes-{}{exe}", host_target_triple());
+    assert_eq!(cache_sidecar_name(), expected);
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -18,6 +18,7 @@ pub mod golangci_lint;
 pub mod manifest;
 pub mod orchestrate;
 pub mod stage;
+pub mod target;
 pub mod test_binaries;
 pub mod upstream_v2ray;
 pub mod wintun;
@@ -25,6 +26,9 @@ pub mod wintun;
 #[cfg(test)]
 #[path = "bindir_tests.rs"]
 mod bindir_tests;
+#[cfg(test)]
+#[path = "galoshes_tests.rs"]
+mod galoshes_tests;
 #[cfg(test)]
 #[path = "manifest_tests.rs"]
 mod manifest_tests;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -27,6 +27,9 @@ pub mod wintun;
 #[path = "bindir_tests.rs"]
 mod bindir_tests;
 #[cfg(test)]
+#[path = "external_bin_tests.rs"]
+mod external_bin_tests;
+#[cfg(test)]
 #[path = "galoshes_tests.rs"]
 mod galoshes_tests;
 #[cfg(test)]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -159,6 +159,16 @@ pub enum Command {
     /// List every target declared in `build.yaml` with its platforms,
     /// host-platform applicability, and a `*` marker for runnables.
     List,
+    /// Print the canonical BINDIR filenames for an OS as a JSON array.
+    ///
+    /// The installer conformance tests consume this so the WiX / Tauri
+    /// manifests are checked against the single source of truth
+    /// (`bindir::bindir_dest_names`) rather than a hand-restated copy.
+    BindirNames {
+        /// Target OS (defaults to the host).
+        #[arg(long)]
+        os: Option<manifest::Os>,
+    },
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -209,7 +219,20 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Command::Build { target, all } => run_build(target, all),
         Command::Run { target } => run_run(target),
         Command::List => run_list(),
+        Command::BindirNames { os } => {
+            let os = os
+                .or_else(manifest::Os::host)
+                .ok_or_else(|| anyhow!("unknown host OS"))?;
+            println!("{}", render_bindir_names(os));
+            Ok(())
+        }
     }
+}
+
+/// Serialize the canonical BINDIR filenames for `os` as a JSON array. Consumed
+/// by `cargo xtask bindir-names` and the installer conformance tests.
+pub fn render_bindir_names(os: manifest::Os) -> String {
+    serde_json::to_string(&bindir::bindir_dest_names(os)).expect("Vec<String> serializes")
 }
 
 pub fn run_stage(profile: Profile, out_dir: &Path) -> Result<()> {

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Deserializer};
 /// Docker / GOOS-style identifiers: matches the project's release-artifact
 /// naming convention (`hole-<version>-windows-amd64.msi`) and the `matrix.os`
 /// dimension already used in `.github/workflows/ci.yaml`.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum Os {
     Windows,

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -1,0 +1,44 @@
+//! Host target-triple resolution, shared by the sidecar builders.
+//!
+//! Tauri's bundler and the ex-ray/galoshes sidecar layouts both name files
+//! `<stem>-<target-triple>{.exe}`, so the triple lives in one place.
+
+/// The Rust target triple for the host platform (e.g. `x86_64-pc-windows-msvc`,
+/// `aarch64-apple-darwin`). Covers every triple in the workspace CI matrix
+/// (Hole's Windows/macOS release set plus the standalone-plugin Linux /
+/// Windows-arm64 test matrix).
+pub fn host_target_triple() -> &'static str {
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "x86_64-pc-windows-msvc"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        "aarch64-pc-windows-msvc"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "aarch64-apple-darwin"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        "x86_64-apple-darwin"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "x86_64-unknown-linux-gnu"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "aarch64-unknown-linux-gnu"
+    }
+    #[cfg(not(any(
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+    )))]
+    compile_error!("unsupported platform for host target triple");
+}


### PR DESCRIPTION
Closes #512.

## Problem

The first-party `galoshes` plugin is built but was shipped by **neither** installer, so a user who selected it got a binary that wasn't on disk post-install.

- **Windows MSI** — `cargo xtask stage` staged `galoshes.exe`, but `hole.wxs` (a separate hand-maintained `<File>` list) never declared it, so WiX dropped it. Missing from every MSI since galoshes was integrated.
- **macOS DMG** — `tauri.conf.json` `externalBin` listed only `ex-ray`; galoshes was never staged into the bundle.

Root cause: `xtask/src/bindir.rs::bindir_files()` is the single source of truth, but the installer manifests restated the payload by hand and each omitted galoshes — and **no test derived its expected payload from the source of truth**. The MSI "as-if-installed" extract test even had a self-fulfilling `if p.name in payload_files` filter that masked the gap.

## Fix

- **Source of truth:** extracted a pure `bindir_dest_names(Os)` + `plugin_sidecar_names()`; `bindir_files()` now derives from them. Added `cargo xtask bindir-names` (JSON) so installer tests check the manifests against it.
- **Windows MSI:** added the galoshes `<Component>`/`<File>`; added a WiX conformance test (`<File>` set must equal `bindir-names --os windows`); derived the MSI staged fixture + extract assertion from the source of truth and removed the self-fulfilling filter; added `galoshes.exe` to the CI post-install check.
- **macOS DMG:** galoshes is staged into the Tauri sidecar layout (`.cache/galoshes/galoshes-<triple>`) and added to `externalBin`; generalized `crates/hole/build.rs`'s compile-time externalBin stub to **derive from `tauri.conf.json`** so a new sidecar can never desync the stub; added an externalBin conformance test + a dmg presence/signature test. Also shipped `NOTICES.md` (Apache-2.0 §4(d)), which the DMG was missing.
- **Docs:** corrected the CONTRIBUTING BINDIR description.

Net: adding a BINDIR file without wiring both installers now fails the suite.

## Verified

`cargo test -p xtask` (80), `cargo clippy -p xtask` clean, `cargo check -p hole` (validates the build.rs stub generalization), msi-installer `test_hole_wxs.py` (45) + `test_hole_msi.py` (16, **real WiX build + `msiexec /a` extract** confirming galoshes round-trips). macOS dmg tests run on the macOS CI lane.

## Deferred to follow-up `azhukova/512-2`

- **`hole.dSYM` on macOS** + full-set macOS conformance: shipping it hit a Tauri compile-time resource-validation wall (the dSYM is the build's own output, absent at validation), and the fix needs validation against a real macOS build.
- **Un-orphaning the bridge→galoshes e2e** (re-gate to Win/mac now that #197 is closed — not a Linux Hole lane).