### PR TITLE
ci: run tombstone crash tests in test-hole (built but never run)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,7 +294,10 @@ jobs:
       # it Cargo recompiles `hole` with `tauri/custom-protocol` ON (different
       # feature set → different fingerprint → fresh build), which expands
       # `tauri::generate_context!()` in production mode and panics on
-      # missing `ui/dist/`. See bindreams/hole#372.
+      # missing `ui/dist/`. See bindreams/hole#372. The
+      # `--features tombstone/crash-dumps,tombstone/crash-child` + `package(tombstone)`
+      # also mirror `hole-tests` so the crash-marker tests `build hole-tests`
+      # compiled actually run (matching feature set → no rebuild). See #522.
       - name: Test (non-TUN)
         id: test-non-tun
         shell: bash
@@ -302,10 +305,11 @@ jobs:
           SKULD_LABELS: "!tun"
         run: >
           cargo nextest run --no-default-features
+          --features tombstone/crash-dumps,tombstone/crash-child
           -E 'package(hole) + package(hole-bridge) + package(hole-common)
               + package(tun-engine) + package(tun-engine-macros)
               + package(dump) + package(dump-macros)
-              + package(handle-holders)'
+              + package(handle-holders) + package(tombstone)'
 
       - name: Test (TUN, runs last for #200)
         if: matrix.os == 'windows' && matrix.arch == 'amd64'
@@ -315,10 +319,11 @@ jobs:
           SKULD_LABELS: "tun"
         run: >
           cargo nextest run --no-default-features
+          --features tombstone/crash-dumps,tombstone/crash-child
           -E 'package(hole) + package(hole-bridge) + package(hole-common)
               + package(tun-engine) + package(tun-engine-macros)
               + package(dump) + package(dump-macros)
-              + package(handle-holders)'
+              + package(handle-holders) + package(tombstone)'
 
       # Upload bridge.log produced by `DistHarness` subprocesses. Matches
       # files that the test harness redirected to `$RUNNER_TEMP` (see

--- a/crates/tombstone/tests/crash_child.rs
+++ b/crates/tombstone/tests/crash_child.rs
@@ -112,8 +112,16 @@ crash_class_test!(crash_marker_segfault, "segfault");
 crash_class_test!(crash_marker_stack_overflow, "stack_overflow");
 crash_class_test!(crash_marker_abort, "abort");
 crash_class_test!(crash_marker_illegal_instruction, "illegal_instruction");
-crash_class_test!(crash_marker_floating_point, "floating_point_exception");
 crash_class_test!(crash_marker_trap, "trap");
+
+// x86-only: integer divide-by-zero raises SIGFPE on x86, but is non-trapping on
+// AArch64 (the ISA returns 0 instead of faulting). There is no crash to observe
+// on arm64, so this fault class can't be exercised there.
+crash_class_test!(
+    crash_marker_floating_point,
+    "floating_point_exception",
+    not(target_arch = "aarch64")
+);
 
 // Windows-only fault classes.
 crash_class_test!(crash_marker_purecall, "purecall", windows);


### PR DESCRIPTION
Closes #522.

## Problem

`crates/tombstone`'s crash-marker tests are **compiled in CI but never executed**. The `test-hole` build step (`cargo xtask build hole-tests`) runs `build.yaml`'s `hole-tests` target, which compiles `-p tombstone --features tombstone/crash-dumps,tombstone/crash-child` (building the `crash_child` helper bin). But `ci.yaml`'s `test-hole` hand-rolled `cargo nextest run -E 'package(...)'` for both passes **omitted `package(tombstone)` and the features** — so the binaries built and nothing ran. The native-crash-observability mechanism (#438) had zero CI coverage.

Found by the orphan-test audit behind #512 (PR #515).

## Fix

Mirror `build.yaml`'s `hole-tests` in both `test-hole` run steps: add `--features tombstone/crash-dumps,tombstone/crash-child` and `+ package(tombstone)`. The feature set now matches the `build hole-tests` step, so nextest reuses the already-built binaries (no rebuild). The crash tests run on `test-hole`'s platforms (windows/amd64, darwin/amd64, darwin/arm64); the per-fault `#[cfg(windows)]` / `#[cfg(unix)]` gates narrow each to where it passes.

## Verification (local, Windows)

`cargo nextest run -p tombstone --features tombstone/crash-dumps,tombstone/crash-child` → **22 passed** (segfault, stack_overflow, abort, illegal_instruction, floating_point, trap, purecall, invalid_parameter, heap_corruption, the minidump-segfault test, plus marker parse/sweep). No Windows Error Reporting popup. The run flags now exactly match `build.yaml`'s `hole-tests` target.

## Scope

PR 3 of the orphan-test audit (PR 1 = #515 bridge→galoshes e2e; PR 2 = #520 util). The structural anti-orphan conformance guard — which would prevent this whole class recurring — is a larger follow-up (see the linked discussion).
