### PR TITLE
fix(bridge): honor galoshes sitrep transports via ExpectSitrep (#536)

### DIFF
--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -253,7 +253,7 @@ async fn spawn_plugin_runner_at(
     ),
     ProxyError,
 > {
-    let mut plugin = garter::BinaryPlugin::new(plugin_path, merged_opts);
+    let mut plugin = garter::BinaryPlugin::new(plugin_path, merged_opts).readiness(readiness_for(plugin_name));
 
     if let Some(dir) = state_dir {
         let dir = dir.to_path_buf();
@@ -422,20 +422,39 @@ fn proxy_err_to_io_err(e: ProxyError) -> std::io::Error {
 ///
 /// Per-plugin syntax differs:
 ///
-/// - **`v2ray-plugin`** / **`ex-ray`**: appends `loglevel=debug`
-///   (semicolon-separated). Both honor the LAST occurrence of any
-///   duplicate key (same v2ray-core log config), so a user's earlier
-///   `loglevel=warning` still loses to our debug. The friendly wire name
-///   `v2ray-plugin` resolves to the first-party `ex-ray` binary
-///   (`hole_common::plugin`), but a config may also name `ex-ray`
-///   directly; this arm covers both spellings (#414).
-/// - Anything else: pass through unchanged. (`galoshes` is a Rust
-///   `ChainPlugin` and not started via this binary path; future binary
-///   plugins can be added here.)
+/// - **`v2ray-plugin`** / **`ex-ray`** / **`galoshes`**: appends
+///   `loglevel=debug` (semicolon-separated). v2ray-core honors the LAST
+///   occurrence of any duplicate key, so a user's earlier `loglevel=warning`
+///   still loses to our debug. The friendly wire name `v2ray-plugin` resolves
+///   to the first-party `ex-ray` binary (`hole_common::plugin`), but a config
+///   may also name `ex-ray` directly; this arm covers both spellings (#414).
+///   `galoshes` ignores the key itself but forwards the whole options string to
+///   its inner ex-ray, so the directive reaches that hop's v2ray-core.
+/// - Anything else: pass through unchanged.
 fn inject_plugin_debug_logging(plugin_name: &str, opts: Option<&str>) -> Option<String> {
     match plugin_name {
-        "v2ray-plugin" | "ex-ray" => Some(append_sip003_directive(opts, "loglevel=debug")),
+        "v2ray-plugin" | "ex-ray" | "galoshes" => Some(append_sip003_directive(opts, "loglevel=debug")),
         _ => opts.map(String::from),
+    }
+}
+
+/// Plugin-readiness mode for the spawn.
+///
+/// Bundled plugins (galoshes, ex-ray / v2ray-plugin) speak the sitrep
+/// handshake, so [`ReadinessMode::ExpectSitrep`] reads their AUTHORITATIVE
+/// transports — the UDP-drop policy needs `tcp,udp` from galoshes, which the
+/// `Probe` self-probe (a TCP connect, hardcoded TCP-only) would discard (#536).
+/// An unknown plugin (an arbitrary binary resolved via PATH — see
+/// [`resolve_plugin_path`] / #414) may not speak sitrep, so it keeps the
+/// conservative `Probe` readiness rather than hanging until the readiness
+/// timeout waiting for a sitrep that never comes.
+///
+/// [`ReadinessMode::ExpectSitrep`]: garter::ReadinessMode::ExpectSitrep
+fn readiness_for(plugin_name: &str) -> garter::ReadinessMode {
+    if hole_common::plugin::is_known(plugin_name) {
+        garter::ReadinessMode::ExpectSitrep
+    } else {
+        garter::ReadinessMode::Probe
     }
 }
 
@@ -540,12 +559,33 @@ mod inject_tests {
     }
 
     #[skuld::test]
+    fn galoshes_existing_opts_get_loglevel_appended() {
+        // galoshes ignores `loglevel` itself but forwards the whole options
+        // string to its inner ex-ray, so the directive reaches that hop.
+        assert_eq!(
+            inject_plugin_debug_logging("galoshes", Some("host=cloudfront.com;path=/")).as_deref(),
+            Some("host=cloudfront.com;path=/;loglevel=debug"),
+        );
+    }
+
+    #[skuld::test]
     fn unknown_plugin_passes_through_unchanged() {
         assert_eq!(
             inject_plugin_debug_logging("some-future-plugin", Some("k=v")).as_deref(),
             Some("k=v")
         );
         assert_eq!(inject_plugin_debug_logging("some-future-plugin", None), None);
+    }
+
+    #[skuld::test]
+    fn readiness_known_plugins_expect_sitrep_unknown_probes() {
+        use garter::ReadinessMode;
+        // Bundled, sitrep-speaking plugins: authoritative transports.
+        assert_eq!(readiness_for("galoshes"), ReadinessMode::ExpectSitrep);
+        assert_eq!(readiness_for("v2ray-plugin"), ReadinessMode::ExpectSitrep);
+        assert_eq!(readiness_for("ex-ray"), ReadinessMode::ExpectSitrep);
+        // Arbitrary PATH plugin (may not speak sitrep): conservative probe.
+        assert_eq!(readiness_for("some-future-plugin"), ReadinessMode::Probe);
     }
 }
 

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -232,6 +232,59 @@ fn e2e_ws_socks_only_roundtrip(
     rt().block_on(run_socks_only_e2e(dist, ss, http));
 }
 
+/// #536: the bridge must honor galoshes' authoritative sitrep transports
+/// (`tcp,udp`) rather than the readiness self-probe's hardcoded TCP-only, so a
+/// galoshes chain reports `udp_proxy_available = true`. With the previous
+/// `ReadinessMode::Probe` this was always false and Full-mode galoshes UDP was
+/// wrongly dropped. Asserts the start-time chain transports via the Status
+/// endpoint — no data flow, so it is independent of the e2e roundtrip path.
+#[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
+fn e2e_galoshes_chain_reports_udp_available(
+    #[fixture(dist_dir)] dist: &Path,
+    #[fixture(ssserver_ws)] ss: &SsServerHandle,
+) {
+    rt().block_on(async {
+        let local_port = allocate_ephemeral_port(Protocols::TCP | Protocols::UDP).await;
+        let config = ProxyConfig {
+            server: entry_from(ss),
+            local_port,
+            tunnel_mode: TunnelMode::SocksOnly,
+            filters: vec![],
+            dns: hole_common::config::DnsConfig {
+                enabled: false,
+                ..hole_common::config::DnsConfig::default()
+            },
+            proxy_socks5: true,
+            proxy_http: false,
+            local_port_http: 4075,
+            diagnostic_plugin_tap: false,
+        };
+
+        let mut harness = DistHarness::spawn(dist).await.expect("spawn DistHarness");
+        let resp = harness.send(BridgeRequest::Start { config }).await.expect("send Start");
+        assert!(matches!(resp, BridgeResponse::Ack), "expected Ack, got {resp:?}");
+
+        let status = harness.send(BridgeRequest::Status).await.expect("send Status");
+        match status {
+            BridgeResponse::Status {
+                running,
+                udp_proxy_available,
+                error,
+                ..
+            } => {
+                assert!(running, "bridge not running (error: {error:?})");
+                assert!(
+                    udp_proxy_available,
+                    "galoshes chain must report UDP available — the bridge must honor the tcp,udp sitrep (ExpectSitrep)"
+                );
+            }
+            other => panic!("expected Status response, got {other:?}"),
+        }
+
+        harness.send(BridgeRequest::Stop).await.expect("send Stop");
+    });
+}
+
 /// Test 3: SocksOnly mode with galoshes (websocket + TLS). `cfg(not(windows))`:
 /// the server presents a self-signed cert and v2ray-core's `getCertPool` drops
 /// custom certs on Windows (same limit as `plugin-e2e`'s `galoshes_ws_tls_roundtrip`).


### PR DESCRIPTION
## Problem

`spawn_plugin_runner_at` (`crates/bridge/src/proxy/plugin.rs`) created the plugin chain with `garter::BinaryPlugin::new(...)` and never set a readiness mode, so it defaulted to `ReadinessMode::Probe`. In Probe mode garter's readiness comes from a TCP-connect self-probe that **hardcodes `Transports::TCP`**, discarding the plugin's authoritative sitrep `ready` transports.

galoshes emits `{"event":"ready","transports":["tcp","udp"]}` (UDP-over-yamux), but the bridge saw TCP-only → `udp_proxy_available = false`, which **wrongly drops `Proxy`-routed UDP in Full/TUN mode** for galoshes servers in production. This contradicts the documented design at `crates/common/src/plugin.rs` ("the authoritative end-to-end UDP capability comes from the plugin's reported sitrep `transports`"). Confirmed locally: with Probe a galoshes chain that emits `tcp,udp` logs `udp_proxy_available: false`; with `ExpectSitrep` it correctly reads `true`.

(SocksOnly mode does not gate on `udp_proxy_available`, so this is a Full/TUN-mode production bug, not a cause of the #518 SocksOnly e2e failures.)

## Fix

Set `.readiness(garter::ReadinessMode::ExpectSitrep)` — all bundled plugins (galoshes, ex-ray/v2ray-plugin) speak sitrep, and garter's docs recommend ExpectSitrep when authoritative transports matter (the bridge requires them). Also extend `inject_plugin_debug_logging` to galoshes (it forwards the options to its inner ex-ray's v2ray-core) and drop the now-false "galoshes is not started via this binary path" comment.

Tests: a galoshes DistHarness test asserts `udp_proxy_available == true` via the Status endpoint (start-time readiness, no data flow); a unit test covers the galoshes `loglevel=debug` injection.

Fixes #536.