### PR TITLE
fix(test): keep galoshes ss-server alive so bridge e2e don't truncate (#518)

### DIFF
--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1129,13 +1129,13 @@ mod proxy_manager_tests;
 // - **Non-galoshes** DistHarness e2e (`e2e_none`, lifecycle, cipher, and the
 //   listener-selection tests) run on every Hole platform (Win+mac).
 // - **galoshes-fronted** tests front a galoshes *server* via the garter
-//   `ChainRunner` launcher (`plugin_e2e::ssserver`). They are all `#[ignore]`d:
-//   galoshes plugin data delivery is flaky on CI — the roundtrips truncate
-//   intermittently across every transport (#518; the bridge itself is correct).
-//   They compile on their real platforms (WS on Win+mac, WS-TLS and QUIC on
-//   macOS only for the Windows custom-cert limit, the full-tunnel test on the
-//   Windows TUN lane) and run again once #518 is fixed. galoshes transport
-//   coverage proper lives in the `plugin-e2e` crate.
+//   `ChainRunner` launcher (`plugin_e2e::ssserver`), which the `SsServerHandle`
+//   fixture keeps alive for the test's lifetime. They run on **macOS**, where
+//   they are reliable. All are gated off the Windows lane pending fixes: the
+//   socks-only WS/IPv6 roundtrips and UDP-associate hit an intermittent Windows
+//   bridge-e2e stall (#542 / #543 for UDP), the full-tunnel TUN test hangs
+//   (#541), and WS-TLS/QUIC are macOS-only anyway (Windows custom-cert limit).
+//   galoshes transport coverage on Windows lives in the `plugin-e2e` crate.
 #[cfg(test)]
 #[path = "proxy_manager_e2e_tests.rs"]
 mod proxy_manager_e2e_tests;

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -219,11 +219,15 @@ fn e2e_metrics_report_tunnel_traffic(
 
 /// Test 2: SocksOnly mode with galoshes (websocket, no TLS).
 ///
-/// `#[ignore]`: galoshes-fronted bridge roundtrips truncate intermittently on
-/// macOS CI (all transports) — see bindreams/hole#518. The galoshes WS transport
-/// proper is covered by `plugin-e2e`'s `galoshes_ws_roundtrip`.
+/// Gated off Windows: the Windows bridge-e2e lane intermittently stalls
+/// 600–740s, and the galoshes/ex-ray chain's internal timeouts fire under the
+/// stall → truncated response. Reliable on macOS; the galoshes WS transport is
+/// covered on Windows by `plugin-e2e`. See bindreams/hole#542.
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-#[ignore = "galoshes bridge e2e flaky on CI (truncated responses) — see bindreams/hole#518"]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "galoshes bridge e2e truncates under the Windows bridge-e2e stall — see bindreams/hole#542"
+)]
 fn e2e_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,
@@ -288,12 +292,8 @@ fn e2e_galoshes_chain_reports_udp_available(
 /// Test 3: SocksOnly mode with galoshes (websocket + TLS). `cfg(not(windows))`:
 /// the server presents a self-signed cert and v2ray-core's `getCertPool` drops
 /// custom certs on Windows (same limit as `plugin-e2e`'s `galoshes_ws_tls_roundtrip`).
-///
-/// `#[ignore]`: galoshes-fronted bridge roundtrips are flaky on CI — see
-/// bindreams/hole#518.
 #[cfg(not(target_os = "windows"))]
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-#[ignore = "galoshes bridge e2e flaky on CI (truncated responses) — see bindreams/hole#518"]
 fn e2e_ws_tls_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws_tls)] ss: &SsServerHandle,
@@ -305,13 +305,8 @@ fn e2e_ws_tls_socks_only_roundtrip(
 /// Test 4: SocksOnly mode with galoshes (QUIC, auto-TLS). Off Windows: QUIC
 /// auto-enables TLS and v2ray-core's `getCertPool` drops the custom cert on
 /// Windows (same limit as `e2e_ws_tls_socks_only_roundtrip`).
-///
-/// `#[ignore]`: galoshes' QUIC (UDP) transport is unreliable on CI runners — the
-/// roundtrip truncates on macOS. Part of the galoshes UDP-flow-on-CI family;
-/// un-ignore once that is fixed. See bindreams/hole#518.
 #[cfg(not(target_os = "windows"))]
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-#[ignore = "galoshes QUIC transport unreliable on CI (truncated roundtrip) — see bindreams/hole#518"]
 fn e2e_quic_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_quic)] ss: &SsServerHandle,
@@ -410,10 +405,12 @@ mod tun {
     /// Test 6: Full mode with galoshes (websocket). Windows-admin only — the
     /// enclosing `mod tun` is `cfg(target_os = "windows")` and TUN needs elevation.
     ///
-    /// `#[ignore]`: galoshes-fronted bridge roundtrips are flaky on CI — see
-    /// bindreams/hole#518.
+    /// `#[ignore]`: deterministically hangs — the galoshes-fronted full-tunnel
+    /// chain never completes one half-close, so the SOCKS5-seam
+    /// `copy_bidirectional` waits forever. The no-plugin full-tunnel path
+    /// (`e2e_none_full_tunnel_roundtrip`) passes. See bindreams/hole#541.
     #[skuld::test(labels = [DIST_BIN, PORT_ALLOC, TUN], serial = TUN)]
-    #[ignore = "galoshes bridge e2e flaky on CI (truncated responses) — see bindreams/hole#518"]
+    #[ignore = "galoshes full-tunnel roundtrip hangs (half-close not propagated) — see bindreams/hole#541"]
     fn e2e_ws_full_tunnel_roundtrip(
         #[fixture(dist_dir)] dist: &Path,
         #[fixture(ssserver_ws)] ss: &SsServerHandle,
@@ -675,10 +672,14 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
 
 /// Test 13: ws plugin, SocksOnly mode, IPv6 HTTP target on `[::1]`.
 ///
-/// `#[ignore]`: galoshes-fronted bridge roundtrips are flaky on CI — see
-/// bindreams/hole#518.
+/// Gated off Windows for the same reason as `e2e_ws_socks_only_roundtrip` (the
+/// intermittent Windows bridge-e2e stall truncates the galoshes chain). Runs on
+/// macOS. See bindreams/hole#542.
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC, IPV6], serial = IPV6)]
-#[ignore = "galoshes bridge e2e flaky on CI (truncated responses) — see bindreams/hole#518"]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "galoshes bridge e2e truncates under the Windows bridge-e2e stall — see bindreams/hole#542"
+)]
 fn ipv6_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,

--- a/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_listener_e2e_tests.rs
@@ -429,11 +429,14 @@ mod socks_only_udp {
 
     /// galoshes (WS) carries SOCKS5 UDP ASSOCIATE over its yamux mux.
     ///
-    /// `#[ignore]`: galoshes' UDP transport detection is flaky on CI — the chain
-    /// intermittently reports TCP-only, so the bridge sets `udp_proxy_available =
-    /// false` and drops the flow. Un-ignore once that is fixed. See bindreams/hole#518.
+    /// Gated off Windows: the UDP **reply** leg is intermittently lost on the
+    /// Windows CI lane ("SOCKS5 UDP reply timeout"); it runs reliably on macOS.
+    /// See bindreams/hole#543.
     #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-    #[ignore = "galoshes UDP transport detection flaky on CI — see bindreams/hole#518"]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "galoshes SOCKS5 UDP reply leg flaky on Windows CI — see bindreams/hole#543"
+    )]
     fn e2e_socks_only_udp_associate_galoshes(
         #[fixture(dist_dir)] dist: &Path,
         #[fixture(ssserver_ws)] ss: &SsServerHandle,

--- a/crates/bridge/src/test_support/skuld_fixtures.rs
+++ b/crates/bridge/src/test_support/skuld_fixtures.rs
@@ -63,18 +63,29 @@ use plugin_e2e::certs::{path_for_plugin_opts, TestCerts};
 use plugin_e2e::locators::locate_built_galoshes;
 use plugin_e2e::ssserver::{
     start_real_ss_server, start_real_ss_server_with_plugin_quic, start_real_ss_server_with_plugin_ws,
-    start_real_ss_server_with_plugin_ws_tls, TEST_METHOD, TEST_METHOD_STR, TEST_PASSWORD,
+    start_real_ss_server_with_plugin_ws_tls, PluginServer, TEST_METHOD, TEST_METHOD_STR, TEST_PASSWORD,
 };
 use std::net::SocketAddr;
 
 /// Common shape for every `ssserver_*` fixture. Owns the tokio runtime that
 /// the server task runs on; dropping the struct shuts down the runtime.
+///
+/// For the plugin variants it ALSO owns the [`PluginServer`] handle: its
+/// `Drop` cancels the galoshes/ex-ray server chain, so the handle must live
+/// as long as the fixture. Dropping it at setup time (the previous bug)
+/// tore the server subprocess down before any test connected — the bridge
+/// client's WS dial was then refused and every response truncated
+/// (bindreams/hole#518). `None` for the no-plugin `ssserver_none`.
 pub(crate) struct SsServerHandle {
     pub addr: SocketAddr,
     pub method: &'static str,
     pub password: String,
     pub plugin: Option<String>,
     pub plugin_opts: Option<String>,
+    // Drop guard: its `Drop` cancels the server chain. Declared before
+    // `_runtime` so the cancel is observed before the runtime aborts the task;
+    // subprocess reaping is guaranteed regardless by garter's `kill_on_drop`.
+    _plugin_server: Option<PluginServer>,
     _runtime: tokio::runtime::Runtime,
 }
 
@@ -114,6 +125,7 @@ pub(crate) fn ssserver_none() -> Result<SsServerHandle, String> {
         password: TEST_PASSWORD.to_string(),
         plugin: None,
         plugin_opts: None,
+        _plugin_server: None,
         _runtime: runtime,
     })
 }
@@ -123,16 +135,15 @@ pub(crate) fn ssserver_none() -> Result<SsServerHandle, String> {
 pub(crate) fn ssserver_ws() -> Result<SsServerHandle, String> {
     let plugin_path = require_galoshes();
     let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
-    let addr = runtime.block_on(async {
-        let (addr, _handle) = start_real_ss_server_with_plugin_ws(TEST_METHOD, TEST_PASSWORD, &plugin_path).await;
-        addr
-    });
+    let (addr, server) =
+        runtime.block_on(async { start_real_ss_server_with_plugin_ws(TEST_METHOD, TEST_PASSWORD, &plugin_path).await });
     Ok(SsServerHandle {
         addr,
         method: TEST_METHOD_STR,
         password: TEST_PASSWORD.to_string(),
         plugin: Some("galoshes".to_string()),
         plugin_opts: Some("host=cloudfront.com;path=/".to_string()),
+        _plugin_server: Some(server),
         _runtime: runtime,
     })
 }
@@ -147,10 +158,8 @@ pub(crate) fn ssserver_ws_tls(#[fixture(test_certs)] certs: &TestCerts) -> Resul
         path_for_plugin_opts(&certs.cert_path),
         path_for_plugin_opts(&certs.key_path)
     );
-    let addr = runtime.block_on(async {
-        let (addr, _handle) =
-            start_real_ss_server_with_plugin_ws_tls(TEST_METHOD, TEST_PASSWORD, &plugin_path, certs).await;
-        addr
+    let (addr, server) = runtime.block_on(async {
+        start_real_ss_server_with_plugin_ws_tls(TEST_METHOD, TEST_PASSWORD, &plugin_path, certs).await
     });
     Ok(SsServerHandle {
         addr,
@@ -158,6 +167,7 @@ pub(crate) fn ssserver_ws_tls(#[fixture(test_certs)] certs: &TestCerts) -> Resul
         password: TEST_PASSWORD.to_string(),
         plugin: Some("galoshes".to_string()),
         plugin_opts: Some(plugin_opts),
+        _plugin_server: Some(server),
         _runtime: runtime,
     })
 }
@@ -173,10 +183,8 @@ pub(crate) fn ssserver_quic(#[fixture(test_certs)] certs: &TestCerts) -> Result<
         path_for_plugin_opts(&certs.cert_path),
         path_for_plugin_opts(&certs.key_path)
     );
-    let addr = runtime.block_on(async {
-        let (addr, _handle) =
-            start_real_ss_server_with_plugin_quic(TEST_METHOD, TEST_PASSWORD, &plugin_path, certs).await;
-        addr
+    let (addr, server) = runtime.block_on(async {
+        start_real_ss_server_with_plugin_quic(TEST_METHOD, TEST_PASSWORD, &plugin_path, certs).await
     });
     Ok(SsServerHandle {
         addr,
@@ -184,6 +192,7 @@ pub(crate) fn ssserver_quic(#[fixture(test_certs)] certs: &TestCerts) -> Result<
         password: TEST_PASSWORD.to_string(),
         plugin: Some("galoshes".to_string()),
         plugin_opts: Some(plugin_opts),
+        _plugin_server: Some(server),
         _runtime: runtime,
     })
 }


### PR DESCRIPTION
## Problem

The 6 galoshes-fronted `DistHarness` e2e tests were `#[ignore]`d as "flaky on CI — truncated responses (#518)". The framing blamed galoshes plugin data delivery / relay truncation; the bridge was assumed correct.

## Root cause (not what the issue assumed)

A **test-fixture bug**. `crates/bridge/src/test_support/skuld_fixtures.rs` built the galoshes-fronted ss-servers as:

```rust
let (addr, _handle) = start_real_ss_server_with_plugin_ws(...).await;  // _handle DROPPED
addr
```

`_handle` is a `plugin_e2e::ssserver::PluginServer` whose `Drop` **cancels the galoshes/ex-ray server chain**. Dropping it at fixture-setup time tore the server subprocess down immediately, so the bridge client's inner ex-ray WebSocket dial got `connection refused` — every response was empty/truncated (no `\r\n\r\n`). The teardown is a race, which is why it was **deterministic locally but intermittent on CI**. Introduced by PR #515's fixture wiring.

Confirmed by a deterministic local Windows reproduction + ex-ray debug logs (`failed to dial ws://…: connection actively refused`). Notably, the previously-suspected `relay_tcp`/`copy_bidirectional` change does **not** fix it (verified); holding the handle alone does.

## Fix

Hold the `PluginServer` handle in `SsServerHandle` for its lifetime (field declared before `_runtime` so the cooperative cancel is observed before the runtime aborts the task), and un-ignore the galoshes-fronted bridge e2e tests **on macOS**, where they are reliable:

- `e2e_ws_socks_only_roundtrip`
- `e2e_ws_tls_socks_only_roundtrip` (macOS only — Windows custom-cert limit)
- `e2e_quic_socks_only_roundtrip` (macOS only — same)
- `ipv6_ws_socks_only_roundtrip`
- `e2e_socks_only_udp_associate_galoshes`

…plus removal of the now-stale flake-narration comments.

The macOS lane now has full galoshes-bridge-e2e coverage (previously zero — all 6 were `#[ignore]`d). On **Windows**, these tests are gated off (see below) because of an unrelated, intermittent Windows bridge-e2e stall; the galoshes **transport** is still covered on Windows by the green `plugin-e2e` crate, so net coverage strictly increases.

## Deferred follow-ups (kept `#[ignore]`d, separately tracked)

- **#541** — `e2e_ws_full_tunnel_roundtrip` (Windows TUN) **deterministically hangs**: a half-close does not propagate end-to-end through the galoshes-fronted full-tunnel chain, so the SOCKS5-seam `copy_bidirectional` waits forever. The no-plugin full-tunnel path passes. Repointed its `#[ignore]` from #518 → #541.
- **#542** — the **Windows bridge-e2e lane intermittently stalls 600–740s per test** (prime suspect: bridge startup `netsh`/`pnputil` diagnostics); the galoshes/ex-ray chain's internal timeouts fire under that stall → truncated response. No-plugin bridge-e2e tests survive the same stall (no timeout) — they just run slow. A *different* galoshes test fails each run. `e2e_ws_socks_only_roundtrip` + `ipv6_ws_socks_only_roundtrip` are gated off Windows via `#[cfg_attr(target_os = "windows", ignore)]`.
- **#543** — `e2e_socks_only_udp_associate_galoshes` intermittently loses its UDP **reply** leg on Windows ("SOCKS5 UDP reply timeout"). Gated off Windows via `#[cfg_attr(target_os = "windows", ignore)]` — still runs on macOS.

Each gate runs the test on macOS (un-orphaned) and skips only the Windows lane where the residual manifests, with a pointer to the tracking issue.

## Verification

Clean fix commit, CI `Test hole`:
- macOS amd64 + arm64: **pass** — full galoshes-bridge-e2e coverage (ws / ws-tls / quic / ipv6 / udp-associate).
- Windows amd64: galoshes-bridge-e2e gated off (ws/ipv6 → #542, udp-associate → #543, full-tunnel → #541); no-plugin bridge e2e + everything else run.

Fixes #518.
