### PR TITLE
feat(tun-engine): leak-free fail-closed cover for the update cutover (#468)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,11 @@ before editing; the sections linked below are the authoritative source.
 - **Crash-recovery sweep.** `bridge-{routes,plugins,dns}.json` + ETW sessions are
   replayed/cleaned on next startup after the IPC socket binds. →
   [CONTRIBUTING.md#crash-recovery](CONTRIBUTING.md#crash-recovery)
+- **Fail-closed cover.** `Routing::install_failclosed_cover` engages a leak-free
+  egress block (permit loopback + server IP only) for the update cutover;
+  persistent WFP filters (Win) / self-contained pf ruleset (mac), swept by
+  `recover_routes` on next start. →
+  [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)
 - **Logging & plugin diagnostics.** Log destinations, the WebView2/console-relay
   tee, `HOLE_BRIDGE_LOG` directives, and the plugin tap. →
   [CONTRIBUTING.md#logging--diagnostics](CONTRIBUTING.md#logging--diagnostics)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,13 @@ socket binds; DNS recovery runs before route recovery so a mid-recovery crash
 leaves working DNS + broken routes, not the inverse):
 
 - **`bridge-routes.json`** — TUN name, server IP, upstream interface;
-  `routing::recover_routes` tears down leaked routes.
+  `routing::recover_routes` tears down leaked routes. The same call also sweeps a
+  stale [fail-closed cover](#fail-closed-cover) (Windows by fixed WFP GUID,
+  macOS via `bridge-failclosed.json`).
+- **`bridge-failclosed.json`** (macOS only) — the `pfctl -E` enable token of an
+  engaged fail-closed cover; `routing::failclosed::recover_cover` restores
+  `/etc/pf.conf` and drops the refcount. Windows keys its cover by fixed WFP
+  GUIDs and needs no file. See [Fail-closed cover](#fail-closed-cover).
 - **`bridge-plugins.json`** — plugin PIDs + start times;
   `plugin_recovery::recover_plugins` kills survivors (PID-reuse-safe).
 - **`bridge-dns.json`** — prior system DNS; `dns::recovery::recover_dns_config`
@@ -231,6 +237,40 @@ installed service `C:\ProgramData\hole\state\` / `/var/db/hole/state/`;
 
 If in-bridge recovery can't run, [`scripts/network-reset.py`](scripts/network-reset.py)
 performs equivalent cleanup from outside.
+
+### Fail-closed cover
+
+`Routing::install_failclosed_cover(server_ip)` engages a leak-free egress block —
+permit loopback and the SS server IP, **block everything else** — as an RAII
+guard whose `Drop` disengages it. It exists for the leak-free in-place-update
+cutover (#468): the bridge is briefly stopped and restarted onto new code, and
+without a cover the missing split routes would let traffic egress in the clear
+(Hole fails *open* — there is no kill switch). The cover holds the line during
+that window; a crash mid-cutover leaves traffic **blocked, not leaked**.
+
+It is **name-agnostic** — it does *not* permit the TUN interface. The new
+bridge's start-time DNS-forwarder self-test runs over loopback to the SS client
+and out to the server IP, so loopback + server-IP permits suffice; app traffic
+into the (briefly absent) tunnel being blocked for the sub-second cover window is
+the accepted fail-closed cost.
+
+- **Windows** ([`routing/failclosed/windows.rs`](crates/tun-engine/src/routing/failclosed/windows.rs)):
+  a persistent provider + sublayer + filter set installed in one FWPM
+  transaction on `ALE_AUTH_CONNECT_V4`/`_V6` (permit loopback + server IP *hard*
+  via `CLEAR_ACTION_RIGHT`, block all else). **Non-dynamic session** — a dynamic
+  session would auto-delete the filters when the engaging process exits, reopening
+  the leak mid-gap. Recovery deletes the fixed compiled-in GUIDs (idempotent), so
+  no state file is needed. The FWPM FFIs are clippy-disallowed outside this module.
+- **macOS** ([`routing/failclosed/macos.rs`](crates/tun-engine/src/routing/failclosed/macos.rs)):
+  `pfctl -E` (refcounted) + a self-contained ruleset loaded over stdin (`pfctl -Fa -f -`). Disengage restores `/etc/pf.conf` and drops the refcount (`pfctl -X <token>`). The token is persisted to `bridge-failclosed.json` *before* the
+  blocking ruleset loads, so recovery can `-X` it cleanly. Caveat: restore reloads
+  the on-disk `/etc/pf.conf`, not a snapshot of a live ruleset (matches wg-quick).
+
+Each platform splits a pure, unit-tested rule/spec builder (`build_cover_spec` /
+`build_pf_ruleset`) from the thin engage layer — mirroring `build_setup_commands`
+vs `run_commands`. The kernel-level engage is exercised by the privileged cutover
+path, not unit tests (the [#165](#bridge-test-isolation-contract) isolation
+contract). The recovery sweep runs on every bridge start via `recover_routes`.
 
 ### Config corruption recovery
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -194,3 +194,48 @@ reason = "Menu commits must go through `tray::rebuild_tray_menu` so rebuilds sta
 [[disallowed-methods]]
 path = "hole_common::config::AppConfig::save"
 reason = "Go through `ConfigStore::save` — direct saves bypass the #467 save_blocked gate and can destroy a quarantine-pending config.json. See bindreams/hole#467."
+
+# tun-engine fail-closed cover — WFP/FWPM native FFI -------------------------------------------------------------------
+#
+# The Windows Filtering Platform FFIs must only be called from inside the
+# fail-closed cover impl (`crates/tun-engine/src/routing/failclosed/windows.rs`)
+# and its recovery sweep, so unit tests exercise only the pure `build_cover_spec`
+# data builder — never the host firewall (the #165 isolation contract). The
+# sanctioned call sites carry per-site `#[allow(clippy::disallowed_methods)]`.
+# `allow-invalid = true` because only tun-engine wires the WFP feature; other
+# workspace crates can't resolve the path (mirrors the Win32 DNS-FFI block).
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmEngineOpen0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`/`recover_cover`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFilterAdd0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmProviderAdd0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmSubLayerAdd0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFilterDeleteByKey0"
+reason = "Fail-closed WFP cover teardown must go through `routing::failclosed` (Drop / recover_cover). Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmSubLayerDeleteByKey0"
+reason = "Fail-closed WFP cover teardown must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmProviderDeleteByKey0"
+reason = "Fail-closed WFP cover teardown must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -239,3 +239,23 @@ allow-invalid = true
 path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmProviderDeleteByKey0"
 reason = "Fail-closed WFP cover teardown must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
 allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmEngineClose0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionBegin0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionCommit0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionAbort0"
+reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
+allow-invalid = true

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -107,6 +107,7 @@ impl StubRouting {
 
 impl Routing for StubRouting {
     type Installed = StubRoutes;
+    type Cover = StubCover;
     fn install(&self, _: &str, _: IpAddr, _: IpAddr, _: &str) -> Result<StubRoutes, RoutingError> {
         Ok(StubRoutes {
             _state_dir: self.state_dir.clone(),
@@ -120,11 +121,20 @@ impl Routing for StubRouting {
             ipv6_available: false,
         })
     }
+    fn install_failclosed_cover(&self, _: IpAddr) -> Result<StubCover, RoutingError> {
+        Ok(StubCover)
+    }
 }
 
 struct StubRoutes {
     // Unused; held only to mirror production's state-dir-owning routes type.
     _state_dir: PathBuf,
+}
+
+struct StubCover;
+
+impl Drop for StubCover {
+    fn drop(&mut self) {}
 }
 
 fn test_socket_path(suffix: &str) -> PathBuf {

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -198,6 +198,18 @@ impl Routing for MockRouting {
             ipv6_available: false,
         })
     }
+
+    type Cover = MockCover;
+
+    fn install_failclosed_cover(&self, _server_ip: IpAddr) -> Result<MockCover, RoutingError> {
+        Ok(MockCover)
+    }
+}
+
+struct MockCover;
+
+impl Drop for MockCover {
+    fn drop(&mut self) {}
 }
 
 struct MockRoutes {

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -166,6 +166,8 @@ struct MockRoutingState {
     teardown_calls: AtomicU32,
     fail_install: AtomicBool,
     fail_gateway: AtomicBool,
+    cover_engage_calls: AtomicU32,
+    cover_disengage_calls: AtomicU32,
 }
 
 impl Default for MockRoutingState {
@@ -175,6 +177,8 @@ impl Default for MockRoutingState {
             teardown_calls: AtomicU32::new(0),
             fail_install: AtomicBool::new(false),
             fail_gateway: AtomicBool::new(false),
+            cover_engage_calls: AtomicU32::new(0),
+            cover_disengage_calls: AtomicU32::new(0),
         }
     }
 }
@@ -264,6 +268,15 @@ impl Routing for MockRouting {
             ipv6_available: false,
         })
     }
+
+    type Cover = MockCover;
+
+    fn install_failclosed_cover(&self, _server_ip: IpAddr) -> Result<MockCover, RoutingError> {
+        self.state.cover_engage_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(MockCover {
+            state: Arc::clone(&self.state),
+        })
+    }
 }
 
 struct MockRoutes {
@@ -275,6 +288,16 @@ impl Drop for MockRoutes {
     fn drop(&mut self) {
         self.state.teardown_calls.fetch_add(1, Ordering::SeqCst);
         let _ = route_state::clear(&self.state_dir);
+    }
+}
+
+struct MockCover {
+    state: Arc<MockRoutingState>,
+}
+
+impl Drop for MockCover {
+    fn drop(&mut self) {
+        self.state.cover_disengage_calls.fetch_add(1, Ordering::SeqCst);
     }
 }
 
@@ -707,6 +730,27 @@ fn proxy_manager_tests_never_spawn_routing_subprocess() {
         count, 0,
         "proxy_manager tests must not spawn routing subprocesses (regression of #165)"
     );
+}
+
+/// The fail-closed cover path must also never spawn a real routing subprocess
+/// from a mock — the #165 isolation contract extends to the cover. Engage +
+/// drop N covers through the mock and assert zero spawns and balanced
+/// engage/disengage counts.
+#[skuld::test(serial)]
+fn mock_cover_engage_disengage_never_spawns() {
+    routing::ROUTING_SUBPROCESS_SPAWN_COUNT.store(0, Ordering::SeqCst);
+
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let st = routing.state();
+    for _ in 0..10 {
+        let cover = routing.install_failclosed_cover("1.2.3.4".parse().unwrap()).unwrap();
+        drop(cover);
+    }
+
+    assert_eq!(routing::ROUTING_SUBPROCESS_SPAWN_COUNT.load(Ordering::SeqCst), 0);
+    assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 10);
+    assert_eq!(st.cover_disengage_calls.load(Ordering::SeqCst), 10);
 }
 
 // last_error coverage for early-failure paths =========================================================================

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -51,7 +51,13 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",
+    "Win32_NetworkManagement_WindowsFilteringPlatform",
     "Win32_Networking_WinSock",
+    # FWPM filter/value/condition structs (FWPM_FILTER0, FWP_VALUE0,
+    # FWP_CONDITION_VALUE0) and FwpmFilterAdd0 are gated behind Win32_Security.
+    "Win32_Security",
+    # RPC_C_AUTHN_WINNT for FwpmEngineOpen0's session auth.
+    "Win32_System_Rpc",
 ] }
 # Pinned to the same minor version that shadowsocks-service 1.24 uses
 # transitively (via tun-0.8.6) so cargo deduplicates the crate.

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -189,63 +189,70 @@ pub(crate) fn run_capturing(
 /// are logged at `warn` level and the function returns `()` (there is no
 /// meaningful caller recovery).
 pub fn recover_routes(state_dir: &Path) {
-    recover_routes_with(state_dir, run_commands);
+    recover_routes_with(state_dir, run_commands, failclosed::recover_cover);
 }
 
-/// Test seam for [`recover_routes`]: accepts an injected command runner so
-/// unit tests can assert on the emitted commands without shelling out to
-/// `netsh`/`route`.
-pub(crate) fn recover_routes_with<R>(state_dir: &Path, runner: R)
+/// Test seam for [`recover_routes`]: accepts an injected command runner and an
+/// injected cover-recovery sweep so unit tests can assert behavior without
+/// shelling out to `netsh`/`route` or touching the host firewall. Production
+/// passes `run_commands` and [`failclosed::recover_cover`].
+pub(crate) fn recover_routes_with<R, S>(state_dir: &Path, runner: R, sweep_cover: S)
 where
     R: Fn(&[Vec<String>], &str) -> std::io::Result<()>,
+    S: FnOnce(&Path),
 {
     info!(state_dir = %state_dir.display(), "starting route recovery");
 
-    // Read the state file first. If absent, there's nothing to recover —
-    // return early without poking any global routing state.
+    // Route recovery is guarded by the route-state file. Its absence means the
+    // previous run installed no routes (the write-ordering contract persists
+    // state BEFORE any route mutation), so we skip route teardown.
     //
     // State-file-driven recovery (not unconditional split-route teardown)
     // is required so concurrent bridge subprocesses don't rip routes out
     // from under each other: a SOCKS5-only bridge unconditionally issuing
     // `netsh delete route ... hole-tun` on startup would tear down the
-    // routes of a concurrent TUN bridge mid-flight. The caller's
-    // write-ordering contract guarantees the state file is persisted
-    // BEFORE any route mutation, so a crashed run that installed routes
-    // MUST have left a state file behind.
-    let Some(st) = state::load(state_dir) else {
+    // routes of a concurrent TUN bridge mid-flight.
+    if let Some(st) = state::load(state_dir) {
+        info!(
+            tun = %st.tun_name,
+            server_ip = %st.server_ip,
+            iface = %st.interface_name,
+            "recovering routes from crashed run"
+        );
+
+        // 1. Split routes (IPv4 + IPv6 halves). Idempotent — harmless if
+        //    absent. Runs under state-file guard so this only fires when we
+        //    have positive evidence of a prior route install. Uses the TUN
+        //    name persisted in the state file (the caller controls this —
+        //    tun-engine has no opinion on naming).
+        let split_cmds = build_split_route_teardown_commands(&st.tun_name);
+        if let Err(e) = runner(&split_cmds, PHASE_RECOVER_SPLIT) {
+            warn!(error = %e, "split-route teardown failed during recovery");
+        }
+
+        // 2. Per-server bypass route recorded in the state file.
+        let bypass_cmds = build_teardown_commands(&st.tun_name, st.server_ip, &st.interface_name);
+        if let Err(e) = runner(&bypass_cmds, PHASE_RECOVER_BYPASS) {
+            warn!(error = %e, "bypass-route teardown failed during recovery");
+        }
+
+        // 3. Delete the state file regardless of command outcomes. Next
+        //    startup re-runs the idempotent teardown if anything leaked
+        //    past a failure.
+        if let Err(e) = state::clear(state_dir) {
+            warn!(error = %e, "failed to clear route-state file during recovery");
+        }
+    } else {
         debug!("no route-state file found, nothing to recover");
-        return;
-    };
-
-    info!(
-        tun = %st.tun_name,
-        server_ip = %st.server_ip,
-        iface = %st.interface_name,
-        "recovering routes from crashed run"
-    );
-
-    // 1. Split routes (IPv4 + IPv6 halves). Idempotent — harmless if
-    //    absent. Runs under state-file guard so this only fires when we
-    //    have positive evidence of a prior route install. Uses the TUN
-    //    name persisted in the state file (the caller controls this —
-    //    tun-engine has no opinion on naming).
-    let split_cmds = build_split_route_teardown_commands(&st.tun_name);
-    if let Err(e) = runner(&split_cmds, PHASE_RECOVER_SPLIT) {
-        warn!(error = %e, "split-route teardown failed during recovery");
     }
 
-    // 2. Per-server bypass route recorded in the state file.
-    let bypass_cmds = build_teardown_commands(&st.tun_name, st.server_ip, &st.interface_name);
-    if let Err(e) = runner(&bypass_cmds, PHASE_RECOVER_BYPASS) {
-        warn!(error = %e, "bypass-route teardown failed during recovery");
-    }
-
-    // 3. Delete the state file regardless of command outcomes. Next
-    //    startup re-runs the idempotent teardown if anything leaked
-    //    past a failure.
-    if let Err(e) = state::clear(state_dir) {
-        warn!(error = %e, "failed to clear route-state file during recovery");
-    }
+    // Sweep any fail-closed cover left by a crashed update cutover. Runs
+    // UNCONDITIONALLY (outside the route-state guard above): a crash can leave a
+    // cover engaged with the routes already torn down, so there is no
+    // bridge-routes.json, yet the cover persists. The cover is keyed
+    // independently — Windows by fixed WFP GUIDs, macOS by bridge-failclosed.json
+    // — and the sweep is idempotent when no cover is present.
+    sweep_cover(state_dir);
 }
 
 // Routing trait =======================================================================================================
@@ -297,6 +304,20 @@ pub trait Routing: Send + Sync {
     /// seam, every consumer unit test would depend on the host having a
     /// route to the Internet.
     fn default_gateway(&self) -> Result<GatewayInfo, RoutingError>;
+
+    /// RAII guard returned by [`install_failclosed_cover`](Self::install_failclosed_cover).
+    /// Dropping it disengages the fail-closed cover. `Send` so a cutover
+    /// coordinator can hold it across `.await`.
+    type Cover: Send;
+
+    /// Engage a fail-closed cover: block all egress except loopback and
+    /// `server_ip`. Returns an RAII guard whose Drop disengages it. The cover
+    /// survives a process crash (Windows: persistent WFP filters keyed by fixed
+    /// GUID; macOS: pf enable token persisted to `bridge-failclosed.json`) and
+    /// is swept by [`recover_routes`] on the next start. Name-agnostic — it does
+    /// NOT permit the TUN interface (the cover only needs loopback + server IP
+    /// for the new bridge's start-time self-test); see the #468 PR2 plan.
+    fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<Self::Cover, RoutingError>;
 }
 
 // System (production) routing =========================================================================================
@@ -316,6 +337,7 @@ impl SystemRouting {
 
 impl Routing for SystemRouting {
     type Installed = SystemRoutes;
+    type Cover = failclosed::Cover;
 
     fn install(
         &self,
@@ -361,6 +383,10 @@ impl Routing for SystemRouting {
 
     fn default_gateway(&self) -> Result<GatewayInfo, RoutingError> {
         get_default_gateway_info().map_err(|e| RoutingError::Gateway(e.to_string()))
+    }
+
+    fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<Self::Cover, RoutingError> {
+        failclosed::engage(server_ip, &self.state_dir)
     }
 }
 

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -1,5 +1,6 @@
 //! Route table management — platform-specific split routing.
 
+pub mod failclosed;
 pub mod state;
 
 use std::net::IpAddr;
@@ -56,6 +57,13 @@ pub(crate) const PHASE_SETUP: &str = "setup";
 pub(crate) const PHASE_TEARDOWN: &str = "teardown";
 pub(crate) const PHASE_RECOVER_SPLIT: &str = "recover-split";
 pub(crate) const PHASE_RECOVER_BYPASS: &str = "recover-bypass";
+pub(crate) const PHASE_RECOVER_COVER: &str = "recover-cover";
+// macOS-only: the pf cover engages via `pfctl` subprocesses (Windows engages
+// via FWPM FFI — no subprocess phase). Gated so it is not dead code on a
+// non-test Windows lib build under `-D warnings`. `PHASE_RECOVER_COVER` stays
+// all-targets because `is_recovery_phase` references it on every platform.
+#[cfg(target_os = "macos")]
+pub(crate) const PHASE_COVER: &str = "cover-engage";
 
 /// Execute route setup commands. Logs each command and its result.
 pub fn setup_routes(
@@ -97,7 +105,10 @@ pub(crate) fn build_split_route_teardown_commands(tun_name: &str) -> Vec<Vec<Str
 /// Adding a new `PHASE_*` constant that should silently tolerate non-zero
 /// exit codes MUST be paired with a matching arm here.
 fn is_recovery_phase(phase: &str) -> bool {
-    matches!(phase, PHASE_RECOVER_SPLIT | PHASE_RECOVER_BYPASS | PHASE_TEARDOWN)
+    matches!(
+        phase,
+        PHASE_RECOVER_SPLIT | PHASE_RECOVER_BYPASS | PHASE_TEARDOWN | PHASE_RECOVER_COVER
+    )
 }
 
 fn run_commands(commands: &[Vec<String>], phase: &str) -> std::io::Result<()> {
@@ -136,6 +147,34 @@ fn run_commands(commands: &[Vec<String>], phase: &str) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Run a single command, feeding `stdin` if present and returning the full
+/// `Output` so callers can parse stdout/stderr. Increments
+/// [`ROUTING_SUBPROCESS_SPAWN_COUNT`] (the no-spawn invariant covers cover
+/// engage too). Used by the macOS pf cover; not for route commands.
+#[cfg(target_os = "macos")]
+pub(crate) fn run_capturing(
+    cmd: &[String],
+    stdin: Option<&[u8]>,
+    phase: &str,
+) -> std::io::Result<std::process::Output> {
+    use std::io::Write;
+    use std::process::Stdio;
+    debug_assert!(!cmd.is_empty(), "command must not be empty");
+    ROUTING_SUBPROCESS_SPAWN_COUNT.fetch_add(1, Ordering::SeqCst);
+    info!(phase, cmd = cmd.join(" "), "running cover command");
+    let mut child = Command::new(&cmd[0])
+        .args(&cmd[1..])
+        .stdin(if stdin.is_some() { Stdio::piped() } else { Stdio::null() })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    if let Some(bytes) = stdin {
+        child.stdin.take().expect("piped stdin").write_all(bytes)?;
+        // stdin dropped here -> EOF to the child.
+    }
+    child.wait_with_output()
 }
 
 // Crash recovery ======================================================================================================

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -1,0 +1,49 @@
+//! Fail-closed network cover: block all egress except loopback and the SS
+//! server IP, as an RAII guard. Used by the update cutover (PR3) to keep the
+//! tunnel leak-free during the brief bridge restart. OS specifics live in the
+//! platform submodules; this facade is `#[cfg]`-free for callers.
+
+use std::net::IpAddr;
+use std::path::Path;
+
+use crate::error::RoutingError;
+
+// macOS persists its pf enable token; Windows recovers WFP filters by fixed
+// GUID and needs no state.
+#[cfg(target_os = "macos")]
+pub mod failclosed_state;
+
+#[cfg(target_os = "windows")]
+#[path = "failclosed/windows.rs"]
+mod platform;
+
+#[cfg(target_os = "macos")]
+#[path = "failclosed/macos.rs"]
+mod platform;
+
+/// RAII guard for an engaged fail-closed cover. Dropping it disengages the
+/// cover (Windows: delete the WFP filters by GUID; macOS: restore
+/// `/etc/pf.conf` and drop the pf enable refcount). `Send` so the PR3 cutover
+/// coordinator can hold it across `.await`.
+//
+// `platform::Cover` carries its own `Drop`; the field-drop runs it. No
+// explicit `Drop for Cover` needed.
+pub struct Cover {
+    #[allow(dead_code)] // engaged only by PR3's cutover; PR2 has no production caller
+    inner: platform::Cover,
+}
+
+/// Engage the cover blocking all egress except loopback and `server_ip`.
+/// `state_dir` is where macOS persists its enable token for crash recovery
+/// (unused on Windows). On failure the host is left uncovered.
+pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError> {
+    Ok(Cover {
+        inner: platform::engage(server_ip, state_dir)?,
+    })
+}
+
+/// Sweep a cover left behind by a crashed run. Idempotent — a no-op when no
+/// cover is present. Called from `routing::recover_routes` at bridge startup.
+pub fn recover_cover(state_dir: &Path) {
+    platform::recover_cover(state_dir);
+}

--- a/crates/tun-engine/src/routing/failclosed/failclosed_state.rs
+++ b/crates/tun-engine/src/routing/failclosed/failclosed_state.rs
@@ -1,0 +1,95 @@
+//! Persisted fail-closed-cover state for crash recovery (macOS only).
+//!
+//! macOS engages the cover by enabling pf with `pfctl -E`, which returns a
+//! reference-count token. We persist that token BEFORE loading the blocking
+//! ruleset so a crashed update cutover can be cleanly reversed on the next
+//! bridge start (`recover_cover`: restore `/etc/pf.conf` + `pfctl -X <token>`).
+//! Windows needs no analogue: its WFP filters carry fixed GUIDs and are swept
+//! by key, so there is nothing to persist.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version for [`FailClosedState`]. Bumped on backwards-incompatible
+/// changes; [`load`] discards a mismatched file rather than risk a corrupt
+/// recovery.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Filename under `state_dir`. Distinct from `bridge-routes.json` because the
+/// cover lifecycle is independent of the route lifecycle (a cover is active
+/// precisely while routes are down, mid-cutover).
+pub const STATE_FILE_NAME: &str = "bridge-failclosed.json";
+
+/// pf state captured at cover-engage time, persisted before the blocking
+/// ruleset is loaded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FailClosedState {
+    pub version: u32,
+    /// Opaque enable token returned by `pfctl -E`, replayed to `pfctl -X` on
+    /// recovery. Stored as a string — it is an opaque handle, not arithmetic.
+    pub pf_token: String,
+    /// Whether pf reported `Status: Enabled` before we engaged. Diagnostic;
+    /// recovery restores `/etc/pf.conf` and drops our refcount regardless.
+    pub pf_was_enabled: bool,
+}
+
+fn state_file(state_dir: &Path) -> PathBuf {
+    state_dir.join(STATE_FILE_NAME)
+}
+
+/// Atomically persist `state` to `<state_dir>/bridge-failclosed.json` (temp
+/// file + same-dir rename, `sync_all` before persist). Creates `state_dir`.
+pub fn save(state_dir: &Path, state: &FailClosedState) -> std::io::Result<()> {
+    std::fs::create_dir_all(state_dir)?;
+    let json = serde_json::to_vec_pretty(state).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(state_dir)?;
+    tmp.write_all(&json)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(state_file(state_dir)).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Load the state file, or `None` on any error (absent / corrupt / unknown
+/// field / version mismatch); logs at `warn`. Recovery is best-effort.
+pub fn load(state_dir: &Path) -> Option<FailClosedState> {
+    let path = state_file(state_dir);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "failclosed-state read failed");
+            return None;
+        }
+    };
+    match serde_json::from_slice::<FailClosedState>(&bytes) {
+        Ok(s) if s.version == SCHEMA_VERSION => Some(s),
+        Ok(other) => {
+            tracing::warn!(
+                got = other.version,
+                want = SCHEMA_VERSION,
+                "failclosed-state schema mismatch, discarding"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "failclosed-state parse failed");
+            None
+        }
+    }
+}
+
+/// Delete the state file; tolerates absence (`Ok`). `Err` only on real I/O error.
+pub fn clear(state_dir: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(state_file(state_dir)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+#[path = "failclosed_state_tests.rs"]
+mod failclosed_state_tests;

--- a/crates/tun-engine/src/routing/failclosed/failclosed_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/failclosed_state_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[skuld::test]
+fn save_then_load_roundtrips() {
+    let tmp = tempfile::tempdir().unwrap();
+    let st = FailClosedState {
+        version: SCHEMA_VERSION,
+        pf_token: "1234567890".into(),
+        pf_was_enabled: true,
+    };
+    save(tmp.path(), &st).unwrap();
+    assert_eq!(load(tmp.path()), Some(st));
+}
+
+#[skuld::test]
+fn load_absent_is_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(load(tmp.path()), None);
+}
+
+#[skuld::test]
+fn load_rejects_schema_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let st = FailClosedState {
+        version: SCHEMA_VERSION + 1,
+        pf_token: "1".into(),
+        pf_was_enabled: false,
+    };
+    // `save` writes whatever version the struct carries, so this fabricates a
+    // future-version file on disk.
+    save(tmp.path(), &st).unwrap();
+    assert_eq!(load(tmp.path()), None, "future schema must be discarded");
+}
+
+#[skuld::test]
+fn clear_removes_file_and_tolerates_absence() {
+    let tmp = tempfile::tempdir().unwrap();
+    let st = FailClosedState {
+        version: SCHEMA_VERSION,
+        pf_token: "9".into(),
+        pf_was_enabled: false,
+    };
+    save(tmp.path(), &st).unwrap();
+    assert!(tmp.path().join(STATE_FILE_NAME).exists());
+    clear(tmp.path()).unwrap();
+    assert!(!tmp.path().join(STATE_FILE_NAME).exists());
+    clear(tmp.path()).unwrap(); // second clear is a no-op, not an error
+}

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -97,12 +97,14 @@ pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError
     let out = pfctl(&["-Fa", "-f", "-"], Some(ruleset.as_bytes()), PHASE_COVER)?;
     if !out.status.success() {
         // A *failed engage* is the sole place this module fails OPEN on its own
-        // error: we must not leave a half-loaded ruleset blocking traffic, so we
-        // roll back (drop our refcount, clear the file) and report the error up.
-        // The PR3 cutover treats an engage error as fatal and aborts before
-        // stopping the old bridge, so the tunnel is never torn down uncovered.
-        let _ = pfctl(&["-X", &token], None, PHASE_RECOVER_COVER);
-        let _ = state::clear(state_dir);
+        // error: we must not leave a half-loaded ruleset blocking traffic. Note
+        // `-Fa` already flushed the host's prior rules, so a full `disengage`
+        // (restore `/etc/pf.conf` + drop our refcount + clear the state file) is
+        // required to undo the flush — dropping only the refcount would strand
+        // the host with an empty pass-all ruleset. The PR3 cutover treats an
+        // engage error as fatal and aborts before stopping the old bridge, so
+        // the tunnel is never torn down uncovered.
+        disengage(&token, state_dir);
         return Err(RoutingError::RouteSetup(format!(
             "pfctl load failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -1,0 +1,152 @@
+//! macOS fail-closed cover via pf (`pfctl`).
+//!
+//! Engage enables pf (refcounted, `pfctl -E`), flushes all state, and loads a
+//! self-contained ruleset that blocks every outbound packet except loopback
+//! and the SS server IP. Disengage restores the canonical `/etc/pf.conf` and
+//! drops our enable refcount (`pfctl -X <token>`).
+//!
+//! Documented caveats (pf has no programmatic API — `pfctl` text I/O IS the
+//! interface, as `netsh`/`route` are for routing):
+//! - Restore reloads the on-disk `/etc/pf.conf`, not a snapshot of whatever
+//!   ruleset was live before us (matches wg-quick's macOS behavior).
+//! - The `pfctl -E` token is parsed from stderr — its only exposure.
+
+use std::net::IpAddr;
+use std::path::Path;
+
+use super::super::{run_capturing, PHASE_COVER, PHASE_RECOVER_COVER};
+use crate::error::RoutingError;
+// `macos.rs` is mounted as `mod platform` under `failclosed`, so `super` is the
+// `failclosed` module and `failclosed_state` is its sibling child.
+use super::failclosed_state as state;
+
+/// Build the self-contained pf ruleset (loaded via `pfctl -f -`).
+///
+/// `set block-policy drop` silently drops blocked packets (no RST/ICMP).
+/// `block out all` is the fail-closed default; the `quick` pass rules for
+/// loopback and the server IP win without depending on pf's last-match rule.
+pub fn build_pf_ruleset(server_ip: IpAddr) -> String {
+    format!(
+        "set block-policy drop\n\
+         block out all\n\
+         pass out quick on lo0 all\n\
+         pass in quick on lo0 all\n\
+         pass out quick from any to {server_ip}\n"
+    )
+}
+
+/// Parse the enable token from `pfctl -E` output (it prints `Token : <n>`).
+pub fn parse_enable_token(output: &str) -> Option<String> {
+    output
+        .lines()
+        .find_map(|l| l.split_once("Token :").map(|(_, t)| t.trim().to_owned()))
+        .filter(|t| !t.is_empty())
+}
+
+/// Parse `pfctl -s info` for the `Status: Enabled` line.
+pub fn parse_pf_enabled(output: &str) -> bool {
+    output
+        .lines()
+        .any(|l| l.trim_start().starts_with("Status:") && l.contains("Enabled"))
+}
+
+// --- engage layer ---
+
+const PFCONF: &str = "/etc/pf.conf";
+
+fn pfctl(args: &[&str], stdin: Option<&[u8]>, phase: &str) -> Result<std::process::Output, RoutingError> {
+    let cmd: Vec<String> = std::iter::once("pfctl")
+        .chain(args.iter().copied())
+        .map(str::to_owned)
+        .collect();
+    run_capturing(&cmd, stdin, phase).map_err(|e| RoutingError::RouteSetup(format!("pfctl spawn failed: {e}")))
+}
+
+/// pf-backed cover guard. Drop restores `/etc/pf.conf` and drops our enable
+/// refcount.
+pub struct Cover {
+    token: String,
+    state_dir: std::path::PathBuf,
+}
+
+pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError> {
+    // 1. Read current enabled-state (read-only).
+    let info = pfctl(&["-s", "info"], None, PHASE_COVER)?;
+    let was_enabled = parse_pf_enabled(&String::from_utf8_lossy(&info.stdout));
+
+    // 2. Enable pf (refcounted) and capture the token.
+    let en = pfctl(&["-E"], None, PHASE_COVER)?;
+    let token = parse_enable_token(&String::from_utf8_lossy(&en.stderr))
+        .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
+        .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))?;
+
+    // 3. Persist BEFORE loading the blocking ruleset (persist-before-mutate),
+    //    so a crash after this point is recoverable (`pfctl -X <token>`).
+    state::save(
+        state_dir,
+        &state::FailClosedState {
+            version: state::SCHEMA_VERSION,
+            pf_token: token.clone(),
+            pf_was_enabled: was_enabled,
+        },
+    )
+    .map_err(|e| RoutingError::RouteSetup(format!("failed to persist failclosed-state: {e}")))?;
+
+    // 4. Flush all + load our self-contained blocking ruleset from stdin.
+    let ruleset = build_pf_ruleset(server_ip);
+    let out = pfctl(&["-Fa", "-f", "-"], Some(ruleset.as_bytes()), PHASE_COVER)?;
+    if !out.status.success() {
+        // A *failed engage* is the sole place this module fails OPEN on its own
+        // error: we must not leave a half-loaded ruleset blocking traffic, so we
+        // roll back (drop our refcount, clear the file) and report the error up.
+        // The PR3 cutover treats an engage error as fatal and aborts before
+        // stopping the old bridge, so the tunnel is never torn down uncovered.
+        let _ = pfctl(&["-X", &token], None, PHASE_RECOVER_COVER);
+        let _ = state::clear(state_dir);
+        return Err(RoutingError::RouteSetup(format!(
+            "pfctl load failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+
+    Ok(Cover {
+        token,
+        state_dir: state_dir.to_owned(),
+    })
+}
+
+impl Drop for Cover {
+    fn drop(&mut self) {
+        disengage(&self.token, &self.state_dir);
+    }
+}
+
+/// Restore the canonical ruleset, drop our enable refcount, clear the file.
+/// Best-effort; logs on failure. Shared by `Drop` and `recover_cover`.
+fn disengage(token: &str, state_dir: &Path) {
+    if let Err(e) = pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER) {
+        tracing::warn!(error = %e, "pf ruleset restore failed during cover disengage");
+    }
+    if let Err(e) = pfctl(&["-X", token], None, PHASE_RECOVER_COVER) {
+        tracing::warn!(error = %e, "pfctl -X failed during cover disengage");
+    }
+    if let Err(e) = state::clear(state_dir) {
+        tracing::warn!(error = %e, "failclosed-state clear failed during cover disengage");
+    }
+}
+
+pub fn recover_cover(state_dir: &Path) {
+    let Some(st) = state::load(state_dir) else {
+        tracing::debug!("no failclosed-state file, nothing to recover");
+        return;
+    };
+    tracing::info!(
+        was_enabled = st.pf_was_enabled,
+        "recovering fail-closed cover from crashed run"
+    );
+    disengage(&st.pf_token, state_dir);
+}
+
+#[cfg(test)]
+#[path = "macos_tests.rs"]
+mod macos_tests;

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+use std::net::IpAddr;
+
+fn v4() -> IpAddr {
+    "203.0.113.7".parse().unwrap()
+}
+fn v6() -> IpAddr {
+    "2001:db8::1".parse().unwrap()
+}
+
+#[skuld::test]
+fn ruleset_blocks_all_outbound() {
+    let r = build_pf_ruleset(v4());
+    assert!(
+        r.contains("block") && r.contains("out") && r.contains("all"),
+        "ruleset must block all outbound:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn ruleset_passes_loopback() {
+    let r = build_pf_ruleset(v4());
+    assert!(r.contains("lo0"), "ruleset must pass loopback:\n{r}");
+}
+
+#[skuld::test]
+fn ruleset_passes_server_ip() {
+    let r = build_pf_ruleset(v4());
+    assert!(r.contains("203.0.113.7"), "ruleset must pass server IP:\n{r}");
+}
+
+#[skuld::test]
+fn ruleset_pass_rules_are_quick() {
+    // `quick` makes the pass rules win over the earlier block-all without
+    // relying on pf's last-match semantics.
+    let r = build_pf_ruleset(v4());
+    for line in r.lines().filter(|l| l.trim_start().starts_with("pass")) {
+        assert!(line.contains("quick"), "pass rule must be quick: {line}");
+    }
+}
+
+#[skuld::test]
+fn ruleset_handles_ipv6_server() {
+    let r = build_pf_ruleset(v6());
+    assert!(r.contains("2001:db8::1"), "ipv6 server must appear:\n{r}");
+}
+
+#[skuld::test]
+fn parse_enable_token_extracts_token() {
+    // `pfctl -E` prints to stderr e.g. "pf enabled\nToken : 12345678901234567890\n"
+    let out = "pf enabled\nToken : 12345678901234567890\n";
+    assert_eq!(parse_enable_token(out).as_deref(), Some("12345678901234567890"));
+}
+
+#[skuld::test]
+fn parse_enable_token_none_when_absent() {
+    assert_eq!(parse_enable_token("pf already enabled\n"), None);
+}
+
+#[skuld::test]
+fn parse_pf_enabled_reads_status() {
+    assert!(parse_pf_enabled("Status: Enabled for 0 days...\n"));
+    assert!(!parse_pf_enabled("Status: Disabled\n"));
+}

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -1,0 +1,384 @@
+//! Windows fail-closed cover via the Windows Filtering Platform (WFP/FWPM).
+//!
+//! Engage installs a persistent provider + sublayer + filter set in one FWPM
+//! transaction: permit loopback (hard) and the SS server IP (hard) on
+//! `ALE_AUTH_CONNECT_V4`/`_V6`, block everything else. Persistent (boot-time)
+//! filters — NOT a dynamic session — so a coordinator crash mid-cutover leaves
+//! traffic blocked (fail-closed), not leaked; `recover_cover` sweeps them by
+//! their fixed GUIDs on the next bridge start.
+
+use std::net::IpAddr;
+use std::path::Path;
+
+use windows::core::{GUID, PCWSTR, PWSTR};
+use windows::Win32::Foundation::{ERROR_SUCCESS, HANDLE};
+use windows::Win32::NetworkManagement::WindowsFilteringPlatform::*;
+use windows::Win32::System::Rpc::RPC_C_AUTHN_WINNT;
+
+use crate::error::RoutingError;
+
+// Fixed Hole identifiers. Compiled in so recovery can delete by key with no
+// persisted runtime state. Generated once; never reuse for anything else.
+pub const PROVIDER_GUID: GUID = GUID::from_u128(0xa3f1c2d4_5b6e_47a8_9c0d_1e2f3a4b5c6d);
+pub const SUBLAYER_GUID: GUID = GUID::from_u128(0xb4e2d3c5_6c7f_58b9_ad1e_2f3a4b5c6d7e);
+// Six fixed filter GUIDs — recovery deletes all six unconditionally
+// (idempotent), so the set is deterministic regardless of server family.
+pub const FILTER_GUIDS: [GUID; 6] = [
+    GUID::from_u128(0xc5f3e4d6_7d80_69ca_be2f_3a4b5c6d7e8f), // loopback V4
+    GUID::from_u128(0xd6041507_8e91_7adb_cf30_4b5c6d7e8f90), // loopback V6
+    GUID::from_u128(0xe7152618_9fa2_8bec_d041_5c6d7e8f9001), // server V4
+    GUID::from_u128(0xf8263729_a0b3_9cfd_e152_6d7e8f900112), // server V6
+    GUID::from_u128(0x0937483a_b1c4_ad0e_f263_7e8f90011223), // block-all V4
+    GUID::from_u128(0x1a48594b_c2d5_be1f_0374_8f9001122334), // block-all V6
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Layer {
+    ConnectV4,
+    ConnectV6,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    Permit,
+    Block,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Condition {
+    /// Match the WFP loopback flag (`FWP_CONDITION_FLAG_IS_LOOPBACK`).
+    Loopback,
+    /// Match a single remote host address (`FWPM_CONDITION_IP_REMOTE_ADDRESS`).
+    RemoteIp(IpAddr),
+    /// No condition — matches every connect at the layer (block-all).
+    Any,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FilterSpec {
+    pub guid: GUID,
+    pub layer: Layer,
+    pub action: Action,
+    pub condition: Condition,
+    /// FWPM filter weight (0..=15). Permits get 15, block gets 0; higher
+    /// weight wins within our sublayer.
+    pub weight: u8,
+    /// `FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT` — a hard permit no lower-priority
+    /// sublayer can veto. Set on permits, not on block.
+    pub hard: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoverSpec {
+    pub provider: GUID,
+    pub sublayer: GUID,
+    pub filters: Vec<FilterSpec>,
+}
+
+/// Filter weight (0..=15) for the hard permits — higher than [`BLOCK_WEIGHT`]
+/// so loopback/server-IP permits win over block-all within our sublayer.
+pub const PERMIT_WEIGHT: u8 = 15;
+/// Filter weight for the block-all filters.
+pub const BLOCK_WEIGHT: u8 = 0;
+
+/// Build the data description of the fail-closed cover for `server_ip`.
+/// Pure — no FFI; the engage layer (`engage`) submits this in one transaction.
+pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
+    let server_layer = match server_ip {
+        IpAddr::V4(_) => Layer::ConnectV4,
+        IpAddr::V6(_) => Layer::ConnectV6,
+    };
+    let filters = vec![
+        FilterSpec {
+            guid: FILTER_GUIDS[0],
+            layer: Layer::ConnectV4,
+            action: Action::Permit,
+            condition: Condition::Loopback,
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        FilterSpec {
+            guid: FILTER_GUIDS[1],
+            layer: Layer::ConnectV6,
+            action: Action::Permit,
+            condition: Condition::Loopback,
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        FilterSpec {
+            guid: if server_layer == Layer::ConnectV4 {
+                FILTER_GUIDS[2]
+            } else {
+                FILTER_GUIDS[3]
+            },
+            layer: server_layer,
+            action: Action::Permit,
+            condition: Condition::RemoteIp(server_ip),
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        FilterSpec {
+            guid: FILTER_GUIDS[4],
+            layer: Layer::ConnectV4,
+            action: Action::Block,
+            condition: Condition::Any,
+            weight: BLOCK_WEIGHT,
+            hard: false,
+        },
+        FilterSpec {
+            guid: FILTER_GUIDS[5],
+            layer: Layer::ConnectV6,
+            action: Action::Block,
+            condition: Condition::Any,
+            weight: BLOCK_WEIGHT,
+            hard: false,
+        },
+    ];
+    CoverSpec {
+        provider: PROVIDER_GUID,
+        sublayer: SUBLAYER_GUID,
+        filters,
+    }
+}
+
+// --- engage layer ---
+
+/// `FWP_E_ALREADY_EXISTS` as the Win32 DWORD the FWPM `*Add0` functions return
+/// (the `windows` crate exposes the constant only as an `HRESULT`). A re-add of
+/// our own object is benign idempotency, not an error.
+const FWP_E_ALREADY_EXISTS_DWORD: u32 = 0x8032_0009;
+
+/// WFP-backed cover guard. Drop deletes our provider/sublayer/filters by GUID.
+pub struct Cover {
+    engine: HANDLE,
+}
+
+// SAFETY: the FWPM engine handle is owned exclusively by this guard and only
+// touched in `engage` and `Drop`. Sending it between threads is sound; FWPM
+// engine handles are not thread-affine.
+unsafe impl Send for Cover {}
+
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// Map a FWPM `u32` return to a `Result`. **FWPM functions return a bare `u32`
+/// Win32 error code — never an `HRESULT` or `windows::core::Result`.**
+fn wfp_check(code: u32, what: &str) -> Result<(), RoutingError> {
+    if code == ERROR_SUCCESS.0 {
+        Ok(())
+    } else {
+        Err(RoutingError::RouteSetup(format!("{what} failed: 0x{code:08x}")))
+    }
+}
+
+/// As [`wfp_check`], but a duplicate-add (`FWP_E_ALREADY_EXISTS`) is also OK —
+/// re-engaging over an unswept cover is idempotent.
+fn ok_or_exists(code: u32, what: &str) -> Result<(), RoutingError> {
+    if code == FWP_E_ALREADY_EXISTS_DWORD {
+        return Ok(());
+    }
+    wfp_check(code, what)
+}
+
+#[allow(clippy::disallowed_methods)] // THIS is the sanctioned FWPM call site
+pub fn engage(server_ip: IpAddr, _state_dir: &Path) -> Result<Cover, RoutingError> {
+    let spec = build_cover_spec(server_ip);
+    unsafe {
+        // A NON-dynamic engine session (`session = None`): a dynamic session
+        // would auto-delete our filters when this process exits, reopening the
+        // leak mid-cutover. Persistent filters + non-dynamic session survive a
+        // crash and are swept by `recover_cover`.
+        let mut engine = HANDLE::default();
+        wfp_check(
+            FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine),
+            "FwpmEngineOpen0",
+        )?;
+
+        // Wrap the mutating steps so any failure aborts the transaction and
+        // closes the engine before returning.
+        let result = (|| -> Result<(), RoutingError> {
+            wfp_check(FwpmTransactionBegin0(engine, 0), "FwpmTransactionBegin0")?;
+            add_provider(engine, spec.provider)?;
+            add_sublayer(engine, spec.sublayer, spec.provider)?;
+            for f in &spec.filters {
+                add_filter(engine, spec.provider, spec.sublayer, f)?;
+            }
+            wfp_check(FwpmTransactionCommit0(engine), "FwpmTransactionCommit0")?;
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            let _ = FwpmTransactionAbort0(engine);
+            let _ = FwpmEngineClose0(engine);
+            return Err(e);
+        }
+        Ok(Cover { engine })
+    }
+}
+
+#[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+unsafe fn add_provider(engine: HANDLE, key: GUID) -> Result<(), RoutingError> {
+    let mut name = wide("Hole fail-closed cover");
+    let provider = FWPM_PROVIDER0 {
+        providerKey: key,
+        displayData: FWPM_DISPLAY_DATA0 {
+            name: PWSTR(name.as_mut_ptr()),
+            description: PWSTR::null(),
+        },
+        flags: FWPM_PROVIDER_FLAG_PERSISTENT,
+        ..Default::default()
+    };
+    ok_or_exists(FwpmProviderAdd0(engine, &provider, None), "FwpmProviderAdd0")
+}
+
+#[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+unsafe fn add_sublayer(engine: HANDLE, key: GUID, provider: GUID) -> Result<(), RoutingError> {
+    let mut name = wide("Hole fail-closed cover");
+    let mut provider_key = provider;
+    let sublayer = FWPM_SUBLAYER0 {
+        subLayerKey: key,
+        displayData: FWPM_DISPLAY_DATA0 {
+            name: PWSTR(name.as_mut_ptr()),
+            description: PWSTR::null(),
+        },
+        flags: FWPM_SUBLAYER_FLAG_PERSISTENT,
+        providerKey: &mut provider_key,
+        weight: 0xffff,
+        ..Default::default()
+    };
+    ok_or_exists(FwpmSubLayerAdd0(engine, &sublayer, None), "FwpmSubLayerAdd0")
+}
+
+#[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterSpec) -> Result<(), RoutingError> {
+    let layer = match f.layer {
+        Layer::ConnectV4 => FWPM_LAYER_ALE_AUTH_CONNECT_V4,
+        Layer::ConnectV6 => FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+    };
+    let action_type = match f.action {
+        Action::Permit => FWP_ACTION_PERMIT,
+        Action::Block => FWP_ACTION_BLOCK,
+    };
+    let flags = FWPM_FILTER_FLAGS(
+        FWPM_FILTER_FLAG_PERSISTENT.0
+            | if f.hard {
+                FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT.0
+            } else {
+                0
+            },
+    );
+
+    // Keep-alive bindings: `FWPM_FILTER0` holds raw pointers into these; they
+    // must outlive the `FwpmFilterAdd0` call below.
+    let mut name = wide("Hole fail-closed filter");
+    let mut provider_key = provider;
+    let mut v6buf = FWP_BYTE_ARRAY16 { byteArray16: [0u8; 16] };
+    let mut conditions: Vec<FWPM_FILTER_CONDITION0> = Vec::new();
+    match f.condition {
+        Condition::Loopback => conditions.push(FWPM_FILTER_CONDITION0 {
+            fieldKey: FWPM_CONDITION_FLAGS,
+            matchType: FWP_MATCH_FLAGS_ALL_SET,
+            conditionValue: FWP_CONDITION_VALUE0 {
+                r#type: FWP_UINT32,
+                Anonymous: FWP_CONDITION_VALUE0_0 {
+                    uint32: FWP_CONDITION_FLAG_IS_LOOPBACK,
+                },
+            },
+        }),
+        Condition::RemoteIp(IpAddr::V4(v4)) => conditions.push(FWPM_FILTER_CONDITION0 {
+            fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
+            matchType: FWP_MATCH_EQUAL,
+            conditionValue: FWP_CONDITION_VALUE0 {
+                r#type: FWP_UINT32,
+                // WFP expects the address in host byte order; `u32::from`
+                // yields exactly that (first octet most-significant).
+                Anonymous: FWP_CONDITION_VALUE0_0 { uint32: u32::from(v4) },
+            },
+        }),
+        Condition::RemoteIp(IpAddr::V6(v6)) => {
+            v6buf.byteArray16 = v6.octets();
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_BYTE_ARRAY16_TYPE,
+                    Anonymous: FWP_CONDITION_VALUE0_0 {
+                        byteArray16: &mut v6buf,
+                    },
+                },
+            });
+        }
+        Condition::Any => {}
+    }
+
+    let filter = FWPM_FILTER0 {
+        filterKey: f.guid,
+        displayData: FWPM_DISPLAY_DATA0 {
+            name: PWSTR(name.as_mut_ptr()),
+            description: PWSTR::null(),
+        },
+        flags,
+        providerKey: &mut provider_key,
+        layerKey: layer,
+        subLayerKey: sublayer,
+        weight: FWP_VALUE0 {
+            r#type: FWP_UINT8,
+            Anonymous: FWP_VALUE0_0 { uint8: f.weight },
+        },
+        numFilterConditions: conditions.len() as u32,
+        filterCondition: if conditions.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            conditions.as_mut_ptr()
+        },
+        action: FWPM_ACTION0 {
+            r#type: action_type,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    ok_or_exists(FwpmFilterAdd0(engine, &filter, None, None), "FwpmFilterAdd0")
+}
+
+impl Drop for Cover {
+    fn drop(&mut self) {
+        unsafe {
+            delete_all(self.engine);
+            #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+            let _ = FwpmEngineClose0(self.engine);
+        }
+    }
+}
+
+pub fn recover_cover(_state_dir: &Path) {
+    unsafe {
+        let mut engine = HANDLE::default();
+        // FwpmEngineOpen0 returns u32 — compare to ERROR_SUCCESS.0, NOT `.is_ok()`.
+        // Open can fail when the bridge isn't elevated; that's a benign no-op
+        // (nothing to sweep that we could reach anyway).
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        if FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine) == ERROR_SUCCESS.0 {
+            delete_all(engine);
+            #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+            let _ = FwpmEngineClose0(engine);
+        }
+    }
+}
+
+/// Delete filters (by their six fixed GUIDs), then the sublayer, then the
+/// provider. Order matters: a sublayer/provider delete fails while filters
+/// still reference it. Each delete is idempotent — a "not found" return is
+/// ignored (recovery runs even when no cover is present).
+#[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+unsafe fn delete_all(engine: HANDLE) {
+    for g in FILTER_GUIDS {
+        let _ = FwpmFilterDeleteByKey0(engine, &g);
+    }
+    let _ = FwpmSubLayerDeleteByKey0(engine, &SUBLAYER_GUID);
+    let _ = FwpmProviderDeleteByKey0(engine, &PROVIDER_GUID);
+}
+
+#[cfg(test)]
+#[path = "windows_tests.rs"]
+mod windows_tests;

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -1,0 +1,86 @@
+use super::*;
+use std::net::IpAddr;
+
+fn v4() -> IpAddr {
+    "203.0.113.7".parse().unwrap()
+}
+fn v6() -> IpAddr {
+    "2001:db8::1".parse().unwrap()
+}
+
+#[skuld::test]
+fn spec_blocks_on_both_v4_and_v6_layers() {
+    let s = build_cover_spec(v4());
+    assert!(s
+        .filters
+        .iter()
+        .any(|f| f.layer == Layer::ConnectV4 && f.action == Action::Block));
+    assert!(s
+        .filters
+        .iter()
+        .any(|f| f.layer == Layer::ConnectV6 && f.action == Action::Block));
+}
+
+#[skuld::test]
+fn spec_permits_loopback_on_both_layers() {
+    let s = build_cover_spec(v4());
+    let loopback_permits = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
+        .count();
+    assert_eq!(loopback_permits, 2, "loopback permit on V4 and V6");
+}
+
+#[skuld::test]
+fn spec_permits_v4_server_on_v4_layer_only() {
+    let s = build_cover_spec(v4());
+    let server_permits: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIp(_)))
+        .collect();
+    assert_eq!(server_permits.len(), 1);
+    assert_eq!(server_permits[0].layer, Layer::ConnectV4);
+    assert!(matches!(server_permits[0].condition, Condition::RemoteIp(ip) if ip == v4()));
+}
+
+#[skuld::test]
+fn spec_permits_v6_server_on_v6_layer_only() {
+    let s = build_cover_spec(v6());
+    let server_permits: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIp(_)))
+        .collect();
+    assert_eq!(server_permits.len(), 1);
+    assert_eq!(server_permits[0].layer, Layer::ConnectV6);
+}
+
+#[skuld::test]
+fn permit_filters_are_hard_and_outweigh_block() {
+    let s = build_cover_spec(v4());
+    for f in &s.filters {
+        match f.action {
+            Action::Permit => {
+                assert!(
+                    f.hard,
+                    "permits must be hard (CLEAR_ACTION_RIGHT) so other firewalls can't veto"
+                );
+                assert_eq!(f.weight, PERMIT_WEIGHT);
+                assert!(f.weight > BLOCK_WEIGHT, "permit must outweigh block in our sublayer");
+            }
+            Action::Block => {
+                assert!(!f.hard);
+                assert_eq!(f.weight, BLOCK_WEIGHT);
+            }
+        }
+    }
+}
+
+#[skuld::test]
+fn spec_uses_the_fixed_hole_guids() {
+    let s = build_cover_spec(v4());
+    assert_eq!(s.provider, PROVIDER_GUID);
+    assert_eq!(s.sublayer, SUBLAYER_GUID);
+}

--- a/crates/tun-engine/src/routing_tests.rs
+++ b/crates/tun-engine/src/routing_tests.rs
@@ -311,7 +311,7 @@ fn recover_without_state_file_is_a_noop() {
     // bridge.
     let tmp = tempfile::tempdir().unwrap();
     let log: RefCell<Captured> = RefCell::new(Vec::new());
-    recover_routes_with(tmp.path(), capturing_runner(&log));
+    recover_routes_with(tmp.path(), capturing_runner(&log), |_| {});
 
     let log = log.into_inner();
     assert!(log.is_empty(), "expected no commands with no state file, got {log:?}");
@@ -330,7 +330,7 @@ fn recover_with_state_file_runs_split_then_bypass_then_clears() {
     state::save(tmp.path(), &persisted_state).unwrap();
 
     let log: RefCell<Captured> = RefCell::new(Vec::new());
-    recover_routes_with(tmp.path(), capturing_runner(&log));
+    recover_routes_with(tmp.path(), capturing_runner(&log), |_| {});
 
     let log = log.into_inner();
     assert_eq!(log.len(), 2, "expected split + bypass phases, got {log:?}");
@@ -355,10 +355,23 @@ fn recover_clears_state_file_even_when_runner_errors() {
 
     let failing =
         |_: &[Vec<String>], _: &str| -> std::io::Result<()> { Err(std::io::Error::other("simulated runner failure")) };
-    recover_routes_with(tmp.path(), failing);
+    recover_routes_with(tmp.path(), failing, |_| {});
 
     assert!(
         !tmp.path().join(STATE_FILE_NAME).exists(),
         "state file should be cleared even when runner returns Err"
     );
+}
+
+#[skuld::test]
+fn recover_invokes_cover_sweep_even_without_route_state() {
+    // A crashed cutover can leave a cover engaged with the routes already torn
+    // down (no route-state file). The cover sweep must run regardless.
+    let tmp = tempfile::tempdir().unwrap();
+    let log: RefCell<Captured> = RefCell::new(Vec::new());
+    let swept = std::cell::Cell::new(false);
+    recover_routes_with(tmp.path(), capturing_runner(&log), |_| swept.set(true));
+
+    assert!(log.into_inner().is_empty(), "no route-state file => no route commands");
+    assert!(swept.get(), "recover_routes_with must invoke the cover sweep");
 }

--- a/crates/tun-engine/src/routing_tests.rs
+++ b/crates/tun-engine/src/routing_tests.rs
@@ -275,6 +275,19 @@ fn setup_phase_is_not_recovery() {
     assert!(!is_recovery_phase(PHASE_SETUP));
 }
 
+#[skuld::test]
+fn recover_cover_phase_is_classified_as_expected_failures() {
+    assert!(is_recovery_phase(PHASE_RECOVER_COVER));
+}
+
+// `PHASE_COVER` is macOS-only (the engage subprocess phase), so this
+// assertion is too. Engage failures are real anomalies that abort the cutover.
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn cover_engage_phase_is_not_recovery() {
+    assert!(!is_recovery_phase(PHASE_COVER));
+}
+
 // recover_routes_with tests ===========================================================================================
 //
 // These use an injectable command runner so the test doesn't shell out.


### PR DESCRIPTION
## What

PR2 of a 3-PR stack for #468 (leak-free in-place update). Adds a **fail-closed network cover** — block all egress except loopback and the SS server IP — as a `Routing`-trait RAII method, plus a crash-recovery sweep and (macOS-only) state file.

- **`Routing::install_failclosed_cover(server_ip) -> Self::Cover`** — an RAII guard whose `Drop` disengages the cover. Name-agnostic (no TUN permit/param): the new bridge's start-time DNS-forwarder self-test runs over loopback → SS client → server IP, so loopback + server-IP permits suffice.
- **Windows:** persistent provider + sublayer + filter set in one FWPM transaction on `ALE_AUTH_CONNECT_V4/_V6` (permit loopback + server IP *hard* via `CLEAR_ACTION_RIGHT`, block all else). **Non-dynamic session** so a crash mid-cutover leaves traffic blocked, not leaked; recovery deletes the fixed compiled-in GUIDs (idempotent, no state file).
- **macOS:** `pfctl -E` (refcounted) + self-contained ruleset over stdin; disengage restores `/etc/pf.conf` + `pfctl -X <token>`. The token is persisted to `bridge-failclosed.json` before the blocking ruleset loads, so recovery can `-X` it cleanly.
- Each platform splits a **pure, unit-tested rule/spec builder** (`build_cover_spec` / `build_pf_ruleset`) from the thin engage layer — mirroring `build_setup_commands` vs `run_commands`.

## Scope note

`install_failclosed_cover`/`engage` has **no production caller in this PR** — PR3 wires it into the update cutover. The **recovery sweep does run on every bridge start** from this PR (`recover_routes` → `failclosed::recover_cover`), so a crashed PR3 cutover can't leave a stale cover. Does **not** close #468.

## Test strategy

The pure spec/ruleset builders, the macOS state I/O, the mock-cover RAII lifecycle, and the recovery-sweep orchestration are all unit-tested. The kernel-level engage (WFP transaction / `pfctl` execution) is compiled-but-not-unit-tested — it needs SYSTEM/root and perturbs the host firewall, the exact I/O the `Routing` seam keeps out of unit tests (#165). PR3 adds the privileged integration test.

## Refinements over the spec

- **Name-agnostic cover** (no TUN permit) — drops the LUID lookup and the "does the adapter exist yet" ordering.
- **Separate macOS-only `bridge-failclosed.json`** instead of folding the cover record into `bridge-routes.json` — the cover lifecycle is independent of the route lifecycle.

## Review

`plan-review` (pre-impl, verified against the vendored `windows` 0.62.2 crate) and `review` (post-impl) agents both ran; all blockers and should-fixes addressed (incl. completing the WFP clippy fence and making the macOS engage-failure rollback symmetric with `disengage`).

Refs #468.
