### PR TITLE
feat: standing kill switch (lockdown mode), opt-in default-off

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,3 +2,20 @@
 # which garter's tests use to locate the mock-plugin fixture bin. See
 # bindreams/hole#496 and crates/garter/tests/common/mod.rs.
 nextest-version = "0.9.130"
+
+# Cross-binary serialization for tests that mutate GLOBAL OS network state
+# (real WFP filters / pf rules / TUN routes). skuld's `serial = TUN` only
+# serializes within ONE test binary, but the Windows TUN lane runs the
+# `hole-bridge` and `tun-engine` binaries concurrently — the bridge's
+# `*_full_tunnel_roundtrip` e2e drives live egress while the tun-engine
+# `windows_lockdown_*` test holds a system-wide block-all WFP cover, so without
+# this they race on global state. `max-threads = 1` makes nextest run the whole
+# group on one thread across binaries. macOS is unaffected (the bridge TUN
+# tests are `cfg(windows)`), but the lockdown pf test joins the group for free.
+# Add any new real-engage/real-TUN test here when introduced.
+[test-groups.global-net-state]
+max-threads = 1
+
+[[profile.default.overrides]]
+filter = 'test(/_full_tunnel_roundtrip$/) + test(/_lockdown_blocks_egress_/) + test(/_lockdown_actually_blocks_/)'
+test-group = 'global-net-state'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,15 +7,27 @@ nextest-version = "0.9.130"
 # (real WFP filters / pf rules / TUN routes). skuld's `serial = TUN` only
 # serializes within ONE test binary, but the Windows TUN lane runs the
 # `hole-bridge` and `tun-engine` binaries concurrently — the bridge's
-# `*_full_tunnel_roundtrip` e2e drives live egress while the tun-engine
-# `windows_lockdown_*` test holds a system-wide block-all WFP cover, so without
-# this they race on global state. `max-threads = 1` makes nextest run the whole
-# group on one thread across binaries. macOS is unaffected (the bridge TUN
-# tests are `cfg(windows)`), but the lockdown pf test joins the group for free.
-# Add any new real-engage/real-TUN test here when introduced.
+# `e2e_none_full_tunnel_roundtrip` e2e drives live egress while the tun-engine
+# `windows_lockdown_permits_server_ip_and_blocks_other_egress` test holds a
+# system-wide block-all WFP cover, so without this they race on global state.
+# `max-threads = 1` makes nextest run the whole group on one thread across
+# binaries. On macOS the bridge TUN e2es are `cfg(windows)` so there is no
+# macOS bridge partner today; the `macos_lockdown_permits_server_ip_...` pf test
+# still joins the group for free (and is auto-grouped against any future macOS
+# bridge TUN e2e).
+#
+# COUPLED NAMES — the filter below matches tests BY NAME SUBSTRING. These names
+# are load-bearing and must change in lockstep with the filter:
+#   - `_full_tunnel_roundtrip` suffix:
+#     crates/bridge/src/proxy_manager_e2e_tests.rs::e2e_none_full_tunnel_roundtrip
+#   - `windows_lockdown_permits_server_ip_` / `macos_lockdown_permits_server_ip_`:
+#     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+# Renaming any of them WITHOUT updating this filter silently drops it from the
+# group → cross-binary data race. Verify with `cargo nextest show-config
+# test-groups`. Add any new real-engage/real-TUN test (and its substring) here.
 [test-groups.global-net-state]
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'test(/_full_tunnel_roundtrip$/) + test(/_lockdown_blocks_egress_/) + test(/_lockdown_actually_blocks_/)'
+filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/)'
 test-group = 'global-net-state'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -320,6 +320,24 @@ jobs:
               + package(dump) + package(dump-macros)
               + package(handle-holders)'
 
+      # macOS TUN lane runs UNDER ROOT: the lockdown real-engage test (#527)
+      # drives `pfctl -E`/`-f`, which require root. The runner's cargo/nextest
+      # and the user-owned `target/` are reused via `sudo env PATH/HOME` (the
+      # binaries are prebuilt above; nextest only re-executes them). macOS
+      # runners have passwordless sudo. Windows engages WFP from the elevated
+      # token above; macOS has no such token, so root is the equivalent.
+      - name: Test (TUN, macOS — root for pfctl)
+        if: matrix.os == 'darwin'
+        id: test-tun-macos
+        shell: bash
+        run: >
+          sudo env "PATH=$PATH" "HOME=$HOME" SKULD_LABELS=tun
+          cargo nextest run --no-default-features
+          -E 'package(hole) + package(hole-bridge) + package(hole-common)
+              + package(tun-engine) + package(tun-engine-macros)
+              + package(dump) + package(dump-macros)
+              + package(handle-holders)'
+
       # Upload bridge.log produced by `DistHarness` subprocesses. Matches
       # files that the test harness redirected to `$RUNNER_TEMP` (see
       # `crates/bridge/src/test_support/dist_harness.rs::new_tempdir`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,8 +271,14 @@ the accepted fail-closed cost.
   transaction. Loopback is permitted on `ALE_AUTH_CONNECT_V4`/`_V6` *and*
   `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
   directions, so a CONNECT-only permit would deny the accept side and break the
-  loopback data plane); the server IP is permitted on CONNECT, all else blocked
-  on CONNECT (egress kill switch). Permits are *hard* via `CLEAR_ACTION_RIGHT`.
+  loopback data plane). Loopback at CONNECT is permitted *two ways*: the
+  `FWP_CONDITION_FLAG_IS_LOOPBACK` flag **and** the destination address range
+  (`127.0.0.0/8` V4, `::1/128` V6). The flag is not reliably set at
+  `ALE_AUTH_CONNECT` under CI's elevated token — flag-only left a loopback connect
+  blocked by block-all — so the address-range permit is the deterministic match;
+  the flag permit is kept additively (it also covers `RECV_ACCEPT`). The server IP
+  is permitted on CONNECT, all else blocked on CONNECT (egress kill switch).
+  Permits are *hard* via `CLEAR_ACTION_RIGHT`.
   **Non-dynamic session** — a dynamic
   session would auto-delete the filters when the engaging process exits, reopening
   the leak mid-gap. Recovery deletes the fixed compiled-in GUIDs (idempotent), so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,7 +279,18 @@ the accepted fail-closed cost.
   connect blocked by block-all *and* the accept side dropped), so it is no longer
   load-bearing; it is kept at CONNECT only as belt-and-suspenders. The server IP
   is permitted on CONNECT, all else blocked on CONNECT (egress kill switch).
-  Permits are *hard* via `CLEAR_ACTION_RIGHT`.
+  **One sublayer, weight-based arbitration**: permits sit at weight 15, block-all
+  at weight 0, and the higher-weight permit wins within the sublayer. **No filter
+  sets `CLEAR_ACTION_RIGHT`** — that flag makes a filter's own action *soft*
+  (cross-sublayer overridable); omitting it makes the action *hard*, and hardness
+  governs only cross-sublayer arbitration, never within one. A `FWP_ACTION_BLOCK`
+  with the flag omitted is therefore a *default hard* block; setting the flag only
+  on the permits (soft) left block-all (hard) vetoing every permit, so the cover
+  blocked everything. This weight-ordered layout matches wireguard-windows (its
+  loopback/TUN/DHCP permits and block-all are weight-ordered with the flag off; it
+  sets `CLEAR_ACTION_RIGHT` only on its own service permit, none of ours). A
+  higher-weight third-party sublayer could in principle override us (accepted), and
+  a two-sublayer hard-permit/soft-block layout is a possible future hardening.
   **Non-dynamic session** — a dynamic
   session would auto-delete the filters when the engaging process exits, reopening
   the leak mid-gap. Recovery deletes the fixed compiled-in GUIDs (idempotent), so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,8 +268,12 @@ the accepted fail-closed cost.
 
 - **Windows** ([`routing/failclosed/windows.rs`](crates/tun-engine/src/routing/failclosed/windows.rs)):
   a persistent provider + sublayer + filter set installed in one FWPM
-  transaction on `ALE_AUTH_CONNECT_V4`/`_V6` (permit loopback + server IP *hard*
-  via `CLEAR_ACTION_RIGHT`, block all else). **Non-dynamic session** — a dynamic
+  transaction. Loopback is permitted on `ALE_AUTH_CONNECT_V4`/`_V6` *and*
+  `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
+  directions, so a CONNECT-only permit would deny the accept side and break the
+  loopback data plane); the server IP is permitted on CONNECT, all else blocked
+  on CONNECT (egress kill switch). Permits are *hard* via `CLEAR_ACTION_RIGHT`.
+  **Non-dynamic session** — a dynamic
   session would auto-delete the filters when the engaging process exits, reopening
   the leak mid-gap. Recovery deletes the fixed compiled-in GUIDs (idempotent), so
   no state file is needed. The FWPM FFIs are clippy-disallowed outside this module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,8 +309,9 @@ three axes:
   connected would block all browsing.
 - **Lifetime.** Lockdown is authoritative and standing — it persists across a
   crash or restart and is reconciled on the next start via
-  `decide_cover_recovery` (Adopt keeps the host fail-closed, removing only the
-  dead TUN permit; Sweep disengages when intent is off). The transient cover
+  `decide_cover_recovery` (Adopt keeps the host fail-closed, dropping the
+  volatile TUN + server permits so the next connect re-adds them fresh; Sweep
+  disengages when intent is off). The transient cover
   exists only for the sub-second cutover window.
 - **Failure mode.** A failed lockdown engage during a lockdown-on start is
   **fail-FATAL** — it aborts the start and tears everything down; the transient

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,13 +240,24 @@ performs equivalent cleanup from outside.
 
 ### Fail-closed cover
 
+Two egress-block covers share the platform `Cover` guard (kind-aware `Drop`):
+the **transient cutover cover** below and the **standing lockdown cover**
+([next section](#lockdown-mode)). Both are RAII guards permitting a curated
+egress set and blocking everything else; they differ in lifetime and which set
+they permit.
+
+#### Transient cutover cover
+
 `Routing::install_failclosed_cover(server_ip)` engages a leak-free egress block —
 permit loopback and the SS server IP, **block everything else** — as an RAII
 guard whose `Drop` disengages it. It exists for the leak-free in-place-update
 cutover (#468): the bridge is briefly stopped and restarted onto new code, and
-without a cover the missing split routes would let traffic egress in the clear
-(Hole fails *open* — there is no kill switch). The cover holds the line during
-that window; a crash mid-cutover leaves traffic **blocked, not leaked**.
+without a cover the missing split routes would let traffic egress in the clear.
+Default-off Hole fails *open* across that gap; the cover makes the cutover
+leak-free **iff [lockdown](#lockdown-mode) is enabled** (the standing cover
+already holds when the cutover starts) — otherwise this transient cover holds the
+line for the sub-second window. A crash mid-cutover leaves traffic **blocked, not
+leaked**.
 
 It is **name-agnostic** — it does *not* permit the TUN interface. The new
 bridge's start-time DNS-forwarder self-test runs over loopback to the SS client
@@ -266,11 +277,49 @@ the accepted fail-closed cost.
   blocking ruleset loads, so recovery can `-X` it cleanly. Caveat: restore reloads
   the on-disk `/etc/pf.conf`, not a snapshot of a live ruleset (matches wg-quick).
 
-Each platform splits a pure, unit-tested rule/spec builder (`build_cover_spec` /
-`build_pf_ruleset`) from the thin engage layer — mirroring `build_setup_commands`
-vs `run_commands`. The kernel-level engage is exercised by the privileged cutover
-path, not unit tests (the [#165](#bridge-test-isolation-contract) isolation
-contract). The recovery sweep runs on every bridge start via `recover_routes`.
+Each platform splits a pure, unit-tested rule/spec builder (transient:
+`build_cover_spec` / `build_pf_ruleset`; lockdown: `build_lockdown_spec` /
+`build_lockdown_main_ruleset`) from the thin engage layer — mirroring
+`build_setup_commands` vs `run_commands`. Under the
+[#165](#bridge-test-isolation-contract) isolation contract the builders are the
+only thing unit-tested; the kernel-level engage is exercised in production and,
+for the lockdown cover, by the privileged-lane real-engage test (Windows
+`hole-tests` TUN lane, #527) that proves the WFP cover actually blocks a
+non-permitted egress while loopback stays permitted. The recovery sweep runs on
+every bridge start via `recover_routes`.
+
+### Lockdown mode
+
+The **standing lockdown cover** (`Routing::install_lockdown`, #527) is an
+opt-in, **default-off**, bridge-owned kill switch. When enabled it engages a
+persistent OS-level egress block permitting **only** loopback, the `hole-tun`
+interface, the onward server connection, and (Windows) the plugin + bridge
+binaries by App-ID — so normal traffic flows while connected and the block holds
+across a bridge restart for free. When disabled, behavior is byte-identical to a
+Hole without it.
+
+It contrasts with the [transient cutover cover](#transient-cutover-cover) on
+three axes:
+
+- **Permit set.** Lockdown adds a TUN-interface permit (Windows: by `NET_LUID`;
+  macOS: `pass out quick on <tun>`) so app traffic flows; the transient cover
+  deliberately omits it (permit loopback + server only) because holding it while
+  connected would block all browsing.
+- **Lifetime.** Lockdown is authoritative and standing — it persists across a
+  crash or restart and is reconciled on the next start via
+  `decide_cover_recovery` (Adopt keeps the host fail-closed, removing only the
+  dead TUN permit; Sweep disengages when intent is off). The transient cover
+  exists only for the sub-second cutover window.
+- **Failure mode.** A failed lockdown engage during a lockdown-on start is
+  **fail-FATAL** — it aborts the start and tears everything down; the transient
+  cover fails *open* on its own engage error so a half-loaded ruleset never
+  strands the host. Lockdown is **last-writer-wins**: an absolute set via
+  `POST /v1/lockdown`, system-wide.
+
+Intent persists to `bridge-lockdown.json`; macOS additionally records the
+pre-lockdown pf snapshot in `bridge-lockdown-pf.json` so Sweep restores the host
+without `-Fa`. The LUID is **never persisted** (a teardown mints a new one) —
+re-resolved every engage via `LuidResolver`.
 
 ### Config corruption recovery
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,11 +253,12 @@ permit loopback and the SS server IP, **block everything else** — as an RAII
 guard whose `Drop` disengages it. It exists for the leak-free in-place-update
 cutover (#468): the bridge is briefly stopped and restarted onto new code, and
 without a cover the missing split routes would let traffic egress in the clear.
-Default-off Hole fails *open* across that gap; the cover makes the cutover
-leak-free **iff [lockdown](#lockdown-mode) is enabled** (the standing cover
-already holds when the cutover starts) — otherwise this transient cover holds the
-line for the sub-second window. A crash mid-cutover leaves traffic **blocked, not
-leaked**.
+This cover holds the line across that **bounded** window regardless of
+[lockdown](#lockdown-mode); a crash mid-cutover leaves traffic **blocked, not
+leaked**. It does *not* cover an indefinite outage (a bridge that stays down,
+or any gap outside an update) — without lockdown, default-off Hole fails *open*
+there. Lockdown closes that broader gap with a standing cover that already holds
+when the cutover starts.
 
 It is **name-agnostic** — it does *not* permit the TUN interface. The new
 bridge's start-time DNS-forwarder self-test runs over loopback to the SS client
@@ -283,10 +284,11 @@ Each platform splits a pure, unit-tested rule/spec builder (transient:
 `build_setup_commands` vs `run_commands`. Under the
 [#165](#bridge-test-isolation-contract) isolation contract the builders are the
 only thing unit-tested; the kernel-level engage is exercised in production and,
-for the lockdown cover, by the privileged-lane real-engage test (Windows
-`hole-tests` TUN lane, #527) that proves the WFP cover actually blocks a
-non-permitted egress while loopback stays permitted. The recovery sweep runs on
-every bridge start via `recover_routes`.
+for the lockdown cover, by the privileged-lane real-engage tests (#527) — both
+on the `tun` lane (Windows under the elevated CI token; macOS under root for
+`pfctl`) — proving the WFP/pf cover actually blocks a non-permitted egress while
+loopback stays permitted. The recovery sweep runs on every bridge start via
+`recover_routes`.
 
 ### Lockdown mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,12 +271,13 @@ the accepted fail-closed cost.
   transaction. Loopback is permitted on `ALE_AUTH_CONNECT_V4`/`_V6` *and*
   `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
   directions, so a CONNECT-only permit would deny the accept side and break the
-  loopback data plane). Loopback at CONNECT is permitted *two ways*: the
-  `FWP_CONDITION_FLAG_IS_LOOPBACK` flag **and** the destination address range
-  (`127.0.0.0/8` V4, `::1/128` V6). The flag is not reliably set at
-  `ALE_AUTH_CONNECT` under CI's elevated token — flag-only left a loopback connect
-  blocked by block-all — so the address-range permit is the deterministic match;
-  the flag permit is kept additively (it also covers `RECV_ACCEPT`). The server IP
+  loopback data plane). The deterministic matcher on *all four* layers is the
+  `FWPM_CONDITION_IP_REMOTE_ADDRESS` range (`127.0.0.0/8` V4, `::1/128` V6) — at
+  CONNECT the remote is the destination, at RECV_ACCEPT the peer, both `127.x`/`::1`
+  for a loopback flow. The `FWP_CONDITION_FLAG_IS_LOOPBACK` flag is **not reliably
+  set at either ALE layer** under CI's elevated token (flag-only left the loopback
+  connect blocked by block-all *and* the accept side dropped), so it is no longer
+  load-bearing; it is kept at CONNECT only as belt-and-suspenders. The server IP
   is permitted on CONNECT, all else blocked on CONNECT (egress kill switch).
   Permits are *hard* via `CLEAR_ACTION_RIGHT`.
   **Non-dynamic session** — a dynamic

--- a/clippy.toml
+++ b/clippy.toml
@@ -259,3 +259,13 @@ allow-invalid = true
 path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionAbort0"
 reason = "Fail-closed WFP cover must go through `routing::failclosed::engage`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#468."
 allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmGetAppIdFromFileName0"
+reason = "Lockdown cover App-ID permit must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See #527."
+allow-invalid = true
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFreeMemory0"
+reason = "Lockdown cover App-ID blob free must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See #527."
+allow-invalid = true

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -124,6 +124,9 @@ impl Routing for StubRouting {
     fn install_failclosed_cover(&self, _: IpAddr) -> Result<StubCover, RoutingError> {
         Ok(StubCover)
     }
+    fn install_lockdown(&self, _: IpAddr, _: &str, _: &[PathBuf]) -> Result<StubCover, RoutingError> {
+        Ok(StubCover)
+    }
 }
 
 struct StubRoutes {

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -231,6 +231,9 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
         invalid_filters: pm.invalid_filters(),
         udp_proxy_available: pm.udp_proxy_available(),
         ipv6_bypass_available: pm.ipv6_bypass_available(),
+        // Populated with the real intent/cover getters in the IPC task.
+        lockdown_enabled: false,
+        lockdown_active: false,
     })
 }
 

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -10,9 +10,10 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use hole_common::protocol::{
-    DiagnosticsResponse, EmptyResponse, ErrorResponse, MetricsResponse, ProxyConfig, StatusResponse, TestServerRequest,
-    TestServerResponse, VersionResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS,
-    ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER, ROUTE_VERSION,
+    DiagnosticsResponse, EmptyResponse, ErrorResponse, LockdownRequest, MetricsResponse, ProxyConfig, StatusResponse,
+    TestServerRequest, TestServerResponse, VersionResponse, CANCELLED_MESSAGE, ROUTE_CANCEL, ROUTE_DIAGNOSTICS,
+    ROUTE_LOCKDOWN, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    ROUTE_VERSION,
 };
 use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
@@ -204,6 +205,7 @@ fn build_router<P: Proxy + 'static, R: Routing + 'static>(state: Arc<IpcState<P,
         .route(ROUTE_DIAGNOSTICS, axum::routing::get(handle_diagnostics::<P, R>))
         .route(ROUTE_TEST_SERVER, axum::routing::post(handle_test_server::<P, R>))
         .route(ROUTE_VERSION, axum::routing::get(handle_version::<P, R>))
+        .route(ROUTE_LOCKDOWN, axum::routing::post(handle_lockdown::<P, R>))
         .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
         .layer(axum::middleware::map_response(
             move |mut resp: axum::response::Response| {
@@ -231,9 +233,8 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
         invalid_filters: pm.invalid_filters(),
         udp_proxy_available: pm.udp_proxy_available(),
         ipv6_bypass_available: pm.ipv6_bypass_available(),
-        // Populated with the real intent/cover getters in the IPC task.
-        lockdown_enabled: false,
-        lockdown_active: false,
+        lockdown_enabled: pm.lockdown_enabled(),
+        lockdown_active: pm.lockdown_active(),
     })
 }
 
@@ -327,6 +328,30 @@ async fn handle_cancel<P: Proxy + 'static, R: Routing + 'static>(
         cs.pending = true;
     }
     Json(EmptyResponse {})
+}
+
+/// Set the standing kill switch intent (last-writer-wins absolute set). Any
+/// authorized caller may toggle it. The bridge is the authority; the GUI only
+/// sends intent. The intent takes effect on the next start/stop — this handler
+/// does NOT engage/disengage a live cover.
+async fn handle_lockdown<P: Proxy + 'static, R: Routing + 'static>(
+    State(state): State<Arc<IpcState<P, R>>>,
+    Json(req): Json<LockdownRequest>,
+) -> Result<Json<EmptyResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let pm = state.proxy.lock().await;
+    match pm.set_lockdown_intent(req.enabled) {
+        Ok(()) => {
+            info!(enabled = req.enabled, "lockdown intent set");
+            Ok(Json(EmptyResponse {}))
+        }
+        Err(e) => {
+            error!(error = %e, "failed to set lockdown intent");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse { message: e.to_string() }),
+            ))
+        }
+    }
 }
 
 async fn handle_stop<P: Proxy + 'static, R: Routing + 'static>(

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -204,6 +204,15 @@ impl Routing for MockRouting {
     fn install_failclosed_cover(&self, _server_ip: IpAddr) -> Result<MockCover, RoutingError> {
         Ok(MockCover)
     }
+
+    fn install_lockdown(
+        &self,
+        _server_ip: IpAddr,
+        _tun_name: &str,
+        _app_ids: &[PathBuf],
+    ) -> Result<MockCover, RoutingError> {
+        Ok(MockCover)
+    }
 }
 
 struct MockCover;

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -245,6 +245,16 @@ fn mock_proxy() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
     Arc::new(Mutex::new(ProxyManager::new(MockProxy::new(), routing)))
 }
 
+/// `mock_proxy` variant whose manager has a persisted state_dir, so
+/// `set_lockdown_intent` can write `bridge-lockdown.json`. The TempDir is
+/// `.keep()`-ed (created, auto-cleanup suppressed) like the other helpers.
+fn mock_proxy_with_state_dir() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
+    let state_dir = tempfile::tempdir().unwrap().keep();
+    let routing = MockRouting::new(state_dir.clone());
+    let pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(state_dir);
+    Arc::new(Mutex::new(pm))
+}
+
 /// `mock_proxy` variant that also hands back the mock's traffic counters
 /// so tests can simulate tunnel bytes.
 fn mock_proxy_with_traffic() -> (Arc<Mutex<ProxyManager<MockProxy, MockRouting>>>, Arc<MockTraffic>) {
@@ -381,6 +391,18 @@ async fn post_cancel(client: &mut TestClient) -> http::Response<hyper::body::Inc
         .uri(ROUTE_CANCEL)
         .header("host", "localhost")
         .body(Full::new(Bytes::new()))
+        .unwrap();
+    client.send(req).await
+}
+
+async fn post_lockdown(client: &mut TestClient, enabled: bool) -> http::Response<hyper::body::Incoming> {
+    let body = serde_json::to_vec(&hole_common::protocol::LockdownRequest { enabled }).unwrap();
+    let req = http::Request::builder()
+        .method("POST")
+        .uri(ROUTE_LOCKDOWN)
+        .header("host", "localhost")
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(body)))
         .unwrap();
     client.send(req).await
 }
@@ -529,6 +551,65 @@ fn multiple_requests_on_same_connection() {
 
         let s2 = get_status(&mut client).await;
         assert!(!s2.running);
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn lockdown_post_sets_intent_and_status_reflects_it() {
+    rt().block_on(async {
+        let path = test_socket_path("lockdown-post");
+        let server = IpcServer::bind(&path, mock_proxy_with_state_dir(), "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+
+        // POST /v1/lockdown { enabled: true }
+        let resp = post_lockdown(&mut client, true).await;
+        assert_eq!(resp.status(), 200, "lockdown POST should 200");
+        assert_eq!(
+            resp.headers().get("x-hole-bridge-version").unwrap(),
+            "test",
+            "version header stamped on the lockdown response"
+        );
+        let _ = resp.into_body().collect().await;
+
+        // GET /v1/status reflects the intent (same connection).
+        let status = get_status(&mut client).await;
+        assert!(status.lockdown_enabled, "status must reflect the set intent");
+        assert!(!status.lockdown_active, "no cover engaged while stopped");
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn lockdown_post_errors_without_state_dir() {
+    // A kill-switch request the bridge cannot persist must fail loudly, not
+    // silently 200: a silent Ok would make the GUI believe lockdown is armed
+    // when nothing was written. `mock_proxy()` has no `.with_state_dir(..)`.
+    rt().block_on(async {
+        let path = test_socket_path("lockdown-no-statedir");
+        let server = IpcServer::bind(&path, mock_proxy(), "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_lockdown(&mut client, true).await;
+        assert_eq!(
+            resp.status(),
+            500,
+            "lockdown POST without a state_dir must error, not silently succeed"
+        );
+        let _ = resp.into_body().collect().await;
 
         drop(client);
         handle.abort();

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -504,6 +504,8 @@ fn status_when_not_running_returns_false() {
                 invalid_filters: Vec::new(),
                 udp_proxy_available: true,
                 ipv6_bypass_available: true,
+                lockdown_enabled: false,
+                lockdown_active: false,
             }
         );
         drop(client);

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -356,6 +356,30 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         self.running.as_ref().map(|r| r.lockdown.is_some()).unwrap_or(false)
     }
 
+    /// Whether the standing kill switch intent is on (from `bridge-lockdown.json`).
+    /// Default-off when there is no state_dir or no file.
+    pub fn lockdown_enabled(&self) -> bool {
+        self.state_dir
+            .as_deref()
+            .map(lockdown_state::load_enabled)
+            .unwrap_or(false)
+    }
+
+    /// Last-writer-wins absolute set of the lockdown intent. Persists to
+    /// `bridge-lockdown.json`. ERRORS when there is no state_dir: the bridge
+    /// cannot honor a kill switch it cannot persist (a silent `Ok(())` would be
+    /// a fail-open footgun — the GUI would believe lockdown is armed when
+    /// nothing was written).
+    pub fn set_lockdown_intent(&self, enabled: bool) -> Result<(), ProxyError> {
+        let dir = self.state_dir.as_deref().ok_or_else(|| {
+            ProxyError::Runtime(std::io::Error::other(
+                "cannot set lockdown intent: bridge has no state_dir to persist it",
+            ))
+        })?;
+        lockdown_state::set_enabled(dir, enabled)
+            .map_err(|e| ProxyError::Runtime(std::io::Error::other(format!("lockdown persist: {e}"))))
+    }
+
     /// Non-cancellable convenience wrapper around
     /// [`start_cancellable`](Self::start_cancellable). Equivalent to
     /// passing a fresh, never-signaled `CancellationToken`. Used by

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -41,6 +41,7 @@ use hole_common::protocol::{ProxyConfig, TunnelMode};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use tun_engine::gateway::GatewayInfo;
+use tun_engine::routing::failclosed::lockdown_state;
 use tun_engine::routing::{Routing, SystemRouting};
 
 use crate::dns::system::{Dns, DnsApplied, DnsError, SystemDns};
@@ -103,6 +104,8 @@ pub enum ProxyState {
 /// 3. `plugin_chain` drop — graceful stop via SIGTERM/CTRL_BREAK.
 /// 4. `proxy.stop().await` — releases SS task.
 /// 5. `routes` drop — RAII teardown.
+/// 6. `lockdown` drop — disengage standing cover (user-approved stop opens
+///    the host). Last so the persistent filters outlive routes by Drop order.
 ///
 /// `None` fields for SocksOnly mode where routing / dispatcher / DNS are
 /// skipped, or when no plugin is configured.
@@ -125,6 +128,11 @@ struct RunningState<P: Proxy, R: Routing, D: Dns> {
     /// Installed routes. `None` in SocksOnly mode.
     #[allow(dead_code)]
     routes: Option<R::Installed>,
+    /// Standing lockdown cover, engaged only when intent is on (#527). `None`
+    /// when lockdown is off — then behavior is byte-identical to today. Read by
+    /// `lockdown_active()`; disengaged in `stop()` after routes tear down (its
+    /// Drop is the catastrophic safety net).
+    lockdown: Option<R::Cover>,
     /// Handle on the running proxy. Drop aborts the task (best-effort);
     /// supported graceful shutdown is via `stop().await` from
     /// [`ProxyManager::stop`].
@@ -342,6 +350,12 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         self.ipv6_bypass_available
     }
 
+    /// Whether a standing lockdown cover is currently engaged (the `active`
+    /// signal). Distinct from the persisted intent (`enabled`).
+    pub fn lockdown_active(&self) -> bool {
+        self.running.as_ref().map(|r| r.lockdown.is_some()).unwrap_or(false)
+    }
+
     /// Non-cancellable convenience wrapper around
     /// [`start_cancellable`](Self::start_cancellable). Equivalent to
     /// passing a fresh, never-signaled `CancellationToken`. Used by
@@ -460,13 +474,17 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// `Err(ProxyError::Cancelled)` cooperatively. Earlier RAII guards
     /// drop in reverse-declaration order when the function returns Err,
     /// tearing down anything that was constructed before the cancel
-    /// observation:
+    /// observation (listed in declaration order — later items drop first):
     ///
     /// 1. `PluginChain` — on drop, cancels its garter token and clears
     ///    the plugin state file.
     /// 2. `P::Running` — on drop, aborts the spawned proxy task.
     /// 3. `R::Installed` — on drop, tears down routes and clears the
     ///    crash-recovery state file.
+    /// 4. `Option<R::Cover>` (lockdown) — declared last, so it drops first,
+    ///    before `R::Installed`; disengages the standing cover (only `Some`
+    ///    when intent is on and engage already succeeded). On the fail-FATAL
+    ///    engage `?` it is never constructed, so only `R::Installed` tears down.
     ///
     /// Per-phase cancellation strategy:
     /// - **Phase 1 (plugin chain)**: the bridge cancel is threaded into
@@ -623,6 +641,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 dispatcher: None,
                 plugin_chain,
                 routes: None,
+                lockdown: None,
                 proxy: running_proxy,
                 server_ip: None,
                 started_at: Instant::now(),
@@ -773,6 +792,21 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
+        // Standing lockdown cover (#527). Engaged only when intent is on; when
+        // off this whole block is a no-op and the start is byte-identical to
+        // today. Engaged AFTER routing.install (TUN exists => LUID resolvable)
+        // and BEFORE Dns::apply, so the line is held the moment routes go live.
+        // FAIL-FATAL: an engage error under intent-on aborts the start; the
+        // locally-owned `routes` guard (declared above) Drops on the Err
+        // unwind, tearing down — the opposite of the transient cover's
+        // fail-open. Committed only on the Ok path (the field below).
+        let lockdown = if state_dir.map(lockdown_state::load_enabled).unwrap_or(false) {
+            let app_ids = lockdown_app_ids(config);
+            Some(routing.install_lockdown(server_ip, TUN_DEVICE_NAME, &app_ids)?)
+        } else {
+            None
+        };
+
         // Phase 7: apply system DNS AFTER routes install so the OS
         // "best-route to DNS server" lookup resolves through the TUN.
         // We advertise the configured upstream resolver IPs — OS UDP/53 to
@@ -818,6 +852,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             dispatcher,
             plugin_chain,
             routes: Some(routes),
+            lockdown,
             proxy: running_proxy,
             server_ip: Some(server_ip),
             started_at: Instant::now(),
@@ -837,6 +872,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             plugin_chain,
             proxy,
             routes,
+            lockdown,
             server_ip: _,
             started_at: _,
             udp_proxy_available: _,
@@ -870,6 +906,11 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
 
         // 4. Routes tear down via RAII Drop.
         drop(routes);
+
+        // 5. Disengage the standing lockdown cover (user-approved stop opens
+        // the host; the cutover-stop exception is PR2). Dropping the guard
+        // disengages it (Windows: delete WFP filters; macOS: restore pf).
+        drop(lockdown);
 
         // Snapshot WFP + NDIS post-teardown. Emits warn when wintun-
         // related references remain in either layer. Cheap and
@@ -1023,6 +1064,35 @@ fn tunnel_mode_label(mode: &TunnelMode) -> &'static str {
     match mode {
         TunnelMode::Full => "full",
         TunnelMode::SocksOnly => "socks_only",
+    }
+}
+
+/// The process image paths the Windows lockdown cover permits by App-ID: the
+/// resolved plugin binary (if a plugin is configured) and the bridge's own exe.
+/// Empty on macOS (pf has no per-process matching). Path-keyed so the permit
+/// survives a cutover rename.
+fn lockdown_app_ids(config: &ProxyConfig) -> Vec<std::path::PathBuf> {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = config;
+        Vec::new()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let mut ids: Vec<std::path::PathBuf> = Vec::new();
+        if let Some(ref plugin) = config.server.plugin {
+            ids.push(std::path::PathBuf::from(crate::proxy::config::resolve_plugin_path(
+                plugin,
+            )));
+        }
+        match std::env::current_exe() {
+            Ok(exe) => ids.push(exe),
+            // The bridge's own egress still rides the server-IP permit, so a
+            // missing exe path narrows but does not break the cover. Warn so a
+            // bug report carries the shrunken-permit-set signal.
+            Err(e) => warn!(error = %e, "lockdown: current_exe() failed; bridge App-ID permit omitted"),
+        }
+        ids
     }
 }
 

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -336,6 +336,12 @@ mod tun {
     /// Test 5: Full mode (TUN + routing), no plugin. Requires Windows
     /// admin. TUN tests are serial because they all bind the hardcoded
     /// `hole-tun` device name.
+    ///
+    /// COUPLED NAME: the `_full_tunnel_roundtrip` suffix is the literal substring
+    /// `.config/nextest.toml`'s `global-net-state` filter matches to serialize
+    /// this live-egress e2e against tun-engine's system-wide WFP lockdown test
+    /// across binaries. Renaming the suffix without updating that filter drops
+    /// this test from the group → cross-binary data race.
     #[skuld::test(labels = [DIST_BIN, TUN], serial = TUN)]
     fn e2e_none_full_tunnel_roundtrip(
         #[fixture(dist_dir)] dist: &Path,

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -17,6 +17,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tun_engine::gateway::GatewayInfo;
+use tun_engine::routing::failclosed::lockdown_state;
 use tun_engine::routing::{self, state as route_state, Routing};
 use tun_engine::RoutingError;
 
@@ -399,6 +400,20 @@ fn new_manager_with_routing(
     dir: tempfile::TempDir,
 ) -> (ProxyManager<MockProxy, MockRouting>, tempfile::TempDir) {
     let pm = ProxyManager::new(proxy, routing);
+    (pm, dir)
+}
+
+/// Build a manager whose routing + manager share `dir` as state_dir, with the
+/// lockdown intent seeded to `enabled`. The shared state_dir is how the manager
+/// reads `bridge-lockdown.json` in `start_inner`.
+fn new_manager_with_lockdown(
+    proxy: MockProxy,
+    routing: MockRouting,
+    dir: tempfile::TempDir,
+    enabled: bool,
+) -> (ProxyManager<MockProxy, MockRouting>, tempfile::TempDir) {
+    lockdown_state::set_enabled(dir.path(), enabled).unwrap();
+    let pm = ProxyManager::new(proxy, routing).with_state_dir(dir.path().to_path_buf());
     (pm, dir)
 }
 
@@ -824,6 +839,101 @@ fn mock_cover_engage_disengage_never_spawns() {
     assert_eq!(routing::ROUTING_SUBPROCESS_SPAWN_COUNT.load(Ordering::SeqCst), 0);
     assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 10);
     assert_eq!(st.cover_disengage_calls.load(Ordering::SeqCst), 10);
+}
+
+// Standing lockdown guard lifecycle (#527) ============================================================================
+//
+// `start_inner` engages the standing lockdown cover AFTER routing.install and
+// BEFORE Dns::apply, ONLY when `bridge-lockdown.json` intent is on. The Cover
+// is committed to RunningState only on the Ok path; `stop()` disengages it. A
+// failed engage under intent-on is fail-FATAL: it aborts the start and the
+// locally-owned routes guard tears down (mirror of the forwarder-self-test gate).
+
+#[skuld::test]
+fn lockdown_off_does_not_engage_cover() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+
+        pm.start(&test_config()).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        assert!(!pm.lockdown_active(), "lockdown OFF must leave no cover engaged");
+        assert_eq!(
+            st.lockdown_engage_calls.load(Ordering::SeqCst),
+            0,
+            "lockdown OFF must be byte-identical to today (no engage)"
+        );
+
+        pm.stop().await.unwrap();
+        assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[skuld::test]
+fn lockdown_on_engages_after_install_and_disengages_on_stop() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
+
+        pm.start(&test_config()).await.unwrap();
+        assert_eq!(pm.state(), ProxyState::Running);
+        assert!(pm.lockdown_active(), "intent-on start must engage the cover");
+        assert_eq!(st.install_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            st.lockdown_engage_calls.load(Ordering::SeqCst),
+            1,
+            "engaged on a lockdown-on start"
+        );
+        assert_eq!(
+            st.lockdown_disengage_calls.load(Ordering::SeqCst),
+            0,
+            "still engaged while running"
+        );
+
+        pm.stop().await.unwrap();
+        assert!(!pm.lockdown_active(), "cover disengaged after stop");
+        assert_eq!(
+            st.lockdown_disengage_calls.load(Ordering::SeqCst),
+            1,
+            "disengaged on stop"
+        );
+    });
+}
+
+#[skuld::test]
+fn lockdown_engage_failure_is_fatal_and_tears_down() {
+    // Fail-FATAL mirror of start_blocks_on_forwarder_self_test_failure: a
+    // failed lockdown engage under intent-ON aborts the start and tears down
+    // routes (the opposite of the transient cover's fail-open).
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::failing_lockdown(dir.path().to_path_buf());
+        let st = routing.state();
+        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
+
+        let err = pm.start(&test_config()).await.unwrap_err();
+        assert!(
+            err.to_string().contains("mock lockdown failure"),
+            "expected the lockdown engage error, got {err}"
+        );
+        assert_eq!(pm.state(), ProxyState::Stopped);
+        // routes WERE installed (engage runs after install) then torn down on
+        // the Err unwind — net teardown count equals install count.
+        assert_eq!(st.install_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            st.teardown_calls.load(Ordering::SeqCst),
+            1,
+            "routes must be torn down when lockdown engage fails (fail-FATAL)"
+        );
+        // The engage never succeeded, so no cover was committed and none disengaged.
+        assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
+        assert!(pm.last_error().is_some());
+    });
 }
 
 // last_error coverage for early-failure paths =========================================================================

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -277,6 +277,18 @@ impl Routing for MockRouting {
             state: Arc::clone(&self.state),
         })
     }
+
+    fn install_lockdown(
+        &self,
+        _server_ip: IpAddr,
+        _tun_name: &str,
+        _app_ids: &[std::path::PathBuf],
+    ) -> Result<MockCover, RoutingError> {
+        self.state.cover_engage_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(MockCover {
+            state: Arc::clone(&self.state),
+        })
+    }
 }
 
 struct MockRoutes {

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -172,6 +172,10 @@ struct MockRoutingState {
     lockdown_engage_calls: AtomicU32,
     lockdown_disengage_calls: AtomicU32,
     fail_lockdown: AtomicBool,
+    /// Ordered record of teardown events ("routes" / "lockdown") so a test can
+    /// observe the unwind teardown sequence. Shared via the `Arc<MockRoutingState>`
+    /// both `MockRoutes` and `MockCover` clone.
+    teardown_order: std::sync::Mutex<Vec<&'static str>>,
 }
 
 impl Default for MockRoutingState {
@@ -186,6 +190,7 @@ impl Default for MockRoutingState {
             lockdown_engage_calls: AtomicU32::new(0),
             lockdown_disengage_calls: AtomicU32::new(0),
             fail_lockdown: AtomicBool::new(false),
+            teardown_order: std::sync::Mutex::new(Vec::new()),
         }
     }
 }
@@ -317,6 +322,7 @@ struct MockRoutes {
 impl Drop for MockRoutes {
     fn drop(&mut self) {
         self.state.teardown_calls.fetch_add(1, Ordering::SeqCst);
+        self.state.teardown_order.lock().unwrap().push("routes");
         let _ = route_state::clear(&self.state_dir);
     }
 }
@@ -333,6 +339,7 @@ impl Drop for MockCover {
     fn drop(&mut self) {
         if self.lockdown {
             self.state.lockdown_disengage_calls.fetch_add(1, Ordering::SeqCst);
+            self.state.teardown_order.lock().unwrap().push("lockdown");
         } else {
             self.state.cover_disengage_calls.fetch_add(1, Ordering::SeqCst);
         }
@@ -933,6 +940,34 @@ fn lockdown_engage_failure_is_fatal_and_tears_down() {
         assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 0);
         assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
         assert!(pm.last_error().is_some());
+    });
+}
+
+#[skuld::test]
+fn lockdown_engage_failure_tears_down_routes_only() {
+    // Fail-FATAL engage: routes were installed (engage runs after install) then the
+    // `?` on install_lockdown unwinds the locally-owned `routes` guard. The lockdown
+    // cover is never constructed (the `?` fires before the `lockdown` binding
+    // completes), so the ordered recorder must show exactly one teardown — "routes" —
+    // and the cover disengage counter must stay at zero. (On a clean stop the order
+    // is the reverse — routes then lockdown — by design; see ProxyManager::stop.)
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::failing_lockdown(dir.path().to_path_buf());
+        let st = routing.state();
+        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
+
+        let err = pm.start(&test_config()).await.unwrap_err();
+        assert!(err.to_string().contains("mock lockdown failure"));
+        assert_eq!(pm.state(), ProxyState::Stopped);
+
+        let order = st.teardown_order.lock().unwrap().clone();
+        assert_eq!(
+            order,
+            vec!["routes"],
+            "engage failure tears down routes only; no cover was created"
+        );
+        assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
     });
 }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -168,6 +168,9 @@ struct MockRoutingState {
     fail_gateway: AtomicBool,
     cover_engage_calls: AtomicU32,
     cover_disengage_calls: AtomicU32,
+    lockdown_engage_calls: AtomicU32,
+    lockdown_disengage_calls: AtomicU32,
+    fail_lockdown: AtomicBool,
 }
 
 impl Default for MockRoutingState {
@@ -179,6 +182,9 @@ impl Default for MockRoutingState {
             fail_gateway: AtomicBool::new(false),
             cover_engage_calls: AtomicU32::new(0),
             cover_disengage_calls: AtomicU32::new(0),
+            lockdown_engage_calls: AtomicU32::new(0),
+            lockdown_disengage_calls: AtomicU32::new(0),
+            fail_lockdown: AtomicBool::new(false),
         }
     }
 }
@@ -211,6 +217,12 @@ impl MockRouting {
     fn failing_gateway(state_dir: PathBuf) -> Self {
         let m = Self::new(state_dir);
         m.state.fail_gateway.store(true, Ordering::SeqCst);
+        m
+    }
+
+    fn failing_lockdown(state_dir: PathBuf) -> Self {
+        let m = Self::new(state_dir);
+        m.state.fail_lockdown.store(true, Ordering::SeqCst);
         m
     }
 
@@ -275,6 +287,7 @@ impl Routing for MockRouting {
         self.state.cover_engage_calls.fetch_add(1, Ordering::SeqCst);
         Ok(MockCover {
             state: Arc::clone(&self.state),
+            lockdown: false,
         })
     }
 
@@ -284,9 +297,13 @@ impl Routing for MockRouting {
         _tun_name: &str,
         _app_ids: &[std::path::PathBuf],
     ) -> Result<MockCover, RoutingError> {
-        self.state.cover_engage_calls.fetch_add(1, Ordering::SeqCst);
+        if self.state.fail_lockdown.load(Ordering::SeqCst) {
+            return Err(RoutingError::RouteSetup("mock lockdown failure".into()));
+        }
+        self.state.lockdown_engage_calls.fetch_add(1, Ordering::SeqCst);
         Ok(MockCover {
             state: Arc::clone(&self.state),
+            lockdown: true,
         })
     }
 }
@@ -305,12 +322,56 @@ impl Drop for MockRoutes {
 
 struct MockCover {
     state: Arc<MockRoutingState>,
+    /// Whether this guard holds the standing lockdown cover (vs the transient
+    /// fail-closed cover) — selects which disengage counter Drop bumps, mirroring
+    /// the kind-aware `failclosed::Cover`.
+    lockdown: bool,
 }
 
 impl Drop for MockCover {
     fn drop(&mut self) {
-        self.state.cover_disengage_calls.fetch_add(1, Ordering::SeqCst);
+        if self.lockdown {
+            self.state.lockdown_disengage_calls.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.state.cover_disengage_calls.fetch_add(1, Ordering::SeqCst);
+        }
     }
+}
+
+// MockRouting lockdown instrumentation ================================================================================
+//
+// These exercise the mock seam directly (no ProxyManager) so the later
+// standing-guard lifecycle tests (engage / fail-FATAL / disengage) can rely on
+// the counters, fail flag, and kind-aware Drop dispatch being correct.
+
+#[skuld::test]
+fn mock_install_lockdown_records_engage_and_drop_records_disengage() {
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+
+    let cover = routing
+        .install_lockdown(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), "hole-tun", &[])
+        .expect("lockdown engages");
+    assert_eq!(state.lockdown_engage_calls.load(Ordering::SeqCst), 1);
+    // The transient-cover counter must NOT move — the two covers are distinct.
+    assert_eq!(state.cover_engage_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(state.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
+
+    drop(cover);
+    assert_eq!(state.lockdown_disengage_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(state.cover_disengage_calls.load(Ordering::SeqCst), 0);
+}
+
+#[skuld::test]
+fn mock_failing_lockdown_returns_err_without_recording() {
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::failing_lockdown(dir.path().to_path_buf());
+    let state = routing.state();
+
+    let result = routing.install_lockdown(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), "hole-tun", &[]);
+    assert!(result.is_err(), "failing_lockdown must return Err");
+    assert_eq!(state.lockdown_engage_calls.load(Ordering::SeqCst), 0);
 }
 
 // Helpers =============================================================================================================

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -31,9 +31,9 @@
 use crate::socket::LocalStream;
 use bytes::Bytes;
 use hole_common::protocol::{
-    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, StatusResponse,
-    TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START,
-    ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, LockdownRequest, MetricsResponse,
+    StatusResponse, TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_LOCKDOWN,
+    ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -553,6 +553,8 @@ impl BridgeIpcClient {
                         invalid_filters: status.invalid_filters,
                         udp_proxy_available: status.udp_proxy_available,
                         ipv6_bypass_available: status.ipv6_bypass_available,
+                        lockdown_enabled: status.lockdown_enabled,
+                        lockdown_active: status.lockdown_active,
                     })
                 } else {
                     parse_bridge_error(resp).await
@@ -635,6 +637,15 @@ impl BridgeIpcClient {
                     Ok(BridgeResponse::TestServerResult {
                         outcome: parsed.outcome,
                     })
+                } else {
+                    parse_bridge_error(resp).await
+                }
+            }
+            BridgeRequest::SetLockdown { enabled } => {
+                let body = serde_json::to_vec(&LockdownRequest { enabled })?;
+                let resp = self.http_post(ROUTE_LOCKDOWN, body).await?;
+                if resp.status().is_success() {
+                    Ok(BridgeResponse::Ack)
                 } else {
                     parse_bridge_error(resp).await
                 }

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -89,6 +89,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/EmptyResponse"
 
+  /v1/lockdown:
+    post:
+      summary: Set the standing kill switch (lockdown mode) intent
+      description: |
+        Last-writer-wins absolute set of the bridge-owned, system-wide
+        lockdown intent. Any authorized caller may toggle it freely. Returns
+        200 with EmptyResponse on success.
+      operationId: setLockdown
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LockdownRequest"
+      responses:
+        "200":
+          description: Lockdown intent recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        "500":
+          description: Failed to persist lockdown intent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /v1/reload:
     post:
       summary: Reload the proxy with new configuration
@@ -190,6 +218,19 @@ components:
         ipv6_bypass_available:
           type: boolean
           default: true
+        lockdown_enabled:
+          type: boolean
+          default: false
+          description: >-
+            Whether the standing kill switch (lockdown mode) intent is on.
+            Bridge-owned, system-wide. serde-default false so older clients that
+            don't send it keep today's behavior.
+        lockdown_active:
+          type: boolean
+          default: false
+          description: >-
+            Whether a lockdown cover is currently engaged. `lockdown_enabled &&
+            !lockdown_active` is a tray warning state — never silent green.
 
     ErrorResponse:
       type: object
@@ -504,3 +545,12 @@ components:
             tunnel_handshake_failed {kind}, server_cannot_reach_internet {kind},
             sentinel_mismatch {kind, detail}, internal_error {kind, detail}.
             See protocol.rs::ServerTestOutcome.
+
+    LockdownRequest:
+      type: object
+      description: "Hand-written in protocol.rs."
+      required:
+        - enabled
+      properties:
+        enabled:
+          type: boolean

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -50,6 +50,11 @@ pub enum BridgeRequest {
     TestServer {
         entry: ServerEntry,
     },
+    /// Set the standing kill switch intent (last-writer-wins). Maps to
+    /// `POST /v1/lockdown`.
+    SetLockdown {
+        enabled: bool,
+    },
 }
 
 /// The exact string the bridge writes into `ErrorResponse` when a `Start` is
@@ -70,6 +75,8 @@ pub enum BridgeResponse {
         invalid_filters: Vec<InvalidFilter>,
         udp_proxy_available: bool,
         ipv6_bypass_available: bool,
+        lockdown_enabled: bool,
+        lockdown_active: bool,
     },
     Error {
         message: String,
@@ -269,6 +276,13 @@ pub struct TestServerRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TestServerResponse {
     pub outcome: ServerTestOutcome,
+}
+
+/// Body of `POST /v1/lockdown`: the absolute lockdown intent to set
+/// (last-writer-wins). Hand-written, not generated.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LockdownRequest {
+    pub enabled: bool,
 }
 
 // Constants ===========================================================================================================

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -113,6 +113,8 @@ fn bridge_response_status_json_roundtrip() {
         }],
         udp_proxy_available: true,
         ipv6_bypass_available: false,
+        lockdown_enabled: false,
+        lockdown_active: false,
     };
     let json = serde_json::to_vec(&resp).unwrap();
     let decoded: BridgeResponse = serde_json::from_slice(&json).unwrap();
@@ -159,6 +161,8 @@ fn status_response_json_roundtrip() {
         }],
         udp_proxy_available: false,
         ipv6_bypass_available: true,
+        lockdown_enabled: false,
+        lockdown_active: false,
     };
     let json = serde_json::to_string(&resp).unwrap();
     let decoded: StatusResponse = serde_json::from_str(&json).unwrap();
@@ -174,6 +178,8 @@ fn status_response_without_error() {
         invalid_filters: Vec::new(),
         udp_proxy_available: true,
         ipv6_bypass_available: true,
+        lockdown_enabled: false,
+        lockdown_active: false,
     };
     let json = serde_json::to_string(&resp).unwrap();
     assert!(!json.contains("error"), "None error should be skipped in serialization");
@@ -216,6 +222,41 @@ fn route_constants_are_correct() {
     assert_eq!(ROUTE_STOP, "/v1/stop");
     assert_eq!(ROUTE_CANCEL, "/v1/cancel");
     assert_eq!(ROUTE_RELOAD, "/v1/reload");
+}
+
+#[skuld::test]
+fn route_lockdown_path_is_stable() {
+    use crate::protocol::ROUTE_LOCKDOWN;
+    assert_eq!(ROUTE_LOCKDOWN, "/v1/lockdown");
+}
+
+#[skuld::test]
+fn status_response_lockdown_fields_default_false_for_old_clients() {
+    use crate::protocol::StatusResponse;
+    // An old client sends a StatusResponse JSON without the lockdown fields;
+    // serde-default must fill them as false (matching udp/ipv6 fields).
+    let json = r#"{"running":true,"uptime_secs":0}"#;
+    let s: StatusResponse = serde_json::from_str(json).unwrap();
+    assert!(!s.lockdown_enabled);
+    assert!(!s.lockdown_active);
+}
+
+#[skuld::test]
+fn lockdown_request_json_roundtrip() {
+    use crate::protocol::LockdownRequest;
+    let req = LockdownRequest { enabled: true };
+    let json = serde_json::to_string(&req).unwrap();
+    assert_eq!(json, r#"{"enabled":true}"#);
+    let decoded: LockdownRequest = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, req);
+}
+
+#[skuld::test]
+fn bridge_request_set_lockdown_json_roundtrip() {
+    let req = BridgeRequest::SetLockdown { enabled: true };
+    let json = serde_json::to_vec(&req).unwrap();
+    let decoded: BridgeRequest = serde_json::from_slice(&json).unwrap();
+    assert_eq!(decoded, req);
 }
 
 // New response types --------------------------------------------------------------------------------------------------

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -2,9 +2,9 @@
 
 use bytes::Bytes;
 use hole_common::protocol::{
-    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, MetricsResponse, StatusResponse,
-    TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START,
-    ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
+    BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, LockdownRequest, MetricsResponse,
+    StatusResponse, TestServerRequest, TestServerResponse, ROUTE_CANCEL, ROUTE_DIAGNOSTICS, ROUTE_LOCKDOWN,
+    ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -110,6 +110,8 @@ impl BridgeClient {
                         invalid_filters: status.invalid_filters,
                         udp_proxy_available: status.udp_proxy_available,
                         ipv6_bypass_available: status.ipv6_bypass_available,
+                        lockdown_enabled: status.lockdown_enabled,
+                        lockdown_active: status.lockdown_active,
                     })
                 } else {
                     parse_bridge_error(resp).await
@@ -195,6 +197,16 @@ impl BridgeClient {
                     Ok(BridgeResponse::TestServerResult {
                         outcome: parsed.outcome,
                     })
+                } else {
+                    parse_bridge_error(resp).await
+                }
+            }
+            BridgeRequest::SetLockdown { enabled } => {
+                let body = serde_json::to_vec(&LockdownRequest { enabled })
+                    .map_err(|e| ClientError::Protocol(e.to_string()))?;
+                let resp = self.http_post(ROUTE_LOCKDOWN, body).await?;
+                if resp.status().is_success() {
+                    Ok(BridgeResponse::Ack)
                 } else {
                     parse_bridge_error(resp).await
                 }

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -31,6 +31,8 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     invalid_filters: Vec::new(),
                     udp_proxy_available: true,
                     ipv6_bypass_available: true,
+                    lockdown_enabled: false,
+                    lockdown_active: false,
                 })
             }),
         )
@@ -122,6 +124,8 @@ fn send_status_request_receives_response() {
                 invalid_filters: Vec::new(),
                 udp_proxy_available: true,
                 ipv6_bypass_available: true,
+                lockdown_enabled: false,
+                lockdown_active: false,
             }
         );
     });
@@ -282,6 +286,8 @@ async fn spawn_error_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<(
                     invalid_filters: Vec::new(),
                     udp_proxy_available: true,
                     ipv6_bypass_available: true,
+                    lockdown_enabled: false,
+                    lockdown_active: false,
                 })
             }),
         )
@@ -430,6 +436,8 @@ async fn spawn_status_mock(path: &std::path::Path, version: Option<&'static str>
                 invalid_filters: Vec::new(),
                 udp_proxy_available: true,
                 ipv6_bypass_available: true,
+                lockdown_enabled: false,
+                lockdown_active: false,
             })
         }),
     );

--- a/crates/hole/src/commands.rs
+++ b/crates/hole/src/commands.rs
@@ -309,6 +309,7 @@ pub async fn get_proxy_status(state: State<'_, AppState>) -> Result<serde_json::
             invalid_filters,
             udp_proxy_available,
             ipv6_bypass_available,
+            ..
         }) => serde_json::json!({
             "uptime_secs": uptime_secs,
             "error": error,

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -131,7 +131,12 @@ impl BridgeLink {
         let mut guard = self.client.lock().await;
         let result = Self::send_locked(&mut guard, &self.socket_path, req).await;
         if let Some(running) = observed_running(kind, &result) {
-            self.cell.commit(running);
+            // A Status exchange reveals lockdown too — commit all three
+            // atomically under this lock; other exchanges know only `running`.
+            match observed_lockdown(&result) {
+                Some((le, la)) => self.cell.commit_status(running, le, la),
+                None => self.cell.commit(running),
+            }
         }
         self.note_mismatch(&result);
         result
@@ -211,7 +216,10 @@ impl BridgeLink {
         let status = Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Status).await;
         self.note_mismatch(&status);
         if let Some(running) = observed_running(ReqKind::Status, &status) {
-            self.cell.commit(running);
+            match observed_lockdown(&status) {
+                Some((le, la)) => self.cell.commit_status(running, le, la),
+                None => self.cell.commit(running),
+            }
         }
         if !matches!(status, Ok(BridgeResponse::Status { running: true, .. })) {
             return Ok(false); // Not running; changes apply on next start.
@@ -237,6 +245,11 @@ impl BridgeLink {
 pub struct ProxySnapshot {
     pub seq: u64,
     pub running: bool,
+    /// Standing kill-switch intent (#527), from the bridge's StatusResponse.
+    pub lockdown_enabled: bool,
+    /// Whether a lockdown cover is engaged. `enabled && !active` is a tray
+    /// warning state — never silent green.
+    pub lockdown_active: bool,
 }
 
 /// Single owner of the GUI's view of "is the proxy running" (#462).
@@ -252,12 +265,18 @@ impl Default for ProxyStateCell {
 
 impl ProxyStateCell {
     pub fn new() -> Self {
-        let (tx, _) = tokio::sync::watch::channel(ProxySnapshot { seq: 0, running: false });
+        let (tx, _) = tokio::sync::watch::channel(ProxySnapshot {
+            seq: 0,
+            running: false,
+            lockdown_enabled: false,
+            lockdown_active: false,
+        });
         Self { tx }
     }
 
     /// Commit an observed running state. Bumps `seq` (and wakes watchers)
-    /// only when the value actually changes.
+    /// only when the value actually changes. Preserves the lockdown fields:
+    /// the non-Status paths that call this only know `running`.
     pub fn commit(&self, running: bool) {
         self.tx.send_if_modified(|snap| {
             if snap.running == running {
@@ -266,6 +285,28 @@ impl ProxyStateCell {
             *snap = ProxySnapshot {
                 seq: snap.seq + 1,
                 running,
+                ..*snap
+            };
+            true
+        });
+    }
+
+    /// Commit a full Status observation (running + lockdown). Bumps `seq`
+    /// (waking watchers) when any field changes. Used by the `Status` arm so
+    /// all three commit atomically under the one client lock.
+    pub fn commit_status(&self, running: bool, lockdown_enabled: bool, lockdown_active: bool) {
+        self.tx.send_if_modified(|snap| {
+            if snap.running == running
+                && snap.lockdown_enabled == lockdown_enabled
+                && snap.lockdown_active == lockdown_active
+            {
+                return false;
+            }
+            *snap = ProxySnapshot {
+                seq: snap.seq + 1,
+                running,
+                lockdown_enabled,
+                lockdown_active,
             };
             true
         });
@@ -350,6 +391,20 @@ pub(crate) fn observed_running(kind: ReqKind, result: &Result<BridgeResponse, Cl
         (Stop, Ok(BridgeResponse::Ack)) => Some(false),
         (Stop, Ok(BridgeResponse::Error { .. })) => None,
         (_, Ok(_)) => None,
+    }
+}
+
+/// The lockdown (enabled, active) a Status exchange revealed, if any. Only a
+/// `Status` Ok carries them; every other exchange yields None (leave the
+/// snapshot's prior lockdown fields untouched).
+pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<(bool, bool)> {
+    match result {
+        Ok(BridgeResponse::Status {
+            lockdown_enabled,
+            lockdown_active,
+            ..
+        }) => Some((*lockdown_enabled, *lockdown_active)),
+        _ => None,
     }
 }
 

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -72,6 +72,26 @@ fn commit_status_carries_lockdown_fields() {
     assert_eq!(s1.seq, 1, "seq bumped on change");
 }
 
+#[skuld::test]
+fn commit_preserves_lockdown_fields() {
+    // Every Start/Stop/reconciler exchange goes through `commit` (not
+    // `commit_status`); its `..*snap` must NOT clobber the lockdown warning state
+    // a prior Status established (`enabled && !active` is the tray warning state).
+    let cell = ProxyStateCell::new();
+    cell.commit_status(true, true, false); // running + lockdown enabled, not active
+    let before = cell.snapshot();
+    assert!(before.lockdown_enabled && !before.lockdown_active);
+
+    cell.commit(false); // a Stop/transport observation knows only `running`
+    let after = cell.snapshot();
+    assert!(!after.running, "running flipped to false");
+    assert!(
+        after.lockdown_enabled && !after.lockdown_active,
+        "commit must preserve the lockdown fields, got {after:?}"
+    );
+    assert_eq!(after.seq, before.seq + 1, "running change bumps seq");
+}
+
 // observed_running ====================================================================================================
 
 fn status_resp(running: bool) -> BridgeResponse {

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -37,6 +37,8 @@ fn status_resp(running: bool) -> BridgeResponse {
         invalid_filters: vec![],
         udp_proxy_available: true,
         ipv6_bypass_available: true,
+        lockdown_enabled: false,
+        lockdown_active: false,
     }
 }
 
@@ -133,6 +135,8 @@ fn status_response(running: bool) -> StatusResponse {
         invalid_filters: Vec::new(),
         udp_proxy_available: true,
         ipv6_bypass_available: true,
+        lockdown_enabled: false,
+        lockdown_active: false,
     }
 }
 

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -7,13 +7,37 @@ use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE};
 #[skuld::test]
 fn cell_bumps_seq_only_on_change() {
     let cell = ProxyStateCell::new();
-    assert_eq!(cell.snapshot(), ProxySnapshot { seq: 0, running: false });
+    assert_eq!(
+        cell.snapshot(),
+        ProxySnapshot {
+            seq: 0,
+            running: false,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
     cell.commit(false);
     assert_eq!(cell.snapshot().seq, 0, "no-change commit must not bump seq");
     cell.commit(true);
-    assert_eq!(cell.snapshot(), ProxySnapshot { seq: 1, running: true });
+    assert_eq!(
+        cell.snapshot(),
+        ProxySnapshot {
+            seq: 1,
+            running: true,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
     cell.commit(false);
-    assert_eq!(cell.snapshot(), ProxySnapshot { seq: 2, running: false });
+    assert_eq!(
+        cell.snapshot(),
+        ProxySnapshot {
+            seq: 2,
+            running: false,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }
 
 #[skuld::test]
@@ -24,7 +48,28 @@ async fn cell_wakes_watchers_only_on_change() {
     assert!(!rx.has_changed().unwrap());
     cell.commit(true);
     assert!(rx.has_changed().unwrap());
-    assert_eq!(*rx.borrow_and_update(), ProxySnapshot { seq: 1, running: true });
+    assert_eq!(
+        *rx.borrow_and_update(),
+        ProxySnapshot {
+            seq: 1,
+            running: true,
+            lockdown_enabled: false,
+            lockdown_active: false,
+        }
+    );
+}
+
+#[skuld::test]
+fn commit_status_carries_lockdown_fields() {
+    let cell = ProxyStateCell::new();
+    // Initial snapshot defaults the lockdown fields to false.
+    let s0 = cell.snapshot();
+    assert!(!s0.lockdown_enabled && !s0.lockdown_active);
+    // A Status commit threads both lockdown bools alongside `running`.
+    cell.commit_status(true, true, false);
+    let s1 = cell.snapshot();
+    assert!(s1.running && s1.lockdown_enabled && !s1.lockdown_active);
+    assert_eq!(s1.seq, 1, "seq bumped on change");
 }
 
 // observed_running ====================================================================================================
@@ -202,7 +247,15 @@ async fn start_ack_commits_true() {
         .await
         .unwrap();
     assert!(matches!(resp, BridgeResponse::Ack));
-    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+    assert_eq!(
+        link.cell().snapshot(),
+        ProxySnapshot {
+            seq: 1,
+            running: true,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }
 
 #[skuld::test]
@@ -245,7 +298,15 @@ async fn transport_error_commits_false() {
     let link = BridgeLink::new(path, noop_hook());
     link.cell().commit(true); // pretend we believed it was running
     let _ = link.send(BridgeRequest::Status).await.unwrap_err();
-    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 2, running: false });
+    assert_eq!(
+        link.cell().snapshot(),
+        ProxySnapshot {
+            seq: 2,
+            running: false,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }
 
 #[skuld::test]
@@ -260,7 +321,15 @@ async fn oneshot_never_commits() {
     let link = BridgeLink::new(path, noop_hook());
     link.cell().commit(true);
     link.send_oneshot(BridgeRequest::Cancel).await.unwrap();
-    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+    assert_eq!(
+        link.cell().snapshot(),
+        ProxySnapshot {
+            seq: 1,
+            running: true,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }
 
 #[skuld::test]
@@ -283,7 +352,15 @@ async fn untracked_requests_never_commit() {
 
     let link = BridgeLink::new(path, noop_hook());
     link.send(BridgeRequest::Metrics).await.unwrap();
-    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 0, running: false });
+    assert_eq!(
+        link.cell().snapshot(),
+        ProxySnapshot {
+            seq: 0,
+            running: false,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }
 
 /// The ordering guarantee under test is the CLIENT-LOCK serialization:
@@ -334,7 +411,15 @@ async fn concurrent_requests_commit_in_bridge_order() {
     assert!(matches!(a, BridgeResponse::Ack));
     assert!(matches!(b, BridgeResponse::Status { running: true, .. }));
     // Start committed true (seq 1); the queued Status confirmed true (no bump).
-    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+    assert_eq!(
+        link.cell().snapshot(),
+        ProxySnapshot {
+            seq: 1,
+            running: true,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }
 
 #[skuld::test]
@@ -388,5 +473,13 @@ async fn reload_if_running_reloads_when_running() {
     assert!(reloaded);
     assert_eq!(reloads.load(Ordering::SeqCst), 1);
     // The Status leg committed the observation.
-    assert_eq!(link.cell().snapshot(), ProxySnapshot { seq: 1, running: true });
+    assert_eq!(
+        link.cell().snapshot(),
+        ProxySnapshot {
+            seq: 1,
+            running: true,
+            lockdown_enabled: false,
+            lockdown_active: false
+        }
+    );
 }

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -132,6 +132,7 @@ const ID_AUTOSTART: &str = "autostart";
 const ID_SETTINGS: &str = "settings";
 const ID_EXIT: &str = "exit";
 const ID_INSTALL_UPDATE: &str = "install_update";
+const ID_LOCKDOWN: &str = "lockdown";
 
 // Window menu ---------------------------------------------------------------------------------------------------------
 const ID_WINDOW_IMPORT: &str = "window_import";
@@ -144,17 +145,30 @@ const ID_COLLECT_LOGS: &str = "window_collect_logs";
 
 // Tray creation =======================================================================================================
 
+/// Tray label for the lockdown toggle from the (enabled, active) snapshot.
+/// `enabled && !active` is a warning state — never silent green (#527).
+fn lockdown_menu_label(enabled: bool, active: bool) -> String {
+    match (enabled, active) {
+        (true, true) => "Lockdown: On".into(),
+        (true, false) => "Lockdown: On (warning: not engaged)".into(),
+        (false, _) => "Lockdown".into(),
+    }
+}
+
 /// Build the tray menu, optionally including an "Install Update" item.
 ///
 /// `running` is the bridge's actual state (from the `ProxyStateCell`,
 /// never persisted config — #462); `transition` is an in-flight
 /// connect/disconnect target, rendered as Connecting…/Disconnecting…
-/// with the action item disabled.
+/// with the action item disabled. `lockdown_enabled`/`lockdown_active` render
+/// the standing kill-switch toggle (#527).
 fn build_tray_menu(
     app: &AppHandle,
     update: Option<&hole::update::UpdateInfo>,
     running: bool,
     transition: Option<bool>,
+    lockdown_enabled: bool,
+    lockdown_active: bool,
 ) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
     let status_text = match (transition, running) {
         (Some(true), _) => "Connecting...",
@@ -173,6 +187,16 @@ fn build_tray_menu(
     let status = MenuItem::with_id(app, ID_STATUS, status_text, false, None::<&str>)?;
     let connect = MenuItem::with_id(app, action_id, action_text, transition.is_none(), None::<&str>)?;
     let autostart = CheckMenuItem::with_id(app, ID_AUTOSTART, "Start at Login", true, false, None::<&str>)?;
+    // Checked tracks intent; the warning label covers the enabled-but-inactive
+    // state since a checkmark alone can't signal "armed but not engaged".
+    let lockdown = CheckMenuItem::with_id(
+        app,
+        ID_LOCKDOWN,
+        lockdown_menu_label(lockdown_enabled, lockdown_active),
+        true,
+        lockdown_enabled,
+        None::<&str>,
+    )?;
     let settings = MenuItem::with_id(app, ID_SETTINGS, "Dashboard...", true, None::<&str>)?;
     let sep1 = PredefinedMenuItem::separator(app)?;
     let sep2 = PredefinedMenuItem::separator(app)?;
@@ -194,6 +218,7 @@ fn build_tray_menu(
                 &connect,
                 &sep1,
                 &autostart,
+                &lockdown,
                 &settings,
                 &sep2,
                 &update_item,
@@ -202,7 +227,10 @@ fn build_tray_menu(
             ],
         )
     } else {
-        tauri::menu::Menu::with_items(app, &[&status, &connect, &sep1, &autostart, &settings, &sep2, &exit])
+        tauri::menu::Menu::with_items(
+            app,
+            &[&status, &connect, &sep1, &autostart, &lockdown, &settings, &sep2, &exit],
+        )
     }
 }
 
@@ -238,9 +266,16 @@ fn sync_autostart_state(app: &AppHandle, menu: &tauri::menu::Menu<tauri::Wry>) {
 /// over no tunnel (#462); the status reconciler's immediate first tick
 /// corrects the genuine bridge-survived-a-GUI-crash case.
 pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
-    let running = app.state::<AppState>().proxy_snapshot().running;
-    let menu = build_tray_menu(app.handle(), None, running, None)?;
-    let icon = tray_icons::tray_image(running.into());
+    let snap = app.state::<AppState>().proxy_snapshot();
+    let menu = build_tray_menu(
+        app.handle(),
+        None,
+        snap.running,
+        None,
+        snap.lockdown_enabled,
+        snap.lockdown_active,
+    )?;
+    let icon = tray_icons::tray_image(snap.running.into());
 
     #[allow(unused_mut)]
     let mut builder = TrayIconBuilder::with_id("main")
@@ -287,7 +322,14 @@ pub fn rebuild_tray_menu(app: &AppHandle) {
         let update_info = update_state.rx.borrow().clone();
         let snap = handle.state::<AppState>().proxy_snapshot();
         let transition = handle.state::<TransitionSlot>().target();
-        match build_tray_menu(&handle, update_info.as_ref(), snap.running, transition) {
+        match build_tray_menu(
+            &handle,
+            update_info.as_ref(),
+            snap.running,
+            transition,
+            snap.lockdown_enabled,
+            snap.lockdown_active,
+        ) {
             Ok(menu) => {
                 sync_autostart_state(&handle, &menu);
                 // Sanctioned `set_menu` site: the one ordered commit point
@@ -555,6 +597,24 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move {
                 handle_install_update_from_tray(app_handle).await;
+            });
+        }
+        ID_LOCKDOWN => {
+            // muda flipped the checkmark before this handler ran. The desired
+            // intent is the inverse of the snapshot we rendered from. The
+            // bridge is the authority (last-writer-wins); send intent, re-fetch
+            // Status (which commits the new lockdown fields into the snapshot),
+            // then rebuild from the authoritative reply.
+            let desired = !app.state::<AppState>().proxy_snapshot().lockdown_enabled;
+            info!(desired, "tray: lockdown toggled");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app_handle.state::<AppState>();
+                if let Err(e) = state.bridge_send(BridgeRequest::SetLockdown { enabled: desired }).await {
+                    error!(error = %e, "tray: SetLockdown failed");
+                }
+                let _ = state.bridge_send(BridgeRequest::Status).await; // commits new snapshot
+                rebuild_tray_menu(&app_handle);
             });
         }
         _ => {}

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -103,3 +103,27 @@ fn persist_intended_enabled_writes_only_on_change(#[fixture(temp_dir)] dir: &Pat
     let (_, reloaded, _) = ConfigStore::load(path, time::OffsetDateTime::UNIX_EPOCH);
     assert!(!reloaded.enabled);
 }
+
+// lockdown_menu_label =================================================================================================
+
+#[skuld::test]
+fn lockdown_enabled_but_inactive_renders_warning_label() {
+    // enabled && !active must never render silent green — it is a warning.
+    let label = lockdown_menu_label(true, false);
+    assert!(
+        label.to_lowercase().contains("warning") || label.contains('!'),
+        "enabled+inactive must signal a warning, got {label:?}"
+    );
+}
+
+#[skuld::test]
+fn lockdown_active_renders_on_label() {
+    let label = lockdown_menu_label(true, true);
+    assert!(label.to_lowercase().contains("on") || label.to_lowercase().contains("lockdown"));
+}
+
+#[skuld::test]
+fn lockdown_off_renders_plain_label() {
+    let label = lockdown_menu_label(false, false);
+    assert!(!label.to_lowercase().contains("warning"));
+}

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -189,7 +189,15 @@ pub(crate) fn run_capturing(
 /// are logged at `warn` level and the function returns `()` (there is no
 /// meaningful caller recovery).
 pub fn recover_routes(state_dir: &Path) {
-    recover_routes_with(state_dir, run_commands, failclosed::recover_cover);
+    let intent = failclosed::lockdown_state::load_enabled(state_dir);
+    recover_routes_with(
+        state_dir,
+        run_commands,
+        failclosed::recover_cover,
+        intent,
+        || failclosed::lockdown_cover_present(state_dir),
+        |decision| failclosed::recover_lockdown(decision, state_dir),
+    );
 }
 
 /// What crash-recovery should do with a possibly-present standing lockdown
@@ -224,14 +232,25 @@ pub fn decide_cover_recovery(intent: bool, prior_present: bool) -> CoverRecovery
     }
 }
 
-/// Test seam for [`recover_routes`]: accepts an injected command runner and an
-/// injected cover-recovery sweep so unit tests can assert behavior without
-/// shelling out to `netsh`/`route` or touching the host firewall. Production
-/// passes `run_commands` and [`failclosed::recover_cover`].
-pub(crate) fn recover_routes_with<R, S>(state_dir: &Path, runner: R, sweep_cover: S)
-where
+/// Test seam for [`recover_routes`]: accepts an injected command runner, an
+/// injected transient-cover sweep, and the standing-lockdown reconciliation
+/// inputs (intent + presence probe + recover action) so unit tests can assert
+/// behavior without shelling out to `netsh`/`route` or touching the host
+/// firewall. Production passes `run_commands`, [`failclosed::recover_cover`],
+/// the persisted lockdown intent, [`failclosed::lockdown_cover_present`], and
+/// [`failclosed::recover_lockdown`].
+pub(crate) fn recover_routes_with<R, S, P, L>(
+    state_dir: &Path,
+    runner: R,
+    sweep_cover: S,
+    lockdown_intent: bool,
+    lockdown_present: P,
+    lockdown_recover: L,
+) where
     R: Fn(&[Vec<String>], &str) -> std::io::Result<()>,
     S: FnOnce(&Path),
+    P: FnOnce() -> bool,
+    L: FnOnce(CoverRecovery),
 {
     info!(state_dir = %state_dir.display(), "starting route recovery");
 
@@ -285,6 +304,13 @@ where
     // independently — Windows by fixed WFP GUIDs, macOS by bridge-failclosed.json
     // — and the sweep is idempotent when no cover is present.
     sweep_cover(state_dir);
+
+    // Reconcile a standing lockdown cover. `prior_present` is the lockdown
+    // cover's OWN evidence (injected probe), NOT the route-state file, whose
+    // lifetime is independent of the cover. The recover action keeps the host
+    // fail-closed (Adopt) or disengages (Sweep).
+    let prior_present = lockdown_present();
+    lockdown_recover(decide_cover_recovery(lockdown_intent, prior_present));
 }
 
 // Routing trait =======================================================================================================
@@ -350,6 +376,22 @@ pub trait Routing: Send + Sync {
     /// NOT permit the TUN interface (the cover only needs loopback + server IP
     /// for the new bridge's start-time self-test); see the #468 PR2 plan.
     fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<Self::Cover, RoutingError>;
+
+    /// Engage the STANDING lockdown cover for this connected session: permit
+    /// loopback + the `tun_name` interface + the onward server connection (and,
+    /// on Windows, the `app_ids` binaries by App-ID), block all else. Returns
+    /// the SAME [`Cover`](Self::Cover) RAII guard
+    /// [`install_failclosed_cover`](Self::install_failclosed_cover) returns —
+    /// the platform guard is kind-aware, so its Drop disengages whichever cover
+    /// it holds. Distinct from `install_failclosed_cover`, which does NOT permit
+    /// the TUN. The LUID is re-resolved on every call (never persisted).
+    /// Fail-FATAL: the bridge aborts the start on Err.
+    fn install_lockdown(
+        &self,
+        server_ip: IpAddr,
+        tun_name: &str,
+        app_ids: &[PathBuf],
+    ) -> Result<Self::Cover, RoutingError>;
 }
 
 // System (production) routing =========================================================================================
@@ -419,6 +461,16 @@ impl Routing for SystemRouting {
 
     fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<Self::Cover, RoutingError> {
         failclosed::engage(server_ip, &self.state_dir)
+    }
+
+    fn install_lockdown(
+        &self,
+        server_ip: IpAddr,
+        tun_name: &str,
+        app_ids: &[PathBuf],
+    ) -> Result<Self::Cover, RoutingError> {
+        let resolver = failclosed::SystemLuidResolver;
+        failclosed::engage_lockdown(server_ip, tun_name, &resolver, app_ids, &self.state_dir)
     }
 }
 

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -205,11 +205,14 @@ pub fn recover_routes(state_dir: &Path) {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoverRecovery {
     /// Intent ON + cover present: KEEP the host fail-closed across the restart.
-    /// Remove ONLY the stale TUN-interface permit (its LUID/utun is dead after
-    /// teardown); block-all + loopback + server-IP + App-ID stay in force. The
-    /// next connect's `install_lockdown` re-adds the TUN permit with a freshly
-    /// resolved LUID/utun (idempotent). This is the crash-leak fix: a crash
-    /// never runs `stop()`, so the persistent cover survives and Adopt holds it.
+    /// The fail-closed floor (block-all + loopback + App-ID) stays in force; the
+    /// volatile permits — the stale TUN-interface permit (dead LUID/utun after
+    /// teardown) and the server-IP permit (the server may change before the next
+    /// connect) — are refreshed by the next connect's `install_lockdown`. Windows
+    /// drops the volatile GUIDs at recovery so the re-add isn't a fixed-key
+    /// no-op; macOS reloads the whole pf ruleset, refreshing them implicitly.
+    /// This is the crash-leak fix: a crash never runs `stop()`, so the persistent
+    /// cover survives and Adopt holds it.
     Adopt,
     /// Intent OFF + cover present: fully disengage the leftover cover (Windows:
     /// delete all lockdown GUIDs; macOS: restore the pre-lockdown snapshot +

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -192,6 +192,38 @@ pub fn recover_routes(state_dir: &Path) {
     recover_routes_with(state_dir, run_commands, failclosed::recover_cover);
 }
 
+/// What crash-recovery should do with a possibly-present standing lockdown
+/// cover, given the persisted lockdown intent and whether a cover is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverRecovery {
+    /// Intent ON + cover present: KEEP the host fail-closed across the restart.
+    /// Remove ONLY the stale TUN-interface permit (its LUID/utun is dead after
+    /// teardown); block-all + loopback + server-IP + App-ID stay in force. The
+    /// next connect's `install_lockdown` re-adds the TUN permit with a freshly
+    /// resolved LUID/utun (idempotent). This is the crash-leak fix: a crash
+    /// never runs `stop()`, so the persistent cover survives and Adopt holds it.
+    Adopt,
+    /// Intent OFF + cover present: fully disengage the leftover cover (Windows:
+    /// delete all lockdown GUIDs; macOS: restore the pre-lockdown snapshot +
+    /// drop the pf token).
+    Sweep,
+    /// No cover present: nothing to do.
+    Noop,
+}
+
+/// Pure recovery decision. `intent` is the persisted lockdown-enabled bool
+/// (`bridge-lockdown.json`); `prior_present` is whether a lockdown cover from a
+/// prior run is present, keyed on the cover's OWN evidence (NOT
+/// `bridge-routes.json` — the cover's lifetime is independent of routes). See
+/// `recover_routes_with` for how `prior_present` is derived per platform.
+pub fn decide_cover_recovery(intent: bool, prior_present: bool) -> CoverRecovery {
+    match (intent, prior_present) {
+        (_, false) => CoverRecovery::Noop,
+        (true, true) => CoverRecovery::Adopt,
+        (false, true) => CoverRecovery::Sweep,
+    }
+}
+
 /// Test seam for [`recover_routes`]: accepts an injected command runner and an
 /// injected cover-recovery sweep so unit tests can assert behavior without
 /// shelling out to `netsh`/`route` or touching the host firewall. Production

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -63,3 +63,11 @@ pub fn engage_lockdown(
         inner: platform::engage_lockdown(server_ip, tun_luid, app_ids, state_dir)?,
     })
 }
+
+/// Reconcile a possibly-present standing lockdown cover with the persisted
+/// intent at bridge startup. `Adopt` keeps the host fail-closed (removes only
+/// the dead TUN permit); `Sweep` disengages fully; `Noop` does nothing.
+#[cfg(target_os = "windows")]
+pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
+    platform::recover_lockdown(decision, state_dir);
+}

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -33,14 +33,12 @@ mod platform;
 /// cover (Windows: delete the WFP filters by GUID; macOS: restore
 /// `/etc/pf.conf` and drop the pf enable refcount). `Send` so the PR3 cutover
 /// coordinator can hold it across `.await`.
-//
-// `platform::Cover` carries its own `Drop`; the field-drop runs it. No
-// explicit `Drop for Cover` needed.
+///
+/// Opaque wrapper over the private `platform::Cover` (the platform module can't
+/// be named by `#[cfg]`-free callers). `_inner` is held only for its `Drop`,
+/// which does the disengage — no explicit `Drop for Cover` needed.
 pub struct Cover {
-    // Read via field-drop; the first production caller (`install_lockdown`,
-    // Task 9) lands the read path. Drop until then.
-    #[allow(dead_code)]
-    inner: platform::Cover,
+    _inner: platform::Cover,
 }
 
 /// Engage the cover blocking all egress except loopback and `server_ip`.
@@ -48,7 +46,7 @@ pub struct Cover {
 /// (unused on Windows). On failure the host is left uncovered.
 pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError> {
     Ok(Cover {
-        inner: platform::engage(server_ip, state_dir)?,
+        _inner: platform::engage(server_ip, state_dir)?,
     })
 }
 
@@ -76,14 +74,14 @@ pub fn engage_lockdown(
     {
         let luid = resolver.resolve(tun_name)?;
         Ok(Cover {
-            inner: platform::engage_lockdown(server_ip, luid, app_ids, state_dir)?,
+            _inner: platform::engage_lockdown(server_ip, luid, app_ids, state_dir)?,
         })
     }
     #[cfg(target_os = "macos")]
     {
         let _ = (resolver, app_ids);
         Ok(Cover {
-            inner: platform::engage_lockdown(server_ip, tun_name, state_dir)?,
+            _inner: platform::engage_lockdown(server_ip, tun_name, state_dir)?,
         })
     }
 }
@@ -94,6 +92,24 @@ pub fn engage_lockdown(
 /// `Noop` does nothing. cfg-free for `routing::recover_routes`.
 pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
     platform::recover_lockdown(decision, state_dir);
+}
+
+/// Whether a standing lockdown cover from a prior run is present — the recovery
+/// decision's `prior_present` signal, keyed on the cover's OWN evidence (NOT
+/// `bridge-routes.json`). macOS: the `bridge-lockdown-pf.json` state file
+/// exists. Windows: always `true` — delete-by-GUID reconciliation is idempotent
+/// (a no-op when no filters exist), so probing would only add a redundant WFP
+/// enumeration; a `Sweep`/`Adopt` on a clean host does nothing.
+pub fn lockdown_cover_present(state_dir: &Path) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        lockdown_pf_state::load(state_dir).is_some()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = state_dir;
+        true
+    }
 }
 
 /// Windows-only test helper: resolve the LUID then build the spec, exercising

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -35,7 +35,9 @@ mod platform;
 // `platform::Cover` carries its own `Drop`; the field-drop runs it. No
 // explicit `Drop for Cover` needed.
 pub struct Cover {
-    #[allow(dead_code)] // engaged only by PR3's cutover; PR2 has no production caller
+    // Read via field-drop; the first production caller (`install_lockdown`,
+    // Task 9) lands the read path. Drop until then.
+    #[allow(dead_code)]
     inner: platform::Cover,
 }
 
@@ -54,26 +56,57 @@ pub fn recover_cover(state_dir: &Path) {
     platform::recover_cover(state_dir);
 }
 
-/// Engage the standing lockdown cover: block all egress except loopback, the
-/// `tun_luid` interface (Windows) so app traffic flows, the `app_ids` binaries,
-/// and `server_ip`. `state_dir` is where macOS persists its recovery state.
-/// On failure the host is left uncovered (the caller decides fail-FATAL).
-#[cfg(target_os = "windows")]
+/// Engage the standing lockdown cover (loopback + TUN + onward-server + —on
+/// Windows— plugin/bridge App-IDs permitted, all else blocked). Returns the
+/// SAME [`Cover`] wrapper the transient `engage` returns — the platform guard
+/// is kind-aware, so dropping it disengages the lockdown cover specifically.
+/// On Windows the LUID is re-resolved here every engage (never persisted). On
+/// failure the host is left uncovered; the bridge's fail-FATAL caller aborts
+/// the start. `app_ids` is empty on macOS (pf has no per-process matching).
 pub fn engage_lockdown(
     server_ip: IpAddr,
-    tun_luid: u64,
+    tun_name: &str,
+    resolver: &dyn LuidResolver,
     app_ids: &[std::path::PathBuf],
     state_dir: &Path,
 ) -> Result<Cover, RoutingError> {
-    Ok(Cover {
-        inner: platform::engage_lockdown(server_ip, tun_luid, app_ids, state_dir)?,
-    })
+    #[cfg(target_os = "windows")]
+    {
+        let luid = resolver.resolve(tun_name)?;
+        Ok(Cover {
+            inner: platform::engage_lockdown(server_ip, luid, app_ids, state_dir)?,
+        })
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (resolver, app_ids);
+        Ok(Cover {
+            inner: platform::engage_lockdown(server_ip, tun_name, state_dir)?,
+        })
+    }
 }
 
-/// Reconcile a possibly-present standing lockdown cover with the persisted
-/// intent at bridge startup. `Adopt` keeps the host fail-closed (removes only
-/// the dead TUN permit); `Sweep` disengages fully; `Noop` does nothing.
-#[cfg(target_os = "windows")]
+/// Act on a [`CoverRecovery`] decision for the standing lockdown cover at
+/// startup. Dispatches to the platform reconciler: `Adopt` keeps the host
+/// fail-closed (removing only the dead TUN permit); `Sweep` fully disengages;
+/// `Noop` does nothing. cfg-free for `routing::recover_routes`.
 pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
     platform::recover_lockdown(decision, state_dir);
 }
+
+/// Windows-only test helper: resolve the LUID then build the spec, exercising
+/// the exact resolve-then-build ordering `engage_lockdown` uses, without FWPM.
+#[cfg(all(test, target_os = "windows"))]
+pub(crate) fn build_lockdown_spec_for_test(
+    resolver: &dyn LuidResolver,
+    tun_name: &str,
+    server_ip: IpAddr,
+    app_ids: &[std::path::PathBuf],
+) -> platform::CoverSpec {
+    let luid = resolver.resolve(tun_name).expect("mock resolver");
+    platform::build_lockdown_spec(server_ip, luid, app_ids)
+}
+
+#[cfg(test)]
+#[path = "failclosed/facade_tests.rs"]
+mod facade_tests;

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -128,3 +128,10 @@ pub(crate) fn build_lockdown_spec_for_test(
 #[cfg(test)]
 #[path = "failclosed/facade_tests.rs"]
 mod facade_tests;
+
+// Privileged-lane real-engage verification (#527): engages the REAL OS cover and
+// asserts it blocks egress. Gated to the elevated `hole-tests` TUN lane by the
+// `TUN` label (see the module docs); excluded from the unprivileged pass.
+#[cfg(test)]
+#[path = "failclosed/lockdown_privileged_tests.rs"]
+mod lockdown_privileged_tests;

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -88,8 +88,8 @@ pub fn engage_lockdown(
 
 /// Act on a [`CoverRecovery`] decision for the standing lockdown cover at
 /// startup. Dispatches to the platform reconciler: `Adopt` keeps the host
-/// fail-closed (removing only the dead TUN permit); `Sweep` fully disengages;
-/// `Noop` does nothing. cfg-free for `routing::recover_routes`.
+/// fail-closed, refreshing the volatile TUN + server permits; `Sweep` fully
+/// disengages; `Noop` does nothing. cfg-free for `routing::recover_routes`.
 pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
     platform::recover_lockdown(decision, state_dir);
 }

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -125,7 +125,9 @@ pub(crate) fn build_lockdown_spec_for_test(
     platform::build_lockdown_spec(server_ip, luid, app_ids)
 }
 
-#[cfg(test)]
+// Windows-only: pins the resolve-then-build LUID ordering. macOS keys pf on the
+// interface name, so there is no LUID to re-resolve.
+#[cfg(all(test, target_os = "windows"))]
 #[path = "failclosed/facade_tests.rs"]
 mod facade_tests;
 

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -16,6 +16,9 @@ pub mod failclosed_state;
 #[cfg(target_os = "macos")]
 pub mod lockdown_pf_state;
 
+pub mod luid;
+pub use luid::{LuidResolver, SystemLuidResolver};
+
 #[cfg(target_os = "windows")]
 #[path = "failclosed/windows.rs"]
 mod platform;

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -19,6 +19,8 @@ pub mod lockdown_pf_state;
 pub mod luid;
 pub use luid::{LuidResolver, SystemLuidResolver};
 
+pub mod lockdown_state;
+
 #[cfg(target_os = "windows")]
 #[path = "failclosed/windows.rs"]
 mod platform;

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -13,6 +13,9 @@ use crate::error::RoutingError;
 #[cfg(target_os = "macos")]
 pub mod failclosed_state;
 
+#[cfg(target_os = "macos")]
+pub mod lockdown_pf_state;
+
 #[cfg(target_os = "windows")]
 #[path = "failclosed/windows.rs"]
 mod platform;

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -47,3 +47,19 @@ pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError
 pub fn recover_cover(state_dir: &Path) {
     platform::recover_cover(state_dir);
 }
+
+/// Engage the standing lockdown cover: block all egress except loopback, the
+/// `tun_luid` interface (Windows) so app traffic flows, the `app_ids` binaries,
+/// and `server_ip`. `state_dir` is where macOS persists its recovery state.
+/// On failure the host is left uncovered (the caller decides fail-FATAL).
+#[cfg(target_os = "windows")]
+pub fn engage_lockdown(
+    server_ip: IpAddr,
+    tun_luid: u64,
+    app_ids: &[std::path::PathBuf],
+    state_dir: &Path,
+) -> Result<Cover, RoutingError> {
+    Ok(Cover {
+        inner: platform::engage_lockdown(server_ip, tun_luid, app_ids, state_dir)?,
+    })
+}

--- a/crates/tun-engine/src/routing/failclosed/facade_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/facade_tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+use crate::routing::failclosed::luid::LuidResolver;
+
+// A recording resolver that asserts resolve() is called (the LUID is never
+// persisted, so every engage must re-resolve).
+struct RecordingResolver {
+    calls: std::sync::atomic::AtomicU32,
+    luid: u64,
+}
+impl LuidResolver for RecordingResolver {
+    fn resolve(&self, _alias: &str) -> Result<u64, crate::error::RoutingError> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(self.luid)
+    }
+}
+
+#[skuld::test]
+fn engage_lockdown_reresolves_luid_every_call() {
+    // The facade must call resolver.resolve() before building the spec — the
+    // LUID is never cached. We can't run real FWPM here (#165), so this test
+    // pins the resolve-then-build ordering via the pure build path exposed
+    // for tests. On non-Windows the resolver is bypassed (pf keys on name),
+    // so this test is Windows-only.
+    #[cfg(target_os = "windows")]
+    {
+        let r = RecordingResolver {
+            calls: std::sync::atomic::AtomicU32::new(0),
+            luid: 0x99,
+        };
+        let spec = build_lockdown_spec_for_test(&r, "hole-tun", "203.0.113.7".parse().unwrap(), &[]);
+        assert_eq!(r.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(spec.filters.iter().any(|f| matches!(
+            f.condition,
+            platform::Condition::LocalInterface(l) if l == 0x99
+        )));
+    }
+    #[cfg(not(target_os = "windows"))]
+    let _ = RecordingResolver {
+        calls: std::sync::atomic::AtomicU32::new(0),
+        luid: 0,
+    };
+}

--- a/crates/tun-engine/src/routing/failclosed/facade_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/facade_tests.rs
@@ -18,25 +18,16 @@ impl LuidResolver for RecordingResolver {
 fn engage_lockdown_reresolves_luid_every_call() {
     // The facade must call resolver.resolve() before building the spec — the
     // LUID is never cached. We can't run real FWPM here (#165), so this test
-    // pins the resolve-then-build ordering via the pure build path exposed
-    // for tests. On non-Windows the resolver is bypassed (pf keys on name),
-    // so this test is Windows-only.
-    #[cfg(target_os = "windows")]
-    {
-        let r = RecordingResolver {
-            calls: std::sync::atomic::AtomicU32::new(0),
-            luid: 0x99,
-        };
-        let spec = build_lockdown_spec_for_test(&r, "hole-tun", "203.0.113.7".parse().unwrap(), &[]);
-        assert_eq!(r.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
-        assert!(spec.filters.iter().any(|f| matches!(
-            f.condition,
-            platform::Condition::LocalInterface(l) if l == 0x99
-        )));
-    }
-    #[cfg(not(target_os = "windows"))]
-    let _ = RecordingResolver {
+    // pins the resolve-then-build ordering via the pure build path exposed for
+    // tests.
+    let r = RecordingResolver {
         calls: std::sync::atomic::AtomicU32::new(0),
-        luid: 0,
+        luid: 0x99,
     };
+    let spec = build_lockdown_spec_for_test(&r, "hole-tun", "203.0.113.7".parse().unwrap(), &[]);
+    assert_eq!(r.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert!(spec.filters.iter().any(|f| matches!(
+        f.condition,
+        platform::Condition::LocalInterface(l) if l == 0x99
+    )));
 }

--- a/crates/tun-engine/src/routing/failclosed/lockdown_pf_state.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_pf_state.rs
@@ -1,9 +1,10 @@
 //! macOS-only persisted state for the STANDING lockdown cover. Distinct file
 //! from `bridge-failclosed.json` (the transient cover, used concurrently by
 //! PR2's cutover): the lockdown cover has an independent lifetime. Records the
-//! pf enable token (replayed to `pfctl -X` on Sweep) and the pre-lockdown main
-//! ruleset snapshot (re-loaded on Sweep to restore the host without `-Fa`,
-//! matching the engaged-without-flush contract).
+//! pf enable token (replayed to `pfctl -X` on Sweep) and the pre-lockdown
+//! filter (`pfctl -sr`) and translation (`pfctl -sn`) snapshots (re-loaded on
+//! Sweep to restore the host without `-Fa`, matching the engaged-without-flush
+//! contract).
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -19,10 +20,14 @@ pub struct LockdownPfState {
     pub version: u32,
     /// Opaque enable token from `pfctl -E`, replayed to `pfctl -X` on Sweep.
     pub pf_token: String,
-    /// The host's main ruleset (`pfctl -sr`) captured before we composed in
-    /// the anchor call-out. Re-loaded on Sweep so the host returns to its
-    /// pre-lockdown policy (NOT a blind `/etc/pf.conf` reload).
+    /// The host's filter ruleset (`pfctl -sr`) captured before we replaced the
+    /// main ruleset with the lockdown policy. Re-loaded on Sweep so the host
+    /// returns to its pre-lockdown policy (NOT a blind `/etc/pf.conf` reload).
     pub main_snapshot: String,
+    /// The host's translation rules (`pfctl -sn`: nat/rdr) captured alongside
+    /// `main_snapshot`. Carried forward into the lockdown ruleset (so the
+    /// session does not flush NAT) and re-loaded on Sweep for restore.
+    pub nat_snapshot: String,
 }
 
 fn state_file(state_dir: &Path) -> PathBuf {

--- a/crates/tun-engine/src/routing/failclosed/lockdown_pf_state.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_pf_state.rs
@@ -1,0 +1,79 @@
+//! macOS-only persisted state for the STANDING lockdown cover. Distinct file
+//! from `bridge-failclosed.json` (the transient cover, used concurrently by
+//! PR2's cutover): the lockdown cover has an independent lifetime. Records the
+//! pf enable token (replayed to `pfctl -X` on Sweep) and the pre-lockdown main
+//! ruleset snapshot (re-loaded on Sweep to restore the host without `-Fa`,
+//! matching the engaged-without-flush contract).
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+pub const SCHEMA_VERSION: u32 = 1;
+pub const STATE_FILE_NAME: &str = "bridge-lockdown-pf.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockdownPfState {
+    pub version: u32,
+    /// Opaque enable token from `pfctl -E`, replayed to `pfctl -X` on Sweep.
+    pub pf_token: String,
+    /// The host's main ruleset (`pfctl -sr`) captured before we composed in
+    /// the anchor call-out. Re-loaded on Sweep so the host returns to its
+    /// pre-lockdown policy (NOT a blind `/etc/pf.conf` reload).
+    pub main_snapshot: String,
+}
+
+fn state_file(state_dir: &Path) -> PathBuf {
+    state_dir.join(STATE_FILE_NAME)
+}
+
+pub fn save(state_dir: &Path, state: &LockdownPfState) -> std::io::Result<()> {
+    std::fs::create_dir_all(state_dir)?;
+    let json = serde_json::to_vec_pretty(state).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(state_dir)?;
+    tmp.write_all(&json)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(state_file(state_dir)).map_err(|e| e.error)?;
+    Ok(())
+}
+
+pub fn load(state_dir: &Path) -> Option<LockdownPfState> {
+    let path = state_file(state_dir);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "lockdown-pf-state read failed");
+            return None;
+        }
+    };
+    match serde_json::from_slice::<LockdownPfState>(&bytes) {
+        Ok(s) if s.version == SCHEMA_VERSION => Some(s),
+        Ok(other) => {
+            tracing::warn!(
+                got = other.version,
+                want = SCHEMA_VERSION,
+                "lockdown-pf-state schema mismatch, discarding"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "lockdown-pf-state parse failed");
+            None
+        }
+    }
+}
+
+pub fn clear(state_dir: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(state_file(state_dir)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+#[path = "lockdown_pf_state_tests.rs"]
+mod lockdown_pf_state_tests;

--- a/crates/tun-engine/src/routing/failclosed/lockdown_pf_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_pf_state_tests.rs
@@ -5,6 +5,7 @@ fn sample() -> LockdownPfState {
         version: SCHEMA_VERSION,
         pf_token: "12345678901234567890".into(),
         main_snapshot: "scrub-anchor \"com.apple/*\" all fragment reassemble\n".into(),
+        nat_snapshot: "nat-anchor \"com.apple/*\" all\n".into(),
     }
 }
 
@@ -13,6 +14,13 @@ fn save_then_load_roundtrips() {
     let tmp = tempfile::tempdir().unwrap();
     save(tmp.path(), &sample()).unwrap();
     assert_eq!(load(tmp.path()), Some(sample()));
+}
+
+#[skuld::test]
+fn roundtrip_preserves_nat_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    save(tmp.path(), &sample()).unwrap();
+    assert_eq!(load(tmp.path()).unwrap().nat_snapshot, sample().nat_snapshot);
 }
 
 #[skuld::test]
@@ -31,11 +39,24 @@ fn load_rejects_schema_mismatch() {
 }
 
 #[skuld::test]
+fn load_rejects_unknown_field() {
+    // `deny_unknown_fields` guards against a half-written/foreign file silently
+    // round-tripping as a valid state.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(STATE_FILE_NAME),
+        br#"{"version":1,"pf_token":"x","main_snapshot":"","nat_snapshot":"","stray":true}"#,
+    )
+    .unwrap();
+    assert_eq!(load(tmp.path()), None, "unknown field must be rejected");
+}
+
+#[skuld::test]
 fn clear_removes_file_and_tolerates_absence() {
     let tmp = tempfile::tempdir().unwrap();
     save(tmp.path(), &sample()).unwrap();
     assert!(tmp.path().join(STATE_FILE_NAME).exists());
     clear(tmp.path()).unwrap();
     assert!(!tmp.path().join(STATE_FILE_NAME).exists());
-    clear(tmp.path()).unwrap();
+    clear(tmp.path()).unwrap(); // second clear is a no-op, not an error
 }

--- a/crates/tun-engine/src/routing/failclosed/lockdown_pf_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_pf_state_tests.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+fn sample() -> LockdownPfState {
+    LockdownPfState {
+        version: SCHEMA_VERSION,
+        pf_token: "12345678901234567890".into(),
+        main_snapshot: "scrub-anchor \"com.apple/*\" all fragment reassemble\n".into(),
+    }
+}
+
+#[skuld::test]
+fn save_then_load_roundtrips() {
+    let tmp = tempfile::tempdir().unwrap();
+    save(tmp.path(), &sample()).unwrap();
+    assert_eq!(load(tmp.path()), Some(sample()));
+}
+
+#[skuld::test]
+fn load_absent_is_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(load(tmp.path()), None);
+}
+
+#[skuld::test]
+fn load_rejects_schema_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut st = sample();
+    st.version = SCHEMA_VERSION + 1;
+    save(tmp.path(), &st).unwrap();
+    assert_eq!(load(tmp.path()), None, "future schema must be discarded");
+}
+
+#[skuld::test]
+fn clear_removes_file_and_tolerates_absence() {
+    let tmp = tempfile::tempdir().unwrap();
+    save(tmp.path(), &sample()).unwrap();
+    assert!(tmp.path().join(STATE_FILE_NAME).exists());
+    clear(tmp.path()).unwrap();
+    assert!(!tmp.path().join(STATE_FILE_NAME).exists());
+    clear(tmp.path()).unwrap();
+}

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -4,12 +4,17 @@
 //! FWPM; macOS: live pf) and assert it actually blocks egress — proving the kill
 //! switch is not inert.
 //!
-//! They run on the elevated `hole-tests` TUN lane only: the `TUN` label (→
-//! skuld filter name `tun`) gates them so the unprivileged `SKULD_LABELS="!tun"`
-//! pass excludes them and the elevated `SKULD_LABELS="tun"` pass (Windows in CI)
-//! runs them. They are NOT `#[ignore]`d and do not skip on missing privilege —
-//! a default `cargo nextest` run on an unelevated box runs them and fails loud;
-//! opting out is the explicit `!tun` filter, and CI provisions the elevation.
+//! They run on the elevated `tun` lane only: the `TUN` label (→ skuld filter
+//! name `tun`) gates them so the unprivileged `SKULD_LABELS="!tun"` pass
+//! excludes them and the `SKULD_LABELS="tun"` pass runs them — Windows under
+//! CI's elevated token, macOS under `sudo` (pf needs root). They are NOT
+//! `#[ignore]`d and do not skip on missing privilege: a default `cargo nextest`
+//! run on an unelevated box runs them and fails loud; opting out is the explicit
+//! `!tun` filter, and CI provisions the elevation.
+//!
+//! Cross-binary serialization for the global WFP/pf/TUN state these touch lives
+//! in `.config/nextest.toml` (`global-net-state` test-group) — skuld's
+//! `serial = TUN` only serializes within one binary.
 
 use super::*;
 
@@ -24,8 +29,9 @@ const TUN: skuld::Label;
 /// The LUID is resolved for the host's loopback adapter ("Loopback
 /// Pseudo-Interface 1") purely to drive the real `ConvertInterfaceAliasToLuid`
 /// + `LocalInterface` filter path; the block assertion does not depend on a
-/// live `hole-tun`. Serial on `TUN`: a single WFP sublayer is shared, and a
-/// concurrent transient-cover test would race the egress assertion.
+/// live `hole-tun`. `serial = TUN` serializes against other in-binary TUN
+/// tests; the cross-binary race with the bridge's real-egress e2e is handled by
+/// the `global-net-state` test-group (`.config/nextest.toml`).
 #[cfg(target_os = "windows")]
 #[skuld::test(labels = [TUN], serial = TUN)]
 fn windows_lockdown_blocks_egress_and_permits_loopback() {
@@ -73,9 +79,12 @@ fn windows_lockdown_blocks_egress_and_permits_loopback() {
 ///
 /// No live utun is needed for the block assertion: `pass out quick on
 /// <tun-absent>` simply never matches, so a probe to an arbitrary IP is blocked
-/// by `block drop out quick all`. Serial on `TUN`: `pfctl -E`/`-X` is
-/// refcounted and the main ruleset is process-global; a concurrent cover test
-/// would race the snapshot restore.
+/// by `block drop out quick all`. `serial = TUN` + the `global-net-state`
+/// test-group serialize the process-global pf state: `pfctl -E`/`-X` is
+/// refcounted and the main ruleset is host-wide, so a concurrent cover test
+/// would race the snapshot restore. (On macOS only this binary carries a TUN
+/// test — the bridge TUN e2e is `cfg(windows)` — so the group is single-member,
+/// but it costs nothing.)
 #[cfg(target_os = "macos")]
 #[skuld::test(labels = [TUN], serial = TUN)]
 fn macos_lockdown_actually_blocks_and_restores() {

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -27,7 +27,9 @@ const TUN: skuld::Label;
 /// public IP is BLOCKED at `ALE_AUTH_CONNECT` — so the cover is not inert.
 ///
 /// Loopback is carried by the `IS_LOOPBACK` flag permit (on CONNECT *and*
-/// RECV_ACCEPT — a loopback connect authorizes on both), NOT by the LUID permit.
+/// RECV_ACCEPT — a loopback connect authorizes on both) AND, at CONNECT, by the
+/// loopback destination-range permit (127.0.0.0/8 + ::1/128) that matches even
+/// when the flag isn't set at ALE_AUTH_CONNECT; NOT by the LUID permit.
 /// The interface alias is resolved only to drive the real
 /// `ConvertInterfaceAliasToLuid` + `LocalInterface` filter path; that permit
 /// matches the named interface's traffic, not loopback in general. The block
@@ -59,7 +61,13 @@ fn windows_lockdown_blocks_egress_and_permits_loopback() {
         &format!("127.0.0.1:{loopback_port}").parse().unwrap(),
         Duration::from_secs(2),
     );
-    assert!(lo.is_ok(), "loopback must stay permitted under lockdown");
+    // Include the OS error so a third failure shows what kind (timeout = still
+    // blocked at CONNECT, refused = permit held but nobody listening, perm = ACL).
+    assert!(
+        lo.is_ok(),
+        "loopback must stay permitted under lockdown: {:?}",
+        lo.err()
+    );
 
     // (b) Egress to a non-permitted public IP is blocked at ALE_AUTH_CONNECT.
     // 198.51.100.1 (TEST-NET-2) discard port: external event with graceful

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -24,6 +24,12 @@
 //! Cross-binary serialization for the global WFP/pf/TUN state these touch lives
 //! in `.config/nextest.toml` (`global-net-state` test-group) — skuld's
 //! `serial = TUN` only serializes within one binary.
+//!
+//! COUPLED NAMES: that group's filter matches these tests by the name prefixes
+//! `windows_lockdown_permits_server_ip_` and `macos_lockdown_permits_server_ip_`.
+//! Renaming a prefix WITHOUT updating `.config/nextest.toml` drops the test from
+//! the group → a silent cross-binary race with the bridge's live-egress
+//! `e2e_none_full_tunnel_roundtrip`. Change both together.
 
 use super::*;
 

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -63,6 +63,25 @@ fn windows_lockdown_blocks_egress_and_permits_loopback() {
     let closed_port = closed_probe.local_addr().unwrap().port();
     drop(closed_probe);
 
+    // Baseline (PRE-cover): characterize the runner so the post-cover result is
+    // interpretable. `base_lo` should be Ok (loopback works without the cover);
+    // `base_closed` tells us whether this runner RSTs a closed loopback port
+    // (ConnectionRefused) or silently drops (TimedOut) — which decides whether the
+    // post-cover closed-port probe can distinguish a CONNECT block from an
+    // accept-side drop at all.
+    let base_lo = std::net::TcpStream::connect_timeout(
+        &format!("127.0.0.1:{loopback_port}").parse().unwrap(),
+        Duration::from_secs(2),
+    )
+    .err()
+    .map(|e| e.kind());
+    let base_closed = std::net::TcpStream::connect_timeout(
+        &format!("127.0.0.1:{closed_port}").parse().unwrap(),
+        Duration::from_secs(2),
+    )
+    .err()
+    .map(|e| e.kind());
+
     let cover = engage_lockdown(server_ip, "Loopback Pseudo-Interface 1", &resolver, &[], dir.path())
         .expect("engage real WFP lockdown cover");
 
@@ -88,7 +107,9 @@ fn windows_lockdown_blocks_egress_and_permits_loopback() {
     // listener-probe timeout is an accept-side drop).
     assert!(
         lo.is_ok(),
-        "loopback must stay permitted under lockdown: listener_probe={:?} closed_port_probe(refused=>connect-permitted)={:?}",
+        "loopback must stay permitted under lockdown: \
+         baseline(pre-cover) lo={base_lo:?} closed={base_closed:?}; \
+         post-cover listener={:?} closed(refused=>connect-permitted)={:?}",
         lo.err(),
         closed_probe_err
     );

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -1,0 +1,113 @@
+//! Privileged-lane real-engage verification for the standing lockdown cover
+//! (#527). Unlike the pure builder unit tests (`windows_tests` / `macos_tests`,
+//! the #165 isolation contract), these engage the REAL OS cover (Windows: live
+//! FWPM; macOS: live pf) and assert it actually blocks egress — proving the kill
+//! switch is not inert.
+//!
+//! They run on the elevated `hole-tests` TUN lane only: the `TUN` label (→
+//! skuld filter name `tun`) gates them so the unprivileged `SKULD_LABELS="!tun"`
+//! pass excludes them and the elevated `SKULD_LABELS="tun"` pass (Windows in CI)
+//! runs them. They are NOT `#[ignore]`d and do not skip on missing privilege —
+//! a default `cargo nextest` run on an unelevated box runs them and fails loud;
+//! opting out is the explicit `!tun` filter, and CI provisions the elevation.
+
+use super::*;
+
+#[skuld::label]
+const TUN: skuld::Label;
+
+/// Windows real-engage verification. Engages the REAL WFP lockdown cover (a
+/// `LocalInterface` LUID permit + loopback permit + block-all) and proves
+/// (a) loopback stays permitted and (b) egress to an arbitrary non-permitted
+/// public IP is BLOCKED at `ALE_AUTH_CONNECT` — so the cover is not inert.
+///
+/// The LUID is resolved for the host's loopback adapter ("Loopback
+/// Pseudo-Interface 1") purely to drive the real `ConvertInterfaceAliasToLuid`
+/// + `LocalInterface` filter path; the block assertion does not depend on a
+/// live `hole-tun`. Serial on `TUN`: a single WFP sublayer is shared, and a
+/// concurrent transient-cover test would race the egress assertion.
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn windows_lockdown_blocks_egress_and_permits_loopback() {
+    use std::net::TcpListener;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let resolver = SystemLuidResolver;
+    let server_ip: std::net::IpAddr = "203.0.113.7".parse().unwrap();
+
+    // A loopback listener proves the loopback permit holds while the cover is up.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let loopback_port = listener.local_addr().unwrap().port();
+
+    let cover = engage_lockdown(server_ip, "Loopback Pseudo-Interface 1", &resolver, &[], dir.path())
+        .expect("engage real WFP lockdown cover");
+
+    // (a) Loopback connect still succeeds (loopback permit). External event with
+    // graceful failure bound: the timeout is the failure-to-human signal, not a
+    // sync sleep; the assertion is success, not "completed within N".
+    let lo = std::net::TcpStream::connect_timeout(
+        &format!("127.0.0.1:{loopback_port}").parse().unwrap(),
+        Duration::from_secs(2),
+    );
+    assert!(lo.is_ok(), "loopback must stay permitted under lockdown");
+
+    // (b) Egress to a non-permitted public IP is blocked at ALE_AUTH_CONNECT.
+    // 198.51.100.1 (TEST-NET-2) discard port: external event with graceful
+    // failure bound — the assertion is that it ERRORS, not that it times out.
+    let blocked = std::net::TcpStream::connect_timeout(&"198.51.100.1:9".parse().unwrap(), Duration::from_secs(2));
+    assert!(blocked.is_err(), "lockdown must block egress to a non-permitted IP");
+
+    // Drop sweeps the lockdown filters (kind-aware Cover Drop); egress restored.
+    drop(cover);
+    drop(listener);
+}
+
+/// macOS real-engage verification. Engages the REAL pf lockdown cover (an
+/// authoritative main-ruleset replace: `block drop out quick all` with earlier
+/// `quick` permits for loopback, the TUN, and the server IP — no anchor, so
+/// there is no inert-anchor failure mode) and proves (a) the live filter
+/// ruleset carries our block rule, (b) egress to a non-server, non-loopback IP
+/// is dropped while the cover holds, and (c) Drop restores the pre-lockdown
+/// snapshot.
+///
+/// No live utun is needed for the block assertion: `pass out quick on
+/// <tun-absent>` simply never matches, so a probe to an arbitrary IP is blocked
+/// by `block drop out quick all`. Serial on `TUN`: `pfctl -E`/`-X` is
+/// refcounted and the main ruleset is process-global; a concurrent cover test
+/// would race the snapshot restore.
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_lockdown_actually_blocks_and_restores() {
+    use std::process::Command;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let resolver = SystemLuidResolver;
+    let server_ip: std::net::IpAddr = "203.0.113.7".parse().unwrap();
+
+    let cover =
+        engage_lockdown(server_ip, "utun-absent", &resolver, &[], dir.path()).expect("engage real pf lockdown cover");
+
+    // (a) The live main ruleset carries our authoritative block rule.
+    let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
+    let rules = String::from_utf8_lossy(&sr.stdout);
+    assert!(
+        rules.contains("block drop out quick all"),
+        "main ruleset must carry the lockdown block (else inert):\n{rules}"
+    );
+
+    // (b) Egress to a non-permitted IP is blocked while the cover holds.
+    // External event with graceful failure bound: the assertion is that it
+    // ERRORS, not that it times out.
+    let blocked = std::net::TcpStream::connect_timeout(&"198.51.100.1:9".parse().unwrap(), Duration::from_secs(2));
+    assert!(blocked.is_err(), "lockdown must block egress to a non-permitted IP");
+
+    // (c) Drop restores the pre-lockdown snapshot; our block rule is gone.
+    drop(cover);
+    let after = Command::new("pfctl").args(["-sr"]).output().unwrap();
+    assert!(
+        !String::from_utf8_lossy(&after.stdout).contains("block drop out quick all"),
+        "snapshot restore must remove our lockdown block rule"
+    );
+}

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -22,16 +22,19 @@ use super::*;
 const TUN: skuld::Label;
 
 /// Windows real-engage verification. Engages the REAL WFP lockdown cover (a
-/// `LocalInterface` LUID permit + loopback permit + block-all) and proves
+/// `LocalInterface` LUID permit + loopback flag permit + block-all) and proves
 /// (a) loopback stays permitted and (b) egress to an arbitrary non-permitted
 /// public IP is BLOCKED at `ALE_AUTH_CONNECT` — so the cover is not inert.
 ///
-/// The LUID is resolved for the host's loopback adapter ("Loopback
-/// Pseudo-Interface 1") purely to drive the real `ConvertInterfaceAliasToLuid`
-/// + `LocalInterface` filter path; the block assertion does not depend on a
-/// live `hole-tun`. `serial = TUN` serializes against other in-binary TUN
-/// tests; the cross-binary race with the bridge's real-egress e2e is handled by
-/// the `global-net-state` test-group (`.config/nextest.toml`).
+/// Loopback is carried by the `IS_LOOPBACK` flag permit (on CONNECT *and*
+/// RECV_ACCEPT — a loopback connect authorizes on both), NOT by the LUID permit.
+/// The interface alias is resolved only to drive the real
+/// `ConvertInterfaceAliasToLuid` + `LocalInterface` filter path; that permit
+/// matches the named interface's traffic, not loopback in general. The block
+/// assertion does not depend on a live `hole-tun`. `serial = TUN` serializes
+/// against other in-binary TUN tests; the cross-binary race with the bridge's
+/// real-egress e2e is handled by the `global-net-state` test-group
+/// (`.config/nextest.toml`).
 #[cfg(target_os = "windows")]
 #[skuld::test(labels = [TUN], serial = TUN)]
 fn windows_lockdown_blocks_egress_and_permits_loopback() {

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -22,15 +22,18 @@ use super::*;
 const TUN: skuld::Label;
 
 /// Windows real-engage verification. Engages the REAL WFP lockdown cover (a
-/// `LocalInterface` LUID permit + loopback flag permit + block-all) and proves
+/// `LocalInterface` LUID permit + loopback permits + block-all) and proves
 /// (a) loopback stays permitted and (b) egress to an arbitrary non-permitted
 /// public IP is BLOCKED at `ALE_AUTH_CONNECT` — so the cover is not inert.
 ///
-/// Loopback is carried by the `IS_LOOPBACK` flag permit (on CONNECT *and*
-/// RECV_ACCEPT — a loopback connect authorizes on both) AND, at CONNECT, by the
-/// loopback destination-range permit (127.0.0.0/8 + ::1/128) that matches even
-/// when the flag isn't set at ALE_AUTH_CONNECT; NOT by the LUID permit.
-/// The interface alias is resolved only to drive the real
+/// Loopback is carried by the address-range permit (127.0.0.0/8 + ::1/128) on all
+/// four ALE layers — CONNECT *and* RECV_ACCEPT, which a loopback connect both
+/// authorizes — plus the `IS_LOOPBACK` flag permit on CONNECT as
+/// belt-and-suspenders; NOT by the LUID permit. The range is the deterministic
+/// matcher because the flag isn't reliably set at either ALE layer on the
+/// elevated lane. A closed-port probe disambiguates any loopback failure
+/// (refused => CONNECT permitted, so a listener-probe timeout is an accept-side
+/// drop). The interface alias is resolved only to drive the real
 /// `ConvertInterfaceAliasToLuid` + `LocalInterface` filter path; that permit
 /// matches the named interface's traffic, not loopback in general. The block
 /// assertion does not depend on a live `hole-tun`. `serial = TUN` serializes
@@ -51,8 +54,26 @@ fn windows_lockdown_blocks_egress_and_permits_loopback() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let loopback_port = listener.local_addr().unwrap().port();
 
+    // A closed loopback port: bind to grab a free port, then drop the listener so
+    // nothing accepts there. Probing it disambiguates a listener-probe failure —
+    // ConnectionRefused proves the CONNECT itself is permitted (kernel reached the
+    // closed port and RST'd), so a listener-probe timeout is an accept-side drop;
+    // TimedOut/PermissionDenied means the CONNECT is blocked outright.
+    let closed_probe = TcpListener::bind("127.0.0.1:0").unwrap();
+    let closed_port = closed_probe.local_addr().unwrap().port();
+    drop(closed_probe);
+
     let cover = engage_lockdown(server_ip, "Loopback Pseudo-Interface 1", &resolver, &[], dir.path())
         .expect("engage real WFP lockdown cover");
+
+    // Discriminating probe: connect to the closed loopback port. See above for how
+    // its error kind separates a CONNECT block from a RECV_ACCEPT drop.
+    let closed_probe_err = std::net::TcpStream::connect_timeout(
+        &format!("127.0.0.1:{closed_port}").parse().unwrap(),
+        Duration::from_secs(2),
+    )
+    .err()
+    .map(|e| e.kind());
 
     // (a) Loopback connect still succeeds (loopback permit). External event with
     // graceful failure bound: the timeout is the failure-to-human signal, not a
@@ -61,12 +82,15 @@ fn windows_lockdown_blocks_egress_and_permits_loopback() {
         &format!("127.0.0.1:{loopback_port}").parse().unwrap(),
         Duration::from_secs(2),
     );
-    // Include the OS error so a third failure shows what kind (timeout = still
-    // blocked at CONNECT, refused = permit held but nobody listening, perm = ACL).
+    // Include both probes' error kinds so a failure shows where the drop is: the
+    // listener probe's kind (timeout = still dropped, refused = nobody listening,
+    // perm = ACL) and the closed-port probe (refused => CONNECT permitted, so a
+    // listener-probe timeout is an accept-side drop).
     assert!(
         lo.is_ok(),
-        "loopback must stay permitted under lockdown: {:?}",
-        lo.err()
+        "loopback must stay permitted under lockdown: listener_probe={:?} closed_port_probe(refused=>connect-permitted)={:?}",
+        lo.err(),
+        closed_probe_err
     );
 
     // (b) Egress to a non-permitted public IP is blocked at ALE_AUTH_CONNECT.

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -1,8 +1,17 @@
 //! Privileged-lane real-engage verification for the standing lockdown cover
 //! (#527). Unlike the pure builder unit tests (`windows_tests` / `macos_tests`,
 //! the #165 isolation contract), these engage the REAL OS cover (Windows: live
-//! FWPM; macOS: live pf) and assert it actually blocks egress — proving the kill
-//! switch is not inert.
+//! FWPM; macOS: live pf) and prove at runtime that it is SELECTIVE: it permits
+//! the configured server IP and blocks all other egress, then restores on
+//! disengage. That catches the block-everything arbitration class of bug (the
+//! permit must beat block-all) AND proves no-leak (a non-permitted host is
+//! blocked).
+//!
+//! The probe is OUTBOUND egress, not inbound loopback: an egress kill switch
+//! governs outbound flows, and the GitHub Actions Windows runner's firewall
+//! drops inbound loopback to the test exe — a pre-cover baseline connect to a
+//! local listener TIMES OUT even with no cover, so loopback can't tell a working
+//! cover from a broken one. Outbound to a routable IP works on the runner.
 //!
 //! They run on the elevated `tun` lane only: the `TUN` label (→ skuld filter
 //! name `tun`) gates them so the unprivileged `SKULD_LABELS="!tun"` pass
@@ -21,135 +30,126 @@ use super::*;
 #[skuld::label]
 const TUN: skuld::Label;
 
-/// Windows real-engage verification. Engages the REAL WFP lockdown cover (a
-/// `LocalInterface` LUID permit + loopback permits + block-all) and proves
-/// (a) loopback stays permitted and (b) egress to an arbitrary non-permitted
-/// public IP is BLOCKED at `ALE_AUTH_CONNECT` — so the cover is not inert.
+// Two routable anycast hosts on :443 (the runner has outbound internet). IP
+// literals only — the cover blocks DNS, so a hostname connect would fail for the
+// wrong reason. PERMITTED is engaged as the server IP; NON_PERMITTED proves the
+// block holds.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const PERMITTED: &str = "1.1.1.1:443";
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const NON_PERMITTED: &str = "8.8.8.8:443";
+
+/// Windows real-engage verification. Engages the REAL WFP lockdown cover with
+/// `server_ip = 1.1.1.1` and proves it is SELECTIVE: egress to the permitted
+/// server IP stays Ok (the permit beats block-all — the assertion that catches
+/// the block-everything arbitration bug) while egress to a non-permitted host is
+/// blocked at `ALE_AUTH_CONNECT` (no leak). Drop restores both.
 ///
-/// Loopback is carried by the address-range permit (127.0.0.0/8 + ::1/128) on all
-/// four ALE layers — CONNECT *and* RECV_ACCEPT, which a loopback connect both
-/// authorizes — plus the `IS_LOOPBACK` flag permit on CONNECT as
-/// belt-and-suspenders; NOT by the LUID permit. The range is the deterministic
-/// matcher because the flag isn't reliably set at either ALE layer on the
-/// elevated lane. A closed-port probe disambiguates any loopback failure
-/// (refused => CONNECT permitted, so a listener-probe timeout is an accept-side
-/// drop). The interface alias is resolved only to drive the real
-/// `ConvertInterfaceAliasToLuid` + `LocalInterface` filter path; that permit
-/// matches the named interface's traffic, not loopback in general. The block
-/// assertion does not depend on a live `hole-tun`. `serial = TUN` serializes
-/// against other in-binary TUN tests; the cross-binary race with the bridge's
-/// real-egress e2e is handled by the `global-net-state` test-group
-/// (`.config/nextest.toml`).
+/// The interface alias resolves a real, always-present LUID purely to drive the
+/// real `ConvertInterfaceAliasToLuid` + `LocalInterface` filter path; the
+/// block/permit assertions don't depend on it (the `LocalInterface` permit
+/// matches that interface's traffic, not the egress probed here), nor on a live
+/// `hole-tun`. `serial = TUN` serializes against other in-binary TUN tests; the
+/// cross-binary race with the bridge's real-egress e2e is handled by the
+/// `global-net-state` test-group (`.config/nextest.toml`).
 #[cfg(target_os = "windows")]
 #[skuld::test(labels = [TUN], serial = TUN)]
-fn windows_lockdown_blocks_egress_and_permits_loopback() {
-    use std::net::TcpListener;
+fn windows_lockdown_permits_server_ip_and_blocks_other_egress() {
+    use std::net::TcpStream;
     use std::time::Duration;
 
     let dir = tempfile::tempdir().unwrap();
     let resolver = SystemLuidResolver;
-    let server_ip: std::net::IpAddr = "203.0.113.7".parse().unwrap();
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
 
-    // A loopback listener proves the loopback permit holds while the cover is up.
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let loopback_port = listener.local_addr().unwrap().port();
+    // External-event probe with a graceful failure bound: the timeout is the
+    // failure-to-human signal, not a sync sleep; assertions are Ok/Err, not timing.
+    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
 
-    // A closed loopback port: bind to grab a free port, then drop the listener so
-    // nothing accepts there. Probing it disambiguates a listener-probe failure —
-    // ConnectionRefused proves the CONNECT itself is permitted (kernel reached the
-    // closed port and RST'd), so a listener-probe timeout is an accept-side drop;
-    // TimedOut/PermissionDenied means the CONNECT is blocked outright.
-    let closed_probe = TcpListener::bind("127.0.0.1:0").unwrap();
-    let closed_port = closed_probe.local_addr().unwrap().port();
-    drop(closed_probe);
+    // Baseline (PRE-cover): both hosts must be reachable. A failure here is a
+    // network/reachability problem, not the cover — fail loud and self-validate the
+    // probe so a network blip is never a false pass.
+    let base_permitted = connect(PERMITTED);
+    let base_non = connect(NON_PERMITTED);
+    assert!(
+        base_permitted.is_ok() && base_non.is_ok(),
+        "NETWORK/ENVIRONMENT problem (not the cover): pre-cover baseline egress must reach both hosts; \
+         {PERMITTED}={:?} {NON_PERMITTED}={:?}",
+        base_permitted.err().map(|e| e.kind()),
+        base_non.err().map(|e| e.kind()),
+    );
 
-    // Baseline (PRE-cover): characterize the runner so the post-cover result is
-    // interpretable. `base_lo` should be Ok (loopback works without the cover);
-    // `base_closed` tells us whether this runner RSTs a closed loopback port
-    // (ConnectionRefused) or silently drops (TimedOut) — which decides whether the
-    // post-cover closed-port probe can distinguish a CONNECT block from an
-    // accept-side drop at all.
-    let base_lo = std::net::TcpStream::connect_timeout(
-        &format!("127.0.0.1:{loopback_port}").parse().unwrap(),
-        Duration::from_secs(2),
-    )
-    .err()
-    .map(|e| e.kind());
-    let base_closed = std::net::TcpStream::connect_timeout(
-        &format!("127.0.0.1:{closed_port}").parse().unwrap(),
-        Duration::from_secs(2),
-    )
-    .err()
-    .map(|e| e.kind());
-
+    // "Loopback Pseudo-Interface 1" is an always-present alias used only as a LUID
+    // source to exercise the real resolve + `LocalInterface` filter path.
     let cover = engage_lockdown(server_ip, "Loopback Pseudo-Interface 1", &resolver, &[], dir.path())
         .expect("engage real WFP lockdown cover");
 
-    // Discriminating probe: connect to the closed loopback port. See above for how
-    // its error kind separates a CONNECT block from a RECV_ACCEPT drop.
-    let closed_probe_err = std::net::TcpStream::connect_timeout(
-        &format!("127.0.0.1:{closed_port}").parse().unwrap(),
-        Duration::from_secs(2),
-    )
-    .err()
-    .map(|e| e.kind());
+    let permitted = connect(PERMITTED);
+    let non = connect(NON_PERMITTED);
 
-    // (a) Loopback connect still succeeds (loopback permit). External event with
-    // graceful failure bound: the timeout is the failure-to-human signal, not a
-    // sync sleep; the assertion is success, not "completed within N".
-    let lo = std::net::TcpStream::connect_timeout(
-        &format!("127.0.0.1:{loopback_port}").parse().unwrap(),
-        Duration::from_secs(2),
-    );
-    // Include both probes' error kinds so a failure shows where the drop is: the
-    // listener probe's kind (timeout = still dropped, refused = nobody listening,
-    // perm = ACL) and the closed-port probe (refused => CONNECT permitted, so a
-    // listener-probe timeout is an accept-side drop).
+    // Permit beats block-all: the server IP stays reachable (catches block-everything).
     assert!(
-        lo.is_ok(),
-        "loopback must stay permitted under lockdown: \
-         baseline(pre-cover) lo={base_lo:?} closed={base_closed:?}; \
-         post-cover listener={:?} closed(refused=>connect-permitted)={:?}",
-        lo.err(),
-        closed_probe_err
+        permitted.is_ok(),
+        "server-IP permit must beat block-all (else the cover blocks everything): \
+         {PERMITTED}={:?}; baseline {PERMITTED}=Ok {NON_PERMITTED}=Ok",
+        permitted.err().map(|e| e.kind()),
     );
-
-    // (b) Egress to a non-permitted public IP is blocked at ALE_AUTH_CONNECT.
-    // 198.51.100.1 (TEST-NET-2) discard port: external event with graceful
-    // failure bound — the assertion is that it ERRORS, not that it times out.
-    let blocked = std::net::TcpStream::connect_timeout(&"198.51.100.1:9".parse().unwrap(), Duration::from_secs(2));
-    assert!(blocked.is_err(), "lockdown must block egress to a non-permitted IP");
+    // No leak: egress to a non-permitted host is blocked at ALE_AUTH_CONNECT.
+    assert!(
+        non.is_err(),
+        "lockdown must block egress to a non-permitted host (leak!): \
+         {NON_PERMITTED} connected; baseline {PERMITTED}=Ok {NON_PERMITTED}=Ok",
+    );
 
     // Drop sweeps the lockdown filters (kind-aware Cover Drop); egress restored.
     drop(cover);
-    drop(listener);
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "disengage must restore egress to the previously-blocked host: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
 }
 
 /// macOS real-engage verification. Engages the REAL pf lockdown cover (an
 /// authoritative main-ruleset replace: `block drop out quick all` with earlier
 /// `quick` permits for loopback, the TUN, and the server IP — no anchor, so
-/// there is no inert-anchor failure mode) and proves (a) the live filter
-/// ruleset carries our block rule, (b) egress to a non-server, non-loopback IP
-/// is dropped while the cover holds, and (c) Drop restores the pre-lockdown
-/// snapshot.
+/// there is no inert-anchor failure mode) with `server_ip = 1.1.1.1` and proves
+/// (a) the live ruleset carries our block rule, (b) it is SELECTIVE — egress to
+/// the server IP stays Ok while a non-permitted host is dropped, and (c) Drop
+/// restores the pre-lockdown snapshot.
 ///
-/// No live utun is needed for the block assertion: `pass out quick on
-/// <tun-absent>` simply never matches, so a probe to an arbitrary IP is blocked
-/// by `block drop out quick all`. `serial = TUN` + the `global-net-state`
-/// test-group serialize the process-global pf state: `pfctl -E`/`-X` is
-/// refcounted and the main ruleset is host-wide, so a concurrent cover test
-/// would race the snapshot restore. (On macOS only this binary carries a TUN
-/// test — the bridge TUN e2e is `cfg(windows)` — so the group is single-member,
-/// but it costs nothing.)
+/// No live utun is needed: `pass out quick on <tun-absent>` simply never matches,
+/// so the block rule governs the probed egress. `serial = TUN` + the
+/// `global-net-state` test-group serialize the process-global pf state:
+/// `pfctl -E`/`-X` is refcounted and the main ruleset is host-wide, so a
+/// concurrent cover test would race the snapshot restore.
 #[cfg(target_os = "macos")]
 #[skuld::test(labels = [TUN], serial = TUN)]
-fn macos_lockdown_actually_blocks_and_restores() {
+fn macos_lockdown_permits_server_ip_blocks_other_egress_and_restores() {
+    use std::net::TcpStream;
     use std::process::Command;
     use std::time::Duration;
 
     let dir = tempfile::tempdir().unwrap();
     let resolver = SystemLuidResolver;
-    let server_ip: std::net::IpAddr = "203.0.113.7".parse().unwrap();
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    // External-event probe with a graceful failure bound: the timeout is the
+    // failure-to-human signal, not a sync sleep; assertions are Ok/Err, not timing.
+    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
+
+    // Baseline (PRE-cover): both hosts must be reachable. A failure here is a
+    // network/reachability problem, not the cover — fail loud and self-validate the
+    // probe so a network blip is never a false pass.
+    let base_permitted = connect(PERMITTED);
+    let base_non = connect(NON_PERMITTED);
+    assert!(
+        base_permitted.is_ok() && base_non.is_ok(),
+        "NETWORK/ENVIRONMENT problem (not the cover): pre-cover baseline egress must reach both hosts; \
+         {PERMITTED}={:?} {NON_PERMITTED}={:?}",
+        base_permitted.err().map(|e| e.kind()),
+        base_non.err().map(|e| e.kind()),
+    );
 
     let cover =
         engage_lockdown(server_ip, "utun-absent", &resolver, &[], dir.path()).expect("engage real pf lockdown cover");
@@ -162,17 +162,32 @@ fn macos_lockdown_actually_blocks_and_restores() {
         "main ruleset must carry the lockdown block (else inert):\n{rules}"
     );
 
-    // (b) Egress to a non-permitted IP is blocked while the cover holds.
-    // External event with graceful failure bound: the assertion is that it
-    // ERRORS, not that it times out.
-    let blocked = std::net::TcpStream::connect_timeout(&"198.51.100.1:9".parse().unwrap(), Duration::from_secs(2));
-    assert!(blocked.is_err(), "lockdown must block egress to a non-permitted IP");
+    let permitted = connect(PERMITTED);
+    let non = connect(NON_PERMITTED);
 
-    // (c) Drop restores the pre-lockdown snapshot; our block rule is gone.
+    // (b) Selective: permit beats block (server IP reachable), non-permitted blocked.
+    assert!(
+        permitted.is_ok(),
+        "server-IP permit must beat block-all (else the cover blocks everything): \
+         {PERMITTED}={:?}; baseline {PERMITTED}=Ok {NON_PERMITTED}=Ok",
+        permitted.err().map(|e| e.kind()),
+    );
+    assert!(
+        non.is_err(),
+        "lockdown must block egress to a non-permitted host (leak!): \
+         {NON_PERMITTED} connected; baseline {PERMITTED}=Ok {NON_PERMITTED}=Ok",
+    );
+
+    // (c) Drop restores the pre-lockdown snapshot: block rule gone, egress restored.
     drop(cover);
     let after = Command::new("pfctl").args(["-sr"]).output().unwrap();
     assert!(
         !String::from_utf8_lossy(&after.stdout).contains("block drop out quick all"),
         "snapshot restore must remove our lockdown block rule"
+    );
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "disengage must restore egress to the previously-blocked host: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
     );
 }

--- a/crates/tun-engine/src/routing/failclosed/lockdown_state.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_state.rs
@@ -1,0 +1,100 @@
+//! Persisted lockdown INTENT (the standing kill switch's enabled bool),
+//! bridge-owned and system-wide. Distinct from `bridge-failclosed.json`
+//! (which records the transient cover's pf token): this file records what the
+//! user *wants*, surviving bridge restarts and crashes. Modeled on
+//! `failclosed_state.rs`: schema version, atomic save, load-None-on-mismatch.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version. [`load`] discards a mismatched file rather than risk a
+/// corrupt recovery (same policy as the route/failclosed state files).
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Filename under `state_dir`.
+pub const STATE_FILE_NAME: &str = "bridge-lockdown.json";
+
+/// Persisted lockdown intent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockdownState {
+    pub version: u32,
+    /// Whether the standing kill switch is enabled.
+    pub enabled: bool,
+}
+
+fn state_file(state_dir: &Path) -> PathBuf {
+    state_dir.join(STATE_FILE_NAME)
+}
+
+/// Atomically persist `state` (temp file + same-dir rename, `sync_all`
+/// before persist). Creates `state_dir`.
+pub fn save(state_dir: &Path, state: &LockdownState) -> std::io::Result<()> {
+    std::fs::create_dir_all(state_dir)?;
+    let json = serde_json::to_vec_pretty(state).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(state_dir)?;
+    tmp.write_all(&json)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(state_file(state_dir)).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Load the intent, or `None` on absent/corrupt/unknown-field/version
+/// mismatch (logs at `warn`). An absent file means "default-off".
+pub fn load(state_dir: &Path) -> Option<LockdownState> {
+    let path = state_file(state_dir);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "lockdown-state read failed");
+            return None;
+        }
+    };
+    match serde_json::from_slice::<LockdownState>(&bytes) {
+        Ok(s) if s.version == SCHEMA_VERSION => Some(s),
+        Ok(other) => {
+            tracing::warn!(
+                got = other.version,
+                want = SCHEMA_VERSION,
+                "lockdown-state schema mismatch, discarding"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "lockdown-state parse failed");
+            None
+        }
+    }
+}
+
+/// Convenience: the effective intent (absent file => false / default-off).
+pub fn load_enabled(state_dir: &Path) -> bool {
+    load(state_dir).map(|s| s.enabled).unwrap_or(false)
+}
+
+/// Last-writer-wins absolute set. Persists `enabled` under the current schema.
+pub fn set_enabled(state_dir: &Path, enabled: bool) -> std::io::Result<()> {
+    save(
+        state_dir,
+        &LockdownState {
+            version: SCHEMA_VERSION,
+            enabled,
+        },
+    )
+}
+
+/// Delete the state file; tolerates absence.
+pub fn clear(state_dir: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(state_file(state_dir)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+#[path = "lockdown_state_tests.rs"]
+mod lockdown_state_tests;

--- a/crates/tun-engine/src/routing/failclosed/lockdown_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_state_tests.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[skuld::test]
+fn save_then_load_roundtrips() {
+    let tmp = tempfile::tempdir().unwrap();
+    let st = LockdownState {
+        version: SCHEMA_VERSION,
+        enabled: true,
+    };
+    save(tmp.path(), &st).unwrap();
+    assert_eq!(load(tmp.path()), Some(st));
+}
+
+#[skuld::test]
+fn load_absent_is_none_and_load_enabled_is_false() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(load(tmp.path()), None);
+    assert!(!load_enabled(tmp.path()), "absent file => default-off");
+}
+
+#[skuld::test]
+fn load_rejects_schema_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let st = LockdownState {
+        version: SCHEMA_VERSION + 1,
+        enabled: true,
+    };
+    save(tmp.path(), &st).unwrap();
+    assert_eq!(load(tmp.path()), None, "future schema must be discarded");
+}
+
+#[skuld::test]
+fn set_enabled_is_last_writer_wins() {
+    let tmp = tempfile::tempdir().unwrap();
+    set_enabled(tmp.path(), true).unwrap();
+    assert!(load_enabled(tmp.path()));
+    set_enabled(tmp.path(), false).unwrap();
+    assert!(!load_enabled(tmp.path()), "second writer wins");
+}
+
+#[skuld::test]
+fn clear_removes_file_and_tolerates_absence() {
+    let tmp = tempfile::tempdir().unwrap();
+    set_enabled(tmp.path(), true).unwrap();
+    assert!(tmp.path().join(STATE_FILE_NAME).exists());
+    clear(tmp.path()).unwrap();
+    assert!(!tmp.path().join(STATE_FILE_NAME).exists());
+    clear(tmp.path()).unwrap(); // second clear is a no-op
+}

--- a/crates/tun-engine/src/routing/failclosed/luid.rs
+++ b/crates/tun-engine/src/routing/failclosed/luid.rs
@@ -1,0 +1,55 @@
+//! Resolve the `hole-tun` interface alias to a `NET_LUID` for the Windows
+//! lockdown cover's `IP_LOCAL_INTERFACE` permit. The LUID is NEVER persisted —
+//! a TUN teardown/recreate or a reboot mints a fresh LUID, so the cover
+//! re-resolves and re-engages on every connect (and recovery deletes
+//! stale-LUID filters before re-engaging).
+//!
+//! `gateway.rs` already calls `ConvertInterfaceAliasToLuid`, but it converts
+//! onward to an interface *index* and discards the LUID; this seam is the
+//! net-new alias->LUID path the cover needs.
+
+use crate::error::RoutingError;
+
+/// Resolves an interface alias (e.g. `hole-tun`) to its `NET_LUID` as a `u64`.
+/// Behind a trait so unit tests substitute a canned LUID without FFI (#165).
+pub trait LuidResolver: Send + Sync {
+    fn resolve(&self, alias: &str) -> Result<u64, RoutingError>;
+}
+
+/// Production resolver: the real `ConvertInterfaceAliasToLuid` FFI.
+pub struct SystemLuidResolver;
+
+#[cfg(target_os = "windows")]
+impl LuidResolver for SystemLuidResolver {
+    fn resolve(&self, alias: &str) -> Result<u64, RoutingError> {
+        use windows::core::HSTRING;
+        use windows::Win32::Foundation::NO_ERROR;
+        use windows::Win32::NetworkManagement::IpHelper::ConvertInterfaceAliasToLuid;
+        use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+
+        let alias_h = HSTRING::from(alias);
+        let mut luid = NET_LUID_LH::default();
+        let err = unsafe { ConvertInterfaceAliasToLuid(&alias_h, &mut luid) };
+        if err != NO_ERROR {
+            return Err(RoutingError::RouteSetup(format!(
+                "ConvertInterfaceAliasToLuid('{alias}'): error {err:?}"
+            )));
+        }
+        // NET_LUID_LH is a union; `.Value` is the u64 representation.
+        Ok(unsafe { luid.Value })
+    }
+}
+
+// On non-Windows the lockdown cover keys on the TUN name (pf), not a LUID, so
+// a SystemLuidResolver is never constructed there; provide a stub impl so the
+// type is nameable in cross-platform signatures.
+#[cfg(not(target_os = "windows"))]
+impl LuidResolver for SystemLuidResolver {
+    fn resolve(&self, _alias: &str) -> Result<u64, RoutingError> {
+        Err(RoutingError::RouteSetup("LUID resolution is Windows-only".into()))
+    }
+}
+
+#[cfg(test)]
+#[path = "luid_tests.rs"]
+mod luid_tests;

--- a/crates/tun-engine/src/routing/failclosed/luid_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/luid_tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+/// Returns a canned LUID, or an error when configured to fail — drives the
+/// re-adopt transaction (Task 6) and the engage path (Task 7) without FFI.
+pub struct MockLuidResolver {
+    pub luid: u64,
+    pub fail: bool,
+    pub last_alias: std::sync::Mutex<Option<String>>,
+}
+
+impl MockLuidResolver {
+    pub fn new(luid: u64) -> Self {
+        Self {
+            luid,
+            fail: false,
+            last_alias: std::sync::Mutex::new(None),
+        }
+    }
+    pub fn failing() -> Self {
+        Self {
+            luid: 0,
+            fail: true,
+            last_alias: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl LuidResolver for MockLuidResolver {
+    fn resolve(&self, alias: &str) -> Result<u64, RoutingError> {
+        *self.last_alias.lock().unwrap() = Some(alias.to_owned());
+        if self.fail {
+            Err(RoutingError::RouteSetup("mock luid failure".into()))
+        } else {
+            Ok(self.luid)
+        }
+    }
+}
+
+#[skuld::test]
+fn mock_resolves_canned_luid_and_records_alias() {
+    let r = MockLuidResolver::new(0x42);
+    assert_eq!(r.resolve("hole-tun").unwrap(), 0x42);
+    assert_eq!(r.last_alias.lock().unwrap().as_deref(), Some("hole-tun"));
+}
+
+#[skuld::test]
+fn mock_failing_resolver_returns_err() {
+    let r = MockLuidResolver::failing();
+    assert!(r.resolve("hole-tun").is_err());
+}

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -8,7 +8,10 @@
 //!   self-contained MAIN ruleset (NO `-Fa`) that carries the host's translation
 //!   rules forward and blocks all egress except the TUN and server IP. Disengage
 //!   restores the host's pre-lockdown filter+nat from the persisted snapshot —
-//!   not a blind `/etc/pf.conf` reload — and drops the refcount.
+//!   not a blind `/etc/pf.conf` reload — and drops the refcount. Engage
+//!   idempotently ENSURES pf is enabled (pf is disabled — and its refcount reset
+//!   — across a reboot, but the state file persists), so a reconnect re-enables
+//!   pf and loads a live ruleset instead of an inert one.
 //!
 //! Documented caveats (pf has no programmatic API — `pfctl` text I/O IS the
 //! interface, as `netsh`/`route` are for routing):
@@ -116,6 +119,31 @@ pub fn parse_pf_enabled(output: &str) -> bool {
         .any(|l| l.trim_start().starts_with("Status:") && l.contains("Enabled"))
 }
 
+/// How `engage_lockdown` must (re)enable pf. Pure so it is table-tested; the live
+/// `pfctl` calls stay behind the privileged path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PfEngageAction {
+    /// No persisted state: snapshot the host + `pfctl -E` + capture the token.
+    FreshEnable,
+    /// Adopt re-engage AND pf still enabled: reuse the persisted token (no `-E`).
+    ReuseToken,
+    /// Adopt re-engage but pf is DISABLED (a reboot reset it AND its refcount): the
+    /// persisted token is stale, so `pfctl -E` again and persist the fresh token.
+    Reenable,
+}
+
+/// Decide how to (re)enable pf for a lockdown engage. `pf_enabled` is read from
+/// `pfctl -s info`; `has_persisted` is whether a valid `bridge-lockdown-pf.json`
+/// exists. The persisted-but-disabled case is the connected-session fail-open this
+/// closes: always load the ruleset into an ENABLED pf, never an inert one.
+fn engage_pf_action(pf_enabled: bool, has_persisted: bool) -> PfEngageAction {
+    match (has_persisted, pf_enabled) {
+        (false, _) => PfEngageAction::FreshEnable,
+        (true, true) => PfEngageAction::ReuseToken,
+        (true, false) => PfEngageAction::Reenable,
+    }
+}
+
 // --- engage layer ---
 
 const PFCONF: &str = "/etc/pf.conf";
@@ -126,6 +154,15 @@ fn pfctl(args: &[&str], stdin: Option<&[u8]>, phase: &str) -> Result<std::proces
         .map(str::to_owned)
         .collect();
     run_capturing(&cmd, stdin, phase).map_err(|e| RoutingError::RouteSetup(format!("pfctl spawn failed: {e}")))
+}
+
+/// `pfctl -E` (refcounted enable) + parse the enable token from its output. The
+/// token prints to stderr (or stdout on some hosts), so try both.
+fn enable_pf_capture_token() -> Result<String, RoutingError> {
+    let en = pfctl(&["-E"], None, PHASE_COVER)?;
+    parse_enable_token(&String::from_utf8_lossy(&en.stderr))
+        .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
+        .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))
 }
 
 /// Which cover a [`Cover`] guard owns — selects its Drop disengage path.
@@ -149,10 +186,7 @@ pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError
     let was_enabled = parse_pf_enabled(&String::from_utf8_lossy(&info.stdout));
 
     // 2. Enable pf (refcounted) and capture the token.
-    let en = pfctl(&["-E"], None, PHASE_COVER)?;
-    let token = parse_enable_token(&String::from_utf8_lossy(&en.stderr))
-        .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
-        .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))?;
+    let token = enable_pf_capture_token()?;
 
     // 3. Persist BEFORE loading the blocking ruleset (persist-before-mutate),
     //    so a crash after this point is recoverable (`pfctl -X <token>`).
@@ -252,29 +286,69 @@ fn capture_and_persist(token: &str, state_dir: &Path) -> Result<String, RoutingE
     Ok(nat_snapshot)
 }
 
-/// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`:
+/// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`. Engage
+/// idempotently ENSURES pf is enabled (`engage_pf_action` on the `pfctl -s info`
+/// read) so the ruleset never loads into a disabled, INERT pf:
 ///
-/// 1. If a valid `bridge-lockdown-pf.json` already exists (Adopt re-engage),
-///    REUSE its token + snapshots — re-running `-sr`/`-sn` here would snapshot
-///    our own lockdown ruleset as the "host" and lose the real host policy.
-/// 2. Else: `pfctl -E` (refcount) + capture token; `pfctl -sr` (filter) and
-///    `pfctl -sn` (nat) snapshots; persist {token, snapshots} before mutating.
-/// 3. Load the self-contained main ruleset via `pfctl -f -` (NO `-Fa`), so the
-///    block takes effect while host translation is carried forward.
+/// 1. `FreshEnable` (no persisted state): `pfctl -E` (refcount) + capture token;
+///    `pfctl -sr` (filter) and `pfctl -sn` (nat) snapshots; persist {token,
+///    snapshots} before mutating.
+/// 2. `ReuseToken` (Adopt re-engage, pf still enabled): reuse the persisted token
+///    + snapshots — re-running `-sr`/`-sn` would snapshot our OWN lockdown ruleset
+///    as the "host" and lose the real host policy.
+/// 3. `Reenable` (Adopt re-engage but pf DISABLED — e.g. a reboot reset pf and its
+///    refcount): the persisted token is stale, so `pfctl -E` for a FRESH token and
+///    re-persist it under the SAME host snapshot. Without this the ruleset would
+///    load into a disabled pf and the cover would be inert while reported active —
+///    egress in the clear during an armed session (not just the boot window).
+///
+/// Then load the self-contained main ruleset via `pfctl -f -` (NO `-Fa`), so the
+/// block takes effect while host translation is carried forward.
 ///
 /// On load failure the host is restored (`lockdown_disengage`) and Err returned;
 /// the bridge's fail-FATAL caller aborts the start.
 pub fn engage_lockdown(server_ip: IpAddr, tun_name: &str, state_dir: &Path) -> Result<Cover, RoutingError> {
-    let (token, nat_snapshot) = match lockdown_state::load(state_dir) {
-        // Adopt re-engage: reuse the persisted host snapshot+token so the real
-        // host policy is preserved for the eventual restore.
-        Some(st) => (st.pf_token, st.nat_snapshot),
-        None => {
-            let en = pfctl(&["-E"], None, PHASE_COVER)?;
-            let token = parse_enable_token(&String::from_utf8_lossy(&en.stderr))
-                .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
-                .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))?;
+    // The `pfctl -s info` read is decision-only — `LockdownPfState` records no
+    // `pf_was_enabled` bit (unlike the transient `FailClosedState`).
+    let info = pfctl(&["-s", "info"], None, PHASE_COVER)?;
+    let pf_enabled = parse_pf_enabled(&String::from_utf8_lossy(&info.stdout));
+    let persisted = lockdown_state::load(state_dir);
 
+    let (token, nat_snapshot) = match engage_pf_action(pf_enabled, persisted.is_some()) {
+        // Live Adopt re-engage within one boot: pf still enabled and we hold the
+        // token+snapshot. Reuse both so the real host policy is preserved for the
+        // eventual restore. ReuseToken assumes our refcount is still live (the
+        // reboot case is `Reenable`); do not double `-E`.
+        PfEngageAction::ReuseToken => {
+            let st = persisted.expect("ReuseToken implies persisted state");
+            (st.pf_token, st.nat_snapshot)
+        }
+        // Persisted state survived but pf was disabled (reboot reset pf and its
+        // refcount). Enable afresh and re-persist the SAME host snapshot under the
+        // fresh token — never re-snapshot the live lockdown ruleset. The single
+        // `pfctl -X <fresh-token>` on disengage matches this single `-E`.
+        PfEngageAction::Reenable => {
+            let st = persisted.expect("Reenable implies persisted state");
+            let token = enable_pf_capture_token()?;
+            let fresh = lockdown_state::LockdownPfState {
+                version: lockdown_state::SCHEMA_VERSION,
+                pf_token: token.clone(),
+                main_snapshot: st.main_snapshot,
+                nat_snapshot: st.nat_snapshot.clone(),
+            };
+            if let Err(e) = lockdown_state::save(state_dir, &fresh) {
+                if let Err(xe) = pfctl(&["-X", &token], None, PHASE_COVER) {
+                    tracing::warn!(error = %xe, "pfctl -X failed unwinding a failed lockdown re-enable");
+                }
+                return Err(RoutingError::RouteSetup(format!(
+                    "failed to re-persist lockdown-pf-state: {e}"
+                )));
+            }
+            (token, st.nat_snapshot)
+        }
+        // First engage: enable + snapshot the host.
+        PfEngageAction::FreshEnable => {
+            let token = enable_pf_capture_token()?;
             // The refcount is now held. Capture + persist may fail, so undo the
             // `-E` on any error before propagating — else the refcount leaks with
             // no state file to recover it from.
@@ -346,10 +420,12 @@ pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Pat
         Adopt => {
             tracing::info!("lockdown recovery: adopting persistent cover (host stays fail-closed)");
             // Intentionally NOTHING removed: the block must survive the
-            // restart (this IS the crash-leak fix). NOTE: macOS pf rules do
-            // NOT survive a reboot, so a reboot opens a boot->first-connect
-            // window — tracked under the deferred Decision C-b (block when
-            // disconnected, needs an early-boot block).
+            // restart (this IS the crash-leak fix). macOS pf rules + enable
+            // state do NOT survive a reboot, but the persisted state file does:
+            // the next reconnect's `engage_lockdown` idempotently re-enables pf
+            // and reloads a live ruleset (so a connected session no longer fails
+            // open). Residual: the boot->first-connect interval is unprotected
+            // (no early-boot block) until that first reconnect re-arms the host.
         }
         Sweep => {
             tracing::info!("lockdown recovery: sweeping leftover cover (intent off)");

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -288,19 +288,12 @@ fn capture_and_persist(token: &str, state_dir: &Path) -> Result<String, RoutingE
 
 /// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`. Engage
 /// idempotently ENSURES pf is enabled (`engage_pf_action` on the `pfctl -s info`
-/// read) so the ruleset never loads into a disabled, INERT pf:
+/// read) so the ruleset never loads into a disabled, INERT pf. The three cases
+/// (single-line bullets keep clippy's doc_lazy_continuation happy):
 ///
-/// 1. `FreshEnable` (no persisted state): `pfctl -E` (refcount) + capture token;
-///    `pfctl -sr` (filter) and `pfctl -sn` (nat) snapshots; persist {token,
-///    snapshots} before mutating.
-/// 2. `ReuseToken` (Adopt re-engage, pf still enabled): reuse the persisted token
-///    + snapshots — re-running `-sr`/`-sn` would snapshot our OWN lockdown ruleset
-///    as the "host" and lose the real host policy.
-/// 3. `Reenable` (Adopt re-engage but pf DISABLED — e.g. a reboot reset pf and its
-///    refcount): the persisted token is stale, so `pfctl -E` for a FRESH token and
-///    re-persist it under the SAME host snapshot. Without this the ruleset would
-///    load into a disabled pf and the cover would be inert while reported active —
-///    egress in the clear during an armed session (not just the boot window).
+/// - `FreshEnable` (no persisted state): `pfctl -E` (refcount) + capture token, snapshot `pfctl -sr` (filter) and `pfctl -sn` (nat), persist {token, snapshots} before mutating.
+/// - `ReuseToken` (Adopt re-engage, pf still enabled): reuse the persisted token + snapshots; re-running `-sr`/`-sn` would snapshot our OWN lockdown ruleset as the host and lose the real host policy.
+/// - `Reenable` (Adopt re-engage but pf DISABLED, e.g. a reboot reset pf and its refcount): the persisted token is stale, so `pfctl -E` for a FRESH token and re-persist it under the SAME host snapshot. Without this the ruleset loads into a disabled pf and the cover is inert while reported active — egress in the clear during an armed session, not just the boot window.
 ///
 /// Then load the self-contained main ruleset via `pfctl -f -` (NO `-Fa`), so the
 /// block takes effect while host translation is carried forward.

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -19,6 +19,7 @@ use crate::error::RoutingError;
 // `macos.rs` is mounted as `mod platform` under `failclosed`, so `super` is the
 // `failclosed` module and `failclosed_state` is its sibling child.
 use super::failclosed_state as state;
+use super::lockdown_pf_state as lockdown_state;
 
 /// Build the self-contained pf ruleset (loaded via `pfctl -f -`).
 ///
@@ -101,11 +102,19 @@ fn pfctl(args: &[&str], stdin: Option<&[u8]>, phase: &str) -> Result<std::proces
     run_capturing(&cmd, stdin, phase).map_err(|e| RoutingError::RouteSetup(format!("pfctl spawn failed: {e}")))
 }
 
-/// pf-backed cover guard. Drop restores `/etc/pf.conf` and drops our enable
-/// refcount.
+/// Which cover a [`Cover`] guard owns — selects its Drop disengage path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoverKind {
+    Transient,
+    Lockdown,
+}
+
+/// pf-backed cover guard. Drop disengages per [`CoverKind`]: the transient
+/// cover restores `/etc/pf.conf`; the lockdown cover restores the snapshot.
 pub struct Cover {
     token: String,
     state_dir: std::path::PathBuf,
+    kind: CoverKind,
 }
 
 pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError> {
@@ -153,12 +162,16 @@ pub fn engage(server_ip: IpAddr, state_dir: &Path) -> Result<Cover, RoutingError
     Ok(Cover {
         token,
         state_dir: state_dir.to_owned(),
+        kind: CoverKind::Transient,
     })
 }
 
 impl Drop for Cover {
     fn drop(&mut self) {
-        disengage(&self.token, &self.state_dir);
+        match self.kind {
+            CoverKind::Transient => disengage(&self.token, &self.state_dir),
+            CoverKind::Lockdown => lockdown_disengage(&self.state_dir),
+        }
     }
 }
 
@@ -186,6 +199,113 @@ pub fn recover_cover(state_dir: &Path) {
         "recovering fail-closed cover from crashed run"
     );
     disengage(&st.pf_token, state_dir);
+}
+
+// --- lockdown layer ---
+
+/// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`:
+///
+/// 1. `pfctl -E` (refcount) + capture token.
+/// 2. `pfctl -sr` snapshot of the current main ruleset.
+/// 3. Persist {token, snapshot} to `bridge-lockdown-pf.json`.
+/// 4. Load the anchor BODY into `com.hole.lockdown` (`-a <anchor> -f -`).
+/// 5. Load the COMPOSED main (snapshot + anchor call-out) WITHOUT `-Fa`, so
+///    the anchor evaluates while host/MDM policy is preserved.
+///
+/// On any load failure the host is restored (Sweep) and Err returned; the
+/// bridge's fail-FATAL caller aborts the start.
+#[allow(dead_code)] // caller is the cfg-free `failclosed::engage_lockdown` facade (not yet wired on macOS)
+pub fn engage_lockdown(server_ip: IpAddr, tun_name: &str, state_dir: &Path) -> Result<Cover, RoutingError> {
+    let en = pfctl(&["-E"], None, PHASE_COVER)?;
+    let token = parse_enable_token(&String::from_utf8_lossy(&en.stderr))
+        .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
+        .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))?;
+
+    let sr = pfctl(&["-sr"], None, PHASE_COVER)?;
+    let main_snapshot = String::from_utf8_lossy(&sr.stdout).into_owned();
+
+    lockdown_state::save(
+        state_dir,
+        &lockdown_state::LockdownPfState {
+            version: lockdown_state::SCHEMA_VERSION,
+            pf_token: token.clone(),
+            main_snapshot: main_snapshot.clone(),
+        },
+    )
+    .map_err(|e| RoutingError::RouteSetup(format!("failed to persist lockdown-pf-state: {e}")))?;
+
+    // Helper to restore-and-fail on any load error.
+    let fail = |what: &str, stderr: &[u8]| -> RoutingError {
+        lockdown_disengage(state_dir);
+        RoutingError::RouteSetup(format!("{what}: {}", String::from_utf8_lossy(stderr).trim()))
+    };
+
+    // 4. Anchor body.
+    let body = build_lockdown_ruleset(tun_name, server_ip);
+    let body_out = pfctl(&["-a", LOCKDOWN_ANCHOR, "-f", "-"], Some(body.as_bytes()), PHASE_COVER)?;
+    if !body_out.status.success() {
+        return Err(fail("pfctl lockdown anchor load failed", &body_out.stderr));
+    }
+
+    // 5. Composed main (NO -Fa) — this is what makes the anchor evaluate.
+    let main = build_main_ruleset_with_anchor(&main_snapshot);
+    let main_out = pfctl(&["-f", "-"], Some(main.as_bytes()), PHASE_COVER)?;
+    if !main_out.status.success() {
+        return Err(fail("pfctl lockdown main load failed", &main_out.stderr));
+    }
+
+    Ok(Cover {
+        token,
+        state_dir: state_dir.to_owned(),
+        kind: CoverKind::Lockdown,
+    })
+}
+
+/// Sweep: restore the snapshot main ruleset, flush the anchor, drop our pf
+/// refcount, clear the state. Shared by Drop (user-stop) and `recover_lockdown`
+/// when the persisted intent is OFF. Best-effort; logs on failure.
+fn lockdown_disengage(state_dir: &Path) {
+    if let Some(st) = lockdown_state::load(state_dir) {
+        if let Err(e) = pfctl(&["-f", "-"], Some(st.main_snapshot.as_bytes()), PHASE_RECOVER_COVER) {
+            tracing::warn!(error = %e, "lockdown main-snapshot restore failed");
+        }
+        if let Err(e) = pfctl(&["-a", LOCKDOWN_ANCHOR, "-F", "all"], None, PHASE_RECOVER_COVER) {
+            tracing::warn!(error = %e, "lockdown anchor flush failed");
+        }
+        if let Err(e) = pfctl(&["-X", &st.pf_token], None, PHASE_RECOVER_COVER) {
+            tracing::warn!(error = %e, "pfctl -X failed during lockdown disengage");
+        }
+    }
+    if let Err(e) = lockdown_state::clear(state_dir) {
+        tracing::warn!(error = %e, "lockdown-pf-state clear failed during disengage");
+    }
+}
+
+/// Act on a recovery decision for the lockdown cover (called from
+/// `failclosed::recover_lockdown`). `Adopt` (intent ON): KEEP the host
+/// fail-closed — leave the composed main + anchor body + state file untouched;
+/// only the now-dead utun permit inside the anchor is stale, and the next
+/// connect's `install_lockdown` reloads the anchor body with the fresh utun
+/// name (idempotent). `Sweep` (intent OFF): full restore via
+/// `lockdown_disengage`. `Noop`: nothing.
+#[allow(dead_code)] // caller is the cfg-free `failclosed::recover_lockdown` facade (not yet wired on macOS)
+pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
+    use crate::routing::CoverRecovery::*;
+    match decision {
+        Noop => {}
+        Adopt => {
+            tracing::info!("lockdown recovery: adopting persistent cover (host stays fail-closed)");
+            // Intentionally NOTHING removed: the block must survive the
+            // restart (this IS the crash-leak fix). NOTE: macOS pf rules do
+            // NOT survive a reboot, so a reboot opens a boot->first-connect
+            // window — tracked under the deferred Decision C-b (block when
+            // disconnected, needs an early-boot block). See spec §9 C.
+        }
+        Sweep => {
+            tracing::info!("lockdown recovery: sweeping leftover cover (intent off)");
+            lockdown_disengage(state_dir);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -264,7 +264,6 @@ fn capture_and_persist(token: &str, state_dir: &Path) -> Result<String, RoutingE
 ///
 /// On load failure the host is restored (`lockdown_disengage`) and Err returned;
 /// the bridge's fail-FATAL caller aborts the start.
-#[allow(dead_code)] // caller is the cfg-free `failclosed::engage_lockdown` facade (not yet wired on macOS)
 pub fn engage_lockdown(server_ip: IpAddr, tun_name: &str, state_dir: &Path) -> Result<Cover, RoutingError> {
     let (token, nat_snapshot) = match lockdown_state::load(state_dir) {
         // Adopt re-engage: reuse the persisted host snapshot+token so the real
@@ -340,7 +339,6 @@ fn lockdown_disengage(state_dir: &Path) {
 /// interface); the next connect's `engage_lockdown` reuses the persisted
 /// snapshot and reloads with the fresh utun name. `Sweep` (intent OFF): full
 /// restore via `lockdown_disengage`. `Noop`: nothing.
-#[allow(dead_code)] // caller is the cfg-free `failclosed::recover_lockdown` facade (not yet wired on macOS)
 pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
     use crate::routing::CoverRecovery::*;
     match decision {

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -1,14 +1,20 @@
-//! macOS fail-closed cover via pf (`pfctl`).
+//! macOS fail-closed cover via pf (`pfctl`). Two layers share the `Cover` guard:
 //!
-//! Engage enables pf (refcounted, `pfctl -E`), flushes all state, and loads a
-//! self-contained ruleset that blocks every outbound packet except loopback
-//! and the SS server IP. Disengage restores the canonical `/etc/pf.conf` and
-//! drops our enable refcount (`pfctl -X <token>`).
+//! - **Transient cover** (`engage`/`disengage`): enables pf (refcounted,
+//!   `pfctl -E`), flushes all state (`-Fa`), and loads a self-contained ruleset
+//!   blocking every outbound packet except loopback and the SS server IP.
+//!   Disengage restores the canonical `/etc/pf.conf` and drops the refcount.
+//! - **Standing lockdown** (`engage_lockdown`/`lockdown_disengage`): loads a
+//!   self-contained MAIN ruleset (NO `-Fa`) that carries the host's translation
+//!   rules forward and blocks all egress except the TUN and server IP. Disengage
+//!   restores the host's pre-lockdown filter+nat from the persisted snapshot —
+//!   not a blind `/etc/pf.conf` reload — and drops the refcount.
 //!
 //! Documented caveats (pf has no programmatic API — `pfctl` text I/O IS the
 //! interface, as `netsh`/`route` are for routing):
-//! - Restore reloads the on-disk `/etc/pf.conf`, not a snapshot of whatever
-//!   ruleset was live before us (matches wg-quick's macOS behavior).
+//! - The transient restore reloads `/etc/pf.conf`; the lockdown restore reloads
+//!   the captured snapshot. Neither can recover prior `set` options (pf exposes
+//!   no dump of them), so both restore under pf defaults.
 //! - The `pfctl -E` token is parsed from stderr — its only exposure.
 
 use std::net::IpAddr;
@@ -36,43 +42,63 @@ pub fn build_pf_ruleset(server_ip: IpAddr) -> String {
     )
 }
 
-/// pf anchor name for the standing lockdown ruleset. Scoped so the
-/// session-long guard does not flush user/MDM pf policy (unlike the transient
-/// cover's `-Fa`). A named anchor only evaluates when the MAIN ruleset
-/// references it — see [`build_main_ruleset_with_anchor`].
-pub const LOCKDOWN_ANCHOR: &str = "com.hole.lockdown";
+/// Normalize a snapshot fragment to end in exactly one `\n`. Empty stays empty
+/// (so an absent NAT section contributes no stray blank line); non-empty text
+/// gets a single trailing newline if it lacks one.
+pub fn ensure_trailing_nl(s: &str) -> String {
+    if s.is_empty() || s.ends_with('\n') {
+        s.to_owned()
+    } else {
+        format!("{s}\n")
+    }
+}
 
-/// Build the BODY loaded into the [`LOCKDOWN_ANCHOR`] (`pfctl -a <anchor> -f -`).
-/// Blocks all outbound except loopback, the TUN interface (so app traffic flows
-/// while connected), and the server IP. pf has no per-process matching, so the
-/// server permit is IP-based (Decision A: macOS pins the server IP for the
-/// session). All passes are `quick` so they win over the anchor's own
-/// `block out all` without relying on last-match. This body is INERT until the
-/// main ruleset references the anchor.
-pub fn build_lockdown_ruleset(tun_name: &str, server_ip: IpAddr) -> String {
+/// Build the self-contained MAIN ruleset for the standing lockdown, loaded via
+/// `pfctl -f -` (NO `-Fa`). It IS the host's egress policy while engaged:
+/// `block drop out quick all` is the fail-closed base, with earlier `quick`
+/// permits for the TUN and the server IP.
+///
+/// `set` lives here (main-ruleset-only — it is a parse error inside an anchor),
+/// and the host's translation rules (`nat_snapshot`, from `pfctl -sn`) are
+/// carried forward so the session does not flush NAT. Ordering is
+/// `require-order`-enforced: Options -> Translation (nat) -> Filter. The server
+/// permit precedes `block drop out quick inet6 all` so a v6 server is not
+/// killed. pf has no per-process matching, so the server permit is IP-based.
+pub fn build_lockdown_main_ruleset(tun_name: &str, server_ip: IpAddr, nat_snapshot: &str) -> String {
+    let proto = "tcp"; // +udp once a UDP-transport plugin lands; egress is TCP-only today.
     format!(
         "set block-policy drop\n\
-         block out all\n\
-         pass out quick on lo0 all\n\
-         pass in quick on lo0 all\n\
-         pass out quick on {tun_name} all\n\
-         pass out quick from any to {server_ip}\n"
+         set skip on lo0\n\
+         {nat}\
+         pass out quick proto {proto} from any to {ip}\n\
+         pass out quick on {tun} all\n\
+         block drop out quick inet6 all\n\
+         block drop out quick all\n",
+        nat = ensure_trailing_nl(nat_snapshot),
+        proto = proto,
+        ip = server_ip,
+        tun = tun_name,
     )
 }
 
-/// Compose the MAIN ruleset to load (NO `-Fa`): the host's pre-lockdown main
-/// ruleset `snapshot` (captured via `pfctl -sr`) followed by the
-/// `anchor "com.hole.lockdown"` call-out that makes the anchor body evaluate.
-/// Without this call-out the lockdown anchor is inert and the kill switch does
-/// nothing — this is the load-bearing composition.
-pub fn build_main_ruleset_with_anchor(snapshot: &str) -> String {
-    let mut main = String::with_capacity(snapshot.len() + 64);
-    main.push_str(snapshot);
-    if !snapshot.ends_with('\n') && !snapshot.is_empty() {
-        main.push('\n');
-    }
-    main.push_str(&format!("anchor \"{LOCKDOWN_ANCHOR}\"\n"));
-    main
+/// Build the ruleset that restores the host's pre-lockdown policy on Sweep,
+/// reloaded via `pfctl -f -`. Composes the captured translation (`nat_snapshot`,
+/// from `pfctl -sn`) and filter (`main_snapshot`, from `pfctl -sr`) snapshots.
+///
+/// `set require-order no` leads: `pfctl -sr` on macOS emits a NORMALIZATION line
+/// (`scrub-anchor "com.apple/*"`) interleaved with filter rules, so naively
+/// concatenating `{nat}{filter}` puts translation before normalization — a
+/// `require-order` parse error that would silently fail the restore. Disabling
+/// the order check lets pfctl accept the snapshots verbatim, exactly as the
+/// host had them loaded.
+pub fn build_lockdown_restore_ruleset(nat_snapshot: &str, main_snapshot: &str) -> String {
+    format!(
+        "set require-order no\n\
+         set block-policy drop\n\
+         {nat}{filter}",
+        nat = ensure_trailing_nl(nat_snapshot),
+        filter = main_snapshot,
+    )
 }
 
 /// Parse the enable token from `pfctl -E` output (it prints `Token : <n>`).
@@ -203,55 +229,78 @@ pub fn recover_cover(state_dir: &Path) {
 
 // --- lockdown layer ---
 
-/// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`:
-///
-/// 1. `pfctl -E` (refcount) + capture token.
-/// 2. `pfctl -sr` snapshot of the current main ruleset.
-/// 3. Persist {token, snapshot} to `bridge-lockdown-pf.json`.
-/// 4. Load the anchor BODY into `com.hole.lockdown` (`-a <anchor> -f -`).
-/// 5. Load the COMPOSED main (snapshot + anchor call-out) WITHOUT `-Fa`, so
-///    the anchor evaluates while host/MDM policy is preserved.
-///
-/// On any load failure the host is restored (Sweep) and Err returned; the
-/// bridge's fail-FATAL caller aborts the start.
-#[allow(dead_code)] // caller is the cfg-free `failclosed::engage_lockdown` facade (not yet wired on macOS)
-pub fn engage_lockdown(server_ip: IpAddr, tun_name: &str, state_dir: &Path) -> Result<Cover, RoutingError> {
-    let en = pfctl(&["-E"], None, PHASE_COVER)?;
-    let token = parse_enable_token(&String::from_utf8_lossy(&en.stderr))
-        .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
-        .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))?;
-
+/// Snapshot the host's filter (`-sr`) and translation (`-sn`) rules and persist
+/// them with `token` (persist-before-mutate). Returns the nat snapshot for the
+/// engage ruleset. Separated so its `?`-error path can be unwound (drop the pf
+/// refcount) by the caller without leaking the `-E` enable.
+fn capture_and_persist(token: &str, state_dir: &Path) -> Result<String, RoutingError> {
     let sr = pfctl(&["-sr"], None, PHASE_COVER)?;
     let main_snapshot = String::from_utf8_lossy(&sr.stdout).into_owned();
+    let sn = pfctl(&["-sn"], None, PHASE_COVER)?;
+    let nat_snapshot = String::from_utf8_lossy(&sn.stdout).into_owned();
 
     lockdown_state::save(
         state_dir,
         &lockdown_state::LockdownPfState {
             version: lockdown_state::SCHEMA_VERSION,
-            pf_token: token.clone(),
-            main_snapshot: main_snapshot.clone(),
+            pf_token: token.to_owned(),
+            main_snapshot,
+            nat_snapshot: nat_snapshot.clone(),
         },
     )
     .map_err(|e| RoutingError::RouteSetup(format!("failed to persist lockdown-pf-state: {e}")))?;
+    Ok(nat_snapshot)
+}
 
-    // Helper to restore-and-fail on any load error.
-    let fail = |what: &str, stderr: &[u8]| -> RoutingError {
-        lockdown_disengage(state_dir);
-        RoutingError::RouteSetup(format!("{what}: {}", String::from_utf8_lossy(stderr).trim()))
+/// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`:
+///
+/// 1. If a valid `bridge-lockdown-pf.json` already exists (Adopt re-engage),
+///    REUSE its token + snapshots — re-running `-sr`/`-sn` here would snapshot
+///    our own lockdown ruleset as the "host" and lose the real host policy.
+/// 2. Else: `pfctl -E` (refcount) + capture token; `pfctl -sr` (filter) and
+///    `pfctl -sn` (nat) snapshots; persist {token, snapshots} before mutating.
+/// 3. Load the self-contained main ruleset via `pfctl -f -` (NO `-Fa`), so the
+///    block takes effect while host translation is carried forward.
+///
+/// On load failure the host is restored (`lockdown_disengage`) and Err returned;
+/// the bridge's fail-FATAL caller aborts the start.
+#[allow(dead_code)] // caller is the cfg-free `failclosed::engage_lockdown` facade (not yet wired on macOS)
+pub fn engage_lockdown(server_ip: IpAddr, tun_name: &str, state_dir: &Path) -> Result<Cover, RoutingError> {
+    let (token, nat_snapshot) = match lockdown_state::load(state_dir) {
+        // Adopt re-engage: reuse the persisted host snapshot+token so the real
+        // host policy is preserved for the eventual restore.
+        Some(st) => (st.pf_token, st.nat_snapshot),
+        None => {
+            let en = pfctl(&["-E"], None, PHASE_COVER)?;
+            let token = parse_enable_token(&String::from_utf8_lossy(&en.stderr))
+                .or_else(|| parse_enable_token(&String::from_utf8_lossy(&en.stdout)))
+                .ok_or_else(|| RoutingError::RouteSetup("pfctl -E returned no token".into()))?;
+
+            // The refcount is now held. Capture + persist may fail, so undo the
+            // `-E` on any error before propagating — else the refcount leaks with
+            // no state file to recover it from.
+            match capture_and_persist(&token, state_dir) {
+                Ok(nat_snapshot) => (token, nat_snapshot),
+                Err(e) => {
+                    if let Err(xe) = pfctl(&["-X", &token], None, PHASE_COVER) {
+                        tracing::warn!(error = %xe, "pfctl -X failed unwinding a failed lockdown engage");
+                    }
+                    return Err(e);
+                }
+            }
+        }
     };
 
-    // 4. Anchor body.
-    let body = build_lockdown_ruleset(tun_name, server_ip);
-    let body_out = pfctl(&["-a", LOCKDOWN_ANCHOR, "-f", "-"], Some(body.as_bytes()), PHASE_COVER)?;
-    if !body_out.status.success() {
-        return Err(fail("pfctl lockdown anchor load failed", &body_out.stderr));
-    }
-
-    // 5. Composed main (NO -Fa) — this is what makes the anchor evaluate.
-    let main = build_main_ruleset_with_anchor(&main_snapshot);
-    let main_out = pfctl(&["-f", "-"], Some(main.as_bytes()), PHASE_COVER)?;
-    if !main_out.status.success() {
-        return Err(fail("pfctl lockdown main load failed", &main_out.stderr));
+    let main = build_lockdown_main_ruleset(tun_name, server_ip, &nat_snapshot);
+    let out = pfctl(&["-f", "-"], Some(main.as_bytes()), PHASE_COVER)?;
+    if !out.status.success() {
+        // Restore the host (snapshot reload + drop refcount) before failing, so
+        // a partially-loaded ruleset never strands the host.
+        lockdown_disengage(state_dir);
+        return Err(RoutingError::RouteSetup(format!(
+            "pfctl lockdown load failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
     }
 
     Ok(Cover {
@@ -261,16 +310,19 @@ pub fn engage_lockdown(server_ip: IpAddr, tun_name: &str, state_dir: &Path) -> R
     })
 }
 
-/// Sweep: restore the snapshot main ruleset, flush the anchor, drop our pf
-/// refcount, clear the state. Shared by Drop (user-stop) and `recover_lockdown`
-/// when the persisted intent is OFF. Best-effort; logs on failure.
+/// Sweep: restore the host's pre-lockdown ruleset from the snapshot, drop our pf
+/// refcount, clear the state. The snapshot reload IS the restore — there is no
+/// anchor to flush. Shared by Drop (user-stop) and `recover_lockdown` when the
+/// persisted intent is OFF. Best-effort; logs on failure.
+///
+/// Caveat: pf exposes no dump of prior `set` options, so the restore reloads the
+/// host's filter+nat rules under pf defaults (same class of limitation the
+/// transient cover documents for its `/etc/pf.conf` reload).
 fn lockdown_disengage(state_dir: &Path) {
     if let Some(st) = lockdown_state::load(state_dir) {
-        if let Err(e) = pfctl(&["-f", "-"], Some(st.main_snapshot.as_bytes()), PHASE_RECOVER_COVER) {
-            tracing::warn!(error = %e, "lockdown main-snapshot restore failed");
-        }
-        if let Err(e) = pfctl(&["-a", LOCKDOWN_ANCHOR, "-F", "all"], None, PHASE_RECOVER_COVER) {
-            tracing::warn!(error = %e, "lockdown anchor flush failed");
+        let restore = build_lockdown_restore_ruleset(&st.nat_snapshot, &st.main_snapshot);
+        if let Err(e) = pfctl(&["-f", "-"], Some(restore.as_bytes()), PHASE_RECOVER_COVER) {
+            tracing::warn!(error = %e, "lockdown snapshot restore failed");
         }
         if let Err(e) = pfctl(&["-X", &st.pf_token], None, PHASE_RECOVER_COVER) {
             tracing::warn!(error = %e, "pfctl -X failed during lockdown disengage");
@@ -283,11 +335,11 @@ fn lockdown_disengage(state_dir: &Path) {
 
 /// Act on a recovery decision for the lockdown cover (called from
 /// `failclosed::recover_lockdown`). `Adopt` (intent ON): KEEP the host
-/// fail-closed — leave the composed main + anchor body + state file untouched;
-/// only the now-dead utun permit inside the anchor is stale, and the next
-/// connect's `install_lockdown` reloads the anchor body with the fresh utun
-/// name (idempotent). `Sweep` (intent OFF): full restore via
-/// `lockdown_disengage`. `Noop`: nothing.
+/// fail-closed — leave the lockdown ruleset + state file in force. The dead
+/// utun name in the `pass out quick on <tun>` line is harmless (matches no live
+/// interface); the next connect's `engage_lockdown` reuses the persisted
+/// snapshot and reloads with the fresh utun name. `Sweep` (intent OFF): full
+/// restore via `lockdown_disengage`. `Noop`: nothing.
 #[allow(dead_code)] // caller is the cfg-free `failclosed::recover_lockdown` facade (not yet wired on macOS)
 pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
     use crate::routing::CoverRecovery::*;
@@ -299,7 +351,7 @@ pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Pat
             // restart (this IS the crash-leak fix). NOTE: macOS pf rules do
             // NOT survive a reboot, so a reboot opens a boot->first-connect
             // window — tracked under the deferred Decision C-b (block when
-            // disconnected, needs an early-boot block). See spec §9 C.
+            // disconnected, needs an early-boot block).
         }
         Sweep => {
             tracing::info!("lockdown recovery: sweeping leftover cover (intent off)");

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -35,6 +35,45 @@ pub fn build_pf_ruleset(server_ip: IpAddr) -> String {
     )
 }
 
+/// pf anchor name for the standing lockdown ruleset. Scoped so the
+/// session-long guard does not flush user/MDM pf policy (unlike the transient
+/// cover's `-Fa`). A named anchor only evaluates when the MAIN ruleset
+/// references it — see [`build_main_ruleset_with_anchor`].
+pub const LOCKDOWN_ANCHOR: &str = "com.hole.lockdown";
+
+/// Build the BODY loaded into the [`LOCKDOWN_ANCHOR`] (`pfctl -a <anchor> -f -`).
+/// Blocks all outbound except loopback, the TUN interface (so app traffic flows
+/// while connected), and the server IP. pf has no per-process matching, so the
+/// server permit is IP-based (Decision A: macOS pins the server IP for the
+/// session). All passes are `quick` so they win over the anchor's own
+/// `block out all` without relying on last-match. This body is INERT until the
+/// main ruleset references the anchor.
+pub fn build_lockdown_ruleset(tun_name: &str, server_ip: IpAddr) -> String {
+    format!(
+        "set block-policy drop\n\
+         block out all\n\
+         pass out quick on lo0 all\n\
+         pass in quick on lo0 all\n\
+         pass out quick on {tun_name} all\n\
+         pass out quick from any to {server_ip}\n"
+    )
+}
+
+/// Compose the MAIN ruleset to load (NO `-Fa`): the host's pre-lockdown main
+/// ruleset `snapshot` (captured via `pfctl -sr`) followed by the
+/// `anchor "com.hole.lockdown"` call-out that makes the anchor body evaluate.
+/// Without this call-out the lockdown anchor is inert and the kill switch does
+/// nothing — this is the load-bearing composition.
+pub fn build_main_ruleset_with_anchor(snapshot: &str) -> String {
+    let mut main = String::with_capacity(snapshot.len() + 64);
+    main.push_str(snapshot);
+    if !snapshot.ends_with('\n') && !snapshot.is_empty() {
+        main.push('\n');
+    }
+    main.push_str(&format!("anchor \"{LOCKDOWN_ANCHOR}\"\n"));
+    main
+}
+
 /// Parse the enable token from `pfctl -E` output (it prints `Token : <n>`).
 pub fn parse_enable_token(output: &str) -> Option<String> {
     output

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -63,6 +63,29 @@ fn parse_pf_enabled_reads_status() {
     assert!(!parse_pf_enabled("Status: Disabled\n"));
 }
 
+// engage_pf_action (idempotent-enable decision) =======================================================================
+
+#[skuld::test]
+fn engage_action_no_persisted_state_is_fresh_enable() {
+    // First engage: snapshot the host + `pfctl -E`, regardless of pf's current state.
+    assert_eq!(engage_pf_action(false, false), PfEngageAction::FreshEnable);
+    assert_eq!(engage_pf_action(true, false), PfEngageAction::FreshEnable);
+}
+
+#[skuld::test]
+fn engage_action_persisted_but_pf_disabled_reenables() {
+    // Reboot reset pf + its refcount but the state file survived: the old token is
+    // stale, so re-enable and capture a fresh one — else the ruleset loads inert.
+    assert_eq!(engage_pf_action(false, true), PfEngageAction::Reenable);
+}
+
+#[skuld::test]
+fn engage_action_persisted_and_pf_enabled_reuses_token() {
+    // Live Adopt re-engage within one boot: pf still enabled and we hold the token —
+    // reuse it, do NOT double `-E` (that would inflate the refcount).
+    assert_eq!(engage_pf_action(true, true), PfEngageAction::ReuseToken);
+}
+
 // ensure_trailing_nl ==================================================================================================
 
 #[skuld::test]

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -63,91 +63,210 @@ fn parse_pf_enabled_reads_status() {
     assert!(!parse_pf_enabled("Status: Disabled\n"));
 }
 
-// build_lockdown_ruleset (anchor body) ================================================================================
+// ensure_trailing_nl ==================================================================================================
 
 #[skuld::test]
-fn lockdown_ruleset_blocks_all_outbound() {
-    let r = build_lockdown_ruleset("utun8", v4());
-    assert!(r.contains("block out"), "lockdown anchor must block outbound:\n{r}");
+fn ensure_trailing_nl_empty_stays_empty() {
+    // Empty NAT snapshot must contribute NOTHING — not a stray blank line that
+    // would land between the `set` options and the first filter rule.
+    assert_eq!(ensure_trailing_nl(""), "");
 }
 
 #[skuld::test]
-fn lockdown_ruleset_passes_loopback() {
-    let r = build_lockdown_ruleset("utun8", v4());
-    assert!(r.contains("lo0"), "lockdown anchor must pass loopback:\n{r}");
+fn ensure_trailing_nl_adds_missing_newline() {
+    assert_eq!(
+        ensure_trailing_nl("nat on en0 from any to any -> (en0)"),
+        "nat on en0 from any to any -> (en0)\n"
+    );
 }
 
 #[skuld::test]
-fn lockdown_ruleset_passes_tun_interface() {
+fn ensure_trailing_nl_keeps_single_newline() {
+    assert_eq!(
+        ensure_trailing_nl("nat-anchor \"com.apple/*\" all\n"),
+        "nat-anchor \"com.apple/*\" all\n"
+    );
+}
+
+// build_lockdown_main_ruleset (authoritative main-ruleset replace) ====================================================
+
+const TUN: &str = "hole-tun";
+
+fn lockdown(ip: IpAddr, nat: &str) -> String {
+    build_lockdown_main_ruleset(TUN, ip, nat)
+}
+
+#[skuld::test]
+fn lockdown_main_has_block_drop_out_quick_all_base() {
+    // The fail-closed base: every outbound packet is dropped unless an earlier
+    // `quick` permit already matched.
+    let r = lockdown(v4(), "");
+    assert!(
+        r.contains("block drop out quick all"),
+        "lockdown main must have the block-drop base:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn lockdown_main_blocks_ipv6() {
+    // No IPv6 permit exists for app traffic, so v6 egress is dropped wholesale
+    // to prevent a v6 leak around the v4 tunnel.
+    let r = lockdown(v4(), "");
+    assert!(
+        r.contains("block drop out quick inet6 all"),
+        "lockdown main must block IPv6 egress:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn lockdown_main_passes_tun_interface() {
     // The defining difference from the transient cover: app traffic flows
     // through the TUN while connected.
-    let r = build_lockdown_ruleset("utun8", v4());
+    let r = lockdown(v4(), "");
     assert!(
-        r.contains("pass out quick on utun8 all"),
-        "lockdown anchor must pass the TUN interface:\n{r}"
+        r.contains("pass out quick on hole-tun all"),
+        "lockdown main must pass the TUN interface:\n{r}"
     );
 }
 
 #[skuld::test]
-fn lockdown_ruleset_passes_server_ip() {
-    let r = build_lockdown_ruleset("utun8", v4());
-    // Match the transient cover idiom `pass out quick from any to {ip}` unless
-    // a reason to diverge surfaces on the host (Task 15).
+fn lockdown_main_passes_server_ip_over_tcp() {
+    let r = lockdown(v4(), "");
     assert!(
-        r.contains("pass out quick from any to 203.0.113.7"),
-        "lockdown anchor must pass server IP:\n{r}"
+        r.contains("pass out quick proto tcp from any to 203.0.113.7"),
+        "lockdown main must pass the server IP over tcp:\n{r}"
     );
 }
 
 #[skuld::test]
-fn lockdown_ruleset_pass_rules_are_quick() {
-    let r = build_lockdown_ruleset("utun8", v4());
-    for line in r.lines().filter(|l| l.trim_start().starts_with("pass")) {
-        assert!(line.contains("quick"), "pass rule must be quick: {line}");
+fn lockdown_main_skips_loopback() {
+    // `set skip on lo0` exempts loopback from filtering wholesale.
+    let r = lockdown(v4(), "");
+    assert!(r.contains("set skip on lo0"), "lockdown main must skip lo0:\n{r}");
+}
+
+#[skuld::test]
+fn lockdown_main_every_filter_rule_is_quick() {
+    // Every pass/block filter rule must be `quick` so it is order-independent
+    // and beats any carried-forward host rule once we own the ruleset.
+    let r = lockdown(v4(), "nat-anchor \"com.apple/*\" all\n");
+    for line in r.lines().filter(|l| {
+        let t = l.trim_start();
+        t.starts_with("pass") || t.starts_with("block")
+    }) {
+        assert!(line.contains("quick"), "filter rule must be quick: {line}");
     }
 }
 
 #[skuld::test]
-fn lockdown_ruleset_handles_ipv6_server() {
-    let r = build_lockdown_ruleset("utun8", v6());
-    assert!(r.contains("2001:db8::1"), "ipv6 server must appear:\n{r}");
+fn lockdown_main_set_options_lead() {
+    // `set` is main-ruleset-only and `require-order` puts Options first.
+    let r = lockdown(v4(), "");
+    assert!(
+        r.starts_with("set block-policy drop\n"),
+        "must open with block-policy:\n{r}"
+    );
+    assert!(r.contains("set skip on lo0\n"), "must set skip on lo0:\n{r}");
 }
 
-// build_main_ruleset_with_anchor (the inert-anchor fix) ===============================================================
-
 #[skuld::test]
-fn composed_main_references_the_lockdown_anchor() {
-    // WITHOUT this call-out the anchor body never evaluates and the kill
-    // switch is a no-op. This is the test that catches the inert-anchor bug.
-    let snapshot = "scrub-anchor \"com.apple/*\" all fragment reassemble\n";
-    let main = build_main_ruleset_with_anchor(snapshot);
+fn lockdown_main_no_set_after_first_filter_rule() {
+    // No stray `set` may appear after filtering begins — `set` is illegal once
+    // the ruleset moves past the Options section.
+    let r = lockdown(v4(), "nat-anchor \"com.apple/*\" all\n");
+    let first_filter = r
+        .find("pass")
+        .or_else(|| r.find("block"))
+        .expect("a filter rule must exist");
     assert!(
-        main.contains("anchor \"com.hole.lockdown\""),
-        "composed main MUST call out the lockdown anchor:\n{main}"
+        !r[first_filter..].contains("set "),
+        "no `set ` may follow the first filter rule:\n{r}"
     );
 }
 
 #[skuld::test]
-fn composed_main_preserves_the_snapshot() {
-    // The composed ruleset is loaded without `-Fa`, so it must carry the
-    // host's prior rules verbatim (no flush of user/MDM policy).
-    let snapshot = "scrub-anchor \"com.apple/*\" all fragment reassemble\nanchor \"com.apple/*\" all\n";
-    let main = build_main_ruleset_with_anchor(snapshot);
-    assert!(main.contains(snapshot), "snapshot rules must be preserved:\n{main}");
+fn lockdown_main_nat_precedes_filter() {
+    // `require-order`: Options -> Translation (nat) -> Filter. The carried NAT
+    // must sit before the first filter rule.
+    let nat = "nat on en0 from any to any -> (en0)\n";
+    let r = lockdown(v4(), nat);
+    let nat_at = r.find("nat on en0").expect("nat must appear");
+    let first_filter = r.find("block drop out quick inet6 all").expect("filter must appear");
+    assert!(nat_at < first_filter, "nat must precede the first filter rule:\n{r}");
 }
 
 #[skuld::test]
-fn composed_main_anchor_call_follows_the_snapshot() {
-    // The anchor call must come AFTER the snapshot so the snapshot's own
-    // anchors keep their relative order; a `quick`-free anchor evaluates by
-    // last-match, and our body uses `quick` so position past the snapshot is
-    // safe and deterministic.
-    let snapshot = "anchor \"com.apple/*\" all\n";
-    let main = build_main_ruleset_with_anchor(snapshot);
-    let snap_at = main.find("com.apple/*").unwrap();
-    let lock_at = main.find("com.hole.lockdown").unwrap();
+fn lockdown_main_empty_nat_has_no_blank_line() {
+    // An empty NAT snapshot must not inject a blank line between the `set`
+    // options and the first filter rule.
+    let r = lockdown(v4(), "");
+    assert!(!r.contains("\n\n"), "empty nat must not produce a blank line:\n{r}");
+}
+
+#[skuld::test]
+fn lockdown_main_carries_nat_verbatim() {
+    let nat = "nat-anchor \"com.apple/*\" all\nrdr-anchor \"com.apple/*\" all\n";
+    let r = lockdown(v4(), nat);
+    assert!(r.contains(nat), "nat snapshot must be carried verbatim:\n{r}");
+}
+
+#[skuld::test]
+fn lockdown_main_v6_server_permit_precedes_inet6_block() {
+    // A v6 server must be permitted BEFORE the wholesale inet6 block, or the
+    // tunnel's own onward connection is killed.
+    let r = lockdown(v6(), "");
+    let permit_at = r.find("to 2001:db8::1").expect("v6 server permit must appear");
+    let block_at = r
+        .find("block drop out quick inet6 all")
+        .expect("inet6 block must appear");
     assert!(
-        lock_at > snap_at,
-        "lockdown anchor call must follow the snapshot:\n{main}"
+        permit_at < block_at,
+        "v6 server permit must precede the inet6 block:\n{r}"
     );
+}
+
+// build_lockdown_restore_ruleset (Sweep restore) ======================================================================
+
+// `pfctl -sr` on macOS emits a normalization line (`scrub-anchor`) interleaved
+// with filter rules; with require-order enforced, `{nat}{filter}` would put
+// translation before normalization and the restore would fail to parse.
+const FILTER_SNAP: &str = "scrub-anchor \"com.apple/*\" all fragment reassemble\nanchor \"com.apple/*\" all\n";
+const NAT_SNAP: &str = "nat-anchor \"com.apple/*\" all\nrdr-anchor \"com.apple/*\" all\n";
+
+#[skuld::test]
+fn restore_disables_require_order() {
+    // Without this the restore parse-fails on a stock host (scrub after nat).
+    let r = build_lockdown_restore_ruleset(NAT_SNAP, FILTER_SNAP);
+    assert!(
+        r.contains("set require-order no"),
+        "restore must disable require-order so the captured snapshot loads verbatim:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn restore_require_order_leads() {
+    // `set` is options-section-only; the require-order toggle must precede any
+    // captured rule, or it cannot relax the order check for what follows.
+    let r = build_lockdown_restore_ruleset(NAT_SNAP, FILTER_SNAP);
+    assert!(
+        r.starts_with("set require-order no\n"),
+        "require-order toggle must lead:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn restore_carries_both_snapshots_verbatim() {
+    let r = build_lockdown_restore_ruleset(NAT_SNAP, FILTER_SNAP);
+    assert!(r.contains(NAT_SNAP), "nat snapshot must be carried verbatim:\n{r}");
+    assert!(
+        r.contains(FILTER_SNAP),
+        "filter snapshot must be carried verbatim:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn restore_empty_nat_has_no_blank_line() {
+    // An empty nat snapshot must not inject a blank line into the restore.
+    let r = build_lockdown_restore_ruleset("", FILTER_SNAP);
+    assert!(!r.contains("\n\n"), "empty nat must not produce a blank line:\n{r}");
 }

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -62,3 +62,92 @@ fn parse_pf_enabled_reads_status() {
     assert!(parse_pf_enabled("Status: Enabled for 0 days...\n"));
     assert!(!parse_pf_enabled("Status: Disabled\n"));
 }
+
+// build_lockdown_ruleset (anchor body) ================================================================================
+
+#[skuld::test]
+fn lockdown_ruleset_blocks_all_outbound() {
+    let r = build_lockdown_ruleset("utun8", v4());
+    assert!(r.contains("block out"), "lockdown anchor must block outbound:\n{r}");
+}
+
+#[skuld::test]
+fn lockdown_ruleset_passes_loopback() {
+    let r = build_lockdown_ruleset("utun8", v4());
+    assert!(r.contains("lo0"), "lockdown anchor must pass loopback:\n{r}");
+}
+
+#[skuld::test]
+fn lockdown_ruleset_passes_tun_interface() {
+    // The defining difference from the transient cover: app traffic flows
+    // through the TUN while connected.
+    let r = build_lockdown_ruleset("utun8", v4());
+    assert!(
+        r.contains("pass out quick on utun8 all"),
+        "lockdown anchor must pass the TUN interface:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn lockdown_ruleset_passes_server_ip() {
+    let r = build_lockdown_ruleset("utun8", v4());
+    // Match the transient cover idiom `pass out quick from any to {ip}` unless
+    // a reason to diverge surfaces on the host (Task 15).
+    assert!(
+        r.contains("pass out quick from any to 203.0.113.7"),
+        "lockdown anchor must pass server IP:\n{r}"
+    );
+}
+
+#[skuld::test]
+fn lockdown_ruleset_pass_rules_are_quick() {
+    let r = build_lockdown_ruleset("utun8", v4());
+    for line in r.lines().filter(|l| l.trim_start().starts_with("pass")) {
+        assert!(line.contains("quick"), "pass rule must be quick: {line}");
+    }
+}
+
+#[skuld::test]
+fn lockdown_ruleset_handles_ipv6_server() {
+    let r = build_lockdown_ruleset("utun8", v6());
+    assert!(r.contains("2001:db8::1"), "ipv6 server must appear:\n{r}");
+}
+
+// build_main_ruleset_with_anchor (the inert-anchor fix) ===============================================================
+
+#[skuld::test]
+fn composed_main_references_the_lockdown_anchor() {
+    // WITHOUT this call-out the anchor body never evaluates and the kill
+    // switch is a no-op. This is the test that catches the inert-anchor bug.
+    let snapshot = "scrub-anchor \"com.apple/*\" all fragment reassemble\n";
+    let main = build_main_ruleset_with_anchor(snapshot);
+    assert!(
+        main.contains("anchor \"com.hole.lockdown\""),
+        "composed main MUST call out the lockdown anchor:\n{main}"
+    );
+}
+
+#[skuld::test]
+fn composed_main_preserves_the_snapshot() {
+    // The composed ruleset is loaded without `-Fa`, so it must carry the
+    // host's prior rules verbatim (no flush of user/MDM policy).
+    let snapshot = "scrub-anchor \"com.apple/*\" all fragment reassemble\nanchor \"com.apple/*\" all\n";
+    let main = build_main_ruleset_with_anchor(snapshot);
+    assert!(main.contains(snapshot), "snapshot rules must be preserved:\n{main}");
+}
+
+#[skuld::test]
+fn composed_main_anchor_call_follows_the_snapshot() {
+    // The anchor call must come AFTER the snapshot so the snapshot's own
+    // anchors keep their relative order; a `quick`-free anchor evaluates by
+    // last-match, and our body uses `quick` so position past the snapshot is
+    // safe and deterministic.
+    let snapshot = "anchor \"com.apple/*\" all\n";
+    let main = build_main_ruleset_with_anchor(snapshot);
+    let snap_at = main.find("com.apple/*").unwrap();
+    let lock_at = main.find("com.hole.lockdown").unwrap();
+    assert!(
+        lock_at > snap_at,
+        "lockdown anchor call must follow the snapshot:\n{main}"
+    );
+}

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -33,7 +33,7 @@ pub const FILTER_GUIDS: [GUID; 6] = [
 ];
 
 // Lockdown-cover filter GUIDs — disjoint from FILTER_GUIDS. Recovery sweeps
-// these (Sweep) or deletes only the TUN-LUID pair (Adopt) — see
+// these (Sweep) or deletes the volatile TUN + server pairs (Adopt) — see
 // `recover_lockdown` / `swept_lockdown_guids`. A crash that leaves the cover
 // engaged is reconciled on the next start.
 // Layout: [loopback V4, loopback V6, TUN V4, TUN V6, server V4, server V6,
@@ -51,9 +51,12 @@ pub const LOCKDOWN_FILTER_GUIDS: [GUID; 8] = [
 ];
 
 /// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the TUN-interface (LUID) permit
-/// pair. Adopt recovery deletes ONLY these (the LUID is dead after teardown);
-/// the next connect's engage re-adds them with a freshly-resolved LUID.
+/// pair — one of the two volatile permits Adopt drops (see
+/// [`adopt_delete_guids`]).
 const LOCKDOWN_TUN_GUID_INDICES: [usize; 2] = [2, 3]; // TUN V4, TUN V6
+/// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the server-IP permit pair — the
+/// other volatile permit Adopt drops (see [`adopt_delete_guids`]).
+const LOCKDOWN_SERVER_GUID_INDICES: [usize; 2] = [4, 5]; // server V4, server V6
 
 /// Derive a deterministic App-ID filter GUID per (binary index, layer) so a
 /// re-engage over an unswept cover is idempotent and recovery can delete by
@@ -83,12 +86,16 @@ fn swept_lockdown_guids() -> Vec<GUID> {
     guids
 }
 
-/// The GUIDs Adopt deletes: ONLY the two stale TUN-LUID permits. Everything
-/// else (block-all, loopback, server, App-ID) stays in force so the host
-/// remains fail-closed across the restart — the crash-leak fix.
+/// The GUIDs Adopt deletes: the VOLATILE permits — the TUN-LUID pair (dies with
+/// the TUN) and the server-IP pair (changes with the server). They carry fixed
+/// keys, so engage's `ok_or_exists` would silently keep a stale one; deleting
+/// them lets the next connect re-add both fresh with current values. The floor
+/// (block-all, loopback, App-ID) is left in force so the host stays fail-closed
+/// across the restart.
 fn adopt_delete_guids() -> Vec<GUID> {
     LOCKDOWN_TUN_GUID_INDICES
         .iter()
+        .chain(LOCKDOWN_SERVER_GUID_INDICES.iter())
         .map(|&i| LOCKDOWN_FILTER_GUIDS[i])
         .collect()
 }
@@ -390,8 +397,9 @@ pub fn engage_lockdown(
             wfp_check(FwpmTransactionBegin0(engine, 0), "FwpmTransactionBegin0")?;
             // Idempotent over an unswept cover: add_provider/add_sublayer use
             // ok_or_exists, and the filter keys are fixed — a re-engage after
-            // an Adopt (which left block-all in place) re-adds only the TUN
-            // permit (its key was deleted by `recover_lockdown`).
+            // an Adopt re-adds the TUN + server permits fresh (their keys were
+            // deleted by `recover_lockdown`, so the new server IP takes effect);
+            // the kept floor (block-all + loopback + App-ID) is a benign re-add.
             add_provider(engine, spec.provider)?;
             add_sublayer(engine, spec.sublayer, spec.provider)?;
             for f in &spec.filters {
@@ -628,8 +636,11 @@ impl Drop for Cover {
 }
 
 /// Reconcile a possibly-present standing lockdown cover with the persisted
-/// intent. Opens the engine; `Adopt` deletes ONLY the dead TUN-LUID permits
-/// (host stays fail-closed); `Sweep` deletes all lockdown + App-ID filters,
+/// intent. Opens the engine; `Adopt` deletes the volatile permits — the dead
+/// TUN-LUID pair and the server-IP pair — keeping the fail-closed floor
+/// (block-all + loopback + App-ID) so the host stays blocked across the restart
+/// and the next connect re-adds TUN + server fresh; `Sweep` deletes all
+/// lockdown + App-ID filters,
 /// then the sublayer/provider IFF the transient cover isn't also using them
 /// (they share PROVIDER_GUID/SUBLAYER_GUID, so leave them — the transient
 /// `delete_all` owns their removal, and an orphaned empty sublayer is benign).

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -50,6 +50,11 @@ pub const LOCKDOWN_FILTER_GUIDS: [GUID; 8] = [
     GUID::from_u128(0x20af67ac_58ec_41e6_a49d_6fd2ed55c184), // block-all V6
 ];
 
+/// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the TUN-interface (LUID) permit
+/// pair. Adopt recovery deletes ONLY these (the LUID is dead after teardown);
+/// the next connect's engage re-adds them with a freshly-resolved LUID.
+const LOCKDOWN_TUN_GUID_INDICES: [usize; 2] = [2, 3]; // TUN V4, TUN V6
+
 /// Derive a deterministic App-ID filter GUID per (binary index, layer) so a
 /// re-engage over an unswept cover is idempotent and recovery can delete by
 /// key. XORs a fixed namespace keyed by the (index, is_v6) pair —
@@ -76,6 +81,16 @@ fn swept_lockdown_guids() -> Vec<GUID> {
         guids.push(appid_filter_guid(i, true));
     }
     guids
+}
+
+/// The GUIDs Adopt deletes: ONLY the two stale TUN-LUID permits. Everything
+/// else (block-all, loopback, server, App-ID) stays in force so the host
+/// remains fail-closed across the restart — the crash-leak fix.
+fn adopt_delete_guids() -> Vec<GUID> {
+    LOCKDOWN_TUN_GUID_INDICES
+        .iter()
+        .map(|&i| LOCKDOWN_FILTER_GUIDS[i])
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -608,6 +623,34 @@ impl Drop for Cover {
             }
             #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
             let _ = FwpmEngineClose0(self.engine);
+        }
+    }
+}
+
+/// Reconcile a possibly-present standing lockdown cover with the persisted
+/// intent. Opens the engine; `Adopt` deletes ONLY the dead TUN-LUID permits
+/// (host stays fail-closed); `Sweep` deletes all lockdown + App-ID filters,
+/// then the sublayer/provider IFF the transient cover isn't also using them
+/// (they share PROVIDER_GUID/SUBLAYER_GUID, so leave them — the transient
+/// `delete_all` owns their removal, and an orphaned empty sublayer is benign).
+/// `Noop`: nothing. Idempotent — a "not found" delete is ignored.
+pub fn recover_lockdown(decision: crate::routing::CoverRecovery, _state_dir: &Path) {
+    use crate::routing::CoverRecovery::*;
+    let guids: Vec<GUID> = match decision {
+        Noop => return,
+        Adopt => adopt_delete_guids(),
+        Sweep => swept_lockdown_guids(),
+    };
+    unsafe {
+        let mut engine = HANDLE::default();
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        if FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine) == ERROR_SUCCESS.0 {
+            #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+            for g in guids {
+                let _ = FwpmFilterDeleteByKey0(engine, &g);
+            }
+            #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+            let _ = FwpmEngineClose0(engine);
         }
     }
 }

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -1,16 +1,33 @@
 //! Windows fail-closed cover via the Windows Filtering Platform (WFP/FWPM).
 //!
 //! Engage installs a persistent provider + sublayer + filter set in one FWPM
-//! transaction: permit loopback (hard) on `ALE_AUTH_CONNECT_V4`/`_V6` and
+//! transaction: permit loopback on `ALE_AUTH_CONNECT_V4`/`_V6` and
 //! `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
 //! directions) — by the loopback address range (127.0.0.0/8, ::1/128) on ALL
 //! four layers, since the IS_LOOPBACK flag isn't reliably set at either ALE layer
 //! in some elevated environments (CONNECT keeps the flag permit too as harmless
-//! belt-and-suspenders) — + the SS server IP (hard) on CONNECT, block everything
-//! else on CONNECT (egress kill switch). Persistent (boot-time) filters — NOT a
-//! dynamic session — so a coordinator crash mid-cutover leaves traffic blocked
-//! (fail-closed), not leaked; `recover_cover` sweeps them by their fixed GUIDs on
-//! the next bridge start.
+//! belt-and-suspenders) — + the SS server IP on CONNECT, block everything else on
+//! CONNECT (egress kill switch).
+//!
+//! One sublayer, weight-based arbitration: the permits sit at weight 15 and the
+//! block-all at weight 0, so within the sublayer the higher-weight permit wins.
+//! NO filter sets `CLEAR_ACTION_RIGHT`. That flag makes THIS filter's own action
+//! soft (cross-sublayer overridable); omitting it makes the action HARD. Hardness
+//! only governs cross-sublayer arbitration — within a sublayer it does nothing.
+//! The old bug: it set the flag on the permits (making them soft) but not on the
+//! block-all (a default-HARD block), so block-all vetoed every permit and the
+//! cover blocked everything. With the flag off everywhere, within-sublayer
+//! arbitration is pure weight: the weight-15 permits beat the weight-0 block-all.
+//! This is the wireguard-windows recipe — its loopback/TUN/DHCP permits and
+//! block-all are weight-ordered with the flag off; it sets `CLEAR_ACTION_RIGHT`
+//! only on its own service app-ID permit, none of ours. The trade-off: a
+//! higher-weight third-party sublayer could in principle override us (accepted —
+//! wireguard ships the same all-but-one-soft layout); a two-sublayer
+//! hard-permit/soft-block layout is a possible future hardening.
+//!
+//! Persistent (boot-time) filters — NOT a dynamic session — so a coordinator crash
+//! mid-cutover leaves traffic blocked (fail-closed), not leaked; `recover_cover`
+//! sweeps them by their fixed GUIDs on the next bridge start.
 
 use std::net::IpAddr;
 use std::path::Path;
@@ -169,12 +186,10 @@ pub struct FilterSpec {
     pub layer: Layer,
     pub action: Action,
     pub condition: Condition,
-    /// FWPM filter weight (0..=15). Permits get 15, block gets 0; higher
-    /// weight wins within our sublayer.
+    /// FWPM filter weight (0..=15). Permits get 15, block gets 0; arbitration
+    /// within our single sublayer is pure weight, so the higher-weight permit
+    /// wins over block-all.
     pub weight: u8,
-    /// `FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT` — a hard permit no lower-priority
-    /// sublayer can veto. Set on permits, not on block.
-    pub hard: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -184,8 +199,11 @@ pub struct CoverSpec {
     pub filters: Vec<FilterSpec>,
 }
 
-/// Filter weight (0..=15) for the hard permits — higher than [`BLOCK_WEIGHT`]
-/// so loopback/server-IP permits win over block-all within our sublayer.
+/// Filter weight (0..=15) for the permits — higher than [`BLOCK_WEIGHT`] so
+/// loopback/server-IP permits win over block-all. Within our single sublayer
+/// WFP arbitrates by weight alone (no `CLEAR_ACTION_RIGHT`), so the higher
+/// weight is what makes the permit beat the block — as in wireguard-windows
+/// (weight-ordered permits ~13-15 over a weight-0 block-all in one sublayer).
 pub const PERMIT_WEIGHT: u8 = 15;
 /// Filter weight for the block-all filters.
 pub const BLOCK_WEIGHT: u8 = 0;
@@ -208,7 +226,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::Loopback,
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         FilterSpec {
             guid: FILTER_GUIDS[1],
@@ -216,7 +233,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::Loopback,
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         // Belt-and-suspenders for the flag permits above: the IS_LOOPBACK flag is
         // not reliably set at ALE_AUTH_CONNECT in CI's elevated lane, so match the
@@ -228,7 +244,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         FilterSpec {
             guid: FILTER_GUIDS[9],
@@ -236,7 +251,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         // A loopback connect is authorized at RECV_ACCEPT too; permitting only at
         // CONNECT denies the accept side, breaking the loopback SOCKS5 data plane.
@@ -251,7 +265,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         FilterSpec {
             guid: FILTER_GUIDS[7],
@@ -259,7 +272,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         FilterSpec {
             guid: if server_layer == Layer::ConnectV4 {
@@ -271,7 +283,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Permit,
             condition: Condition::RemoteIp(server_ip),
             weight: PERMIT_WEIGHT,
-            hard: true,
         },
         FilterSpec {
             guid: FILTER_GUIDS[4],
@@ -279,7 +290,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Block,
             condition: Condition::Any,
             weight: BLOCK_WEIGHT,
-            hard: false,
         },
         FilterSpec {
             guid: FILTER_GUIDS[5],
@@ -287,7 +297,6 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             action: Action::Block,
             condition: Condition::Any,
             weight: BLOCK_WEIGHT,
-            hard: false,
         },
     ];
     CoverSpec {
@@ -305,8 +314,9 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
 /// and block-all; plus a loopback address-range permit at `ALE_AUTH_RECV_ACCEPT`
 /// (the accept side a loopback connect also authorizes — the flag is unreliable
 /// there, so the range is the only matcher). Block stays CONNECT-only — egress
-/// kill switch, not inbound. All permits hard (`CLEAR_ACTION_RIGHT`) at
-/// `PERMIT_WEIGHT`. Pure — no FFI.
+/// kill switch, not inbound. Permits at `PERMIT_WEIGHT`, block at `BLOCK_WEIGHT`;
+/// within the single sublayer the higher-weight permit wins (no
+/// `CLEAR_ACTION_RIGHT`). Pure — no FFI.
 pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::path::PathBuf]) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
@@ -391,7 +401,6 @@ fn permit(guid: GUID, layer: Layer, condition: Condition) -> FilterSpec {
         action: Action::Permit,
         condition,
         weight: PERMIT_WEIGHT,
-        hard: true,
     }
 }
 
@@ -402,7 +411,6 @@ fn block(guid: GUID, layer: Layer) -> FilterSpec {
         action: Action::Block,
         condition: Condition::Any,
         weight: BLOCK_WEIGHT,
-        hard: false,
     }
 }
 
@@ -612,14 +620,15 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
         Action::Permit => FWP_ACTION_PERMIT,
         Action::Block => FWP_ACTION_BLOCK,
     };
-    let flags = FWPM_FILTER_FLAGS(
-        FWPM_FILTER_FLAG_PERSISTENT.0
-            | if f.hard {
-                FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT.0
-            } else {
-                0
-            },
-    );
+    // PERSISTENT only — NO CLEAR_ACTION_RIGHT. Setting that flag makes a filter's
+    // action SOFT (cross-sublayer overridable); omitting it makes the action HARD,
+    // and hardness governs only cross-sublayer arbitration. A BLOCK with the flag
+    // omitted is thus a default-HARD block — and the old code set the flag on the
+    // permits (soft) but not the block (hard), so block-all vetoed every permit
+    // (the cover blocked everything). With the flag off everywhere, within-sublayer
+    // arbitration is pure weight: the weight-15 permits beat the weight-0 block-all
+    // (the wireguard-windows recipe — see the module doc).
+    let flags = FWPM_FILTER_FLAGS(FWPM_FILTER_FLAG_PERSISTENT.0);
 
     // Keep-alive bindings: `FWPM_FILTER0` holds raw pointers into these; they
     // must outlive the `FwpmFilterAdd0` call below.

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -3,13 +3,14 @@
 //! Engage installs a persistent provider + sublayer + filter set in one FWPM
 //! transaction: permit loopback (hard) on `ALE_AUTH_CONNECT_V4`/`_V6` and
 //! `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
-//! directions) — by both the IS_LOOPBACK flag AND the loopback destination range
-//! (127.0.0.0/8, ::1/128) at CONNECT, since the flag isn't reliably set at
-//! ALE_AUTH_CONNECT in some elevated environments — + the SS server IP (hard) on
-//! CONNECT, block everything else on CONNECT (egress kill switch). Persistent
-//! (boot-time) filters — NOT a dynamic session — so a coordinator crash
-//! mid-cutover leaves traffic blocked (fail-closed), not leaked; `recover_cover`
-//! sweeps them by their fixed GUIDs on the next bridge start.
+//! directions) — by the loopback address range (127.0.0.0/8, ::1/128) on ALL
+//! four layers, since the IS_LOOPBACK flag isn't reliably set at either ALE layer
+//! in some elevated environments (CONNECT keeps the flag permit too as harmless
+//! belt-and-suspenders) — + the SS server IP (hard) on CONNECT, block everything
+//! else on CONNECT (egress kill switch). Persistent (boot-time) filters — NOT a
+//! dynamic session — so a coordinator crash mid-cutover leaves traffic blocked
+//! (fail-closed), not leaked; `recover_cover` sweeps them by their fixed GUIDs on
+//! the next bridge start.
 
 use std::net::IpAddr;
 use std::path::Path;
@@ -137,12 +138,15 @@ pub enum Action {
 pub enum Condition {
     /// Match the WFP loopback flag (`FWP_CONDITION_FLAG_IS_LOOPBACK`).
     Loopback,
-    /// Match the loopback network by the connect's DESTINATION address range:
+    /// Match the loopback network by `FWPM_CONDITION_IP_REMOTE_ADDRESS` range:
     /// V4 -> 127.0.0.0/8, V6 -> ::1/128 (the carried `IpAddr` selects only the
-    /// family). The IS_LOOPBACK flag is not reliably set at ALE_AUTH_CONNECT in
-    /// some elevated environments, so the flag permit alone leaves a loopback
-    /// connect denied by block-all; an address-range permit on the destination
-    /// matches deterministically. Additive to [`Condition::Loopback`].
+    /// family). The IS_LOOPBACK flag is not reliably set at either ALE layer in
+    /// some elevated environments, so the flag permit alone leaves a loopback flow
+    /// denied by block-all; the address-range permit on the remote address matches
+    /// deterministically. At CONNECT the remote is the destination, at RECV_ACCEPT
+    /// the peer — both are 127.0.0.1/::1 for a loopback flow, so the same range
+    /// matches on all four layers. At CONNECT it co-exists with the (now-redundant)
+    /// [`Condition::Loopback`] flag permit; at RECV_ACCEPT it is the only matcher.
     LoopbackNet(IpAddr),
     /// Match a single remote host address (`FWPM_CONDITION_IP_REMOTE_ADDRESS`).
     RemoteIp(IpAddr),
@@ -188,10 +192,10 @@ pub const BLOCK_WEIGHT: u8 = 0;
 
 /// Build the data description of the fail-closed cover for `server_ip`.
 /// Permits loopback on CONNECT *and* RECV_ACCEPT (loopback connects authorize on
-/// both ALE directions) — by both the IS_LOOPBACK flag and the loopback
-/// destination range at CONNECT — + the server IP on CONNECT; blocks all else on
-/// CONNECT only (egress kill switch). Pure — no FFI; `engage` submits it in one
-/// transaction.
+/// both ALE directions) by the loopback address range (127.0.0.0/8, ::1/128) on
+/// all four layers, plus the IS_LOOPBACK flag on CONNECT as belt-and-suspenders,
+/// plus the server IP on CONNECT; blocks all else on CONNECT only (egress kill
+/// switch). Pure — no FFI; `engage` submits it in one transaction.
 pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
@@ -236,11 +240,16 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
         },
         // A loopback connect is authorized at RECV_ACCEPT too; permitting only at
         // CONNECT denies the accept side, breaking the loopback SOCKS5 data plane.
+        // Match by the address range, not the IS_LOOPBACK flag: on CI's elevated
+        // lane the flag isn't set at RECV_ACCEPT, so a flag-only permit drops the
+        // loopback accept (connect-side then times out). At RECV_ACCEPT
+        // IP_REMOTE_ADDRESS is the peer = 127.0.0.1/::1 for a loopback accept, so
+        // the 127.0.0.0/8 or ::1/128 range matches deterministically.
         FilterSpec {
             guid: FILTER_GUIDS[6],
             layer: Layer::RecvAcceptV4,
             action: Action::Permit,
-            condition: Condition::Loopback,
+            condition: Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
             hard: true,
         },
@@ -248,7 +257,7 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             guid: FILTER_GUIDS[7],
             layer: Layer::RecvAcceptV6,
             action: Action::Permit,
-            condition: Condition::Loopback,
+            condition: Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
             hard: true,
         },
@@ -291,11 +300,12 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
 /// Build the data description of the standing lockdown cover for `server_ip`,
 /// the hole-tun interface `tun_luid`, and the process image paths `app_ids`
 /// (plugin binary plus the bridge's own exe). Per family (V4+V6) at
-/// `ALE_AUTH_CONNECT`: a loopback permit (flag and destination range), a
+/// `ALE_AUTH_CONNECT`: a loopback permit (address range and flag), a
 /// LocalInterface(luid) permit, one AppId permit per binary, a server-IP permit,
-/// and block-all; plus a loopback flag permit at `ALE_AUTH_RECV_ACCEPT` (the
-/// accept side a loopback connect also authorizes). Block stays CONNECT-only —
-/// egress kill switch, not inbound. All permits hard (`CLEAR_ACTION_RIGHT`) at
+/// and block-all; plus a loopback address-range permit at `ALE_AUTH_RECV_ACCEPT`
+/// (the accept side a loopback connect also authorizes — the flag is unreliable
+/// there, so the range is the only matcher). Block stays CONNECT-only — egress
+/// kill switch, not inbound. All permits hard (`CLEAR_ACTION_RIGHT`) at
 /// `PERMIT_WEIGHT`. Pure — no FFI.
 pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::path::PathBuf]) -> CoverSpec {
     let server_layer = match server_ip {
@@ -321,8 +331,21 @@ pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::pat
         ),
         // A loopback connect is authorized at RECV_ACCEPT too; permitting only at
         // CONNECT denies the accept side, breaking the loopback SOCKS5 data plane.
-        permit(LOCKDOWN_FILTER_GUIDS[8], Layer::RecvAcceptV4, Condition::Loopback),
-        permit(LOCKDOWN_FILTER_GUIDS[9], Layer::RecvAcceptV6, Condition::Loopback),
+        // Match by the address range, not the IS_LOOPBACK flag: on CI's elevated
+        // lane the flag isn't set at RECV_ACCEPT, so a flag-only permit drops the
+        // loopback accept (connect-side then times out). At RECV_ACCEPT
+        // IP_REMOTE_ADDRESS is the peer = 127.0.0.1/::1 for a loopback accept, so
+        // the 127.0.0.0/8 or ::1/128 range matches deterministically.
+        permit(
+            LOCKDOWN_FILTER_GUIDS[8],
+            Layer::RecvAcceptV4,
+            Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        ),
+        permit(
+            LOCKDOWN_FILTER_GUIDS[9],
+            Layer::RecvAcceptV6,
+            Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
+        ),
         permit(
             LOCKDOWN_FILTER_GUIDS[2],
             Layer::ConnectV4,
@@ -626,10 +649,11 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
                 },
             },
         }),
-        // Match the connect's DESTINATION against the loopback range. addr/mask are
-        // host byte order, mirroring the RemoteIp(V4) arm's `u32::from`. Fields are
-        // mutated in place (mirror of the v6buf pattern) so the keep-alive struct
-        // outlives FwpmFilterAdd0.
+        // Match IP_REMOTE_ADDRESS against the loopback range (the destination at
+        // CONNECT, the peer at RECV_ACCEPT — both 127.x/::1 for loopback; the
+        // encoding is layer-independent). addr/mask are host byte order, mirroring
+        // the RemoteIp(V4) arm's `u32::from`. Fields are mutated in place (mirror
+        // of the v6buf pattern) so the keep-alive struct outlives FwpmFilterAdd0.
         Condition::LoopbackNet(IpAddr::V4(_)) => {
             v4mask.addr = 0x7F00_0000; // 127.0.0.0
             v4mask.mask = 0xFF00_0000; // /8

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -32,6 +32,52 @@ pub const FILTER_GUIDS: [GUID; 6] = [
     GUID::from_u128(0x1a48594b_c2d5_be1f_0374_8f9001122334), // block-all V6
 ];
 
+// Lockdown-cover filter GUIDs — disjoint from FILTER_GUIDS. Recovery sweeps
+// these (Sweep) or deletes only the TUN-LUID pair (Adopt) — see
+// `recover_lockdown` / `swept_lockdown_guids`. A crash that leaves the cover
+// engaged is reconciled on the next start.
+// Layout: [loopback V4, loopback V6, TUN V4, TUN V6, server V4, server V6,
+//          block-all V4, block-all V6]. App-ID filters get per-binary
+//          dynamically-derived GUIDs (see build_lockdown_spec).
+pub const LOCKDOWN_FILTER_GUIDS: [GUID; 8] = [
+    GUID::from_u128(0x216a841b_f264_4047_8881_39f24b4d6dce), // loopback V4
+    GUID::from_u128(0x4d9cd0a2_c48f_40cf_8225_89ce3f8a1376), // loopback V6
+    GUID::from_u128(0x04216435_0209_4b16_95c4_41f7c26af397), // TUN V4
+    GUID::from_u128(0x316261ca_7bd2_4949_a64b_08f6ddd66519), // TUN V6
+    GUID::from_u128(0x38bea56b_116b_4df8_8cac_280ef661d248), // server V4
+    GUID::from_u128(0xf733418b_a1c8_4365_85b5_d5ce8810b144), // server V6
+    GUID::from_u128(0x4710d661_94cb_4fc7_ab52_f03f75774d3e), // block-all V4
+    GUID::from_u128(0x20af67ac_58ec_41e6_a49d_6fd2ed55c184), // block-all V6
+];
+
+/// Derive a deterministic App-ID filter GUID per (binary index, layer) so a
+/// re-engage over an unswept cover is idempotent and recovery can delete by
+/// key. XORs a fixed namespace keyed by the (index, is_v6) pair —
+/// collision-free for the small binary counts we use, asserted by
+/// `all_swept_guids_are_mutually_distinct`.
+fn appid_filter_guid(index: usize, v6: bool) -> GUID {
+    let base = 0xf611_568d_6af6_4127_8600_2d32_3950_0000u128;
+    let salt = ((index as u128) << 8) | (v6 as u128);
+    GUID::from_u128(base ^ salt)
+}
+
+/// Per-binary App-ID GUID budget recovery sweeps: the plugin + bridge exe; 4
+/// gives headroom. Sweeping a superset is idempotent (a "not found" delete is
+/// ignored), so an unused App-ID slot is harmless.
+const MAX_APPID_BINARIES: usize = 4;
+
+/// Every lockdown filter GUID a full Sweep must delete: the eight fixed
+/// lockdown GUIDs + the per-binary App-ID GUIDs. (Transient GUIDs are swept
+/// separately by `delete_all`.)
+fn swept_lockdown_guids() -> Vec<GUID> {
+    let mut guids: Vec<GUID> = LOCKDOWN_FILTER_GUIDS.to_vec();
+    for i in 0..MAX_APPID_BINARIES {
+        guids.push(appid_filter_guid(i, false));
+        guids.push(appid_filter_guid(i, true));
+    }
+    guids
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Layer {
     ConnectV4,
@@ -44,17 +90,26 @@ pub enum Action {
     Block,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Condition {
     /// Match the WFP loopback flag (`FWP_CONDITION_FLAG_IS_LOOPBACK`).
     Loopback,
     /// Match a single remote host address (`FWPM_CONDITION_IP_REMOTE_ADDRESS`).
     RemoteIp(IpAddr),
+    /// Match the local interface by `NET_LUID` (`FWPM_CONDITION_IP_LOCAL_INTERFACE`,
+    /// `FWP_UINT64`). Carries app traffic: route selection picks hole-tun
+    /// before `ALE_AUTH_CONNECT`, so a connect to any destination classifies
+    /// on the tunnel's LUID.
+    LocalInterface(u64),
+    /// Match the connecting process image path (`FWPM_CONDITION_ALE_APP_ID`).
+    /// Carries the onward server connection regardless of which A-record the
+    /// plugin re-resolves to; path-keyed so it survives the cutover rename.
+    AppId(std::path::PathBuf),
     /// No condition — matches every connect at the layer (block-all).
     Any,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct FilterSpec {
     pub guid: GUID,
     pub layer: Layer,
@@ -141,6 +196,80 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
     }
 }
 
+/// Build the data description of the standing lockdown cover for `server_ip`,
+/// the hole-tun interface `tun_luid`, and the process image paths `app_ids`
+/// (plugin binary + the bridge's own exe). Per family (V4+V6) at
+/// `ALE_AUTH_CONNECT`: loopback permit + LocalInterface(luid) permit + one
+/// AppId permit per binary + server-IP permit + block-all. All permits hard
+/// (`CLEAR_ACTION_RIGHT`) at `PERMIT_WEIGHT`. Pure — no FFI.
+pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::path::PathBuf]) -> CoverSpec {
+    let server_layer = match server_ip {
+        IpAddr::V4(_) => Layer::ConnectV4,
+        IpAddr::V6(_) => Layer::ConnectV6,
+    };
+    let mut filters = vec![
+        permit(LOCKDOWN_FILTER_GUIDS[0], Layer::ConnectV4, Condition::Loopback),
+        permit(LOCKDOWN_FILTER_GUIDS[1], Layer::ConnectV6, Condition::Loopback),
+        permit(
+            LOCKDOWN_FILTER_GUIDS[2],
+            Layer::ConnectV4,
+            Condition::LocalInterface(tun_luid),
+        ),
+        permit(
+            LOCKDOWN_FILTER_GUIDS[3],
+            Layer::ConnectV6,
+            Condition::LocalInterface(tun_luid),
+        ),
+    ];
+    for (i, path) in app_ids.iter().enumerate() {
+        filters.push(permit(
+            appid_filter_guid(i, false),
+            Layer::ConnectV4,
+            Condition::AppId(path.clone()),
+        ));
+        filters.push(permit(
+            appid_filter_guid(i, true),
+            Layer::ConnectV6,
+            Condition::AppId(path.clone()),
+        ));
+    }
+    let server_guid = if server_layer == Layer::ConnectV4 {
+        LOCKDOWN_FILTER_GUIDS[4]
+    } else {
+        LOCKDOWN_FILTER_GUIDS[5]
+    };
+    filters.push(permit(server_guid, server_layer, Condition::RemoteIp(server_ip)));
+    filters.push(block(LOCKDOWN_FILTER_GUIDS[6], Layer::ConnectV4));
+    filters.push(block(LOCKDOWN_FILTER_GUIDS[7], Layer::ConnectV6));
+    CoverSpec {
+        provider: PROVIDER_GUID,
+        sublayer: SUBLAYER_GUID,
+        filters,
+    }
+}
+
+fn permit(guid: GUID, layer: Layer, condition: Condition) -> FilterSpec {
+    FilterSpec {
+        guid,
+        layer,
+        action: Action::Permit,
+        condition,
+        weight: PERMIT_WEIGHT,
+        hard: true,
+    }
+}
+
+fn block(guid: GUID, layer: Layer) -> FilterSpec {
+    FilterSpec {
+        guid,
+        layer,
+        action: Action::Block,
+        condition: Condition::Any,
+        weight: BLOCK_WEIGHT,
+        hard: false,
+    }
+}
+
 // --- engage layer ---
 
 /// `FWP_E_ALREADY_EXISTS` as the Win32 DWORD the FWPM `*Add0` functions return
@@ -148,9 +277,17 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
 /// our own object is benign idempotency, not an error.
 const FWP_E_ALREADY_EXISTS_DWORD: u32 = 0x8032_0009;
 
-/// WFP-backed cover guard. Drop deletes our provider/sublayer/filters by GUID.
+/// Which cover a [`Cover`] guard owns — selects the GUID set its Drop deletes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoverKind {
+    Transient,
+    Lockdown,
+}
+
+/// WFP-backed cover guard. Drop deletes the filters it installed by GUID.
 pub struct Cover {
     engine: HANDLE,
+    kind: CoverKind,
 }
 
 // SAFETY: the FWPM engine handle is owned exclusively by this guard and only
@@ -213,7 +350,50 @@ pub fn engage(server_ip: IpAddr, _state_dir: &Path) -> Result<Cover, RoutingErro
             let _ = FwpmEngineClose0(engine);
             return Err(e);
         }
-        Ok(Cover { engine })
+        Ok(Cover {
+            engine,
+            kind: CoverKind::Transient,
+        })
+    }
+}
+
+#[allow(clippy::disallowed_methods)] // THIS is the sanctioned FWPM call site
+pub fn engage_lockdown(
+    server_ip: IpAddr,
+    tun_luid: u64,
+    app_ids: &[std::path::PathBuf],
+    _state_dir: &Path,
+) -> Result<Cover, RoutingError> {
+    let spec = build_lockdown_spec(server_ip, tun_luid, app_ids);
+    unsafe {
+        let mut engine = HANDLE::default();
+        wfp_check(
+            FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine),
+            "FwpmEngineOpen0",
+        )?;
+        let result = (|| -> Result<(), RoutingError> {
+            wfp_check(FwpmTransactionBegin0(engine, 0), "FwpmTransactionBegin0")?;
+            // Idempotent over an unswept cover: add_provider/add_sublayer use
+            // ok_or_exists, and the filter keys are fixed — a re-engage after
+            // an Adopt (which left block-all in place) re-adds only the TUN
+            // permit (its key was deleted by `recover_lockdown`).
+            add_provider(engine, spec.provider)?;
+            add_sublayer(engine, spec.sublayer, spec.provider)?;
+            for f in &spec.filters {
+                add_filter(engine, spec.provider, spec.sublayer, f)?;
+            }
+            wfp_check(FwpmTransactionCommit0(engine), "FwpmTransactionCommit0")?;
+            Ok(())
+        })();
+        if let Err(e) = result {
+            let _ = FwpmTransactionAbort0(engine);
+            let _ = FwpmEngineClose0(engine);
+            return Err(e);
+        }
+        Ok(Cover {
+            engine,
+            kind: CoverKind::Lockdown,
+        })
     }
 }
 
@@ -250,6 +430,39 @@ unsafe fn add_sublayer(engine: HANDLE, key: GUID, provider: GUID) -> Result<(), 
     ok_or_exists(FwpmSubLayerAdd0(engine, &sublayer, None), "FwpmSubLayerAdd0")
 }
 
+/// Owned WFP app-id blob produced by `FwpmGetAppIdFromFileName0`; frees the
+/// WFP-allocated `FWP_BYTE_BLOB` on drop.
+struct AppIdBlob {
+    ptr: *mut FWP_BYTE_BLOB,
+}
+impl AppIdBlob {
+    fn as_mut_ptr(&mut self) -> *mut FWP_BYTE_BLOB {
+        self.ptr
+    }
+}
+impl Drop for AppIdBlob {
+    fn drop(&mut self) {
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        unsafe {
+            if !self.ptr.is_null() {
+                let mut p = self.ptr as *mut core::ffi::c_void;
+                FwpmFreeMemory0(&mut p);
+            }
+        }
+    }
+}
+
+#[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+unsafe fn get_app_id_blob(path: &Path) -> Result<AppIdBlob, RoutingError> {
+    let wide_path = wide(&path.to_string_lossy());
+    let mut out: *mut FWP_BYTE_BLOB = std::ptr::null_mut();
+    wfp_check(
+        FwpmGetAppIdFromFileName0(PCWSTR(wide_path.as_ptr()), &mut out),
+        "FwpmGetAppIdFromFileName0",
+    )?;
+    Ok(AppIdBlob { ptr: out })
+}
+
 #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
 unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterSpec) -> Result<(), RoutingError> {
     let layer = match f.layer {
@@ -274,8 +487,15 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
     let mut name = wide("Hole fail-closed filter");
     let mut provider_key = provider;
     let mut v6buf = FWP_BYTE_ARRAY16 { byteArray16: [0u8; 16] };
+    // The placeholder initializers below are overwritten in the matching arm
+    // before the pointer is taken; declared here only so they outlive the FFI
+    // call (the keep-alive contract).
+    #[allow(unused_assignments)]
+    let mut luid_buf: u64 = 0; // keep-alive for FWP_UINT64's *mut u64
+    #[allow(unused_assignments)]
+    let mut app_id_blob: Option<AppIdBlob> = None; // keep-alive for the app-id blob
     let mut conditions: Vec<FWPM_FILTER_CONDITION0> = Vec::new();
-    match f.condition {
+    match &f.condition {
         Condition::Loopback => conditions.push(FWPM_FILTER_CONDITION0 {
             fieldKey: FWPM_CONDITION_FLAGS,
             matchType: FWP_MATCH_FLAGS_ALL_SET,
@@ -293,7 +513,7 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
                 r#type: FWP_UINT32,
                 // WFP expects the address in host byte order; `u32::from`
                 // yields exactly that (first octet most-significant).
-                Anonymous: FWP_CONDITION_VALUE0_0 { uint32: u32::from(v4) },
+                Anonymous: FWP_CONDITION_VALUE0_0 { uint32: u32::from(*v4) },
             },
         }),
         Condition::RemoteIp(IpAddr::V6(v6)) => {
@@ -305,6 +525,36 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
                     r#type: FWP_BYTE_ARRAY16_TYPE,
                     Anonymous: FWP_CONDITION_VALUE0_0 {
                         byteArray16: &mut v6buf,
+                    },
+                },
+            });
+        }
+        // FWP_UINT64 carries a *mut u64; `luid_buf` is the stack keep-alive (mirror
+        // of the v6buf pattern). FWPM copies the pointee during FwpmFilterAdd0.
+        Condition::LocalInterface(luid) => {
+            luid_buf = *luid;
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_LOCAL_INTERFACE,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT64,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint64: &mut luid_buf },
+                },
+            });
+        }
+        // FwpmGetAppIdFromFileName0 normalizes the path to the kernel device form WFP
+        // expects; the returned FWP_BYTE_BLOB is WFP-owned and freed on AppIdBlob drop
+        // (after FwpmFilterAdd0 copies it during the transaction commit).
+        Condition::AppId(path) => {
+            app_id_blob = Some(get_app_id_blob(path)?);
+            let blob = app_id_blob.as_mut().expect("just set");
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_ALE_APP_ID,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_BYTE_BLOB_TYPE,
+                    Anonymous: FWP_CONDITION_VALUE0_0 {
+                        byteBlob: blob.as_mut_ptr(),
                     },
                 },
             });
@@ -344,7 +594,18 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
 impl Drop for Cover {
     fn drop(&mut self) {
         unsafe {
-            delete_all(self.engine);
+            match self.kind {
+                // Transient: today's full sweep (filters + sublayer + provider).
+                CoverKind::Transient => delete_all(self.engine),
+                // Lockdown: delete only the lockdown + App-ID filters; the
+                // shared sublayer/provider are owned by the transient sweep.
+                #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+                CoverKind::Lockdown => {
+                    for g in swept_lockdown_guids() {
+                        let _ = FwpmFilterDeleteByKey0(self.engine, &g);
+                    }
+                }
+            }
             #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
             let _ = FwpmEngineClose0(self.engine);
         }

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -1,8 +1,10 @@
 //! Windows fail-closed cover via the Windows Filtering Platform (WFP/FWPM).
 //!
 //! Engage installs a persistent provider + sublayer + filter set in one FWPM
-//! transaction: permit loopback (hard) and the SS server IP (hard) on
-//! `ALE_AUTH_CONNECT_V4`/`_V6`, block everything else. Persistent (boot-time)
+//! transaction: permit loopback (hard) on `ALE_AUTH_CONNECT_V4`/`_V6` and
+//! `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
+//! directions) + the SS server IP (hard) on CONNECT, block everything else on
+//! CONNECT (egress kill switch). Persistent (boot-time)
 //! filters — NOT a dynamic session — so a coordinator crash mid-cutover leaves
 //! traffic blocked (fail-closed), not leaked; `recover_cover` sweeps them by
 //! their fixed GUIDs on the next bridge start.
@@ -21,33 +23,40 @@ use crate::error::RoutingError;
 // persisted runtime state. Generated once; never reuse for anything else.
 pub const PROVIDER_GUID: GUID = GUID::from_u128(0xa3f1c2d4_5b6e_47a8_9c0d_1e2f3a4b5c6d);
 pub const SUBLAYER_GUID: GUID = GUID::from_u128(0xb4e2d3c5_6c7f_58b9_ad1e_2f3a4b5c6d7e);
-// Six fixed filter GUIDs — recovery deletes all six unconditionally
+// Eight fixed filter GUIDs — recovery deletes all eight unconditionally
 // (idempotent), so the set is deterministic regardless of server family.
-pub const FILTER_GUIDS: [GUID; 6] = [
-    GUID::from_u128(0xc5f3e4d6_7d80_69ca_be2f_3a4b5c6d7e8f), // loopback V4
-    GUID::from_u128(0xd6041507_8e91_7adb_cf30_4b5c6d7e8f90), // loopback V6
+pub const FILTER_GUIDS: [GUID; 8] = [
+    GUID::from_u128(0xc5f3e4d6_7d80_69ca_be2f_3a4b5c6d7e8f), // loopback CONNECT V4
+    GUID::from_u128(0xd6041507_8e91_7adb_cf30_4b5c6d7e8f90), // loopback CONNECT V6
     GUID::from_u128(0xe7152618_9fa2_8bec_d041_5c6d7e8f9001), // server V4
     GUID::from_u128(0xf8263729_a0b3_9cfd_e152_6d7e8f900112), // server V6
     GUID::from_u128(0x0937483a_b1c4_ad0e_f263_7e8f90011223), // block-all V4
     GUID::from_u128(0x1a48594b_c2d5_be1f_0374_8f9001122334), // block-all V6
+    GUID::from_u128(0x9fc31d47_1c7d_662f_c0af_263264e68d4c), // loopback RECV_ACCEPT V4
+    GUID::from_u128(0x64f1885c_8acb_79c4_fac2_cd84e29f45eb), // loopback RECV_ACCEPT V6
 ];
 
 // Lockdown-cover filter GUIDs — disjoint from FILTER_GUIDS. Recovery sweeps
 // these (Sweep) or deletes the volatile TUN + server pairs (Adopt) — see
 // `recover_lockdown` / `swept_lockdown_guids`. A crash that leaves the cover
 // engaged is reconciled on the next start.
-// Layout: [loopback V4, loopback V6, TUN V4, TUN V6, server V4, server V6,
-//          block-all V4, block-all V6]. App-ID filters get per-binary
-//          dynamically-derived GUIDs (see build_lockdown_spec).
-pub const LOCKDOWN_FILTER_GUIDS: [GUID; 8] = [
-    GUID::from_u128(0x216a841b_f264_4047_8881_39f24b4d6dce), // loopback V4
-    GUID::from_u128(0x4d9cd0a2_c48f_40cf_8225_89ce3f8a1376), // loopback V6
+// Layout: [loopback CONNECT V4, loopback CONNECT V6, TUN V4, TUN V6,
+//          server V4, server V6, block-all V4, block-all V6,
+//          loopback RECV_ACCEPT V4, loopback RECV_ACCEPT V6]. The accept-side
+//          loopback pair is appended (indices 8/9) so the earlier indices
+//          referenced by LOCKDOWN_{TUN,SERVER}_GUID_INDICES stay stable. App-ID
+//          filters get per-binary dynamically-derived GUIDs (see build_lockdown_spec).
+pub const LOCKDOWN_FILTER_GUIDS: [GUID; 10] = [
+    GUID::from_u128(0x216a841b_f264_4047_8881_39f24b4d6dce), // loopback CONNECT V4
+    GUID::from_u128(0x4d9cd0a2_c48f_40cf_8225_89ce3f8a1376), // loopback CONNECT V6
     GUID::from_u128(0x04216435_0209_4b16_95c4_41f7c26af397), // TUN V4
     GUID::from_u128(0x316261ca_7bd2_4949_a64b_08f6ddd66519), // TUN V6
     GUID::from_u128(0x38bea56b_116b_4df8_8cac_280ef661d248), // server V4
     GUID::from_u128(0xf733418b_a1c8_4365_85b5_d5ce8810b144), // server V6
     GUID::from_u128(0x4710d661_94cb_4fc7_ab52_f03f75774d3e), // block-all V4
     GUID::from_u128(0x20af67ac_58ec_41e6_a49d_6fd2ed55c184), // block-all V6
+    GUID::from_u128(0xfcd09bee_0a6a_7bb7_de78_f59dcf653693), // loopback RECV_ACCEPT V4
+    GUID::from_u128(0xda582b53_9a85_b667_c519_e80db74ab67e), // loopback RECV_ACCEPT V6
 ];
 
 /// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the TUN-interface (LUID) permit
@@ -74,7 +83,7 @@ fn appid_filter_guid(index: usize, v6: bool) -> GUID {
 /// ignored), so an unused App-ID slot is harmless.
 const MAX_APPID_BINARIES: usize = 4;
 
-/// Every lockdown filter GUID a full Sweep must delete: the eight fixed
+/// Every lockdown filter GUID a full Sweep must delete: the ten fixed
 /// lockdown GUIDs + the per-binary App-ID GUIDs. (Transient GUIDs are swept
 /// separately by `delete_all`.)
 fn swept_lockdown_guids() -> Vec<GUID> {
@@ -104,6 +113,11 @@ fn adopt_delete_guids() -> Vec<GUID> {
 pub enum Layer {
     ConnectV4,
     ConnectV6,
+    /// Inbound accept side (`ALE_AUTH_RECV_ACCEPT`). A loopback connect is
+    /// authorized here as well as at CONNECT; the cover permits loopback on both
+    /// so the loopback data plane works. We never block here (egress-only).
+    RecvAcceptV4,
+    RecvAcceptV6,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -159,7 +173,9 @@ pub const PERMIT_WEIGHT: u8 = 15;
 pub const BLOCK_WEIGHT: u8 = 0;
 
 /// Build the data description of the fail-closed cover for `server_ip`.
-/// Pure — no FFI; the engage layer (`engage`) submits this in one transaction.
+/// Permits loopback on CONNECT *and* RECV_ACCEPT (loopback connects authorize on
+/// both ALE directions) + the server IP on CONNECT; blocks all else on CONNECT
+/// only (egress kill switch). Pure — no FFI; `engage` submits it in one transaction.
 pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
@@ -177,6 +193,24 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
         FilterSpec {
             guid: FILTER_GUIDS[1],
             layer: Layer::ConnectV6,
+            action: Action::Permit,
+            condition: Condition::Loopback,
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        // A loopback connect is authorized at RECV_ACCEPT too; permitting only at
+        // CONNECT denies the accept side, breaking the loopback SOCKS5 data plane.
+        FilterSpec {
+            guid: FILTER_GUIDS[6],
+            layer: Layer::RecvAcceptV4,
+            action: Action::Permit,
+            condition: Condition::Loopback,
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        FilterSpec {
+            guid: FILTER_GUIDS[7],
+            layer: Layer::RecvAcceptV6,
             action: Action::Permit,
             condition: Condition::Loopback,
             weight: PERMIT_WEIGHT,
@@ -222,8 +256,10 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
 /// the hole-tun interface `tun_luid`, and the process image paths `app_ids`
 /// (plugin binary + the bridge's own exe). Per family (V4+V6) at
 /// `ALE_AUTH_CONNECT`: loopback permit + LocalInterface(luid) permit + one
-/// AppId permit per binary + server-IP permit + block-all. All permits hard
-/// (`CLEAR_ACTION_RIGHT`) at `PERMIT_WEIGHT`. Pure — no FFI.
+/// AppId permit per binary + server-IP permit + block-all; plus a loopback
+/// permit at `ALE_AUTH_RECV_ACCEPT` (the accept side a loopback connect also
+/// authorizes). Block stays CONNECT-only — egress kill switch, not inbound. All
+/// permits hard (`CLEAR_ACTION_RIGHT`) at `PERMIT_WEIGHT`. Pure — no FFI.
 pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::path::PathBuf]) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
@@ -232,6 +268,10 @@ pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::pat
     let mut filters = vec![
         permit(LOCKDOWN_FILTER_GUIDS[0], Layer::ConnectV4, Condition::Loopback),
         permit(LOCKDOWN_FILTER_GUIDS[1], Layer::ConnectV6, Condition::Loopback),
+        // A loopback connect is authorized at RECV_ACCEPT too; permitting only at
+        // CONNECT denies the accept side, breaking the loopback SOCKS5 data plane.
+        permit(LOCKDOWN_FILTER_GUIDS[8], Layer::RecvAcceptV4, Condition::Loopback),
+        permit(LOCKDOWN_FILTER_GUIDS[9], Layer::RecvAcceptV6, Condition::Loopback),
         permit(
             LOCKDOWN_FILTER_GUIDS[2],
             Layer::ConnectV4,
@@ -491,6 +531,8 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
     let layer = match f.layer {
         Layer::ConnectV4 => FWPM_LAYER_ALE_AUTH_CONNECT_V4,
         Layer::ConnectV6 => FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+        Layer::RecvAcceptV4 => FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4,
+        Layer::RecvAcceptV6 => FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6,
     };
     let action_type = match f.action {
         Action::Permit => FWP_ACTION_PERMIT,
@@ -681,7 +723,7 @@ pub fn recover_cover(_state_dir: &Path) {
     }
 }
 
-/// Delete filters (by their six fixed GUIDs), then the sublayer, then the
+/// Delete filters (by their fixed GUIDs), then the sublayer, then the
 /// provider. Order matters: a sublayer/provider delete fails while filters
 /// still reference it. Each delete is idempotent — a "not found" return is
 /// ignored (recovery runs even when no cover is present).

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -3,11 +3,13 @@
 //! Engage installs a persistent provider + sublayer + filter set in one FWPM
 //! transaction: permit loopback (hard) on `ALE_AUTH_CONNECT_V4`/`_V6` and
 //! `ALE_AUTH_RECV_ACCEPT_V4`/`_V6` (a loopback connect authorizes on both ALE
-//! directions) + the SS server IP (hard) on CONNECT, block everything else on
-//! CONNECT (egress kill switch). Persistent (boot-time)
-//! filters — NOT a dynamic session — so a coordinator crash mid-cutover leaves
-//! traffic blocked (fail-closed), not leaked; `recover_cover` sweeps them by
-//! their fixed GUIDs on the next bridge start.
+//! directions) — by both the IS_LOOPBACK flag AND the loopback destination range
+//! (127.0.0.0/8, ::1/128) at CONNECT, since the flag isn't reliably set at
+//! ALE_AUTH_CONNECT in some elevated environments — + the SS server IP (hard) on
+//! CONNECT, block everything else on CONNECT (egress kill switch). Persistent
+//! (boot-time) filters — NOT a dynamic session — so a coordinator crash
+//! mid-cutover leaves traffic blocked (fail-closed), not leaked; `recover_cover`
+//! sweeps them by their fixed GUIDs on the next bridge start.
 
 use std::net::IpAddr;
 use std::path::Path;
@@ -23,9 +25,9 @@ use crate::error::RoutingError;
 // persisted runtime state. Generated once; never reuse for anything else.
 pub const PROVIDER_GUID: GUID = GUID::from_u128(0xa3f1c2d4_5b6e_47a8_9c0d_1e2f3a4b5c6d);
 pub const SUBLAYER_GUID: GUID = GUID::from_u128(0xb4e2d3c5_6c7f_58b9_ad1e_2f3a4b5c6d7e);
-// Eight fixed filter GUIDs — recovery deletes all eight unconditionally
+// Ten fixed filter GUIDs — recovery deletes all ten unconditionally
 // (idempotent), so the set is deterministic regardless of server family.
-pub const FILTER_GUIDS: [GUID; 8] = [
+pub const FILTER_GUIDS: [GUID; 10] = [
     GUID::from_u128(0xc5f3e4d6_7d80_69ca_be2f_3a4b5c6d7e8f), // loopback CONNECT V4
     GUID::from_u128(0xd6041507_8e91_7adb_cf30_4b5c6d7e8f90), // loopback CONNECT V6
     GUID::from_u128(0xe7152618_9fa2_8bec_d041_5c6d7e8f9001), // server V4
@@ -34,6 +36,8 @@ pub const FILTER_GUIDS: [GUID; 8] = [
     GUID::from_u128(0x1a48594b_c2d5_be1f_0374_8f9001122334), // block-all V6
     GUID::from_u128(0x9fc31d47_1c7d_662f_c0af_263264e68d4c), // loopback RECV_ACCEPT V4
     GUID::from_u128(0x64f1885c_8acb_79c4_fac2_cd84e29f45eb), // loopback RECV_ACCEPT V6
+    GUID::from_u128(0x8827e6e8_461b_48a0_9e88_dc6371486cb0), // loopback-net CONNECT V4 (127.0.0.0/8)
+    GUID::from_u128(0x07d38d29_4bbb_472f_aeb3_e9d71f8967d9), // loopback-net CONNECT V6 (::1/128)
 ];
 
 // Lockdown-cover filter GUIDs — disjoint from FILTER_GUIDS. Recovery sweeps
@@ -42,11 +46,12 @@ pub const FILTER_GUIDS: [GUID; 8] = [
 // engaged is reconciled on the next start.
 // Layout: [loopback CONNECT V4, loopback CONNECT V6, TUN V4, TUN V6,
 //          server V4, server V6, block-all V4, block-all V6,
-//          loopback RECV_ACCEPT V4, loopback RECV_ACCEPT V6]. The accept-side
-//          loopback pair is appended (indices 8/9) so the earlier indices
-//          referenced by LOCKDOWN_{TUN,SERVER}_GUID_INDICES stay stable. App-ID
+//          loopback RECV_ACCEPT V4, loopback RECV_ACCEPT V6,
+//          loopback-net CONNECT V4, loopback-net CONNECT V6]. New pairs are
+//          appended so the earlier indices referenced by
+//          LOCKDOWN_{TUN,SERVER}_GUID_INDICES stay stable. App-ID
 //          filters get per-binary dynamically-derived GUIDs (see build_lockdown_spec).
-pub const LOCKDOWN_FILTER_GUIDS: [GUID; 10] = [
+pub const LOCKDOWN_FILTER_GUIDS: [GUID; 12] = [
     GUID::from_u128(0x216a841b_f264_4047_8881_39f24b4d6dce), // loopback CONNECT V4
     GUID::from_u128(0x4d9cd0a2_c48f_40cf_8225_89ce3f8a1376), // loopback CONNECT V6
     GUID::from_u128(0x04216435_0209_4b16_95c4_41f7c26af397), // TUN V4
@@ -57,6 +62,8 @@ pub const LOCKDOWN_FILTER_GUIDS: [GUID; 10] = [
     GUID::from_u128(0x20af67ac_58ec_41e6_a49d_6fd2ed55c184), // block-all V6
     GUID::from_u128(0xfcd09bee_0a6a_7bb7_de78_f59dcf653693), // loopback RECV_ACCEPT V4
     GUID::from_u128(0xda582b53_9a85_b667_c519_e80db74ab67e), // loopback RECV_ACCEPT V6
+    GUID::from_u128(0x2f10387e_8f54_4f82_91ca_44aa862d945e), // loopback-net CONNECT V4 (127.0.0.0/8)
+    GUID::from_u128(0xd766a20f_050a_4c40_8de3_33bf259b7e34), // loopback-net CONNECT V6 (::1/128)
 ];
 
 /// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the TUN-interface (LUID) permit
@@ -130,6 +137,13 @@ pub enum Action {
 pub enum Condition {
     /// Match the WFP loopback flag (`FWP_CONDITION_FLAG_IS_LOOPBACK`).
     Loopback,
+    /// Match the loopback network by the connect's DESTINATION address range:
+    /// V4 -> 127.0.0.0/8, V6 -> ::1/128 (the carried `IpAddr` selects only the
+    /// family). The IS_LOOPBACK flag is not reliably set at ALE_AUTH_CONNECT in
+    /// some elevated environments, so the flag permit alone leaves a loopback
+    /// connect denied by block-all; an address-range permit on the destination
+    /// matches deterministically. Additive to [`Condition::Loopback`].
+    LoopbackNet(IpAddr),
     /// Match a single remote host address (`FWPM_CONDITION_IP_REMOTE_ADDRESS`).
     RemoteIp(IpAddr),
     /// Match the local interface by `NET_LUID` (`FWPM_CONDITION_IP_LOCAL_INTERFACE`,
@@ -174,8 +188,10 @@ pub const BLOCK_WEIGHT: u8 = 0;
 
 /// Build the data description of the fail-closed cover for `server_ip`.
 /// Permits loopback on CONNECT *and* RECV_ACCEPT (loopback connects authorize on
-/// both ALE directions) + the server IP on CONNECT; blocks all else on CONNECT
-/// only (egress kill switch). Pure — no FFI; `engage` submits it in one transaction.
+/// both ALE directions) — by both the IS_LOOPBACK flag and the loopback
+/// destination range at CONNECT — + the server IP on CONNECT; blocks all else on
+/// CONNECT only (egress kill switch). Pure — no FFI; `engage` submits it in one
+/// transaction.
 pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
@@ -195,6 +211,26 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             layer: Layer::ConnectV6,
             action: Action::Permit,
             condition: Condition::Loopback,
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        // Belt-and-suspenders for the flag permits above: the IS_LOOPBACK flag is
+        // not reliably set at ALE_AUTH_CONNECT in CI's elevated lane, so match the
+        // connect's DESTINATION range (127.0.0.0/8, ::1/128) — that classifies
+        // deterministically.
+        FilterSpec {
+            guid: FILTER_GUIDS[8],
+            layer: Layer::ConnectV4,
+            action: Action::Permit,
+            condition: Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+            weight: PERMIT_WEIGHT,
+            hard: true,
+        },
+        FilterSpec {
+            guid: FILTER_GUIDS[9],
+            layer: Layer::ConnectV6,
+            action: Action::Permit,
+            condition: Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
             weight: PERMIT_WEIGHT,
             hard: true,
         },
@@ -254,12 +290,13 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
 
 /// Build the data description of the standing lockdown cover for `server_ip`,
 /// the hole-tun interface `tun_luid`, and the process image paths `app_ids`
-/// (plugin binary + the bridge's own exe). Per family (V4+V6) at
-/// `ALE_AUTH_CONNECT`: loopback permit + LocalInterface(luid) permit + one
-/// AppId permit per binary + server-IP permit + block-all; plus a loopback
-/// permit at `ALE_AUTH_RECV_ACCEPT` (the accept side a loopback connect also
-/// authorizes). Block stays CONNECT-only — egress kill switch, not inbound. All
-/// permits hard (`CLEAR_ACTION_RIGHT`) at `PERMIT_WEIGHT`. Pure — no FFI.
+/// (plugin binary plus the bridge's own exe). Per family (V4+V6) at
+/// `ALE_AUTH_CONNECT`: a loopback permit (flag and destination range), a
+/// LocalInterface(luid) permit, one AppId permit per binary, a server-IP permit,
+/// and block-all; plus a loopback flag permit at `ALE_AUTH_RECV_ACCEPT` (the
+/// accept side a loopback connect also authorizes). Block stays CONNECT-only —
+/// egress kill switch, not inbound. All permits hard (`CLEAR_ACTION_RIGHT`) at
+/// `PERMIT_WEIGHT`. Pure — no FFI.
 pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::path::PathBuf]) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
@@ -268,6 +305,20 @@ pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::pat
     let mut filters = vec![
         permit(LOCKDOWN_FILTER_GUIDS[0], Layer::ConnectV4, Condition::Loopback),
         permit(LOCKDOWN_FILTER_GUIDS[1], Layer::ConnectV6, Condition::Loopback),
+        // Belt-and-suspenders for the flag permits above: the IS_LOOPBACK flag is
+        // not reliably set at ALE_AUTH_CONNECT in CI's elevated lane, so match the
+        // connect's DESTINATION range (127.0.0.0/8, ::1/128) — that classifies
+        // deterministically.
+        permit(
+            LOCKDOWN_FILTER_GUIDS[10],
+            Layer::ConnectV4,
+            Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+        ),
+        permit(
+            LOCKDOWN_FILTER_GUIDS[11],
+            Layer::ConnectV6,
+            Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
+        ),
         // A loopback connect is authorized at RECV_ACCEPT too; permitting only at
         // CONNECT denies the accept side, breaking the loopback SOCKS5 data plane.
         permit(LOCKDOWN_FILTER_GUIDS[8], Layer::RecvAcceptV4, Condition::Loopback),
@@ -552,6 +603,10 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
     let mut name = wide("Hole fail-closed filter");
     let mut provider_key = provider;
     let mut v6buf = FWP_BYTE_ARRAY16 { byteArray16: [0u8; 16] };
+    // Keep-alive for the addr+mask structs the LoopbackNet arms point at (mirror
+    // of the v6buf pattern); FWPM copies the pointee during FwpmFilterAdd0.
+    let mut v4mask = FWP_V4_ADDR_AND_MASK::default();
+    let mut v6mask = FWP_V6_ADDR_AND_MASK::default();
     // The placeholder initializers below are overwritten in the matching arm
     // before the pointer is taken; declared here only so they outlive the FFI
     // call (the keep-alive contract).
@@ -571,6 +626,38 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
                 },
             },
         }),
+        // Match the connect's DESTINATION against the loopback range. addr/mask are
+        // host byte order, mirroring the RemoteIp(V4) arm's `u32::from`. Fields are
+        // mutated in place (mirror of the v6buf pattern) so the keep-alive struct
+        // outlives FwpmFilterAdd0.
+        Condition::LoopbackNet(IpAddr::V4(_)) => {
+            v4mask.addr = 0x7F00_0000; // 127.0.0.0
+            v4mask.mask = 0xFF00_0000; // /8
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_V4_ADDR_MASK,
+                    Anonymous: FWP_CONDITION_VALUE0_0 {
+                        v4AddrMask: &mut v4mask,
+                    },
+                },
+            });
+        }
+        Condition::LoopbackNet(IpAddr::V6(_)) => {
+            v6mask.addr = std::net::Ipv6Addr::LOCALHOST.octets(); // ::1
+            v6mask.prefixLength = 128;
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_V6_ADDR_MASK,
+                    Anonymous: FWP_CONDITION_VALUE0_0 {
+                        v6AddrMask: &mut v6mask,
+                    },
+                },
+            });
+        }
         Condition::RemoteIp(IpAddr::V4(v4)) => conditions.push(FWPM_FILTER_CONDITION0 {
             fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
             matchType: FWP_MATCH_EQUAL,

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -559,7 +559,7 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
         }
         // FwpmGetAppIdFromFileName0 normalizes the path to the kernel device form WFP
         // expects; the returned FWP_BYTE_BLOB is WFP-owned and freed on AppIdBlob drop
-        // (after FwpmFilterAdd0 copies it during the transaction commit).
+        // (after FwpmFilterAdd0 copies it during the FwpmFilterAdd0 call itself).
         Condition::AppId(path) => {
             app_id_blob = Some(get_app_id_blob(path)?);
             let blob = app_id_blob.as_mut().expect("just set");

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -35,14 +35,10 @@ fn spec_permits_loopback_on_all_four_ale_layers() {
     // A loopback connect is authorized at CONNECT *and* RECV_ACCEPT (the inbound
     // accept side); a permit on CONNECT alone is denied at accept. Hole's data
     // plane runs app->hole-tun->loopback SOCKS5->ss-service, so the cover must
-    // permit loopback on both ALE directions, V4 and V6.
+    // permit loopback on both ALE directions, V4 and V6. The deterministic
+    // matcher is the address range (LoopbackNet) on ALL FOUR layers; the
+    // IS_LOOPBACK flag isn't reliably set on CI's elevated lane.
     let s = build_cover_spec(v4());
-    let loopback_permits = s
-        .filters
-        .iter()
-        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
-        .count();
-    assert_eq!(loopback_permits, 4, "loopback permit on CONNECT + RECV_ACCEPT, V4 + V6");
     for layer in [
         Layer::ConnectV4,
         Layer::ConnectV6,
@@ -50,10 +46,10 @@ fn spec_permits_loopback_on_all_four_ale_layers() {
         Layer::RecvAcceptV6,
     ] {
         assert!(
-            s.filters
-                .iter()
-                .any(|f| f.layer == layer && f.action == Action::Permit && matches!(f.condition, Condition::Loopback)),
-            "loopback permit missing on {layer:?}"
+            s.filters.iter().any(|f| f.layer == layer
+                && f.action == Action::Permit
+                && matches!(f.condition, Condition::LoopbackNet(_))),
+            "address-range loopback permit missing on {layer:?}"
         );
     }
 }
@@ -126,14 +122,22 @@ fn bridge_path() -> std::path::PathBuf {
 #[skuld::test]
 fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
     let s = build_lockdown_spec(v4(), luid(), &[plugin_path(), bridge_path()]);
-    // loopback on all four ALE layers (CONNECT + RECV_ACCEPT) — see
-    // spec_permits_loopback_on_all_four_ale_layers for why the accept side matters.
-    let loopback = s
-        .filters
-        .iter()
-        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
-        .count();
-    assert_eq!(loopback, 4, "loopback permit on CONNECT + RECV_ACCEPT, V4 + V6");
+    // loopback on all four ALE layers (CONNECT + RECV_ACCEPT) by the deterministic
+    // address-range matcher — see spec_permits_loopback_on_all_four_ale_layers for
+    // why the accept side matters and why the flag is unreliable.
+    for layer in [
+        Layer::ConnectV4,
+        Layer::ConnectV6,
+        Layer::RecvAcceptV4,
+        Layer::RecvAcceptV6,
+    ] {
+        assert!(
+            s.filters.iter().any(|f| f.layer == layer
+                && f.action == Action::Permit
+                && matches!(f.condition, Condition::LoopbackNet(_))),
+            "address-range loopback permit missing on {layer:?}"
+        );
+    }
     // local-interface (TUN LUID) permit on both layers
     let tun = s
         .filters
@@ -336,22 +340,32 @@ fn adopt_drops_server_permit_so_reengage_can_update_it() {
 }
 
 #[skuld::test]
-fn both_specs_permit_loopback_recv_accept_on_the_accept_layers() {
+fn both_specs_permit_loopback_recv_accept_by_address_range() {
     // The accept-side permits must land on the RECV_ACCEPT layers (not a second
-    // CONNECT permit). Asserts the layer mapping for both covers.
+    // CONNECT permit) AND match by the deterministic address range, not the
+    // IS_LOOPBACK flag: on CI's elevated lane the flag doesn't match at
+    // RECV_ACCEPT, so a flag-only permit leaves the loopback accept dropped. At
+    // RECV_ACCEPT IP_REMOTE_ADDRESS is the peer (127.0.0.1 for a loopback accept),
+    // so the 127.0.0.0/8 or ::1/128 range matches. The matching family per layer:
+    // V4 range on RecvAcceptV4, V6 range on RecvAcceptV6.
     for s in [
         build_cover_spec(v4()),
         build_lockdown_spec(v4(), luid(), &[plugin_path()]),
     ] {
-        for layer in [Layer::RecvAcceptV4, Layer::RecvAcceptV6] {
-            assert!(
-                s.filters.iter().any(|f| f.layer == layer
-                    && f.action == Action::Permit
-                    && f.hard
-                    && matches!(f.condition, Condition::Loopback)),
-                "loopback permit missing on {layer:?}"
-            );
-        }
+        assert!(
+            s.filters.iter().any(|f| f.layer == Layer::RecvAcceptV4
+                && f.action == Action::Permit
+                && f.hard
+                && f.condition == Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))),
+            "address-range loopback permit (127.0.0.0/8) missing on RECV_ACCEPT V4"
+        );
+        assert!(
+            s.filters.iter().any(|f| f.layer == Layer::RecvAcceptV6
+                && f.action == Action::Permit
+                && f.hard
+                && f.condition == Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))),
+            "address-range loopback permit (::1/128) missing on RECV_ACCEPT V6"
+        );
     }
 }
 
@@ -447,19 +461,29 @@ fn both_specs_permit_loopback_by_address_range_at_connect() {
 }
 
 #[skuld::test]
-fn flag_loopback_permits_are_kept_alongside_the_address_range_ones() {
-    // The address-range permits are ADDITIVE belt-and-suspenders: the flag permits
-    // on all four ALE layers must still be present (the diagnosis keeps both).
+fn flag_loopback_permits_are_kept_only_on_connect() {
+    // At CONNECT the flag permits stay as harmless belt-and-suspenders alongside
+    // the address-range ones (don't churn them). At RECV_ACCEPT the flag is
+    // dropped in favor of the deterministic address-range permit, because the
+    // flag doesn't match there on CI's elevated lane.
     let s = build_cover_spec(v4());
-    let flag_permits = s
+    let flag_permits: Vec<_> = s
         .filters
         .iter()
         .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
-        .count();
+        .collect();
     assert_eq!(
-        flag_permits, 4,
-        "flag loopback permits (CONNECT + RECV_ACCEPT, V4+V6) kept"
+        flag_permits.len(),
+        2,
+        "flag loopback permits kept on CONNECT V4+V6 only"
     );
+    for f in &flag_permits {
+        assert!(
+            matches!(f.layer, Layer::ConnectV4 | Layer::ConnectV6),
+            "flag loopback permit must be CONNECT-only, found on {:?}",
+            f.layer
+        );
+    }
 }
 
 #[skuld::test]

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -183,3 +183,59 @@ fn lockdown_spec_v6_server_lands_on_v6_layer() {
     assert_eq!(server.len(), 1);
     assert_eq!(server[0].layer, Layer::ConnectV6);
 }
+
+// lockdown sweep / Adopt GUID sets ====================================================================================
+
+#[skuld::test]
+fn all_swept_guids_cover_both_covers() {
+    // The lockdown sweep must iterate every fixed lockdown GUID plus the
+    // per-binary App-ID GUIDs so an intent-OFF leftover is fully cleaned.
+    let swept = swept_lockdown_guids();
+    for g in LOCKDOWN_FILTER_GUIDS {
+        assert!(swept.contains(&g), "lockdown GUID {g:?} must be swept");
+    }
+    for i in 0..MAX_APPID_BINARIES {
+        assert!(swept.contains(&appid_filter_guid(i, false)));
+        assert!(swept.contains(&appid_filter_guid(i, true)));
+    }
+}
+
+#[skuld::test]
+fn all_swept_guids_are_mutually_distinct() {
+    // Transient six + lockdown eight + every App-ID-derived GUID must be
+    // pairwise distinct: two filters sharing a key means the second add
+    // silently clobbers the first (FwpmFilterAdd0 keys on filterKey). GUID
+    // derives Hash + Eq, so collect directly (no to_u128 — it doesn't exist).
+    let mut all: Vec<GUID> = FILTER_GUIDS.to_vec();
+    all.extend(swept_lockdown_guids());
+    let unique: std::collections::HashSet<GUID> = all.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "every filter GUID (transient + lockdown + App-ID) must be distinct"
+    );
+}
+
+#[skuld::test]
+fn adopt_deletes_only_the_tun_luid_pair() {
+    // Adopt keeps the host fail-closed: it removes ONLY the two stale TUN-LUID
+    // permits (their LUID is dead after teardown), never block-all / loopback /
+    // server / App-ID. The next connect re-adds the TUN permit.
+    let adopt = adopt_delete_guids();
+    assert_eq!(adopt.len(), 2);
+    for &i in &LOCKDOWN_TUN_GUID_INDICES {
+        assert!(
+            adopt.contains(&LOCKDOWN_FILTER_GUIDS[i]),
+            "Adopt must delete the TUN permit at index {i}"
+        );
+    }
+    // It must NOT delete the block-all or server permits.
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[6]),
+        "Adopt must NOT delete block-all V4"
+    );
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[4]),
+        "Adopt must NOT delete the server permit"
+    );
+}

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -217,25 +217,71 @@ fn all_swept_guids_are_mutually_distinct() {
 }
 
 #[skuld::test]
-fn adopt_deletes_only_the_tun_luid_pair() {
-    // Adopt keeps the host fail-closed: it removes ONLY the two stale TUN-LUID
-    // permits (their LUID is dead after teardown), never block-all / loopback /
-    // server / App-ID. The next connect re-adds the TUN permit.
+fn adopt_deletes_volatile_permits() {
+    // Adopt keeps the host fail-closed but drops the VOLATILE permits — the
+    // TUN-LUID pair (LUID dead after teardown) AND the server-IP pair (the
+    // server changes between connects). Both are re-added fresh by the next
+    // connect's engage with current values. The fail-closed floor (block-all,
+    // loopback, App-ID) stays in force.
     let adopt = adopt_delete_guids();
-    assert_eq!(adopt.len(), 2);
+    assert_eq!(adopt.len(), 4, "TUN V4/V6 + server V4/V6");
     for &i in &LOCKDOWN_TUN_GUID_INDICES {
         assert!(
             adopt.contains(&LOCKDOWN_FILTER_GUIDS[i]),
             "Adopt must delete the TUN permit at index {i}"
         );
     }
-    // It must NOT delete the block-all or server permits.
+    for &i in &LOCKDOWN_SERVER_GUID_INDICES {
+        assert!(
+            adopt.contains(&LOCKDOWN_FILTER_GUIDS[i]),
+            "Adopt must delete the server permit at index {i}"
+        );
+    }
+    // It must NOT delete the fail-closed floor: block-all or loopback.
     assert!(
         !adopt.contains(&LOCKDOWN_FILTER_GUIDS[6]),
         "Adopt must NOT delete block-all V4"
     );
     assert!(
-        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[4]),
-        "Adopt must NOT delete the server permit"
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[7]),
+        "Adopt must NOT delete block-all V6"
     );
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[0]),
+        "Adopt must NOT delete loopback V4"
+    );
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[1]),
+        "Adopt must NOT delete loopback V6"
+    );
+}
+
+#[skuld::test]
+fn adopt_drops_server_permit_so_reengage_can_update_it() {
+    // Regression: keeping the fixed-GUID server permit across an Adopt left a
+    // stale IP permitted — the next engage to a different server hits
+    // FWP_E_ALREADY_EXISTS (treated as success) and never updates the address.
+    // Adopt must drop the server GUIDs (so engage re-adds fresh) while keeping
+    // the floor (block-all + loopback + App-ID), which must survive untouched.
+    let adopt: std::collections::HashSet<GUID> = adopt_delete_guids().into_iter().collect();
+
+    // Server permits MUST be in the Adopt-delete set.
+    assert!(adopt.contains(&LOCKDOWN_FILTER_GUIDS[4]), "server V4 must be dropped");
+    assert!(adopt.contains(&LOCKDOWN_FILTER_GUIDS[5]), "server V6 must be dropped");
+
+    // The fail-closed floor MUST NOT be in the Adopt-delete set.
+    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[6]), "block-all V4 stays");
+    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[7]), "block-all V6 stays");
+    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[0]), "loopback V4 stays");
+    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[1]), "loopback V6 stays");
+    for i in 0..MAX_APPID_BINARIES {
+        assert!(
+            !adopt.contains(&appid_filter_guid(i, false)),
+            "App-ID floor stays (V4 #{i})"
+        );
+        assert!(
+            !adopt.contains(&appid_filter_guid(i, true)),
+            "App-ID floor stays (V6 #{i})"
+        );
+    }
 }

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -9,7 +9,10 @@ fn v6() -> IpAddr {
 }
 
 #[skuld::test]
-fn spec_blocks_on_both_v4_and_v6_layers() {
+fn spec_blocks_egress_only_on_both_v4_and_v6_layers() {
+    // The block-all is an egress kill switch: CONNECT only. Blocking RECV_ACCEPT
+    // would make it an inbound firewall (out of scope, and inconsistent with the
+    // macOS `set skip on lo0` egress-only model).
     let s = build_cover_spec(v4());
     assert!(s
         .filters
@@ -19,17 +22,40 @@ fn spec_blocks_on_both_v4_and_v6_layers() {
         .filters
         .iter()
         .any(|f| f.layer == Layer::ConnectV6 && f.action == Action::Block));
+    assert!(
+        !s.filters
+            .iter()
+            .any(|f| matches!(f.layer, Layer::RecvAcceptV4 | Layer::RecvAcceptV6) && f.action == Action::Block),
+        "block-all must stay CONNECT-only (egress kill switch, not an inbound firewall)"
+    );
 }
 
 #[skuld::test]
-fn spec_permits_loopback_on_both_layers() {
+fn spec_permits_loopback_on_all_four_ale_layers() {
+    // A loopback connect is authorized at CONNECT *and* RECV_ACCEPT (the inbound
+    // accept side); a permit on CONNECT alone is denied at accept. Hole's data
+    // plane runs app->hole-tun->loopback SOCKS5->ss-service, so the cover must
+    // permit loopback on both ALE directions, V4 and V6.
     let s = build_cover_spec(v4());
     let loopback_permits = s
         .filters
         .iter()
         .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
         .count();
-    assert_eq!(loopback_permits, 2, "loopback permit on V4 and V6");
+    assert_eq!(loopback_permits, 4, "loopback permit on CONNECT + RECV_ACCEPT, V4 + V6");
+    for layer in [
+        Layer::ConnectV4,
+        Layer::ConnectV6,
+        Layer::RecvAcceptV4,
+        Layer::RecvAcceptV6,
+    ] {
+        assert!(
+            s.filters
+                .iter()
+                .any(|f| f.layer == layer && f.action == Action::Permit && matches!(f.condition, Condition::Loopback)),
+            "loopback permit missing on {layer:?}"
+        );
+    }
 }
 
 #[skuld::test]
@@ -100,13 +126,14 @@ fn bridge_path() -> std::path::PathBuf {
 #[skuld::test]
 fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
     let s = build_lockdown_spec(v4(), luid(), &[plugin_path(), bridge_path()]);
-    // loopback on both layers
+    // loopback on all four ALE layers (CONNECT + RECV_ACCEPT) — see
+    // spec_permits_loopback_on_all_four_ale_layers for why the accept side matters.
     let loopback = s
         .filters
         .iter()
         .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
         .count();
-    assert_eq!(loopback, 2, "loopback permit on V4 and V6");
+    assert_eq!(loopback, 4, "loopback permit on CONNECT + RECV_ACCEPT, V4 + V6");
     // local-interface (TUN LUID) permit on both layers
     let tun = s
         .filters
@@ -129,7 +156,7 @@ fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
         .collect();
     assert_eq!(server.len(), 1);
     assert_eq!(server[0].layer, Layer::ConnectV4);
-    // block-all on both layers
+    // block-all on both CONNECT layers; never on RECV_ACCEPT (egress-only kill switch)
     assert!(s
         .filters
         .iter()
@@ -138,6 +165,12 @@ fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
         .filters
         .iter()
         .any(|f| f.layer == Layer::ConnectV6 && f.action == Action::Block));
+    assert!(
+        !s.filters
+            .iter()
+            .any(|f| matches!(f.layer, Layer::RecvAcceptV4 | Layer::RecvAcceptV6) && f.action == Action::Block),
+        "lockdown block-all must stay CONNECT-only (egress kill switch)"
+    );
 }
 
 #[skuld::test]
@@ -202,7 +235,7 @@ fn all_swept_guids_cover_both_covers() {
 
 #[skuld::test]
 fn all_swept_guids_are_mutually_distinct() {
-    // Transient six + lockdown eight + every App-ID-derived GUID must be
+    // Transient eight + lockdown ten + every App-ID-derived GUID must be
     // pairwise distinct: two filters sharing a key means the second add
     // silently clobbers the first (FwpmFilterAdd0 keys on filterKey). GUID
     // derives Hash + Eq, so collect directly (no to_u128 — it doesn't exist).
@@ -248,11 +281,19 @@ fn adopt_deletes_volatile_permits() {
     );
     assert!(
         !adopt.contains(&LOCKDOWN_FILTER_GUIDS[0]),
-        "Adopt must NOT delete loopback V4"
+        "Adopt must NOT delete loopback CONNECT V4"
     );
     assert!(
         !adopt.contains(&LOCKDOWN_FILTER_GUIDS[1]),
-        "Adopt must NOT delete loopback V6"
+        "Adopt must NOT delete loopback CONNECT V6"
+    );
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[8]),
+        "Adopt must NOT delete loopback RECV_ACCEPT V4 (fail-closed floor)"
+    );
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[9]),
+        "Adopt must NOT delete loopback RECV_ACCEPT V6 (fail-closed floor)"
     );
 }
 
@@ -272,8 +313,16 @@ fn adopt_drops_server_permit_so_reengage_can_update_it() {
     // The fail-closed floor MUST NOT be in the Adopt-delete set.
     assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[6]), "block-all V4 stays");
     assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[7]), "block-all V6 stays");
-    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[0]), "loopback V4 stays");
-    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[1]), "loopback V6 stays");
+    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[0]), "loopback CONNECT V4 stays");
+    assert!(!adopt.contains(&LOCKDOWN_FILTER_GUIDS[1]), "loopback CONNECT V6 stays");
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[8]),
+        "loopback RECV_ACCEPT V4 stays"
+    );
+    assert!(
+        !adopt.contains(&LOCKDOWN_FILTER_GUIDS[9]),
+        "loopback RECV_ACCEPT V6 stays"
+    );
     for i in 0..MAX_APPID_BINARIES {
         assert!(
             !adopt.contains(&appid_filter_guid(i, false)),
@@ -283,5 +332,82 @@ fn adopt_drops_server_permit_so_reengage_can_update_it() {
             !adopt.contains(&appid_filter_guid(i, true)),
             "App-ID floor stays (V6 #{i})"
         );
+    }
+}
+
+#[skuld::test]
+fn both_specs_permit_loopback_recv_accept_on_the_accept_layers() {
+    // The accept-side permits must land on the RECV_ACCEPT layers (not a second
+    // CONNECT permit). Asserts the layer mapping for both covers.
+    for s in [
+        build_cover_spec(v4()),
+        build_lockdown_spec(v4(), luid(), &[plugin_path()]),
+    ] {
+        for layer in [Layer::RecvAcceptV4, Layer::RecvAcceptV6] {
+            assert!(
+                s.filters.iter().any(|f| f.layer == layer
+                    && f.action == Action::Permit
+                    && f.hard
+                    && matches!(f.condition, Condition::Loopback)),
+                "loopback permit missing on {layer:?}"
+            );
+        }
+    }
+}
+
+#[skuld::test]
+fn loopback_recv_accept_permits_are_in_both_sweep_floors() {
+    // The accept-side loopback permits are part of the fail-closed FLOOR: the
+    // transient sweep (delete_all iterates FILTER_GUIDS) and the lockdown sweep
+    // (swept_lockdown_guids) must both delete them, but Adopt must keep them.
+    // The transient cover wires its RECV_ACCEPT loopback GUIDs from FILTER_GUIDS,
+    // so iterating the array sweeps them; assert they actually appear in the spec.
+    let cover = build_cover_spec(v4());
+    let cover_guids: std::collections::HashSet<GUID> = cover.filters.iter().map(|f| f.guid).collect();
+    assert!(
+        cover_guids.contains(&FILTER_GUIDS[6]),
+        "transient RECV_ACCEPT V4 in spec"
+    );
+    assert!(
+        cover_guids.contains(&FILTER_GUIDS[7]),
+        "transient RECV_ACCEPT V6 in spec"
+    );
+
+    let swept = swept_lockdown_guids();
+    assert!(
+        swept.contains(&LOCKDOWN_FILTER_GUIDS[8]),
+        "lockdown RECV_ACCEPT V4 swept"
+    );
+    assert!(
+        swept.contains(&LOCKDOWN_FILTER_GUIDS[9]),
+        "lockdown RECV_ACCEPT V6 swept"
+    );
+}
+
+#[skuld::test]
+fn every_emitted_filter_guid_is_in_its_sweep_set() {
+    // Structural fail-closed invariant: any filter a cover installs must be
+    // deletable by recovery, else a crash leaks an unswept block across restarts.
+    // Transient -> delete_all iterates FILTER_GUIDS; lockdown -> swept_lockdown_guids.
+    for ip in [v4(), v6()] {
+        let cover = build_cover_spec(ip);
+        for f in &cover.filters {
+            assert!(
+                FILTER_GUIDS.contains(&f.guid),
+                "transient filter {:?} ({:?}) is not in FILTER_GUIDS",
+                f.guid,
+                f.layer
+            );
+        }
+        let swept: std::collections::HashSet<GUID> = swept_lockdown_guids().into_iter().collect();
+        let lock = build_lockdown_spec(ip, luid(), &[plugin_path(), bridge_path()]);
+        for f in &lock.filters {
+            assert!(
+                swept.contains(&f.guid),
+                "lockdown filter {:?} ({:?}) is not in swept_lockdown_guids",
+                f.guid,
+                f.layer
+            );
+        }
     }
 }

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -235,8 +235,8 @@ fn all_swept_guids_cover_both_covers() {
 
 #[skuld::test]
 fn all_swept_guids_are_mutually_distinct() {
-    // Transient eight + lockdown ten + every App-ID-derived GUID must be
-    // pairwise distinct: two filters sharing a key means the second add
+    // Every transient + lockdown + App-ID-derived GUID must be pairwise
+    // distinct: two filters sharing a key means the second add
     // silently clobbers the first (FwpmFilterAdd0 keys on filterKey). GUID
     // derives Hash + Eq, so collect directly (no to_u128 — it doesn't exist).
     let mut all: Vec<GUID> = FILTER_GUIDS.to_vec();
@@ -410,4 +410,109 @@ fn every_emitted_filter_guid_is_in_its_sweep_set() {
             );
         }
     }
+}
+
+// address-range loopback permits at CONNECT ===========================================================================
+
+#[skuld::test]
+fn both_specs_permit_loopback_by_address_range_at_connect() {
+    // The IS_LOOPBACK flag is not reliably set at ALE_AUTH_CONNECT in CI's
+    // elevated lane, so the flag permit alone leaves loopback connects denied by
+    // block-all. An address-range permit keyed on the connect's DESTINATION
+    // matches deterministically: 127.0.0.0/8 on CONNECT V4, ::1/128 on CONNECT V6.
+    for s in [
+        build_cover_spec(v4()),
+        build_lockdown_spec(v4(), luid(), &[plugin_path()]),
+    ] {
+        let v4_net = s.filters.iter().any(|f| {
+            f.layer == Layer::ConnectV4
+                && f.action == Action::Permit
+                && f.hard
+                && f.weight == PERMIT_WEIGHT
+                && f.condition == Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+        });
+        assert!(
+            v4_net,
+            "address-range loopback permit (127.0.0.0/8) missing on CONNECT V4"
+        );
+        let v6_net = s.filters.iter().any(|f| {
+            f.layer == Layer::ConnectV6
+                && f.action == Action::Permit
+                && f.hard
+                && f.weight == PERMIT_WEIGHT
+                && f.condition == Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
+        });
+        assert!(v6_net, "address-range loopback permit (::1/128) missing on CONNECT V6");
+    }
+}
+
+#[skuld::test]
+fn flag_loopback_permits_are_kept_alongside_the_address_range_ones() {
+    // The address-range permits are ADDITIVE belt-and-suspenders: the flag permits
+    // on all four ALE layers must still be present (the diagnosis keeps both).
+    let s = build_cover_spec(v4());
+    let flag_permits = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
+        .count();
+    assert_eq!(
+        flag_permits, 4,
+        "flag loopback permits (CONNECT + RECV_ACCEPT, V4+V6) kept"
+    );
+}
+
+#[skuld::test]
+fn new_loopbacknet_guids_are_in_their_sweep_floors_and_distinct() {
+    // The new address-range loopback GUIDs are part of the fail-closed FLOOR:
+    // the transient sweep (delete_all iterates FILTER_GUIDS) and the lockdown
+    // sweep (swept_lockdown_guids) must both delete them. They must also be
+    // distinct from every prior GUID (a shared key silently clobbers).
+    let cover = build_cover_spec(v4());
+    for f in cover
+        .filters
+        .iter()
+        .filter(|f| matches!(f.condition, Condition::LoopbackNet(_)))
+    {
+        assert!(
+            FILTER_GUIDS.contains(&f.guid),
+            "transient LoopbackNet GUID {:?} must be in FILTER_GUIDS (transient sweep)",
+            f.guid
+        );
+    }
+    let swept: std::collections::HashSet<GUID> = swept_lockdown_guids().into_iter().collect();
+    let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
+    for f in lock
+        .filters
+        .iter()
+        .filter(|f| matches!(f.condition, Condition::LoopbackNet(_)))
+    {
+        assert!(
+            swept.contains(&f.guid),
+            "lockdown LoopbackNet GUID {:?} must be swept",
+            f.guid
+        );
+    }
+}
+
+#[skuld::test]
+fn adopt_does_not_delete_the_address_range_loopback_floor() {
+    // The address-range loopback permits are floor, not volatile: Adopt must keep
+    // them (only the TUN-LUID + server-IP pairs are dropped). adopt_delete_guids
+    // is keyed on the [2,3] / [4,5] indices, which the appended GUIDs do not touch.
+    let adopt: std::collections::HashSet<GUID> = adopt_delete_guids().into_iter().collect();
+    let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
+    for f in lock
+        .filters
+        .iter()
+        .filter(|f| matches!(f.condition, Condition::LoopbackNet(_)))
+    {
+        assert!(
+            !adopt.contains(&f.guid),
+            "Adopt must NOT delete the address-range loopback floor {:?}",
+            f.guid
+        );
+    }
+    // Adopt still drops exactly the four volatile permits — unchanged by this fix.
+    assert_eq!(adopt.len(), 4, "adopt_delete_guids unchanged: TUN V4/V6 + server V4/V6");
 }

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -79,23 +79,18 @@ fn spec_permits_v6_server_on_v6_layer_only() {
     assert_eq!(server_permits[0].layer, Layer::ConnectV6);
 }
 
+// Arbitration within our single sublayer is pure weight (no CLEAR_ACTION_RIGHT on
+// any filter): the permits must outweigh block-all, else block-all wins and the
+// cover blocks everything. A compile-time invariant, not a runtime check.
+const _: () = assert!(PERMIT_WEIGHT > BLOCK_WEIGHT);
+
 #[skuld::test]
-fn permit_filters_are_hard_and_outweigh_block() {
+fn permit_filters_outweigh_block() {
     let s = build_cover_spec(v4());
     for f in &s.filters {
         match f.action {
-            Action::Permit => {
-                assert!(
-                    f.hard,
-                    "permits must be hard (CLEAR_ACTION_RIGHT) so other firewalls can't veto"
-                );
-                assert_eq!(f.weight, PERMIT_WEIGHT);
-                assert!(f.weight > BLOCK_WEIGHT, "permit must outweigh block in our sublayer");
-            }
-            Action::Block => {
-                assert!(!f.hard);
-                assert_eq!(f.weight, BLOCK_WEIGHT);
-            }
+            Action::Permit => assert_eq!(f.weight, PERMIT_WEIGHT),
+            Action::Block => assert_eq!(f.weight, BLOCK_WEIGHT),
         }
     }
 }
@@ -178,18 +173,13 @@ fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
 }
 
 #[skuld::test]
-fn lockdown_spec_permits_are_hard_and_outweigh_block() {
+fn lockdown_spec_permits_outweigh_block() {
+    // Weight-only arbitration in one sublayer (see the const assert above).
     let s = build_lockdown_spec(v6(), luid(), &[plugin_path()]);
     for f in &s.filters {
         match f.action {
-            Action::Permit => {
-                assert!(f.hard, "lockdown permits must be hard (CLEAR_ACTION_RIGHT)");
-                assert_eq!(f.weight, PERMIT_WEIGHT);
-            }
-            Action::Block => {
-                assert!(!f.hard);
-                assert_eq!(f.weight, BLOCK_WEIGHT);
-            }
+            Action::Permit => assert_eq!(f.weight, PERMIT_WEIGHT),
+            Action::Block => assert_eq!(f.weight, BLOCK_WEIGHT),
         }
     }
 }
@@ -355,14 +345,14 @@ fn both_specs_permit_loopback_recv_accept_by_address_range() {
         assert!(
             s.filters.iter().any(|f| f.layer == Layer::RecvAcceptV4
                 && f.action == Action::Permit
-                && f.hard
+                && f.weight == PERMIT_WEIGHT
                 && f.condition == Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))),
             "address-range loopback permit (127.0.0.0/8) missing on RECV_ACCEPT V4"
         );
         assert!(
             s.filters.iter().any(|f| f.layer == Layer::RecvAcceptV6
                 && f.action == Action::Permit
-                && f.hard
+                && f.weight == PERMIT_WEIGHT
                 && f.condition == Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))),
             "address-range loopback permit (::1/128) missing on RECV_ACCEPT V6"
         );
@@ -441,7 +431,6 @@ fn both_specs_permit_loopback_by_address_range_at_connect() {
         let v4_net = s.filters.iter().any(|f| {
             f.layer == Layer::ConnectV4
                 && f.action == Action::Permit
-                && f.hard
                 && f.weight == PERMIT_WEIGHT
                 && f.condition == Condition::LoopbackNet(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
         });
@@ -452,7 +441,6 @@ fn both_specs_permit_loopback_by_address_range_at_connect() {
         let v6_net = s.filters.iter().any(|f| {
             f.layer == Layer::ConnectV6
                 && f.action == Action::Permit
-                && f.hard
                 && f.weight == PERMIT_WEIGHT
                 && f.condition == Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
         });

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -84,3 +84,102 @@ fn spec_uses_the_fixed_hole_guids() {
     assert_eq!(s.provider, PROVIDER_GUID);
     assert_eq!(s.sublayer, SUBLAYER_GUID);
 }
+
+// build_lockdown_spec =================================================================================================
+
+fn luid() -> u64 {
+    0x0000_0006_0000_0000 // a representative NET_LUID value
+}
+fn plugin_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(r"C:\Program Files\Hole\ex-ray.exe")
+}
+fn bridge_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(r"C:\Program Files\Hole\hole.exe")
+}
+
+#[skuld::test]
+fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
+    let s = build_lockdown_spec(v4(), luid(), &[plugin_path(), bridge_path()]);
+    // loopback on both layers
+    let loopback = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::Loopback))
+        .count();
+    assert_eq!(loopback, 2, "loopback permit on V4 and V6");
+    // local-interface (TUN LUID) permit on both layers
+    let tun = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::LocalInterface(l) if l == luid()))
+        .count();
+    assert_eq!(tun, 2, "TUN LUID permit on V4 and V6");
+    // one AppId permit per binary, on both layers
+    let appids = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::AppId(_)))
+        .count();
+    assert_eq!(appids, 4, "two binaries x V4+V6");
+    // server permit, on the v4 layer only
+    let server: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIp(_)))
+        .collect();
+    assert_eq!(server.len(), 1);
+    assert_eq!(server[0].layer, Layer::ConnectV4);
+    // block-all on both layers
+    assert!(s
+        .filters
+        .iter()
+        .any(|f| f.layer == Layer::ConnectV4 && f.action == Action::Block));
+    assert!(s
+        .filters
+        .iter()
+        .any(|f| f.layer == Layer::ConnectV6 && f.action == Action::Block));
+}
+
+#[skuld::test]
+fn lockdown_spec_permits_are_hard_and_outweigh_block() {
+    let s = build_lockdown_spec(v6(), luid(), &[plugin_path()]);
+    for f in &s.filters {
+        match f.action {
+            Action::Permit => {
+                assert!(f.hard, "lockdown permits must be hard (CLEAR_ACTION_RIGHT)");
+                assert_eq!(f.weight, PERMIT_WEIGHT);
+            }
+            Action::Block => {
+                assert!(!f.hard);
+                assert_eq!(f.weight, BLOCK_WEIGHT);
+            }
+        }
+    }
+}
+
+#[skuld::test]
+fn lockdown_spec_uses_distinct_guids_from_transient_cover() {
+    let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
+    let cover = build_cover_spec(v4());
+    let lock_guids: std::collections::HashSet<_> = lock.filters.iter().map(|f| f.guid).collect();
+    let cover_guids: std::collections::HashSet<_> = cover.filters.iter().map(|f| f.guid).collect();
+    assert!(
+        lock_guids.is_disjoint(&cover_guids),
+        "lockdown and transient covers must use disjoint filter GUIDs so recovery sweeps both unconditionally"
+    );
+    // shared provider + sublayer (one Hole sublayer)
+    assert_eq!(lock.provider, PROVIDER_GUID);
+    assert_eq!(lock.sublayer, SUBLAYER_GUID);
+}
+
+#[skuld::test]
+fn lockdown_spec_v6_server_lands_on_v6_layer() {
+    let s = build_lockdown_spec(v6(), luid(), &[plugin_path()]);
+    let server: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIp(_)))
+        .collect();
+    assert_eq!(server.len(), 1);
+    assert_eq!(server[0].layer, Layer::ConnectV6);
+}

--- a/crates/tun-engine/src/routing_tests.rs
+++ b/crates/tun-engine/src/routing_tests.rs
@@ -311,7 +311,7 @@ fn recover_without_state_file_is_a_noop() {
     // bridge.
     let tmp = tempfile::tempdir().unwrap();
     let log: RefCell<Captured> = RefCell::new(Vec::new());
-    recover_routes_with(tmp.path(), capturing_runner(&log), |_| {});
+    recover_routes_with(tmp.path(), capturing_runner(&log), |_| {}, false, || false, |_| {});
 
     let log = log.into_inner();
     assert!(log.is_empty(), "expected no commands with no state file, got {log:?}");
@@ -330,7 +330,7 @@ fn recover_with_state_file_runs_split_then_bypass_then_clears() {
     state::save(tmp.path(), &persisted_state).unwrap();
 
     let log: RefCell<Captured> = RefCell::new(Vec::new());
-    recover_routes_with(tmp.path(), capturing_runner(&log), |_| {});
+    recover_routes_with(tmp.path(), capturing_runner(&log), |_| {}, false, || false, |_| {});
 
     let log = log.into_inner();
     assert_eq!(log.len(), 2, "expected split + bypass phases, got {log:?}");
@@ -355,7 +355,7 @@ fn recover_clears_state_file_even_when_runner_errors() {
 
     let failing =
         |_: &[Vec<String>], _: &str| -> std::io::Result<()> { Err(std::io::Error::other("simulated runner failure")) };
-    recover_routes_with(tmp.path(), failing, |_| {});
+    recover_routes_with(tmp.path(), failing, |_| {}, false, || false, |_| {});
 
     assert!(
         !tmp.path().join(STATE_FILE_NAME).exists(),
@@ -370,10 +370,70 @@ fn recover_invokes_cover_sweep_even_without_route_state() {
     let tmp = tempfile::tempdir().unwrap();
     let log: RefCell<Captured> = RefCell::new(Vec::new());
     let swept = std::cell::Cell::new(false);
-    recover_routes_with(tmp.path(), capturing_runner(&log), |_| swept.set(true));
+    recover_routes_with(
+        tmp.path(),
+        capturing_runner(&log),
+        |_| swept.set(true),
+        false,
+        || false,
+        |_| {},
+    );
 
     assert!(log.into_inner().is_empty(), "no route-state file => no route commands");
     assert!(swept.get(), "recover_routes_with must invoke the cover sweep");
+}
+
+// recover_routes_with lockdown wiring =================================================================================
+
+#[skuld::test]
+fn recover_sweeps_lockdown_when_intent_off_and_present() {
+    // NO route-state file — proves the lockdown decision is decoupled from
+    // bridge-routes.json (keyed on the injected presence probe instead).
+    let tmp = tempfile::tempdir().unwrap();
+    let log: RefCell<Captured> = RefCell::new(Vec::new());
+    let decided: std::cell::Cell<Option<CoverRecovery>> = std::cell::Cell::new(None);
+    recover_routes_with(
+        tmp.path(),
+        capturing_runner(&log),
+        |_| {},
+        false,
+        || true,
+        |decision| decided.set(Some(decision)),
+    );
+    assert_eq!(decided.get(), Some(CoverRecovery::Sweep));
+}
+
+#[skuld::test]
+fn recover_adopts_lockdown_when_intent_on_and_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log: RefCell<Captured> = RefCell::new(Vec::new());
+    let decided: std::cell::Cell<Option<CoverRecovery>> = std::cell::Cell::new(None);
+    recover_routes_with(
+        tmp.path(),
+        capturing_runner(&log),
+        |_| {},
+        true,
+        || true,
+        |d| decided.set(Some(d)),
+    );
+    assert_eq!(decided.get(), Some(CoverRecovery::Adopt));
+}
+
+#[skuld::test]
+fn recover_lockdown_noop_when_cover_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log: RefCell<Captured> = RefCell::new(Vec::new());
+    let decided: std::cell::Cell<Option<CoverRecovery>> = std::cell::Cell::new(None);
+    // Probe says no cover present => Noop regardless of intent.
+    recover_routes_with(
+        tmp.path(),
+        capturing_runner(&log),
+        |_| {},
+        true,
+        || false,
+        |d| decided.set(Some(d)),
+    );
+    assert_eq!(decided.get(), Some(CoverRecovery::Noop), "absent cover => Noop");
 }
 
 // decide_cover_recovery ===============================================================================================

--- a/crates/tun-engine/src/routing_tests.rs
+++ b/crates/tun-engine/src/routing_tests.rs
@@ -375,3 +375,21 @@ fn recover_invokes_cover_sweep_even_without_route_state() {
     assert!(log.into_inner().is_empty(), "no route-state file => no route commands");
     assert!(swept.get(), "recover_routes_with must invoke the cover sweep");
 }
+
+// decide_cover_recovery ===============================================================================================
+
+#[skuld::test]
+fn cover_recovery_on_and_present_adopts() {
+    assert_eq!(decide_cover_recovery(true, true), CoverRecovery::Adopt);
+}
+
+#[skuld::test]
+fn cover_recovery_off_and_present_sweeps() {
+    assert_eq!(decide_cover_recovery(false, true), CoverRecovery::Sweep);
+}
+
+#[skuld::test]
+fn cover_recovery_absent_is_noop_regardless_of_intent() {
+    assert_eq!(decide_cover_recovery(true, false), CoverRecovery::Noop);
+    assert_eq!(decide_cover_recovery(false, false), CoverRecovery::Noop);
+}


### PR DESCRIPTION
Part of #527 (PR1 of 3). First step of the in-place-update rework.

## What

Adds a real, opt-in **kill switch** ("lockdown mode"). When on, all egress is
blocked except the tunnel (`hole-tun`), the SS server, and loopback — and the
block is a **persistent OS-level filter that outlives the bridge process**, so a
crash/restart no longer leaks. Default off ⇒ behavior is byte-identical to today.

This promotes the transient cutover cover (#521) into a standing feature; the
transient cover is left unchanged for PR2's cutover.

## Design

- **Windows (WFP):** `build_lockdown_spec` — per family (V4+V6) at
  `ALE_AUTH_CONNECT`: permit loopback, the `hole-tun` LUID (carries tunneled app
  traffic), the plugin+bridge **App-IDs** (the onward server connection, robust to
  DNS re-resolution), and the server IP (defense-in-depth); block all else.
- **macOS (pf):** authoritative **main-ruleset-replace** (an anchor would
  parse-fail on `set` and leak past a host `pass out quick` — confirmed against
  `pf.conf(5)` and Mullvad's source). `set` at top, host NAT carried forward,
  every rule `quick`, IPv6 blocked, server-IP + TUN permits, `block drop out quick
  all` base; snapshot/restore via `bridge-lockdown-pf.json`.
- **Bridge-owned intent** (`bridge-lockdown.json`, last-writer-wins) so multi-user
  clients can't desync; engaged as a standing `RunningState` guard (after routes,
  before DNS; **fail-FATAL** under lockdown-on); disengaged on user stop.
- **Crash recovery:** `decide_cover_recovery` → `Adopt` keeps the host fail-closed
  across a restart and refreshes only the volatile permits; `Sweep` fully restores
  when intent is off. Keyed on the cover's own evidence, not `bridge-routes.json`.
- **Surface:** `SetLockdown` IPC + `/v1/lockdown`; `lockdown_enabled`/`active` on
  `StatusResponse` (serde-default for old clients); tray toggle rendering
  `enabled && !active` as a warning via the ordered-commit `ProxySnapshot`.

## Verification

Local (Windows box): `tun-engine` 110 pass, `hole-common`/`hole-bridge`(lockdown,
status)/`hole`(tray, snapshot) green, `clippy -D warnings` clean (incl.
`--target aarch64-apple-darwin` for the macOS production code). macOS pf runtime
and the privileged real-engage "egress actually blocked" tests run on CI's TUN
lanes (Windows + a new root macOS lane; fail-loud unprivileged, opt out with
`SKULD_LABELS="!tun"`).

## Deferred (explicitly, not silently)

- End-to-end NIC-capture UDP no-leak proof → **PR2**.
- Dashboard/webview lockdown UI + a CLI toggle → **PR3**.
- macOS reboot→first-connect window (needs an early-boot block) → Decision C-b
  (block-when-disconnected), already agreed as deferred.
