### PR TITLE
test(xtask): structural anti-orphan CI-coverage guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,7 +309,8 @@ jobs:
           -E 'package(hole) + package(hole-bridge) + package(hole-common)
               + package(tun-engine) + package(tun-engine-macros)
               + package(dump) + package(dump-macros)
-              + package(handle-holders) + package(tombstone)'
+              + package(handle-holders) + package(tombstone)
+              + package(hole-test-observability)'
 
       - name: Test (TUN, runs last for #200)
         if: matrix.os == 'windows' && matrix.arch == 'amd64'
@@ -323,7 +324,8 @@ jobs:
           -E 'package(hole) + package(hole-bridge) + package(hole-common)
               + package(tun-engine) + package(tun-engine-macros)
               + package(dump) + package(dump-macros)
-              + package(handle-holders) + package(tombstone)'
+              + package(handle-holders) + package(tombstone)
+              + package(hole-test-observability)'
 
       # Upload bridge.log produced by `DistHarness` subprocesses. Matches
       # files that the test harness redirected to `$RUNNER_TEMP` (see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -677,6 +677,11 @@ timeouts. Job-level timeouts (`build` 30m, `test-hole` 20m, `test-garter`/
   framework/job timeout is the failure-to-human signal). Use the codebase's
   rendezvous primitives (oneshot, `watch`, `WaitableWriter`, `CancellationToken`,
   `JoinHandle.await`, `tokio::time::pause/advance`) for intra-process sync (#383).
+- **Every crate runs in CI** — the `every_workspace_crate_runs_in_ci` conformance
+  test ([`xtask/src/ci_coverage.rs`](xtask/src/ci_coverage.rs)) fails if a
+  workspace crate's tests are run by no CI job (the recurring orphaned-test
+  class). A new crate must join some CI test job's package filter, or — if it has
+  no runnable tests — get an `UNTESTED_IN_CI` entry with a reason. (#526)
 
 ## Logging & diagnostics
 

--- a/build.yaml
+++ b/build.yaml
@@ -163,13 +163,15 @@ targets:
       -E 'package(hole) + package(hole-bridge) + package(hole-common)
           + package(tun-engine) + package(tun-engine-macros)
           + package(dump) + package(dump-macros)
-          + package(handle-holders) + package(tombstone)'
+          + package(handle-holders) + package(tombstone)
+          + package(hole-test-observability)'
     run: >
       cargo nextest run --no-default-features --features tombstone/crash-dumps,tombstone/crash-child
       -E 'package(hole) + package(hole-bridge) + package(hole-common)
           + package(tun-engine) + package(tun-engine-macros)
           + package(dump) + package(dump-macros)
-          + package(handle-holders) + package(tombstone)'
+          + package(handle-holders) + package(tombstone)
+          + package(hole-test-observability)'
 
   plugin-e2e-tests:
     # Plugin interop/e2e area (crate `plugin-e2e`, #435): ex-ray↔stock interop

--- a/xtask/src/ci_coverage.rs
+++ b/xtask/src/ci_coverage.rs
@@ -32,6 +32,10 @@ use crate::manifest::{Manifest, Step};
 /// (nextest filter expressions, possibly several in one `-E '...'`) and
 /// `-p <name>` (space-separated). A valid name is `[A-Za-z0-9_-]+`; tokens that
 /// don't fully match (e.g. a `tombstone/crash-dumps` feature path) are ignored.
+///
+/// Assumes additive filters — every `package(...)` names something the command
+/// RUNS. An exclusion expression (`not(package(x))`, `all() - package(x)`) would
+/// be mis-credited; ci.yaml uses only `+` unions today, so revisit if that changes.
 pub fn package_tokens(cmd: &str) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
 

--- a/xtask/src/ci_coverage.rs
+++ b/xtask/src/ci_coverage.rs
@@ -1,0 +1,216 @@
+//! CI coverage analysis: which workspace packages does `.github/workflows/ci.yaml`
+//! actually RUN tests for?
+//!
+//! Backs the `every_workspace_crate_runs_in_ci` conformance test, which fails CI
+//! if a workspace crate's tests run on no platform — the "orphaned test" class
+//! (recent: #519 util, #522 tombstone, this issue's #526 hole-test-observability).
+//!
+//! The analysis is per-COMMAND, not per-`run:`-block: each `run:` script is a
+//! multi-statement shell snippet (`mkdir -p target/debug && cargo nextest run …`),
+//! so a block is split on shell separators and every command judged on its own.
+//! A package is credited only when a command that actually RUNS tests names it —
+//! never from a `cargo clippy -p …` lint or a `--no-run` compile. Counting those
+//! would let a crate that is merely linted/built masquerade as test-covered.
+//!
+//! Two layers:
+//!   - [`package_tokens`] pulls cargo package names out of one command, from both
+//!     `package(<name>)` (nextest filter expressions) and `-p <name>`.
+//!   - [`ci_run_packages`] walks every `run:` step in `ci.yaml`, and for each
+//!     command either harvests a test-running nextest invocation or resolves a
+//!     `cargo xtask run <target>` through `build.yaml` and recurses into that
+//!     target's `run:`/`build:` commands under the same per-command rule.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Context, Result};
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::manifest::{Manifest, Step};
+
+/// Cargo package names referenced in `cmd`, from both `package(<name>)`
+/// (nextest filter expressions, possibly several in one `-E '...'`) and
+/// `-p <name>` (space-separated). A valid name is `[A-Za-z0-9_-]+`; tokens that
+/// don't fully match (e.g. a `tombstone/crash-dumps` feature path) are ignored.
+pub fn package_tokens(cmd: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+
+    // `package(<name>)` — scan every occurrence, not just the first.
+    let mut rest = cmd;
+    while let Some(open) = rest.find("package(") {
+        let after = &rest[open + "package(".len()..];
+        if let Some(close) = after.find(')') {
+            let inner = after[..close].trim();
+            if is_package_name(inner) {
+                out.insert(inner.to_string());
+            }
+            rest = &after[close + 1..];
+        } else {
+            break;
+        }
+    }
+
+    // `-p <name>` — the token immediately after a bare `-p`.
+    let toks: Vec<&str> = cmd.split_whitespace().collect();
+    for (i, &tok) in toks.iter().enumerate() {
+        if tok == "-p" {
+            if let Some(&name) = toks.get(i + 1) {
+                if is_package_name(name) {
+                    out.insert(name.to_string());
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// A valid cargo package name token: non-empty, all chars in `[A-Za-z0-9_-]`.
+fn is_package_name(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+// Minimal `ci.yaml` shape — serde ignores every field we don't name, so this
+// tracks only `jobs.<id>.steps[].run`.
+
+#[derive(Deserialize)]
+struct CiYaml {
+    jobs: IndexMap<String, Job>,
+}
+
+#[derive(Deserialize)]
+struct Job {
+    #[serde(default)]
+    steps: Vec<CiStep>,
+}
+
+#[derive(Deserialize)]
+struct CiStep {
+    #[serde(default)]
+    run: Option<String>,
+}
+
+/// The set of packages CI actually RUNS tests for. Each step's `run:` script is
+/// split into commands; every command is judged on its own (see module docs).
+pub fn ci_run_packages(ci_yaml: &str, manifest: &Manifest) -> Result<BTreeSet<String>> {
+    let ci: CiYaml = serde_yml::from_str(ci_yaml).context("parsing ci.yaml")?;
+    let mut covered = BTreeSet::new();
+
+    for job in ci.jobs.values() {
+        for step in &job.steps {
+            let Some(run) = &step.run else { continue };
+            let joined = join_line_continuations(run);
+            for cmd in split_commands(&joined) {
+                collect_from_command(&cmd, manifest, &mut covered, &mut BTreeSet::new());
+            }
+        }
+    }
+
+    Ok(covered)
+}
+
+/// Collapse shell backslash-newline line continuations into spaces, so a command
+/// written across several lines (as the archive-lane nextest invocations are)
+/// is one logical command before [`split_commands`] runs.
+fn join_line_continuations(script: &str) -> String {
+    script.replace("\\\r\n", " ").replace("\\\n", " ")
+}
+
+/// Credit `cmd`'s packages into `covered`. A test-running nextest invocation
+/// contributes its [`package_tokens`]; a `cargo xtask run <target>` resolves the
+/// target and recurses into its `run:`/`build:` commands. `visited` guards the
+/// (currently unused) run→run chain against an accidental manifest cycle.
+fn collect_from_command(
+    cmd: &str,
+    manifest: &Manifest,
+    covered: &mut BTreeSet<String>,
+    visited: &mut BTreeSet<String>,
+) {
+    if is_nextest_run(cmd) {
+        covered.extend(package_tokens(cmd));
+    }
+
+    if let Some(target) = xtask_run_target(cmd) {
+        if visited.insert(target.to_string()) {
+            if let Some(t) = manifest.get(target) {
+                for step in t.run.iter().chain(t.build.iter()) {
+                    let joined = join_line_continuations(&step_command(step));
+                    for inner in split_commands(&joined) {
+                        collect_from_command(&inner, manifest, covered, visited);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Split a (possibly multi-statement) shell script into individual commands on
+/// the unquoted shell separators `&&`, `||`, `|`, `;`, and newlines. Separators
+/// inside `'…'` / `"…"` are NOT command boundaries — this matters because a
+/// nextest `-E '…'` filter expression (folded YAML) carries newlines inside its
+/// single quotes. Tokens within a command stay whitespace-separated, so
+/// downstream `split_whitespace` matching is unaffected.
+fn split_commands(script: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quote: Option<char> = None;
+
+    for c in script.chars() {
+        match quote {
+            Some(q) => {
+                cur.push(c);
+                if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                '\'' | '"' => {
+                    quote = Some(c);
+                    cur.push(c);
+                }
+                '\n' | ';' | '|' | '&' => {
+                    push_command(&mut out, &mut cur);
+                }
+                _ => cur.push(c),
+            },
+        }
+    }
+    push_command(&mut out, &mut cur);
+    out
+}
+
+/// Flush the accumulated command into `out` if it is non-empty after trimming.
+fn push_command(out: &mut Vec<String>, cur: &mut String) {
+    let trimmed = cur.trim();
+    if !trimmed.is_empty() {
+        out.push(trimmed.to_string());
+    }
+    cur.clear();
+}
+
+/// Does this single command RUN tests? True iff it spawns nextest with the `run`
+/// subcommand (`cargo nextest run` OR `cargo-nextest nextest run`) and is not a
+/// `--no-run` compile-only invocation.
+fn is_nextest_run(cmd: &str) -> bool {
+    let toks: Vec<&str> = cmd.split_whitespace().collect();
+    if toks.contains(&"--no-run") {
+        return false;
+    }
+    toks.windows(2).any(|w| w[0] == "nextest" && w[1] == "run")
+}
+
+/// The target of a `cargo xtask run <target>` command, if `cmd` is one.
+fn xtask_run_target(cmd: &str) -> Option<&str> {
+    let toks: Vec<&str> = cmd.split_whitespace().collect();
+    toks.windows(4)
+        .find(|w| w[0] == "cargo" && w[1] == "xtask" && w[2] == "run")
+        .map(|w| w[3])
+}
+
+/// The command-line text of a manifest step, for token extraction.
+fn step_command(step: &Step) -> String {
+    match step {
+        Step::Bash { command, .. } => command.clone(),
+        Step::Process { args, .. } => args.join(" "),
+    }
+}

--- a/xtask/src/ci_coverage_tests.rs
+++ b/xtask/src/ci_coverage_tests.rs
@@ -1,0 +1,241 @@
+//! Unit tests for the token extractors plus the `every_workspace_crate_runs_in_ci`
+//! structural conformance test (the anti-orphan gate, #526).
+
+use std::collections::BTreeSet;
+use std::fs;
+
+use crate::ci_coverage::{ci_run_packages, package_tokens};
+use crate::manifest::Manifest;
+
+fn set(items: &[&str]) -> BTreeSet<String> {
+    items.iter().map(|s| s.to_string()).collect()
+}
+
+// ===== package_tokens ================================================================================================
+
+#[skuld::test]
+fn package_tokens_from_filter_expression() {
+    assert_eq!(
+        package_tokens("cargo nextest run -E 'package(a) + package(b)'"),
+        set(&["a", "b"])
+    );
+}
+
+#[skuld::test]
+fn package_tokens_from_dash_p() {
+    assert_eq!(
+        package_tokens("cargo nextest archive -p garter -p garter-bin"),
+        set(&["garter", "garter-bin"])
+    );
+}
+
+#[skuld::test]
+fn package_tokens_mixed_forms() {
+    assert_eq!(
+        package_tokens("cargo nextest run -p util -E 'package(hole) + package(dump)'"),
+        set(&["util", "hole", "dump"])
+    );
+}
+
+#[skuld::test]
+fn package_tokens_ignores_feature_paths() {
+    // The real test-hole invocation: `--features tombstone/crash-dumps,…` must
+    // NOT contribute a bogus token, but `package(tombstone)` must still yield
+    // `tombstone`. A slash-bearing feature path is not a valid package name.
+    let cmd = "cargo nextest run --no-default-features \
+        --features tombstone/crash-dumps,tombstone/crash-child \
+        -E 'package(hole) + package(hole-bridge) + package(tombstone)'";
+    assert_eq!(package_tokens(cmd), set(&["hole", "hole-bridge", "tombstone"]));
+}
+
+#[skuld::test]
+fn package_tokens_empty_when_none() {
+    assert_eq!(package_tokens("cargo build --release"), BTreeSet::new());
+}
+
+// ===== ci_run_packages ===============================================================================================
+
+fn fixture_manifest() -> Manifest {
+    // `foo-tests` build names a DIFFERENT package (`foo-build-only`) than its
+    // run, so resolving it via `cargo xtask run` must yield only `foo` — the
+    // `--no-run` build must not leak `foo-build-only`. `lint-only` mimics a
+    // clippy target: a `-p`-bearing command that is not a test run.
+    Manifest::parse(
+        r"
+targets:
+  foo-tests:
+    platforms: windows/amd64
+    build: cargo nextest run --no-run -p foo-build-only
+    run: cargo nextest run -p foo
+  bar-tests:
+    platforms: windows/amd64
+    run: cargo nextest run -E 'package(bar) + package(bar-extra)'
+  lint-only:
+    platforms: windows/amd64
+    run: cargo clippy -p linted-pkg --all-targets -- -D warnings
+",
+    )
+    .expect("fixture manifest parses")
+}
+
+#[skuld::test]
+fn ci_run_packages_direct_nextest_run() {
+    let ci = r"
+jobs:
+  test:
+    steps:
+      - name: Run tests
+        run: cargo nextest run -E 'package(a) + package(b)'
+";
+    assert_eq!(ci_run_packages(ci, &fixture_manifest()).unwrap(), set(&["a", "b"]));
+}
+
+#[skuld::test]
+fn ci_run_packages_ignores_archive_and_no_run() {
+    // `cargo nextest archive` builds but does not RUN; `--no-run` likewise.
+    let ci = r"
+jobs:
+  build:
+    steps:
+      - run: cargo nextest archive -p a -p b --archive-file x.tar.zst
+      - run: cargo nextest run --no-run -p c
+";
+    assert_eq!(ci_run_packages(ci, &fixture_manifest()).unwrap(), BTreeSet::new());
+}
+
+#[skuld::test]
+fn ci_run_packages_matches_cargo_nextest_spelling() {
+    // The archive-lane test jobs invoke `cargo-nextest nextest run` (binary
+    // name, then subcommand), not `cargo nextest run`. Both must be recognized
+    // as test runs — missing this is how test-garter/test-galoshes were
+    // silently uncredited.
+    let ci = r"
+jobs:
+  test:
+    steps:
+      - run: |
+          mkdir -p target/debug
+          cargo-nextest nextest run --archive-file x.tar.zst -E 'package(a)'
+";
+    assert_eq!(ci_run_packages(ci, &fixture_manifest()).unwrap(), set(&["a"]));
+}
+
+#[skuld::test]
+fn ci_run_packages_resolves_xtask_run_target() {
+    // `cargo xtask run foo-tests` must contribute `foo` from the target's RUN
+    // command only. Its `--no-run` build names `foo-build-only`, which must NOT
+    // leak in — building is not running.
+    let ci = r"
+jobs:
+  e2e:
+    steps:
+      - run: cargo xtask run foo-tests
+";
+    assert_eq!(ci_run_packages(ci, &fixture_manifest()).unwrap(), set(&["foo"]));
+}
+
+#[skuld::test]
+fn ci_run_packages_does_not_credit_clippy_p_flags() {
+    // `cargo xtask run lint-only` resolves to a `cargo clippy -p linted-pkg`
+    // command. Clippy compiles, it does not run tests — `linted-pkg` must not
+    // be credited. Counting it would let a merely-linted crate masquerade as
+    // test-covered (the #513 self-fulfilling-filter trap).
+    let ci = r"
+jobs:
+  lint:
+    steps:
+      - run: cargo xtask run lint-only
+";
+    assert_eq!(ci_run_packages(ci, &fixture_manifest()).unwrap(), BTreeSet::new());
+}
+
+#[skuld::test]
+fn ci_run_packages_splits_multi_statement_run_block() {
+    // A `run:` block is a shell script: the leading `mkdir` must not swallow the
+    // nextest command that follows it on the next line / after `&&`.
+    let ci = r"
+jobs:
+  test:
+    steps:
+      - run: |
+          mkdir -p target/debug
+          cargo nextest run -p a && echo done
+";
+    assert_eq!(ci_run_packages(ci, &fixture_manifest()).unwrap(), set(&["a"]));
+}
+
+#[skuld::test]
+fn ci_run_packages_unions_across_jobs_and_steps() {
+    let ci = r"
+jobs:
+  one:
+    steps:
+      - run: cargo nextest run -p direct
+  two:
+    steps:
+      - run: cargo xtask run bar-tests
+";
+    assert_eq!(
+        ci_run_packages(ci, &fixture_manifest()).unwrap(),
+        set(&["direct", "bar", "bar-extra"])
+    );
+}
+
+// ===== Structural conformance: every workspace crate runs in CI ======================================================
+
+/// Workspace crates that legitimately run on no CI test job, each with a reason.
+///
+/// HYGIENE (enforced below): every entry must be a real workspace member AND
+/// must NOT already be covered. If a crate gains CI coverage, delete its entry —
+/// a stale allowlist would mask a future regression (the #513 "no
+/// self-fulfilling filter" rule).
+const UNTESTED_IN_CI: &[(&str, &str)] = &[];
+
+#[skuld::test]
+fn every_workspace_crate_runs_in_ci() {
+    let root = crate::repo_root().expect("repo root");
+
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(root.join("Cargo.toml"))
+        .no_deps()
+        .exec()
+        .expect("cargo metadata");
+    let members: BTreeSet<String> = metadata
+        .workspace_packages()
+        .iter()
+        .map(|p| p.name.to_string())
+        .collect();
+
+    let manifest = Manifest::parse(&fs::read_to_string(root.join("build.yaml")).expect("read build.yaml"))
+        .expect("parse build.yaml");
+    let ci_yaml = fs::read_to_string(root.join(".github/workflows/ci.yaml")).expect("read ci.yaml");
+    let covered = ci_run_packages(&ci_yaml, &manifest).expect("compute CI coverage");
+
+    let allowlisted: BTreeSet<String> = UNTESTED_IN_CI.iter().map(|(name, _)| name.to_string()).collect();
+
+    // Every member must be covered by a CI test job or explicitly allowlisted.
+    let uncovered: Vec<&String> = members
+        .iter()
+        .filter(|m| !covered.contains(*m) && !allowlisted.contains(*m))
+        .collect();
+    assert!(
+        uncovered.is_empty(),
+        "these workspace crates run on no CI test job and are not allowlisted: {uncovered:?}\n\
+         add a CI test job or an UNTESTED_IN_CI entry (with a reason)"
+    );
+
+    // Allowlist hygiene: no phantom entries (must be a real member) ...
+    for (name, _) in UNTESTED_IN_CI {
+        assert!(
+            members.contains(*name),
+            "UNTESTED_IN_CI lists {name:?}, which is not a workspace member — remove the stale entry"
+        );
+    }
+    // ... and no stale entries (a now-covered crate must lose its exemption).
+    for (name, _) in UNTESTED_IN_CI {
+        assert!(
+            !covered.contains(*name),
+            "UNTESTED_IN_CI lists {name:?}, but CI now runs it — remove the stale allowlist entry"
+        );
+    }
+}

--- a/xtask/src/ci_coverage_tests.rs
+++ b/xtask/src/ci_coverage_tests.rs
@@ -139,7 +139,7 @@ fn ci_run_packages_does_not_credit_clippy_p_flags() {
     // `cargo xtask run lint-only` resolves to a `cargo clippy -p linted-pkg`
     // command. Clippy compiles, it does not run tests — `linted-pkg` must not
     // be credited. Counting it would let a merely-linted crate masquerade as
-    // test-covered (the #513 self-fulfilling-filter trap).
+    // test-covered (a self-fulfilling pass that hides a real orphan).
     let ci = r"
 jobs:
   lint:
@@ -187,8 +187,8 @@ jobs:
 ///
 /// HYGIENE (enforced below): every entry must be a real workspace member AND
 /// must NOT already be covered. If a crate gains CI coverage, delete its entry —
-/// a stale allowlist would mask a future regression (the #513 "no
-/// self-fulfilling filter" rule).
+/// a stale allowlist entry that still matched a now-covered crate would mask a
+/// future regression.
 const UNTESTED_IN_CI: &[(&str, &str)] = &[];
 
 #[skuld::test]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -12,6 +12,7 @@ use crate::manifest::{Manifest, Platform};
 use crate::orchestrate::{execute, execute_run, relocate_self_if_windows, render_list, Plan};
 
 pub mod bindir;
+pub mod ci_coverage;
 pub mod ex_ray;
 pub mod galoshes;
 pub mod golangci_lint;
@@ -26,6 +27,9 @@ pub mod wintun;
 #[cfg(test)]
 #[path = "bindir_tests.rs"]
 mod bindir_tests;
+#[cfg(test)]
+#[path = "ci_coverage_tests.rs"]
+mod ci_coverage_tests;
 #[cfg(test)]
 #[path = "external_bin_tests.rs"]
 mod external_bin_tests;


### PR DESCRIPTION
Closes #526.

## Problem

The orphaned-test class keeps recurring — a crate has tests but no CI job runs them, so they silently pass on no platform (#519 util, #522 tombstone, historically #185/#189). Each was found by hand; nothing structurally prevents the next.

## Change

A new `xtask` conformance test, `every_workspace_crate_runs_in_ci` (runs on the 6-platform `test-tooling` lane):

- Enumerates workspace crates via `cargo_metadata`.
- Computes the set CI **actually runs** by parsing `ci.yaml`'s real commands — every `cargo nextest run` (not `--no-run`/`archive`/clippy) plus `cargo xtask run <target>` resolved through `build.yaml` — and extracting `package(X)` / `-p X`.
- Asserts every crate is in that run-set **or** in an explicit `UNTESTED_IN_CI` allowlist (with hygiene checks: no stale, already-covered, or non-member allowlist entries — the #513 "no self-fulfilling filter" rigor).

Because it reads what CI *runs*, it catches **both** orphan classes: no-coverage-anywhere (util) **and** build-vs-run drift (tombstone, where `build.yaml` had the package but `ci.yaml`'s run filter didn't).

### It immediately found a 4th real orphan

`hole-test-observability` (`crates/test-observability/`) — 7 `#[skuld::test]` tests (incl. the #147 perf-regression guard) in **no** CI job. Not allowlistable (it has real tests), so wired into **test-hole** (it's the `hole` release group; `hole-common` is available on Win/mac, where all 7 tests run). `UNTESTED_IN_CI` ends up **empty** — every workspace crate is genuinely CI-covered.

The analyzer is deliberately robust (a first cut had three compensating bugs, caught in review and rewritten): quote-aware command splitting so folded `-E '…'` filters survive; an `is_nextest_run` predicate matching both `cargo nextest run` and `cargo-nextest nextest run` and excluding `--no-run`; package-name charset validation (so `tombstone/crash-dumps` yields no bogus token); `cargo xtask run` resolution with a cycle guard.

## Verification (local, Windows)

- `cargo nextest run -p xtask` → **93 passed** (the conformance test + 11 analyzer unit tests).
- `hole-test-observability` → 7 tests pass.
- `cargo clippy -p xtask --all-targets -- -D warnings` clean.

## Scope

PR 4 (final) of the orphan-test audit — PR 1 #515 (bridge→galoshes e2e), PR 2 #520 (util), PR 3 #523 (tombstone). Built on clean `main` after #520+#523 merged, so the guard is green.
