### PR TITLE
test(ex-ray): cover getCertPool nil receiver; record v2ray-core fork mirror

### DIFF
--- a/crates/ex-ray/third_party/VENDORING.md
+++ b/crates/ex-ray/third_party/VENDORING.md
@@ -24,19 +24,40 @@ repo's linters and formatters (`prek.toml` top-level `exclude`,
 
 ## The fork is a mirror, not a dependency
 
-A `bindreams/v2ray-core` GitHub fork is (or will be) created **only** as a review
-and upstreaming surface. It is never referenced by `go.mod` and is never on the
-build path. Keeping it in sync is a manual step done when a patch is ready for
-human review or for proposing back to v2fly.
+The [`bindreams/v2ray-core`](https://github.com/bindreams/v2ray-core) GitHub fork
+exists **only** as a review and upstreaming surface. It is never referenced by
+`go.mod` and is never on the build path; keeping it in sync is a manual,
+one-directional step (the fork is downstream of the subrepo). It carries two
+first-party patches, extracted on the current pin:
+
+- **`getcertpool-nil-safety`** — guards a nil `*Config` receiver in `getCertPool`
+  (reachable: `GetTLSConfig` calls it before its own `if c == nil` check). Fork
+  PR: [bindreams/v2ray-core#2](https://github.com/bindreams/v2ray-core/pull/2).
+  Its regression test (`config_nil_{other,windows}_test.go`) also lives in-tree.
+- **`ech-fail-closed-retry`** — the ECH fail-closed gate + `retry_configs`
+  recovery (RFC 9849). It depends on the getCertPool fix (the fail-closed client
+  factory exercises the nil-receiver path), so it is **stacked** on it. Fork PR:
+  [bindreams/v2ray-core#3](https://github.com/bindreams/v2ray-core/pull/3).
 
 ## Sync workflow
 
-When a patch lands here and you want it reviewed / upstreamed:
+Patches are reviewed against a dedicated **review base** on the fork, not the
+fork's `master` (which tracks upstream and would swamp the diff):
 
-1. Extract the in-tree delta vs pinned upstream (the commits on top of v5.51.2).
-1. Apply that delta to a feature branch on the `bindreams/v2ray-core` fork.
-1. Open a fork-internal PR (feature -> fork `main`) for human review.
-1. If upstreaming, open a PR from the fork branch to `v2fly/v2ray-core`.
+1. Create `hole/<tag>` on the fork = the pinned upstream tag + **one** labeled
+   `ci: enable fork CI` commit (drops the linter's `github.repository` fork-guard
+   so lint runs; drops the secret-only codecov step). Head branches off this base,
+   so the CI commit never appears in a PR diff.
+1. Branch one feature per patch off `hole/<tag>` — or, for a dependent patch, off
+   the branch it depends on — and apply that patch's delta only.
+1. Open a fork-internal PR per patch targeting its base, so each diff is exactly
+   the patch. On a `pull_request` event GitHub runs the workflow from the
+   head-merged base, so lint/tests run with the fork-guard lifted.
+1. Drive v2ray-core's own `test.yml` + `linter.yml` green. Validate via `lint`,
+   the cross-compile `build` matrix, the patched-package tests, and the macOS
+   `test` job — v5.52.0's heavy `testing/scenarios` integration suite is flaky on
+   hosted runners, independent of any patch.
+1. If upstreaming, reuse the patch branch and PR body against `v2fly/v2ray-core`.
 
 This is one-directional and by hand; the fork is downstream of the subrepo, not
 the other way around.

--- a/crates/ex-ray/third_party/v2ray-core/transport/internet/tls/config_nil_other_test.go
+++ b/crates/ex-ray/third_party/v2ray-core/transport/internet/tls/config_nil_other_test.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package tls
+
+import "testing"
+
+// A nil *Config receiver must not panic, and on non-Windows must return the
+// system root pool — never a nil pool (which would silently disable verification).
+func TestGetCertPoolNilReceiver(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("getCertPool(nil) panicked: %v", r)
+		}
+	}()
+	var c *Config
+	if pool, err := c.getCertPool(); err == nil && pool == nil {
+		t.Fatal("getCertPool(nil): (nil, nil) — system roots silently disabled")
+	}
+}

--- a/crates/ex-ray/third_party/v2ray-core/transport/internet/tls/config_nil_windows_test.go
+++ b/crates/ex-ray/third_party/v2ray-core/transport/internet/tls/config_nil_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package tls
+
+import "testing"
+
+// A nil *Config receiver must not panic; on Windows it returns (nil, nil) so Go
+// uses the platform verifier.
+func TestGetCertPoolNilReceiver(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("getCertPool(nil) panicked: %v", r)
+		}
+	}()
+	var c *Config
+	if pool, err := c.getCertPool(); err != nil || pool != nil {
+		t.Fatalf("getCertPool(nil): want (nil, nil), got (%v, %v)", pool, err)
+	}
+}


### PR DESCRIPTION
Closes #623.

Records the `bindreams/v2ray-core` fork mirror as our v2ray-core upstreaming-review surface, and adds the getCertPool regression test to the in-tree vendored copy.

## What

- **In-tree regression test** for the getCertPool nil-receiver fix
  (`config_nil_{other,windows}_test.go`): a nil `*Config` must not panic, and
  must return the platform-correct cert pool (non-Windows: never `(nil, nil)`,
  which would silently disable verification; Windows: `(nil, nil)`).
- **`VENDORING.md`**: the fork is live; documents the two mirrored patches
  (getCertPool, ECH — stacked), the `hole/<tag>` review-base model, and the
  fork-CI validation approach.

## Mirror PRs (fork, no v2fly contact)

- getCertPool → [bindreams/v2ray-core#2](https://github.com/bindreams/v2ray-core/pull/2)
- ECH (stacked) → [bindreams/v2ray-core#3](https://github.com/bindreams/v2ray-core/pull/3)

## Verify

`cargo xtask run ex-ray-tests` (the go-test lane over the vendored tree) exercises the new tests.
