### PR TITLE
fix(gui): don't prompt to install / elevate for an externally-supervised bridge (#569)

### DIFF
--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -109,11 +109,12 @@ impl AppState {
 /// Resolve the bridge socket path and whether it was externally provided.
 /// `override_path` is the `HOLE_BRIDGE_SOCKET` value (read once at `AppState`
 /// construction; the env var is process-global and skuld tests share a process,
-/// so this takes the value as a parameter to stay purely testable). `Some` ⇒
-/// externally supervised (dev-console / manual dev run); `None` ⇒ the platform
-/// default production socket.
+/// so this takes the value as a parameter to stay purely testable). A non-empty
+/// value ⇒ externally supervised (dev-console / manual dev run); absent or empty
+/// ⇒ the platform default production socket (an empty `HOLE_BRIDGE_SOCKET=` is
+/// malformed and conventionally means unset — never an external "" socket).
 fn resolve_bridge_socket(override_path: Option<PathBuf>) -> (PathBuf, bool) {
-    match override_path {
+    match override_path.filter(|path| !path.as_os_str().is_empty()) {
         Some(path) => (path, true),
         None => (hole_common::protocol::default_bridge_socket_path(), false),
     }

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -27,6 +27,13 @@ pub struct AppState {
     /// first time the bridge proves reachable (so a cold-boot race against the
     /// bridge's socket bind can't drop the connect).
     pending_startup_connect: AtomicBool,
+    /// Whether the bridge is externally supervised — the GUI was pointed at a
+    /// caller-provided socket via `HOLE_BRIDGE_SOCKET` (dev-console / manual dev
+    /// run) instead of the platform default. In that mode the GUI does NOT own
+    /// the bridge lifecycle: it must not prompt to install the production service
+    /// nor elevate, since the elevated helper and the post-install reachability
+    /// poll both target the default production socket, not this one (#569).
+    bridge_externally_supervised: bool,
 }
 
 // Loading (with quarantine, logging, and the #481/#467 recovery dialog data)
@@ -38,13 +45,16 @@ impl AppState {
         // its own). `hole::selfheal` resolves in both the lib and bin units.
         let hook_app = app_handle.clone();
         let self_heal: SelfHealHook = std::sync::Arc::new(move |bridge| hole::selfheal::trigger(&hook_app, bridge));
+        let (socket_path, externally_supervised) =
+            resolve_bridge_socket(std::env::var_os("HOLE_BRIDGE_SOCKET").map(PathBuf::from));
         Self {
             config_store,
             config: Mutex::new(config),
             app_handle,
-            link: BridgeLink::new(resolve_bridge_socket_path(), self_heal),
+            link: BridgeLink::new(socket_path, self_heal),
             test_locks: tokio::sync::Mutex::new(HashMap::new()),
             pending_startup_connect: AtomicBool::new(false),
+            bridge_externally_supervised: externally_supervised,
         }
     }
 
@@ -85,20 +95,28 @@ impl AppState {
         self.link.cell().snapshot()
     }
 
+    /// True when the GUI was pointed at a caller-provided bridge socket via
+    /// `HOLE_BRIDGE_SOCKET` (dev-console / manual dev run); see the field doc.
+    pub fn bridge_is_externally_supervised(&self) -> bool {
+        self.bridge_externally_supervised
+    }
+
     pub fn subscribe_proxy_state(&self) -> tokio::sync::watch::Receiver<ProxySnapshot> {
         self.link.cell().subscribe()
     }
 }
 
-/// Resolve the bridge socket path from `HOLE_BRIDGE_SOCKET` or the
-/// platform default. Read once at `AppState` construction; tests inject
-/// per-test paths directly into `BridgeLink::new` instead (the env var is
-/// process-global and skuld tests may share a process).
-fn resolve_bridge_socket_path() -> PathBuf {
-    std::env::var("HOLE_BRIDGE_SOCKET")
-        .ok()
-        .map(PathBuf::from)
-        .unwrap_or_else(hole_common::protocol::default_bridge_socket_path)
+/// Resolve the bridge socket path and whether it was externally provided.
+/// `override_path` is the `HOLE_BRIDGE_SOCKET` value (read once at `AppState`
+/// construction; the env var is process-global and skuld tests share a process,
+/// so this takes the value as a parameter to stay purely testable). `Some` ⇒
+/// externally supervised (dev-console / manual dev run); `None` ⇒ the platform
+/// default production socket.
+fn resolve_bridge_socket(override_path: Option<PathBuf>) -> (PathBuf, bool) {
+    match override_path {
+        Some(path) => (path, true),
+        None => (hole_common::protocol::default_bridge_socket_path(), false),
+    }
 }
 
 // BridgeLink ==========================================================================================================

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -727,3 +727,20 @@ async fn reload_if_running_reloads_when_running() {
         }
     );
 }
+
+// resolve_bridge_socket ===============================================================================================
+
+#[skuld::test]
+fn resolve_bridge_socket_override_is_external() {
+    let custom = std::path::PathBuf::from("/tmp/hole-dev.sock");
+    let (path, external) = resolve_bridge_socket(Some(custom.clone()));
+    assert_eq!(path, custom);
+    assert!(external, "an explicit HOLE_BRIDGE_SOCKET ⇒ externally supervised");
+}
+
+#[skuld::test]
+fn resolve_bridge_socket_default_is_not_external() {
+    let (path, external) = resolve_bridge_socket(None);
+    assert_eq!(path, hole_common::protocol::default_bridge_socket_path());
+    assert!(!external, "the platform default ⇒ GUI owns the bridge lifecycle");
+}

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -744,3 +744,13 @@ fn resolve_bridge_socket_default_is_not_external() {
     assert_eq!(path, hole_common::protocol::default_bridge_socket_path());
     assert!(!external, "the platform default ⇒ GUI owns the bridge lifecycle");
 }
+
+#[skuld::test]
+fn resolve_bridge_socket_empty_override_is_not_external() {
+    // An empty HOLE_BRIDGE_SOCKET= is malformed; treat it as unset (production
+    // default, GUI owns the bridge) rather than an external "" socket — otherwise
+    // an empty env var would wrongly skip the install gate.
+    let (path, external) = resolve_bridge_socket(Some(std::path::PathBuf::from("")));
+    assert_eq!(path, hole_common::protocol::default_bridge_socket_path());
+    assert!(!external, "an empty override ⇒ not externally supervised");
+}

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -91,6 +91,51 @@ pub(crate) fn transport_after_elevation_toast(detail: &str) -> String {
     format!("Could not reach the Hole bridge after elevation. {detail} See gui.log for details.")
 }
 
+/// Toast shown when an externally-supervised bridge (`HOLE_BRIDGE_SOCKET`)
+/// denies the connection. Hole will not elevate in this mode: the elevated
+/// `hole bridge ipc-send` helper connects to the default production socket, not
+/// this caller-provided one, so elevation would mis-target (#569). The
+/// underlying permission error still lands in `gui.log`.
+pub(crate) fn external_bridge_denied_toast() -> String {
+    "Permission denied by the bridge. Hole does not elevate an externally-supervised bridge \
+     (HOLE_BRIDGE_SOCKET); ensure your user was granted access to its socket. See gui.log for details."
+        .into()
+}
+
+/// Resolution of a bridge `NeedsElevation` signal, before any UI. Pure so the
+/// matrix (externally-supervised × prompts × disconnect) is unit-tested.
+pub(crate) enum ElevationDecision {
+    /// Run the elevated helper (interactive UAC/osascript).
+    Elevate,
+    /// Do not elevate; fail with this toast.
+    Decline(String),
+}
+
+/// Decide whether a `NeedsElevation` should actually elevate.
+/// - Externally supervised (`HOLE_BRIDGE_SOCKET`): never — the elevated helper
+///   targets the default production socket, not this one (#569).
+/// - Disconnect is always interactive, so it may elevate.
+/// - Connect may elevate only when prompts are allowed; an unattended startup
+///   auto-connect (#458) fails passively instead of throwing UAC at a login.
+pub(crate) fn decide_elevation(
+    externally_supervised: bool,
+    prompts: Prompts,
+    is_disconnect: bool,
+) -> ElevationDecision {
+    if externally_supervised {
+        return ElevationDecision::Decline(external_bridge_denied_toast());
+    }
+    if is_disconnect {
+        return ElevationDecision::Elevate;
+    }
+    match prompts {
+        Prompts::Allowed => ElevationDecision::Elevate,
+        Prompts::Forbidden => {
+            ElevationDecision::Decline("Connecting requires elevation, which is unavailable at startup.".into())
+        }
+    }
+}
+
 pub(crate) fn outcome_for_start_response(
     result: &Result<BridgeResponse, crate::bridge_client::ClientError>,
 ) -> StartDecision {
@@ -567,14 +612,17 @@ async fn set_proxy_enabled_inner(
                 info!(?outcome, "proxy start settled");
                 Ok(outcome)
             }
-            StartDecision::NeedsElevation => match prompts {
-                Prompts::Allowed => elevate_and_confirm(app, request).await,
-                // No UAC at an unattended startup; fail into Disconnected.
-                Prompts::Forbidden => {
-                    debug!("startup auto-connect needs elevation; skipping (unattended)");
-                    Err("Connecting requires elevation, which is unavailable at startup.".into())
+            StartDecision::NeedsElevation => {
+                match decide_elevation(state.bridge_is_externally_supervised(), prompts, false) {
+                    ElevationDecision::Elevate => elevate_and_confirm(app, request).await,
+                    // Externally-supervised bridge or an unattended startup: no UAC;
+                    // fail into Disconnected.
+                    ElevationDecision::Decline(msg) => {
+                        debug!("proxy start needs elevation but declining: {msg}");
+                        Err(msg)
+                    }
                 }
-            },
+            }
             StartDecision::Fail(msg) => {
                 error!("proxy start failed: {msg}");
                 Err(msg)
@@ -588,7 +636,12 @@ async fn set_proxy_enabled_inner(
                 info!(?outcome, "proxy stop settled");
                 Ok(outcome)
             }
-            StartDecision::NeedsElevation => elevate_and_confirm(app, request).await,
+            StartDecision::NeedsElevation => {
+                match decide_elevation(state.bridge_is_externally_supervised(), prompts, true) {
+                    ElevationDecision::Elevate => elevate_and_confirm(app, request).await,
+                    ElevationDecision::Decline(msg) => Err(msg),
+                }
+            }
             StartDecision::Fail(msg) => {
                 error!("proxy stop failed: {msg}");
                 Err(msg)

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -150,6 +150,21 @@ pub(crate) fn startup_should_connect(behavior: StartupBehavior, last_enabled: bo
     }
 }
 
+/// Install-gate decision (#569). The GUI prompts to install the production bridge
+/// service only when it OWNS the bridge lifecycle. When the bridge is externally
+/// supervised (`HOLE_BRIDGE_SOCKET` — dev-console / manual dev run) a live bridge
+/// is already reachable on that socket and the production install state (launchd
+/// plist / SCM service) is irrelevant, so the gate must never fire — otherwise
+/// dev mode demands admin to install a service over an already-running bridge.
+/// `status_fn` is lazy so the production status probe (a stat, and on macOS a
+/// `launchctl` subprocess) is skipped entirely when externally supervised.
+pub(crate) fn should_prompt_install(
+    externally_supervised: bool,
+    status_fn: impl FnOnce() -> crate::setup::BridgeInstallStatus,
+) -> bool {
+    !externally_supervised && status_fn() == crate::setup::BridgeInstallStatus::NotInstalled
+}
+
 // Menu IDs ============================================================================================================
 
 // Tray menu -----------------------------------------------------------------------------------------------------------
@@ -501,10 +516,16 @@ async fn set_proxy_enabled_inner(
 ) -> Result<ToggleOutcome, String> {
     let state = app.state::<AppState>();
 
-    // Bridge install gate: if the user is trying to enable the proxy and
-    // the bridge isn't installed yet, prompt for installation BEFORE
-    // anything else.
-    if enable && crate::setup::bridge_install_status() == crate::setup::BridgeInstallStatus::NotInstalled {
+    // Bridge install gate: when the GUI owns the bridge lifecycle and no
+    // production service is installed, prompt to install BEFORE anything else.
+    // An externally-supervised bridge (HOLE_BRIDGE_SOCKET, dev) skips this
+    // entirely — it is already reachable on its own socket (#569).
+    if enable
+        && should_prompt_install(
+            state.bridge_is_externally_supervised(),
+            crate::setup::bridge_install_status,
+        )
+    {
         match prompts {
             Prompts::Allowed => {
                 if !crate::setup::prompt_bridge_install(app.clone()).await {

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -113,8 +113,9 @@ pub(crate) enum ElevationDecision {
 
 /// Decide whether a `NeedsElevation` should actually elevate.
 /// - Externally supervised (`HOLE_BRIDGE_SOCKET`): never — the elevated helper
-///   targets the default production socket, not this one (#569).
-/// - Disconnect is always interactive, so it may elevate.
+///   targets the default production socket, not this one (#569). Checked first,
+///   so it overrides the disconnect/prompts rules below.
+/// - Disconnect (when GUI-owned) is always interactive, so it may elevate.
 /// - Connect may elevate only when prompts are allowed; an unattended startup
 ///   auto-connect (#458) fails passively instead of throwing UAC at a login.
 pub(crate) fn decide_elevation(

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -201,3 +201,27 @@ fn transport_after_elevation_toast_points_to_log() {
     assert!(toast.contains("gui.log"), "{toast}");
     assert!(toast.contains("connection refused"), "{toast}");
 }
+
+// should_prompt_install ===============================================================================================
+
+#[skuld::test]
+fn install_gate_skips_externally_supervised_bridge() {
+    use crate::setup::BridgeInstallStatus::*;
+    // Externally supervised (HOLE_BRIDGE_SOCKET / dev): never prompt, and the
+    // production status probe is never even consulted (it may spawn launchctl).
+    let mut probed = false;
+    assert!(!should_prompt_install(true, || {
+        probed = true;
+        NotInstalled
+    }));
+    assert!(!probed, "external bridge must short-circuit before the status probe");
+}
+
+#[skuld::test]
+fn install_gate_prompts_only_when_production_service_absent() {
+    use crate::setup::BridgeInstallStatus::*;
+    // GUI owns the bridge: prompt iff the production service is absent.
+    assert!(should_prompt_install(false, || NotInstalled));
+    assert!(!should_prompt_install(false, || Installed));
+    assert!(!should_prompt_install(false, || Running));
+}

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -225,3 +225,39 @@ fn install_gate_prompts_only_when_production_service_absent() {
     assert!(!should_prompt_install(false, || Installed));
     assert!(!should_prompt_install(false, || Running));
 }
+
+// decide_elevation ====================================================================================================
+
+#[skuld::test]
+fn elevation_declined_for_externally_supervised_bridge() {
+    use ElevationDecision::*;
+    // Externally supervised: never elevate — neither connect nor disconnect,
+    // regardless of prompts (the elevated helper would mis-target the default socket).
+    for is_disconnect in [false, true] {
+        for prompts in [Prompts::Allowed, Prompts::Forbidden] {
+            assert!(
+                matches!(decide_elevation(true, prompts, is_disconnect), Decline(_)),
+                "external must decline elevation (disconnect={is_disconnect})"
+            );
+        }
+    }
+}
+
+#[skuld::test]
+fn elevation_matrix_when_gui_owns_bridge() {
+    use ElevationDecision::*;
+    // Connect, prompts allowed -> elevate.
+    assert!(matches!(decide_elevation(false, Prompts::Allowed, false), Elevate));
+    // Connect, unattended startup -> decline (no UAC at login).
+    assert!(matches!(decide_elevation(false, Prompts::Forbidden, false), Decline(_)));
+    // Disconnect is always interactive -> elevate regardless of prompts.
+    assert!(matches!(decide_elevation(false, Prompts::Allowed, true), Elevate));
+    assert!(matches!(decide_elevation(false, Prompts::Forbidden, true), Elevate));
+}
+
+#[skuld::test]
+fn external_bridge_denied_toast_is_actionable() {
+    let toast = external_bridge_denied_toast();
+    assert!(toast.to_lowercase().contains("permission denied"), "{toast}");
+    assert!(toast.contains("gui.log"), "{toast}");
+}


### PR DESCRIPTION
Clicking Connect in dev mode popped "The Hole bridge is not installed — install it now? (requires administrator privileges)", even though the dev-console had already spawned a live bridge and pointed the GUI at it via `HOLE_BRIDGE_SOCKET`.

Root cause: the connect-time install gate consults production install state (`is_installed()` → on macOS, the launchd plist exists; on Windows, SCM registration), which is blind to `HOLE_BRIDGE_SOCKET`. With no production service installed it reports `NotInstalled` and the GUI demands an admin install over an already-running bridge. The same blindness silently fails startup auto-connect (#458) and, on the `NeedsElevation` fallback, spawns an elevated `hole bridge ipc-send` that targets the *default* production socket rather than the dev one.

## Fix

Treat a non-empty `HOLE_BRIDGE_SOCKET` as "the bridge is externally supervised": the GUI does not own its lifecycle, so it must neither prompt to install a production service nor elevate. Threaded through `AppState::bridge_is_externally_supervised()` and consulted by two pure decisions:

- `should_prompt_install` — install gate skips both branches (interactive connect and unattended startup auto-connect) when externally supervised; otherwise unchanged.
- `decide_elevation` — both `NeedsElevation` arms (Start and Stop) decline elevation when externally supervised, surfacing the denial instead of running a mis-targeting elevated helper.

With `HOLE_BRIDGE_SOCKET` unset, `externally_supervised == false` and behavior is identical to before. An empty `HOLE_BRIDGE_SOCKET=` is treated as unset.

## Out of scope

Two CLI paths are also blind to `HOLE_BRIDGE_SOCKET` but off the GUI connect flow, so #569's symptoms are fully addressed without them: `hole bridge status` (reports production install state — intentional) and `hole proxy start/stop` (`send_bridge_request_inner` hard-codes the default socket). Worth a separate follow-up.

## Verification

`cargo test -p hole` — lib 201, bin 239, 0 failed; new pure-function tests pin the regression (external ⇒ no prompt / no elevate, across the full matrix). `cargo clippy -p hole --all-targets` clean.

Closes #569.

https://claude.ai/code/session_01U2dKKZ4VWH31QgmtjR1bYf