### PR TITLE
WIP/investigation: Windows bridge-e2e stall — ETW opt-out (disproven, do not merge) (#542)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -835,6 +835,22 @@ The out-of-process plugin (`ex-ray`, `galoshes`) is otherwise invisible:
   `loglevel=debug` to `SS_PLUGIN_OPTIONS` for `v2ray-plugin`/`ex-ray`; stderr is
   captured via `garter::binary` and filtered by `HOLE_BRIDGE_LOG`.
 
+### ETW consumer (HOLE_BRIDGE_ETW, Windows)
+
+On Windows the bridge runs an ETW consumer
+([`diagnostics::etw`](crates/bridge/src/diagnostics/etw.rs)) that snapshots its
+own TCP/Winsock/WFP activity into `bridge.log` for bug reports. It opens a
+*system-wide* real-time trace and filters to the bridge PID in userspace.
+
+`HOLE_BRIDGE_ETW=0` (also `off`/`false`/`no`, case-insensitive, trimmed)
+disables the consumer; absent or any other value keeps it on. The stale-session
+[crash-recovery](#crash-recovery) sweep runs regardless. One bridge pays the
+trace cost once, but N concurrent bridges each re-parse every other's events —
+O(N²) — so the e2e `DistHarness` sets `HOLE_BRIDGE_ETW=0`. It is a coarse
+on/off rather than a kernel PID filter because `ferrisetw`'s
+`EventFilter::ByPids` is effective only on kernel-mode logger sessions, not the
+`UserTrace` this uses (bindreams/hole#542).
+
 ## CLI (dev/admin commands)
 
 User-facing commands are in [README.md](README.md#commands). The rest:

--- a/crates/bridge/src/diagnostics/etw.rs
+++ b/crates/bridge/src/diagnostics/etw.rs
@@ -25,18 +25,21 @@
 //!    crash-recovery snapshots. It:
 //!    a. Sweeps any stale `hole-bridge-etw-*` sessions left by a crashed
 //!    prior bridge instance ([`sweep_stale_sessions`] via the Win32
-//!    `QueryAllTracesW` + `ControlTraceW` APIs).
-//!    b. Builds three [`ferrisetw::Provider`]s with all keywords
+//!    `QueryAllTracesW` + `ControlTraceW` APIs). This always runs — it is
+//!    the crash-recovery invariant, independent of the consumer.
+//!    b. Returns `Ok(None)` if the consumer is disabled via
+//!    `HOLE_BRIDGE_ETW` (see [`etw_enabled_from`]); otherwise continues.
+//!    c. Builds three [`ferrisetw::Provider`]s with all keywords
 //!    enabled. High-volume firehose events are filtered in userspace
 //!    via [`HIGH_VOLUME_TCPIP_EVENTS`] rather than at the kernel
 //!    level — events 1004, 1077, and the rest of the SendPath family
 //!    must stay visible — see [`TCPIP_KEYWORDS`].
-//!    c. Starts a [`ferrisetw::UserTrace`] session named
+//!    d. Starts a [`ferrisetw::UserTrace`] session named
 //!    `hole-bridge-etw-<pid>` with `buffer_size = 256` KB to absorb
 //!    the wider event volume without kernel ring-buffer overrun.
-//!    d. Spawns a dedicated OS thread that calls `process_from_handle`
+//!    e. Spawns a dedicated OS thread that calls `process_from_handle`
 //!    in a blocking loop. This thread runs the per-event callback.
-//!    e. Returns an [`EtwGuard`] that owns the session + the join handle.
+//!    f. Returns `Ok(Some(`[`EtwGuard`]`))` owning the session + join handle.
 //!
 //! 2. The callback ([`handle_event`]) filters by `process_id`, extracts
 //!    a minimal shape-only [`ParsedFields`] struct from the live
@@ -257,13 +260,48 @@ pub enum EtwError {
 
 // Entry point =========================================================================================================
 
+/// Env var gating the per-bridge ETW consumer. Absent → enabled.
+const ETW_ENABLED_ENV: &str = "HOLE_BRIDGE_ETW";
+
+/// Whether the per-bridge ETW consumer should run, given the
+/// `HOLE_BRIDGE_ETW` value. Pure for unit testing.
+///
+/// Default ON (absent / empty / non-UTF-8 / unrecognized → enabled) so a
+/// real bridge keeps full diagnostics; only an explicit `0`/`off`/`false`/
+/// `no` (case-insensitive, trimmed) opts out. The consumer opens a
+/// *system-wide* real-time trace and filters to the bridge PID in userspace
+/// ([`dispatch`]): one production bridge pays that once, but N concurrent
+/// bridges (the e2e harness) each re-parse every other bridge's loopback
+/// events — O(N²), enough to starve a 4-vCPU runner — so the harness opts
+/// out. A kernel-side PID filter would localize it, but ferrisetw's
+/// `EventFilter::ByPids` is "only effective on kernel mode logger session"
+/// and unreliable even there (ferrisetw 1.2.0 `provider/event_filter.rs`;
+/// upstream n4r1b/ferrisetw#51), and this consumer uses `UserTrace`. See
+/// bindreams/hole#542.
+fn etw_enabled_from(value: Option<std::ffi::OsString>) -> bool {
+    match value.as_deref().and_then(|v| v.to_str()) {
+        Some(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "off" | "false" | "no"),
+        None => true,
+    }
+}
+
 /// Start the ETW consumer. Best-effort — returns `Err` only on
-/// infrastructure failure.
-pub fn start_consumer() -> Result<EtwGuard, EtwError> {
+/// infrastructure failure. Returns `Ok(None)` when the consumer is disabled
+/// via [`ETW_ENABLED_ENV`]; the stale-session sweep still runs (it is the
+/// crash-recovery invariant, not part of the consumer).
+pub fn start_consumer() -> Result<Option<EtwGuard>, EtwError> {
     let bridge_pid = std::process::id();
     let session_name = format!("hole-bridge-etw-{bridge_pid}");
 
+    // Sweep FIRST and unconditionally — the stale-`hole-bridge-etw-*` sweep
+    // is the crash-recovery invariant (CONTRIBUTING.md#crash-recovery),
+    // independent of whether this run goes on to consume.
     sweep_stale_sessions();
+
+    if !etw_enabled_from(std::env::var_os(ETW_ENABLED_ENV)) {
+        info!("etw: consumer disabled via {ETW_ENABLED_ENV}");
+        return Ok(None);
+    }
 
     let tcpip = Provider::by_guid(TCPIP_PROVIDER)
         .any(TCPIP_KEYWORDS)
@@ -322,11 +360,11 @@ pub fn start_consumer() -> Result<EtwGuard, EtwError> {
         .map_err(EtwError::ThreadSpawn)?;
 
     info!(session = %session_name, "etw: consumer started");
-    Ok(EtwGuard {
+    Ok(Some(EtwGuard {
         trace: Some(trace),
         thread: Some(thread),
         session_name,
-    })
+    }))
 }
 
 /// Query the live ETW session via Win32 `ControlTraceW(QUERY)` and log

--- a/crates/bridge/src/diagnostics/etw_tests.rs
+++ b/crates/bridge/src/diagnostics/etw_tests.rs
@@ -493,3 +493,35 @@ fn provider_name_unknown_returns_guid_string() {
     );
     assert_ne!(got, "unknown", "must preserve GUID, not return literal \"unknown\"");
 }
+
+// HOLE_BRIDGE_ETW toggle ==============================================================================================
+
+#[skuld::test]
+fn etw_enabled_from_defaults_on_and_honors_disable_tokens() {
+    use std::ffi::OsString;
+    // Absent → enabled: a production bridge keeps full diagnostics unless an
+    // operator (or the e2e harness) explicitly opts out.
+    assert!(etw_enabled_from(None), "absent env must enable");
+    // Explicit falsey tokens disable — case-insensitive and whitespace-trimmed.
+    for off in ["0", "off", "false", "no", "OFF", "False", "No", "  off  "] {
+        assert!(!etw_enabled_from(Some(OsString::from(off))), "{off:?} must disable");
+    }
+    // Empty and unrecognized values keep diagnostics ON (fail-safe: a typo must
+    // never silently drop observability on a real bridge).
+    for on in ["", "1", "on", "true", "yes", "offf", "garbage", " "] {
+        assert!(
+            etw_enabled_from(Some(OsString::from(on))),
+            "{on:?} must keep ETW enabled"
+        );
+    }
+}
+
+#[skuld::test]
+fn etw_enabled_from_non_utf8_keeps_enabled() {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    // A non-UTF-8 value can't be a disable token, so it must not silently turn
+    // diagnostics off. 0xD800 is an unpaired high surrogate.
+    let bad = OsString::from_wide(&[0xD800]);
+    assert!(etw_enabled_from(Some(bad)), "non-UTF-8 must keep ETW enabled");
+}

--- a/crates/bridge/src/foreground.rs
+++ b/crates/bridge/src/foreground.rs
@@ -167,13 +167,14 @@ async fn run_inner(
         }
     }
 
-    // Start the always-on ETW consumer. Held for the server's lifetime;
-    // Drop stops the session and joins the processing thread. Failure
-    // logs at error (not warn) — a silent ETW-broken customer machine
-    // is the opposite of the diagnostic goal. See diagnostics::etw.
+    // Start the ETW consumer (default-on; opt-out via HOLE_BRIDGE_ETW).
+    // Held for the server's lifetime; Drop stops the session and joins the
+    // processing thread. Failure logs at error (not warn) — a silent
+    // ETW-broken customer machine is the opposite of the diagnostic goal.
+    // See diagnostics::etw.
     #[cfg(target_os = "windows")]
     let _etw_guard = match crate::diagnostics::etw::start_consumer() {
-        Ok(g) => Some(g),
+        Ok(g) => g, // Some(guard) when running; None when disabled
         Err(e) => {
             tracing::error!(error = %e, "etw consumer failed to start");
             None

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -151,10 +151,11 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
             tracing::warn!(error = %e, "ndis startup snapshot task panicked");
         }
 
-        // Always-on ETW consumer. Held for the service's run lifetime;
-        // Drop stops the session and joins the processing thread.
+        // ETW consumer (default-on; opt-out via HOLE_BRIDGE_ETW). Held for
+        // the service's run lifetime; Drop stops the session and joins the
+        // processing thread.
         let _etw_guard = match crate::diagnostics::etw::start_consumer() {
-            Ok(g) => Some(g),
+            Ok(g) => g, // Some(guard) when running; None when disabled
             Err(e) => {
                 tracing::error!(error = %e, "etw consumer failed to start");
                 None

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -219,15 +219,12 @@ fn e2e_metrics_report_tunnel_traffic(
 
 /// Test 2: SocksOnly mode with galoshes (websocket, no TLS).
 ///
-/// Gated off Windows: the Windows bridge-e2e lane intermittently stalls
-/// 600–740s, and the galoshes/ex-ray chain's internal timeouts fire under the
-/// stall → truncated response. Reliable on macOS; the galoshes WS transport is
-/// covered on Windows by `plugin-e2e`. See bindreams/hole#542.
+/// Runs on every platform. `DistHarness` sets `HOLE_BRIDGE_ETW=0`: the
+/// per-bridge ETW consumer's system-wide trace, multiplied across the
+/// concurrent e2e bridges, otherwise starves the Windows runner until the
+/// galoshes/ex-ray 600s idle reaper truncates the response. See
+/// bindreams/hole#542.
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "galoshes bridge e2e truncates under the Windows bridge-e2e stall — see bindreams/hole#542"
-)]
 fn e2e_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,
@@ -672,14 +669,9 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
 
 /// Test 13: ws plugin, SocksOnly mode, IPv6 HTTP target on `[::1]`.
 ///
-/// Gated off Windows for the same reason as `e2e_ws_socks_only_roundtrip` (the
-/// intermittent Windows bridge-e2e stall truncates the galoshes chain). Runs on
-/// macOS. See bindreams/hole#542.
+/// Runs on every platform; same `HOLE_BRIDGE_ETW=0` rationale as
+/// `e2e_ws_socks_only_roundtrip`. See bindreams/hole#542.
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC, IPV6], serial = IPV6)]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "galoshes bridge e2e truncates under the Windows bridge-e2e stall — see bindreams/hole#542"
-)]
 fn ipv6_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -173,7 +173,15 @@ impl DistHarness {
             // `shadowsocks_service` continues to emit its
             // "TCP listening on ..." INFO line that we rely on.
             .env("HOLE_BRIDGE_LOG", "hole_bridge=debug")
-            .env("HOLE_BRIDGE_SELF_TEST", "1");
+            .env("HOLE_BRIDGE_SELF_TEST", "1")
+            // Disable the per-bridge ETW consumer. It opens a *system-wide*
+            // real-time trace, so N concurrent DistHarness bridges each
+            // re-parse every other bridge's loopback events (O(N²)) and
+            // starve the CI runner into the multi-minute stall that truncated
+            // the galoshes chain. HOLE_BRIDGE_ETW is a genuine production
+            // opt-out (honored by `diagnostics::etw::start_consumer`), not a
+            // test-only code seam. See bindreams/hole#542.
+            .env("HOLE_BRIDGE_ETW", "0");
 
         // Use the diagnostic wrapper so any `ACCESS_DENIED` / `ETXTBSY`
         // spawn failure (typically Windows Defender scanning the freshly


### PR DESCRIPTION
> ⚠️ **DRAFT — this fix was empirically DISPROVEN by its own CI run. Do not merge.**
> Kept as an investigation record. See "CI result" below.

## What this tried
Hypothesis: each `hole bridge run` opens an always-on, system-wide, all-keywords
ETW real-time trace (TCPIP+WFP+AFD) filtered to its own PID in userspace, so N
concurrent e2e bridges re-parse every other bridge's loopback events (O(N²)),
starving the 4-vCPU `windows-latest` runner — and the galoshes/ex-ray 600s
`ConnectionIdle` reaper then truncates the frozen connection. Fix: make the ETW
consumer opt-out (`HOLE_BRIDGE_ETW`, default on; gated after the crash-recovery
sweep), set it off in `DistHarness::spawn`, un-gate the two #542 TCP tests.

This was supported by: source inspection, the macOS-no-ETW green control, and a
clean implementation review.

## CI result — DISPROVEN
Run [27789722898](https://github.com/bindreams/hole/actions/runs/27789722898),
`Test hole (windows/amd64)`, with the fix active (bridge.log confirms
`etw: consumer disabled via HOLE_BRIDGE_ETW`, startup completed in ~4s):

- The **same ~10-minute global freeze still happened** (per-minute completions:
  548 @ 21:33 → **~0 from 21:38–21:46** → resume 21:47).
- `ipv6_ws_socks_only_roundtrip` FAILED at 684s — the ex-ray 600s reaper fired on
  a still-frozen connection.
- **No-plugin** bridge e2e (`lifecycle_*`, `mock_cover_*`,
  `e2e_socks5_only_http_port_unbound`) also stalled 600s+.

So ETW is **not** the cause. Both ETW and the netsh/pnputil startup diagnostics
are Windows-only, so the macOS control could not distinguish them — and the
diagnostics ran fast (~4s) here, so they aren't it either. The freeze is a global
~10-min, Windows-only, intermittent loopback/data-path stall affecting every
bridge DistHarness e2e — the signature of the **#200-class NDIS/Azure
loopback-corruption** phenomenon, which #200 concluded is "not fixable at hole's
layer."

## Status
Re-opening the root-cause investigation. The next step is **direct measurement**
on the CI runner (pktmon loopback capture + CPU/process sampling during the
stall) to settle loopback-break vs. CPU-starvation before any further fix —
guessing has now produced three wrong root causes in this area. The `HOLE_BRIDGE_ETW`
opt-out itself is a harmless, small improvement but does not address #542.

Does **not** close #542.

https://claude.ai/code/session_01FiW3DNfUBgaF8fHcgukMoF
