### PR TITLE
fix(dev-console): stop building from the supervisor so dev runs can't overwrite its own exe (#564)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -583,7 +583,7 @@ build graph; `cargo xtask list` prints the target table.
 npm install                  # frontend deps (first time only)
 cargo xtask deps             # build ex-ray (Go) + download/verify wintun.dll (cached)
 cargo xtask build hole       # deps + cargo build (debug) + stage to target/debug/dist
-cargo xtask run hole         # dev mode (= build hole + dev-console)
+cargo xtask run hole         # dev mode (build cascade, then dev-console supervises)
 cargo xtask run hole-tests   # canonical local nextest invocation
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -650,10 +650,11 @@ cargo xtask run hole
 > Closing this sudo-invocation path structurally is tracked in #453.
 
 `cargo xtask run hole` launches the [`dev-console`](crates/dev-console/)
-supervisor, which builds the workspace, starts Vite, and launches bridge + GUI
-with multiplexed color-coded logs. `cargo run -p dev-console` works standalone
-too (it runs `cargo xtask build hole` itself). Frontend changes hot-reload via
-Vite HMR; Rust changes need Ctrl+C and re-run.
+supervisor, which starts Vite and launches bridge + GUI with multiplexed
+color-coded logs. dev-console builds nothing — the xtask cascade builds first
+(#564); `cargo run -p dev-console` works standalone against an already-built
+tree. Frontend changes hot-reload via Vite HMR; Rust changes need Ctrl+C and
+re-run.
 
 - **dev-console runs unprivileged and elevates only the bridge.** On macOS it
   prompts for your sudo password once, then `sudo`s just `bridge grant-access` +

--- a/build.yaml
+++ b/build.yaml
@@ -67,12 +67,13 @@ targets:
     # via msi-installer / tauri, which run their own `cargo build --release`
     # — so `hole` itself is what you build for development and tests.
     #
-    # `cargo xtask run hole` launches dev mode via the dev-console crate.
-    # dev-console runs `cargo xtask build hole` internally so `cargo run -p
-    # dev-console` also works standalone; after this target's build cascade
-    # that inner build is an incremental no-op. dev-console runs unprivileged
-    # and elevates only the bridge — via sudo on POSIX (prompts for your
-    # password), inheriting the elevated token on Windows (#452, #454).
+    # `cargo xtask run hole` launches dev mode via the dev-console crate. The
+    # cascade below builds the workspace; dev-console only supervises — it builds
+    # nothing (#564). `hole.run` rebuilds galoshes with dev-only crash-dumps
+    # before launching, so release/--all builds stay minidump-free (#438).
+    # dev-console runs unprivileged and elevates only the bridge — via sudo on
+    # POSIX (prompts for your password), inheriting the elevated token on
+    # Windows (#452, #454).
     #
     # `--no-default-features` keeps Tauri's `cfg(dev) = true` so the webview
     # loads from the Vite dev server (`http://localhost:1420`) instead of
@@ -84,7 +85,18 @@ targets:
     build:
       - cargo build --workspace --no-default-features --features tombstone/crash-dumps
       - cargo xtask stage --profile debug --out-dir target/debug/dist
-    run: cargo run --package dev-console --quiet
+    run:
+      # Dev-only galoshes minidumps (#438): rebuild galoshes WITH crash-dumps
+      # here, in a run-only step, so `cargo xtask build --all` and the release
+      # installers never link minidump-writer. The cascade above already produced
+      # everything; this step only swaps in the dev galoshes.
+      - process:
+          args: [cargo, xtask, galoshes]
+          environment: { HOLE_CRASH_DUMPS: "1" }
+      # Launch the cascade-built supervisor directly: dev-console builds nothing,
+      # so nothing can overwrite its own running exe (#564). `{exe}` → host suffix;
+      # the relative path resolves against the repo root (see run_step).
+      - process: ["target/debug/dev-console{exe}"]
 
   hole-msi:
     # NOT a dependent of `hole`. The msi-installer Python entry point does its

--- a/crates/dev-console/Cargo.toml
+++ b/crates/dev-console/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 license = "GPL-3.0-or-later"
-description = "Dev-mode supervisor: builds the workspace, then runs bridge (elevated) + Vite + GUI with multiplexed colored logs. Replaces scripts/dev.py (#454)."
+description = "Dev-mode supervisor: runs bridge (elevated) + Vite + GUI with multiplexed colored logs. Builds nothing — the xtask cascade does. Replaces scripts/dev.py (#454)."
 
 [lints]
 workspace = true

--- a/crates/dev-console/src/lib.rs
+++ b/crates/dev-console/src/lib.rs
@@ -1,10 +1,10 @@
 //! Dev-mode supervisor (replaces scripts/dev.py — bindreams/hole#454).
 //!
-//! Builds the workspace, then runs three processes with multiplexed colored
-//! logs: the bridge (real TUN + routing, elevated), the Vite dev server
-//! (frontend HMR on port 1420), and the GUI (Tauri webview loading from
-//! Vite). Runs UNPRIVILEGED; only the bridge is elevated (sudo on POSIX; on
-//! Windows an elevated shell is required and all children inherit the token).
+//! Runs three processes with multiplexed colored logs: the bridge (real TUN +
+//! routing, elevated), the Vite dev server (frontend HMR on port 1420), and the
+//! GUI (Tauri webview loading from Vite). Runs UNPRIVILEGED; only the bridge is
+//! elevated (sudo on POSIX; on Windows an elevated shell is required and all
+//! children inherit the token). Builds nothing — the xtask cascade does (#564).
 
 use std::process::ExitCode;
 

--- a/crates/dev-console/src/steps.rs
+++ b/crates/dev-console/src/steps.rs
@@ -1,5 +1,5 @@
-//! Preflight steps: tool resolution, npm install, workspace build, per-pid
-//! staging. Children here run with INHERITED stdio (the user watches
+//! Preflight steps: tool resolution, npm install, per-pid staging. Children
+//! here run with INHERITED stdio (the user watches
 //! cargo/npm output directly) and are not process-grouped — terminal Ctrl+C
 //! reaches the step child via the console group AND resolves our interrupt
 //! watcher: we reap the child and unwind with `Interrupted`, so guards Drop
@@ -87,19 +87,6 @@ pub async fn ensure_node_modules(npm: &Path, interrupts: &mut Interrupts) -> Res
     let mut cmd = tokio::process::Command::new(npm);
     cmd.args(["install", "--no-audit", "--no-fund"]);
     run_step(cmd, "npm install", false, interrupts).await
-}
-
-/// `cargo xtask build hole` — walks the build.yaml DAG. When invoked via
-/// `cargo xtask run hole` the cascade just built everything as this same
-/// user, so this is an incremental no-op; it exists so `cargo run -p
-/// dev-console` also works standalone. HOLE_CRASH_DUMPS opts galoshes into
-/// the dev-only minidump feature (#438); never set in release builds.
-pub async fn cargo_build(cargo: &Path, interrupts: &mut Interrupts) -> Result<()> {
-    println!("{BOLD}Building hole (cargo xtask build hole)...{RESET}");
-    let mut cmd = tokio::process::Command::new(cargo);
-    cmd.args(["xtask", "build", "hole"]);
-    cmd.env("HOLE_CRASH_DUMPS", "1");
-    run_step(cmd, "cargo xtask build hole", false, interrupts).await
 }
 
 /// `$TMPDIR/hole-dev-<pid>` — per-pid so concurrent runs don't collide and

--- a/crates/dev-console/src/supervise.rs
+++ b/crates/dev-console/src/supervise.rs
@@ -174,7 +174,9 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
     let cargo = steps::resolve_tool("cargo")?;
     let npm = steps::resolve_tool("npm")?;
     steps::ensure_node_modules(&npm, interrupts).await?;
-    steps::cargo_build(&cargo, interrupts).await?;
+    // No workspace build here: dev-console supervises only (#564). The xtask
+    // cascade built everything; a standalone run reuses the existing build,
+    // which `stage_bindir` (cargo xtask stage) validates.
 
     // 3. Per-pid stage (guard registered BEFORE mkdir; dev.py §5.11) ==================================================
     let stage_guard = steps::StageDirGuard::register(steps::stage_dir_path(std::process::id()));

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 
 [features]
 # Dev-only minidump passthrough (bindreams/hole#438). NON-DEFAULT. Enabled
-# only by `cargo xtask galoshes` when HOLE_CRASH_DUMPS is set (dev path via
-# dev-console). Release / MSI / standalone galoshes builds never set it,
+# only by `cargo xtask galoshes` when HOLE_CRASH_DUMPS is set (the dev path sets
+# it in the `hole` run step). Release / MSI / standalone galoshes builds never set it,
 # so minidump-writer is absent from the windows-arm64 galoshes matrix (where
 # it has no support). The marker→breadcrumb path still works there.
 crash-dumps = ["tombstone/crash-dumps"]

--- a/xtask/src/galoshes.rs
+++ b/xtask/src/galoshes.rs
@@ -16,9 +16,10 @@ use anyhow::{anyhow, bail, Context, Result};
 /// `<repo>/.cache/ex-ray/` by [`super::ex_ray::build`] (which
 /// is what `cargo xtask deps` does just before calling this).
 pub fn build(repo_root: &Path) -> Result<PathBuf> {
-    // Dev-only minidump opt-in (bindreams/hole#438). dev-console sets
-    // HOLE_CRASH_DUMPS=1; release / standalone galoshes builds do not, so
-    // minidump-writer never links into the windows-arm64 galoshes matrix.
+    // Dev-only minidump opt-in (#438). The `hole` target's run: step sets
+    // HOLE_CRASH_DUMPS=1 (run-only, so `--all` / release builds never do);
+    // without it minidump-writer never links — keeping it out of the
+    // windows-arm64 galoshes matrix and every release artifact.
     let mut args: Vec<&str> = vec!["build", "--release", "-p", "galoshes"];
     if std::env::var_os("HOLE_CRASH_DUMPS").is_some() {
         args.push("--features");

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -823,15 +823,18 @@ fn hole_run_is_dev_mode_build_and_launch() {
         ]
     );
 
-    // #438 defense: the crash-dumps env must live ONLY on a run step, never the
-    // build cascade (which `--all` and the release installers execute).
-    for step in &t.build {
-        let environment = match step {
-            Step::Bash { environment, .. } | Step::Process { environment, .. } => environment,
-        };
-        assert!(
-            !environment.contains_key("HOLE_CRASH_DUMPS"),
-            "HOLE_CRASH_DUMPS must not appear in hole's build steps (#438)"
-        );
+    // #438 defense: the crash-dumps env must live ONLY on a run step, never any
+    // target's build cascade (which `--all` and the release installers execute).
+    for target in m.iter() {
+        for step in &target.build {
+            let environment = match step {
+                Step::Bash { environment, .. } | Step::Process { environment, .. } => environment,
+            };
+            assert!(
+                !environment.contains_key("HOLE_CRASH_DUMPS"),
+                "HOLE_CRASH_DUMPS must not appear in any build step (target {:?}, #438)",
+                target.name
+            );
+        }
     }
 }

--- a/xtask/src/manifest_tests.rs
+++ b/xtask/src/manifest_tests.rs
@@ -796,3 +796,42 @@ fn tests_targets_run_matches_build_minus_no_run() {
         assert!(!run_cmd.contains("--no-run"), "{name:?} run must not contain --no-run");
     }
 }
+
+#[skuld::test]
+fn hole_run_is_dev_mode_build_and_launch() {
+    // #564: dev-console builds nothing. `hole.run` rebuilds galoshes WITH
+    // crash-dumps (dev-only #438 minidumps, kept out of release/--all by living
+    // in a run-only step) then launches the cascade-built dev-console binary
+    // directly (no rebuild → it cannot overwrite its own running exe).
+    let yaml = include_str!("../../build.yaml");
+    let m = Manifest::parse(yaml).expect("production build.yaml must parse cleanly");
+    let t = m.get("hole").expect("hole target missing");
+
+    let mut crash_env = HashMap::new();
+    crash_env.insert("HOLE_CRASH_DUMPS".to_string(), "1".to_string());
+    assert_eq!(
+        t.run,
+        vec![
+            Step::Process {
+                args: vec!["cargo".to_string(), "xtask".to_string(), "galoshes".to_string()],
+                environment: crash_env,
+            },
+            Step::Process {
+                args: vec!["target/debug/dev-console{exe}".to_string()],
+                environment: HashMap::new(),
+            },
+        ]
+    );
+
+    // #438 defense: the crash-dumps env must live ONLY on a run step, never the
+    // build cascade (which `--all` and the release installers execute).
+    for step in &t.build {
+        let environment = match step {
+            Step::Bash { environment, .. } | Step::Process { environment, .. } => environment,
+        };
+        assert!(
+            !environment.contains_key("HOLE_CRASH_DUMPS"),
+            "HOLE_CRASH_DUMPS must not appear in hole's build steps (#438)"
+        );
+    }
+}

--- a/xtask/src/orchestrate.rs
+++ b/xtask/src/orchestrate.rs
@@ -16,9 +16,7 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 #[cfg(windows)]
 use std::io;
-use std::path::Path;
-#[cfg(windows)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -284,6 +282,40 @@ fn relocate_self_windows() -> Result<()> {
 
 // ===== Step execution ================================================================================================
 
+/// Host executable suffix: `.exe` on Windows, empty elsewhere.
+fn exe_suffix() -> &'static str {
+    if cfg!(windows) {
+        ".exe"
+    } else {
+        ""
+    }
+}
+
+/// Substitute the reserved `{exe}` token with the host executable suffix, so a
+/// `build.yaml` step can name a built binary cross-platform — e.g.
+/// `target/debug/dev-console{exe}` → `dev-console.exe` on Windows,
+/// `dev-console` elsewhere.
+pub(crate) fn substitute_exe(s: &str) -> String {
+    s.replace("{exe}", exe_suffix())
+}
+
+/// Resolve a `process:` step's program. A bare command name (no path separator)
+/// is left for PATH lookup; a relative path WITH separators is resolved against
+/// `repo_root` (the step's working directory). This is required because
+/// `Command::current_dir` does NOT affect how a relative *program* path is
+/// resolved — on Windows it resolves against the parent process's cwd (which,
+/// for `cargo xtask`, is wherever the user invoked it). See the
+/// `std::process::Command::current_dir` docs. (#564)
+pub(crate) fn resolve_program(program: &str, repo_root: &Path) -> PathBuf {
+    let has_sep = program.contains('/') || program.contains('\\');
+    let p = Path::new(program);
+    if has_sep && p.is_relative() {
+        repo_root.join(p)
+    } else {
+        p.to_path_buf()
+    }
+}
+
 /// Execute one [`Step`] from the given working directory.
 ///
 /// CWD is always `repo_root`. The step inherits stdio. On non-zero exit this
@@ -295,17 +327,22 @@ pub fn run_step(step: &Step, repo_root: &Path) -> Result<()> {
             let mut cmd = Command::new(resolve_bash()?);
             // `-e` so multi-line bash heredocs fail fast on the first error,
             // matching the driver's overall fail-fast contract.
-            cmd.arg("-e").arg("-c").arg(command).current_dir(repo_root);
+            cmd.arg("-e")
+                .arg("-c")
+                .arg(substitute_exe(command))
+                .current_dir(repo_root);
             for (k, v) in environment {
                 cmd.env(k, v);
             }
             run(cmd, &format!("bash step: {command}"))
         }
         Step::Process { args, environment } => {
+            let args: Vec<String> = args.iter().map(|a| substitute_exe(a)).collect();
             let (program, rest) = args
                 .split_first()
                 .ok_or_else(|| anyhow!("process step has empty args list"))?;
-            let mut cmd = Command::new(program);
+            let program = resolve_program(program, repo_root);
+            let mut cmd = Command::new(&program);
             cmd.args(rest).current_dir(repo_root);
             for (k, v) in environment {
                 cmd.env(k, v);

--- a/xtask/src/orchestrate_tests.rs
+++ b/xtask/src/orchestrate_tests.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use clap::Parser;
 
 use crate::manifest::*;
@@ -618,4 +620,45 @@ fn cli_run_requires_target_positional() {
         "expected MissingRequiredArgument, got: {:?}",
         err.kind()
     );
+}
+
+// ===== {exe} token + relative-program resolution (run_step, #564) ====================================================
+
+#[skuld::test]
+fn substitute_exe_maps_token_to_host_suffix() {
+    let out = substitute_exe("target/debug/dev-console{exe}");
+    if cfg!(windows) {
+        assert_eq!(out, "target/debug/dev-console.exe");
+    } else {
+        assert_eq!(out, "target/debug/dev-console");
+    }
+    assert_eq!(substitute_exe("cargo"), "cargo"); // no token → unchanged
+}
+
+#[skuld::test]
+fn resolve_program_absolutizes_relative_paths_against_repo_root() {
+    let root = Path::new(if cfg!(windows) { r"C:\repo" } else { "/repo" });
+    // Relative path WITH separators → joined to repo_root. `Command::current_dir`
+    // does not affect relative *program* resolution (#564).
+    assert_eq!(
+        resolve_program("target/debug/dev-console", root),
+        root.join("target/debug/dev-console")
+    );
+    // Bare command name (no separator) → left for PATH lookup.
+    assert_eq!(resolve_program("cargo", root), PathBuf::from("cargo"));
+    // Absolute path → unchanged.
+    let abs = if cfg!(windows) { r"C:\bin\tool.exe" } else { "/bin/tool" };
+    assert_eq!(resolve_program(abs, root), PathBuf::from(abs));
+}
+
+#[skuld::test]
+fn run_step_bash_substitutes_exe_token() {
+    // Pins that `{exe}` is resolved inside a bash command, not just process args.
+    let dir = tempfile::tempdir().unwrap();
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    let step = Step::Bash {
+        command: format!(r#"[ "dev-console{{exe}}" = "dev-console{suffix}" ]"#),
+        environment: Default::default(),
+    };
+    run_step(&step, dir.path()).unwrap();
 }


### PR DESCRIPTION
## Why

`cargo xtask run hole` intermittently failed on Windows:

```
error: failed to remove file `target\debug\dev-console.exe`
Caused by: Access is denied. (os error 5)
```

dev-console ran an inner `cargo xtask build hole` *while it was the running
process*, re-uplifting `dev-console.exe` over itself. Win11's `FILE_SHARE_DELETE`
usually let the replace slip through, but Defender's real-time scan (`target/`
unexcluded) intermittently held a non-share-delete handle, so the remove failed.
Full analysis in #564.

## What

Move build-job complexity into `xtask`/`build.yaml`; make dev-console a pure
supervisor that builds nothing.

- **dev-console builds nothing** — removed the inner `cargo xtask build hole`.
  With no build, nothing can overwrite the running `dev-console.exe`, on the
  orchestrated *and* standalone paths. This is the structural fix.
- **`hole.run`** now (1) rebuilds galoshes with dev-only `crash-dumps` in a
  **run-only** step — so `--all` / `hole-msi` / `hole-dmg` never link
  `minidump-writer` (the #438 privacy invariant) — then (2) launches the
  cascade-built `dev-console{exe}` directly.
- **`run_step`** gained a `{exe}` token and relative-program resolution
  (`resolve_program`): a relative process program is absolutized against
  `repo_root`, because Windows ignores `current_dir` for relative *program*
  resolution (per Rust's `Command::current_dir` docs) — without it the launch
  fails with os-error-2 when `cargo xtask` is invoked from a subdirectory.
- Corrected the now-stale "dev-console builds the workspace" docs
  (`lib.rs`, `steps.rs`, `Cargo.toml`, `CONTRIBUTING.md`, `galoshes.rs`).

## Verify

- `cargo nextest run -p xtask` — 97 pass (incl. `substitute_exe`,
  `resolve_program`, `run_step_bash_substitutes_exe_token`,
  `hole_run_is_dev_mode_build_and_launch`, and a workspace-wide #438 guard that
  no target's *build* step carries `HOLE_CRASH_DUMPS`).
- `SKULD_LABELS='!windows_console' cargo nextest run -p dev-console` — 38 pass
  (matches the CI label filter).
- Manual: `cargo xtask run hole`, then run it again immediately — no
  `failed to remove file dev-console.exe`; the bridge runs the crash-dumps
  galoshes. (Real elevation + TUN + webview — not unit-testable.)

Closes #564.

https://claude.ai/code/session_01NFK67Rt4grS7KSiUvx55k6
