### PR TITLE
fix(hole): macOS menu-bar identity (multi-res ICNS, LSUIElement, runtime Dock icon)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,6 +2986,9 @@ dependencies = [
  "ico",
  "libc",
  "minisign-verify",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "png 0.18.1",
  "resvg",
  "same-file",
@@ -4532,9 +4535,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -4554,6 +4565,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -4612,6 +4624,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1397,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
+]
+
+[[package]]
 name = "defmt"
 version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,7 +2048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "zlib-rs",
 ]
 
@@ -2966,6 +2982,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "icns",
  "ico",
  "libc",
  "minisign-verify",
@@ -3257,6 +3274,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icns"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ccfbad7e08da70a5b48a924994a5afd93125ce5d45a3b0ba0b8da7bda59a40"
+dependencies = [
+ "byteorder",
+ "png 0.16.8",
 ]
 
 [[package]]
@@ -4108,6 +4135,15 @@ name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -5136,6 +5172,18 @@ dependencies = [
 
 [[package]]
 name = "png"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide 0.3.7",
+]
+
+[[package]]
+name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
@@ -5144,7 +5192,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -5157,7 +5205,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -89,8 +89,7 @@ walkdir = "2"
 # `relaunch::ArmedWait` uses kqueue (EVFILT_PROC/NOTE_EXIT) to wait on the
 # predecessor's exit during a self-heal relaunch.
 libc = "0.2"
-# Runtime Dock icon (`dock_icon.rs`): set NSApplication.applicationIconImage at
-# startup so unbundled dev runs (no Info.plist) still show the Hole icon.
+# Runtime Dock icon (`dock_icon.rs`): unbundled dev runs (no Info.plist) still show the Hole icon.
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder", "NSImage"] }
 objc2-foundation = { version = "0.3", features = ["NSData"] }

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -92,6 +92,7 @@ libc = "0.2"
 
 [dev-dependencies]
 skuld = { workspace = true }
+icns = "0.3"
 hole-test-observability = { path = "../test-observability" }
 # Test-only: the #572 cross-uid ownership proof drives `util::ownership::chown_path`
 # directly; no non-test `hole` code references the `util` crate.
@@ -113,4 +114,5 @@ xtask-lib = { path = "../../xtask-lib", features = ["version"] }
 resvg = "0.47"
 png = "0.18"
 ico = "0.5"
+icns = "0.3"
 serde_json = "1"

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -89,10 +89,16 @@ walkdir = "2"
 # `relaunch::ArmedWait` uses kqueue (EVFILT_PROC/NOTE_EXIT) to wait on the
 # predecessor's exit during a self-heal relaunch.
 libc = "0.2"
+# Runtime Dock icon (`dock_icon.rs`): set NSApplication.applicationIconImage at
+# startup so unbundled dev runs (no Info.plist) still show the Hole icon.
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder", "NSImage"] }
+objc2-foundation = { version = "0.3", features = ["NSData"] }
 
 [dev-dependencies]
 skuld = { workspace = true }
 icns = "0.3"
+png = "0.18"
 hole-test-observability = { path = "../test-observability" }
 # Test-only: the #572 cross-uid ownership proof drives `util::ownership::chown_path`
 # directly; no non-test `hole` code references the `util` crate.

--- a/crates/hole/Info.plist
+++ b/crates/hole/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -97,7 +97,34 @@ fn emit_version_env(repo_root: &Path) {
 
 // Icons ===============================================================================================================
 
-fn generate_icons(icons_dir: &Path, out_dir: &Path) {
+/// (render size, ICNS element type). The 2x types carry retina pixel counts.
+const ICNS_ENTRIES: &[(u32, icns::IconType)] = &[
+    (16, icns::IconType::RGBA32_16x16),
+    (32, icns::IconType::RGBA32_32x32),
+    (64, icns::IconType::RGBA32_32x32_2x),
+    (128, icns::IconType::RGBA32_128x128),
+    (256, icns::IconType::RGBA32_256x256),
+    (512, icns::IconType::RGBA32_512x512),
+    (1024, icns::IconType::RGBA32_512x512_2x),
+];
+
+/// Encode a multi-resolution ICNS from the macOS app SVG.
+fn build_icns_bytes(tree: &resvg::usvg::Tree) -> Vec<u8> {
+    use std::io::Cursor;
+    let mut family = icns::IconFamily::new();
+    for &(size, icon_type) in ICNS_ENTRIES {
+        let png = render_png_in_memory(tree, size);
+        let image = icns::Image::read_png(Cursor::new(png)).expect("re-decode rendered PNG");
+        family
+            .add_icon_with_type(&image, icon_type)
+            .unwrap_or_else(|e| panic!("add {icon_type:?} to icns: {e}"));
+    }
+    let mut bytes = Vec::new();
+    family.write(&mut bytes).expect("encode icns");
+    bytes
+}
+
+fn generate_icons(icons_dir: &Path, cache_icons_dir: &Path) {
     // Always produce platform-correct ICO and ICNS regardless of host.
     // ICO is consumed by Windows bundles, ICNS by macOS. Reading the
     // wrong SVG into either would silently ship the wrong design on a
@@ -107,12 +134,17 @@ fn generate_icons(icons_dir: &Path, out_dir: &Path) {
     let win_tree = parse_svg(&icons_dir.join("icon-windows.svg"));
     let mac_tree = parse_svg(&icons_dir.join("icon-macos.svg"));
 
-    render_ico(&win_tree, &out_dir.join("icon.ico"));
+    render_ico(&win_tree, &cache_icons_dir.join("icon.ico"));
 
-    // ICNS: render the macOS SVG to 128×128 PNG and wrap in a minimal
-    // ic07 container.
-    let mac_128_png = render_png_in_memory(&mac_tree, 128);
-    write_icns(&out_dir.join("icon.icns"), &mac_128_png);
+    // ICNS: same bytes to the bundled .cache copy (tauri.conf.json) and a
+    // cargo-isolated OUT_DIR copy. The test reads the OUT_DIR copy — .cache is a
+    // repo-root shared path a concurrent build could write mid-read.
+    let icns = build_icns_bytes(&mac_tree);
+    std::fs::write(cache_icons_dir.join("icon.icns"), &icns).unwrap();
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let icns_out = out_dir.join("icon.icns");
+    std::fs::write(&icns_out, &icns).unwrap();
+    println!("cargo:rustc-env=HOLE_ICNS_PATH={}", icns_out.display());
 
     // PNG fallbacks (referenced unconditionally by tauri.conf.json,
     // used as window icon on the host platform). Render from the
@@ -123,7 +155,7 @@ fn generate_icons(icons_dir: &Path, out_dir: &Path) {
         other => panic!("app icon not provided for target_os={other}"),
     };
     for size in [32u32, 128] {
-        render_png(host_tree, size, &out_dir.join(format!("{size}x{size}.png")));
+        render_png(host_tree, size, &cache_icons_dir.join(format!("{size}x{size}.png")));
     }
 }
 
@@ -161,19 +193,6 @@ fn render_ico(tree: &resvg::usvg::Tree, path: &Path) {
     }
     let file = std::fs::File::create(path).unwrap();
     icon_dir.write(file).unwrap();
-}
-
-fn write_icns(path: &Path, png_data: &[u8]) {
-    // Minimal ICNS: magic + size header, then ic07 (128x128 PNG) entry
-    let entry_size = (8 + png_data.len()) as u32;
-    let total_size = 8 + entry_size;
-    let mut buf = Vec::with_capacity(total_size as usize);
-    buf.extend_from_slice(b"icns");
-    buf.extend_from_slice(&total_size.to_be_bytes());
-    buf.extend_from_slice(b"ic07");
-    buf.extend_from_slice(&entry_size.to_be_bytes());
-    buf.extend_from_slice(png_data);
-    std::fs::write(path, buf).unwrap();
 }
 
 // Tray icons ==========================================================================================================

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -97,6 +97,9 @@ fn emit_version_env(repo_root: &Path) {
 
 // Icons ===============================================================================================================
 
+/// Render size (px) of the runtime Dock icon PNG (`dock_icon.rs`).
+const APP_ICON_PX: u32 = 512;
+
 /// (render size, ICNS element type). The 2x types carry retina pixel counts.
 const ICNS_ENTRIES: &[(u32, icns::IconType)] = &[
     (16, icns::IconType::RGBA32_16x16),
@@ -145,6 +148,10 @@ fn generate_icons(icons_dir: &Path, cache_icons_dir: &Path) {
     let icns_out = out_dir.join("icon.icns");
     std::fs::write(&icns_out, &icns).unwrap();
     println!("cargo:rustc-env=HOLE_ICNS_PATH={}", icns_out.display());
+
+    // Runtime Dock icon (dock_icon.rs); emitted on every host, not just macOS.
+    // Reuses `out_dir` from the ICNS block above.
+    render_png(&mac_tree, APP_ICON_PX, &out_dir.join("app-icon.png"));
 
     // PNG fallbacks (referenced unconditionally by tauri.conf.json,
     // used as window icon on the host platform). Render from the

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -100,7 +100,6 @@ fn emit_version_env(repo_root: &Path) {
 /// Render size (px) of the runtime Dock icon PNG (`dock_icon.rs`).
 const APP_ICON_PX: u32 = 512;
 
-/// (render size px, ICNS element type).
 const ICNS_ENTRIES: &[(u32, icns::IconType)] = &[
     (16, icns::IconType::RGBA32_16x16),
     (32, icns::IconType::RGBA32_32x32),

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -100,7 +100,7 @@ fn emit_version_env(repo_root: &Path) {
 /// Render size (px) of the runtime Dock icon PNG (`dock_icon.rs`).
 const APP_ICON_PX: u32 = 512;
 
-/// (render size, ICNS element type). The 2x types carry retina pixel counts.
+/// (render size px, ICNS element type).
 const ICNS_ENTRIES: &[(u32, icns::IconType)] = &[
     (16, icns::IconType::RGBA32_16x16),
     (32, icns::IconType::RGBA32_32x32),
@@ -149,7 +149,7 @@ fn generate_icons(icons_dir: &Path, cache_icons_dir: &Path) {
     std::fs::write(&icns_out, &icns).unwrap();
     println!("cargo:rustc-env=HOLE_ICNS_PATH={}", icns_out.display());
 
-    // Runtime Dock icon (dock_icon.rs); emitted on every host, not just macOS.
+    // Runtime Dock icon (dock_icon.rs).
     render_png(&mac_tree, APP_ICON_PX, &out_dir.join("app-icon.png"));
 
     // PNG fallbacks (referenced unconditionally by tauri.conf.json,

--- a/crates/hole/build.rs
+++ b/crates/hole/build.rs
@@ -150,7 +150,6 @@ fn generate_icons(icons_dir: &Path, cache_icons_dir: &Path) {
     println!("cargo:rustc-env=HOLE_ICNS_PATH={}", icns_out.display());
 
     // Runtime Dock icon (dock_icon.rs); emitted on every host, not just macOS.
-    // Reuses `out_dir` from the ICNS block above.
     render_png(&mac_tree, APP_ICON_PX, &out_dir.join("app-icon.png"));
 
     // PNG fallbacks (referenced unconditionally by tauri.conf.json,

--- a/crates/hole/src/build_assets_tests.rs
+++ b/crates/hole/src/build_assets_tests.rs
@@ -1,0 +1,31 @@
+//! Verifies build.rs assets: the app ICNS and the runtime Dock-icon PNG.
+
+use std::io::Cursor;
+
+#[skuld::test]
+fn app_icns_has_required_resolutions() {
+    // The canonical bundled artifact (build.rs exports its path), not a copy.
+    // The generated ICNS, via HOLE_ICNS_PATH — a cargo-isolated OUT_DIR copy of
+    // the bundled bytes (the shared .cache path can be written mid-read).
+    const ICNS: &[u8] = include_bytes!(env!("HOLE_ICNS_PATH"));
+    let family = icns::IconFamily::read(Cursor::new(ICNS)).expect("icon.icns must parse");
+    let have = family.available_icons();
+    // Independent minimum, not build.rs's ICNS_ENTRIES: dropping any of these from
+    // the producer must fail here.
+    use icns::IconType::{
+        RGBA32_128x128, RGBA32_16x16, RGBA32_256x256, RGBA32_32x32, RGBA32_512x512, RGBA32_512x512_2x,
+    };
+    for t in [
+        RGBA32_16x16,
+        RGBA32_32x32,
+        RGBA32_128x128,
+        RGBA32_256x256,
+        RGBA32_512x512,
+        RGBA32_512x512_2x,
+    ] {
+        assert!(have.contains(&t), "icon.icns missing required {t:?}; have {have:?}");
+        // The stored image must decode and be non-empty (guards a corrupt entry).
+        let img = family.get_icon_with_type(t).expect("required type present");
+        assert!(img.width() > 0 && img.height() > 0, "{t:?} decoded empty");
+    }
+}

--- a/crates/hole/src/build_assets_tests.rs
+++ b/crates/hole/src/build_assets_tests.rs
@@ -29,3 +29,15 @@ fn app_icns_has_required_resolutions() {
         assert!(img.width() > 0 && img.height() > 0, "{t:?} decoded empty");
     }
 }
+
+#[skuld::test]
+fn app_icon_png_is_square_hi_res() {
+    // Independent minimum: the Dock icon must be a square, hi-res PNG.
+    const PNG: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/app-icon.png"));
+    let reader = png::Decoder::new(Cursor::new(PNG))
+        .read_info()
+        .expect("app-icon.png must be a valid PNG");
+    let info = reader.info();
+    assert_eq!(info.width, info.height, "app-icon.png must be square");
+    assert!(info.width >= 256, "app-icon.png must be >=256px, got {}", info.width);
+}

--- a/crates/hole/src/build_assets_tests.rs
+++ b/crates/hole/src/build_assets_tests.rs
@@ -4,7 +4,7 @@ use std::io::Cursor;
 
 #[skuld::test]
 fn app_icns_has_required_resolutions() {
-    // Read the OUT_DIR copy (HOLE_ICNS_PATH), not shared .cache, which a concurrent build can rewrite mid-read.
+    // Read the OUT_DIR copy (HOLE_ICNS_PATH), not shared .cache.
     const ICNS: &[u8] = include_bytes!(env!("HOLE_ICNS_PATH"));
     let family = icns::IconFamily::read(Cursor::new(ICNS)).expect("icon.icns must parse");
     let have = family.available_icons();

--- a/crates/hole/src/build_assets_tests.rs
+++ b/crates/hole/src/build_assets_tests.rs
@@ -4,9 +4,8 @@ use std::io::Cursor;
 
 #[skuld::test]
 fn app_icns_has_required_resolutions() {
-    // The canonical bundled artifact (build.rs exports its path), not a copy.
-    // The generated ICNS, via HOLE_ICNS_PATH — a cargo-isolated OUT_DIR copy of
-    // the bundled bytes (the shared .cache path can be written mid-read).
+    // Read via HOLE_ICNS_PATH: a cargo-isolated OUT_DIR copy of the bundled
+    // bytes (the shared .cache copy can be written mid-read).
     const ICNS: &[u8] = include_bytes!(env!("HOLE_ICNS_PATH"));
     let family = icns::IconFamily::read(Cursor::new(ICNS)).expect("icon.icns must parse");
     let have = family.available_icons();
@@ -24,20 +23,40 @@ fn app_icns_has_required_resolutions() {
         RGBA32_512x512_2x,
     ] {
         assert!(have.contains(&t), "icon.icns missing required {t:?}; have {have:?}");
-        // The stored image must decode and be non-empty (guards a corrupt entry).
         let img = family.get_icon_with_type(t).expect("required type present");
         assert!(img.width() > 0 && img.height() > 0, "{t:?} decoded empty");
     }
+    // Content, not just geometry: a blank/transparent render (broken SVG, resvg
+    // regression) has the right dimensions but ships an invisible icon.
+    let rgba = family
+        .get_icon_with_type(RGBA32_128x128)
+        .expect("128px present")
+        .convert_to(icns::PixelFormat::RGBA);
+    assert!(
+        rgba.data().chunks_exact(4).any(|px| px[3] != 0),
+        "icon.icns 128px is fully transparent"
+    );
 }
 
 #[skuld::test]
 fn app_icon_png_is_square_hi_res() {
-    // Independent minimum: the Dock icon must be a square, hi-res PNG.
     const PNG: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/app-icon.png"));
-    let reader = png::Decoder::new(Cursor::new(PNG))
+    let mut reader = png::Decoder::new(Cursor::new(PNG))
         .read_info()
         .expect("app-icon.png must be a valid PNG");
-    let info = reader.info();
-    assert_eq!(info.width, info.height, "app-icon.png must be square");
-    assert!(info.width >= 256, "app-icon.png must be >=256px, got {}", info.width);
+    let (w, h, color) = {
+        let info = reader.info();
+        (info.width, info.height, info.color_type)
+    };
+    // Independent minimum: a square, hi-res PNG.
+    assert_eq!(w, h, "app-icon.png must be square");
+    assert!(w >= 256, "app-icon.png must be >=256px, got {w}");
+    // Content, not just geometry: build.rs writes RGBA, so require an opaque pixel.
+    assert_eq!(color, png::ColorType::Rgba, "expected an RGBA app-icon.png");
+    let mut buf = vec![0u8; reader.output_buffer_size().expect("app-icon.png buffer size")];
+    let frame = reader.next_frame(&mut buf).expect("decode app-icon.png frame");
+    assert!(
+        buf[..frame.buffer_size()].chunks_exact(4).any(|px| px[3] != 0),
+        "app-icon.png is fully transparent"
+    );
 }

--- a/crates/hole/src/build_assets_tests.rs
+++ b/crates/hole/src/build_assets_tests.rs
@@ -4,8 +4,7 @@ use std::io::Cursor;
 
 #[skuld::test]
 fn app_icns_has_required_resolutions() {
-    // Read via HOLE_ICNS_PATH: a cargo-isolated OUT_DIR copy of the bundled
-    // bytes (the shared .cache copy can be written mid-read).
+    // Read the OUT_DIR copy (HOLE_ICNS_PATH), not shared .cache, which a concurrent build can rewrite mid-read.
     const ICNS: &[u8] = include_bytes!(env!("HOLE_ICNS_PATH"));
     let family = icns::IconFamily::read(Cursor::new(ICNS)).expect("icon.icns must parse");
     let have = family.available_icons();

--- a/crates/hole/src/dock_icon.rs
+++ b/crates/hole/src/dock_icon.rs
@@ -14,8 +14,8 @@ fn app_icon_png() -> &'static [u8] {
     include_bytes!(concat!(env!("OUT_DIR"), "/app-icon.png"))
 }
 
-/// Decode the compiled-in app icon. Split out so the NSData→NSImage bridge is
-/// unit-testable without a running NSApplication.
+/// Decode the compiled-in app icon. Split out to unit-test the NSData→NSImage
+/// bridge without a running NSApplication.
 fn decode_app_icon() -> Option<Retained<NSImage>> {
     let data = NSData::with_bytes(app_icon_png());
     NSImage::initWithData(NSImage::alloc(), &data)

--- a/crates/hole/src/dock_icon.rs
+++ b/crates/hole/src/dock_icon.rs
@@ -26,10 +26,17 @@ fn is_bundled_exe(exe: &Path) -> bool {
     macos.ends_with("Contents/MacOS") && app.extension().is_some_and(|e| e == "app")
 }
 
-/// Whether the running process is a bundled `.app` — which carries the ICNS the
-/// Dock uses. Only unbundled runs need the runtime override.
+/// Whether the running process is a bundled `.app` (which carries its own Dock ICNS).
 fn running_bundled() -> bool {
-    std::env::current_exe().ok().is_some_and(|exe| is_bundled_exe(&exe))
+    match std::env::current_exe() {
+        Ok(exe) => is_bundled_exe(&exe),
+        // Benign either way (the override is idempotent); default to unbundled, but
+        // trace it so a real bundled install that ever hits this is diagnosable.
+        Err(e) => {
+            tracing::debug!(error = %e, "current_exe() failed; treating process as unbundled for the Dock icon");
+            false
+        }
+    }
 }
 
 /// Decode the compiled-in app icon. Split out to unit-test the NSData→NSImage
@@ -43,13 +50,10 @@ fn decode_app_icon() -> Option<Retained<NSImage>> {
 
 /// Set the Dock icon. Call site: Tauri `setup` (main thread).
 pub fn set_dock_icon(mtm: MainThreadMarker) {
-    // A bundled release already has the multi-resolution ICNS for the Dock; only
-    // unbundled runs (no Info.plist icon) need the runtime override.
     if running_bundled() {
         return;
     }
-    // Cosmetic: a decode failure is near-impossible (build-rendered PNG, decode
-    // test) but must never abort a running VPN — warn and keep the default icon.
+    // Cosmetic: never abort a running VPN over a Dock icon — warn and keep the default.
     let Some(image) = decode_app_icon() else {
         warn!("could not decode the app icon; leaving the default Dock icon");
         return;

--- a/crates/hole/src/dock_icon.rs
+++ b/crates/hole/src/dock_icon.rs
@@ -26,7 +26,7 @@ fn is_bundled_exe(exe: &Path) -> bool {
     macos.ends_with("Contents/MacOS") && app.extension().is_some_and(|e| e == "app")
 }
 
-/// Whether the running process is a bundled `.app` (which carries its own Dock ICNS).
+/// Whether the running process is a bundled `.app`.
 fn running_bundled() -> bool {
     match std::env::current_exe() {
         Ok(exe) => is_bundled_exe(&exe),
@@ -39,8 +39,7 @@ fn running_bundled() -> bool {
     }
 }
 
-/// Decode the compiled-in app icon. Split out to unit-test the NSData→NSImage
-/// bridge without a running NSApplication. `None` for a nil or zero-size image.
+/// Decode the compiled-in app icon. `None` for a nil or zero-size image.
 fn decode_app_icon() -> Option<Retained<NSImage>> {
     let data = NSData::with_bytes(app_icon_png());
     let image = NSImage::initWithData(NSImage::alloc(), &data)?;

--- a/crates/hole/src/dock_icon.rs
+++ b/crates/hole/src/dock_icon.rs
@@ -1,0 +1,39 @@
+//! macOS Dock icon set at runtime via `applicationIconImage`.
+//!
+//! Unbundled runs (`cargo tauri dev`, `target/debug/hole`) have no `Info.plist`,
+//! so macOS shows the generic icon; this gives the real Hole icon in every launch mode.
+
+use objc2::rc::Retained;
+use objc2::{AnyThread, MainThreadMarker};
+use objc2_app_kit::{NSApplication, NSImage};
+use objc2_foundation::NSData;
+use tracing::warn;
+
+/// App icon PNG, rendered from `icons/icon-macos.svg` by build.rs.
+fn app_icon_png() -> &'static [u8] {
+    include_bytes!(concat!(env!("OUT_DIR"), "/app-icon.png"))
+}
+
+/// Decode the compiled-in app icon. Split out so the NSData→NSImage bridge is
+/// unit-testable without a running NSApplication.
+fn decode_app_icon() -> Option<Retained<NSImage>> {
+    let data = NSData::with_bytes(app_icon_png());
+    NSImage::initWithData(NSImage::alloc(), &data)
+}
+
+/// Set the Dock icon. Call site: Tauri `setup` (main thread).
+pub fn set_dock_icon(mtm: MainThreadMarker) {
+    // Cosmetic: a decode failure is near-impossible (build-rendered PNG, decode
+    // test) but must never abort a running VPN — warn and keep the default icon.
+    let Some(image) = decode_app_icon() else {
+        warn!("could not decode the app icon; leaving the default Dock icon");
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    // SAFETY: `image` is a valid NSImage.
+    unsafe { app.setApplicationIconImage(Some(&image)) };
+}
+
+#[cfg(test)]
+#[path = "dock_icon_tests.rs"]
+mod dock_icon_tests;

--- a/crates/hole/src/dock_icon.rs
+++ b/crates/hole/src/dock_icon.rs
@@ -1,7 +1,10 @@
 //! macOS Dock icon set at runtime via `applicationIconImage`.
 //!
 //! Unbundled runs (`cargo tauri dev`, `target/debug/hole`) have no `Info.plist`,
-//! so macOS shows the generic icon; this gives the real Hole icon in every launch mode.
+//! so macOS would show the generic icon; setting it at runtime covers them. A
+//! bundled release already has the multi-resolution ICNS, so it is left alone.
+
+use std::path::Path;
 
 use objc2::rc::Retained;
 use objc2::{AnyThread, MainThreadMarker};
@@ -14,15 +17,37 @@ fn app_icon_png() -> &'static [u8] {
     include_bytes!(concat!(env!("OUT_DIR"), "/app-icon.png"))
 }
 
+/// Whether `exe` sits inside a macOS bundle (`.../<name>.app/Contents/MacOS/<bin>`).
+fn is_bundled_exe(exe: &Path) -> bool {
+    let Some(macos) = exe.parent() else { return false };
+    let Some(app) = macos.parent().and_then(Path::parent) else {
+        return false;
+    };
+    macos.ends_with("Contents/MacOS") && app.extension().is_some_and(|e| e == "app")
+}
+
+/// Whether the running process is a bundled `.app` — which carries the ICNS the
+/// Dock uses. Only unbundled runs need the runtime override.
+fn running_bundled() -> bool {
+    std::env::current_exe().ok().is_some_and(|exe| is_bundled_exe(&exe))
+}
+
 /// Decode the compiled-in app icon. Split out to unit-test the NSData→NSImage
-/// bridge without a running NSApplication.
+/// bridge without a running NSApplication. `None` for a nil or zero-size image.
 fn decode_app_icon() -> Option<Retained<NSImage>> {
     let data = NSData::with_bytes(app_icon_png());
-    NSImage::initWithData(NSImage::alloc(), &data)
+    let image = NSImage::initWithData(NSImage::alloc(), &data)?;
+    let size = image.size();
+    (size.width > 0.0 && size.height > 0.0).then_some(image)
 }
 
 /// Set the Dock icon. Call site: Tauri `setup` (main thread).
 pub fn set_dock_icon(mtm: MainThreadMarker) {
+    // A bundled release already has the multi-resolution ICNS for the Dock; only
+    // unbundled runs (no Info.plist icon) need the runtime override.
+    if running_bundled() {
+        return;
+    }
     // Cosmetic: a decode failure is near-impossible (build-rendered PNG, decode
     // test) but must never abort a running VPN — warn and keep the default icon.
     let Some(image) = decode_app_icon() else {
@@ -30,7 +55,7 @@ pub fn set_dock_icon(mtm: MainThreadMarker) {
         return;
     };
     let app = NSApplication::sharedApplication(mtm);
-    // SAFETY: `image` is a valid NSImage.
+    // SAFETY: called on the main thread (`mtm`) with a valid NSImage.
     unsafe { app.setApplicationIconImage(Some(&image)) };
 }
 

--- a/crates/hole/src/dock_icon_tests.rs
+++ b/crates/hole/src/dock_icon_tests.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+#[skuld::test]
+fn app_icon_decodes_to_nonempty_nsimage() {
+    // Decodes on the BUILD host and is non-empty. (End-user AppKit may differ, so
+    // set_dock_icon degrades at runtime rather than assuming this holds there.)
+    let image = decode_app_icon().expect("app-icon.png must decode as an NSImage");
+    let size = image.size(); // NSSize; if it needs a feature/unsafe, adjust at impl time.
+    assert!(size.width > 0.0 && size.height > 0.0, "decoded NSImage is empty");
+}

--- a/crates/hole/src/dock_icon_tests.rs
+++ b/crates/hole/src/dock_icon_tests.rs
@@ -2,9 +2,10 @@ use super::*;
 
 #[skuld::test]
 fn app_icon_decodes_to_nonempty_nsimage() {
-    // Decodes on the BUILD host and is non-empty. (End-user AppKit may differ, so
-    // set_dock_icon degrades at runtime rather than assuming this holds there.)
+    // The compiled-in PNG is content-checked by app_icon_png_is_square_hi_res;
+    // this proves the NSData→NSImage bridge decodes it to a non-degenerate image.
+    // (set_dock_icon degrades at runtime if end-user AppKit ever differs.)
     let image = decode_app_icon().expect("app-icon.png must decode as an NSImage");
-    let size = image.size(); // NSSize; if it needs a feature/unsafe, adjust at impl time.
+    let size = image.size();
     assert!(size.width > 0.0 && size.height > 0.0, "decoded NSImage is empty");
 }

--- a/crates/hole/src/dock_icon_tests.rs
+++ b/crates/hole/src/dock_icon_tests.rs
@@ -3,9 +3,17 @@ use super::*;
 #[skuld::test]
 fn app_icon_decodes_to_nonempty_nsimage() {
     // The compiled-in PNG is content-checked by app_icon_png_is_square_hi_res;
-    // this proves the NSData→NSImage bridge decodes it to a non-degenerate image.
-    // (set_dock_icon degrades at runtime if end-user AppKit ever differs.)
-    let image = decode_app_icon().expect("app-icon.png must decode as an NSImage");
-    let size = image.size();
-    assert!(size.width > 0.0 && size.height > 0.0, "decoded NSImage is empty");
+    // this proves the NSData→NSImage bridge decodes it (decode_app_icon rejects
+    // a nil or zero-size image).
+    assert!(
+        decode_app_icon().is_some(),
+        "app-icon.png must decode as a non-empty NSImage"
+    );
+}
+
+#[skuld::test]
+fn is_bundled_exe_detects_app_layout() {
+    assert!(is_bundled_exe(Path::new("/Applications/Hole.app/Contents/MacOS/hole")));
+    assert!(!is_bundled_exe(Path::new("/Users/me/src/hole/target/debug/hole")));
+    assert!(!is_bundled_exe(Path::new("hole")));
 }

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -34,6 +34,10 @@ fn main() {
 }
 
 #[cfg(test)]
+#[path = "build_assets_tests.rs"]
+mod build_assets_tests;
+
+#[cfg(test)]
 #[allow(clippy::assertions_on_constants)]
 #[skuld::test]
 fn debug_assertions_enabled() {

--- a/crates/hole/src/lib.rs
+++ b/crates/hole/src/lib.rs
@@ -9,6 +9,8 @@ pub mod bridge_client;
 pub mod cli_log;
 pub mod commands;
 pub mod config_recovery;
+#[cfg(target_os = "macos")]
+pub mod dock_icon;
 pub mod elevation;
 pub mod logging;
 pub mod path_management;

--- a/crates/hole/src/platform.rs
+++ b/crates/hole/src/platform.rs
@@ -1,5 +1,3 @@
-// Platform-specific behavior (macOS dock icon toggling).
-
 /// Single owner of the macOS dock/menu-bar activation policy. `dock_visible`
 /// true → Regular (Dashboard open); false → Accessory (menu-bar only). The
 /// bundle's LSUIElement=true is the Accessory default; this drives the runtime

--- a/crates/hole/src/platform.rs
+++ b/crates/hole/src/platform.rs
@@ -20,8 +20,6 @@ fn set_menu_bar_mode(app: &tauri::AppHandle, dock_visible: bool) {
 pub fn on_setup(_app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "macos")]
     {
-        // Dock shows the Hole icon whenever the app is Regular (Dashboard open),
-        // including unbundled runs with no Info.plist icon.
         let mtm = objc2::MainThreadMarker::new().expect("contract: Tauri setup runs on the main thread");
         hole::dock_icon::set_dock_icon(mtm);
         set_menu_bar_mode(_app.handle(), false);

--- a/crates/hole/src/platform.rs
+++ b/crates/hole/src/platform.rs
@@ -1,11 +1,30 @@
 // Platform-specific behavior (macOS dock icon toggling).
 
+/// Single owner of the macOS dock/menu-bar activation policy. `dock_visible`
+/// true → Regular (Dashboard open); false → Accessory (menu-bar only). The
+/// bundle's LSUIElement=true is the Accessory default; this drives the runtime
+/// transitions and the unbundled/dev fallback.
+#[cfg(target_os = "macos")]
+fn set_menu_bar_mode(app: &tauri::AppHandle, dock_visible: bool) {
+    let policy = if dock_visible {
+        tauri::ActivationPolicy::Regular
+    } else {
+        tauri::ActivationPolicy::Accessory
+    };
+    if let Err(e) = app.set_activation_policy(policy) {
+        tracing::warn!(error = %e, dock_visible, "failed to set macOS activation policy");
+    }
+}
+
 /// Called during Tauri setup.
 pub fn on_setup(_app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "macos")]
     {
-        // Hide dock icon on startup (tray-only mode)
-        _app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+        // Dock shows the Hole icon whenever the app is Regular (Dashboard open),
+        // including unbundled runs with no Info.plist icon.
+        let mtm = objc2::MainThreadMarker::new().expect("contract: Tauri setup runs on the main thread");
+        hole::dock_icon::set_dock_icon(mtm);
+        set_menu_bar_mode(_app.handle(), false);
     }
     Ok(())
 }
@@ -13,11 +32,11 @@ pub fn on_setup(_app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
 /// Show dock icon (call when settings window opens).
 #[cfg(target_os = "macos")]
 pub fn show_dock_icon(app: &tauri::AppHandle) {
-    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+    set_menu_bar_mode(app, true);
 }
 
 /// Hide dock icon (call when settings window closes).
 #[cfg(target_os = "macos")]
 pub fn hide_dock_icon(app: &tauri::AppHandle) {
-    let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+    set_menu_bar_mode(app, false);
 }

--- a/dmg-installer/tests/test_dmg_payload.py
+++ b/dmg-installer/tests/test_dmg_payload.py
@@ -5,6 +5,7 @@ and #512 defer-1 (hole.dSYM must ship next to the binary so production panic
 backtraces resolve at runtime — parity with the Windows hole.pdb).
 """
 
+import plistlib
 import re
 import subprocess
 from pathlib import Path
@@ -37,6 +38,13 @@ def test_dmg_ships_full_canonical_bindir(installed_app: Path) -> None:
         f"(searched Contents/MacOS + Contents/Resources). Expected (from "
         f"`cargo xtask bindir-names --os darwin`): {sorted(expected)}."
     )
+
+
+def test_bundle_is_menu_bar_app(installed_app: Path) -> None:
+    """The shipped bundle must carry LSUIElement=true (Tauri merges
+    crates/hole/Info.plist), or macOS treats Hole as a regular Dock app."""
+    info = plistlib.loads((installed_app / "Contents" / "Info.plist").read_bytes())
+    assert info.get("LSUIElement") is True, "bundle Info.plist missing LSUIElement=true"
 
 
 def test_dsym_is_sibling_of_binary(installed_app: Path) -> None:


### PR DESCRIPTION
Fixes the generic "exec" icon on macOS (#608).

- **Multi-resolution ICNS** (16→1024 incl. retina) replacing the hand-rolled single-128px `ic07` icon, so the Dock/Finder/switcher icon is crisp at every size.
- **`LSUIElement=true`** (`crates/hole/Info.plist`, Tauri-merged) so the release is a menu-bar (agent) app with no launch-time Dock flash. The *merge* into the shipped bundle is gated on every PR by a new `dmg-installer` pytest (`test_bundle_is_menu_bar_app`) via the existing `test-dmg-signing` job.
- **Runtime Dock icon** (`dock_icon.rs`) via `NSApplication.applicationIconImage`, applied **only to unbundled runs** (dev: `cargo tauri dev` / `target/debug/hole`) — a bundled release keeps the multi-res ICNS. Degrades gracefully (warn, never abort) on a nil/zero-size decode.
- All macOS activation-policy transitions now route through one `set_menu_bar_mode` helper (single chokepoint).

The unbundled process/menu **name** intentionally stays `hole` — no supported API sets it without a bundle.

Follow-up: unify build.rs's per-artifact icon generation into one asset table — #611.

Closes #608.
