### PR TITLE
feat(gui): version-lockstep self-heal between GUI and bridge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,6 +312,32 @@ target; status/connect text is baked into the menu at build time. Persisted
 designated input for a future `StartupBehavior::RestoreLastState` consumer),
 with `tray::persist_intended_enabled` as its sole writer.
 
+### Version lockstep
+
+The GUI and bridge must never *operate* as a mismatched-version pair — the
+single-exe design assumes it and the IPC contract has no version negotiation.
+The bridge stamps its build version on **every** IPC response
+(`X-Hole-Bridge-Version`, in [`build_router`](crates/bridge/src/ipc.rs)) and
+serves it at `GET /v1/version`; the value is injected into `IpcServer::bind`
+from the `hole` crate (the bridge crate can't read `HOLE_VERSION`). The GUI
+client compares that header to its own `HOLE_VERSION` on every exchange and
+returns `ClientError::VersionMismatch`; [`BridgeLink`](crates/hole/src/state.rs)
+fires an injected self-heal hook ([selfheal.rs](crates/hole/src/selfheal.rs))
+which, by `same_file` file-identity (startup image vs. the file at that path
+now), either relaunches the updated image — via the cross-platform exit-wait
+primitive [relaunch.rs](crates/hole/src/relaunch.rs) (Windows
+`WaitForSingleObject`, macOS `kqueue`/`NOTE_EXIT`) — or, if it *is* the
+installed image, shows a path-free reinstall dialog. The only `#[cfg]` live in
+the `ArmedWait`/identity seams; `decide` and the wiring are platform-agnostic
+and table-tested. Inert until an update produces a mismatch, and gated off for
+dev/snapshot builds.
+
+**One-time caveat:** a GUI built *before* this feature has no self-heal logic,
+so the *first* upgrade-to-this-version can run a stale GUI against the new
+bridge until the user restarts it — benign because the change is purely
+additive (the IPC contract is preserved). The bridge cutover that *produces*
+the mismatch leak-free is a follow-up PR.
+
 ## Workspace layout
 
 Each publishable member declares a release group in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ico",
+ "libc",
  "minisign-verify",
  "png 0.18.1",
  "resvg",

--- a/crates/bridge/src/foreground.rs
+++ b/crates/bridge/src/foreground.rs
@@ -23,9 +23,10 @@ pub fn run(
     state_dir: &Path,
     log_dir: &Path,
     ready_notify: Option<&str>,
+    version: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(run_inner(socket_path, state_dir, log_dir, ready_notify))
+    rt.block_on(run_inner(socket_path, state_dir, log_dir, ready_notify, version))
 }
 
 /// Resolve when a shutdown signal arrives: Ctrl+C (SIGINT) everywhere,
@@ -107,6 +108,7 @@ async fn run_inner(
     state_dir: &Path,
     log_dir: &Path,
     ready_notify: Option<&str>,
+    version: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let proxy = std::sync::Arc::new(tokio::sync::Mutex::new(
         ProxyManager::new(ShadowsocksProxy::new(), SystemRouting::new(state_dir.to_path_buf()))
@@ -116,7 +118,7 @@ async fn run_inner(
 
     // Bind BEFORE recovery. If a second bridge instance tries to run, the
     // bind() fails and we exit without touching any routing state.
-    let server = crate::ipc::IpcServer::bind(socket_path, proxy)?;
+    let server = crate::ipc::IpcServer::bind(socket_path, proxy, version)?;
 
     // First-party readiness signal (#454): the dev supervisor pre-binds a
     // localhost listener and passes `--ready-notify ADDR/TOKEN`; we connect

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -152,7 +152,7 @@ fn foreground_run_accepts_ipc_and_shuts_down() {
             )));
             let proxy_shutdown = std::sync::Arc::clone(&proxy);
 
-            let server = crate::ipc::IpcServer::bind(&path_clone, proxy).unwrap();
+            let server = crate::ipc::IpcServer::bind(&path_clone, proxy, "test").unwrap();
             // Server is bound; let the test side connect.
             let _ = ready_tx.send(());
 

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -11,8 +11,8 @@ use axum::http::StatusCode;
 use axum::Json;
 use hole_common::protocol::{
     DiagnosticsResponse, EmptyResponse, ErrorResponse, MetricsResponse, ProxyConfig, StatusResponse, TestServerRequest,
-    TestServerResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START,
-    ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    TestServerResponse, VersionResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
+    ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER, ROUTE_VERSION,
 };
 use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
@@ -51,6 +51,10 @@ pub struct IpcState<P: Proxy, R: Routing> {
     pub proxy: Arc<Mutex<ProxyManager<P, R>>>,
     // std::sync::Mutex — never held across .await. See StartCancelState docs.
     pub start_cancel: Arc<std::sync::Mutex<StartCancelState>>,
+    /// This bridge's build version, stamped on every response
+    /// (`X-Hole-Bridge-Version`) and served at `/v1/version` so a
+    /// freshly-updated GUI can detect a still-old bridge.
+    pub version: String,
 }
 
 // Server ==============================================================================================================
@@ -74,6 +78,7 @@ impl IpcServer {
     pub fn bind<P: Proxy + 'static, R: Routing + 'static>(
         path: &Path,
         proxy: Arc<Mutex<ProxyManager<P, R>>>,
+        version: &str,
     ) -> std::io::Result<Self> {
         #[cfg(not(test))]
         let listener = LocalListener::bind_restricted(path)?;
@@ -86,8 +91,9 @@ impl IpcServer {
         let state = Arc::new(IpcState {
             proxy,
             start_cancel: Arc::new(std::sync::Mutex::new(StartCancelState::default())),
+            version: version.to_owned(),
         });
-        let router = build_router(state);
+        let router = build_router(state, version);
         Ok(Self {
             listener,
             router,
@@ -183,7 +189,11 @@ where
 
 // Router ==============================================================================================================
 
-fn build_router<P: Proxy + 'static, R: Routing + 'static>(state: Arc<IpcState<P, R>>) -> axum::Router {
+fn build_router<P: Proxy + 'static, R: Routing + 'static>(state: Arc<IpcState<P, R>>, version: &str) -> axum::Router {
+    // Stamped on every response — including handler errors and routing 404s,
+    // which axum has already converted to a `Response` before this layer runs.
+    let header_val =
+        axum::http::HeaderValue::from_str(version).unwrap_or_else(|_| axum::http::HeaderValue::from_static("unknown"));
     axum::Router::new()
         .route(ROUTE_STATUS, axum::routing::get(handle_status::<P, R>))
         .route(ROUTE_START, axum::routing::post(handle_start::<P, R>))
@@ -193,7 +203,17 @@ fn build_router<P: Proxy + 'static, R: Routing + 'static>(state: Arc<IpcState<P,
         .route(ROUTE_METRICS, axum::routing::get(handle_metrics::<P, R>))
         .route(ROUTE_DIAGNOSTICS, axum::routing::get(handle_diagnostics::<P, R>))
         .route(ROUTE_TEST_SERVER, axum::routing::post(handle_test_server::<P, R>))
+        .route(ROUTE_VERSION, axum::routing::get(handle_version::<P, R>))
         .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
+        .layer(axum::middleware::map_response(
+            move |mut resp: axum::response::Response| {
+                let header_val = header_val.clone();
+                async move {
+                    resp.headers_mut().insert("x-hole-bridge-version", header_val);
+                    resp
+                }
+            },
+        ))
         .with_state(state)
 }
 
@@ -418,6 +438,14 @@ async fn handle_test_server<P: Proxy + 'static, R: Routing + 'static>(
     let cfg = TestConfig::production();
     let outcome = run_server_test(&req.entry, &cfg).await;
     Json(TestServerResponse { outcome })
+}
+
+async fn handle_version<P: Proxy + 'static, R: Routing + 'static>(
+    State(state): State<Arc<IpcState<P, R>>>,
+) -> Json<VersionResponse> {
+    Json(VersionResponse {
+        version: state.version.clone(),
+    })
 }
 
 // Security ============================================================================================================

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -382,7 +382,7 @@ async fn post_reload(client: &mut TestClient, config: &ProxyConfig) -> http::Res
 fn server_accepts_connection() {
     rt().block_on(async {
         let path = test_socket_path("accept");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -394,10 +394,79 @@ fn server_accepts_connection() {
 }
 
 #[skuld::test]
+fn every_response_carries_bridge_version_header() {
+    rt().block_on(async {
+        let path = test_socket_path("ver-header");
+        let server = IpcServer::bind(&path, mock_proxy(), "9.9.9").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+        let mut client = TestClient::connect(&path).await;
+        let req = http::Request::builder()
+            .method("GET")
+            .uri(ROUTE_STATUS)
+            .header("host", "localhost")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let resp = client.send(req).await;
+        assert_eq!(resp.headers().get("x-hole-bridge-version").unwrap(), "9.9.9");
+        let _ = resp.into_body().collect().await;
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn error_response_carries_bridge_version_header() {
+    rt().block_on(async {
+        let path = test_socket_path("ver-err-header");
+        let server = IpcServer::bind(&path, failing_proxy(), "9.9.9").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_start(&mut client, &sample_config()).await;
+        assert_eq!(resp.status(), 500);
+        assert_eq!(resp.headers().get("x-hole-bridge-version").unwrap(), "9.9.9");
+        let _ = resp.into_body().collect().await;
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn version_route_returns_injected_version() {
+    rt().block_on(async {
+        let path = test_socket_path("ver-route");
+        let server = IpcServer::bind(&path, mock_proxy(), "9.9.9").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+        let mut client = TestClient::connect(&path).await;
+        let req = http::Request::builder()
+            .method("GET")
+            .uri(ROUTE_VERSION)
+            .header("host", "localhost")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+        let resp = client.send(req).await;
+        assert_eq!(resp.status(), 200);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: hole_common::protocol::VersionResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v.version, "9.9.9");
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
 fn status_when_not_running_returns_false() {
     rt().block_on(async {
         let path = test_socket_path("status");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -426,7 +495,7 @@ fn status_when_not_running_returns_false() {
 fn multiple_requests_on_same_connection() {
     rt().block_on(async {
         let path = test_socket_path("multi");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -448,7 +517,7 @@ fn multiple_requests_on_same_connection() {
 fn invalid_request_returns_error_response() {
     rt().block_on(async {
         let path = test_socket_path("invalid");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -476,7 +545,7 @@ fn invalid_request_returns_error_response() {
 fn server_handles_client_disconnect() {
     rt().block_on(async {
         let path = test_socket_path("disconnect");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -493,7 +562,7 @@ fn start_request_starts_proxy() {
     rt().block_on(async {
         let path = test_socket_path("start");
         let pm = mock_proxy();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -521,7 +590,7 @@ fn stop_request_stops_proxy() {
     rt().block_on(async {
         let path = test_socket_path("stop");
         let pm = mock_proxy();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -549,7 +618,7 @@ fn start_failure_returns_error() {
     rt().block_on(async {
         let path = test_socket_path("start-fail");
         let pm = failing_proxy();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -577,7 +646,7 @@ fn reload_request_reloads_proxy() {
     rt().block_on(async {
         let path = test_socket_path("reload");
         let pm = mock_proxy();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -607,7 +676,7 @@ fn reload_request_reloads_proxy() {
 fn run_cancellation_aborts_connection_handlers() {
     rt().block_on(async {
         let path = test_socket_path("run-cancel");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run().await.unwrap();
         });
@@ -649,7 +718,7 @@ fn run_cancellation_aborts_connection_handlers() {
 fn unknown_route_returns_404() {
     rt().block_on(async {
         let path = test_socket_path("404");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -674,7 +743,7 @@ fn unknown_route_returns_404() {
 fn wrong_method_returns_405() {
     rt().block_on(async {
         let path = test_socket_path("405");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -729,7 +798,7 @@ async fn get_diagnostics(client: &mut TestClient) -> DiagnosticsResponse {
 fn metrics_returns_zeros_when_stopped() {
     rt().block_on(async {
         let path = test_socket_path("metrics-stopped");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -754,7 +823,7 @@ fn metrics_returns_uptime_when_running() {
     rt().block_on(async {
         let path = test_socket_path("metrics-running");
         let pm = mock_proxy();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -785,7 +854,7 @@ fn metrics_reports_traffic_totals_when_running() {
     rt().block_on(async {
         let path = test_socket_path("metrics-traffic");
         let (pm, traffic) = mock_proxy_with_traffic();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -819,7 +888,7 @@ fn metrics_reports_speed_over_window() {
         let path = test_socket_path("metrics-speed");
         let (pm, traffic) = mock_proxy_with_traffic();
         let pm_for_shift = Arc::clone(&pm);
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -858,7 +927,7 @@ fn diagnostics_bridge_running() {
     rt().block_on(async {
         let path = test_socket_path("diag-running");
         let pm = mock_proxy();
-        let server = IpcServer::bind(&path, pm).unwrap();
+        let server = IpcServer::bind(&path, pm, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -891,7 +960,7 @@ fn diagnostics_bridge_running() {
 fn diagnostics_network_error_when_gateway_unavailable() {
     rt().block_on(async {
         let path = test_socket_path("diag-net-err");
-        let server = IpcServer::bind(&path, gateway_failing_proxy()).unwrap();
+        let server = IpcServer::bind(&path, gateway_failing_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -919,7 +988,7 @@ fn diagnostics_network_error_when_gateway_unavailable() {
 fn diagnostics_proxy_stopped() {
     rt().block_on(async {
         let path = test_socket_path("diag-stopped");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -951,7 +1020,7 @@ fn diagnostics_proxy_stopped() {
 fn diagnostics_bridge_error_after_failed_start() {
     rt().block_on(async {
         let path = test_socket_path("diag-bridge-err");
-        let server = IpcServer::bind(&path, gateway_failing_proxy()).unwrap();
+        let server = IpcServer::bind(&path, gateway_failing_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -1003,7 +1072,7 @@ fn cancel_while_start_in_flight_returns_cancelled() {
         let path = test_socket_path("cancel-in-flight");
         let gate = Arc::new(tokio::sync::Notify::new());
         let (entered_tx, entered_rx) = oneshot::channel();
-        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx)).unwrap();
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx), "test").unwrap();
         // Bound the accept loop to exactly the two connections this test
         // uses, instead of running indefinitely. See `run_n` docstring.
         let handle = tokio::spawn(async move { server.run_n(2).await });
@@ -1058,7 +1127,7 @@ fn cancel_before_start_is_pre_armed_and_consumed() {
     // proxy mutex or call Proxy::start.
     rt().block_on(async {
         let path = test_socket_path("cancel-prearm");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         // Single client connection — use run_once to avoid long-lived
         // accept polling on Windows.
         let handle = tokio::spawn(async move { server.run_once().await });
@@ -1091,7 +1160,7 @@ fn cancel_with_no_start_is_ack_idempotent() {
     // is idempotent: arming it twice is equivalent to arming it once.
     rt().block_on(async {
         let path = test_socket_path("cancel-noop");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move { server.run_once().await });
 
         let mut client = TestClient::connect(&path).await;
@@ -1116,7 +1185,7 @@ fn concurrent_start_is_rejected_with_conflict() {
         let path = test_socket_path("concurrent-start");
         let gate = Arc::new(tokio::sync::Notify::new());
         let (entered_tx, entered_rx) = oneshot::channel();
-        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx)).unwrap();
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx), "test").unwrap();
         // 3 connections: A start, B start, C cancel.
         let handle = tokio::spawn(async move { server.run_n(3).await });
 
@@ -1171,7 +1240,7 @@ fn sequential_start_cancel_start_consumes_pre_arm_once() {
     // consumed exactly once, not forever.
     rt().block_on(async {
         let path = test_socket_path("seq-start-cancel-start");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         // Single client connection — use run_once.
         let handle = tokio::spawn(async move { server.run_once().await });
 
@@ -1212,7 +1281,7 @@ fn concurrent_double_cancel_during_start_both_succeed() {
         let path = test_socket_path("double-cancel");
         let gate = Arc::new(tokio::sync::Notify::new());
         let (entered_tx, entered_rx) = oneshot::channel();
-        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx)).unwrap();
+        let server = IpcServer::bind(&path, gated_proxy(gate.clone(), entered_tx), "test").unwrap();
         // 3 connections: A start, B cancel, C cancel.
         let handle = tokio::spawn(async move { server.run_n(3).await });
 
@@ -1334,7 +1403,7 @@ fn is_valid_sid_string_rejects_invalid() {
 fn bind_accepts_connection() {
     rt().block_on(async {
         let path = test_socket_path("bind-accept");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -1349,7 +1418,7 @@ fn bind_accepts_connection() {
 fn bind_status_query() {
     rt().block_on(async {
         let path = test_socket_path("bind-status");
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();
         });
@@ -1373,13 +1442,13 @@ fn socket_recreated_on_bind() {
         let path = test_socket_path("recreate");
 
         // First bind
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         assert!(path.exists(), "socket file should exist after bind");
         drop(server); // Drop removes the file
         assert!(!path.exists(), "socket file should be removed after drop");
 
         // Second bind (recreates the socket)
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         assert!(path.exists(), "socket file should exist after second bind");
         drop(server);
     });
@@ -1390,7 +1459,7 @@ fn socket_removed_on_drop() {
     rt().block_on(async {
         let path = test_socket_path("drop-cleanup");
 
-        let server = IpcServer::bind(&path, mock_proxy()).unwrap();
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
         assert!(path.exists(), "socket file should exist after bind");
 
         drop(server);

--- a/crates/bridge/src/platform/macos.rs
+++ b/crates/bridge/src/platform/macos.rs
@@ -211,6 +211,7 @@ pub fn run(
     socket_path: &std::path::Path,
     state_dir: &std::path::Path,
     log_dir: &std::path::Path,
+    version: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -227,7 +228,7 @@ pub fn run(
         // can touch routing state. Route recovery is offloaded via
         // spawn_blocking so a hung netsh/route command cannot wedge the
         // runtime while the IPC socket is bound but not yet serving.
-        let server = crate::ipc::IpcServer::bind(socket_path, proxy)?;
+        let server = crate::ipc::IpcServer::bind(socket_path, proxy, version)?;
         // DNS recovery runs first; see crate::dns::recovery docs for ordering.
         let state_dir_dns = state_dir.to_path_buf();
         if let Err(e) =

--- a/crates/bridge/src/platform/macos.rs
+++ b/crates/bridge/src/platform/macos.rs
@@ -256,16 +256,10 @@ pub fn run(
             tracing::warn!(error = %e, "crash sweep task panicked");
         }
 
-        tokio::select! {
-            result = server.run() => {
-                if let Err(e) = result {
-                    tracing::error!(error = %e, "IPC server error");
-                }
-            }
-            _ = tokio::signal::ctrl_c() => {
-                info!("received shutdown signal");
-            }
-        }
+        // launchd stops the daemon with SIGTERM; awaiting only ctrl_c (SIGINT)
+        // here would skip the pm.stop() teardown below and leak routes/DNS.
+        // `shutdown_signal()` handles SIGINT *and* SIGTERM (foreground.rs).
+        serve_until_signal(server.run(), crate::foreground::shutdown_signal()).await;
 
         // Clean shutdown: stop proxy before exiting
         let mut pm = proxy_shutdown.lock().await;
@@ -276,6 +270,25 @@ pub fn run(
         Ok::<(), Box<dyn std::error::Error>>(())
     })?;
     Ok(())
+}
+
+/// Drive the IPC server until it finishes or a shutdown signal arrives,
+/// whichever comes first. Extracted from `run` so the select can be
+/// unit-tested without delivering real OS signals.
+pub(crate) async fn serve_until_signal(
+    server: impl std::future::Future<Output = std::io::Result<()>>,
+    shutdown: impl std::future::Future<Output = ()>,
+) {
+    tokio::select! {
+        result = server => {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "IPC server error");
+            }
+        }
+        _ = shutdown => {
+            info!("received shutdown signal");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/platform/macos_tests.rs
+++ b/crates/bridge/src/platform/macos_tests.rs
@@ -39,6 +39,21 @@ fn helper_path_is_stable() {
 }
 
 #[skuld::test]
+async fn serve_until_signal_returns_when_signal_fires() {
+    // A server future that never completes, and a shutdown future we control.
+    // Firing the shutdown must return control so the daemon's pm.stop()
+    // teardown runs — the SIGTERM-graceful behavior under test.
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let server = std::future::pending::<std::io::Result<()>>();
+    let shutdown = async move {
+        let _ = rx.await;
+    };
+    let join = tokio::spawn(serve_until_signal(server, shutdown));
+    tx.send(()).unwrap();
+    join.await.unwrap();
+}
+
+#[skuld::test]
 fn plist_does_not_set_standard_paths() {
     // The FD-level stdio redirect in hole_common::logging::init captures
     // stdout/stderr into bridge.log; a launchd-side capture would only

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -29,15 +29,20 @@ static STATE_DIR_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
 /// Used by diagnostic artefacts to land alongside `bridge.log` in the
 /// same directory.
 static LOG_DIR_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+/// GUI build version override set by the CLI before service dispatch. The
+/// `bind` runs inside `service_main` (a SCM callback with no access to
+/// `run`'s args), so the version is threaded through this static.
+static VERSION_OVERRIDE: OnceLock<String> = OnceLock::new();
 
 /// Run as a Windows Service (called by the service control manager).
-pub fn run(socket_path: &Path, state_dir: &Path, log_dir: &Path) -> Result<(), windows_service::Error> {
+pub fn run(socket_path: &Path, state_dir: &Path, log_dir: &Path, version: &str) -> Result<(), windows_service::Error> {
     let default = hole_common::protocol::default_bridge_socket_path();
     if socket_path != default {
         SOCKET_PATH_OVERRIDE.set(socket_path.to_owned()).ok();
     }
     STATE_DIR_OVERRIDE.set(state_dir.to_owned()).ok();
     LOG_DIR_OVERRIDE.set(log_dir.to_owned()).ok();
+    VERSION_OVERRIDE.set(version.to_owned()).ok();
     service_dispatcher::start(SERVICE_NAME, ffi_service_main)
 }
 
@@ -108,7 +113,8 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
         // can touch routing state. Route recovery is offloaded via
         // spawn_blocking so a hung netsh/route command cannot wedge the
         // runtime while the IPC socket is bound but not yet serving.
-        let server = crate::ipc::IpcServer::bind(&socket_path, proxy)?;
+        let version = VERSION_OVERRIDE.get().cloned().unwrap_or_else(|| "unknown".to_string());
+        let server = crate::ipc::IpcServer::bind(&socket_path, proxy, &version)?;
         // DNS recovery runs first; see crate::dns::recovery docs for ordering.
         let state_dir_for_dns = state_dir.clone();
         if let Err(e) =

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -17,6 +17,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/StatusResponse"
 
+  /v1/version:
+    get:
+      summary: Get the bridge build version
+      operationId: getVersion
+      responses:
+        "200":
+          description: The bridge's build version string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VersionResponse"
+
   /v1/start:
     post:
       summary: Start the proxy
@@ -185,6 +197,14 @@ components:
         - message
       properties:
         message:
+          type: string
+
+    VersionResponse:
+      type: object
+      required:
+        - version
+      properties:
+        version:
           type: string
 
     EmptyResponse:

--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -1,6 +1,6 @@
 //! Generates Rust types and route constants from the OpenAPI spec at `api/openapi.yaml`.
 //!
-//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `InvalidFilter`, `FilterMetrics`.
+//! Generated types: `StatusResponse`, `ErrorResponse`, `EmptyResponse`, `MetricsResponse`, `DiagnosticsResponse`, `InvalidFilter`, `FilterMetrics`, `VersionResponse`.
 //! Generated constants: one `ROUTE_*` const per `/v1/*` path in `api/openapi.yaml` (e.g. `ROUTE_STATUS`, `ROUTE_START`, `ROUTE_STOP`, `ROUTE_CANCEL`, `ROUTE_RELOAD`, …).
 //!
 //! The remaining schemas — including `ProxyConfig`, `ServerEntry`, `ValidationState`,
@@ -27,6 +27,7 @@ fn main() {
         "DiagnosticsResponse",
         "InvalidFilter",
         "FilterMetrics",
+        "VersionResponse",
     ];
 
     let ref_types: Vec<(String, Schema)> = types_to_generate

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -29,6 +29,18 @@ fn sample_config() -> ProxyConfig {
     }
 }
 
+#[skuld::test]
+fn version_response_roundtrips_and_route_const_exists() {
+    use crate::protocol::{VersionResponse, ROUTE_VERSION};
+    assert_eq!(ROUTE_VERSION, "/v1/version");
+    let v = VersionResponse {
+        version: "1.2.3".to_string(),
+    };
+    assert_eq!(serde_json::to_string(&v).unwrap(), r#"{"version":"1.2.3"}"#);
+    let back: VersionResponse = serde_json::from_str(r#"{"version":"1.2.3"}"#).unwrap();
+    assert_eq!(back.version, "1.2.3");
+}
+
 // BridgeRequest/BridgeResponse JSON serialization (used by elevation flow) --------------------------------------------
 
 #[skuld::test]

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -84,6 +84,9 @@ windows = { version = "0.62", features = [
 # because the bug it fixes (osascript-admin elevation creating user-home
 # files as root) doesn't occur on Windows (UAC same-user elevation).
 walkdir = "2"
+# `relaunch::ArmedWait` uses kqueue (EVFILT_PROC/NOTE_EXIT) to wait on the
+# predecessor's exit during a self-heal relaunch.
+libc = "0.2"
 
 [dev-dependencies]
 skuld = { workspace = true }

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -27,6 +27,11 @@ pub enum ClientError {
     Io(#[from] std::io::Error),
     #[error("protocol error: {0}")]
     Protocol(String),
+    /// The bridge reported a different version than ours (or, when `bridge`
+    /// is `None`, sent no version header — an old bridge predating the
+    /// stamp). Path-free by construction so it can never leak PII to a toast.
+    #[error("version mismatch: the Hole bridge is a different version")]
+    VersionMismatch { bridge: Option<String> },
 }
 
 // Client ==============================================================================================================
@@ -36,6 +41,9 @@ pub struct BridgeClient {
     sender: http1::SendRequest<Full<Bytes>>,
     /// Background task driving the HTTP/1.1 connection. Aborted on drop.
     conn_task: tokio::task::JoinHandle<()>,
+    /// Our own build version, compared against the bridge's
+    /// `X-Hole-Bridge-Version` on every response.
+    own_version: String,
 }
 
 impl Drop for BridgeClient {
@@ -46,16 +54,24 @@ impl Drop for BridgeClient {
 }
 
 impl BridgeClient {
-    /// Connect to the bridge at the given Unix domain socket path.
+    /// Connect to the bridge at the given Unix domain socket path, comparing
+    /// the bridge's version against our own `HOLE_VERSION`.
     pub async fn connect(path: &Path) -> Result<Self, ClientError> {
+        Self::connect_with_version(path, hole::version::VERSION).await
+    }
+
+    /// Like [`connect`](Self::connect) but with an explicit own-version — the
+    /// value matched against the bridge's `X-Hole-Bridge-Version`. Tests use
+    /// this to drive matched / mismatched version pairs.
+    pub async fn connect_with_version(path: &Path, own_version: &str) -> Result<Self, ClientError> {
         let stream = hole_bridge::socket::LocalStream::connect(path)
             .await
             .map_err(map_connect_error)?;
-        Self::handshake(stream).await
+        Self::handshake(stream, own_version.to_owned()).await
     }
 
     /// Perform HTTP/1.1 handshake over a connected stream.
-    async fn handshake<S>(stream: S) -> Result<Self, ClientError>
+    async fn handshake<S>(stream: S, own_version: String) -> Result<Self, ClientError>
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
@@ -68,7 +84,11 @@ impl BridgeClient {
                 debug!(error = %e, "HTTP client connection ended");
             }
         });
-        Ok(Self { sender, conn_task })
+        Ok(Self {
+            sender,
+            conn_task,
+            own_version,
+        })
     }
 
     /// Send a request and wait for the response.
@@ -182,7 +202,26 @@ impl BridgeClient {
         }
     }
 
+    /// GET that validates the bridge's version header before returning, so
+    /// every `send` arm refuses to operate a mismatched bridge.
     async fn http_get(&mut self, path: &str) -> Result<http::Response<hyper::body::Incoming>, ClientError> {
+        let resp = self.http_get_unchecked(path).await?;
+        self.check_version(&resp)?;
+        Ok(resp)
+    }
+
+    /// POST counterpart to [`http_get`](Self::http_get).
+    async fn http_post(
+        &mut self,
+        path: &str,
+        body: Vec<u8>,
+    ) -> Result<http::Response<hyper::body::Incoming>, ClientError> {
+        let resp = self.http_post_unchecked(path, body).await?;
+        self.check_version(&resp)?;
+        Ok(resp)
+    }
+
+    async fn http_get_unchecked(&mut self, path: &str) -> Result<http::Response<hyper::body::Incoming>, ClientError> {
         let req = http::Request::builder()
             .method("GET")
             .uri(path)
@@ -200,7 +239,7 @@ impl BridgeClient {
             .map_err(|e| ClientError::Protocol(e.to_string()))
     }
 
-    async fn http_post(
+    async fn http_post_unchecked(
         &mut self,
         path: &str,
         body: Vec<u8>,
@@ -221,6 +260,22 @@ impl BridgeClient {
             .send_request(req)
             .await
             .map_err(|e| ClientError::Protocol(e.to_string()))
+    }
+
+    /// Compare the bridge's stamped version against ours. An absent header
+    /// means an old bridge predating the stamp ⇒ treated as a mismatch.
+    fn check_version(&self, resp: &http::Response<hyper::body::Incoming>) -> Result<(), ClientError> {
+        let bridge = resp
+            .headers()
+            .get("x-hole-bridge-version")
+            .and_then(|v| v.to_str().ok());
+        if bridge == Some(self.own_version.as_str()) {
+            Ok(())
+        } else {
+            Err(ClientError::VersionMismatch {
+                bridge: bridge.map(str::to_owned),
+            })
+        }
     }
 }
 

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -74,7 +74,16 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     internet: "ok".to_string(),
                 })
             }),
-        );
+        )
+        .layer(axum::middleware::map_response(
+            |mut resp: axum::response::Response| async move {
+                resp.headers_mut().insert(
+                    "x-hole-bridge-version",
+                    axum::http::HeaderValue::from_static(hole::version::VERSION),
+                );
+                resp
+            },
+        ));
 
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
@@ -286,7 +295,16 @@ async fn spawn_error_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<(
                     }),
                 )
             }),
-        );
+        )
+        .layer(axum::middleware::map_response(
+            |mut resp: axum::response::Response| async move {
+                resp.headers_mut().insert(
+                    "x-hole-bridge-version",
+                    axum::http::HeaderValue::from_static(hole::version::VERSION),
+                );
+                resp
+            },
+        ));
 
     tokio::spawn(async move {
         let stream = listener.accept().await.unwrap();
@@ -373,6 +391,96 @@ fn send_metrics_returns_response() {
                 filter: None,
             }
         );
+    });
+}
+
+// Version lockstep ====================================================================================================
+
+/// Accept one connection and serve the given router on it.
+fn serve_one(listener: hole_bridge::socket::LocalListener, router: axum::Router) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let stream = listener.accept().await.unwrap();
+        let io = hyper_util::rt::TokioIo::new(stream);
+        let service = hyper::service::service_fn(move |req: http::Request<Incoming>| {
+            let router = router.clone();
+            async move {
+                use tower::ServiceExt;
+                let resp = router.oneshot(req.map(axum::body::Body::new)).await.unwrap();
+                Ok::<_, std::convert::Infallible>(resp)
+            }
+        });
+        let _ = hyper::server::conn::http1::Builder::new()
+            .serve_connection(io, service)
+            .await;
+    })
+}
+
+/// Mock serving GET /v1/status. When `version` is `Some`, stamps it on every
+/// response via `X-Hole-Bridge-Version`; when `None`, sends no such header
+/// (an old bridge predating the stamp). Has no /v1/version route (→ 404).
+async fn spawn_status_mock(path: &std::path::Path, version: Option<&'static str>) -> tokio::task::JoinHandle<()> {
+    let listener = hole_bridge::socket::LocalListener::bind(path).unwrap();
+    let mut router = axum::Router::new().route(
+        hole_common::protocol::ROUTE_STATUS,
+        axum::routing::get(|| async {
+            Json(StatusResponse {
+                running: false,
+                uptime_secs: 0,
+                error: None,
+                invalid_filters: Vec::new(),
+                udp_proxy_available: true,
+                ipv6_bypass_available: true,
+            })
+        }),
+    );
+    if let Some(v) = version {
+        router = router.layer(axum::middleware::map_response(
+            move |mut resp: axum::response::Response| async move {
+                resp.headers_mut()
+                    .insert("x-hole-bridge-version", axum::http::HeaderValue::from_static(v));
+                resp
+            },
+        ));
+    }
+    serve_one(listener, router)
+}
+
+#[skuld::test]
+fn matching_version_is_ok() {
+    rt().block_on(async {
+        let path = test_socket_path("ver-match");
+        let _m = spawn_status_mock(&path, Some("7.0.0")).await;
+        let mut c = BridgeClient::connect_with_version(&path, "7.0.0").await.unwrap();
+        assert!(matches!(
+            c.send(BridgeRequest::Status).await,
+            Ok(BridgeResponse::Status { .. })
+        ));
+    });
+}
+
+#[skuld::test]
+fn mismatching_version_is_version_mismatch() {
+    rt().block_on(async {
+        let path = test_socket_path("ver-mismatch");
+        let _m = spawn_status_mock(&path, Some("6.0.0")).await;
+        let mut c = BridgeClient::connect_with_version(&path, "7.0.0").await.unwrap();
+        assert!(matches!(
+            c.send(BridgeRequest::Status).await,
+            Err(ClientError::VersionMismatch { .. })
+        ));
+    });
+}
+
+#[skuld::test]
+fn absent_version_header_is_version_mismatch() {
+    rt().block_on(async {
+        let path = test_socket_path("ver-absent");
+        let _m = spawn_status_mock(&path, None).await; // old bridge: no header
+        let mut c = BridgeClient::connect_with_version(&path, "7.0.0").await.unwrap();
+        assert!(matches!(
+            c.send(BridgeRequest::Status).await,
+            Err(ClientError::VersionMismatch { .. })
+        ));
     });
 }
 

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -375,14 +375,21 @@ fn handle_bridge(action: BridgeAction) -> i32 {
             let result: Result<(), Box<dyn std::error::Error>> = if service {
                 #[cfg(target_os = "macos")]
                 {
-                    hole_bridge::platform::os::run(&socket_path, &state_dir, &log_dir)
+                    hole_bridge::platform::os::run(&socket_path, &state_dir, &log_dir, hole::version::VERSION)
                 }
                 #[cfg(target_os = "windows")]
                 {
-                    hole_bridge::platform::os::run(&socket_path, &state_dir, &log_dir).map_err(|e| Box::new(e) as _)
+                    hole_bridge::platform::os::run(&socket_path, &state_dir, &log_dir, hole::version::VERSION)
+                        .map_err(|e| Box::new(e) as _)
                 }
             } else {
-                hole_bridge::foreground::run(&socket_path, &state_dir, &log_dir, ready_notify.as_deref())
+                hole_bridge::foreground::run(
+                    &socket_path,
+                    &state_dir,
+                    &log_dir,
+                    ready_notify.as_deref(),
+                    hole::version::VERSION,
+                )
             };
 
             if let Err(e) = result {

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config_recovery;
 pub mod elevation;
 pub mod logging;
 pub mod path_management;
+pub mod relaunch;
 pub mod selfheal;
 pub mod setup;
 pub mod state;

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -1,3 +1,9 @@
+// Self-alias so modules compiled in BOTH the lib and the bin (e.g.
+// `bridge_client`, `state`) can name this crate uniformly as `hole::`:
+// `crate::version` breaks in the bin (no `mod version` there), `hole::version`
+// breaks in the lib without this alias.
+extern crate self as hole;
+
 pub mod bridge_client;
 #[macro_use]
 pub mod cli_log;

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config_recovery;
 pub mod elevation;
 pub mod logging;
 pub mod path_management;
+pub mod selfheal;
 pub mod setup;
 pub mod state;
 pub mod tray_icons;

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -62,6 +62,19 @@ fn main() {
 }
 
 fn launch_gui(show_dashboard: bool) {
+    // BEFORE logging redirects stdout into the (lossy) log relay: if we were
+    // relaunched to take over a stale predecessor (version self-heal, or
+    // post-update), signal READY over the inherited stdout pipe and wait for
+    // the predecessor to exit, so the single-instance plugin acquires the
+    // `com.hole.app` lock uncontested. Routing READY through the relay could
+    // drop it and hang the handshake, so it must happen pre-`logging::init`.
+    // No-op (returns immediately) for an ordinary launch — the env marker is
+    // unset, so no console/stdout is touched. No subscriber yet, so report a
+    // (rare) failure to stderr.
+    if let Err(e) = hole::relaunch::await_predecessor() {
+        eprintln!("hole: await_predecessor failed; launching anyway: {e}");
+    }
+
     // Determine paths
     let config_dir = dirs::config_dir().expect("no config directory found").join("hole");
     let config_path = config_dir.join("config.json");
@@ -75,14 +88,6 @@ fn launch_gui(show_dashboard: bool) {
     // spawn_blocking — there is no runtime worker to protect yet).
     tombstone::sweep(&log_dir);
 
-    // If we were relaunched to take over from a stale predecessor (version
-    // self-heal, or post-update), wait for it to exit before the
-    // single-instance plugin contends for the `com.hole.app` lock — otherwise
-    // we would forward-and-exit to the old instance. No-op for an ordinary
-    // launch (the env marker is unset).
-    if let Err(e) = hole::relaunch::await_predecessor() {
-        tracing::warn!(error = %e, "await_predecessor failed; launching anyway");
-    }
     // Snapshot the installed image identity now, before any later update can
     // rename it — the self-heal compares against it on a version mismatch.
     hole::selfheal::init_startup();

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -75,6 +75,15 @@ fn launch_gui(show_dashboard: bool) {
     // spawn_blocking — there is no runtime worker to protect yet).
     tombstone::sweep(&log_dir);
 
+    // If we were relaunched to take over from a stale predecessor (version
+    // self-heal, or post-update), wait for it to exit before the
+    // single-instance plugin contends for the `com.hole.app` lock — otherwise
+    // we would forward-and-exit to the old instance. No-op for an ordinary
+    // launch (the env marker is unset).
+    if let Err(e) = hole::relaunch::await_predecessor() {
+        tracing::warn!(error = %e, "await_predecessor failed; launching anyway");
+    }
+
     tauri::Builder::default()
         // `UiReady` is registered on the builder (not in `.setup`) so
         // it is available to command handlers at first dispatch — the

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -83,6 +83,9 @@ fn launch_gui(show_dashboard: bool) {
     if let Err(e) = hole::relaunch::await_predecessor() {
         tracing::warn!(error = %e, "await_predecessor failed; launching anyway");
     }
+    // Snapshot the installed image identity now, before any later update can
+    // rename it — the self-heal compares against it on a version mismatch.
+    hole::selfheal::init_startup();
 
     tauri::Builder::default()
         // `UiReady` is registered on the builder (not in `.setup`) so

--- a/crates/hole/src/relaunch.rs
+++ b/crates/hole/src/relaunch.rs
@@ -1,0 +1,160 @@
+//! Cross-platform exit-wait relaunch.
+//!
+//! When the GUI must replace itself with a new on-disk image (self-heal, or
+//! post-update), it can't just spawn-and-exit: the new instance would lose
+//! the `com.hole.app` single-instance lock to the still-running old one and
+//! silently forward-and-exit. Instead the old GUI spawns the new image with
+//! [`spawn_successor`], which (via [`await_predecessor`] at the top of the
+//! new process) **arms a kernel wait on the old PID while it is provably
+//! alive**, signals `READY`, and only then blocks. The old GUI exits on
+//! `READY`; the new image's wait fires and it proceeds to a normal launch,
+//! winning the now-free lock. Arming-before-READY-before-exit closes the
+//! PID-reuse window — no sleeps, no polling.
+
+use std::path::Path;
+
+const AWAIT_ENV: &str = "HOLE_AWAIT_EXIT_PID";
+const READY: &str = "READY";
+
+/// A kernel wait on another process's exit, armed while that process is
+/// still alive (so its PID cannot be recycled out from under us).
+pub struct ArmedWait(platform::Inner);
+
+impl ArmedWait {
+    /// Arm a wait on `pid`'s exit. Must be called while `pid` is alive; if it
+    /// is already gone, [`wait`](Self::wait) becomes a no-op.
+    pub fn arm(pid: u32) -> std::io::Result<Self> {
+        Ok(Self(platform::Inner::arm(pid)?))
+    }
+
+    /// Block until the armed process exits (kernel wait, no timeout).
+    pub fn wait(self) {
+        self.0.wait();
+    }
+}
+
+/// Spawn the canonical image to take over after we exit, blocking until it
+/// has armed its wait on us (the `READY` line). The caller exits next, at
+/// which point the successor's wait fires.
+pub fn spawn_successor(canonical: &Path) -> std::io::Result<()> {
+    use std::io::BufRead;
+    let mut child = std::process::Command::new(canonical)
+        .env(AWAIT_ENV, std::process::id().to_string())
+        .stdout(std::process::Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let mut line = String::new();
+    std::io::BufReader::new(stdout).read_line(&mut line)?;
+    if line.trim_end() != READY {
+        return Err(std::io::Error::other("successor did not arm exit-wait"));
+    }
+    Ok(())
+}
+
+/// Called at the very top of GUI launch. If we were spawned to take over a
+/// predecessor, arm a wait on it, signal `READY` (so it may exit), then
+/// block until it does — after which a normal launch proceeds uncontested.
+/// A no-op (returns immediately) for an ordinary launch.
+pub fn await_predecessor() -> std::io::Result<()> {
+    let Some(pid) = std::env::var(AWAIT_ENV).ok().and_then(|s| s.parse::<u32>().ok()) else {
+        return Ok(());
+    };
+    // edition 2021: env mutation is still safe-callable.
+    std::env::remove_var(AWAIT_ENV);
+    let armed = ArmedWait::arm(pid)?;
+    println!("{READY}");
+    use std::io::Write;
+    std::io::stdout().flush().ok();
+    armed.wait();
+    Ok(())
+}
+
+// Windows: OpenProcess(SYNCHRONIZE) + WaitForSingleObject(INFINITE) ===================================================
+
+#[cfg(windows)]
+mod platform {
+    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows::Win32::System::Threading::{OpenProcess, WaitForSingleObject, INFINITE, PROCESS_SYNCHRONIZE};
+
+    pub(super) struct Inner(Option<HANDLE>);
+
+    impl Inner {
+        pub(super) fn arm(pid: u32) -> std::io::Result<Self> {
+            // SAFETY: plain Win32 call. On failure (no such process / already
+            // exited / access denied for a reaped PID) the wait is a no-op.
+            match unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, pid) } {
+                Ok(h) if !h.is_invalid() => Ok(Self(Some(h))),
+                _ => Ok(Self(None)),
+            }
+        }
+
+        pub(super) fn wait(self) {
+            if let Some(h) = self.0 {
+                // SAFETY: `h` is a live process handle from OpenProcess; we
+                // block on it then close it exactly once. Any return value
+                // means the process has exited (or the wait failed) — either
+                // way the caller proceeds.
+                unsafe {
+                    let _ = WaitForSingleObject(h, INFINITE);
+                    let _ = CloseHandle(h);
+                }
+            }
+        }
+    }
+}
+
+// macOS: kqueue EVFILT_PROC / NOTE_EXIT ===============================================================================
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    pub(super) struct Inner(Option<OwnedFd>);
+
+    impl Inner {
+        pub(super) fn arm(pid: u32) -> std::io::Result<Self> {
+            // SAFETY: kqueue() returns a new fd or -1.
+            let kq = unsafe { libc::kqueue() };
+            if kq < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            // SAFETY: kq is a fresh, owned kqueue fd.
+            let kq = unsafe { OwnedFd::from_raw_fd(kq) };
+
+            let kev = libc::kevent {
+                ident: pid as libc::uintptr_t,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_ADD | libc::EV_ONESHOT,
+                fflags: libc::NOTE_EXIT,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            };
+            // SAFETY: register one change (nevents=0). A dead PID yields -1 +
+            // ESRCH, which we map to a no-op wait.
+            let rc = unsafe { libc::kevent(kq.as_raw_fd(), &kev, 1, std::ptr::null_mut(), 0, std::ptr::null()) };
+            if rc < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::ESRCH) {
+                    return Ok(Self(None));
+                }
+                return Err(err);
+            }
+            Ok(Self(Some(kq)))
+        }
+
+        pub(super) fn wait(self) {
+            let Some(kq) = self.0 else {
+                return;
+            };
+            // SAFETY: blocking kevent (NULL timeout) for the one NOTE_EXIT.
+            // Any return means the process has exited; the kqueue fd is closed
+            // by OwnedFd's Drop.
+            let mut out: libc::kevent = unsafe { std::mem::zeroed() };
+            let _ = unsafe { libc::kevent(kq.as_raw_fd(), std::ptr::null(), 0, &mut out, 1, std::ptr::null()) };
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "relaunch_tests.rs"]
+mod relaunch_tests;

--- a/crates/hole/src/relaunch_tests.rs
+++ b/crates/hole/src/relaunch_tests.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[skuld::test]
+fn armed_wait_returns_after_child_exits() {
+    // Spawn a real, short-lived child and arm a wait on it; whether we arm
+    // before or after it exits, `wait()` must return (a live handle blocks
+    // until exit; an already-gone PID is a no-op). Waiting on an external
+    // process's exit is the sanctioned timing exception.
+    #[cfg(windows)]
+    let mut child = std::process::Command::new("cmd").args(["/c", "exit"]).spawn().unwrap();
+    #[cfg(unix)]
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+
+    let pid = child.id();
+    let armed = ArmedWait::arm(pid).unwrap();
+    child.wait().unwrap();
+    armed.wait();
+}

--- a/crates/hole/src/selfheal.rs
+++ b/crates/hole/src/selfheal.rs
@@ -75,6 +75,103 @@ pub fn file_identity(p: &Path) -> std::io::Result<same_file::Handle> {
     same_file::Handle::from_path(p)
 }
 
+/// Show the path-free "please reinstall" dialog (the `Reinstall` action). The
+/// running-image-vs-canonical path detail is logged to `gui.log` at the
+/// trigger, never shown — PII stays out of the dialog.
+pub fn show_reinstall_dialog(app: &tauri::AppHandle) {
+    use tauri_plugin_dialog::DialogExt;
+    app.dialog()
+        .message("Hole is in an inconsistent state and needs to be reinstalled.")
+        .title("Hole")
+        .show(|_| {});
+}
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Installed image identity, snapshotted at startup via [`init_startup`].
+/// `None` ⇒ a dev build that never self-heals.
+static STARTUP: std::sync::OnceLock<Option<StartupIdentity>> = std::sync::OnceLock::new();
+
+/// Snapshot the startup image identity. Called once at GUI launch, while
+/// `current_exe` is still the installed path (before any update renames it).
+pub fn init_startup() {
+    let _ = STARTUP.set(capture_startup_identity());
+}
+
+/// At most one self-heal evaluation in flight — bounds thread spawns so a
+/// stuck `Transient` cannot spawn a thread per poll. A terminal action exits
+/// the process; `Operate`/`Transient`/relaunch-spawn-failure release it.
+static EVALUATING: AtomicBool = AtomicBool::new(false);
+
+/// Seam for unit-testing the action dispatch without a real relaunch /
+/// dialog / process exit.
+pub trait SelfHealOs {
+    fn spawn_successor(&mut self) -> std::io::Result<()>;
+    fn show_reinstall_dialog(&mut self);
+    fn request_exit(&mut self);
+}
+
+/// Unit-tested core: decide, then dispatch via the injected seam.
+pub fn run_with<T: PartialEq>(
+    own: &str,
+    bridge: Option<&str>,
+    running: T,
+    canonical: Option<T>,
+    os: &mut impl SelfHealOs,
+) -> SelfHealAction {
+    let action = decide(own, bridge, running, canonical);
+    match action {
+        SelfHealAction::Relaunch => {
+            if os.spawn_successor().is_ok() {
+                os.request_exit();
+            }
+        }
+        SelfHealAction::Reinstall => {
+            os.show_reinstall_dialog();
+            os.request_exit();
+        }
+        SelfHealAction::Operate | SelfHealAction::Transient => {}
+    }
+    action
+}
+
+/// Production driver, fired on every observed version mismatch. Decides once
+/// with the *real* startup-vs-now image identities and dispatches directly
+/// (it does NOT call [`run_with`] — that is the separately-tested core).
+/// `decide`'s quick stat runs inline; only the blocking relaunch goes to a
+/// thread, which is intentionally never joined (the process exits).
+pub fn trigger(app: &tauri::AppHandle, bridge: Option<String>) {
+    let Some(Some(startup)) = STARTUP.get() else {
+        return; // dev build (or pre-init) — never self-heal
+    };
+    if EVALUATING.swap(true, Ordering::SeqCst) {
+        return; // an evaluation is already in flight
+    }
+
+    let now = file_identity(&startup.exe).ok();
+    match decide(crate::version::VERSION, bridge.as_deref(), &startup.id, now.as_ref()) {
+        SelfHealAction::Relaunch => {
+            tracing::warn!(exe = %startup.exe.display(), "self-heal: installed image changed under us; relaunching");
+            let (app, exe) = (app.clone(), startup.exe.clone());
+            std::thread::spawn(move || {
+                if crate::relaunch::spawn_successor(&exe).is_ok() {
+                    app.exit(0); // EVALUATING stays set; the process is exiting
+                } else {
+                    EVALUATING.store(false, Ordering::SeqCst); // spawn failed → allow retry next poll
+                }
+            });
+        }
+        SelfHealAction::Reinstall => {
+            tracing::warn!(exe = %startup.exe.display(), "self-heal: version mismatch, image unchanged; prompting reinstall");
+            show_reinstall_dialog(app);
+            app.exit(0); // EVALUATING stays set; the process is exiting
+        }
+        SelfHealAction::Operate | SelfHealAction::Transient => {
+            EVALUATING.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "selfheal_tests.rs"]
 mod selfheal_tests;

--- a/crates/hole/src/selfheal.rs
+++ b/crates/hole/src/selfheal.rs
@@ -3,8 +3,8 @@
 //! When the GUI detects (via the `X-Hole-Bridge-Version` header) that the
 //! bridge runs a different version, it must not operate the mismatched pair.
 //! [`decide`] is the pure, `#[cfg]`-free policy; the OS-specific bits live
-//! behind the [`canonical_install_exe`](capture_startup_identity)/identity
-//! seam and [`crate::relaunch`]. Inert until an update produces a mismatch.
+//! behind the [`capture_startup_identity`]/[`file_identity`] seam and
+//! [`crate::relaunch`]. Inert until an update produces a mismatch.
 
 use std::path::{Path, PathBuf};
 
@@ -75,15 +75,18 @@ pub fn file_identity(p: &Path) -> std::io::Result<same_file::Handle> {
     same_file::Handle::from_path(p)
 }
 
-/// Show the path-free "please reinstall" dialog (the `Reinstall` action). The
-/// running-image-vs-canonical path detail is logged to `gui.log` at the
-/// trigger, never shown — PII stays out of the dialog.
-pub fn show_reinstall_dialog(app: &tauri::AppHandle) {
+/// Show the path-free "please reinstall" dialog (the `Reinstall` action),
+/// blocking until the user dismisses it (so it actually renders before the
+/// process exits). The running-image-vs-canonical path detail is logged to
+/// `gui.log` at the trigger, never shown — PII stays out of the dialog. Must
+/// run off the main thread / reactor; the trigger runs it on a dedicated thread.
+fn show_reinstall_dialog(app: &tauri::AppHandle) {
     use tauri_plugin_dialog::DialogExt;
-    app.dialog()
+    let _ = app
+        .dialog()
         .message("Hole is in an inconsistent state and needs to be reinstalled.")
         .title("Hole")
-        .show(|_| {});
+        .blocking_show();
 }
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -103,23 +106,17 @@ pub fn init_startup() {
 /// the process; `Operate`/`Transient`/relaunch-spawn-failure release it.
 static EVALUATING: AtomicBool = AtomicBool::new(false);
 
-/// Seam for unit-testing the action dispatch without a real relaunch /
-/// dialog / process exit.
-pub trait SelfHealOs {
+/// Effects seam, so the dispatch shipped in production is exactly the one the
+/// tests drive (via a recording stub). Each method may block.
+trait SelfHealOs {
     fn spawn_successor(&mut self) -> std::io::Result<()>;
     fn show_reinstall_dialog(&mut self);
     fn request_exit(&mut self);
 }
 
-/// Unit-tested core: decide, then dispatch via the injected seam.
-pub fn run_with<T: PartialEq>(
-    own: &str,
-    bridge: Option<&str>,
-    running: T,
-    canonical: Option<T>,
-    os: &mut impl SelfHealOs,
-) -> SelfHealAction {
-    let action = decide(own, bridge, running, canonical);
+/// Perform `action` via the seam. Shared by [`trigger`] (production) and the
+/// unit tests, so the shipped dispatch IS the tested one.
+fn dispatch(action: SelfHealAction, os: &mut impl SelfHealOs) {
     match action {
         SelfHealAction::Relaunch => {
             if os.spawn_successor().is_ok() {
@@ -132,14 +129,36 @@ pub fn run_with<T: PartialEq>(
         }
         SelfHealAction::Operate | SelfHealAction::Transient => {}
     }
-    action
+}
+
+/// Production effects: relaunch via the exit-wait primitive, the blocking
+/// reinstall dialog, and `app.exit`. `exited` records whether a terminal
+/// action ran, so the caller knows whether to release the single-flight latch.
+struct ProdOs {
+    app: tauri::AppHandle,
+    exe: PathBuf,
+    exited: bool,
+}
+
+impl SelfHealOs for ProdOs {
+    fn spawn_successor(&mut self) -> std::io::Result<()> {
+        crate::relaunch::spawn_successor(&self.exe)
+    }
+    fn show_reinstall_dialog(&mut self) {
+        show_reinstall_dialog(&self.app);
+    }
+    fn request_exit(&mut self) {
+        self.app.exit(0);
+        self.exited = true;
+    }
 }
 
 /// Production driver, fired on every observed version mismatch. Decides once
-/// with the *real* startup-vs-now image identities and dispatches directly
-/// (it does NOT call [`run_with`] — that is the separately-tested core).
-/// `decide`'s quick stat runs inline; only the blocking relaunch goes to a
-/// thread, which is intentionally never joined (the process exits).
+/// with the *real* startup-vs-now image identities, then runs the (blocking)
+/// dispatch on a dedicated thread — `spawn_successor` waits on the successor's
+/// READY and the reinstall dialog blocks until dismissed, neither of which may
+/// run on the reactor. The thread is never joined (the process exits on a
+/// terminal action).
 pub fn trigger(app: &tauri::AppHandle, bridge: Option<String>) {
     let Some(Some(startup)) = STARTUP.get() else {
         return; // dev build (or pre-init) — never self-heal
@@ -148,28 +167,29 @@ pub fn trigger(app: &tauri::AppHandle, bridge: Option<String>) {
         return; // an evaluation is already in flight
     }
 
+    // Quick stat inline; compare the startup identity (borrowed) against the
+    // file at that path now. Only the blocking dispatch is offloaded.
     let now = file_identity(&startup.exe).ok();
-    match decide(crate::version::VERSION, bridge.as_deref(), &startup.id, now.as_ref()) {
-        SelfHealAction::Relaunch => {
-            tracing::warn!(exe = %startup.exe.display(), "self-heal: installed image changed under us; relaunching");
-            let (app, exe) = (app.clone(), startup.exe.clone());
-            std::thread::spawn(move || {
-                if crate::relaunch::spawn_successor(&exe).is_ok() {
-                    app.exit(0); // EVALUATING stays set; the process is exiting
-                } else {
-                    EVALUATING.store(false, Ordering::SeqCst); // spawn failed → allow retry next poll
-                }
-            });
-        }
-        SelfHealAction::Reinstall => {
-            tracing::warn!(exe = %startup.exe.display(), "self-heal: version mismatch, image unchanged; prompting reinstall");
-            show_reinstall_dialog(app);
-            app.exit(0); // EVALUATING stays set; the process is exiting
-        }
-        SelfHealAction::Operate | SelfHealAction::Transient => {
+    let action = decide(crate::version::VERSION, bridge.as_deref(), &startup.id, now.as_ref());
+    if matches!(action, SelfHealAction::Operate | SelfHealAction::Transient) {
+        EVALUATING.store(false, Ordering::SeqCst);
+        return;
+    }
+
+    tracing::warn!(exe = %startup.exe.display(), ?action, "self-heal: bridge version mismatch");
+    let mut os = ProdOs {
+        app: app.clone(),
+        exe: startup.exe.clone(),
+        exited: false,
+    };
+    std::thread::spawn(move || {
+        dispatch(action, &mut os);
+        if !os.exited {
+            // Relaunch's spawn_successor failed — release the latch so the
+            // next status poll retries.
             EVALUATING.store(false, Ordering::SeqCst);
         }
-    }
+    });
 }
 
 #[cfg(test)]

--- a/crates/hole/src/selfheal.rs
+++ b/crates/hole/src/selfheal.rs
@@ -1,0 +1,80 @@
+//! GUI ↔ bridge version-lockstep self-heal.
+//!
+//! When the GUI detects (via the `X-Hole-Bridge-Version` header) that the
+//! bridge runs a different version, it must not operate the mismatched pair.
+//! [`decide`] is the pure, `#[cfg]`-free policy; the OS-specific bits live
+//! behind the [`canonical_install_exe`](capture_startup_identity)/identity
+//! seam and [`crate::relaunch`]. Inert until an update produces a mismatch.
+
+use std::path::{Path, PathBuf};
+
+/// What the GUI should do about an observed version mismatch.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SelfHealAction {
+    /// Versions match — operate normally.
+    Operate,
+    /// The installed image changed under us (an update) — relaunch it.
+    Relaunch,
+    /// We are the installed image but the bridge differs — genuine
+    /// misconfiguration; prompt the user to reinstall.
+    Reinstall,
+    /// The installed file is transiently absent (mid-swap) — retry later.
+    Transient,
+}
+
+/// Pure self-heal policy. `bridge` is the bridge's reported version, or
+/// `None` for an old bridge predating the version stamp (treated as a
+/// mismatch). `running` is our startup image identity; `canonical` is the
+/// identity of the file at that same path *now*, or `None` if it is
+/// transiently absent. Generic over the identity token so it is fully
+/// table-testable without touching the filesystem.
+pub fn decide<T: PartialEq>(own: &str, bridge: Option<&str>, running: T, canonical: Option<T>) -> SelfHealAction {
+    if bridge == Some(own) {
+        return SelfHealAction::Operate;
+    }
+    match canonical {
+        None => SelfHealAction::Transient,
+        Some(c) if c != running => SelfHealAction::Relaunch,
+        Some(_) => SelfHealAction::Reinstall,
+    }
+}
+
+/// The GUI image identity captured at startup, before any update can rename
+/// it. Compared later against the file at the same path: a difference means
+/// an update swapped the binary underneath us. The path is derived from
+/// `current_exe` (not a hardcoded `Program Files` location), so a custom
+/// install directory is handled automatically.
+pub struct StartupIdentity {
+    pub exe: PathBuf,
+    pub id: same_file::Handle,
+}
+
+/// Capture the running image's identity once at startup. Returns `None` for
+/// dev/snapshot builds (built in lockstep — never self-heal) or if the exe
+/// identity cannot be read.
+pub fn capture_startup_identity() -> Option<StartupIdentity> {
+    if is_dev_build() {
+        return None;
+    }
+    let exe = std::env::current_exe().ok()?;
+    let id = same_file::Handle::from_path(&exe).ok()?;
+    Some(StartupIdentity { exe, id })
+}
+
+/// Dev/snapshot builds are built in lockstep and must never self-heal.
+fn is_dev_build() -> bool {
+    matches!(
+        hole_common::version::ReleaseVersion::from_build_version(crate::version::VERSION),
+        Ok((_, true)) // is_snapshot
+    )
+}
+
+/// File identity via the cross-platform `same_file` crate (volume serial +
+/// file index on Windows; device + inode on Unix). No FFI, no `#[cfg]`.
+pub fn file_identity(p: &Path) -> std::io::Result<same_file::Handle> {
+    same_file::Handle::from_path(p)
+}
+
+#[cfg(test)]
+#[path = "selfheal_tests.rs"]
+mod selfheal_tests;

--- a/crates/hole/src/selfheal_tests.rs
+++ b/crates/hole/src/selfheal_tests.rs
@@ -31,3 +31,79 @@ fn canonical_absent_is_transient() {
     // installed file momentarily missing mid-swap ⇒ retry, never fatal.
     assert_eq!(decide("6", Some("7"), 1u8, None::<u8>), SelfHealAction::Transient);
 }
+
+// run_with: action dispatch via the injected seam (no real relaunch/dialog/exit).
+
+#[derive(Default)]
+struct Spy {
+    spawned: bool,
+    dialoged: bool,
+    exited: bool,
+    spawn_ok: bool,
+}
+
+impl Spy {
+    fn ok() -> Self {
+        Self {
+            spawn_ok: true,
+            ..Self::default()
+        }
+    }
+}
+
+impl SelfHealOs for Spy {
+    fn spawn_successor(&mut self) -> std::io::Result<()> {
+        self.spawned = true;
+        if self.spawn_ok {
+            Ok(())
+        } else {
+            Err(std::io::Error::other("spawn failed"))
+        }
+    }
+    fn show_reinstall_dialog(&mut self) {
+        self.dialoged = true;
+    }
+    fn request_exit(&mut self) {
+        self.exited = true;
+    }
+}
+
+#[skuld::test]
+fn run_with_relaunch_spawns_then_exits() {
+    let mut spy = Spy::ok();
+    assert_eq!(
+        run_with("6", Some("7"), 1u8, Some(2u8), &mut spy),
+        SelfHealAction::Relaunch
+    );
+    assert!(spy.spawned && spy.exited && !spy.dialoged);
+}
+
+#[skuld::test]
+fn run_with_reinstall_dialogs_then_exits() {
+    let mut spy = Spy::ok();
+    assert_eq!(
+        run_with("7", Some("6"), 1u8, Some(1u8), &mut spy),
+        SelfHealAction::Reinstall
+    );
+    assert!(spy.dialoged && spy.exited && !spy.spawned);
+}
+
+#[skuld::test]
+fn run_with_transient_does_nothing() {
+    let mut spy = Spy::ok();
+    assert_eq!(
+        run_with("6", Some("7"), 1u8, None::<u8>, &mut spy),
+        SelfHealAction::Transient
+    );
+    assert!(!spy.spawned && !spy.dialoged && !spy.exited);
+}
+
+#[skuld::test]
+fn run_with_relaunch_spawn_failure_does_not_exit() {
+    let mut spy = Spy::default(); // spawn_ok = false
+    assert_eq!(
+        run_with("6", Some("7"), 1u8, Some(2u8), &mut spy),
+        SelfHealAction::Relaunch
+    );
+    assert!(spy.spawned && !spy.exited);
+}

--- a/crates/hole/src/selfheal_tests.rs
+++ b/crates/hole/src/selfheal_tests.rs
@@ -69,41 +69,36 @@ impl SelfHealOs for Spy {
 }
 
 #[skuld::test]
-fn run_with_relaunch_spawns_then_exits() {
+fn dispatch_relaunch_spawns_then_exits() {
     let mut spy = Spy::ok();
-    assert_eq!(
-        run_with("6", Some("7"), 1u8, Some(2u8), &mut spy),
-        SelfHealAction::Relaunch
-    );
+    dispatch(SelfHealAction::Relaunch, &mut spy);
     assert!(spy.spawned && spy.exited && !spy.dialoged);
 }
 
 #[skuld::test]
-fn run_with_reinstall_dialogs_then_exits() {
+fn dispatch_reinstall_dialogs_then_exits() {
     let mut spy = Spy::ok();
-    assert_eq!(
-        run_with("7", Some("6"), 1u8, Some(1u8), &mut spy),
-        SelfHealAction::Reinstall
-    );
+    dispatch(SelfHealAction::Reinstall, &mut spy);
     assert!(spy.dialoged && spy.exited && !spy.spawned);
 }
 
 #[skuld::test]
-fn run_with_transient_does_nothing() {
+fn dispatch_operate_does_nothing() {
     let mut spy = Spy::ok();
-    assert_eq!(
-        run_with("6", Some("7"), 1u8, None::<u8>, &mut spy),
-        SelfHealAction::Transient
-    );
+    dispatch(SelfHealAction::Operate, &mut spy);
     assert!(!spy.spawned && !spy.dialoged && !spy.exited);
 }
 
 #[skuld::test]
-fn run_with_relaunch_spawn_failure_does_not_exit() {
+fn dispatch_transient_does_nothing() {
+    let mut spy = Spy::ok();
+    dispatch(SelfHealAction::Transient, &mut spy);
+    assert!(!spy.spawned && !spy.dialoged && !spy.exited);
+}
+
+#[skuld::test]
+fn dispatch_relaunch_spawn_failure_does_not_exit() {
     let mut spy = Spy::default(); // spawn_ok = false
-    assert_eq!(
-        run_with("6", Some("7"), 1u8, Some(2u8), &mut spy),
-        SelfHealAction::Relaunch
-    );
+    dispatch(SelfHealAction::Relaunch, &mut spy);
     assert!(spy.spawned && !spy.exited);
 }

--- a/crates/hole/src/selfheal_tests.rs
+++ b/crates/hole/src/selfheal_tests.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+// `decide` is pure and `#[cfg]`-free; identities are any `PartialEq` token
+// (`u8` here, `same_file::Handle` in production).
+
+#[skuld::test]
+fn matched_operates() {
+    assert_eq!(decide("7", Some("7"), 1u8, Some(1u8)), SelfHealAction::Operate);
+}
+
+#[skuld::test]
+fn stale_image_relaunches() {
+    // running != canonical, version differs ⇒ an update swapped us underneath.
+    assert_eq!(decide("6", Some("7"), 1u8, Some(2u8)), SelfHealAction::Relaunch);
+}
+
+#[skuld::test]
+fn absent_header_with_stale_image_relaunches() {
+    // old bridge (no version header) + stale image ⇒ still relaunch.
+    assert_eq!(decide("6", None, 1u8, Some(2u8)), SelfHealAction::Relaunch);
+}
+
+#[skuld::test]
+fn same_image_mismatch_is_reinstall() {
+    // I am the installed image but the bridge differs ⇒ genuine misconfig.
+    assert_eq!(decide("7", Some("6"), 1u8, Some(1u8)), SelfHealAction::Reinstall);
+}
+
+#[skuld::test]
+fn canonical_absent_is_transient() {
+    // installed file momentarily missing mid-swap ⇒ retry, never fatal.
+    assert_eq!(decide("6", Some("7"), 1u8, None::<u8>), SelfHealAction::Transient);
+}

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -28,11 +28,15 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(config_store: ConfigStore, config: AppConfig, app_handle: tauri::AppHandle) -> Self {
+        // The self-heal hook captures the AppHandle (BridgeLink has none of
+        // its own). `hole::selfheal` resolves in both the lib and bin units.
+        let hook_app = app_handle.clone();
+        let self_heal: SelfHealHook = std::sync::Arc::new(move |bridge| hole::selfheal::trigger(&hook_app, bridge));
         Self {
             config_store,
             config: Mutex::new(config),
             app_handle,
-            link: BridgeLink::new(resolve_bridge_socket_path()),
+            link: BridgeLink::new(resolve_bridge_socket_path(), self_heal),
             test_locks: tokio::sync::Mutex::new(HashMap::new()),
         }
     }
@@ -85,23 +89,38 @@ fn resolve_bridge_socket_path() -> PathBuf {
 /// exchange revealed about `running` (see `observed_running`) BEFORE
 /// releasing the client lock — commit order therefore equals bridge
 /// processing order, with no separate synchronization.
+/// Fired (off the reactor) whenever a bridge exchange reveals a version
+/// mismatch, to drive the GUI self-heal. Injected so `BridgeLink` stays
+/// testable and holds no `AppHandle` of its own.
+pub type SelfHealHook = std::sync::Arc<dyn Fn(Option<String>) + Send + Sync>;
+
 pub struct BridgeLink {
     socket_path: PathBuf,
     client: tokio::sync::Mutex<Option<BridgeClient>>,
     cell: ProxyStateCell,
+    self_heal: SelfHealHook,
 }
 
 impl BridgeLink {
-    pub fn new(socket_path: PathBuf) -> Self {
+    pub fn new(socket_path: PathBuf, self_heal: SelfHealHook) -> Self {
         Self {
             socket_path,
             client: tokio::sync::Mutex::new(None),
             cell: ProxyStateCell::new(),
+            self_heal,
         }
     }
 
     pub fn cell(&self) -> &ProxyStateCell {
         &self.cell
+    }
+
+    /// Drive the self-heal hook if the exchange revealed a version mismatch.
+    /// Covers every send path (pooled, oneshot, reload) since all funnel here.
+    fn note_mismatch(&self, result: &Result<BridgeResponse, ClientError>) {
+        if let Err(ClientError::VersionMismatch { bridge }) = result {
+            (self.self_heal)(bridge.clone());
+        }
     }
 
     /// Send a request to the bridge, lazily connecting on first use.
@@ -114,6 +133,7 @@ impl BridgeLink {
         if let Some(running) = observed_running(kind, &result) {
             self.cell.commit(running);
         }
+        self.note_mismatch(&result);
         result
     }
 
@@ -144,6 +164,10 @@ impl BridgeLink {
             .await
         {
             Ok(resp) => Ok(resp),
+            // A version mismatch is not a broken connection — keep the pooled
+            // client (reconnecting cannot fix a version skew). `ClientError`
+            // is not `Clone`, so bind-and-move the error out of the match.
+            Err(e @ ClientError::VersionMismatch { .. }) => Err(e),
             Err(e) => {
                 // Connection broken — clear so next call reconnects
                 warn!(error = %e, "bridge communication error, will reconnect");
@@ -168,7 +192,9 @@ impl BridgeLink {
     /// is still the right choice for normal request traffic.
     pub async fn send_oneshot(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
         let mut client = BridgeClient::connect(&self.socket_path).await?;
-        client.send(req).await
+        let result = client.send(req).await;
+        self.note_mismatch(&result);
+        result
     }
 
     /// Send Reload iff the proxy is running, decided at the linearization
@@ -183,13 +209,16 @@ impl BridgeLink {
     pub async fn reload_if_running(&self, config: hole_common::protocol::ProxyConfig) -> Result<bool, String> {
         let mut guard = self.client.lock().await;
         let status = Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Status).await;
+        self.note_mismatch(&status);
         if let Some(running) = observed_running(ReqKind::Status, &status) {
             self.cell.commit(running);
         }
         if !matches!(status, Ok(BridgeResponse::Status { running: true, .. })) {
             return Ok(false); // Not running; changes apply on next start.
         }
-        match Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Reload { config }).await {
+        let reload = Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Reload { config }).await;
+        self.note_mismatch(&reload);
+        match reload {
             Ok(BridgeResponse::Ack) => Ok(true),
             Ok(BridgeResponse::Error { message }) => Err(message),
             Ok(_) => Err("unexpected response from bridge".into()),
@@ -306,6 +335,9 @@ pub(crate) fn observed_running(kind: ReqKind, result: &Result<BridgeResponse, Cl
     match (kind, result) {
         (Other, _) => None,
         (_, Err(ClientError::PermissionDenied)) => None,
+        // A version mismatch triggers self-heal; do not flip `running` during
+        // the self-heal window (must precede the `(_, Err(_))` catch-all).
+        (_, Err(ClientError::VersionMismatch { .. })) => None,
         (_, Err(_)) => Some(false),
         (Status, Ok(BridgeResponse::Status { running, .. })) => Some(*running),
         (Start, Ok(BridgeResponse::Ack)) => Some(true),

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -136,12 +136,31 @@ fn status_response(running: bool) -> StatusResponse {
     }
 }
 
+/// A no-op self-heal hook for `BridgeLink` tests that don't exercise a
+/// version mismatch.
+fn noop_hook() -> SelfHealHook {
+    std::sync::Arc::new(|_| {})
+}
+
 /// Serve `router` on `path`, accepting connections in a loop (BridgeLink
 /// reconnects after transport errors, and `send_oneshot` always dials
 /// fresh). Each connection is served on its own task so a parked handler
 /// cannot block later accepts.
 async fn serve_router(path: &std::path::Path, router: axum::Router) -> tokio::task::JoinHandle<()> {
     let listener = hole_bridge::socket::LocalListener::bind(path).unwrap();
+    // Stamp the matching version unless the test already set one (mismatch
+    // tests do) — otherwise the client's per-response check rejects every reply.
+    let router = router.layer(axum::middleware::map_response(
+        |mut resp: axum::response::Response| async move {
+            if !resp.headers().contains_key("x-hole-bridge-version") {
+                resp.headers_mut().insert(
+                    "x-hole-bridge-version",
+                    axum::http::HeaderValue::from_static(hole::version::VERSION),
+                );
+            }
+            resp
+        },
+    ));
     tokio::spawn(async move {
         loop {
             let Ok(stream) = listener.accept().await else { return };
@@ -170,7 +189,7 @@ async fn start_ack_commits_true() {
     let router = axum::Router::new().route(ROUTE_START, post(|| async { Json(EmptyResponse {}) }));
     let _mock = serve_router(&path, router).await;
 
-    let link = BridgeLink::new(path);
+    let link = BridgeLink::new(path, noop_hook());
     assert!(!link.cell().snapshot().running);
     let resp = link
         .send(BridgeRequest::Start {
@@ -183,10 +202,43 @@ async fn start_ack_commits_true() {
 }
 
 #[skuld::test]
+async fn version_mismatch_fires_hook_and_does_not_flip_running() {
+    let path = test_socket_path("ver-mismatch-link");
+    // Mock stamps a mismatching version (overrides serve_router's default).
+    let router = axum::Router::new()
+        .route(ROUTE_STATUS, get(|| async { Json(status_response(true)) }))
+        .layer(axum::middleware::map_response(
+            |mut resp: axum::response::Response| async move {
+                resp.headers_mut().insert(
+                    "x-hole-bridge-version",
+                    axum::http::HeaderValue::from_static("0.0.0-mismatch"),
+                );
+                resp
+            },
+        ));
+    let _mock = serve_router(&path, router).await;
+
+    let fired = Arc::new(AtomicUsize::new(0));
+    let fired2 = fired.clone();
+    let link = BridgeLink::new(
+        path,
+        Arc::new(move |_| {
+            fired2.fetch_add(1, Ordering::SeqCst);
+        }),
+    );
+
+    let before = link.cell().snapshot();
+    let result = link.send(BridgeRequest::Status).await;
+    assert!(matches!(result, Err(ClientError::VersionMismatch { .. })));
+    assert_eq!(fired.load(Ordering::SeqCst), 1, "self-heal hook fires once");
+    assert_eq!(link.cell().snapshot(), before, "running must not flip during self-heal");
+}
+
+#[skuld::test]
 async fn transport_error_commits_false() {
     let path = test_socket_path("dead");
     let _ = std::fs::remove_file(&path);
-    let link = BridgeLink::new(path);
+    let link = BridgeLink::new(path, noop_hook());
     link.cell().commit(true); // pretend we believed it was running
     let _ = link.send(BridgeRequest::Status).await.unwrap_err();
     assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 2, running: false });
@@ -201,7 +253,7 @@ async fn oneshot_never_commits() {
     );
     let _mock = serve_router(&path, router).await;
 
-    let link = BridgeLink::new(path);
+    let link = BridgeLink::new(path, noop_hook());
     link.cell().commit(true);
     link.send_oneshot(BridgeRequest::Cancel).await.unwrap();
     assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
@@ -225,7 +277,7 @@ async fn untracked_requests_never_commit() {
     );
     let _mock = serve_router(&path, router).await;
 
-    let link = BridgeLink::new(path);
+    let link = BridgeLink::new(path, noop_hook());
     link.send(BridgeRequest::Metrics).await.unwrap();
     assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 0, running: false });
 }
@@ -254,7 +306,7 @@ async fn concurrent_requests_commit_in_bridge_order() {
         .route(ROUTE_STATUS, get(|| async { Json(status_response(true)) }));
     let _mock = serve_router(&path, router).await;
 
-    let link = Arc::new(BridgeLink::new(path));
+    let link = Arc::new(BridgeLink::new(path, noop_hook()));
     let a = tokio::spawn({
         let link = link.clone();
         async move {
@@ -300,7 +352,7 @@ async fn reload_if_running_skips_when_stopped() {
         );
     let _mock = serve_router(&path, router).await;
 
-    let link = BridgeLink::new(path);
+    let link = BridgeLink::new(path, noop_hook());
     let reloaded = link.reload_if_running(test_proxy_config()).await.unwrap();
     assert!(!reloaded);
     // The resurrection guard: bridge-side `reload` on a stopped proxy
@@ -327,7 +379,7 @@ async fn reload_if_running_reloads_when_running() {
         );
     let _mock = serve_router(&path, router).await;
 
-    let link = BridgeLink::new(path);
+    let link = BridgeLink::new(path, noop_hook());
     let reloaded = link.reload_if_running(test_proxy_config()).await.unwrap();
     assert!(reloaded);
     assert_eq!(reloads.load(Ordering::SeqCst), 1);


### PR DESCRIPTION
**PR 1 of 3 for #468** (leak-free Windows in-place update). This PR does **not** close #468 — that lands with PR 3.

## What this PR does — lockstep machinery
The GUI and bridge must never *operate* as a mismatched-version pair (the single-exe design assumes it; the IPC contract has no version negotiation). This adds the detection + self-heal, **inert until an update produces a mismatch**:

- Bridge stamps `X-Hole-Bridge-Version` on **every** IPC response (incl. errors/404) and serves `GET /v1/version`; the version is injected via `IpcServer::bind` (the bridge crate can't read `HOLE_VERSION`).
- GUI client returns `ClientError::VersionMismatch` on a mismatched **or absent** header (absent = old bridge predating the stamp).
- Pure `selfheal::decide` + startup-identity capture (`same_file`, no FFI); a cross-platform exit-wait `relaunch` primitive (Windows `WaitForSingleObject`, macOS `kqueue`/`NOTE_EXIT`); a path-free reinstall dialog; wired into `BridgeLink` so all send paths (pooled / oneshot / reload) self-heal.
- macOS daemon now shuts down gracefully on **SIGTERM** (was `ctrl_c()`/SIGINT-only → launchd stop leaked routes/DNS).

OS-specifics are confined to named seams (`relaunch::ArmedWait`, the identity seam); `decide`, the client check, and the `state.rs` wiring are `#[cfg]`-free and table-tested.

## Stack
1. **This PR** — lockstep machinery (dormant until a mismatch occurs).
2. Fail-closed WFP(Win)/PF(macOS) cover — the leak-free cutover primitive.
3. File swap + idempotent install + coordinator — the actual #468 fix (closes it).

## Deferred / follow-ups
- `bridge_version()` client probe → PR 3 (no caller here; would be dead code).
- `galoshes.exe` staged-but-not-in-MSI gap → tracked separately.

## Testing
366 `hole` unit tests green locally (incl. `decide`/`dispatch`/version-mismatch wiring) + targeted bridge version-header tests; clippy clean. macOS-only paths (SIGTERM handler, `kqueue` wait) compile/verify on the darwin CI lane.

One-time caveat documented in CONTRIBUTING: a GUI built *before* this feature has no self-heal logic, so the first upgrade-to-this-version can run a stale GUI against the new bridge until the user restarts it — benign (the IPC change is purely additive).