### PR TITLE
chore(release): bump galoshes to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "galoshes"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "galoshes"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Bumps galoshes for the June 2026 release cycle. galoshes gained one product
fix since v0.2.0 — `relay_tcp` half-close correctness via `copy_bidirectional`
(#537), which prevents in-flight response truncation when a client half-closes
its write side — so this is a patch.

hole stays at 0.3.0 (already staged); garter and ex-ray are not part of this
cycle. Once merged, the hole 0.3.0 and galoshes 0.2.1 draft-release workflows
run against the merge commit.

Part of #577.

https://claude.ai/code/session_0176u3JN1SGYcxiM7UPLe9CM
