### PR TITLE
fix(dev): prime sudo without gating on stdin isatty (#567)

### DIFF
--- a/crates/stepstool/src/posix.rs
+++ b/crates/stepstool/src/posix.rs
@@ -8,42 +8,41 @@ use std::process::Command;
 #[derive(Debug, thiserror::Error)]
 pub enum PrimeSudoError {
     /// sudo itself could not be spawned (not on PATH / not executable).
-    /// Message text = dev.py:489 verbatim.
     #[error("sudo not found on PATH; cannot elevate the bridge ({0})")]
     SudoNotFound(std::io::Error),
-    /// A TTY was available, the interactive prompt ran, and it FAILED
-    /// (wrong password / Ctrl+C at the prompt). Message = dev.py:486.
-    #[error("sudo authentication failed")]
-    AuthFailed,
-    /// No cached credentials and no TTY to prompt on.
+    /// `sudo -v` ran but did not cache credentials: a wrong password, a
+    /// Ctrl+C at the prompt, or no terminal / askpass helper to prompt on.
     #[error(
-        "sudo credentials are unavailable and there is no TTY to prompt on; \
-             run `sudo -v` in this terminal first, or re-run from an interactive shell"
+        "could not cache sudo credentials (wrong password, or no terminal to \
+         prompt on); run `sudo -v` in this terminal first, or re-run from an \
+         interactive shell"
     )]
-    NoTty,
+    PrimingFailed,
 }
 
 /// Prime sudo's credential cache so the immediately-following sudo-wrapped
 /// spawns do not prompt: probe `sudo -n true` (cached cred / NOPASSWD); on
-/// failure run interactive `sudo -v` — but only when stdin is a TTY (a blind
-/// `sudo -v` hangs or fails TTY-less, e.g. on macOS under an IDE runner).
+/// failure run interactive `sudo -v`.
+///
+/// `sudo -v` reads the password from the controlling terminal (`/dev/tty`),
+/// not stdin — so we always attempt it and let sudo prompt (or fall back to
+/// an askpass helper, or fail fast with "a terminal is required" when neither
+/// is available). We deliberately do NOT gate on `isatty(stdin)`: under
+/// `cargo xtask run hole` the orchestrator spawns dev-console with
+/// stdin = /dev/null, so a stdin check is always false even from an
+/// interactive shell (bindreams/hole#567).
 pub fn prime_sudo() -> Result<(), PrimeSudoError> {
-    // SAFETY: isatty has no preconditions.
-    let has_tty = unsafe { libc::isatty(libc::STDIN_FILENO) } == 1;
-    prime_sudo_with(Path::new("sudo"), has_tty)
+    prime_sudo_with(Path::new("sudo"))
 }
 
-/// Testable core: `sudo` binary and TTY-ness injected.
-pub fn prime_sudo_with(sudo: &Path, has_tty: bool) -> Result<(), PrimeSudoError> {
+/// Testable core: the `sudo` binary is injected.
+pub fn prime_sudo_with(sudo: &Path) -> Result<(), PrimeSudoError> {
     let probe = Command::new(sudo)
         .args(["-n", "true"])
         .status()
         .map_err(PrimeSudoError::SudoNotFound)?;
     if probe.success() {
         return Ok(());
-    }
-    if !has_tty {
-        return Err(PrimeSudoError::NoTty);
     }
     let interactive = Command::new(sudo)
         .arg("-v")
@@ -52,7 +51,7 @@ pub fn prime_sudo_with(sudo: &Path, has_tty: bool) -> Result<(), PrimeSudoError>
     if interactive.success() {
         Ok(())
     } else {
-        Err(PrimeSudoError::AuthFailed)
+        Err(PrimeSudoError::PrimingFailed)
     }
 }
 

--- a/crates/stepstool/src/posix_tests.rs
+++ b/crates/stepstool/src/posix_tests.rs
@@ -1,6 +1,8 @@
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 
+use skuld::env;
+
 use crate::posix::{prime_sudo_with, sudo_command, PrimeSudoError};
 
 /// Write an executable fake `sudo` into `dir` that exits 0/1 per `script`.
@@ -16,38 +18,29 @@ fn prime_succeeds_when_noninteractive_probe_passes() {
     let dir = tempfile::tempdir().unwrap();
     // `sudo -n true` succeeding (cached cred / NOPASSWD) must be enough.
     let sudo = fake_sudo(dir.path(), r#"[ "$1" = "-n" ] && exit 0; exit 1"#);
-    prime_sudo_with(&sudo, false).unwrap();
+    prime_sudo_with(&sudo).unwrap();
 }
 
 #[skuld::test]
-fn prime_falls_back_to_interactive_on_tty() {
+fn prime_falls_back_to_interactive_prompt() {
     let dir = tempfile::tempdir().unwrap();
-    // Probe fails; interactive `sudo -v` succeeds; has_tty=true allows it.
+    // Probe (`-n`) fails; interactive `sudo -v` succeeds.
     let sudo = fake_sudo(dir.path(), r#"[ "$1" = "-v" ] && exit 0; exit 1"#);
-    prime_sudo_with(&sudo, true).unwrap();
+    prime_sudo_with(&sudo).unwrap();
 }
 
+/// A failed `sudo -v` (wrong password, or no terminal/askpass) is PrimingFailed.
 #[skuld::test]
-fn prime_fails_loudly_without_tty() {
+fn prime_reports_failure_when_prompt_fails() {
     let dir = tempfile::tempdir().unwrap();
     let sudo = fake_sudo(dir.path(), "exit 1");
-    let err = prime_sudo_with(&sudo, false).unwrap_err();
-    assert!(matches!(err, PrimeSudoError::NoTty));
-}
-
-/// On a TTY, a failed interactive prompt is AuthFailed (dev.py:486 "sudo
-/// authentication failed"), not the no-TTY message.
-#[skuld::test]
-fn prime_reports_auth_failure_on_tty() {
-    let dir = tempfile::tempdir().unwrap();
-    let sudo = fake_sudo(dir.path(), "exit 1");
-    let err = prime_sudo_with(&sudo, true).unwrap_err();
-    assert!(matches!(err, PrimeSudoError::AuthFailed));
+    let err = prime_sudo_with(&sudo).unwrap_err();
+    assert!(matches!(err, PrimeSudoError::PrimingFailed));
 }
 
 #[skuld::test]
 fn prime_reports_missing_sudo() {
-    let err = prime_sudo_with(Path::new("/nonexistent/sudo"), true).unwrap_err();
+    let err = prime_sudo_with(Path::new("/nonexistent/sudo")).unwrap_err();
     assert!(matches!(err, PrimeSudoError::SudoNotFound(_)));
 }
 
@@ -73,4 +66,61 @@ fn sudo_command_argv_shape() {
 #[skuld::test]
 fn preserve_env_arg_is_the_single_owner() {
     assert_eq!(crate::preserve_env_arg(&["A", "B"]), "--preserve-env=A,B");
+}
+
+/// Redirect process fd 0 to /dev/null for the guard's lifetime; restore on drop.
+struct StdinGuard {
+    saved: libc::c_int,
+}
+impl StdinGuard {
+    fn redirect_to_dev_null() -> Self {
+        // SAFETY: dup/open/dup2 on fd 0. `saved` is owned by the returned
+        // guard before any fallible step, so an assert-panic still restores it;
+        // /dev/null is closed before the dup2 assert so it cannot leak either.
+        unsafe {
+            let saved = libc::dup(libc::STDIN_FILENO);
+            assert!(saved >= 0, "dup(stdin) failed");
+            let guard = Self { saved };
+            let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_RDONLY);
+            assert!(devnull >= 0, "open(/dev/null) failed");
+            let rc = libc::dup2(devnull, libc::STDIN_FILENO);
+            libc::close(devnull);
+            assert!(rc >= 0, "dup2 onto stdin failed");
+            guard
+        }
+    }
+}
+impl Drop for StdinGuard {
+    fn drop(&mut self) {
+        // SAFETY: restore the saved fd onto stdin and close the backup.
+        unsafe {
+            libc::dup2(self.saved, libc::STDIN_FILENO);
+            libc::close(self.saved);
+        }
+    }
+}
+
+/// #567: under `cargo xtask run hole` the orchestrator spawns dev-console with
+/// stdin = /dev/null, so an `isatty(stdin)` check is always false even from an
+/// interactive shell. Priming must still reach the interactive `sudo -v`
+/// (sudo prompts on /dev/tty, not stdin). `serial` because fd 0 + PATH are
+/// process-global; `env` (EnvGuard) auto-reverts PATH.
+#[skuld::test(serial)]
+fn priming_does_not_require_a_tty_on_stdin(#[fixture] env: &skuld::EnvGuard) {
+    use crate::posix::prime_sudo;
+
+    let dir = tempfile::tempdir().unwrap();
+    // `sudo -n` fails (no cached cred); interactive `sudo -v` succeeds. The
+    // returned path is intentionally unused: prime_sudo() resolves "sudo" via
+    // PATH, which we point at this dir below.
+    fake_sudo(dir.path(), r#"[ "$1" = "-v" ] && exit 0; exit 1"#);
+
+    let prepended = format!("{}:{}", dir.path().display(), std::env::var("PATH").unwrap_or_default());
+    env.set("PATH", &prepended);
+
+    let _stdin = StdinGuard::redirect_to_dev_null();
+
+    // Pre-fix this returned Err (stdin not a tty failed the isatty gate);
+    // post-fix it succeeds because sudo prompts on /dev/tty, not stdin.
+    prime_sudo().expect("priming must succeed even when stdin is not a tty");
 }


### PR DESCRIPTION
## Root cause

`prime_sudo` gated the interactive `sudo -v` on `isatty(STDIN_FILENO)`. The dev
orchestrator spawns dev-console with `stdin = /dev/null`
(`xtask/src/orchestrate.rs:364`), so that check is always false even from an
interactive terminal. The first `cargo xtask run hole` of a session therefore
aborted with "no TTY to prompt on" instead of prompting for the password.

`sudo -v` reads the password from the controlling terminal (`/dev/tty`), not
stdin, so the stdin gate was checking the wrong thing.

## Fix

Drop the stdin gate: always attempt `sudo -v` after the `sudo -n true`
fast-path. sudo prompts on the tty, uses `SUDO_ASKPASS` when headless, or fails
fast with "a terminal is required" when neither is available (per `man sudo` —
it does not hang). The now-redundant `NoTty` and `AuthFailed` variants collapse
into one `PrimingFailed`. Sole production consumer (`dev-console/supervise.rs`)
uses `Display` only, so it is unaffected.

## Test

New regression test `priming_does_not_require_a_tty_on_stdin` redirects fd 0 to
`/dev/null` and points PATH at a fake `sudo` whose `-n` probe fails but `-v`
succeeds; priming must still return `Ok`. Verified red before the fix
(panicked with `NoTty`), green after. Existing priming tests updated for the
one-arg `prime_sudo_with` signature.

Closes #567

https://claude.ai/code/session_012EuAB52PrZDhYsh2NCnoRA
