### PR TITLE
feat(logging): native per-sink log levels + dev-console dev-run capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ crates/hole/gen/
 # Build cache (xtask deps: v2ray-plugin Go build, wintun download, generated icons)
 /.cache/
 
+# Dev-run logs and Claude scratch (also covered by the user global ignore,
+# pinned here so fresh clones / CI don't see it untracked).
+/.tmp/
+
 # Claude Code
 CLAUDE.local.md
 .claude/*.local.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -885,6 +885,19 @@ content/PII: `import_servers_from_file` returns `ImportFailure::SaveFailed` /
 byte counts (`L2R N bytes, R2L M bytes`) — a load-bearing #248-class diagnostic,
 but expensive (≥1 TRACE line per TCP connection); use for debugging only.
 
+The file and stderr sinks filter independently. `HOLE_LOG` sets the file-sink
+directives; `HOLE_LOG_STDERR` sets the stderr-sink directives (defaults to
+mirroring the file sink when unset); `HOLE_LOG_DIR` overrides the log directory.
+`HOLE_BRIDGE_LOG` stays the bridge's file-sink override and takes precedence over
+`HOLE_LOG`.
+
+### Dev-run capture
+
+`cargo xtask run hole` writes `<repo>/.tmp/dev-run/<datetime>/` per run:
+`bridge.log` and `gui.log` at trace (Hole crates trace, deps debug), plus
+`dev-console.log` (the supervisor transcript and the runtime mux at info). No
+retention — old run dirs are kept until you delete them.
+
 ### Plugin diagnostics
 
 The out-of-process plugin (`ex-ray`, `galoshes`) is otherwise invisible:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,9 @@ dependencies = [
 name = "dev-console"
 version = "0.1.0"
 dependencies = [
+ "anstream",
  "anyhow",
+ "chrono",
  "futures-util",
  "hole-test-observability",
  "kill-group",

--- a/crates/bridge/src/logging.rs
+++ b/crates/bridge/src/logging.rs
@@ -5,91 +5,11 @@ use std::path::Path;
 
 /// Initialize bridge logging (stderr + size-rotated file).
 ///
-/// The default directive is `hole_bridge=info`. Set `HOLE_BRIDGE_LOG` to
-/// override — a single directive (`hole_bridge=debug`) or a comma-separated
-/// list (`hole_bridge=debug,shadowsocks_service=trace`).
-///
-/// All comma-separated directives are honored: the env var is split, each
-/// piece is trimmed, blanks are dropped, and the rest are passed to
-/// `EnvFilter::add_directive` in order via [`hole_common::logging::init_multi`].
-/// This is needed so e.g. `shadowsocks_service=trace` relay byte-count
-/// logs (`L2R N bytes, R2L M bytes`) survive alongside `hole_bridge=debug`.
-///
-/// `RUST_LOG` is also still honored upstream of the directive list (via
-/// `EnvFilter::from_env_lossy` inside `init_multi`), so e.g.
-/// `RUST_LOG=shadowsocks_service=trace HOLE_BRIDGE_LOG=hole_bridge=debug`
-/// composes the same way.
+/// File sink: `HOLE_BRIDGE_LOG` (comma-separated directives), else `HOLE_LOG`,
+/// else the default `hole_bridge=info`. Stderr sink: `HOLE_LOG_STDERR` if set,
+/// else mirrors the file sink — so an unset environment behaves exactly as
+/// before. `RUST_LOG` is honored upstream of both via `from_env_lossy`.
 pub fn init(log_dir: &Path) -> LogGuard {
-    let raw = std::env::var("HOLE_BRIDGE_LOG").unwrap_or_else(|_| "hole_bridge=info".to_string());
-    let directives = parse_directives(&raw);
-    // Empty / whitespace-only env var falls back to the default rather than
-    // passing zero directives to `init_multi` (which would let the global
-    // INFO default win without any bridge-specific override).
-    if directives.is_empty() {
-        hole_common::logging::init_multi(log_dir, "bridge", "bridge.log", ["hole_bridge=info"])
-    } else {
-        hole_common::logging::init_multi(log_dir, "bridge", "bridge.log", directives)
-    }
-}
-
-/// Split a comma-separated `HOLE_BRIDGE_LOG`-style value into its
-/// component directives. Trims whitespace around each piece and drops
-/// blanks (so trailing commas / `a,, b` don't produce empty filters).
-///
-/// Pulled into a named function so the splitting rules are unit-testable
-/// without standing up the global subscriber.
-fn parse_directives(raw: &str) -> Vec<&str> {
-    raw.split(',').map(str::trim).filter(|s| !s.is_empty()).collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_directives;
-
-    #[skuld::test]
-    fn single_directive_yields_one_element() {
-        assert_eq!(parse_directives("hole_bridge=debug"), vec!["hole_bridge=debug"]);
-    }
-
-    #[skuld::test]
-    fn comma_separated_yields_each_directive_in_order() {
-        assert_eq!(
-            parse_directives("hole_bridge=debug,shadowsocks_service=trace"),
-            vec!["hole_bridge=debug", "shadowsocks_service=trace"],
-        );
-    }
-
-    #[skuld::test]
-    fn whitespace_around_directives_is_trimmed() {
-        assert_eq!(
-            parse_directives("  hole_bridge=debug ,\tshadowsocks_service=trace  "),
-            vec!["hole_bridge=debug", "shadowsocks_service=trace"],
-        );
-    }
-
-    #[skuld::test]
-    fn empty_string_yields_no_directives() {
-        assert!(parse_directives("").is_empty());
-    }
-
-    #[skuld::test]
-    fn whitespace_only_yields_no_directives() {
-        assert!(parse_directives("   \t  ").is_empty());
-    }
-
-    #[skuld::test]
-    fn trailing_and_doubled_commas_drop_blanks() {
-        assert_eq!(
-            parse_directives("hole_bridge=debug,,shadowsocks_service=trace,"),
-            vec!["hole_bridge=debug", "shadowsocks_service=trace"],
-        );
-    }
-
-    #[skuld::test]
-    fn three_directives_preserved() {
-        assert_eq!(
-            parse_directives("hole_bridge=debug,shadowsocks_service=trace,hyper=warn"),
-            vec!["hole_bridge=debug", "shadowsocks_service=trace", "hyper=warn"],
-        );
-    }
+    let (file, stderr) = hole_common::logging::resolve_sink_directives("hole_bridge=info", Some("HOLE_BRIDGE_LOG"));
+    hole_common::logging::init_dual(log_dir, "bridge", "bridge.log", &file, &stderr)
 }

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -142,6 +142,67 @@ pub fn default_log_dir() -> PathBuf {
     crate::paths::default_user_subdir("logs")
 }
 
+// Per-sink directive resolution =======================================================================================
+
+/// Split a comma-separated directive value: trim each piece, drop blanks.
+pub fn split_directives(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Resolve `(file_directives, stderr_directives)` from the environment for the
+/// native per-sink logging policy. `default` is the component's built-in file
+/// directive (`hole=info` / `hole_bridge=info`); `component_file_env` is an
+/// optional component-specific override var name (e.g. `HOLE_BRIDGE_LOG`).
+///
+/// File sink: component env, else `HOLE_LOG`, else `default`. Stderr sink:
+/// `HOLE_LOG_STDERR` if set, else mirror the file sink — so with nothing set
+/// both sinks match exactly (production parity).
+pub fn resolve_sink_directives(default: &str, component_file_env: Option<&str>) -> (Vec<String>, Vec<String>) {
+    let component_file = component_file_env.and_then(|name| std::env::var(name).ok());
+    let hole_log = std::env::var("HOLE_LOG").ok();
+    let hole_log_stderr = std::env::var("HOLE_LOG_STDERR").ok();
+    resolve_sink_directives_from(
+        default,
+        component_file.as_deref(),
+        hole_log.as_deref(),
+        hole_log_stderr.as_deref(),
+    )
+}
+
+/// Pure core of [`resolve_sink_directives`] — no env reads, table-testable.
+fn resolve_sink_directives_from(
+    default: &str,
+    component_file: Option<&str>,
+    hole_log: Option<&str>,
+    hole_log_stderr: Option<&str>,
+) -> (Vec<String>, Vec<String>) {
+    let nonblank = |s: &str| (!s.trim().is_empty()).then(|| s.to_string());
+    let file_raw = component_file
+        .and_then(nonblank)
+        .or_else(|| hole_log.and_then(nonblank))
+        .unwrap_or_else(|| default.to_string());
+    let mut file = split_directives(&file_raw);
+    if file.is_empty() {
+        file = split_directives(default);
+    }
+    let stderr = match hole_log_stderr.and_then(nonblank) {
+        Some(raw) => {
+            let s = split_directives(&raw);
+            if s.is_empty() {
+                file.clone()
+            } else {
+                s
+            }
+        }
+        None => file.clone(),
+    };
+    (file, stderr)
+}
+
 // Stdio redirect ======================================================================================================
 
 /// Which standard stream we're redirecting.

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -560,26 +560,73 @@ const MAX_LOG_BYTES: usize = 10 * 1024 * 1024;
 /// With a value of 1, the on-disk layout is `<name>` (current) + `<name>.1` (previous).
 const MAX_ROTATED_LOGS: usize = 1;
 
-/// Initialize logging with one caller-supplied filter directive.
+/// Build one `EnvFilter` from a directive slice: global default `info`,
+/// `RUST_LOG` via `from_env_lossy`, the slice on top, then the
+/// `hole::logging=debug` pin. Built per sink because `EnvFilter` is not Clone.
+fn build_filter(directives: &[String]) -> EnvFilter {
+    let mut f = EnvFilter::builder()
+        .with_default_directive("info".parse().expect("valid directive"))
+        .from_env_lossy();
+    for d in directives {
+        f = f.add_directive(d.parse().expect("valid tracing directive"));
+    }
+    f.add_directive("hole::logging=debug".parse().expect("valid directive"))
+}
+
+/// Compose the two filtered fmt layers over a registry. Generic over the
+/// writers so unit tests can supply capturing buffers and the production
+/// caller supplies non-blocking writers. The stderr layer additionally drops
+/// the relay-target events; the file layer keeps them.
+fn compose_subscriber<FW, SW>(
+    file_writer: FW,
+    stderr_writer: SW,
+    file_directives: &[String],
+    stderr_directives: &[String],
+) -> impl tracing::Subscriber + Send + Sync
+where
+    FW: for<'a> tracing_subscriber::fmt::MakeWriter<'a> + Send + Sync + 'static,
+    SW: for<'a> tracing_subscriber::fmt::MakeWriter<'a> + Send + Sync + 'static,
+{
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use tracing_subscriber::Layer as _;
+
+    let no_relay = tracing_subscriber::filter::filter_fn(|m| {
+        !m.target().starts_with("hole::stderr_relay") && !m.target().starts_with("hole::stdout_relay")
+    });
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(file_writer)
+        .with_ansi(false)
+        .event_format(yaml_format::YamlFormat)
+        .with_filter(build_filter(file_directives));
+
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(stderr_writer)
+        .with_ansi(true)
+        .event_format(yaml_format::YamlFormat)
+        .with_filter(no_relay)
+        .with_filter(build_filter(stderr_directives));
+
+    tracing_subscriber::registry().with(file_layer).with(stderr_layer)
+}
+
+/// Initialize logging with one caller-supplied filter directive (both sinks).
 ///
-/// Thin wrapper around [`init_multi`] preserved for callers that only have
+/// Thin wrapper around [`init_dual`] preserved for callers that only have
 /// one directive to pass. Creates `log_dir` if it doesn't exist; returns a
 /// guard that must be held for the process lifetime to ensure logs are
 /// flushed and the relay reader threads stay alive.
 pub fn init(log_dir: &Path, kind: &'static str, log_filename: &str, default_directive: &str) -> LogGuard {
-    init_multi(log_dir, kind, log_filename, [default_directive])
+    let d = [default_directive.to_string()];
+    init_dual(log_dir, kind, log_filename, &d, &d)
 }
 
-/// Initialize logging with one or more caller-supplied filter directives.
+/// Initialize logging with one or more caller-supplied filter directives
+/// (both sinks).
 ///
 /// Each directive is parsed and added to the env filter via
 /// `EnvFilter::add_directive`, in the order given. Later directives override
 /// earlier ones at equal specificity per `tracing-subscriber`'s rules.
-///
-/// The global default of `info` is set first; `RUST_LOG` (read by
-/// `from_env_lossy`) is layered next; the caller's directives are layered on
-/// top; finally `hole::logging=debug` is pinned so the logging subsystem
-/// itself emits lifecycle events.
 ///
 /// Use this rather than [`init`] when the caller wants to honor a
 /// comma-separated env var like
@@ -591,17 +638,35 @@ where
     I: IntoIterator,
     I::Item: AsRef<str>,
 {
+    let v: Vec<String> = directives.into_iter().map(|d| d.as_ref().to_string()).collect();
+    init_dual(log_dir, kind, log_filename, &v, &v)
+}
+
+/// Initialize logging with independent file-sink and stderr-sink directives —
+/// the native per-sink path. The file sink can run at TRACE while stderr stays
+/// at INFO. Creates `log_dir`; returns a guard that must be held for the
+/// process lifetime to ensure logs are flushed and the relay reader threads
+/// stay alive.
+///
+/// The global default of `info` is set per sink (third-party crates emit
+/// useful startup/warning diagnostics without per-crate directives); `RUST_LOG`
+/// is layered next; the sink's directives are layered on top; finally
+/// `hole::logging=debug` is pinned so the logging subsystem itself emits
+/// lifecycle events.
+pub fn init_dual(
+    log_dir: &Path,
+    kind: &'static str,
+    log_filename: &str,
+    file_directives: &[String],
+    stderr_directives: &[String],
+) -> LogGuard {
     let _ = std::fs::create_dir_all(log_dir);
     cleanup_legacy_daily_logs(log_dir, log_filename);
 
     // Order matters: redirect BEFORE constructing the non-blocking stderr
     // writer so the writer targets the saved-original handle, not the pipe.
-    //
-    // `HOLE_LOGGING_DISABLE_REDIRECT` is honored only in dev/test builds
-    // (`debug_assertions`). Tests that call `init()` but don't want a global
-    // FD redirect set it because libtest-mimic prints per-test result lines
-    // to FD 1, and the redirect would eat them. In release builds the env
-    // var is ignored — the FD safety net is non-negotiable in production.
+    // `HOLE_LOGGING_DISABLE_REDIRECT` is honored only in dev/test builds; in
+    // release the FD safety net is non-negotiable (the env var is a no-op).
     let (relays, original_stderr) = if disable_redirect_for_tests() {
         (
             StdioRelayHandles {
@@ -623,67 +688,18 @@ where
         file_rotate::compression::Compression::None,
         None,
     );
-    // The FILE appender is `lossy(false)`: the proxy-stop teardown burst
-    // (SystemRoutes::drop sequence — route commands, state-file clear,
-    // Remove-NetAdapter — emitted in tens of ms) must never be silently
-    // truncated, or `bridge.log` loses the diagnostic for a teardown that
-    // broke the user's network. Trade-off: a wedged disk (full filesystem,
-    // OneDrive sync stall, AV scan) back-pressures the tracing producer,
-    // bounded by `buffered_lines_limit` (default 128k events).
-    //
-    // The STDERR non-blocking writer keeps `lossy(true)`: a wedged
-    // terminal (Ctrl+S on a console session) MUST NOT block the bridge.
+    // File appender is `lossy(false)`: the proxy-stop teardown burst must never
+    // be truncated or `bridge.log` loses the teardown diagnostic; back-pressure
+    // is bounded by `buffered_lines_limit` (default 128k events). The stderr
+    // writer keeps `lossy(true)`: a wedged terminal must not block the bridge.
     let (file_nb, file_guard) = NonBlockingBuilder::default().lossy(false).finish(file_appender);
     let (stderr_nb, stderr_guard) = NonBlockingBuilder::default().lossy(true).finish(original_stderr);
 
-    // Global default is INFO so third-party crates (shadowsocks-service,
-    // hickory, hyper, etc.) emit useful startup/warning diagnostics without
-    // needing per-crate directives. Caller directives are layered on top,
-    // each one independently parseable (e.g. `hole_bridge=debug` and
-    // `shadowsocks_service=trace` together).
-    //
-    // `hole::logging=debug` is the only pin below INFO — it lets the
-    // logging subsystem itself emit debug-level lifecycle events.
-    let mut env_filter = EnvFilter::builder()
-        .with_default_directive("info".parse().expect("valid directive"))
-        .from_env_lossy();
-    for d in directives {
-        env_filter = env_filter.add_directive(d.as_ref().parse().expect("valid tracing directive"));
-    }
-    let env_filter = env_filter.add_directive("hole::logging=debug".parse().expect("valid directive"));
-
-    // Filter that excludes the relay's own events from the stderr layer to
-    // prevent any feedback loop in either direction. The file layer has no
-    // such filter — the whole point is to capture relay events to the file.
-    let no_relay = tracing_subscriber::filter::filter_fn(|m| {
-        !m.target().starts_with("hole::stderr_relay") && !m.target().starts_with("hole::stdout_relay")
-    });
-
-    let file_layer = tracing_subscriber::fmt::layer()
-        .with_writer(file_nb)
-        .with_ansi(false)
-        .event_format(yaml_format::YamlFormat);
-
-    let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_writer(stderr_nb)
-        .with_ansi(true)
-        .event_format(yaml_format::YamlFormat)
-        .with_filter(no_relay);
-
-    use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
-    use tracing_subscriber::Layer;
-    // Sanctioned by clippy.toml `disallowed_methods` (see #301).
-    // Production bridge logger — this is the ONE caller of
-    // `try_init` workspace-wide. Tests use
-    // `hole_test_observability::register!()` instead.
+    // Sanctioned by clippy.toml `disallowed_methods` (see #301): the ONE
+    // production `try_init` workspace-wide. Tests use `register!()`.
     #[allow(clippy::disallowed_methods)]
-    if let Err(e) = tracing_subscriber::registry()
-        .with(env_filter)
-        .with(file_layer)
-        .with(stderr_layer)
-        .try_init()
-    {
+    if let Err(e) = compose_subscriber(file_nb, stderr_nb, file_directives, stderr_directives).try_init() {
         // Subscriber not yet active; write directly to FD 2. Goes through the
         // redirect → relay → file layer once installed elsewhere.
         let _ = writeln!(io::stderr(), "hole: tracing subscriber init failed: {e}");

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -142,6 +142,19 @@ pub fn default_log_dir() -> PathBuf {
     crate::paths::default_user_subdir("logs")
 }
 
+/// Resolve the log directory: explicit `override_dir`, else `HOLE_LOG_DIR`,
+/// else [`default_log_dir`]. A blank `HOLE_LOG_DIR` is ignored.
+pub fn resolve_log_dir(override_dir: Option<PathBuf>) -> PathBuf {
+    let env_dir = std::env::var_os("HOLE_LOG_DIR")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from);
+    resolve_log_dir_from(override_dir, env_dir)
+}
+
+fn resolve_log_dir_from(override_dir: Option<PathBuf>, env_dir: Option<PathBuf>) -> PathBuf {
+    override_dir.or(env_dir).unwrap_or_else(default_log_dir)
+}
+
 // Per-sink directive resolution =======================================================================================
 
 /// Split a comma-separated directive value: trim each piece, drop blanks.

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -615,3 +615,73 @@ fn resolve_log_dir_falls_back_to_default() {
     let got = super::resolve_log_dir_from(None, None);
     assert_eq!(got, super::default_log_dir());
 }
+
+// Per-sink composition ------------------------------------------------------------------------------------------------
+#[derive(Clone)]
+struct CapBuf(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+impl CapBuf {
+    fn new() -> Self {
+        Self(std::sync::Arc::new(std::sync::Mutex::new(Vec::new())))
+    }
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+impl std::io::Write for CapBuf {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapBuf {
+    type Writer = CapBuf;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[skuld::test]
+fn file_sink_gets_trace_stderr_does_not() {
+    let file = CapBuf::new();
+    let err = CapBuf::new();
+    let sub = super::compose_subscriber(
+        file.clone(),
+        err.clone(),
+        &["t1_target=trace".to_string()],
+        &["t1_target=info".to_string()],
+    );
+    // Install as the thread-local default via the workspace helper (raw
+    // set_default is clippy-disallowed; hole-common depends on garter, so the
+    // helper is available — cf. the existing `panic_hook_emits_tracing_event`
+    // test). Target-specific directives in `sub` override any ambient RUST_LOG
+    // (caller directives are added after from_env_lossy and win at equal/greater
+    // specificity), so this is deterministic regardless of the environment.
+    let _g = garter::tracing_test::set_default_in_current_thread(sub);
+    tracing::trace!(target: "t1_target", "trace-line");
+    tracing::info!(target: "t1_target", "info-line");
+    let f = file.contents();
+    let e = err.contents();
+    assert!(f.contains("trace-line"), "file missing trace:\n{f}");
+    assert!(f.contains("info-line"), "file missing info:\n{f}");
+    assert!(!e.contains("trace-line"), "stderr leaked trace:\n{e}");
+    assert!(e.contains("info-line"), "stderr missing info:\n{e}");
+}
+
+#[skuld::test]
+fn relay_events_go_to_file_not_stderr() {
+    let file = CapBuf::new();
+    let err = CapBuf::new();
+    let sub = super::compose_subscriber(file.clone(), err.clone(), &["info".to_string()], &["info".to_string()]);
+    let _g = garter::tracing_test::set_default_in_current_thread(sub);
+    tracing::info!(target: "hole::stderr_relay", "relayed-line");
+    drop(_g);
+    assert!(file.contents().contains("relayed-line"), "file dropped relay event");
+    assert!(
+        !err.contents().contains("relayed-line"),
+        "stderr must exclude relay events:\n{}",
+        err.contents()
+    );
+}

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -529,3 +529,67 @@ fn log_crate_macros_reach_file(#[fixture(temp_dir)] dir: &Path) {
         "log crate event not bridged to tracing file:\n{contents}"
     );
 }
+
+// Tests: per-sink directive resolution ================================================================================
+
+// split_directives ----------------------------------------------------------------------------------------------------
+#[skuld::test]
+fn split_directives_trims_and_drops_blanks() {
+    assert_eq!(
+        super::split_directives("  hole=debug ,, \tshadowsocks_service=trace ,"),
+        vec!["hole=debug".to_string(), "shadowsocks_service=trace".to_string()],
+    );
+}
+
+#[skuld::test]
+fn split_directives_empty_is_empty() {
+    assert!(super::split_directives("   \t ").is_empty());
+}
+
+// resolve_sink_directives_from ----------------------------------------------------------------------------------------
+#[skuld::test]
+fn resolve_defaults_when_nothing_set() {
+    let (file, stderr) = super::resolve_sink_directives_from("hole_bridge=info", None, None, None);
+    assert_eq!(file, vec!["hole_bridge=info".to_string()]);
+    assert_eq!(stderr, file, "stderr mirrors file when HOLE_LOG_STDERR unset");
+}
+
+#[skuld::test]
+fn resolve_component_env_overrides_file_and_stderr_mirrors() {
+    // HOLE_BRIDGE_LOG=debug → file debug; stderr mirrors (back-compat).
+    let (file, stderr) = super::resolve_sink_directives_from("hole_bridge=info", Some("hole_bridge=debug"), None, None);
+    assert_eq!(file, vec!["hole_bridge=debug".to_string()]);
+    assert_eq!(stderr, file);
+}
+
+#[skuld::test]
+fn resolve_component_env_takes_precedence_over_hole_log() {
+    let (file, _stderr) =
+        super::resolve_sink_directives_from("hole_bridge=info", Some("hole_bridge=debug"), Some("hole=trace"), None);
+    assert_eq!(
+        file,
+        vec!["hole_bridge=debug".to_string()],
+        "component env wins over HOLE_LOG"
+    );
+}
+
+#[skuld::test]
+fn resolve_hole_log_used_when_no_component_env() {
+    let (file, _stderr) = super::resolve_sink_directives_from("hole=info", None, Some("debug,hole=trace"), None);
+    assert_eq!(file, vec!["debug".to_string(), "hole=trace".to_string()]);
+}
+
+#[skuld::test]
+fn resolve_stderr_diverges_when_set() {
+    let (file, stderr) =
+        super::resolve_sink_directives_from("hole=info", None, Some("debug,hole=trace"), Some("hole=info"));
+    assert_eq!(file, vec!["debug".to_string(), "hole=trace".to_string()]);
+    assert_eq!(stderr, vec!["hole=info".to_string()]);
+}
+
+#[skuld::test]
+fn resolve_blank_component_env_falls_back() {
+    // A whitespace/comma-only value must not zero out the filter.
+    let (file, _stderr) = super::resolve_sink_directives_from("hole=info", Some(" , "), None, None);
+    assert_eq!(file, vec!["hole=info".to_string()]);
+}

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -593,3 +593,25 @@ fn resolve_blank_component_env_falls_back() {
     let (file, _stderr) = super::resolve_sink_directives_from("hole=info", Some(" , "), None, None);
     assert_eq!(file, vec!["hole=info".to_string()]);
 }
+
+// resolve_log_dir -----------------------------------------------------------------------------------------------------
+#[skuld::test]
+fn resolve_log_dir_prefers_explicit_override() {
+    let got = super::resolve_log_dir_from(
+        Some(std::path::PathBuf::from("/explicit")),
+        Some(std::path::PathBuf::from("/env")),
+    );
+    assert_eq!(got, std::path::PathBuf::from("/explicit"));
+}
+
+#[skuld::test]
+fn resolve_log_dir_uses_env_when_no_override() {
+    let got = super::resolve_log_dir_from(None, Some(std::path::PathBuf::from("/env")));
+    assert_eq!(got, std::path::PathBuf::from("/env"));
+}
+
+#[skuld::test]
+fn resolve_log_dir_falls_back_to_default() {
+    let got = super::resolve_log_dir_from(None, None);
+    assert_eq!(got, super::default_log_dir());
+}

--- a/crates/dev-console/Cargo.toml
+++ b/crates/dev-console/Cargo.toml
@@ -17,7 +17,9 @@ name = "dev-console"
 path = "src/main.rs"
 
 [dependencies]
+anstream = "1" # strip ANSI when writing the dev-console.log transcript; already in the lockfile (1.0.0, via clap_builder)
 anyhow = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"] } # local timestamp for the dev-run dir; already in the lockfile (0.4.44, clock enabled via file-rotate)
 futures-util = { version = "0.3", default-features = false, features = ["std"] } # catch_unwind for the teardown funnel
 kill-group = { version = "0.1", path = "../kill-group" }
 stepstool = { path = "../stepstool" }

--- a/crates/dev-console/src/banner.rs
+++ b/crates/dev-console/src/banner.rs
@@ -8,17 +8,26 @@ use crate::ansi::{BOLD, CYAN, MAGENTA, RESET, YELLOW};
 pub const CDP_PORT: u16 = 9222;
 pub const VITE_PORT: u16 = 1420;
 
-pub fn startup_banner(socket: &Path, state_dir: &Path, bridge_bin: &Path, gui_bin: &Path, sudo_note: &str) -> String {
+pub fn startup_banner(
+    socket: &Path,
+    state_dir: &Path,
+    run_dir: &Path,
+    bridge_bin: &Path,
+    gui_bin: &Path,
+    sudo_note: &str,
+) -> String {
     format!(
         "\n{BOLD}Starting dev environment...{RESET}\n\
          \x20 Socket:    {}\n\
          \x20 State dir: {}\n\
+         \x20 Dev-run:   {} (bridge.log/gui.log at trace; dev-console.log transcript)\n\
          \x20 {CYAN}[bridge]{RESET} {sudo_note}{} → real TUN + routing (elevated)\n\
          \x20 {MAGENTA}[client]{RESET} {} (GUI, as you)\n\
          \x20 {YELLOW}[  vite]{RESET} npm run dev → port {VITE_PORT} (as you)\n\
          \x20 Frontend changes hot-reload. Rust changes need Ctrl+C and re-run.\n",
         socket.display(),
         state_dir.display(),
+        run_dir.display(),
         bridge_bin.display(),
         gui_bin.display(),
     )

--- a/crates/dev-console/src/lib.rs
+++ b/crates/dev-console/src/lib.rs
@@ -8,6 +8,8 @@
 
 use std::process::ExitCode;
 
+#[macro_use]
+pub mod transcript;
 pub mod ansi;
 pub mod banner;
 #[cfg(unix)]

--- a/crates/dev-console/src/mux.rs
+++ b/crates/dev-console/src/mux.rs
@@ -180,10 +180,14 @@ pub async fn pump(mut stream: impl AsyncRead + Unpin, mode: StreamMode, prefix: 
     }
 }
 
-/// The single writer: receives entries from every pump and writes each as
-/// one contiguous block. One writer == atomic entries (replaces dev.py's
-/// print lock).
-pub async fn printer(mut rx: mpsc::Receiver<Entry>, mut out: impl AsyncWrite + Unpin) -> std::io::Result<()> {
+/// The single writer: receives entries from every pump, writes each as one
+/// contiguous block to `out` (terminal, ANSI kept), and mirrors it into
+/// `transcript` (ANSI stripped) for `dev-console.log`.
+pub async fn printer(
+    mut rx: mpsc::Receiver<Entry>,
+    mut out: impl AsyncWrite + Unpin,
+    transcript: crate::transcript::Transcript,
+) -> std::io::Result<()> {
     while let Some(entry) = rx.recv().await {
         let mut block = String::new();
         for line in &entry.lines {
@@ -193,6 +197,7 @@ pub async fn printer(mut rx: mpsc::Receiver<Entry>, mut out: impl AsyncWrite + U
         }
         out.write_all(block.as_bytes()).await?;
         out.flush().await?;
+        transcript.write_block(&block);
     }
     Ok(())
 }

--- a/crates/dev-console/src/mux_tests.rs
+++ b/crates/dev-console/src/mux_tests.rs
@@ -125,7 +125,7 @@ async fn concurrent_streams_never_split_entries() {
             pump_b,
             // tokio 1.52 implements AsyncWrite for Vec<u8> (and the &mut
             // blanket lifts it) — verified against the vendored tokio source.
-            crate::mux::printer(rx, &mut sink),
+            crate::mux::printer(rx, &mut sink, crate::transcript::Transcript::disabled()),
         );
         let (_, _) = (f1, f2);
         printed.unwrap();
@@ -177,6 +177,51 @@ async fn eof_emits_cr_terminated_empty_line() {
     );
     assert!(rx.recv().await.is_none());
     pump_task.await.unwrap();
+}
+
+// `Entry` is already imported at the top of mux_tests.rs. Async tests use a
+// plain `#[skuld::test]` on an `async fn` (see concurrent_streams_never_split_entries).
+#[skuld::test]
+async fn printer_mirrors_blocks_into_transcript() {
+    use crate::transcript::Transcript;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+    impl std::io::Write for SharedBuf {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let tbuf = Arc::new(Mutex::new(Vec::new()));
+    let transcript = Transcript::from_writer(Box::new(SharedBuf(tbuf.clone())));
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Entry>(8);
+    tx.send(Entry {
+        prefix: "\x1b[36m[bridge]\x1b[0m ".to_string(),
+        lines: vec!["hello".to_string()],
+    })
+    .await
+    .unwrap();
+    drop(tx); // close the channel so the printer drains and returns
+
+    // `&mut Vec<u8>` implements tokio's AsyncWrite (as
+    // concurrent_streams_never_split_entries already relies on).
+    let mut term: Vec<u8> = Vec::new();
+    crate::mux::printer(rx, &mut term, transcript).await.unwrap();
+
+    let t = String::from_utf8(tbuf.lock().unwrap().clone()).unwrap();
+    assert_eq!(t, "[bridge] hello\n", "transcript must be ANSI-stripped");
+    let term_s = String::from_utf8(term).unwrap();
+    assert!(
+        term_s.contains("\x1b[36m[bridge]\x1b[0m hello"),
+        "terminal keeps ANSI: {term_s:?}"
+    );
 }
 
 /// Per-line mode emits without buffering (Vite has no anchors; buffering

--- a/crates/dev-console/src/policy.rs
+++ b/crates/dev-console/src/policy.rs
@@ -192,6 +192,17 @@ pub fn dev_run_file_directives() -> String {
 pub const DEV_RUN_STDERR_BRIDGE: &str = "hole_bridge=info";
 pub const DEV_RUN_STDERR_GUI: &str = "hole=info";
 
+/// The per-sink log env a dev child (bridge or GUI) gets: file=trace into the
+/// run dir, stderr=`stderr_directive` to the terminal. Returned as (name, value)
+/// pairs so the caller applies them with `Command::env`.
+pub fn dev_run_child_env(run_dir: &std::path::Path, stderr_directive: &str) -> Vec<(&'static str, std::ffi::OsString)> {
+    vec![
+        ("HOLE_LOG_DIR", run_dir.as_os_str().to_owned()),
+        ("HOLE_LOG", dev_run_file_directives().into()),
+        ("HOLE_LOG_STDERR", stderr_directive.into()),
+    ]
+}
+
 /// Filesystem-safe, sortable local timestamp for the dev-run subdir.
 pub fn dev_run_subdir_name(now: chrono::NaiveDateTime) -> String {
     now.format("%Y-%m-%d_%H-%M-%S").to_string()

--- a/crates/dev-console/src/policy.rs
+++ b/crates/dev-console/src/policy.rs
@@ -2,10 +2,17 @@
 //! branches, as data — testable on any host (the PR #456 strategy-as-data
 //! pattern).
 
-/// Env vars carried across the sudo boundary into the elevated bridge —
-/// log filtering + backtraces. sudo scrubs the environment otherwise,
-/// silently changing dev logging behavior (dev.py §5.9).
-pub const SUDO_PRESERVE_ENV: [&str; 3] = ["RUST_LOG", "RUST_BACKTRACE", "HOLE_BRIDGE_LOG"];
+/// Env vars carried across the sudo boundary into the elevated bridge — log
+/// filtering, backtraces, per-sink levels, and the dev-run log dir. sudo
+/// scrubs the environment otherwise, silently changing dev logging behavior.
+pub const SUDO_PRESERVE_ENV: [&str; 6] = [
+    "RUST_LOG",
+    "RUST_BACKTRACE",
+    "HOLE_BRIDGE_LOG",
+    "HOLE_LOG",
+    "HOLE_LOG_STDERR",
+    "HOLE_LOG_DIR",
+];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Os {
@@ -146,6 +153,49 @@ pub fn supervision_exit_code(cause: ExitCause) -> u8 {
 /// The POSIX bridge-timeout recovery message, verbatim from dev.py:344-349
 /// (fidelity item 12 demands the exact text; pinned by a test).
 pub const NETWORK_RESET_WARNING: &str = "\x1b[33mThe bridge did not exit within 10s and may still be running as root with routing changes in place.\nRun `sudo scripts/network-reset.py` to restore connectivity.\x1b[0m";
+
+// Dev-run log filtering ===============================================================================================
+
+/// First-party crates pinned to TRACE in the dev-run file logs. Deps stay at
+/// the `debug` default. Mirrors `hole_test_observability::DEFAULT_FILTER`'s
+/// crate list (kept separate: that crate is a dev-dep and `util` is
+/// deliberately Hole-agnostic, so there is no shared home without a heavyweight
+/// dep — a new first-party crate must be added to both lists).
+const DEV_RUN_TRACE_CRATES: &[&str] = &[
+    "hole",
+    "hole_common",
+    "hole_bridge",
+    "tun_engine",
+    "tun_engine_macros",
+    "garter",
+    "garter_bin",
+    "galoshes",
+    "ex_ray",
+    "dump",
+    "dump_macros",
+    "handle_holders",
+];
+
+/// `HOLE_LOG` value for the dev-run file sink: deps at `debug`, first-party at
+/// `trace`.
+pub fn dev_run_file_directives() -> String {
+    let mut s = String::from("debug");
+    for c in DEV_RUN_TRACE_CRATES {
+        s.push(',');
+        s.push_str(c);
+        s.push_str("=trace");
+    }
+    s
+}
+
+/// `HOLE_LOG_STDERR` for the bridge / GUI terminal view — today's info level.
+pub const DEV_RUN_STDERR_BRIDGE: &str = "hole_bridge=info";
+pub const DEV_RUN_STDERR_GUI: &str = "hole=info";
+
+/// Filesystem-safe, sortable local timestamp for the dev-run subdir.
+pub fn dev_run_subdir_name(now: chrono::NaiveDateTime) -> String {
+    now.format("%Y-%m-%d_%H-%M-%S").to_string()
+}
 
 #[cfg(test)]
 #[path = "policy_tests.rs"]

--- a/crates/dev-console/src/policy_tests.rs
+++ b/crates/dev-console/src/policy_tests.rs
@@ -29,7 +29,7 @@ fn grant_access_argv_posix() {
         argv,
         [
             "sudo",
-            "--preserve-env=RUST_LOG,RUST_BACKTRACE,HOLE_BRIDGE_LOG",
+            "--preserve-env=RUST_LOG,RUST_BACKTRACE,HOLE_BRIDGE_LOG,HOLE_LOG,HOLE_LOG_STDERR,HOLE_LOG_DIR",
             "/stage/hole",
             "bridge",
             "grant-access"
@@ -58,7 +58,7 @@ fn bridge_argv_posix_includes_ready_notify() {
         argv,
         [
             "sudo",
-            "--preserve-env=RUST_LOG,RUST_BACKTRACE,HOLE_BRIDGE_LOG",
+            "--preserve-env=RUST_LOG,RUST_BACKTRACE,HOLE_BRIDGE_LOG,HOLE_LOG,HOLE_LOG_STDERR,HOLE_LOG_DIR",
             "/stage/hole",
             "bridge",
             "run",
@@ -161,4 +161,39 @@ fn network_reset_warning_is_verbatim() {
         "The bridge did not exit within 10s and may still be running as root with routing changes in place."
     ));
     assert!(NETWORK_RESET_WARNING.contains("Run `sudo scripts/network-reset.py` to restore connectivity."));
+}
+
+// Dev-run log filtering ===============================================================================================
+
+#[skuld::test]
+fn sudo_preserve_env_carries_log_vars() {
+    for v in [
+        "RUST_LOG",
+        "RUST_BACKTRACE",
+        "HOLE_BRIDGE_LOG",
+        "HOLE_LOG",
+        "HOLE_LOG_STDERR",
+        "HOLE_LOG_DIR",
+    ] {
+        assert!(super::SUDO_PRESERVE_ENV.contains(&v), "missing {v}");
+    }
+}
+
+#[skuld::test]
+fn dev_run_file_directives_traces_first_party_debug_deps() {
+    let d = super::dev_run_file_directives();
+    assert!(d.starts_with("debug"), "deps default must be debug: {d}");
+    assert!(d.contains("hole_bridge=trace"), "{d}");
+    assert!(d.contains("hole=trace"), "{d}");
+    assert!(d.contains("galoshes=trace"), "{d}");
+}
+
+#[skuld::test]
+fn dev_run_subdir_name_is_filesystem_safe() {
+    use chrono::{NaiveDate, NaiveDateTime};
+    let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2026, 6, 20)
+        .unwrap()
+        .and_hms_opt(15, 30, 45)
+        .unwrap();
+    assert_eq!(super::dev_run_subdir_name(dt), "2026-06-20_15-30-45");
 }

--- a/crates/dev-console/src/policy_tests.rs
+++ b/crates/dev-console/src/policy_tests.rs
@@ -189,6 +189,20 @@ fn dev_run_file_directives_traces_first_party_debug_deps() {
 }
 
 #[skuld::test]
+fn dev_run_child_env_is_the_three_per_sink_vars() {
+    use std::ffi::OsString;
+    let env = super::dev_run_child_env(std::path::Path::new("/run/dir"), super::DEV_RUN_STDERR_BRIDGE);
+    assert_eq!(
+        env,
+        vec![
+            ("HOLE_LOG_DIR", OsString::from("/run/dir")),
+            ("HOLE_LOG", OsString::from(super::dev_run_file_directives())),
+            ("HOLE_LOG_STDERR", OsString::from(super::DEV_RUN_STDERR_BRIDGE)),
+        ]
+    );
+}
+
+#[skuld::test]
 fn dev_run_subdir_name_is_filesystem_safe() {
     use chrono::{NaiveDate, NaiveDateTime};
     let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2026, 6, 20)

--- a/crates/dev-console/src/steps.rs
+++ b/crates/dev-console/src/steps.rs
@@ -83,7 +83,7 @@ async fn run_step(
 /// dependency additions pulled from a new commit and leave Vite failing to
 /// resolve the import; ~1s on a healthy tree (dev.py §5.12).
 pub async fn ensure_node_modules(npm: &Path, interrupts: &mut Interrupts) -> Result<()> {
-    println!("{BOLD}Syncing npm dependencies...{RESET}");
+    note!("{BOLD}Syncing npm dependencies...{RESET}");
     let mut cmd = tokio::process::Command::new(npm);
     cmd.args(["install", "--no-audit", "--no-fund"]);
     run_step(cmd, "npm install", false, interrupts).await

--- a/crates/dev-console/src/supervise.rs
+++ b/crates/dev-console/src/supervise.rs
@@ -54,6 +54,23 @@ pub(crate) fn is_reaped(child: &Child) -> bool {
     child.id().is_none()
 }
 
+/// Create the per-run dir `<parent>/<name>`. On a same-second collision (the
+/// dir already exists — a concurrent run the Vite-port guard will reject), fall
+/// back to `<name>-<pid>` so the doomed run can't truncate the live run's logs.
+pub(crate) fn create_run_dir(parent: &Path, name: &str, pid: u32) -> std::io::Result<std::path::PathBuf> {
+    std::fs::create_dir_all(parent)?;
+    let primary = parent.join(name);
+    match std::fs::create_dir(&primary) {
+        Ok(()) => Ok(primary),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let alt = parent.join(format!("{name}-{pid}"));
+            std::fs::create_dir_all(&alt)?;
+            Ok(alt)
+        }
+        Err(e) => Err(e),
+    }
+}
+
 impl BridgeChild {
     fn child_mut(&mut self) -> &mut Child {
         match self {
@@ -142,11 +159,13 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
     // Dev-run capture: <repo>/.tmp/dev-run/<datetime>/ with bridge.log +
     // gui.log (trace, native file sinks redirected here) and dev-console.log
     // (this supervisor's status + the runtime mux at info, ANSI stripped).
-    let run_dir = repo_root
-        .join(".tmp")
-        .join("dev-run")
-        .join(crate::policy::dev_run_subdir_name(chrono::Local::now().naive_local()));
-    std::fs::create_dir_all(&run_dir).context("creating dev-run dir")?;
+    let run_parent = repo_root.join(".tmp").join("dev-run");
+    let run_dir = create_run_dir(
+        &run_parent,
+        &crate::policy::dev_run_subdir_name(chrono::Local::now().naive_local()),
+        std::process::id(),
+    )
+    .context("creating dev-run dir")?;
     crate::transcript::set_global(crate::transcript::Transcript::create(&run_dir.join("dev-console.log")));
 
     // 1. Privilege policy (dev.py §5.10) ==============================================================================
@@ -366,9 +385,9 @@ async fn startup_and_supervise(
     cmd.args(&argv[1..]);
     // Per-sink dev logging: file=trace into the run dir, stderr=info to the
     // terminal. These ride the sudo boundary via SUDO_PRESERVE_ENV.
-    cmd.env("HOLE_LOG_DIR", run_dir);
-    cmd.env("HOLE_LOG", crate::policy::dev_run_file_directives());
-    cmd.env("HOLE_LOG_STDERR", crate::policy::DEV_RUN_STDERR_BRIDGE);
+    for (k, v) in crate::policy::dev_run_child_env(run_dir, crate::policy::DEV_RUN_STDERR_BRIDGE) {
+        cmd.env(k, v);
+    }
     // stdin=null: an expired sudo timestamp gets EOF and exits non-zero
     // instead of hanging on an invisible prompt (with the setsid TTY detach
     // in spawn_bridge); also the console-corruption discipline every child
@@ -450,9 +469,9 @@ async fn startup_and_supervise(
     cmd.arg("--show-dashboard");
     cmd.env("HOLE_BRIDGE_SOCKET", socket_path);
     cmd.env("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", webview_args);
-    cmd.env("HOLE_LOG_DIR", run_dir);
-    cmd.env("HOLE_LOG", crate::policy::dev_run_file_directives());
-    cmd.env("HOLE_LOG_STDERR", crate::policy::DEV_RUN_STDERR_GUI);
+    for (k, v) in crate::policy::dev_run_child_env(run_dir, crate::policy::DEV_RUN_STDERR_GUI) {
+        cmd.env(k, v);
+    }
     cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
     cmd.kill_on_drop(true);
     let gui = gui_slot.insert(GroupedChild::spawn(&mut cmd, Nesting::Mark).context("spawning the GUI")?);

--- a/crates/dev-console/src/supervise.rs
+++ b/crates/dev-console/src/supervise.rs
@@ -115,11 +115,11 @@ pub async fn main() -> ExitCode {
                 // dev.py parity: npm/cargo failures exit with the child's
                 // code and no extra line; stage prints its yellow message.
                 if let Some(msg) = &step.message {
-                    eprintln!("{YELLOW}{msg}{RESET}");
+                    enote!("{YELLOW}{msg}{RESET}");
                 }
                 return ExitCode::from(step.code.clamp(1, 255) as u8);
             }
-            eprintln!("{YELLOW}dev-console: {e:#}{RESET}");
+            enote!("{YELLOW}dev-console: {e:#}{RESET}");
             ExitCode::FAILURE
         }
     }
@@ -139,6 +139,16 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
     }
     std::env::set_current_dir(&repo_root).context("cd to repo root")?;
 
+    // Dev-run capture: <repo>/.tmp/dev-run/<datetime>/ with bridge.log +
+    // gui.log (trace, native file sinks redirected here) and dev-console.log
+    // (this supervisor's status + the runtime mux at info, ANSI stripped).
+    let run_dir = repo_root
+        .join(".tmp")
+        .join("dev-run")
+        .join(crate::policy::dev_run_subdir_name(chrono::Local::now().naive_local()));
+    std::fs::create_dir_all(&run_dir).context("creating dev-run dir")?;
+    crate::transcript::set_global(crate::transcript::Transcript::create(&run_dir.join("dev-console.log")));
+
     // 1. Privilege policy (dev.py §5.10) ==============================================================================
     let euid: Option<u32>;
     #[cfg(unix)]
@@ -155,12 +165,12 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
         {
             #[cfg(windows)]
             if let Err(e) = stepstool::require_elevated() {
-                eprintln!("ERROR: {e}");
+                enote!("ERROR: {e}");
                 return Ok(ExitCode::FAILURE);
             }
         }
         ElevationAction::PosixErrorRoot => {
-            eprintln!(
+            enote!(
                 "ERROR: do not run dev mode as root / under sudo.\n\
                  Run `cargo xtask run hole` (no sudo) — dev-console elevates only the\n\
                  bridge itself. Running as root leaves root-owned files in target/."
@@ -191,7 +201,7 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
 
     // 4. Leaked-vite preflight (Delta 7): vite uses strictPort 1420 ===================================================
     if port_in_use(VITE_PORT).await {
-        eprintln!(
+        enote!(
             "{YELLOW}Port {VITE_PORT} is already in use — a previous dev run's Vite may have \
              leaked. Kill it (or whatever holds the port) and re-run.{RESET}"
         );
@@ -201,22 +211,22 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
     // 5. sudo preflight (POSIX; dev.py §5.8) ==========================================================================
     #[cfg(unix)]
     {
-        println!("{BOLD}Dev mode needs root for the bridge — caching sudo credentials...{RESET}");
+        note!("{BOLD}Dev mode needs root for the bridge — caching sudo credentials...{RESET}");
         if let Err(e) = stepstool::prime_sudo() {
-            eprintln!("{YELLOW}{e}{RESET}");
+            enote!("{YELLOW}{e}{RESET}");
             return Ok(ExitCode::FAILURE);
         }
     }
 
     // 6. grant-access via the production path (dev.py §5.15) ==========================================================
-    println!("{BOLD}Granting IPC access (creates hole group, adds user)...{RESET}");
+    note!("{BOLD}Granting IPC access (creates hole group, adds user)...{RESET}");
     let ga = grant_access_argv(Os::host(), &bridge_bin.to_string_lossy());
     let mut cmd = Command::new(&ga[0]);
     cmd.args(&ga[1..]);
     let status = cmd.status().await.context("spawning bridge grant-access")?;
     if !status.success() {
         let code = status.code().unwrap_or(1);
-        eprintln!("{YELLOW}bridge grant-access failed (exit {code}){RESET}");
+        enote!("{YELLOW}bridge grant-access failed (exit {code}){RESET}");
         return Ok(ExitCode::from(code.clamp(1, 255) as u8));
     }
 
@@ -226,12 +236,12 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
         let gid = match crate::group_gate::hole_gid() {
             Ok(g) => g,
             Err(warn) => {
-                eprintln!("{YELLOW}warning: could not look up 'hole' group: {warn}{RESET}");
+                enote!("{YELLOW}warning: could not look up 'hole' group: {warn}{RESET}");
                 None
             }
         };
         if crate::group_gate::missing_hole_group(gid, &crate::group_gate::current_gids()) {
-            eprintln!(
+            enote!(
                 "\n{YELLOW}Added you to the 'hole' group, but your current login session \
                  predates it,\nso the dashboard can't reach the bridge yet. Log out and back \
                  in (or reboot),\nthen run `cargo xtask run hole` again. One-time per machine. \
@@ -243,13 +253,22 @@ async fn run(interrupts: &mut Interrupts) -> Result<ExitCode> {
 
     // 8. Banner =======================================================================================================
     let sudo_note = if cfg!(windows) { "" } else { "sudo " };
-    print!(
+    note!(
         "{}",
-        startup_banner(&socket_path, &state_dir, &bridge_bin, &gui_bin, sudo_note)
+        startup_banner(&socket_path, &state_dir, &run_dir, &bridge_bin, &gui_bin, sudo_note).trim_end()
     );
-    println!();
+    note!("");
 
-    supervise_children(interrupts, &npm, &bridge_bin, &gui_bin, &socket_path, &state_dir).await
+    supervise_children(
+        interrupts,
+        &npm,
+        &bridge_bin,
+        &gui_bin,
+        &socket_path,
+        &state_dir,
+        &run_dir,
+    )
+    .await
 }
 
 /// Spawn-and-supervise with a SINGLE exit funnel: whatever the startup or
@@ -262,9 +281,14 @@ async fn supervise_children(
     gui_bin: &Path,
     socket_path: &Path,
     state_dir: &Path,
+    run_dir: &Path,
 ) -> Result<ExitCode> {
     let (tx, rx) = mpsc::channel::<Entry>(256);
-    let mut printer = tokio::spawn(crate::mux::printer(rx, tokio::io::stdout()));
+    let mut printer = tokio::spawn(crate::mux::printer(
+        rx,
+        tokio::io::stdout(),
+        crate::transcript::global(),
+    ));
 
     let mut bridge: Option<BridgeChild> = None;
     let mut vite: Option<GroupedChild> = None;
@@ -282,6 +306,7 @@ async fn supervise_children(
         gui_bin,
         socket_path,
         state_dir,
+        run_dir,
         &tx,
         &mut bridge,
         &mut vite,
@@ -321,6 +346,7 @@ async fn startup_and_supervise(
     gui_bin: &Path,
     socket_path: &Path,
     state_dir: &Path,
+    run_dir: &Path,
     tx: &mpsc::Sender<Entry>,
     bridge_slot: &mut Option<BridgeChild>,
     vite_slot: &mut Option<GroupedChild>,
@@ -338,6 +364,11 @@ async fn startup_and_supervise(
     );
     let mut cmd = Command::new(&argv[0]);
     cmd.args(&argv[1..]);
+    // Per-sink dev logging: file=trace into the run dir, stderr=info to the
+    // terminal. These ride the sudo boundary via SUDO_PRESERVE_ENV.
+    cmd.env("HOLE_LOG_DIR", run_dir);
+    cmd.env("HOLE_LOG", crate::policy::dev_run_file_directives());
+    cmd.env("HOLE_LOG_STDERR", crate::policy::DEV_RUN_STDERR_BRIDGE);
     // stdin=null: an expired sudo timestamp gets EOF and exits non-zero
     // instead of hanging on an invisible prompt (with the setsid TTY detach
     // in spawn_bridge); also the console-corruption discipline every child
@@ -358,7 +389,7 @@ async fn startup_and_supervise(
             // printer) — dev.py parity: its prints didn't take the print
             // lock either; a rare interleave with a child entry is accepted.
             // dev.py:578-585 (stdout, like dev.py's print):
-            println!(
+            note!(
                 "{YELLOW}Bridge exited with code {} (sudo credentials may have expired, or a \
                  restrictive sudoers env_check/env_delete rejected --preserve-env){RESET}",
                 status.code().unwrap_or(-1)
@@ -370,7 +401,7 @@ async fn startup_and_supervise(
             r.context("ready listener failed")?;
         }
         _ = tokio::time::sleep(SOCKET_READY_TIMEOUT) => {
-            println!("{YELLOW}Bridge did not signal readiness within {}s{RESET}", SOCKET_READY_TIMEOUT.as_secs());
+            note!("{YELLOW}Bridge did not signal readiness within {}s{RESET}", SOCKET_READY_TIMEOUT.as_secs());
             return Ok(ExitCause::StartupFailed);
         }
     }
@@ -391,13 +422,13 @@ async fn startup_and_supervise(
     tokio::select! {
         biased;
         status = vite.child.wait() => {
-            println!("{YELLOW}Vite exited with code {}{RESET}", status?.code().unwrap_or(-1));
+            note!("{YELLOW}Vite exited with code {}{RESET}", status?.code().unwrap_or(-1));
             return Ok(ExitCause::StartupFailed);
         }
         _ = interrupts.recv() => return Ok(ExitCause::Interrupted),
         up = wait_for_port(VITE_PORT, VITE_READY_TIMEOUT) => {
             if !up {
-                println!("{YELLOW}Vite did not start on port {VITE_PORT} within {}s{RESET}", VITE_READY_TIMEOUT.as_secs());
+                note!("{YELLOW}Vite did not start on port {VITE_PORT} within {}s{RESET}", VITE_READY_TIMEOUT.as_secs());
                 return Ok(ExitCause::StartupFailed);
             }
         }
@@ -413,12 +444,15 @@ async fn startup_and_supervise(
         format!("{} {cdp}", existing.trim())
     };
     if !webview_debug_hint().is_empty() {
-        println!("{}", webview_debug_hint());
+        note!("{}", webview_debug_hint());
     }
     let mut cmd = Command::new(gui_bin);
     cmd.arg("--show-dashboard");
     cmd.env("HOLE_BRIDGE_SOCKET", socket_path);
     cmd.env("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", webview_args);
+    cmd.env("HOLE_LOG_DIR", run_dir);
+    cmd.env("HOLE_LOG", crate::policy::dev_run_file_directives());
+    cmd.env("HOLE_LOG_STDERR", crate::policy::DEV_RUN_STDERR_GUI);
     cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
     cmd.kill_on_drop(true);
     let gui = gui_slot.insert(GroupedChild::spawn(&mut cmd, Nesting::Mark).context("spawning the GUI")?);
@@ -440,15 +474,15 @@ async fn startup_and_supervise(
 fn exited(name: &str, status: std::io::Result<std::process::ExitStatus>) -> ExitCause {
     match status {
         Ok(s) if s.success() => {
-            println!("{YELLOW}{name} exited; shutting down{RESET}");
+            note!("{YELLOW}{name} exited; shutting down{RESET}");
             ExitCause::ChildExitedClean
         }
         Ok(s) => {
-            eprintln!("{YELLOW}{name} exited unexpectedly ({s}){RESET}");
+            enote!("{YELLOW}{name} exited unexpectedly ({s}){RESET}");
             ExitCause::ChildFailed
         }
         Err(e) => {
-            eprintln!("{YELLOW}{name} exited unexpectedly (wait error: {e}){RESET}");
+            enote!("{YELLOW}{name} exited unexpectedly (wait error: {e}){RESET}");
             ExitCause::ChildFailed
         }
     }
@@ -460,7 +494,7 @@ async fn shutdown(bridge: Option<&mut BridgeChild>, vite: Option<&mut GroupedChi
     if bridge.is_none() && vite.is_none() && gui.is_none() {
         return;
     }
-    println!("\n{BOLD}Shutting down...{RESET}");
+    note!("\n{BOLD}Shutting down...{RESET}");
     if let Some(bridge) = bridge {
         // dev.py poll() guard (see is_reaped): a reaped bridge means a
         // possibly-recycled pgid — never signal it, and there is nothing
@@ -474,7 +508,7 @@ async fn shutdown(bridge: Option<&mut BridgeChild>, vite: Option<&mut GroupedChi
                 .is_err()
             {
                 match grace_timeout_action(ChildRole::Bridge, Os::host()) {
-                    GraceTimeoutAction::WarnRecovery => eprintln!("{NETWORK_RESET_WARNING}"),
+                    GraceTimeoutAction::WarnRecovery => enote!("{NETWORK_RESET_WARNING}"),
                     GraceTimeoutAction::HardKill => bridge.hard_kill().await,
                 }
             }

--- a/crates/dev-console/src/supervise_tests.rs
+++ b/crates/dev-console/src/supervise_tests.rs
@@ -4,11 +4,38 @@
 //! it needs a password prompt and a real network stack.
 
 use crate::policy::ChildRole;
-use crate::supervise::{is_reaped, teardown_grouped};
+use crate::supervise::{create_run_dir, is_reaped, teardown_grouped};
 use crate::test_child;
 
 use tokio::io::AsyncReadExt as _;
 use tokio::net::TcpListener;
+
+/// A fresh parent yields the plain `<parent>/<name>` leaf.
+#[skuld::test]
+fn create_run_dir_uses_plain_name_when_free() {
+    let tmp = tempfile::tempdir().unwrap();
+    let parent = tmp.path().join("dev-run");
+    let dir = create_run_dir(&parent, "2026-06-20_15-30-45", 4242).unwrap();
+    assert_eq!(dir, parent.join("2026-06-20_15-30-45"));
+    assert!(dir.is_dir());
+}
+
+/// A same-second collision (the leaf already exists) falls back to
+/// `<name>-<pid>` so the doomed run can't truncate the live run's logs.
+#[skuld::test]
+fn create_run_dir_falls_back_to_pid_on_collision() {
+    let tmp = tempfile::tempdir().unwrap();
+    let parent = tmp.path().join("dev-run");
+    let primary = parent.join("2026-06-20_15-30-45");
+    std::fs::create_dir_all(&primary).unwrap();
+    // Sentinel: the original must survive untouched.
+    std::fs::write(primary.join("dev-console.log"), b"live").unwrap();
+
+    let dir = create_run_dir(&parent, "2026-06-20_15-30-45", 4242).unwrap();
+    assert_eq!(dir, parent.join("2026-06-20_15-30-45-4242"));
+    assert!(dir.is_dir());
+    assert_eq!(std::fs::read(primary.join("dev-console.log")).unwrap(), b"live");
+}
 
 #[skuld::test]
 async fn fake_bridge_satisfies_ready_listener() {

--- a/crates/dev-console/src/transcript.rs
+++ b/crates/dev-console/src/transcript.rs
@@ -1,0 +1,98 @@
+//! Secondary capture sink for the dev-run transcript (`dev-console.log`).
+//!
+//! The dev console keeps writing to the terminal exactly as before; a
+//! [`Transcript`] additionally mirrors the dev console's OWN output — status
+//! lines and the multiplexed child stream — into `dev-console.log`, ANSI
+//! stripped. Preflight cargo/npm children keep inherited stdio and are NOT
+//! captured (runtime-only policy). Best-effort: a failed file open disables
+//! the sink rather than failing the run.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex, OnceLock};
+
+#[derive(Clone)]
+pub struct Transcript(Option<Arc<Mutex<Box<dyn Write + Send>>>>);
+
+impl Transcript {
+    pub fn disabled() -> Self {
+        Self(None)
+    }
+
+    pub fn from_writer(w: Box<dyn Write + Send>) -> Self {
+        Self(Some(Arc::new(Mutex::new(w))))
+    }
+
+    /// Open `path` for the transcript. On failure, warn once to stderr and
+    /// return a disabled sink — the transcript is a convenience, never fatal.
+    pub fn create(path: &Path) -> Self {
+        match std::fs::File::create(path) {
+            Ok(f) => Self::from_writer(Box::new(f)),
+            Err(e) => {
+                eprintln!("dev-console: could not open transcript {}: {e}", path.display());
+                Self::disabled()
+            }
+        }
+    }
+
+    /// Append `s` (ANSI stripped) followed by a newline.
+    pub fn write_line(&self, s: &str) {
+        self.write_stripped(s);
+        self.write_raw(b"\n");
+    }
+
+    /// Append `s` verbatim (ANSI stripped). `s` already carries its newlines.
+    pub fn write_block(&self, s: &str) {
+        self.write_stripped(s);
+    }
+
+    fn write_stripped(&self, s: &str) {
+        let stripped = anstream::adapter::strip_str(s).to_string();
+        self.write_raw(stripped.as_bytes());
+    }
+
+    fn write_raw(&self, bytes: &[u8]) {
+        if let Some(sink) = &self.0 {
+            if let Ok(mut w) = sink.lock() {
+                let _ = w.write_all(bytes);
+                let _ = w.flush();
+            }
+        }
+    }
+}
+
+static GLOBAL: OnceLock<Transcript> = OnceLock::new();
+
+/// The process-wide transcript. Disabled until [`set_global`] runs.
+pub fn global() -> Transcript {
+    GLOBAL.get().cloned().unwrap_or_else(Transcript::disabled)
+}
+
+/// Install the process-wide transcript. Idempotent (first wins).
+pub fn set_global(t: Transcript) {
+    let _ = GLOBAL.set(t);
+}
+
+/// `println!` to the terminal AND mirror the line into the transcript.
+/// Intra-crate macro (no `#[macro_export]`) — reached by bare name via the
+/// `#[macro_use]` on the module in `lib.rs`, like the existing `cli_log!`.
+macro_rules! note {
+    ($($arg:tt)*) => {{
+        let __s = format!($($arg)*);
+        println!("{__s}");
+        $crate::transcript::global().write_line(&__s);
+    }};
+}
+
+/// `eprintln!` to the terminal AND mirror the line into the transcript.
+macro_rules! enote {
+    ($($arg:tt)*) => {{
+        let __s = format!($($arg)*);
+        eprintln!("{__s}");
+        $crate::transcript::global().write_line(&__s);
+    }};
+}
+
+#[cfg(test)]
+#[path = "transcript_tests.rs"]
+mod transcript_tests;

--- a/crates/dev-console/src/transcript_tests.rs
+++ b/crates/dev-console/src/transcript_tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+impl std::io::Write for SharedBuf {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[skuld::test]
+fn write_line_strips_ansi_and_terminates() {
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let t = Transcript::from_writer(Box::new(SharedBuf(buf.clone())));
+    t.write_line("\x1b[1mBuilding hole...\x1b[0m");
+    let s = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert_eq!(s, "Building hole...\n");
+}
+
+#[skuld::test]
+fn write_block_strips_ansi_keeps_newlines() {
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let t = Transcript::from_writer(Box::new(SharedBuf(buf.clone())));
+    t.write_block("\x1b[36m[bridge]\x1b[0m line one\n\x1b[36m[bridge]\x1b[0m line two\n");
+    let s = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert_eq!(s, "[bridge] line one\n[bridge] line two\n");
+}
+
+#[skuld::test]
+fn disabled_transcript_is_a_noop() {
+    let t = Transcript::disabled();
+    t.write_line("\x1b[1mx\x1b[0m"); // must not panic
+}

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -284,7 +284,7 @@ pub(crate) fn resolve_cli_log_dir(command: &Command) -> Option<std::path::PathBu
         Command::Bridge {
             action: BridgeAction::Install { log_dir: Some(d), .. },
         } => Some(d.clone()),
-        _ => Some(hole_common::logging::default_log_dir()),
+        _ => Some(hole_common::logging::resolve_log_dir(None)),
     }
 }
 
@@ -404,7 +404,7 @@ fn handle_bridge(action: BridgeAction) -> i32 {
             state_dir,
             ready_notify,
         } => {
-            let log_dir = log_dir.unwrap_or_else(hole_common::logging::default_log_dir);
+            let log_dir = hole_common::logging::resolve_log_dir(log_dir);
             let _guard = hole_bridge::logging::init(&log_dir);
             tracing::info!("hole bridge starting");
 

--- a/crates/hole/src/logging.rs
+++ b/crates/hole/src/logging.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 
 /// Initialize GUI logging (stderr + size-rotated file).
 pub fn init(log_dir: &Path) -> LogGuard {
-    hole_common::logging::init(log_dir, "gui", "gui.log", "hole=info")
+    let (file, stderr) = hole_common::logging::resolve_sink_directives("hole=info", None);
+    hole_common::logging::init_dual(log_dir, "gui", "gui.log", &file, &stderr)
 }
 
 #[cfg(test)]

--- a/crates/hole/src/main.rs
+++ b/crates/hole/src/main.rs
@@ -78,7 +78,7 @@ fn launch_gui(show_dashboard: bool) {
     // Determine paths
     let config_dir = dirs::config_dir().expect("no config directory found").join("hole");
     let config_path = config_dir.join("config.json");
-    let log_dir = hole_common::logging::default_log_dir();
+    let log_dir = hole_common::logging::resolve_log_dir(None);
 
     let _log_guard = logging::init(&log_dir);
 


### PR DESCRIPTION
## Why

`cargo xtask run hole` streamed build→run output to the terminal only — nothing persisted, so a developer who saw something go wrong had no trace to inspect afterward. And you couldn't get "trace in a file, info in the terminal" without setting the children to trace and string-filtering on the dev-console side, because Hole's logging applied **one** `EnvFilter` to both the file and stderr sinks.

## What

**1. Native per-sink log levels** (`crates/common/src/logging.rs`). The rotating file sink and the stderr sink now get independent `EnvFilter`s. New general env overrides, honored by the GUI, bridge, and gui-cli init paths:

- `HOLE_LOG` — file-sink filter directives
- `HOLE_LOG_STDERR` — stderr-sink filter directives
- `HOLE_LOG_DIR` — overrides the log directory
- `HOLE_BRIDGE_LOG` — retained as the bridge's file-sink override (precedence over `HOLE_LOG`)

Back-compat is exact: the stderr sink **mirrors** the file sink unless `HOLE_LOG_STDERR` is set, so with nothing set production behavior is byte-identical (same filter both sinks, same log dir, same `RUST_LOG`/`#147` LogTracer cheap-rejection).

**2. Dev-run capture** (`crates/dev-console`). Each `cargo xtask run hole` writes `<repo>/.tmp/dev-run/<YYYY-MM-DD_HH-MM-SS>/`:

- `bridge.log`, `gui.log` — per-process **TRACE** (Hole crates trace, deps debug), via the children's native file sinks redirected with `HOLE_LOG_DIR` (sudo-preserved across the bridge's elevation).
- `dev-console.log` — the supervisor's own status lines + the runtime multiplexed child output at **INFO**, ANSI-stripped.

The terminal keeps today's info view; the dev console does no log-level filtering — the split is native to Hole. Raw cargo/npm compiler output stays inherited-stdio (terminal-only). The run dir is collision-safe (`<datetime>`, falling back to `<datetime>-<pid>` if a same-second concurrent run would otherwise truncate the live log). No retention. `/.tmp/` is gitignored.

## How to verify

- Unit tests cover: per-sink filtering (a TRACE event reaches the file sink, not stderr), `resolve_sink_directives` precedence + blank-fallback + stderr-mirror, `resolve_log_dir`/`HOLE_LOG_DIR`, the ANSI-stripping transcript + printer tee, the dev-run directive sets, and the collision-safe `create_run_dir` (asserts the live log is not truncated).
- `cargo xtask run hole` (elevated) produces `.tmp/dev-run/<datetime>/` with the three logs — bridge/gui at trace, terminal/dev-console.log at info.
- With no new env vars set, existing behavior is unchanged.

Closes #566.

https://claude.ai/code/session_018DmFtFR4yid8YYfSQVnT2X
