### PR TITLE
ci: run the util crate's tests (orphaned — in no CI job)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ci-artifacts
-          cargo nextest archive -p garter -p garter-bin -p galoshes -p kill-group -p stepstool -p dev-console -p xtask -p xtask-lib --features garter/test-utils --archive-file ci-artifacts/tests.tar.zst
+          cargo nextest archive -p garter -p garter-bin -p galoshes -p kill-group -p stepstool -p dev-console -p xtask -p xtask-lib -p util --features garter/test-utils --archive-file ci-artifacts/tests.tar.zst
 
       # The artifact is consumed by test-garter, test-galoshes, and
       # test-tooling; test-hole does its own build.
@@ -245,7 +245,7 @@ jobs:
           cargo nextest run \
             --archive-file ci-artifacts/tests.tar.zst \
             --workspace-remap "${{ github.workspace }}" \
-            -E 'package(kill-group) + package(stepstool) + package(dev-console) + package(xtask) + package(xtask-lib)'
+            -E 'package(kill-group) + package(stepstool) + package(dev-console) + package(xtask) + package(xtask-lib) + package(util)'
 
   # test-hole runs a fresh build + nextest run (no archive). Hole tests have
   # too many environmental couplings (trybuild --offline registry, dist_fixture

--- a/build.yaml
+++ b/build.yaml
@@ -235,6 +235,12 @@ targets:
     build: cargo nextest run --no-run -p dev-console
     run: cargo nextest run -p dev-console
 
+  util-tests:
+    platforms:
+      matrix: { os: [windows, linux, darwin], arch: [amd64, arm64] }
+    build: cargo nextest run --no-run -p util
+    run: cargo nextest run -p util
+
   # ===== Lint & check targets ==============================================
   # No build phase; the tool's incremental cache is the build. Each is a
   # first-class runnable invoked via `cargo xtask run <name>`, replacing the


### PR DESCRIPTION
Closes #519.

## Problem

`crates/util` (Apache-2.0: ephemeral port allocation + retry-with-backoff; shared by Hole's GPL crates and the Apache plugin world) is a workspace member in **no** CI test job's package filter and has **no** `build.yaml` test target — so its `retry_tests.rs` / `port_alloc_tests.rs` (incl. `#[cfg(windows)]` and `#[cfg(target_os = "macos")]` cases) run on **no platform**. Found by the orphan-test audit behind #512.

## Fix

`util` is cross-platform (like `kill-group`/`stepstool`), so wire it into the 6-platform tooling lane:

- `build.yaml`: new `util-tests` target (mirrors `kill-group-tests`).
- `ci.yaml`: `-p util` added to the `build` job's `nextest archive`; `+ package(util)` added to `test-tooling`'s `-E` filter.

No `util` source changes — purely CI wiring.

## Verification (local, Windows)

- `cargo nextest run -p util` → **47 passed** (including the Windows-gated `is_file_contention_access_denied_windows`; the macOS-gated case is correctly filtered off Windows).
- `cargo xtask run util-tests` → **47 passed** (validates the new `build.yaml` target end-to-end).

## Scope

PR 2 of 3 for the orphan-test audit (PR 1 = #515 bridge→galoshes e2e; PR 3 = `tombstone` + a structural anti-orphan conformance guard).
