### PR TITLE
feat(diagnostics): report a network-blocked server distinctly from credential failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,8 +2451,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2462,9 +2464,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3026,7 +3030,9 @@ dependencies = [
  "lru",
  "plist",
  "plugin-e2e",
+ "quinn",
  "rand 0.10.1",
+ "rcgen",
  "regex",
  "rustls",
  "rustls-pki-types",
@@ -3911,6 +3917,12 @@ checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lru_time_cache"
@@ -5386,6 +5398,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5929,6 +5996,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -98,6 +98,10 @@ tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 rustls-pki-types = { workspace = true }
 webpki-roots = { workspace = true }
+# QUIC reachability probe (#580). quinn 0.11/quinn-proto 0.11 pin rustls 0.23
+# with the `quic` feature, which unifies additively with the workspace rustls
+# (ring provider) — no second rustls in the tree.
+quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
@@ -145,6 +149,8 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 # shadowsocks-service's `server` feature + rcgen + base64 transitively; the
 # bridge's own tests no longer reference those directly after the move (#435).
 plugin-e2e = { path = "../plugin-e2e" }
+# Self-signed cert for the quinn server fixture in reachability_tests (#580).
+rcgen = "0.14"
 rand = "0.10"
 # Used by `test_support::net_discovery` for primary IPv4 detection in TUN tests.
 default-net = "0.22"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -98,7 +98,7 @@ tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 rustls-pki-types = { workspace = true }
 webpki-roots = { workspace = true }
-# QUIC reachability probe (#580). quinn 0.11/quinn-proto 0.11 pin rustls 0.23
+# QUIC reachability probe. quinn 0.11/quinn-proto 0.11 pin rustls 0.23
 # with the `quic` feature, which unifies additively with the workspace rustls
 # (ring provider) — no second rustls in the tree.
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
@@ -149,7 +149,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 # shadowsocks-service's `server` feature + rcgen + base64 transitively; the
 # bridge's own tests no longer reference those directly after the move (#435).
 plugin-e2e = { path = "../plugin-e2e" }
-# Self-signed cert for the quinn server fixture in reachability_tests (#580).
+# Self-signed cert for the quinn server fixture in reachability_tests.
 rcgen = "0.14"
 rand = "0.10"
 # Used by `test_support::net_discovery` for primary IPv4 detection in TUN tests.

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -15,6 +15,7 @@ pub mod plugin_recovery;
 pub mod plugin_state;
 pub mod proxy;
 pub mod proxy_manager;
+pub mod reachability;
 pub mod server_test;
 pub mod socket;
 

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -92,7 +92,7 @@ pub enum ProxyError {
     /// the server handshake (DPI / censorship), distinct from a credential/config
     /// failure. `Display` is the host-free censorship sentence alone (the shared
     /// [`hole_common::protocol::NETWORK_BLOCKED_MESSAGE`]); the GUI matches it
-    /// verbatim to render a clean toast. The IPC round-trips it via `to_string()`.
+    /// verbatim to render a clean toast.
     #[error("{}", hole_common::protocol::NETWORK_BLOCKED_MESSAGE)]
     NetworkBlocked,
 }

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -88,6 +88,13 @@ pub enum ProxyError {
         attempts: u32,
         elapsed_ms: u64,
     },
+    /// The start-time reachability probe found the network is resetting/dropping
+    /// the server handshake (DPI / censorship), distinct from a credential/config
+    /// failure. `Display` is the host-free censorship sentence alone (the shared
+    /// [`crate::reachability::NETWORK_BLOCKED_MESSAGE`]); the GUI matches it
+    /// verbatim to render a clean toast. The IPC round-trips it via `to_string()`.
+    #[error("{}", crate::reachability::NETWORK_BLOCKED_MESSAGE)]
+    NetworkBlocked,
 }
 
 // Error conversions from tun-engine ===================================================================================

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -91,9 +91,9 @@ pub enum ProxyError {
     /// The start-time reachability probe found the network is resetting/dropping
     /// the server handshake (DPI / censorship), distinct from a credential/config
     /// failure. `Display` is the host-free censorship sentence alone (the shared
-    /// [`crate::reachability::NETWORK_BLOCKED_MESSAGE`]); the GUI matches it
+    /// [`hole_common::protocol::NETWORK_BLOCKED_MESSAGE`]); the GUI matches it
     /// verbatim to render a clean toast. The IPC round-trips it via `to_string()`.
-    #[error("{}", crate::reachability::NETWORK_BLOCKED_MESSAGE)]
+    #[error("{}", hole_common::protocol::NETWORK_BLOCKED_MESSAGE)]
     NetworkBlocked,
 }
 

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -812,7 +812,33 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 cancel.clone(),
             )
             .await;
-            outcome.into_result(started.elapsed().as_millis() as u64)?;
+            // On a self-test failure, probe the server out-of-band: if the
+            // network is blocking it (reset/no-response), rewrite the toast
+            // reason from the generic forwarder failure to a censorship-aware
+            // one. Threads the existing cooperative `cancel` token (#580).
+            if let Err(err) = outcome.into_result(started.elapsed().as_millis() as u64) {
+                if let ProxyError::ForwarderSelfTestFailed {
+                    attempts, elapsed_ms, ..
+                } = &err
+                {
+                    if let Some(reason) = diagnose_self_test_failure(
+                        &config.server.server,
+                        config.server.server_port,
+                        config.server.plugin.as_deref(),
+                        config.server.plugin_opts.as_deref(),
+                        &cancel,
+                    )
+                    .await
+                    {
+                        return Err(ProxyError::ForwarderSelfTestFailed {
+                            attempts: *attempts,
+                            elapsed_ms: *elapsed_ms,
+                            reason,
+                        });
+                    }
+                }
+                return Err(err);
+            }
         }
 
         // Phase 5: cancel checkpoint before Dispatcher::new (sync, cannot
@@ -1393,6 +1419,30 @@ impl SelfTestOutcome {
             Self::Cancelled => Err(ProxyError::Cancelled),
         }
     }
+}
+
+/// On a forwarder self-test failure, probe the server directly to see whether
+/// the network is blocking it. Returns a better, host-free toast reason, or
+/// `None` to keep the original self-test reason. Full detail (host/verdict)
+/// lands in `bridge.log` via the probe; only `user_message()` reaches the toast.
+async fn diagnose_self_test_failure(
+    host: &str,
+    port: u16,
+    plugin: Option<&str>,
+    plugin_opts: Option<&str>,
+    cancel: &CancellationToken,
+) -> Option<String> {
+    crate::reachability::probe_server_reachability(
+        host,
+        port,
+        plugin,
+        plugin_opts,
+        crate::reachability::PROBE_DEADLINE,
+        cancel,
+    )
+    .await
+    .user_message()
+    .map(str::to_owned)
 }
 
 /// Treat "any well-formed DNS reply that isn't SERVFAIL" as success.

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -819,7 +819,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 let opts = config.server.plugin_opts.clone();
                 let pc = cancel.child_token();
                 // Hold a clone to wind the probe down cooperatively on the paths
-                // that don't await its verdict (the task owns the inner `pc`).
+                // that don't await its verdict.
                 let stop = pc.clone();
                 let handle = tokio::spawn(async move {
                     crate::reachability::probe_server_reachability(&host, port, plugin.as_deref(), opts.as_deref(), &pc)
@@ -837,7 +837,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             )
             .await;
             match outcome.into_result(started.elapsed().as_millis() as u64) {
-                // Self-test passed: cancel the probe token (let the task wind down).
+                // Self-test passed: cancel the probe token.
                 Ok(_) => {
                     if let Some((_, stop)) = probe {
                         stop.cancel();
@@ -868,7 +868,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                     }
                     return Err(self_test_error_for(verdict, attempts, elapsed_ms, reason));
                 }
-                // Any other error (e.g. Cancelled): cancel the probe token and propagate.
+                // Any other error (e.g. Cancelled): stop the probe, propagate as-is.
                 Err(e) => {
                     if let Some((_, stop)) = probe {
                         stop.cancel();

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -804,6 +804,30 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // observes cancel cooperatively between retry attempts and races
         // each per-attempt forward against it (#397).
         if let Some(fwd) = forwarder.as_ref() {
+            // Race an out-of-band reachability probe against the self-test so it
+            // adds NO latency (#580). Skip it under an active fail-closed cover: a
+            // standing kill-switch (intent on) blocks non-permitted egress, so a
+            // probe would mis-report Hole's OWN lockdown as censorship — keep the
+            // original self-test reason. This bridge installs its own cover later
+            // (after routing.install); at this gate the cover is a pre-existing /
+            // adopted one, and the intent is its honest signal.
+            let cover_active = state_dir.map(lockdown_state::load_enabled).unwrap_or(false);
+            let probe = (!cover_active).then(|| {
+                let host = config.server.server.clone();
+                let port = config.server.server_port;
+                let plugin = config.server.plugin.clone();
+                let opts = config.server.plugin_opts.clone();
+                let pc = cancel.child_token();
+                // Hold a clone to wind the probe down cooperatively on the paths
+                // that don't await its verdict (the task owns the inner `pc`).
+                let stop = pc.clone();
+                let handle = tokio::spawn(async move {
+                    crate::reachability::probe_server_reachability(&host, port, plugin.as_deref(), opts.as_deref(), &pc)
+                        .await
+                });
+                (handle, stop)
+            });
+
             let started = std::time::Instant::now();
             let outcome = run_forwarder_self_test(
                 std::sync::Arc::clone(fwd),
@@ -812,32 +836,39 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 cancel.clone(),
             )
             .await;
-            // On a self-test failure, probe the server out-of-band: if the
-            // network is blocking it (reset/no-response), rewrite the toast
-            // reason from the generic forwarder failure to a censorship-aware
-            // one. Threads the existing cooperative `cancel` token (#580).
-            if let Err(err) = outcome.into_result(started.elapsed().as_millis() as u64) {
-                if let ProxyError::ForwarderSelfTestFailed {
-                    attempts, elapsed_ms, ..
-                } = &err
-                {
-                    if let Some(reason) = diagnose_self_test_failure(
-                        &config.server.server,
-                        config.server.server_port,
-                        config.server.plugin.as_deref(),
-                        config.server.plugin_opts.as_deref(),
-                        &cancel,
-                    )
-                    .await
-                    {
-                        return Err(ProxyError::ForwarderSelfTestFailed {
-                            attempts: *attempts,
-                            elapsed_ms: *elapsed_ms,
-                            reason,
-                        });
+            match outcome.into_result(started.elapsed().as_millis() as u64) {
+                // Self-test passed: cancel the probe token (let the task wind down).
+                Ok(_) => {
+                    if let Some((_, stop)) = probe {
+                        stop.cancel();
                     }
                 }
-                return Err(err);
+                // The forwarder failed: await the concurrent probe's verdict and
+                // reclassify the error. It ran in parallel, so the wait is at most
+                // the probe's remaining budget, not its full duration on top.
+                Err(ProxyError::ForwarderSelfTestFailed {
+                    attempts,
+                    elapsed_ms,
+                    reason,
+                }) => {
+                    let verdict = match probe {
+                        Some((handle, _stop)) => handle.await.ok(),
+                        None => None,
+                    };
+                    // A cancel that fired during the gate makes the probe return
+                    // Inconclusive; surface it as Cancelled, not a server toast (#580).
+                    if cancel.is_cancelled() {
+                        return Err(ProxyError::Cancelled);
+                    }
+                    return Err(self_test_error_for(verdict, attempts, elapsed_ms, reason));
+                }
+                // Any other error (e.g. Cancelled): cancel the probe token and propagate.
+                Err(e) => {
+                    if let Some((_, stop)) = probe {
+                        stop.cancel();
+                    }
+                    return Err(e);
+                }
             }
         }
 
@@ -1421,21 +1452,31 @@ impl SelfTestOutcome {
     }
 }
 
-/// On a forwarder self-test failure, probe the server directly to see whether
-/// the network is blocking it. Returns a better, host-free toast reason, or
-/// `None` to keep the original self-test reason. Full detail (host/verdict)
-/// lands in `bridge.log` via the probe; only `user_message()` reaches the toast.
-async fn diagnose_self_test_failure(
-    host: &str,
-    port: u16,
-    plugin: Option<&str>,
-    plugin_opts: Option<&str>,
-    cancel: &CancellationToken,
-) -> Option<String> {
-    crate::reachability::probe_server_reachability(host, port, plugin, plugin_opts, cancel)
-        .await
-        .user_message()
-        .map(str::to_owned)
+/// Map a self-test failure to the `ProxyError` the toast sees, given the
+/// out-of-band reachability `verdict` (`None` when the probe was skipped). A
+/// `Blocked` verdict becomes the typed [`ProxyError::NetworkBlocked`];
+/// `TcpRefused`/`TcpTimeout` rewrite the reason to the probe's `user_message`;
+/// every other verdict keeps the `original` self-test reason.
+fn self_test_error_for(
+    verdict: Option<crate::reachability::ReachabilityVerdict>,
+    attempts: u32,
+    elapsed_ms: u64,
+    original: String,
+) -> ProxyError {
+    use crate::reachability::ReachabilityVerdict::*;
+    match verdict {
+        Some(Blocked) => ProxyError::NetworkBlocked,
+        Some(v @ (TcpRefused | TcpTimeout)) => ProxyError::ForwarderSelfTestFailed {
+            attempts,
+            elapsed_ms,
+            reason: v.user_message().unwrap_or_default().to_owned(),
+        },
+        _ => ProxyError::ForwarderSelfTestFailed {
+            attempts,
+            elapsed_ms,
+            reason: original,
+        },
+    }
 }
 
 /// Treat "any well-formed DNS reply that isn't SERVFAIL" as success.

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -805,7 +805,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // each per-attempt forward against it (#397).
         if let Some(fwd) = forwarder.as_ref() {
             // Race an out-of-band reachability probe against the self-test so it
-            // adds NO latency (#580). Skip it under an active fail-closed cover: a
+            // adds NO latency. Skip it under an active fail-closed cover: a
             // standing kill-switch (intent on) blocks non-permitted egress, so a
             // probe would mis-report Hole's OWN lockdown as censorship — keep the
             // original self-test reason. This bridge installs its own cover later
@@ -852,11 +852,17 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                     reason,
                 }) => {
                     let verdict = match probe {
-                        Some((handle, _stop)) => handle.await.ok(),
+                        Some((handle, _stop)) => match handle.await {
+                            Ok(v) => Some(v),
+                            Err(e) => {
+                                tracing::debug!(%e, "reachability probe task did not complete");
+                                None
+                            }
+                        },
                         None => None,
                     };
                     // A cancel that fired during the gate makes the probe return
-                    // Inconclusive; surface it as Cancelled, not a server toast (#580).
+                    // Inconclusive; surface it as Cancelled, not a server toast.
                     if cancel.is_cancelled() {
                         return Err(ProxyError::Cancelled);
                     }
@@ -1469,7 +1475,10 @@ fn self_test_error_for(
         Some(v @ (TcpRefused | TcpTimeout)) => ProxyError::ForwarderSelfTestFailed {
             attempts,
             elapsed_ms,
-            reason: v.user_message().unwrap_or_default().to_owned(),
+            reason: v
+                .user_message()
+                .expect("TcpRefused/TcpTimeout always carry a user_message")
+                .to_owned(),
         },
         _ => ProxyError::ForwarderSelfTestFailed {
             attempts,

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1432,17 +1432,10 @@ async fn diagnose_self_test_failure(
     plugin_opts: Option<&str>,
     cancel: &CancellationToken,
 ) -> Option<String> {
-    crate::reachability::probe_server_reachability(
-        host,
-        port,
-        plugin,
-        plugin_opts,
-        crate::reachability::PROBE_DEADLINE,
-        cancel,
-    )
-    .await
-    .user_message()
-    .map(str::to_owned)
+    crate::reachability::probe_server_reachability(host, port, plugin, plugin_opts, cancel)
+        .await
+        .user_message()
+        .map(str::to_owned)
 }
 
 /// Treat "any well-formed DNS reply that isn't SERVFAIL" as success.

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use crate::proxy::{Proxy, ProxyError, RunningProxy, TrafficTotals};
+use crate::reachability::ReachabilityVerdict;
 use hole_common::config::ServerEntry;
 use hole_common::protocol::ProxyConfig;
 use std::io;
@@ -2142,17 +2143,148 @@ mod self_test {
         });
     }
 
-    // Self-test diagnosis (live-Connect reason rewrite) ---------------------------------------------------------------
+    // Self-test verdict → error mapping (live-Connect reason rewrite) -------------------------------------------------
     //
-    // `diagnose_self_test_failure` runs the out-of-band reachability probe on a
-    // forwarder self-test failure and yields a host-free toast reason only when
-    // the network is blocking the server. These unit-test the helper directly;
-    // no real TUN / bridge start is needed.
+    // `self_test_error_for` is the pure mapping from a reachability verdict to the
+    // `ProxyError` surfaced to the toast: `Blocked` becomes the typed
+    // `NetworkBlocked`; `TcpRefused`/`TcpTimeout` rewrite the reason; everything
+    // else keeps the original self-test reason. No real TUN / bridge start needed.
 
-    /// A TLS-transport endpoint that accepts TCP then resets the handshake →
-    /// the probe verdict is `Blocked` → a censorship-aware reason is returned.
-    #[skuld::test(name = "proxy_manager_tests::diagnose_reports_block_for_reset_endpoint")]
-    async fn diagnose_reports_block_for_reset_endpoint() {
+    fn original_reason() -> String {
+        "attempt 3 timed out".to_string()
+    }
+
+    #[skuld::test]
+    fn self_test_error_blocked_is_network_blocked() {
+        let e = self_test_error_for(Some(ReachabilityVerdict::Blocked), 3, 200, original_reason());
+        assert!(
+            matches!(e, ProxyError::NetworkBlocked),
+            "Blocked must map to the typed NetworkBlocked, got {e:?}"
+        );
+    }
+
+    #[skuld::test]
+    fn self_test_error_tcp_refused_rewrites_reason() {
+        let e = self_test_error_for(Some(ReachabilityVerdict::TcpRefused), 3, 200, original_reason());
+        match e {
+            ProxyError::ForwarderSelfTestFailed { reason, .. } => {
+                assert!(reason.contains("refused"), "got {reason:?}");
+            }
+            other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+        }
+    }
+
+    #[skuld::test]
+    fn self_test_error_tcp_timeout_rewrites_reason() {
+        let e = self_test_error_for(Some(ReachabilityVerdict::TcpTimeout), 3, 200, original_reason());
+        match e {
+            ProxyError::ForwarderSelfTestFailed { reason, .. } => {
+                assert!(reason.contains("did not respond"), "got {reason:?}");
+            }
+            other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+        }
+    }
+
+    #[skuld::test]
+    fn self_test_error_reachable_keeps_original() {
+        let e = self_test_error_for(Some(ReachabilityVerdict::Reachable), 3, 200, original_reason());
+        match e {
+            ProxyError::ForwarderSelfTestFailed {
+                reason,
+                attempts,
+                elapsed_ms,
+            } => {
+                assert_eq!(reason, original_reason());
+                assert_eq!(attempts, 3);
+                assert_eq!(elapsed_ms, 200);
+            }
+            other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+        }
+    }
+
+    #[skuld::test]
+    fn self_test_error_inconclusive_keeps_original() {
+        let e = self_test_error_for(Some(ReachabilityVerdict::Inconclusive), 3, 200, original_reason());
+        match e {
+            ProxyError::ForwarderSelfTestFailed { reason, .. } => assert_eq!(reason, original_reason()),
+            other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+        }
+    }
+
+    #[skuld::test]
+    fn self_test_error_none_keeps_original() {
+        let e = self_test_error_for(None, 3, 200, original_reason());
+        match e {
+            ProxyError::ForwarderSelfTestFailed { reason, .. } => assert_eq!(reason, original_reason()),
+            other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+        }
+    }
+
+    /// A server config whose `server` points at a closed loopback port, so the
+    /// out-of-band probe (no plugin → Raw transport) terminates fast with
+    /// `TcpRefused` and the self-test gate fails (MockProxy binds no listener for
+    /// the forwarder). Returns the (manager, config) ready to drive the gate.
+    fn gate_failure_setup(lockdown: bool) -> (ProxyManager<MockProxy, MockRouting>, ProxyConfig, tempfile::TempDir) {
+        // A bound-then-dropped listener yields a port that is closed for the test's
+        // duration, so a connect there is refused, not accepted.
+        let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let closed = probe_l.local_addr().unwrap();
+        drop(probe_l);
+
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let (pm, dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, lockdown);
+
+        let mut cfg = test_config();
+        cfg.server.server = closed.ip().to_string();
+        cfg.server.server_port = closed.port();
+        cfg.dns.enabled = true;
+        cfg.dns.servers = vec!["127.0.0.1".parse().unwrap()];
+        (pm, cfg, dir)
+    }
+
+    /// #6 cover-skip: with the lockdown intent ON, the gate must NOT run the probe
+    /// (a standing kill-switch cover would block it and we'd mis-report Hole's own
+    /// lockdown as censorship). The probe would rewrite the reason to "refused";
+    /// with the probe skipped the ORIGINAL self-test reason survives.
+    #[skuld::test]
+    fn lockdown_on_skips_probe_keeps_original_reason() {
+        rt().block_on(async {
+            let (mut pm, cfg, _dir) = gate_failure_setup(true);
+            let err = pm.start_cancellable(&cfg, CancellationToken::new()).await.unwrap_err();
+            match err {
+                ProxyError::ForwarderSelfTestFailed { reason, .. } => assert!(
+                    !reason.contains("refused"),
+                    "lockdown-on must skip the probe and keep the original reason, got {reason:?}"
+                ),
+                other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+            }
+        });
+    }
+
+    /// #6 control: with lockdown OFF the probe DOES run, so the same closed-port
+    /// server rewrites the reason to the probe's `TcpRefused` message — proving
+    /// the lockdown-on skip above is load-bearing, not vacuous.
+    #[skuld::test]
+    fn lockdown_off_runs_probe_rewrites_reason() {
+        rt().block_on(async {
+            let (mut pm, cfg, _dir) = gate_failure_setup(false);
+            let err = pm.start_cancellable(&cfg, CancellationToken::new()).await.unwrap_err();
+            match err {
+                ProxyError::ForwarderSelfTestFailed { reason, .. } => assert!(
+                    reason.contains("refused"),
+                    "lockdown-off must run the probe and rewrite the reason, got {reason:?}"
+                ),
+                other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
+            }
+        });
+    }
+
+    /// End-to-end-ish: a TLS-transport endpoint that accepts TCP then resets the
+    /// handshake → the live probe verdict is `Blocked` → `self_test_error_for`
+    /// yields the typed `NetworkBlocked`.
+    #[skuld::test(name = "proxy_manager_tests::reset_endpoint_maps_to_network_blocked")]
+    async fn reset_endpoint_maps_to_network_blocked() {
         let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let a = l.local_addr().unwrap();
         tokio::spawn(async move {
@@ -2160,7 +2292,7 @@ mod self_test {
                 drop(s);
             }
         });
-        let r = diagnose_self_test_failure(
+        let verdict = crate::reachability::probe_server_reachability(
             &a.ip().to_string(),
             a.port(),
             Some("galoshes"),
@@ -2168,37 +2300,10 @@ mod self_test {
             &CancellationToken::new(),
         )
         .await;
-        assert!(r.unwrap().contains("firewall or censorship"));
-    }
-
-    /// A TLS-transport endpoint that answers with bytes → the probe verdict is
-    /// `Reachable` → `None`, so the original self-test reason is kept.
-    #[skuld::test(name = "proxy_manager_tests::diagnose_keeps_reason_when_reachable")]
-    async fn diagnose_keeps_reason_when_reachable() {
-        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let a = l.local_addr().unwrap();
-        tokio::spawn(async move {
-            if let Ok((mut s, _)) = l.accept().await {
-                use tokio::io::{AsyncReadExt, AsyncWriteExt};
-                let mut b = [0u8; 64];
-                let _ = s.read(&mut b).await; // wait for the probe's ClientHello first-flight
-                let _ = s.write_all(b"\x15\x03\x03\x00\x02\x02\x28").await; // bytes came back
-                let mut drain = [0u8; 256];
-                while let Ok(n) = s.read(&mut drain).await {
-                    if n == 0 {
-                        break; // peer closed: reply has been delivered
-                    }
-                }
-            }
-        });
-        assert!(diagnose_self_test_failure(
-            &a.ip().to_string(),
-            a.port(),
-            Some("galoshes"),
-            Some("tls;host=h"),
-            &CancellationToken::new(),
-        )
-        .await
-        .is_none());
+        assert_eq!(verdict, ReachabilityVerdict::Blocked);
+        assert!(matches!(
+            self_test_error_for(Some(verdict), 3, 200, original_reason()),
+            ProxyError::NetworkBlocked
+        ));
     }
 }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -2221,9 +2221,10 @@ mod self_test {
     }
 
     /// A server config whose `server` points at a closed loopback port, so the
-    /// out-of-band probe (no plugin → Raw transport) terminates fast with
-    /// `TcpRefused` and the self-test gate fails (MockProxy binds no listener for
-    /// the forwarder). Returns the (manager, config) ready to drive the gate.
+    /// out-of-band probe (no plugin → Raw transport) terminates fast with a
+    /// closed-port verdict (`TcpRefused`, or `TcpTimeout` on a Windows runner
+    /// that SYN-drops) and the self-test gate fails (MockProxy binds no listener
+    /// for the forwarder). Returns the (manager, config) ready to drive the gate.
     fn gate_failure_setup(lockdown: bool) -> (ProxyManager<MockProxy, MockRouting>, ProxyConfig, tempfile::TempDir) {
         // A bound-then-dropped listener yields a port that is closed for the test's
         // duration, so a connect there is refused, not accepted.
@@ -2243,7 +2244,7 @@ mod self_test {
         (pm, cfg, dir)
     }
 
-    /// #6 cover-skip: with the lockdown intent ON, the gate must NOT run the probe
+    /// cover-skip: with the lockdown intent ON, the gate must NOT run the probe
     /// (a standing kill-switch cover would block it and we'd mis-report Hole's own
     /// lockdown as censorship). The probe would rewrite the reason to "refused";
     /// with the probe skipped the ORIGINAL self-test reason survives.
@@ -2262,19 +2263,29 @@ mod self_test {
         });
     }
 
-    /// #6 control: with lockdown OFF the probe DOES run, so the same closed-port
-    /// server rewrites the reason to the probe's `TcpRefused` message — proving
-    /// the lockdown-on skip above is load-bearing, not vacuous.
+    /// Control: with lockdown OFF the probe DOES run, so the same closed-port
+    /// server rewrites the reason to the probe's verdict — proving the
+    /// lockdown-on skip above is load-bearing, not vacuous. The closed port is
+    /// refused on most kernels (`TcpRefused`) but SYN-dropped on Windows GitHub
+    /// runners (`TcpTimeout` → "did not respond"); either rewrite proves the
+    /// probe ran.
     #[skuld::test]
     fn lockdown_off_runs_probe_rewrites_reason() {
         rt().block_on(async {
             let (mut pm, cfg, _dir) = gate_failure_setup(false);
             let err = pm.start_cancellable(&cfg, CancellationToken::new()).await.unwrap_err();
             match err {
-                ProxyError::ForwarderSelfTestFailed { reason, .. } => assert!(
-                    reason.contains("refused"),
-                    "lockdown-off must run the probe and rewrite the reason, got {reason:?}"
-                ),
+                ProxyError::ForwarderSelfTestFailed { reason, .. } => {
+                    let rewritten = if cfg!(target_os = "windows") {
+                        reason.contains("refused") || reason.contains("did not respond")
+                    } else {
+                        reason.contains("refused")
+                    };
+                    assert!(
+                        rewritten,
+                        "lockdown-off must run the probe and rewrite the reason, got {reason:?}"
+                    );
+                }
                 other => panic!("expected ForwarderSelfTestFailed, got {other:?}"),
             }
         });

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -2141,4 +2141,64 @@ mod self_test {
             pm.stop().await.unwrap();
         });
     }
+
+    // Self-test diagnosis (live-Connect reason rewrite) ---------------------------------------------------------------
+    //
+    // `diagnose_self_test_failure` runs the out-of-band reachability probe on a
+    // forwarder self-test failure and yields a host-free toast reason only when
+    // the network is blocking the server. These unit-test the helper directly;
+    // no real TUN / bridge start is needed.
+
+    /// A TLS-transport endpoint that accepts TCP then resets the handshake →
+    /// the probe verdict is `Blocked` → a censorship-aware reason is returned.
+    #[skuld::test(name = "proxy_manager_tests::diagnose_reports_block_for_reset_endpoint")]
+    async fn diagnose_reports_block_for_reset_endpoint() {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let a = l.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((s, _)) = l.accept().await {
+                drop(s);
+            }
+        });
+        let r = diagnose_self_test_failure(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(r.unwrap().contains("firewall or censorship"));
+    }
+
+    /// A TLS-transport endpoint that answers with bytes → the probe verdict is
+    /// `Reachable` → `None`, so the original self-test reason is kept.
+    #[skuld::test(name = "proxy_manager_tests::diagnose_keeps_reason_when_reachable")]
+    async fn diagnose_keeps_reason_when_reachable() {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let a = l.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut s, _)) = l.accept().await {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut b = [0u8; 64];
+                let _ = s.read(&mut b).await; // wait for the probe's ClientHello first-flight
+                let _ = s.write_all(b"\x15\x03\x03\x00\x02\x02\x28").await; // bytes came back
+                let mut drain = [0u8; 256];
+                while let Ok(n) = s.read(&mut drain).await {
+                    if n == 0 {
+                        break; // peer closed: reply has been delivered
+                    }
+                }
+            }
+        });
+        assert!(diagnose_self_test_failure(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await
+        .is_none());
+    }
 }

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -1,0 +1,237 @@
+//! Out-of-band server reachability probe — distinguishes a network-blocked /
+//! reset server from a credential/config failure. See bindreams/hole#580.
+use std::io;
+use std::net::IpAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::net::{lookup_host, TcpStream};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+pub const PROBE_DEADLINE: Duration = Duration::from_secs(6);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReachabilityVerdict {
+    Reachable,
+    DnsFailed,
+    TcpRefused,
+    TcpTimeout,
+    Blocked,
+    Inconclusive,
+}
+
+impl ReachabilityVerdict {
+    /// Host/IP-free toast text; `None` means "do not override the existing reason".
+    pub fn user_message(&self) -> Option<&'static str> {
+        match self {
+            ReachabilityVerdict::Blocked => Some(
+                "The network is blocking the connection to this server — the handshake was \
+                 reset or got no response. This usually means a firewall or censorship; \
+                 try a different server.",
+            ),
+            ReachabilityVerdict::TcpRefused => Some("The server refused the connection."),
+            ReachabilityVerdict::TcpTimeout => Some("The server did not respond (connection timed out)."),
+            _ => None,
+        }
+    }
+}
+
+enum ProbeTransport {
+    TlsWs { sni: String },
+    PlainWs { host: String, path: String },
+    Quic { sni: String },
+    Raw,
+}
+
+fn classify_transport(plugin: Option<&str>, plugin_opts: Option<&str>, server_host: &str) -> ProbeTransport {
+    if plugin.is_none() {
+        return ProbeTransport::Raw;
+    }
+    let opts = plugin_opts.map(garter::parse_plugin_options).unwrap_or_default();
+    let get = |k: &str| opts.iter().find(|(kk, _)| kk == k).map(|(_, v)| v.clone());
+    let has = |k: &str| opts.iter().any(|(kk, _)| kk == k);
+    let sni = get("host").unwrap_or_else(|| server_host.to_string());
+    if get("mode").as_deref() == Some("quic") {
+        return ProbeTransport::Quic { sni };
+    }
+    if has("tls") {
+        return ProbeTransport::TlsWs { sni };
+    }
+    ProbeTransport::PlainWs {
+        host: sni,
+        path: get("path").unwrap_or_else(|| "/".into()),
+    }
+}
+
+pub async fn probe_server_reachability(
+    host: &str,
+    port: u16,
+    plugin: Option<&str>,
+    plugin_opts: Option<&str>,
+    deadline: Duration,
+    cancel: &CancellationToken,
+) -> ReachabilityVerdict {
+    let transport = classify_transport(plugin, plugin_opts, host);
+    let v = tokio::select! {
+        _ = cancel.cancelled() => ReachabilityVerdict::Inconclusive,
+        v = probe_inner(host, port, &transport, deadline) => v,
+    };
+    debug!(host, port, ?v, "reachability probe"); // full detail to bridge.log; toast gets only user_message()
+    v
+}
+
+async fn probe_inner(host: &str, port: u16, transport: &ProbeTransport, deadline: Duration) -> ReachabilityVerdict {
+    if let ProbeTransport::Quic { sni } = transport {
+        return probe_quic(host, port, sni, deadline).await; // Task 2
+    }
+    if host.parse::<IpAddr>().is_err() {
+        let resolved = match lookup_host((host, port)).await {
+            Ok(mut it) => it.next().is_some(),
+            Err(_) => false,
+        };
+        if !resolved {
+            return ReachabilityVerdict::DnsFailed;
+        }
+    }
+    let stream = match tokio::time::timeout(deadline, TcpStream::connect((host, port))).await {
+        Err(_) => return ReachabilityVerdict::TcpTimeout,
+        Ok(Err(e)) if e.kind() == io::ErrorKind::ConnectionRefused => return ReachabilityVerdict::TcpRefused,
+        Ok(Err(_)) => return ReachabilityVerdict::TcpTimeout,
+        Ok(Ok(s)) => s,
+    };
+    match transport {
+        ProbeTransport::Raw => ReachabilityVerdict::Reachable,
+        ProbeTransport::PlainWs { host, path } => first_flight_http(stream, host, path, deadline).await,
+        ProbeTransport::TlsWs { sni } => first_flight_tls(stream, sni, deadline).await,
+        ProbeTransport::Quic { .. } => unreachable!(),
+    }
+}
+
+/// Send the WS-upgrade GET; any bytes back ⇒ Reachable; zero bytes (reset / timeout
+/// / clean EOF / write error) ⇒ Blocked.
+async fn first_flight_http(mut s: TcpStream, host: &str, path: &str, deadline: Duration) -> ReachabilityVerdict {
+    let req = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
+    if s.write_all(req.as_bytes()).await.is_err() {
+        return ReachabilityVerdict::Blocked;
+    }
+    let mut buf = [0u8; 64];
+    match tokio::time::timeout(deadline, s.read(&mut buf)).await {
+        Ok(Ok(n)) if n > 0 => ReachabilityVerdict::Reachable,
+        _ => ReachabilityVerdict::Blocked, // Ok(Ok(0)) clean EOF, Ok(Err) reset, Err timeout
+    }
+}
+
+/// Drive a no-verify TLS handshake; handshake completes OR any server byte arrives
+/// ⇒ Reachable; reset / timeout / clean-EOF with zero bytes ⇒ Blocked.
+async fn first_flight_tls(stream: TcpStream, sni: &str, deadline: Duration) -> ReachabilityVerdict {
+    use rustls::pki_types::ServerName;
+    let saw = Arc::new(AtomicBool::new(false));
+    let sniffed = ByteSniff {
+        inner: stream,
+        saw: saw.clone(),
+    };
+    let name = match ServerName::try_from(sni.to_string()) {
+        Ok(n) => n,
+        Err(_) => match sni.parse::<IpAddr>() {
+            Ok(ip) => ServerName::IpAddress(ip.into()),
+            Err(_) => return ReachabilityVerdict::Inconclusive,
+        },
+    };
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(no_verify_tls_config(vec![b"http/1.1".to_vec()])));
+    match tokio::time::timeout(deadline, connector.connect(name, sniffed)).await {
+        Ok(Ok(_)) => ReachabilityVerdict::Reachable,
+        _ if saw.load(Ordering::SeqCst) => ReachabilityVerdict::Reachable,
+        _ => ReachabilityVerdict::Blocked,
+    }
+}
+
+/// No-verify rustls client config (ring provider), used by the TLS probe.
+/// `alpn` lets the QUIC probe (Task 2) request `h3` instead of `http/1.1`.
+pub(crate) fn no_verify_tls_config(alpn: Vec<Vec<u8>>) -> rustls::ClientConfig {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut cfg = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()
+        .expect("ring supports default versions")
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify(provider)))
+        .with_no_client_auth();
+    cfg.alpn_protocols = alpn;
+    cfg
+}
+
+#[derive(Debug)]
+struct NoVerify(Arc<rustls::crypto::CryptoProvider>);
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _e: &rustls::pki_types::CertificateDer,
+        _i: &[rustls::pki_types::CertificateDer],
+        _s: &rustls::pki_types::ServerName,
+        _o: &[u8],
+        _n: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        m: &[u8],
+        c: &rustls::pki_types::CertificateDer,
+        d: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(m, c, d, &self.0.signature_verification_algorithms)
+    }
+    fn verify_tls13_signature(
+        &self,
+        m: &[u8],
+        c: &rustls::pki_types::CertificateDer,
+        d: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(m, c, d, &self.0.signature_verification_algorithms)
+    }
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+/// Flips `saw` when any non-empty read completes, so the TLS probe can tell
+/// "server answered" from "reset before any byte".
+struct ByteSniff<S> {
+    inner: S,
+    saw: Arc<AtomicBool>,
+}
+impl<S: AsyncRead + Unpin> AsyncRead for ByteSniff<S> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        let pre = buf.filled().len();
+        let r = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &r {
+            if buf.filled().len() > pre {
+                self.saw.store(true, Ordering::SeqCst);
+            }
+        }
+        r
+    }
+}
+impl<S: AsyncWrite + Unpin> AsyncWrite for ByteSniff<S> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, b: &[u8]) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, b)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+// Temporary stub so Task 1 compiles; Task 2 replaces it with a real quinn probe.
+async fn probe_quic(_: &str, _: u16, _: &str, _: Duration) -> ReachabilityVerdict {
+    ReachabilityVerdict::Inconclusive
+}
+
+#[cfg(test)]
+#[path = "reachability_tests.rs"]
+mod reachability_tests;

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -20,6 +20,14 @@ const CONNECT_DEADLINE: Duration = Duration::from_secs(3); // DNS resolve + TCP 
 const FIRSTFLIGHT_DEADLINE: Duration = Duration::from_secs(3); // TLS/HTTP first-flight read
 const QUIC_DEADLINE: Duration = Duration::from_secs(6); // whole quinn connect
 
+/// Host-free censorship toast text, shared by [`ReachabilityVerdict::user_message`]
+/// and [`crate::proxy::ProxyError::NetworkBlocked`]'s `Display` so the live-Connect
+/// and Server-Test surfaces read identically. The GUI matches this verbatim to
+/// render the toast standalone (see `crates/hole/src/state.rs`).
+pub const NETWORK_BLOCKED_MESSAGE: &str = "The network is blocking the connection to this server — the handshake was \
+     reset or got no response. This usually means a firewall or censorship; \
+     try a different server.";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReachabilityVerdict {
     Reachable,
@@ -34,11 +42,7 @@ impl ReachabilityVerdict {
     /// Host/IP-free toast text; `None` means "do not override the existing reason".
     pub fn user_message(&self) -> Option<&'static str> {
         match self {
-            ReachabilityVerdict::Blocked => Some(
-                "The network is blocking the connection to this server — the handshake was \
-                 reset or got no response. This usually means a firewall or censorship; \
-                 try a different server.",
-            ),
+            ReachabilityVerdict::Blocked => Some(NETWORK_BLOCKED_MESSAGE),
             ReachabilityVerdict::TcpRefused => Some("The server refused the connection."),
             ReachabilityVerdict::TcpTimeout => Some("The server did not respond (connection timed out)."),
             _ => None,

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -227,10 +227,11 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ByteSniff<S> {
     }
 }
 
-/// Drive a no-verify QUIC handshake. A completed handshake or any peer-origin
-/// `ConnectionError` (`VersionMismatch`/`TransportError`/`Reset`/`*Closed`)
-/// means the server answered ⇒ Reachable; `TimedOut` or the outer deadline
-/// elapsing (no response at all) ⇒ Blocked.
+/// Drive a no-verify QUIC handshake. A completed handshake or a peer-origin
+/// `ConnectionError` (remote-closed (`ConnectionClosed`/`ApplicationClosed`)/`Reset`/`VersionMismatch`/`TransportError`:
+/// peer answered) means the server answered ⇒ Reachable; local-only
+/// `LocallyClosed`/`CidsExhausted` ⇒ Inconclusive; `TimedOut` or the outer
+/// deadline elapsing (no response at all) ⇒ Blocked.
 async fn probe_quic(host: &str, port: u16, sni: &str, deadline: Duration) -> ReachabilityVerdict {
     use quinn::{ClientConfig, ConnectionError, Endpoint};
     let addr = match lookup_host((host, port)).await {
@@ -258,8 +259,9 @@ async fn probe_quic(host: &str, port: u16, sni: &str, deadline: Duration) -> Rea
     let v = match tokio::time::timeout(deadline, connecting).await {
         Ok(Ok(_)) => ReachabilityVerdict::Reachable, // handshake completed
         Ok(Err(ConnectionError::TimedOut)) => ReachabilityVerdict::Blocked, // no response
-        Ok(Err(_)) => ReachabilityVerdict::Reachable, // VersionMismatch/TransportError/Reset/etc: peer responded
-        Err(_) => ReachabilityVerdict::Blocked,      // outer deadline, no response
+        Ok(Err(ConnectionError::LocallyClosed | ConnectionError::CidsExhausted)) => ReachabilityVerdict::Inconclusive, // local-only failure
+        Ok(Err(_)) => ReachabilityVerdict::Reachable, // VersionMismatch/TransportError/(Application|Connection)Closed/Reset: peer answered
+        Err(_) => ReachabilityVerdict::Blocked,       // outer deadline elapsed
     };
     ep.close(0u32.into(), b"");
     v

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -1,5 +1,5 @@
 //! Out-of-band server reachability probe — distinguishes a network-blocked /
-//! reset server from a credential/config failure. See bindreams/hole#580.
+//! reset server from a credential/config failure.
 use std::io;
 use std::net::IpAddr;
 use std::pin::Pin;
@@ -12,7 +12,13 @@ use tokio::net::{lookup_host, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
-pub const PROBE_DEADLINE: Duration = Duration::from_secs(6);
+// Per-phase budgets bound the total while preserving the connect-vs-first-flight
+// verdict split: a connect timeout stays `TcpTimeout` (a closed-port SYN-drop),
+// a first-flight no-response stays `Blocked` (a real block). One outer timeout
+// would conflate them. Non-QUIC worst case ≈ CONNECT_DEADLINE + FIRSTFLIGHT_DEADLINE = 6s.
+const CONNECT_DEADLINE: Duration = Duration::from_secs(3); // DNS resolve + TCP connect
+const FIRSTFLIGHT_DEADLINE: Duration = Duration::from_secs(3); // TLS/HTTP first-flight read
+const QUIC_DEADLINE: Duration = Duration::from_secs(6); // whole quinn connect
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReachabilityVerdict {
@@ -72,54 +78,65 @@ pub async fn probe_server_reachability(
     port: u16,
     plugin: Option<&str>,
     plugin_opts: Option<&str>,
-    deadline: Duration,
     cancel: &CancellationToken,
 ) -> ReachabilityVerdict {
     let transport = classify_transport(plugin, plugin_opts, host);
     let v = tokio::select! {
         _ = cancel.cancelled() => ReachabilityVerdict::Inconclusive,
-        v = probe_inner(host, port, &transport, deadline) => v,
+        v = probe_inner(host, port, &transport) => v,
     };
-    debug!(host, port, ?v, "reachability probe"); // full detail to bridge.log; toast gets only user_message()
+    debug!(host, port, ?v, "reachability probe");
     v
 }
 
-async fn probe_inner(host: &str, port: u16, transport: &ProbeTransport, deadline: Duration) -> ReachabilityVerdict {
+async fn probe_inner(host: &str, port: u16, transport: &ProbeTransport) -> ReachabilityVerdict {
     if let ProbeTransport::Quic { sni } = transport {
-        return probe_quic(host, port, sni, deadline).await; // Task 2
+        return probe_quic(host, port, sni).await;
     }
+    // Bound DNS resolve + TCP connect together so the slow-DNS case stays inside
+    // CONNECT_DEADLINE.
+    let stream = match tokio::time::timeout(CONNECT_DEADLINE, connect_tcp(host, port)).await {
+        Err(_) => return ReachabilityVerdict::TcpTimeout, // connect-phase deadline elapsed
+        Ok(Err(v)) => return v,                           // DnsFailed / TcpRefused / TcpTimeout
+        Ok(Ok(s)) => s,
+    };
+    match transport {
+        ProbeTransport::Raw => ReachabilityVerdict::Reachable,
+        ProbeTransport::PlainWs { host, path } => first_flight_http(stream, host, path).await,
+        ProbeTransport::TlsWs { sni } => first_flight_tls(stream, sni).await,
+        ProbeTransport::Quic { .. } => unreachable!(),
+    }
+}
+
+/// Resolve (if `host` is not a literal IP) then TCP-connect. `Err` carries the
+/// terminal verdict (`DnsFailed`/`TcpRefused`/`TcpTimeout`); the caller bounds
+/// the whole thing with `CONNECT_DEADLINE`.
+async fn connect_tcp(host: &str, port: u16) -> Result<TcpStream, ReachabilityVerdict> {
     if host.parse::<IpAddr>().is_err() {
         let resolved = match lookup_host((host, port)).await {
             Ok(mut it) => it.next().is_some(),
             Err(_) => false,
         };
         if !resolved {
-            return ReachabilityVerdict::DnsFailed;
+            return Err(ReachabilityVerdict::DnsFailed);
         }
     }
-    let stream = match tokio::time::timeout(deadline, TcpStream::connect((host, port))).await {
-        Err(_) => return ReachabilityVerdict::TcpTimeout,
-        Ok(Err(e)) if e.kind() == io::ErrorKind::ConnectionRefused => return ReachabilityVerdict::TcpRefused,
-        Ok(Err(_)) => return ReachabilityVerdict::TcpTimeout,
-        Ok(Ok(s)) => s,
-    };
-    match transport {
-        ProbeTransport::Raw => ReachabilityVerdict::Reachable,
-        ProbeTransport::PlainWs { host, path } => first_flight_http(stream, host, path, deadline).await,
-        ProbeTransport::TlsWs { sni } => first_flight_tls(stream, sni, deadline).await,
-        ProbeTransport::Quic { .. } => unreachable!(),
+    match TcpStream::connect((host, port)).await {
+        Ok(s) => Ok(s),
+        Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => Err(ReachabilityVerdict::TcpRefused),
+        Err(_) => Err(ReachabilityVerdict::TcpTimeout),
     }
 }
 
 /// Send the WS-upgrade GET; any bytes back ⇒ Reachable; zero bytes (reset / timeout
 /// / clean EOF / write error) ⇒ Blocked.
-async fn first_flight_http(mut s: TcpStream, host: &str, path: &str, deadline: Duration) -> ReachabilityVerdict {
+async fn first_flight_http(mut s: TcpStream, host: &str, path: &str) -> ReachabilityVerdict {
     let req = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
     if s.write_all(req.as_bytes()).await.is_err() {
         return ReachabilityVerdict::Blocked;
     }
     let mut buf = [0u8; 64];
-    match tokio::time::timeout(deadline, s.read(&mut buf)).await {
+    match tokio::time::timeout(FIRSTFLIGHT_DEADLINE, s.read(&mut buf)).await {
         Ok(Ok(n)) if n > 0 => ReachabilityVerdict::Reachable,
         _ => ReachabilityVerdict::Blocked, // Ok(Ok(0)) clean EOF, Ok(Err) reset, Err timeout
     }
@@ -127,22 +144,24 @@ async fn first_flight_http(mut s: TcpStream, host: &str, path: &str, deadline: D
 
 /// Drive a no-verify TLS handshake; handshake completes OR any server byte arrives
 /// ⇒ Reachable; reset / timeout / clean-EOF with zero bytes ⇒ Blocked.
-async fn first_flight_tls(stream: TcpStream, sni: &str, deadline: Duration) -> ReachabilityVerdict {
+async fn first_flight_tls(stream: TcpStream, sni: &str) -> ReachabilityVerdict {
     use rustls::pki_types::ServerName;
     let saw = Arc::new(AtomicBool::new(false));
     let sniffed = ByteSniff {
         inner: stream,
         saw: saw.clone(),
     };
+    // `ServerName::try_from(String)` parses a DNS name and falls back to an IP
+    // literal, so a manual IP arm would be dead.
     let name = match ServerName::try_from(sni.to_string()) {
         Ok(n) => n,
-        Err(_) => match sni.parse::<IpAddr>() {
-            Ok(ip) => ServerName::IpAddress(ip.into()),
-            Err(_) => return ReachabilityVerdict::Inconclusive,
-        },
+        Err(e) => {
+            debug!(%e, sni, "reachability probe: unparseable SNI");
+            return ReachabilityVerdict::Inconclusive;
+        }
     };
     let connector = tokio_rustls::TlsConnector::from(Arc::new(no_verify_tls_config(vec![b"http/1.1".to_vec()])));
-    match tokio::time::timeout(deadline, connector.connect(name, sniffed)).await {
+    match tokio::time::timeout(FIRSTFLIGHT_DEADLINE, connector.connect(name, sniffed)).await {
         Ok(Ok(_)) => ReachabilityVerdict::Reachable,
         _ if saw.load(Ordering::SeqCst) => ReachabilityVerdict::Reachable,
         _ => ReachabilityVerdict::Blocked,
@@ -150,7 +169,7 @@ async fn first_flight_tls(stream: TcpStream, sni: &str, deadline: Duration) -> R
 }
 
 /// No-verify rustls client config (ring provider), used by the TLS probe.
-/// `alpn` lets the QUIC probe (Task 2) request `h3` instead of `http/1.1`.
+/// `alpn` lets the QUIC probe request `h3` instead of `http/1.1`.
 pub(crate) fn no_verify_tls_config(alpn: Vec<Vec<u8>>) -> rustls::ClientConfig {
     let provider = Arc::new(rustls::crypto::ring::default_provider());
     let mut cfg = rustls::ClientConfig::builder_with_provider(provider.clone())
@@ -232,7 +251,7 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ByteSniff<S> {
 /// peer answered) means the server answered ⇒ Reachable; local-only
 /// `LocallyClosed`/`CidsExhausted` ⇒ Inconclusive; `TimedOut` or the outer
 /// deadline elapsing (no response at all) ⇒ Blocked.
-async fn probe_quic(host: &str, port: u16, sni: &str, deadline: Duration) -> ReachabilityVerdict {
+async fn probe_quic(host: &str, port: u16, sni: &str) -> ReachabilityVerdict {
     use quinn::{ClientConfig, ConnectionError, Endpoint};
     let addr = match lookup_host((host, port)).await {
         Ok(mut it) => match it.next() {
@@ -241,30 +260,41 @@ async fn probe_quic(host: &str, port: u16, sni: &str, deadline: Duration) -> Rea
         },
         Err(_) => return ReachabilityVerdict::DnsFailed,
     };
-    let mut ep = match Endpoint::client("0.0.0.0:0".parse().unwrap()) {
+    // Bind the endpoint to the remote's family: quinn rejects a v6 remote on a v4
+    // endpoint, and a wildcard-v6 socket isn't reliably dual-stack on Windows.
+    let bind = if addr.is_ipv6() { "[::]:0" } else { "0.0.0.0:0" };
+    let mut ep = match Endpoint::client(bind.parse().unwrap()) {
         Ok(e) => e,
-        Err(_) => return ReachabilityVerdict::Inconclusive,
+        Err(e) => {
+            debug!(%e, "quic probe: endpoint bind failed");
+            return ReachabilityVerdict::Inconclusive;
+        }
     };
     // QUIC needs TLS 1.3 (the default protocol versions include it) + h3 ALPN.
     let tls = no_verify_tls_config(vec![b"h3".to_vec()]);
     let qcc = match quinn::crypto::rustls::QuicClientConfig::try_from(tls) {
         Ok(c) => c,
-        Err(_) => return ReachabilityVerdict::Inconclusive,
+        Err(e) => {
+            debug!(%e, "quic probe: client config failed");
+            return ReachabilityVerdict::Inconclusive;
+        }
     };
     ep.set_default_client_config(ClientConfig::new(Arc::new(qcc)));
     let connecting = match ep.connect(addr, sni) {
         Ok(c) => c,
-        Err(_) => return ReachabilityVerdict::Inconclusive,
+        Err(e) => {
+            debug!(%e, "quic probe: connect setup failed");
+            return ReachabilityVerdict::Inconclusive;
+        }
     };
-    let v = match tokio::time::timeout(deadline, connecting).await {
+    // `Drop` owns endpoint teardown; no explicit `ep.close()` on any exit.
+    match tokio::time::timeout(QUIC_DEADLINE, connecting).await {
         Ok(Ok(_)) => ReachabilityVerdict::Reachable, // handshake completed
         Ok(Err(ConnectionError::TimedOut)) => ReachabilityVerdict::Blocked, // no response
         Ok(Err(ConnectionError::LocallyClosed | ConnectionError::CidsExhausted)) => ReachabilityVerdict::Inconclusive, // local-only failure
         Ok(Err(_)) => ReachabilityVerdict::Reachable, // VersionMismatch/TransportError/(Application|Connection)Closed/Reset: peer answered
         Err(_) => ReachabilityVerdict::Blocked,       // outer deadline elapsed
-    };
-    ep.close(0u32.into(), b"");
-    v
+    }
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -20,14 +20,6 @@ const CONNECT_DEADLINE: Duration = Duration::from_secs(3); // DNS resolve + TCP 
 const FIRSTFLIGHT_DEADLINE: Duration = Duration::from_secs(3); // TLS/HTTP first-flight read
 const QUIC_DEADLINE: Duration = Duration::from_secs(6); // whole quinn connect
 
-/// Host-free censorship toast text, shared by [`ReachabilityVerdict::user_message`]
-/// and [`crate::proxy::ProxyError::NetworkBlocked`]'s `Display` so the live-Connect
-/// and Server-Test surfaces read identically. The GUI matches this verbatim to
-/// render the toast standalone (see `crates/hole/src/state.rs`).
-pub const NETWORK_BLOCKED_MESSAGE: &str = "The network is blocking the connection to this server — the handshake was \
-     reset or got no response. This usually means a firewall or censorship; \
-     try a different server.";
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReachabilityVerdict {
     Reachable,
@@ -42,7 +34,7 @@ impl ReachabilityVerdict {
     /// Host/IP-free toast text; `None` means "do not override the existing reason".
     pub fn user_message(&self) -> Option<&'static str> {
         match self {
-            ReachabilityVerdict::Blocked => Some(NETWORK_BLOCKED_MESSAGE),
+            ReachabilityVerdict::Blocked => Some(hole_common::protocol::NETWORK_BLOCKED_MESSAGE),
             ReachabilityVerdict::TcpRefused => Some("The server refused the connection."),
             ReachabilityVerdict::TcpTimeout => Some("The server did not respond (connection timed out)."),
             _ => None,
@@ -250,11 +242,9 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ByteSniff<S> {
     }
 }
 
-/// Drive a no-verify QUIC handshake. A completed handshake or a peer-origin
-/// `ConnectionError` (remote-closed (`ConnectionClosed`/`ApplicationClosed`)/`Reset`/`VersionMismatch`/`TransportError`:
-/// peer answered) means the server answered ⇒ Reachable; local-only
-/// `LocallyClosed`/`CidsExhausted` ⇒ Inconclusive; `TimedOut` or the outer
-/// deadline elapsing (no response at all) ⇒ Blocked.
+/// Drive a no-verify QUIC handshake. Any peer response (handshake or a peer-origin
+/// `ConnectionError`) ⇒ Reachable; a local-only failure ⇒ Inconclusive; timeout /
+/// silence ⇒ Blocked. The match arms below enumerate each variant.
 async fn probe_quic(host: &str, port: u16, sni: &str) -> ReachabilityVerdict {
     use quinn::{ClientConfig, ConnectionError, Endpoint};
     let addr = match lookup_host((host, port)).await {

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -16,7 +16,7 @@ use tracing::debug;
 // verdict split: a connect timeout stays `TcpTimeout` (a closed-port SYN-drop),
 // a first-flight no-response stays `Blocked` (a real block). One outer timeout
 // would conflate them. Non-QUIC worst case ≈ CONNECT_DEADLINE + FIRSTFLIGHT_DEADLINE = 6s.
-const CONNECT_DEADLINE: Duration = Duration::from_secs(3); // DNS resolve + TCP connect
+const CONNECT_DEADLINE: Duration = Duration::from_secs(3); // TCP connect (DNS resolve precedes it)
 const FIRSTFLIGHT_DEADLINE: Duration = Duration::from_secs(3); // TLS/HTTP first-flight read
 const QUIC_DEADLINE: Duration = Duration::from_secs(6); // whole quinn connect
 
@@ -42,14 +42,14 @@ impl ReachabilityVerdict {
     }
 }
 
-enum ProbeTransport {
+pub(crate) enum ProbeTransport {
     TlsWs { sni: String },
     PlainWs { host: String, path: String },
     Quic { sni: String },
     Raw,
 }
 
-fn classify_transport(plugin: Option<&str>, plugin_opts: Option<&str>, server_host: &str) -> ProbeTransport {
+pub(crate) fn classify_transport(plugin: Option<&str>, plugin_opts: Option<&str>, server_host: &str) -> ProbeTransport {
     if plugin.is_none() {
         return ProbeTransport::Raw;
     }
@@ -89,12 +89,11 @@ async fn probe_inner(host: &str, port: u16, transport: &ProbeTransport) -> Reach
     if let ProbeTransport::Quic { sni } = transport {
         return probe_quic(host, port, sni).await;
     }
-    // Bound DNS resolve + TCP connect together so the slow-DNS case stays inside
-    // CONNECT_DEADLINE.
-    let stream = match tokio::time::timeout(CONNECT_DEADLINE, connect_tcp(host, port)).await {
-        Err(_) => return ReachabilityVerdict::TcpTimeout, // connect-phase deadline elapsed
-        Ok(Err(v)) => return v,                           // DnsFailed / TcpRefused / TcpTimeout
-        Ok(Ok(s)) => s,
+    let stream = match resolve_and_connect(host, port, CONNECT_DEADLINE).await {
+        ConnectResult::Connected(s) => s,
+        ConnectResult::DnsFailed => return ReachabilityVerdict::DnsFailed,
+        ConnectResult::Refused => return ReachabilityVerdict::TcpRefused,
+        ConnectResult::Timeout => return ReachabilityVerdict::TcpTimeout,
     };
     match transport {
         ProbeTransport::Raw => ReachabilityVerdict::Reachable,
@@ -104,23 +103,34 @@ async fn probe_inner(host: &str, port: u16, transport: &ProbeTransport) -> Reach
     }
 }
 
-/// Resolve (if `host` is not a literal IP) then TCP-connect. `Err` carries the
-/// terminal verdict (`DnsFailed`/`TcpRefused`/`TcpTimeout`); the caller bounds
-/// the whole thing with `CONNECT_DEADLINE`.
-async fn connect_tcp(host: &str, port: u16) -> Result<TcpStream, ReachabilityVerdict> {
+/// Outcome of [`resolve_and_connect`], shared by the reachability probe and the
+/// server-test preflight so both classify a connect the same way.
+pub(crate) enum ConnectResult {
+    Connected(TcpStream),
+    DnsFailed,
+    Refused,
+    Timeout,
+}
+
+/// Resolve (when `host` is not a literal IP) then TCP-connect within `deadline`.
+/// A resolve miss is [`ConnectResult::DnsFailed`]; a `ConnectionRefused` is
+/// [`ConnectResult::Refused`]; an elapsed `deadline` or any other connect error
+/// is [`ConnectResult::Timeout`]; success carries the stream.
+pub(crate) async fn resolve_and_connect(host: &str, port: u16, deadline: Duration) -> ConnectResult {
     if host.parse::<IpAddr>().is_err() {
         let resolved = match lookup_host((host, port)).await {
             Ok(mut it) => it.next().is_some(),
             Err(_) => false,
         };
         if !resolved {
-            return Err(ReachabilityVerdict::DnsFailed);
+            return ConnectResult::DnsFailed;
         }
     }
-    match TcpStream::connect((host, port)).await {
-        Ok(s) => Ok(s),
-        Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => Err(ReachabilityVerdict::TcpRefused),
-        Err(_) => Err(ReachabilityVerdict::TcpTimeout),
+    match tokio::time::timeout(deadline, TcpStream::connect((host, port))).await {
+        Err(_) => ConnectResult::Timeout,
+        Ok(Ok(s)) => ConnectResult::Connected(s),
+        Ok(Err(e)) if e.kind() == io::ErrorKind::ConnectionRefused => ConnectResult::Refused,
+        Ok(Err(_)) => ConnectResult::Timeout,
     }
 }
 
@@ -264,7 +274,7 @@ async fn probe_quic(host: &str, port: u16, sni: &str) -> ReachabilityVerdict {
             return ReachabilityVerdict::Inconclusive;
         }
     };
-    // QUIC needs TLS 1.3 (the default protocol versions include it) + h3 ALPN.
+    // QUIC needs TLS 1.3 + h3 ALPN.
     let tls = no_verify_tls_config(vec![b"h3".to_vec()]);
     let qcc = match quinn::crypto::rustls::QuicClientConfig::try_from(tls) {
         Ok(c) => c,
@@ -281,7 +291,7 @@ async fn probe_quic(host: &str, port: u16, sni: &str) -> ReachabilityVerdict {
             return ReachabilityVerdict::Inconclusive;
         }
     };
-    // `Drop` owns endpoint teardown; no explicit `ep.close()` on any exit.
+    // `Drop` owns endpoint teardown.
     match tokio::time::timeout(QUIC_DEADLINE, connecting).await {
         Ok(Ok(_)) => ReachabilityVerdict::Reachable, // handshake completed
         Ok(Err(ConnectionError::TimedOut)) => ReachabilityVerdict::Blocked, // no response

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -227,9 +227,42 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for ByteSniff<S> {
     }
 }
 
-// Temporary stub so Task 1 compiles; Task 2 replaces it with a real quinn probe.
-async fn probe_quic(_: &str, _: u16, _: &str, _: Duration) -> ReachabilityVerdict {
-    ReachabilityVerdict::Inconclusive
+/// Drive a no-verify QUIC handshake. A completed handshake or any peer-origin
+/// `ConnectionError` (`VersionMismatch`/`TransportError`/`Reset`/`*Closed`)
+/// means the server answered ⇒ Reachable; `TimedOut` or the outer deadline
+/// elapsing (no response at all) ⇒ Blocked.
+async fn probe_quic(host: &str, port: u16, sni: &str, deadline: Duration) -> ReachabilityVerdict {
+    use quinn::{ClientConfig, ConnectionError, Endpoint};
+    let addr = match lookup_host((host, port)).await {
+        Ok(mut it) => match it.next() {
+            Some(a) => a,
+            None => return ReachabilityVerdict::DnsFailed,
+        },
+        Err(_) => return ReachabilityVerdict::DnsFailed,
+    };
+    let mut ep = match Endpoint::client("0.0.0.0:0".parse().unwrap()) {
+        Ok(e) => e,
+        Err(_) => return ReachabilityVerdict::Inconclusive,
+    };
+    // QUIC needs TLS 1.3 (the default protocol versions include it) + h3 ALPN.
+    let tls = no_verify_tls_config(vec![b"h3".to_vec()]);
+    let qcc = match quinn::crypto::rustls::QuicClientConfig::try_from(tls) {
+        Ok(c) => c,
+        Err(_) => return ReachabilityVerdict::Inconclusive,
+    };
+    ep.set_default_client_config(ClientConfig::new(Arc::new(qcc)));
+    let connecting = match ep.connect(addr, sni) {
+        Ok(c) => c,
+        Err(_) => return ReachabilityVerdict::Inconclusive,
+    };
+    let v = match tokio::time::timeout(deadline, connecting).await {
+        Ok(Ok(_)) => ReachabilityVerdict::Reachable, // handshake completed
+        Ok(Err(ConnectionError::TimedOut)) => ReachabilityVerdict::Blocked, // no response
+        Ok(Err(_)) => ReachabilityVerdict::Reachable, // VersionMismatch/TransportError/Reset/etc: peer responded
+        Err(_) => ReachabilityVerdict::Blocked,      // outer deadline, no response
+    };
+    ep.close(0u32.into(), b"");
+    v
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -1,0 +1,171 @@
+// Sanctioned per-test CancellationToken::new (no caller-side token in unit fixtures). See clippy.toml.
+#![allow(clippy::disallowed_methods)]
+use super::*;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+const DL: Duration = Duration::from_secs(3);
+
+// Fixture: accept then drop (RST / FIN with zero app bytes).
+async fn accept_then_reset() -> SocketAddr {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((s, _)) = l.accept().await {
+            drop(s);
+        }
+    });
+    addr
+}
+// Fixture: accept, read first-flight, write a few bytes (server "answered").
+//
+// After writing the reply we drain to EOF instead of dropping the socket: on
+// Windows, closing a TCP stream that still holds unread bytes (the rest of the
+// client's first-flight that we didn't read) emits an RST that discards the
+// reply we just wrote, which the probe would then misread as Blocked. Draining
+// until the peer closes lets the reply land first — no timer, pure rendezvous.
+async fn accept_then_answer() -> SocketAddr {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((mut s, _)) = l.accept().await {
+            let mut b = [0u8; 64];
+            let _ = s.read(&mut b).await; // wait for ClientHello / GET first-flight
+            let _ = s.write_all(b"\x15\x03\x03\x00\x02\x02\x28").await; // bytes came back
+            let mut drain = [0u8; 256];
+            while let Ok(n) = s.read(&mut drain).await {
+                if n == 0 {
+                    break; // peer closed: reply has been delivered
+                }
+            }
+        }
+    });
+    addr
+}
+
+// All tests use `#[skuld::test]` (incl. the sync classifier ones): this crate
+// runs a custom skuld harness (`harness = false`) that collects only
+// `#[skuld::test]` functions — plain `#[test]` ones are silently never run.
+// Each carries an explicit `name = "reachability_tests::…"`: skuld reports the
+// bare fn ident as the test name (no module prefix), so the documented
+// `nextest run … reachability_tests` substring filter only matches with it.
+#[skuld::test(name = "reachability_tests::classify_no_plugin_is_raw")]
+fn classify_no_plugin_is_raw() {
+    assert!(matches!(classify_transport(None, None, "ex.com"), ProbeTransport::Raw));
+}
+#[skuld::test(name = "reachability_tests::classify_tls_ws_uses_host_as_sni")]
+fn classify_tls_ws_uses_host_as_sni() {
+    assert!(
+        matches!(classify_transport(Some("galoshes"), Some("tls;path=/t/x;host=h.ex.com"), "srv"),
+        ProbeTransport::TlsWs { sni } if sni == "h.ex.com")
+    );
+}
+#[skuld::test(name = "reachability_tests::classify_plain_ws_defaults_path_and_host")]
+fn classify_plain_ws_defaults_path_and_host() {
+    match classify_transport(Some("galoshes"), Some("path=/t/x"), "srv.ex.com") {
+        ProbeTransport::PlainWs { host, path } => {
+            assert_eq!(host, "srv.ex.com");
+            assert_eq!(path, "/t/x");
+        }
+        _ => panic!(),
+    }
+}
+#[skuld::test(name = "reachability_tests::classify_quic_forces_quic")]
+fn classify_quic_forces_quic() {
+    assert!(
+        matches!(classify_transport(Some("galoshes"), Some("mode=quic;host=h"), "srv"),
+        ProbeTransport::Quic { sni } if sni == "h")
+    );
+}
+#[skuld::test(name = "reachability_tests::user_message_is_host_free")]
+fn user_message_is_host_free() {
+    let m = ReachabilityVerdict::Blocked.user_message().unwrap();
+    assert!(m.contains("firewall or censorship"));
+    assert!(ReachabilityVerdict::Reachable.user_message().is_none());
+}
+
+#[skuld::test(name = "reachability_tests::plain_ws_reset_is_blocked")]
+async fn plain_ws_reset_is_blocked() {
+    let a = accept_then_reset().await;
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("path=/x"),
+            DL,
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Blocked
+    );
+}
+#[skuld::test(name = "reachability_tests::plain_ws_answered_is_reachable")]
+async fn plain_ws_answered_is_reachable() {
+    let a = accept_then_answer().await;
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("path=/x"),
+            DL,
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Reachable
+    );
+}
+#[skuld::test(name = "reachability_tests::tls_ws_bytes_back_is_reachable")]
+async fn tls_ws_bytes_back_is_reachable() {
+    let a = accept_then_answer().await;
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            DL,
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Reachable
+    );
+}
+#[skuld::test(name = "reachability_tests::tls_ws_reset_is_blocked")]
+async fn tls_ws_reset_is_blocked() {
+    let a = accept_then_reset().await;
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            DL,
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Blocked
+    );
+}
+#[skuld::test(name = "reachability_tests::closed_port_is_refused_or_timeout")]
+async fn closed_port_is_refused_or_timeout() {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let a = l.local_addr().unwrap();
+    drop(l);
+    let v = probe_server_reachability(&a.ip().to_string(), a.port(), None, None, DL, &CancellationToken::new()).await;
+    assert!(matches!(
+        v,
+        ReachabilityVerdict::TcpRefused | ReachabilityVerdict::TcpTimeout
+    )); // Windows: timeout
+}
+#[skuld::test(name = "reachability_tests::bogus_host_is_dns_failed")]
+async fn bogus_host_is_dns_failed() {
+    assert_eq!(
+        probe_server_reachability("no-such-host.invalid", 443, None, None, DL, &CancellationToken::new()).await,
+        ReachabilityVerdict::DnsFailed
+    );
+}

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -169,3 +169,83 @@ async fn bogus_host_is_dns_failed() {
         ReachabilityVerdict::DnsFailed
     );
 }
+
+// QUIC probe (quinn) ==================================================================================================
+
+// Fixture: a quinn server endpoint with a self-signed cert + `h3` ALPN that
+// accepts connections and immediately drops them. The handshake still
+// completes (the client sees a peer response), so the probe reports Reachable.
+// Returns the bound UDP address; the endpoint is kept alive by the spawned task
+// owning it.
+async fn spawn_quinn_server() -> SocketAddr {
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+
+    let key_pair = rcgen::KeyPair::generate().expect("rcgen key generation");
+    let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+        .expect("rcgen accepts localhost as a subject name")
+        .self_signed(&key_pair)
+        .expect("rcgen self-sign");
+    let cert_der = CertificateDer::from(cert);
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+
+    // Explicit ring provider: the workspace rustls is built with
+    // `default-features = false`, so there is no installed process-level
+    // default `CryptoProvider` for `ServerConfig::builder()` to pick up.
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut server_crypto = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .expect("ring supports default versions")
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .expect("single-cert server config");
+    server_crypto.alpn_protocols = vec![b"h3".to_vec()];
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(
+        quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto).expect("quic server config"),
+    ));
+
+    let endpoint =
+        quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap()).expect("quinn server endpoint");
+    let addr = endpoint.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            tokio::spawn(async move {
+                let _ = incoming.await; // complete the handshake, then drop
+            });
+        }
+    });
+    addr
+}
+
+#[skuld::test(name = "reachability_tests::quic_silent_udp_is_blocked")]
+async fn quic_silent_udp_is_blocked() {
+    let s = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap(); // bound, never answers QUIC
+    let a = s.local_addr().unwrap();
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("mode=quic;host=h"),
+            Duration::from_secs(3),
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Blocked
+    );
+}
+#[skuld::test(name = "reachability_tests::quic_server_is_reachable")]
+async fn quic_server_is_reachable() {
+    let a = spawn_quinn_server().await; // rcgen self-signed quinn endpoint that accepts+ignores
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("mode=quic;host=localhost"),
+            Duration::from_secs(5),
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Reachable
+    );
+}

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -249,7 +249,7 @@ async fn quic_server_is_reachable() {
 }
 #[skuld::test(name = "reachability_tests::quic_server_v6_is_reachable")]
 async fn quic_server_v6_is_reachable() {
-    let a = spawn_quinn_server("[::1]:0").await; // IPv6 quinn endpoint — the v4-only-endpoint bug (#580) never probed this
+    let a = spawn_quinn_server("[::1]:0").await; // IPv6 endpoint: exercises the v6 bind path
     assert_eq!(
         probe_server_reachability(
             &a.ip().to_string(),

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -2,12 +2,9 @@
 #![allow(clippy::disallowed_methods)]
 use super::*;
 use std::net::SocketAddr;
-use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
-
-const DL: Duration = Duration::from_secs(3);
 
 // Fixture: accept then drop (RST / FIN with zero app bytes).
 async fn accept_then_reset() -> SocketAddr {
@@ -20,8 +17,6 @@ async fn accept_then_reset() -> SocketAddr {
     });
     addr
 }
-// Fixture: accept, read first-flight, write a few bytes (server "answered").
-//
 // After writing the reply we drain to EOF instead of dropping the socket: on
 // Windows, closing a TCP stream that still holds unread bytes (the rest of the
 // client's first-flight that we didn't read) emits an RST that discards the
@@ -96,7 +91,6 @@ async fn plain_ws_reset_is_blocked() {
             a.port(),
             Some("galoshes"),
             Some("path=/x"),
-            DL,
             &CancellationToken::new()
         )
         .await,
@@ -112,7 +106,6 @@ async fn plain_ws_answered_is_reachable() {
             a.port(),
             Some("galoshes"),
             Some("path=/x"),
-            DL,
             &CancellationToken::new()
         )
         .await,
@@ -128,7 +121,6 @@ async fn tls_ws_bytes_back_is_reachable() {
             a.port(),
             Some("galoshes"),
             Some("tls;host=h"),
-            DL,
             &CancellationToken::new()
         )
         .await,
@@ -144,7 +136,6 @@ async fn tls_ws_reset_is_blocked() {
             a.port(),
             Some("galoshes"),
             Some("tls;host=h"),
-            DL,
             &CancellationToken::new()
         )
         .await,
@@ -156,16 +147,26 @@ async fn closed_port_is_refused_or_timeout() {
     let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let a = l.local_addr().unwrap();
     drop(l);
-    let v = probe_server_reachability(&a.ip().to_string(), a.port(), None, None, DL, &CancellationToken::new()).await;
-    assert!(matches!(
-        v,
-        ReachabilityVerdict::TcpRefused | ReachabilityVerdict::TcpTimeout
-    )); // Windows: timeout
+    let v = probe_server_reachability(&a.ip().to_string(), a.port(), None, None, &CancellationToken::new()).await;
+    // Non-Windows kernels RST a closed port (TcpRefused); Windows GitHub runners
+    // drop inbound SYNs to closed ephemeral loopback ports → TcpTimeout. Both are
+    // correct "port is closed" verdicts. Mirrors server_test_tests.rs preflight.
+    if cfg!(target_os = "windows") {
+        assert!(
+            matches!(v, ReachabilityVerdict::TcpRefused | ReachabilityVerdict::TcpTimeout),
+            "expected TcpRefused or TcpTimeout on Windows, got {v:?}"
+        );
+    } else {
+        assert!(
+            matches!(v, ReachabilityVerdict::TcpRefused),
+            "expected TcpRefused, got {v:?}"
+        );
+    }
 }
 #[skuld::test(name = "reachability_tests::bogus_host_is_dns_failed")]
 async fn bogus_host_is_dns_failed() {
     assert_eq!(
-        probe_server_reachability("no-such-host.invalid", 443, None, None, DL, &CancellationToken::new()).await,
+        probe_server_reachability("no-such-host.invalid", 443, None, None, &CancellationToken::new()).await,
         ReachabilityVerdict::DnsFailed
     );
 }
@@ -175,9 +176,9 @@ async fn bogus_host_is_dns_failed() {
 // Fixture: a quinn server endpoint with a self-signed cert + `h3` ALPN that
 // accepts connections and immediately drops them. The handshake still
 // completes (the client sees a peer response), so the probe reports Reachable.
-// Returns the bound UDP address; the endpoint is kept alive by the spawned task
-// owning it.
-async fn spawn_quinn_server() -> SocketAddr {
+// `bind` selects the family (`127.0.0.1:0` v4 / `[::1]:0` v6). Returns the bound
+// UDP address; the endpoint is kept alive by the spawned task owning it.
+async fn spawn_quinn_server(bind: &str) -> SocketAddr {
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 
     let key_pair = rcgen::KeyPair::generate().expect("rcgen key generation");
@@ -203,8 +204,7 @@ async fn spawn_quinn_server() -> SocketAddr {
         quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto).expect("quic server config"),
     ));
 
-    let endpoint =
-        quinn::Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap()).expect("quinn server endpoint");
+    let endpoint = quinn::Endpoint::server(server_config, bind.parse().unwrap()).expect("quinn server endpoint");
     let addr = endpoint.local_addr().unwrap();
     tokio::spawn(async move {
         while let Some(incoming) = endpoint.accept().await {
@@ -226,7 +226,6 @@ async fn quic_silent_udp_is_blocked() {
             a.port(),
             Some("galoshes"),
             Some("mode=quic;host=h"),
-            Duration::from_secs(3),
             &CancellationToken::new()
         )
         .await,
@@ -235,17 +234,52 @@ async fn quic_silent_udp_is_blocked() {
 }
 #[skuld::test(name = "reachability_tests::quic_server_is_reachable")]
 async fn quic_server_is_reachable() {
-    let a = spawn_quinn_server().await; // rcgen self-signed quinn endpoint that accepts+ignores
+    let a = spawn_quinn_server("127.0.0.1:0").await; // rcgen self-signed quinn endpoint that accepts+ignores
     assert_eq!(
         probe_server_reachability(
             &a.ip().to_string(),
             a.port(),
             Some("galoshes"),
             Some("mode=quic;host=localhost"),
-            Duration::from_secs(5),
             &CancellationToken::new()
         )
         .await,
         ReachabilityVerdict::Reachable
+    );
+}
+#[skuld::test(name = "reachability_tests::quic_server_v6_is_reachable")]
+async fn quic_server_v6_is_reachable() {
+    let a = spawn_quinn_server("[::1]:0").await; // IPv6 quinn endpoint — the v4-only-endpoint bug (#580) never probed this
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("mode=quic;host=localhost"),
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Reachable
+    );
+}
+#[skuld::test(name = "reachability_tests::cancel_against_silent_endpoint_is_inconclusive")]
+async fn cancel_against_silent_endpoint_is_inconclusive() {
+    // A bound-but-never-answering UDP socket is a black hole: the QUIC probe
+    // would otherwise sit until QUIC_DEADLINE. Signalling the token first must
+    // short-circuit to Inconclusive via the `cancel.cancelled()` select-arm.
+    let s = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let a = s.local_addr().unwrap();
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some("mode=quic;host=h"),
+            &cancel
+        )
+        .await,
+        ReachabilityVerdict::Inconclusive
     );
 }

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -41,11 +41,8 @@ async fn accept_then_answer() -> SocketAddr {
     addr
 }
 
-// All tests use `#[skuld::test]` (incl. the sync classifier ones): this crate
-// runs a custom skuld harness (`harness = false`) that collects only
-// `#[skuld::test]` functions — plain `#[test]` ones are silently never run.
-// Each carries an explicit `name = "reachability_tests::…"`: skuld reports the
-// bare fn ident as the test name (no module prefix), so the documented
+// Each test carries an explicit `name = "reachability_tests::…"`: skuld reports
+// the bare fn ident as the test name (no module prefix), so the documented
 // `nextest run … reachability_tests` substring filter only matches with it.
 #[skuld::test(name = "reachability_tests::classify_no_plugin_is_raw")]
 fn classify_no_plugin_is_raw() {
@@ -75,10 +72,33 @@ fn classify_quic_forces_quic() {
         ProbeTransport::Quic { sni } if sni == "h")
     );
 }
-#[skuld::test(name = "reachability_tests::user_message_is_host_free")]
-fn user_message_is_host_free() {
-    let m = ReachabilityVerdict::Blocked.user_message().unwrap();
-    assert!(m.contains("firewall or censorship"));
+// A `.` flanked by alphanumerics on both sides — the shape of a domain label or
+// IP octet boundary (`ex.com`, `1.2.3.4`). A sentence-final `.` (followed by a
+// space or end-of-string) does not match, so prose passes.
+fn has_host_token(msg: &str) -> bool {
+    let b = msg.as_bytes();
+    (1..b.len().saturating_sub(1))
+        .any(|i| b[i] == b'.' && b[i - 1].is_ascii_alphanumeric() && b[i + 1].is_ascii_alphanumeric())
+}
+
+#[skuld::test(name = "reachability_tests::production_user_messages_are_host_free")]
+fn production_user_messages_are_host_free() {
+    // `self_test_error_for` calls `user_message()` only on these two verdicts;
+    // their text reaches the toast verbatim, so it must name no host/IP.
+    for v in [ReachabilityVerdict::TcpRefused, ReachabilityVerdict::TcpTimeout] {
+        let m = v.user_message().unwrap();
+        assert!(!m.is_empty(), "{v:?} message must be non-empty");
+        assert!(!has_host_token(m), "{v:?} message leaks a host token: {m:?}");
+    }
+    // `Blocked` never reaches `user_message()` in production (it maps to the
+    // typed `NetworkBlocked`), but the same text backs `NetworkBlocked`'s
+    // Display, so it must exist and stay host-free too.
+    let blocked = ReachabilityVerdict::Blocked.user_message().unwrap();
+    assert!(blocked.contains("firewall or censorship"));
+    assert!(
+        !has_host_token(blocked),
+        "Blocked message leaks a host token: {blocked:?}"
+    );
     assert!(ReachabilityVerdict::Reachable.user_message().is_none());
 }
 
@@ -150,7 +170,7 @@ async fn closed_port_is_refused_or_timeout() {
     let v = probe_server_reachability(&a.ip().to_string(), a.port(), None, None, &CancellationToken::new()).await;
     // Non-Windows kernels RST a closed port (TcpRefused); Windows GitHub runners
     // drop inbound SYNs to closed ephemeral loopback ports → TcpTimeout. Both are
-    // correct "port is closed" verdicts. Mirrors server_test_tests.rs preflight.
+    // correct "port is closed" verdicts.
     if cfg!(target_os = "windows") {
         assert!(
             matches!(v, ReachabilityVerdict::TcpRefused | ReachabilityVerdict::TcpTimeout),

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -132,11 +132,25 @@ pub async fn run_server_test(entry: &ServerEntry, cfg: &TestConfig) -> ServerTes
         }
     }
 
-    if handshake_timeout_observed {
+    let tunnel_outcome = if handshake_timeout_observed {
         ServerTestOutcome::TunnelHandshakeFailed
     } else {
         ServerTestOutcome::ServerCannotReachInternet
-    }
+    };
+
+    reclassify_blocked(
+        tunnel_outcome,
+        &entry.server,
+        entry.server_port,
+        entry.plugin.as_deref(),
+        entry.plugin_opts.as_deref(),
+        // One-shot probe; no caller-side cancel exists in run_server_test.
+        &{
+            #[allow(clippy::disallowed_methods)] // See clippy.toml: one-shot CancellationToken::new.
+            CancellationToken::new()
+        },
+    )
+    .await
 }
 
 // Helpers -------------------------------------------------------------------------------------------------------------
@@ -148,6 +162,41 @@ enum SentinelOutcome {
     Mismatch { detail: String },
     Timeout,
     Internal(String),
+}
+
+/// If the tunnel test ended in a failure a network block can masquerade as,
+/// probe the server out-of-band and upgrade to [`ServerTestOutcome::NetworkBlocked`]
+/// when the probe confirms the network reset or dropped the connection. Every
+/// other outcome passes through unchanged, so `PluginStartFailed`, `Reachable`,
+/// etc. are preserved and a reachable server can never be falsely blocked.
+async fn reclassify_blocked(
+    tunnel_outcome: ServerTestOutcome,
+    host: &str,
+    port: u16,
+    plugin: Option<&str>,
+    plugin_opts: Option<&str>,
+    cancel: &CancellationToken,
+) -> ServerTestOutcome {
+    match tunnel_outcome {
+        ServerTestOutcome::TunnelHandshakeFailed | ServerTestOutcome::ServerCannotReachInternet => {
+            if crate::reachability::probe_server_reachability(
+                host,
+                port,
+                plugin,
+                plugin_opts,
+                crate::reachability::PROBE_DEADLINE,
+                cancel,
+            )
+            .await
+                == crate::reachability::ReachabilityVerdict::Blocked
+            {
+                ServerTestOutcome::NetworkBlocked
+            } else {
+                tunnel_outcome
+            }
+        }
+        other => other,
+    }
 }
 
 /// True if the server's public endpoint is reached over UDP rather than TCP,

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -15,12 +15,10 @@ use shadowsocks::context::{Context, SharedContext};
 use shadowsocks::crypto::CipherKind;
 use shadowsocks::relay::socks5::Address;
 use shadowsocks::ProxyClientStream;
-use std::io::ErrorKind;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{lookup_host, TcpStream};
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
@@ -197,17 +195,14 @@ async fn reclassify_blocked(
 /// TCP listener to connect to — so [`run_server_test`] skips it and lets the
 /// full tunnel handshake produce the diagnosis. Covers a direct
 /// v2ray-plugin/ex-ray QUIC server AND a galoshes server (which passes
-/// `mode=quic` through to its embedded ex-ray). Parses the SIP003 options with
-/// the same parser `garter::Mode::from_plugin_options` uses for the `server`
-/// key, so this is config parsing — not a stringified-type-recovery hack. See
+/// `mode=quic` through to its embedded ex-ray). Shares the reachability probe's
+/// transport classifier, so the two agree on what a QUIC endpoint is. See
 /// bindreams/hole#421.
 fn server_endpoint_is_udp(entry: &ServerEntry) -> bool {
-    entry.plugin.is_some()
-        && entry.plugin_opts.as_deref().is_some_and(|opts| {
-            garter::parse_plugin_options(opts)
-                .iter()
-                .any(|(k, v)| k == "mode" && v == "quic")
-        })
+    matches!(
+        crate::reachability::classify_transport(entry.plugin.as_deref(), entry.plugin_opts.as_deref(), &entry.server),
+        crate::reachability::ProbeTransport::Quic { .. }
+    )
 }
 
 /// DNS-resolve (when needed) and raw-TCP-connect to `host:port`. Returns
@@ -215,24 +210,12 @@ fn server_endpoint_is_udp(entry: &ServerEntry) -> bool {
 /// successful connect (the stream is dropped immediately — only the connect
 /// matters).
 async fn preflight(host: &str, port: u16, timeout_dur: Duration) -> Result<(), ServerTestOutcome> {
-    if host.parse::<IpAddr>().is_err() {
-        // Domain name → resolve first so we can distinguish DNS failure from
-        // TCP failure.
-        match lookup_host((host, port)).await {
-            Ok(mut iter) => {
-                if iter.next().is_none() {
-                    return Err(ServerTestOutcome::DnsFailed);
-                }
-            }
-            Err(_) => return Err(ServerTestOutcome::DnsFailed),
-        }
-    }
-
-    match timeout(timeout_dur, TcpStream::connect((host, port))).await {
-        Err(_) => Err(ServerTestOutcome::TcpTimeout),
-        Ok(Err(e)) if e.kind() == ErrorKind::ConnectionRefused => Err(ServerTestOutcome::TcpRefused),
-        Ok(Err(_)) => Err(ServerTestOutcome::TcpTimeout),
-        Ok(Ok(_)) => Ok(()),
+    use crate::reachability::ConnectResult;
+    match crate::reachability::resolve_and_connect(host, port, timeout_dur).await {
+        ConnectResult::Connected(_) => Ok(()),
+        ConnectResult::DnsFailed => Err(ServerTestOutcome::DnsFailed),
+        ConnectResult::Refused => Err(ServerTestOutcome::TcpRefused),
+        ConnectResult::Timeout => Err(ServerTestOutcome::TcpTimeout),
     }
 }
 

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -179,15 +179,7 @@ async fn reclassify_blocked(
 ) -> ServerTestOutcome {
     match tunnel_outcome {
         ServerTestOutcome::TunnelHandshakeFailed | ServerTestOutcome::ServerCannotReachInternet => {
-            if crate::reachability::probe_server_reachability(
-                host,
-                port,
-                plugin,
-                plugin_opts,
-                crate::reachability::PROBE_DEADLINE,
-                cancel,
-            )
-            .await
+            if crate::reachability::probe_server_reachability(host, port, plugin, plugin_opts, cancel).await
                 == crate::reachability::ReachabilityVerdict::Blocked
             {
                 ServerTestOutcome::NetworkBlocked

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -8,6 +8,10 @@
 //! The server/sentinel/port helpers live in the crate-wide `test_support`
 //! module so `proxy_manager_e2e_tests.rs` can reuse them.
 
+// Sanctioned per-test CancellationToken::new (no caller-side token in these unit
+// fixtures). See clippy.toml.
+#![allow(clippy::disallowed_methods)]
+
 use super::{run_server_test, TestConfig};
 use crate::test_support::port_alloc::wait_for_port;
 use crate::test_support::rt;
@@ -21,7 +25,9 @@ use plugin_e2e::ssserver::{
 };
 use std::net::SocketAddr;
 use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 
 /// Build a [`ServerEntry`] for the runner under test.
 fn entry(host: &str, port: u16, method: &str, password: &str) -> ServerEntry {
@@ -446,5 +452,159 @@ fn run_test_returns_tcp_timeout_for_blackhole() {
             matches!(outcome, ServerTestOutcome::TcpTimeout),
             "expected TcpTimeout, got {outcome:?}"
         );
+    });
+}
+// `reclassify_blocked` tests ==========================================================================================
+//
+// These exercise the post-tunnel-failure reclassification helper DIRECTLY: it
+// runs only the out-of-band reachability probe (no plugin / SS server), so the
+// fixtures are two tiny loopback listeners. The probe upgrades a tunnel failure
+// a network block can masquerade as (`TunnelHandshakeFailed` /
+// `ServerCannotReachInternet`) to `NetworkBlocked` iff the probe says `Blocked`;
+// every other outcome passes through untouched.
+
+/// Fixture: accept, then drop the socket (RST / FIN with zero app bytes) — the
+/// probe reads no reply and reports `Blocked`.
+async fn accept_then_reset() -> SocketAddr {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((s, _)) = l.accept().await {
+            drop(s);
+        }
+    });
+    addr
+}
+
+/// Fixture: accept, read the first-flight, write a few bytes (server
+/// "answered"), then drain to EOF so the reply lands before the socket closes
+/// (closing with unread bytes RSTs on Windows and discards the reply). The
+/// probe sees bytes back and reports `Reachable`.
+async fn accept_then_answer() -> SocketAddr {
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((mut s, _)) = l.accept().await {
+            let mut b = [0u8; 64];
+            let _ = s.read(&mut b).await; // wait for the first-flight
+            let _ = s.write_all(b"\x15\x03\x03\x00\x02\x02\x28").await; // bytes came back
+            let mut drain = [0u8; 256];
+            while let Ok(n) = s.read(&mut drain).await {
+                if n == 0 {
+                    break; // peer closed: reply has been delivered
+                }
+            }
+        }
+    });
+    addr
+}
+
+/// `TunnelHandshakeFailed` + a TLS-WS plugin + a reset endpoint → the probe
+/// confirms the block, so the helper upgrades to `NetworkBlocked`.
+#[skuld::test]
+fn run_test_reclassify_handshake_failed_reset_is_network_blocked() {
+    rt().block_on(async {
+        let addr = accept_then_reset().await;
+        let out = super::reclassify_blocked(
+            ServerTestOutcome::TunnelHandshakeFailed,
+            &addr.ip().to_string(),
+            addr.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            matches!(out, ServerTestOutcome::NetworkBlocked),
+            "expected NetworkBlocked, got {out:?}"
+        );
+    });
+}
+
+/// `TunnelHandshakeFailed` + a TLS-WS plugin + an answering endpoint → the probe
+/// reports `Reachable`, so the original `TunnelHandshakeFailed` is preserved.
+#[skuld::test]
+fn run_test_reclassify_handshake_failed_answered_stays_handshake_failed() {
+    rt().block_on(async {
+        let addr = accept_then_answer().await;
+        let out = super::reclassify_blocked(
+            ServerTestOutcome::TunnelHandshakeFailed,
+            &addr.ip().to_string(),
+            addr.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            matches!(out, ServerTestOutcome::TunnelHandshakeFailed),
+            "expected TunnelHandshakeFailed (probe Reachable), got {out:?}"
+        );
+    });
+}
+
+/// `ServerCannotReachInternet` + a TLS-WS plugin + a reset endpoint → upgraded
+/// to `NetworkBlocked`.
+#[skuld::test]
+fn run_test_reclassify_cannot_reach_reset_is_network_blocked() {
+    rt().block_on(async {
+        let addr = accept_then_reset().await;
+        let out = super::reclassify_blocked(
+            ServerTestOutcome::ServerCannotReachInternet,
+            &addr.ip().to_string(),
+            addr.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            matches!(out, ServerTestOutcome::NetworkBlocked),
+            "expected NetworkBlocked, got {out:?}"
+        );
+    });
+}
+
+/// A `Reachable` outcome is not one a block can masquerade as: the probe must
+/// NOT run and the outcome passes through unchanged. Points at a reset endpoint
+/// to prove the probe is never consulted (a probe would have said `Blocked`).
+#[skuld::test]
+fn run_test_reclassify_reachable_passes_through() {
+    rt().block_on(async {
+        let addr = accept_then_reset().await;
+        let out = super::reclassify_blocked(
+            ServerTestOutcome::Reachable { latency_ms: 5 },
+            &addr.ip().to_string(),
+            addr.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await;
+        assert!(
+            matches!(out, ServerTestOutcome::Reachable { latency_ms: 5 }),
+            "expected unchanged Reachable, got {out:?}"
+        );
+    });
+}
+
+/// A `PluginStartFailed` outcome passes through unchanged (probe must NOT run).
+#[skuld::test]
+fn run_test_reclassify_plugin_start_failed_passes_through() {
+    rt().block_on(async {
+        let addr = accept_then_reset().await;
+        let out = super::reclassify_blocked(
+            ServerTestOutcome::PluginStartFailed { detail: "x".into() },
+            &addr.ip().to_string(),
+            addr.port(),
+            Some("galoshes"),
+            Some("tls;host=h"),
+            &CancellationToken::new(),
+        )
+        .await;
+        match out {
+            ServerTestOutcome::PluginStartFailed { detail } => assert_eq!(detail, "x"),
+            other => panic!("expected unchanged PluginStartFailed, got {other:?}"),
+        }
     });
 }

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -630,7 +630,8 @@ components:
             Tagged union with `kind` discriminator. Variants:
             reachable {kind, latency_ms}, dns_failed {kind}, tcp_refused {kind},
             tcp_timeout {kind}, plugin_start_failed {kind, detail},
-            tunnel_handshake_failed {kind}, server_cannot_reach_internet {kind},
+            tunnel_handshake_failed {kind}, network_blocked {kind},
+            server_cannot_reach_internet {kind},
             sentinel_mismatch {kind, detail}, internal_error {kind, detail}.
             See protocol.rs::ServerTestOutcome.
 

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -244,7 +244,10 @@ impl Default for ProxyConfig {
 /// Granularity ceiling: the shadowsocks protocol does not let a client
 /// distinguish "wrong cipher" from "wrong password" from "v2ray-plugin
 /// handshake rejected at the server side". All three collapse into
-/// `TunnelHandshakeFailed`.
+/// `TunnelHandshakeFailed`. The orthogonal "the network reset/dropped the
+/// transport before any handshake" axis is now separable out-of-band via the
+/// reachability probe (`NetworkBlocked`); see
+/// `crates/bridge/src/reachability.rs`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ServerTestOutcome {
@@ -272,6 +275,11 @@ pub enum ServerTestOutcome {
     /// wrong password, wrong cipher, and v2ray-plugin handshake rejected at
     /// the server side, indistinguishably.
     TunnelHandshakeFailed,
+    /// Pre-flight reached the server at TCP but the network reset/dropped the
+    /// transport handshake (e.g. DPI range-blocking). Out-of-band signal from
+    /// the reachability probe; distinct from `TunnelHandshakeFailed`
+    /// (credentials/config). See `crates/bridge/src/reachability.rs` / #580.
+    NetworkBlocked,
     /// Tunnel established (server decrypted credentials successfully) but
     /// the upstream sentinel was unreachable through the tunnel. The
     /// shadowsocks server tried to forward our request and either could not

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -278,7 +278,7 @@ pub enum ServerTestOutcome {
     /// Pre-flight reached the server at TCP but the network reset/dropped the
     /// transport handshake (e.g. DPI range-blocking). Out-of-band signal from
     /// the reachability probe; distinct from `TunnelHandshakeFailed`
-    /// (credentials/config). See `crates/bridge/src/reachability.rs` / #580.
+    /// (credentials/config). See `crates/bridge/src/reachability.rs`.
     NetworkBlocked,
     /// Tunnel established (server decrypted credentials successfully) but
     /// the upstream sentinel was unreachable through the tunnel. The

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -91,6 +91,16 @@ pub enum BridgeRequest {
 /// wire-compatibility break.
 pub const CANCELLED_MESSAGE: &str = "cancelled";
 
+/// Host-free censorship toast text the bridge writes into `ErrorResponse` when
+/// the reachability probe finds the network is resetting/dropping the server
+/// handshake. The GUI matches it verbatim across the IPC boundary to render the
+/// toast standalone, so — like [`CANCELLED_MESSAGE`] — changing it is a
+/// wire-compatibility break. The duplicated copy in `ui/servers.ts` must stay
+/// byte-identical.
+pub const NETWORK_BLOCKED_MESSAGE: &str = "The network is blocking the connection to this server — the handshake was \
+     reset or got no response. This usually means a firewall or censorship; \
+     try a different server.";
+
 /// Client-side response enum. Used by the GUI client API and elevation flow.
 /// Not part of the wire protocol — the client maps HTTP responses back to
 /// these variants internally.
@@ -245,9 +255,8 @@ impl Default for ProxyConfig {
 /// distinguish "wrong cipher" from "wrong password" from "v2ray-plugin
 /// handshake rejected at the server side". All three collapse into
 /// `TunnelHandshakeFailed`. The orthogonal "the network reset/dropped the
-/// transport before any handshake" axis is now separable out-of-band via the
-/// reachability probe (`NetworkBlocked`); see
-/// `crates/bridge/src/reachability.rs`.
+/// transport before any handshake" axis is separable out-of-band via the
+/// reachability probe (`NetworkBlocked`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ServerTestOutcome {
@@ -276,9 +285,9 @@ pub enum ServerTestOutcome {
     /// the server side, indistinguishably.
     TunnelHandshakeFailed,
     /// Pre-flight reached the server at TCP but the network reset/dropped the
-    /// transport handshake (e.g. DPI range-blocking). Out-of-band signal from
-    /// the reachability probe; distinct from `TunnelHandshakeFailed`
-    /// (credentials/config). See `crates/bridge/src/reachability.rs`.
+    /// transport handshake (e.g. DPI range-blocking). Out-of-band signal
+    /// produced by the reachability probe; distinct from `TunnelHandshakeFailed`
+    /// (credentials/config).
     NetworkBlocked,
     /// Tunnel established (server decrypted credentials successfully) but
     /// the upstream sentinel was unreachable through the tunnel. The

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -391,6 +391,20 @@ fn network_blocked_round_trips() {
     assert_eq!(serde_json::from_str::<ServerTestOutcome>(&j).unwrap(), o);
 }
 
+/// The censorship sentence is shown from two sources — the Rust
+/// `NETWORK_BLOCKED_MESSAGE` sentinel (live-Connect) and the TS
+/// `network_blocked` arm in `ui/servers.ts` (Server-Test). They must read
+/// byte-identically; this fails if either side drifts.
+#[skuld::test]
+fn network_blocked_message_matches_ui() {
+    use crate::protocol::NETWORK_BLOCKED_MESSAGE;
+    let servers_ts = include_str!("../../../ui/servers.ts");
+    assert!(
+        servers_ts.contains(NETWORK_BLOCKED_MESSAGE),
+        "ui/servers.ts must contain NETWORK_BLOCKED_MESSAGE verbatim"
+    );
+}
+
 // TunnelMode wire compatibility =======================================================================================
 
 #[skuld::test]

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -381,6 +381,16 @@ fn bridge_response_diagnostics_roundtrips() {
     assert_eq!(resp, parsed);
 }
 
+// ServerTestOutcome wire compatibility ================================================================================
+
+#[skuld::test]
+fn network_blocked_round_trips() {
+    let o = ServerTestOutcome::NetworkBlocked;
+    let j = serde_json::to_string(&o).unwrap();
+    assert_eq!(j, r#"{"kind":"network_blocked"}"#);
+    assert_eq!(serde_json::from_str::<ServerTestOutcome>(&j).unwrap(), o);
+}
+
 // TunnelMode wire compatibility =======================================================================================
 
 #[skuld::test]

--- a/crates/hole/src/elevation.rs
+++ b/crates/hole/src/elevation.rs
@@ -149,7 +149,9 @@ pub fn classify_elevated_send(result: &Result<hole_common::protocol::BridgeRespo
     match result {
         Ok(BridgeResponse::Error { message }) => match classify_start_error(message) {
             StartErrorKind::Cancelled | StartErrorKind::AlreadyRunning => ElevatedOutcome::Success,
-            StartErrorKind::Other => ElevatedOutcome::BridgeError {
+            // NetworkBlocked carries a toast-ready message; the parent renders it
+            // clean via `start_error_toast` (#580).
+            StartErrorKind::NetworkBlocked | StartErrorKind::Other => ElevatedOutcome::BridgeError {
                 message: message.clone(),
             },
         },

--- a/crates/hole/src/elevation.rs
+++ b/crates/hole/src/elevation.rs
@@ -150,7 +150,7 @@ pub fn classify_elevated_send(result: &Result<hole_common::protocol::BridgeRespo
         Ok(BridgeResponse::Error { message }) => match classify_start_error(message) {
             StartErrorKind::Cancelled | StartErrorKind::AlreadyRunning => ElevatedOutcome::Success,
             // NetworkBlocked carries a toast-ready message; the parent renders it
-            // clean via `start_error_toast` (#580).
+            // clean via `start_error_toast`.
             StartErrorKind::NetworkBlocked | StartErrorKind::Other => ElevatedOutcome::BridgeError {
                 message: message.clone(),
             },

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -3,7 +3,7 @@
 use crate::bridge_client::{BridgeClient, ClientError};
 use hole_common::config::AppConfig;
 use hole_common::config_store::ConfigStore;
-use hole_common::protocol::{BridgeRequest, BridgeResponse, CANCELLED_MESSAGE};
+use hole_common::protocol::{BridgeRequest, BridgeResponse, CANCELLED_MESSAGE, NETWORK_BLOCKED_MESSAGE};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -423,7 +423,7 @@ pub(crate) enum StartErrorKind {
     AlreadyRunning,
     /// The network reset/dropped the server handshake (DPI / censorship). Carried
     /// over IPC as the stable `NETWORK_BLOCKED_MESSAGE` sentinel (like
-    /// `CANCELLED_MESSAGE`); the toast renders that message standalone (#580).
+    /// `CANCELLED_MESSAGE`); the toast renders that message standalone.
     NetworkBlocked,
     Other,
 }
@@ -431,7 +431,7 @@ pub(crate) enum StartErrorKind {
 pub(crate) fn classify_start_error(message: &str) -> StartErrorKind {
     if message == CANCELLED_MESSAGE {
         StartErrorKind::Cancelled
-    } else if message == hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE {
+    } else if message == NETWORK_BLOCKED_MESSAGE {
         StartErrorKind::NetworkBlocked
     } else if message.contains("already running") {
         StartErrorKind::AlreadyRunning

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -421,12 +421,18 @@ impl ReqKind {
 pub(crate) enum StartErrorKind {
     Cancelled,
     AlreadyRunning,
+    /// The network reset/dropped the server handshake (DPI / censorship). Carried
+    /// over IPC as the stable `NETWORK_BLOCKED_MESSAGE` sentinel (like
+    /// `CANCELLED_MESSAGE`); the toast renders that message standalone (#580).
+    NetworkBlocked,
     Other,
 }
 
 pub(crate) fn classify_start_error(message: &str) -> StartErrorKind {
     if message == CANCELLED_MESSAGE {
         StartErrorKind::Cancelled
+    } else if message == hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE {
+        StartErrorKind::NetworkBlocked
     } else if message.contains("already running") {
         StartErrorKind::AlreadyRunning
     } else {
@@ -470,7 +476,7 @@ pub(crate) fn observed_running(
         (Start, Ok(BridgeResponse::Error { message })) => match classify_start_error(message) {
             StartErrorKind::Cancelled => Some(false),
             // A failed start is rolled back bridge-side.
-            StartErrorKind::Other => Some(false),
+            StartErrorKind::NetworkBlocked | StartErrorKind::Other => Some(false),
             StartErrorKind::AlreadyRunning => Some(true),
         },
         (Stop, Ok(BridgeResponse::Ack)) => Some(false),

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::bridge_client::ClientError;
-use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE};
+use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE, NETWORK_BLOCKED_MESSAGE};
 
 // ProxyStateCell ======================================================================================================
 
@@ -210,11 +210,7 @@ fn observed_running_rules() {
         (Start, Ok(BridgeResponse::Ack), Some(true)),
         (Start, Ok(err_resp(CANCELLED_MESSAGE)), Some(false)),
         (Start, Ok(err_resp("proxy already running")), Some(true)),
-        (
-            Start,
-            Ok(err_resp(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE)),
-            Some(false),
-        ),
+        (Start, Ok(err_resp(NETWORK_BLOCKED_MESSAGE)), Some(false)),
         (Start, Ok(err_resp("plugin failed")), Some(false)),
         (Stop, Ok(BridgeResponse::Ack), Some(false)),
         (Stop, Ok(err_resp("teardown failed")), None),
@@ -274,7 +270,7 @@ fn start_error_classification() {
         StartErrorKind::AlreadyRunning
     );
     assert_eq!(
-        classify_start_error(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE),
+        classify_start_error(NETWORK_BLOCKED_MESSAGE),
         StartErrorKind::NetworkBlocked
     );
     assert_eq!(classify_start_error("plugin failed"), StartErrorKind::Other);

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -210,6 +210,11 @@ fn observed_running_rules() {
         (Start, Ok(BridgeResponse::Ack), Some(true)),
         (Start, Ok(err_resp(CANCELLED_MESSAGE)), Some(false)),
         (Start, Ok(err_resp("proxy already running")), Some(true)),
+        (
+            Start,
+            Ok(err_resp(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE)),
+            Some(false),
+        ),
         (Start, Ok(err_resp("plugin failed")), Some(false)),
         (Stop, Ok(BridgeResponse::Ack), Some(false)),
         (Stop, Ok(err_resp("teardown failed")), None),
@@ -267,6 +272,10 @@ fn start_error_classification() {
     assert_eq!(
         classify_start_error("proxy already running"),
         StartErrorKind::AlreadyRunning
+    );
+    assert_eq!(
+        classify_start_error(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE),
+        StartErrorKind::NetworkBlocked
     );
     assert_eq!(classify_start_error("plugin failed"), StartErrorKind::Other);
 }

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -85,6 +85,18 @@ pub(crate) fn bridge_error_toast(message: &str) -> String {
     format!("Bridge error: {message}")
 }
 
+/// Final toast for a bridge Start-error `message`, shared by the live-Connect and
+/// elevated paths so they read identically. A `NetworkBlocked` message is
+/// host-free and self-contained, so it is shown raw; every other rejection is
+/// wrapped by [`bridge_error_toast`] (#580).
+pub(crate) fn start_error_toast(message: &str) -> String {
+    use crate::state::{classify_start_error, StartErrorKind};
+    match classify_start_error(message) {
+        StartErrorKind::NetworkBlocked => message.to_string(),
+        _ => bridge_error_toast(message),
+    }
+}
+
 /// Toast for a transport failure observed AFTER a successful elevation — the
 /// bridge is unreachable, which is not an elevation denial.
 pub(crate) fn transport_after_elevation_toast(detail: &str) -> String {
@@ -146,7 +158,9 @@ pub(crate) fn outcome_for_start_response(
         Ok(BridgeResponse::Error { message }) => match classify_start_error(message) {
             StartErrorKind::Cancelled => StartDecision::Outcome(ToggleOutcome::Cancelled),
             StartErrorKind::AlreadyRunning => StartDecision::Outcome(ToggleOutcome::Running),
-            StartErrorKind::Other => StartDecision::Fail(bridge_error_toast(message)),
+            // NetworkBlocked renders clean, Other is wrapped — both via the one
+            // message→toast producer (#580).
+            StartErrorKind::NetworkBlocked | StartErrorKind::Other => StartDecision::Fail(start_error_toast(message)),
         },
         Ok(_) => StartDecision::Fail("Unexpected response from bridge".into()),
         Err(crate::bridge_client::ClientError::PermissionDenied) => StartDecision::NeedsElevation,
@@ -502,7 +516,7 @@ async fn elevate_and_confirm(app: &AppHandle, request: BridgeRequest) -> Result<
                 ToggleOutcome::Stopped
             })
         }
-        ElevationResult::BridgeError(message) => Err(bridge_error_toast(&message)),
+        ElevationResult::BridgeError(message) => Err(start_error_toast(&message)),
         ElevationResult::Transport(detail) => Err(transport_after_elevation_toast(&detail)),
         ElevationResult::Cancelled => Err("Elevation was cancelled.".into()),
         ElevationResult::LaunchFailure => Err("The elevated helper could not start. See gui.log for details.".into()),

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -88,7 +88,7 @@ pub(crate) fn bridge_error_toast(message: &str) -> String {
 /// Final toast for a bridge Start-error `message`, shared by the live-Connect and
 /// elevated paths so they read identically. A `NetworkBlocked` message is
 /// host-free and self-contained, so it is shown raw; every other rejection is
-/// wrapped by [`bridge_error_toast`] (#580).
+/// wrapped by [`bridge_error_toast`].
 pub(crate) fn start_error_toast(message: &str) -> String {
     use crate::state::{classify_start_error, StartErrorKind};
     match classify_start_error(message) {
@@ -159,7 +159,7 @@ pub(crate) fn outcome_for_start_response(
             StartErrorKind::Cancelled => StartDecision::Outcome(ToggleOutcome::Cancelled),
             StartErrorKind::AlreadyRunning => StartDecision::Outcome(ToggleOutcome::Running),
             // NetworkBlocked renders clean, Other is wrapped — both via the one
-            // message→toast producer (#580).
+            // message→toast producer.
             StartErrorKind::NetworkBlocked | StartErrorKind::Other => StartDecision::Fail(start_error_toast(message)),
         },
         Ok(_) => StartDecision::Fail("Unexpected response from bridge".into()),

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -158,8 +158,7 @@ pub(crate) fn outcome_for_start_response(
         Ok(BridgeResponse::Error { message }) => match classify_start_error(message) {
             StartErrorKind::Cancelled => StartDecision::Outcome(ToggleOutcome::Cancelled),
             StartErrorKind::AlreadyRunning => StartDecision::Outcome(ToggleOutcome::Running),
-            // NetworkBlocked renders clean, Other is wrapped — both via the one
-            // message→toast producer.
+            // NetworkBlocked renders clean, Other is wrapped — start_error_toast decides.
             StartErrorKind::NetworkBlocked | StartErrorKind::Other => StartDecision::Fail(start_error_toast(message)),
         },
         Ok(_) => StartDecision::Fail("Unexpected response from bridge".into()),

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -7,7 +7,7 @@
 use super::*;
 use crate::bridge_client::ClientError;
 use hole_common::config_store::ConfigStore;
-use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE};
+use hole_common::protocol::{BridgeResponse, CANCELLED_MESSAGE, NETWORK_BLOCKED_MESSAGE};
 use skuld::temp_dir;
 use std::path::Path;
 use std::sync::Mutex;
@@ -62,19 +62,18 @@ fn start_response_outcomes() {
     assert!(matches!(outcome_for_start_response(&Err(transport_err())), Fail(_)));
 }
 
-/// #580: a `NetworkBlocked` start error renders a CLEAN toast — the host-free
+/// A `NetworkBlocked` start error renders a CLEAN toast — the host-free
 /// censorship sentence standalone, NOT wrapped in `Bridge error:` / attempts
 /// noise — mirroring how `CANCELLED_MESSAGE` is handled by sentinel.
 #[skuld::test]
 fn network_blocked_renders_clean_toast() {
     use StartDecision::*;
-    let resp = Ok(err_resp(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE));
+    let resp = Ok(err_resp(NETWORK_BLOCKED_MESSAGE));
     let Fail(toast) = outcome_for_start_response(&resp) else {
         panic!("expected StartDecision::Fail with the clean message");
     };
     assert_eq!(
-        toast,
-        hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE,
+        toast, NETWORK_BLOCKED_MESSAGE,
         "the censorship toast must be standalone"
     );
     assert!(!toast.contains("Bridge error:"), "no Bridge error: prefix: {toast}");
@@ -82,10 +81,7 @@ fn network_blocked_renders_clean_toast() {
 
     // The shared message→toast producer (also used by the elevated path) renders
     // NetworkBlocked clean and everything else wrapped.
-    assert_eq!(
-        start_error_toast(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE),
-        hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE
-    );
+    assert_eq!(start_error_toast(NETWORK_BLOCKED_MESSAGE), NETWORK_BLOCKED_MESSAGE);
     assert_eq!(start_error_toast("plugin failed"), "Bridge error: plugin failed");
 }
 

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -62,6 +62,33 @@ fn start_response_outcomes() {
     assert!(matches!(outcome_for_start_response(&Err(transport_err())), Fail(_)));
 }
 
+/// #580: a `NetworkBlocked` start error renders a CLEAN toast — the host-free
+/// censorship sentence standalone, NOT wrapped in `Bridge error:` / attempts
+/// noise — mirroring how `CANCELLED_MESSAGE` is handled by sentinel.
+#[skuld::test]
+fn network_blocked_renders_clean_toast() {
+    use StartDecision::*;
+    let resp = Ok(err_resp(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE));
+    let Fail(toast) = outcome_for_start_response(&resp) else {
+        panic!("expected StartDecision::Fail with the clean message");
+    };
+    assert_eq!(
+        toast,
+        hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE,
+        "the censorship toast must be standalone"
+    );
+    assert!(!toast.contains("Bridge error:"), "no Bridge error: prefix: {toast}");
+    assert!(toast.contains("firewall or censorship"), "{toast}");
+
+    // The shared message→toast producer (also used by the elevated path) renders
+    // NetworkBlocked clean and everything else wrapped.
+    assert_eq!(
+        start_error_toast(hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE),
+        hole_bridge::reachability::NETWORK_BLOCKED_MESSAGE
+    );
+    assert_eq!(start_error_toast("plugin failed"), "Bridge error: plugin failed");
+}
+
 #[skuld::test]
 fn stop_response_outcomes() {
     use StartDecision::*;

--- a/ui/servers.test.ts
+++ b/ui/servers.test.ts
@@ -328,3 +328,10 @@ describe("server test failure handling", () => {
     expect(document.querySelector<HTMLButtonElement>(".srv-test")!.disabled).toBe(true);
   });
 });
+
+describe("userMessageFor", () => {
+  it("maps network_blocked to a censorship-aware message", async () => {
+    const { userMessageFor } = await import("./servers");
+    expect(userMessageFor({ kind: "network_blocked" })).toMatch(/firewall or censorship/);
+  });
+});

--- a/ui/servers.ts
+++ b/ui/servers.ts
@@ -20,7 +20,7 @@ function statusClassFor(v: ValidationState | null | undefined): "untested" | "ok
   return v.outcome.kind === "reachable" ? "ok" : "fail";
 }
 
-function userMessageFor(o: ServerTestOutcome): string {
+export function userMessageFor(o: ServerTestOutcome): string {
   switch (o.kind) {
     case "reachable":
       return o.latency_ms === LATENCY_VALIDATED_ON_CONNECT
@@ -36,6 +36,8 @@ function userMessageFor(o: ServerTestOutcome): string {
       return `Plugin failed to start: ${o.detail}`;
     case "tunnel_handshake_failed":
       return "Server rejected the connection (wrong password, cipher, or plugin config).";
+    case "network_blocked":
+      return "The network is blocking the connection to this server — the handshake was reset or got no response. This usually means a firewall or censorship; try a different server.";
     case "server_cannot_reach_internet":
       return "Server cannot reach the public internet.";
     case "sentinel_mismatch":

--- a/ui/types.ts
+++ b/ui/types.ts
@@ -14,6 +14,7 @@ export type ServerTestOutcome =
   | { kind: "tcp_timeout" }
   | { kind: "plugin_start_failed"; detail: string }
   | { kind: "tunnel_handshake_failed" }
+  | { kind: "network_blocked" }
   | { kind: "server_cannot_reach_internet" }
   | { kind: "sentinel_mismatch"; detail: string }
   | { kind: "internal_error"; detail: string };


### PR DESCRIPTION
## What

Hole now distinguishes a **network-blocked / reset server** from a credential/config failure, in both the server **Test** and the live **Connect** failure. A new out-of-band reachability probe (`crates/bridge/src/reachability.rs`) connects directly bridge→server (no plugin, no tunnel), replicates the plugin's outermost network layer (TLS-WS / plain-WS / QUIC), and classifies "any response vs reset/timeout". On a tunnel failure the diagnosis is upgraded to a new `NetworkBlocked` outcome — typed `ServerTestOutcome::NetworkBlocked` (Test) and typed `ProxyError::NetworkBlocked` rendered as a clean toast (Connect).

## Why

A beta tester in a censored region couldn't connect (see #580). TCP to their server connected, but the network reset the TLS handshake to the server's whole hosting range. Hole previously reported this as a DNS timeout (Connect) and as *"Server rejected the connection (wrong password, cipher, or plugin config)"* (Test) — sending the user to chase credentials. It now reports *"The network is blocking the connection to this server … firewall or censorship; try a different server."*

## Design

- Transport-aware probe: TLS-WS handshake / plain-WS upgrade / QUIC (via `quinn`), classifying on "any bytes back vs RST/timeout" so a picky/ALPN-strict server still reads as Reachable. IPv4+IPv6.
- **Server Test** reclassifies `TunnelHandshakeFailed`/`ServerCannotReachInternet` → `NetworkBlocked` only when the probe confirms a block; every existing outcome (incl. `PluginStartFailed`, wrong-creds) is preserved.
- **Live Connect** runs the probe **concurrently** with the forwarder self-test (no added latency); **skips** it under an active fail-closed/kill-switch cover (so Hole's own kill switch isn't mis-reported as censorship); a user cancel surfaces as `Cancelled`.
- Fail-closed behavior is unchanged — only the explanation improves.

## Review

Built TDD task-by-task with per-task review, then three rounds of a multi-lens review panel (correctness / architecture / failure-handling / tests / conciseness) with adversarial verification; all must-fix findings addressed.

## Follow-ups (deferred, agreed scope)

- #585 — carry a typed start-error kind over IPC instead of the stringly sentinel (pre-existing flat-channel pattern).
- #586 — generate the censorship message into TS from the Rust const (a containment test guards drift meanwhile).

Closes #580.

https://claude.ai/code/session_01R1FnGJbxnXzoDnUWAaFuNZ