### PR TITLE
fix(xtask): make the launcher transparent to Ctrl+C so dev shutdown finishes before the prompt (#568)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -676,6 +676,11 @@ Vite HMR; Rust changes need Ctrl+C and re-run.
   that ignore the graceful signal for 10s are force-killed with their process
   trees — except the macOS bridge, which sudo cannot force-kill; dev-console
   prints a `network-reset.py` recovery pointer instead.
+- **Multiplexed logs (`mux`).** Steady state streams each child's entries in
+  arrival order, deferring an EntryBuffered stream's most-recent entry until its
+  next anchor or pipe EOF (atomic multi-line framing). At shutdown the printer
+  switches to collect-and-sort, emitting the trailing burst ordered by ISO
+  timestamp instead of pump-EOF order (bindreams/hole#568).
 
 ### Manual workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9583,9 +9594,11 @@ dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",
  "clap",
+ "ctrlc",
  "flate2",
  "glob",
  "indexmap 2.14.0",
+ "libc",
  "petgraph",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9608,6 +9608,7 @@ dependencies = [
  "tar",
  "tempfile",
  "ureq",
+ "windows 0.62.2",
  "xtask-lib",
  "zip",
 ]

--- a/crates/dev-console/src/mux.rs
+++ b/crates/dev-console/src/mux.rs
@@ -6,6 +6,14 @@
 //! be interleaved with another stream's lines; Vite (no timestamp anchor)
 //! prints per-line. Atomicity is structural: every stream pumps into one
 //! mpsc consumed by a single printer task — one writer, no lock.
+//!
+//! Shutdown ordering (issue #568): in steady state the most-recent entry of an
+//! EntryBuffered stream is deferred until its next anchor or pipe EOF, so the
+//! shutdown burst would otherwise print in pump-EOF order, not time order. The
+//! printer therefore switches to a collect-and-sort phase on `enter_drain`
+//! (fired by the supervisor at shutdown), emitting trailing entries sorted by
+//! ISO timestamp; `finalize` bounds the case where a pump never EOFs. Atomic
+//! multi-line entries are preserved (each sorted unit is a whole entry).
 
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
 use tokio::sync::mpsc;
@@ -37,6 +45,20 @@ pub fn is_entry_start(line: &str) -> bool {
         && b[8].is_ascii_digit()
         && b[9].is_ascii_digit()
         && b[10] == b'T'
+}
+
+/// Sort key for the shutdown drain: the leading ISO timestamp token of an
+/// entry's first line, if that line is an anchor. `None` for anchorless entries
+/// (Vite/PerLine, bare Immediate lines), which the drain sorts AFTER keyed
+/// entries in arrival order. ISO-8601 fixed-format timestamps sort lexically ==
+/// chronologically, so a string key is sufficient.
+pub fn anchor_key(entry: &Entry) -> Option<String> {
+    let first = entry.lines.first()?;
+    if !is_entry_start(first) {
+        return None;
+    }
+    let end = first.find(' ').unwrap_or(first.len());
+    Some(first[..end].to_string())
 }
 
 pub enum FramerOutput {
@@ -180,21 +202,61 @@ pub async fn pump(mut stream: impl AsyncRead + Unpin, mode: StreamMode, prefix: 
     }
 }
 
-/// The single writer: receives entries from every pump and writes each as
-/// one contiguous block. One writer == atomic entries (replaces dev.py's
-/// print lock).
-pub async fn printer(mut rx: mpsc::Receiver<Entry>, mut out: impl AsyncWrite + Unpin) -> std::io::Result<()> {
-    while let Some(entry) = rx.recv().await {
-        let mut block = String::new();
-        for line in &entry.lines {
-            block.push_str(&entry.prefix);
-            block.push_str(line);
-            block.push('\n');
+/// The single writer. Phase 1 streams entries in arrival order (one atomic
+/// block each) until `enter_drain` fires. Phase 2 collects the trailing
+/// (deferred final) entries and emits them sorted by ISO timestamp — so the
+/// shutdown burst prints in time order, not pump-EOF order (issue #568) —
+/// bounded by `finalize` for the WarnRecovery case where a pump never EOFs and
+/// `rx` never closes. One writer == atomic entries (replaces dev.py's print
+/// lock).
+pub async fn printer(
+    mut rx: mpsc::Receiver<Entry>,
+    mut out: impl AsyncWrite + Unpin,
+    mut enter_drain: tokio::sync::oneshot::Receiver<()>,
+    mut finalize: tokio::sync::oneshot::Receiver<()>,
+) -> std::io::Result<()> {
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut enter_drain => break,
+            entry = rx.recv() => match entry {
+                Some(e) => write_entry(&mut out, &e).await?,
+                None => return Ok(()), // all streams ended before shutdown
+            }
         }
-        out.write_all(block.as_bytes()).await?;
-        out.flush().await?;
+    }
+    let mut tail = Vec::new();
+    loop {
+        tokio::select! {
+            biased;
+            _ = &mut finalize => break,
+            entry = rx.recv() => match entry {
+                Some(e) => tail.push(e),
+                None => break, // all reapable pumps EOF'd
+            }
+        }
+    }
+    // Stable: keyed entries first, by timestamp; anchorless entries last, in
+    // arrival order.
+    tail.sort_by_key(|e| {
+        let k = anchor_key(e);
+        (k.is_none(), k)
+    });
+    for e in &tail {
+        write_entry(&mut out, e).await?;
     }
     Ok(())
+}
+
+async fn write_entry(out: &mut (impl AsyncWrite + Unpin), entry: &Entry) -> std::io::Result<()> {
+    let mut block = String::new();
+    for line in &entry.lines {
+        block.push_str(&entry.prefix);
+        block.push_str(line);
+        block.push('\n');
+    }
+    out.write_all(block.as_bytes()).await?;
+    out.flush().await
 }
 
 #[cfg(test)]

--- a/crates/dev-console/src/mux_tests.rs
+++ b/crates/dev-console/src/mux_tests.rs
@@ -1,6 +1,27 @@
-use crate::mux::{is_entry_start, pump, split_lines_universal, Entry, EntryFramer, FramerOutput, StreamMode};
+use crate::mux::{
+    anchor_key, is_entry_start, pump, split_lines_universal, Entry, EntryFramer, FramerOutput, StreamMode,
+};
 
 // Framing core (pure) =================================================================================================
+
+#[skuld::test]
+fn anchor_key_extracts_timestamp_token_or_none() {
+    let keyed = Entry {
+        prefix: "[bridge] ".into(),
+        lines: vec!["2026-01-01T00:00:01Z INFO hi".into()],
+    };
+    assert_eq!(anchor_key(&keyed).as_deref(), Some("2026-01-01T00:00:01Z"));
+    let unkeyed = Entry {
+        prefix: "[  vite] ".into(),
+        lines: vec!["VITE ready".into()],
+    };
+    assert_eq!(anchor_key(&unkeyed), None);
+    let empty = Entry {
+        prefix: "[x] ".into(),
+        lines: vec![],
+    };
+    assert_eq!(anchor_key(&empty), None);
+}
 
 #[skuld::test]
 fn anchor_detection_matches_iso_timestamps_only() {
@@ -91,6 +112,44 @@ fn splits_lf_crlf_and_lone_cr() {
     assert_eq!(pending, b"f");
 }
 
+// Shutdown drain ordering (#568) ======================================================================================
+
+/// At shutdown the printer collects post-`enter_drain` entries and emits them
+/// sorted by ISO timestamp (out-of-order arrival -> in-order output), each entry
+/// still an atomic prefixed block.
+#[skuld::test]
+async fn shutdown_drain_emits_trailing_entries_in_timestamp_order() {
+    use tokio::sync::{mpsc, oneshot};
+    let (tx, rx) = mpsc::channel::<Entry>(16);
+    let (drain_tx, drain_rx) = oneshot::channel();
+    let (_fin_tx, fin_rx) = oneshot::channel(); // held: finalize never fires; rx-close ends collect
+    let mut sink: Vec<u8> = Vec::new();
+
+    drain_tx.send(()).unwrap(); // shutdown begins: everything below is "trailing"
+    tx.send(Entry {
+        prefix: "[client] ".into(),
+        lines: vec!["2026-01-01T00:00:05Z later".into()],
+    })
+    .await
+    .unwrap();
+    tx.send(Entry {
+        prefix: "[bridge] ".into(),
+        lines: vec!["2026-01-01T00:00:01Z earlier".into()],
+    })
+    .await
+    .unwrap();
+    drop(tx); // rx closes -> printer sorts + flushes
+
+    crate::mux::printer(rx, &mut sink, drain_rx, fin_rx).await.unwrap();
+    assert_eq!(
+        String::from_utf8(sink).unwrap().lines().collect::<Vec<_>>(),
+        vec![
+            "[bridge] 2026-01-01T00:00:01Z earlier",
+            "[client] 2026-01-01T00:00:05Z later"
+        ],
+    );
+}
+
 // Cross-stream atomicity (ports dev_tests.py:288-354) =================================================================
 
 /// Two entry-buffered streams pumped concurrently into one printer must
@@ -104,6 +163,10 @@ async fn concurrent_streams_never_split_entries() {
         let (b_w, b_r) = tokio::io::duplex(4096);
         let (tx, rx) = tokio::sync::mpsc::channel::<Entry>(64);
         let mut sink: Vec<u8> = Vec::new();
+        // Never-firing control signals: senders held in named locals so a
+        // dropped sender can't fire the receiver and wrongly trigger drain.
+        let (_drain_tx, drain_rx) = tokio::sync::oneshot::channel();
+        let (_fin_tx, fin_rx) = tokio::sync::oneshot::channel();
 
         let pump_a = tokio::spawn(pump(a_r, StreamMode::EntryBuffered, "[bridge] ".into(), tx.clone()));
         let pump_b = tokio::spawn(pump(b_r, StreamMode::EntryBuffered, "[client] ".into(), tx.clone()));
@@ -125,7 +188,7 @@ async fn concurrent_streams_never_split_entries() {
             pump_b,
             // tokio 1.52 implements AsyncWrite for Vec<u8> (and the &mut
             // blanket lifts it) — verified against the vendored tokio source.
-            crate::mux::printer(rx, &mut sink),
+            crate::mux::printer(rx, &mut sink, drain_rx, fin_rx),
         );
         let (_, _) = (f1, f2);
         printed.unwrap();

--- a/crates/dev-console/src/supervise.rs
+++ b/crates/dev-console/src/supervise.rs
@@ -262,7 +262,14 @@ async fn supervise_children(
     state_dir: &Path,
 ) -> Result<ExitCode> {
     let (tx, rx) = mpsc::channel::<Entry>(256);
-    let mut printer = tokio::spawn(crate::mux::printer(rx, tokio::io::stdout()));
+    let (enter_drain_tx, enter_drain_rx) = tokio::sync::oneshot::channel();
+    let (finalize_tx, finalize_rx) = tokio::sync::oneshot::channel();
+    let mut printer = tokio::spawn(crate::mux::printer(
+        rx,
+        tokio::io::stdout(),
+        enter_drain_rx,
+        finalize_rx,
+    ));
 
     let mut bridge: Option<BridgeChild> = None;
     let mut vite: Option<GroupedChild> = None;
@@ -273,7 +280,7 @@ async fn supervise_children(
     // below always runs, on panics too.
     // AssertUnwindSafe: after a panic the funnel touches only the slot
     // Options, which are coherent at every await point.
-    let outcome: Result<ExitCause> = match std::panic::AssertUnwindSafe(startup_and_supervise(
+    let caught = std::panic::AssertUnwindSafe(startup_and_supervise(
         interrupts,
         npm,
         bridge_bin,
@@ -286,8 +293,12 @@ async fn supervise_children(
         &mut gui,
     ))
     .catch_unwind()
-    .await
-    {
+    .await;
+    // We are now shutting down: stop streaming so the trailing entries are
+    // collected and emitted in timestamp order (#568). Fired ONCE, before
+    // both the panic-arm shutdown and the normal shutdown.
+    let _ = enter_drain_tx.send(());
+    let outcome: Result<ExitCause> = match caught {
         Ok(outcome) => outcome,
         Err(panic) => {
             // dev.py's `finally` ran on arbitrary exceptions: tear down the
@@ -300,11 +311,18 @@ async fn supervise_children(
     shutdown(bridge.as_mut(), vite.as_mut(), gui.as_mut()).await;
 
     drop(tx);
-    // Class-2 bound (external pipes that may never EOF): the WarnRecovery
-    // bridge is deliberately never killed, so its pump can hold its sender
-    // forever; drain what's buffered, then abandon (dev.py join(timeout=5)).
+    // Drain. The printer is collecting the post-`enter_drain` tail; on rx
+    // close it sorts + flushes. Class-2 bound (external pipes that may never
+    // EOF): the WarnRecovery bridge is deliberately never killed, so its pump
+    // can hold its sender forever and `rx` never closes. On that timeout fire
+    // `finalize` so the printer still sorts + writes what it collected, then
+    // re-bound the flush so a wedged stdout can't hang teardown (dev.py
+    // join(timeout=5)).
     if tokio::time::timeout(PRINTER_DRAIN_TIMEOUT, &mut printer).await.is_err() {
-        printer.abort();
+        let _ = finalize_tx.send(());
+        if tokio::time::timeout(PRINTER_DRAIN_TIMEOUT, &mut printer).await.is_err() {
+            printer.abort();
+        }
     }
 
     let cause = outcome?;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 anyhow = "1"
 cargo_metadata = "0.23"
 clap = { version = "4", features = ["derive"] }
+ctrlc = "3" # transparent-launcher interrupt handling (#568): a handler (not SIG_IGN) resets to default across exec, so children stay interruptible while xtask survives Ctrl+C and propagates the child's exit status
 glob = "0.3"
 xtask-lib = { path = "../xtask-lib", features = ["serde", "clap", "version"] }
 
@@ -44,3 +45,6 @@ petgraph = "0.8"
 [dev-dependencies]
 skuld = { workspace = true }
 tempfile = "3"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2" # raise()/kill() + SIGINT in signal tests

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -48,3 +48,6 @@ tempfile = "3"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2" # raise()/kill() + SIGINT in signal tests
+
+[target.'cfg(windows)'.dev-dependencies]
+windows = { version = "0.62", features = ["Win32_System_Console"] } # GenerateConsoleCtrlEvent in the Ctrl+Break e2e test (#568)

--- a/xtask/src/interrupt.rs
+++ b/xtask/src/interrupt.rs
@@ -1,0 +1,29 @@
+//! Transparent interrupt handling for the xtask launcher (issue #568).
+//!
+//! xtask is a pass-through launcher: every subcommand spawns child processes
+//! (cargo, dev-console, ...) and waits with `Command::status()`. On Ctrl+C the
+//! terminal delivers SIGINT to the whole foreground process group, so the
+//! children receive it directly and own their own shutdown. xtask must NOT die
+//! from that signal mid-`status()`: otherwise it abandons the wait, the shell
+//! regains control before the child (e.g. dev-console) has finished its
+//! teardown, and the child keeps printing to the inherited TTY after the prompt
+//! returns.
+//!
+//! Fix: install a no-op SIGINT / console-ctrl handler. A handler — unlike
+//! `SIG_IGN` — is reset to the default disposition across `execve`, so spawned
+//! children stay interruptible; xtask itself survives the signal and its
+//! `status()` wait resumes and returns the child's real exit status.
+
+/// Install the no-op interrupt handler. Call once at startup. Idempotent: a
+/// second registration (`ctrlc` allows only one handler per process) is
+/// swallowed, not a panic.
+pub fn install_transparent_interrupt() {
+    // `ctrlc` handles SIGINT (POSIX) and CTRL_C_EVENT (Windows console) behind
+    // one API. The empty closure swallows the signal in xtask; the child in the
+    // same process/console group still receives and acts on it.
+    let _ = ctrlc::set_handler(|| {});
+}
+
+#[cfg(test)]
+#[path = "interrupt_tests.rs"]
+mod interrupt_tests;

--- a/xtask/src/interrupt_tests.rs
+++ b/xtask/src/interrupt_tests.rs
@@ -1,6 +1,8 @@
-//! Unix-gated and nextest-isolated: run with `cargo nextest run` so each test
-//! is its own process; self-`raise(SIGINT)` would otherwise hit the shared
-//! `cargo test` process (skuld runs in-process). Mirrors
+//! Nextest-isolated: run with `cargo nextest run` so each test is its own
+//! process; self-`raise(SIGINT)` (unix) / CTRL_BREAK to a process group
+//! (windows) would otherwise hit the shared `cargo test` process (skuld runs
+//! in-process). The unix tests are `#[cfg(unix)]`, the CTRL_BREAK e2e is
+//! `#[cfg(windows)]`; `spawn_and_rendezvous` is shared. Mirrors
 //! crates/dev-console/src/interrupts_tests.rs.
 
 /// After installing the transparent handler, a SIGINT must NOT terminate the
@@ -20,16 +22,19 @@ fn transparent_handler_survives_sigint() {
 /// parent's readiness conn (parent announced "about to wait"), the grandchild's
 /// conn (held open by the caller — drop it to release the grandchild), and the
 /// grandchild's pid. Sleep-free: both readiness lines must arrive before we act.
-#[cfg(unix)]
 fn spawn_and_rendezvous() -> (std::process::Child, std::net::TcpStream, std::net::TcpStream, u32) {
     use std::io::{BufRead as _, BufReader};
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind control");
     let addr = listener.local_addr().unwrap().to_string();
-    let parent = std::process::Command::new(std::env::current_exe().unwrap())
-        .env(crate::test_child::MODE_ENV, "interrupt-parent")
-        .env(crate::test_child::CONTROL_ENV, &addr)
-        .spawn()
-        .expect("spawn parent-under-test");
+    let mut cmd = std::process::Command::new(std::env::current_exe().unwrap());
+    cmd.env(crate::test_child::MODE_ENV, "interrupt-parent")
+        .env(crate::test_child::CONTROL_ENV, &addr);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        cmd.creation_flags(0x0000_0200); // CREATE_NEW_PROCESS_GROUP — parent's group == its pid; CTRL_BREAK to it won't hit the test console
+    }
+    let parent = cmd.spawn().expect("spawn parent-under-test");
 
     let (mut parent_conn, mut child_conn, mut child_pid) = (None, None, None);
     for _ in 0..2 {
@@ -86,5 +91,28 @@ fn child_sigint_disposition_resets_across_exec() {
         status.code(),
         Some(128 + libc::SIGINT),
         "grandchild must inherit the DEFAULT SIGINT disposition across exec (got {status:?})"
+    );
+}
+
+/// Windows analog of `parent_survives_sigint_and_forwards_child_exit`: a
+/// CTRL_BREAK delivered to the launcher's (isolated) process group mid-wait must
+/// not kill it — `ctrlc`'s handler returns TRUE for every console event — so it
+/// keeps waiting and forwards the grandchild's exit code. CTRL_BREAK (not
+/// CTRL_C) because only it can target a single new process group without hitting
+/// the test runner's console.
+#[cfg(windows)]
+#[skuld::test]
+fn parent_survives_ctrl_break_and_forwards_child_exit() {
+    use windows::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
+    let (mut parent, _parent_conn, child_conn, _child_pid) = spawn_and_rendezvous();
+    // The parent was spawned with CREATE_NEW_PROCESS_GROUP, so its group id == its pid.
+    // SAFETY: FFI call into kernel32; the group id is our live child's pid.
+    unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, parent.id()) }.expect("GenerateConsoleCtrlEvent(CTRL_BREAK)");
+    drop(child_conn); // release the grandchild -> it exits CHILD_RELEASE_EXIT
+    let status = parent.wait().expect("wait parent");
+    assert_eq!(
+        status.code(),
+        Some(crate::test_child::CHILD_RELEASE_EXIT),
+        "parent must survive CTRL_BREAK and forward the child's exit code, not die from it (got {status:?})"
     );
 }

--- a/xtask/src/interrupt_tests.rs
+++ b/xtask/src/interrupt_tests.rs
@@ -15,3 +15,76 @@ fn transparent_handler_survives_sigint() {
     assert_eq!(unsafe { libc::raise(libc::SIGINT) }, 0);
     // If the handler were absent, the process would have died on the line above.
 }
+
+/// Spawn the parent-under-test and rendezvous: returns the parent handle, the
+/// parent's readiness conn (parent announced "about to wait"), the grandchild's
+/// conn (held open by the caller — drop it to release the grandchild), and the
+/// grandchild's pid. Sleep-free: both readiness lines must arrive before we act.
+#[cfg(unix)]
+fn spawn_and_rendezvous() -> (std::process::Child, std::net::TcpStream, std::net::TcpStream, u32) {
+    use std::io::{BufRead as _, BufReader};
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind control");
+    let addr = listener.local_addr().unwrap().to_string();
+    let parent = std::process::Command::new(std::env::current_exe().unwrap())
+        .env(crate::test_child::MODE_ENV, "interrupt-parent")
+        .env(crate::test_child::CONTROL_ENV, &addr)
+        .spawn()
+        .expect("spawn parent-under-test");
+
+    let (mut parent_conn, mut child_conn, mut child_pid) = (None, None, None);
+    for _ in 0..2 {
+        let (conn, _) = listener.accept().expect("accept readiness");
+        let mut br = BufReader::new(conn);
+        let mut line = String::new();
+        br.read_line(&mut line).expect("read readiness line");
+        let conn = br.into_inner();
+        match line.trim_end() {
+            "P" => parent_conn = Some(conn),
+            other => {
+                let pid = other.strip_prefix('C').expect("readiness 'P' or 'C<pid>'");
+                child_pid = Some(pid.parse().expect("grandchild pid"));
+                child_conn = Some(conn);
+            }
+        }
+    }
+    (parent, parent_conn.unwrap(), child_conn.unwrap(), child_pid.unwrap())
+}
+
+/// The real #568 regression: SIGINT delivered to a launcher WHILE it waits must
+/// not kill the launcher; it keeps waiting and returns the child's exit code.
+#[cfg(unix)]
+#[skuld::test]
+fn parent_survives_sigint_and_forwards_child_exit() {
+    let (mut parent, _parent_conn, child_conn, _child_pid) = spawn_and_rendezvous();
+    // Parent announced "about to wait" -> SIGINT it now (mid-wait), parent pid
+    // only (not the group, so the grandchild is untouched). A regressed parent
+    // dies here. SAFETY: kill(2) to a pid we own.
+    assert_eq!(unsafe { libc::kill(parent.id() as libc::pid_t, libc::SIGINT) }, 0);
+    drop(child_conn); // release the grandchild -> it exits CHILD_RELEASE_EXIT
+    let status = parent.wait().unwrap();
+    assert_eq!(
+        status.code(),
+        Some(crate::test_child::CHILD_RELEASE_EXIT),
+        "parent must survive SIGINT and forward the child's exit code, not die from the signal (got {status:?})"
+    );
+}
+
+/// The handler must be a HANDLER, not SIG_IGN: a handler resets to the default
+/// disposition across exec, so a grandchild that installs nothing dies on
+/// SIGINT. (SIG_IGN would be inherited across exec and the grandchild would
+/// ignore the signal — the parent's wait would never return and this test would
+/// fail via the per-test timeout.)
+#[cfg(unix)]
+#[skuld::test]
+fn child_sigint_disposition_resets_across_exec() {
+    let (mut parent, _parent_conn, _child_conn, child_pid) = spawn_and_rendezvous();
+    // Do NOT release the grandchild; SIGINT IT. SAFETY: kill(2) to a pid our
+    // descendant reported.
+    assert_eq!(unsafe { libc::kill(child_pid as libc::pid_t, libc::SIGINT) }, 0);
+    let status = parent.wait().unwrap();
+    assert_eq!(
+        status.code(),
+        Some(128 + libc::SIGINT),
+        "grandchild must inherit the DEFAULT SIGINT disposition across exec (got {status:?})"
+    );
+}

--- a/xtask/src/interrupt_tests.rs
+++ b/xtask/src/interrupt_tests.rs
@@ -1,0 +1,17 @@
+//! Unix-gated and nextest-isolated: run with `cargo nextest run` so each test
+//! is its own process; self-`raise(SIGINT)` would otherwise hit the shared
+//! `cargo test` process (skuld runs in-process). Mirrors
+//! crates/dev-console/src/interrupts_tests.rs.
+
+/// After installing the transparent handler, a SIGINT must NOT terminate the
+/// process (default disposition would). Reaching the line past the raise is the
+/// proof of survival — no timing (raise delivers synchronously before return).
+#[cfg(unix)]
+#[skuld::test]
+fn transparent_handler_survives_sigint() {
+    crate::install_transparent_interrupt();
+    // SAFETY: raising SIGINT to our own process is sound; the no-op handler
+    // installed above replaced the default (terminate) disposition.
+    assert_eq!(unsafe { libc::raise(libc::SIGINT) }, 0);
+    // If the handler were absent, the process would have died on the line above.
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
+pub use interrupt::install_transparent_interrupt;
+
 use crate::manifest::{Manifest, Platform};
 use crate::orchestrate::{execute, execute_run, relocate_self_if_windows, render_list, Plan};
 
@@ -16,6 +18,7 @@ pub mod ci_coverage;
 pub mod ex_ray;
 pub mod galoshes;
 pub mod golangci_lint;
+pub mod interrupt;
 pub mod manifest;
 pub mod orchestrate;
 pub mod stage;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -401,7 +401,12 @@ pub fn run_version(group: Option<xtask_lib::version::Group>, check: bool, exact:
 
 pub use xtask_lib::repo_root::repo_root;
 
+#[cfg(all(test, unix))]
+pub mod test_child;
+
 #[cfg(test)]
 fn main() {
+    #[cfg(unix)]
+    test_child::maybe_run();
     skuld::run_all();
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -401,12 +401,11 @@ pub fn run_version(group: Option<xtask_lib::version::Group>, check: bool, exact:
 
 pub use xtask_lib::repo_root::repo_root;
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 pub mod test_child;
 
 #[cfg(test)]
 fn main() {
-    #[cfg(unix)]
     test_child::maybe_run();
     skuld::run_all();
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ use std::process::ExitCode;
 use clap::Parser;
 
 fn main() -> ExitCode {
+    xtask::install_transparent_interrupt();
     let cli = xtask::Cli::parse();
     match xtask::dispatch(cli) {
         Ok(()) => ExitCode::SUCCESS,

--- a/xtask/src/test_child.rs
+++ b/xtask/src/test_child.rs
@@ -32,11 +32,14 @@ pub fn maybe_run() {
 fn run_interrupt_parent() -> ! {
     crate::install_transparent_interrupt();
     let addr = std::env::var(CONTROL_ENV).expect("control env");
-    let mut child = std::process::Command::new(std::env::current_exe().expect("current_exe"))
-        .env(MODE_ENV, "interrupt-child")
-        .env(CONTROL_ENV, &addr)
-        .spawn()
-        .expect("spawn grandchild");
+    let mut cmd = std::process::Command::new(std::env::current_exe().expect("current_exe"));
+    cmd.env(MODE_ENV, "interrupt-child").env(CONTROL_ENV, &addr);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        cmd.creation_flags(0x0000_0200); // CREATE_NEW_PROCESS_GROUP — isolate the grandchild from the parent-group CTRL_BREAK
+    }
+    let mut child = cmd.spawn().expect("spawn grandchild");
     // Announce AFTER spawning that we have committed to waiting; the test
     // SIGINTs only after reading this. (The handler was installed before the
     // spawn, so the parent survives wherever the signal lands relative to wait.)
@@ -45,14 +48,28 @@ fn run_interrupt_parent() -> ! {
         conn.write_all(b"P\n").expect("parent readiness");
     }
     let status = child.wait().expect("wait grandchild");
-    let code = match status.code() {
-        Some(c) => c,
-        None => {
-            use std::os::unix::process::ExitStatusExt as _;
-            128 + status.signal().unwrap_or(0)
+    std::process::exit(encode_exit(status));
+}
+
+/// Encode a child's outcome as an exit code the test asserts on: a clean exit
+/// forwards its code; on unix a signal death maps to 128+signum. On Windows a
+/// process always carries an exit code (even a CTRL_BREAK kill), so `code()` is
+/// authoritative.
+fn encode_exit(status: std::process::ExitStatus) -> i32 {
+    #[cfg(unix)]
+    {
+        match status.code() {
+            Some(c) => c,
+            None => {
+                use std::os::unix::process::ExitStatusExt as _;
+                128 + status.signal().unwrap_or(0)
+            }
         }
-    };
-    std::process::exit(code);
+    }
+    #[cfg(windows)]
+    {
+        status.code().unwrap_or(-1)
+    }
 }
 
 /// Grandchild: installs NO handler (its disposition reflects what it inherited

--- a/xtask/src/test_child.rs
+++ b/xtask/src/test_child.rs
@@ -1,0 +1,75 @@
+//! Self-reinvoke child modes for xtask's signal tests (mirrors
+//! crates/dev-console/src/test_child.rs). When `XTASK_TEST_CHILD` is set,
+//! `maybe_run` takes over the process and never returns.
+
+use std::io::{Read as _, Write as _};
+use std::net::TcpStream;
+
+pub const MODE_ENV: &str = "XTASK_TEST_CHILD";
+pub const CONTROL_ENV: &str = "XTASK_TEST_CONTROL";
+/// Grandchild's clean-release exit code (shared so the test can't drift).
+pub const CHILD_RELEASE_EXIT: i32 = 42;
+/// Grandchild's error-path exit code — a read error must NOT masquerade as the
+/// clean-release code.
+pub const CHILD_ERROR_EXIT: i32 = 99;
+
+pub fn maybe_run() {
+    let Ok(mode) = std::env::var(MODE_ENV) else { return };
+    match mode.as_str() {
+        "interrupt-parent" => run_interrupt_parent(),
+        "interrupt-child" => run_interrupt_child(),
+        other => {
+            eprintln!("unknown {MODE_ENV} mode: {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// Process under test: install the transparent handler, spawn the grandchild,
+/// announce "about to wait", then wait. Exit code encodes the grandchild's fate
+/// so the test asserts on it: a clean exit forwards its code; a signal death
+/// maps to 128+signum (shell convention).
+fn run_interrupt_parent() -> ! {
+    crate::install_transparent_interrupt();
+    let addr = std::env::var(CONTROL_ENV).expect("control env");
+    let mut child = std::process::Command::new(std::env::current_exe().expect("current_exe"))
+        .env(MODE_ENV, "interrupt-child")
+        .env(CONTROL_ENV, &addr)
+        .spawn()
+        .expect("spawn grandchild");
+    // Announce AFTER spawning that we have committed to waiting; the test
+    // SIGINTs only after reading this. (The handler was installed before the
+    // spawn, so the parent survives wherever the signal lands relative to wait.)
+    {
+        let mut conn = TcpStream::connect(&addr).expect("dial control (parent)");
+        conn.write_all(b"P\n").expect("parent readiness");
+    }
+    let status = child.wait().expect("wait grandchild");
+    let code = match status.code() {
+        Some(c) => c,
+        None => {
+            use std::os::unix::process::ExitStatusExt as _;
+            128 + status.signal().unwrap_or(0)
+        }
+    };
+    std::process::exit(code);
+}
+
+/// Grandchild: installs NO handler (its disposition reflects what it inherited
+/// across exec). Announce readiness with our pid, then block until the control
+/// socket closes (clean EOF -> CHILD_RELEASE_EXIT). A read error is distinct so
+/// a broken rendezvous can't masquerade as a clean release.
+fn run_interrupt_child() -> ! {
+    let addr = std::env::var(CONTROL_ENV).expect("control env");
+    let mut conn = TcpStream::connect(addr).expect("dial control (child)");
+    conn.write_all(format!("C{}\n", std::process::id()).as_bytes())
+        .expect("child readiness");
+    let mut buf = [0u8; 64];
+    loop {
+        match conn.read(&mut buf) {
+            Ok(0) => std::process::exit(CHILD_RELEASE_EXIT), // clean EOF => release
+            Ok(_) => {}                                      // ignore stray bytes
+            Err(_) => std::process::exit(CHILD_ERROR_EXIT),
+        }
+    }
+}


### PR DESCRIPTION
Closes #568.

## Why
`cargo xtask run hole` returned the shell prompt **before** `dev-console` finished tearing down on Ctrl+C, so stray `[client]`/`[bridge]` log lines printed *after* the prompt, with scrambled timestamps. On Unix `cargo run` exec-replaces itself, so the live chain is `zsh → xtask → dev-console`; `xtask` had no signal handler and died mid-`Command::status()`, handing the prompt back while `dev-console` (which owns teardown) kept running detached and printing. Secondary: dev-console's log mux defers each stream's last entry until its next anchor/EOF, so the shutdown burst printed in flush order, not timestamp order.

## What
- **xtask is now a transparent launcher** — installs a no-op SIGINT/console-ctrl handler (`ctrlc`). A *handler* (not `SIG_IGN`) resets to the default disposition across `exec`, so children stay interruptible while xtask survives the signal and its wait returns dev-console's real exit code. The prompt now returns only after teardown completes.
- **dev-console sorts the shutdown log burst by timestamp** — the printer collect-and-sorts trailing entries at shutdown, preserving the atomic-multi-line-entry invariant (#393) and using no timer (a `finalize` signal bounds the WarnRecovery never-EOF case).
- **Signal tests** — unix e2e (SIGINT mid-wait forwards the child's exit; the handler resets across `exec`) plus a Windows CTRL_BREAK e2e analog (CTRL_BREAK is the isolatable console interrupt `ctrlc`'s handler swallows; the Windows leg is validated by CI).

## Verify
- `cargo nextest run -p xtask -p dev-console` → 137 pass (macOS).
- Manual: `cargo xtask run hole`, then Ctrl+C → "Shutting down…", teardown logs, and the prompt returns **after** the last log line — nothing prints after the prompt.

Dev-only (the `dev-console` supervisor); production manages the bridge via the installed privileged service.

https://claude.ai/code/session_01Xckej3h4VhnJijpVzbSra3
