### PR TITLE
feat(gui): informed consent before a lockdown-off update restart

### DIFF
--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -23,7 +23,11 @@ pub(crate) enum Command {
     /// Print version information
     Version,
     /// Check for updates and install the latest version
-    Upgrade,
+    Upgrade {
+        /// Assume "yes" to the update consent prompt (for non-interactive use).
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
     /// Manage the privileged bridge service
     Bridge {
         #[command(subcommand)]
@@ -373,7 +377,7 @@ pub(crate) fn dispatch(command: Command) -> ! {
             println!("hole {}", hole::version::VERSION);
             0
         }
-        Command::Upgrade => handle_upgrade(),
+        Command::Upgrade { yes } => handle_upgrade(yes),
         Command::Bridge { action } => handle_bridge(action),
         Command::Proxy { action } => handle_proxy(action),
         Command::Path { action } => handle_path(action),
@@ -382,7 +386,7 @@ pub(crate) fn dispatch(command: Command) -> ! {
     std::process::exit(code)
 }
 
-fn handle_upgrade() -> i32 {
+fn handle_upgrade(yes: bool) -> i32 {
     cli_log!(info, "checking for updates...");
     match hole::update::check_for_update() {
         Ok(Some(info)) => {
@@ -422,19 +426,74 @@ fn handle_upgrade() -> i32 {
                 return 1;
             }
 
+            // Gate consent at send time: read lockdown fresh and disclose the leak.
+            use std::io::{IsTerminal, Write};
+            let status = send_bridge_request_inner(hole_common::protocol::BridgeRequest::Status);
+            let lockdown_enabled = match crate::state::classify_lockdown(&status) {
+                crate::state::LockdownRead::Known { enabled, .. } => enabled,
+                crate::state::LockdownRead::WrongReply => {
+                    cli_log!(
+                        warn,
+                        "consent gate: Status returned an unexpected reply ({status:?}); assuming lockdown off"
+                    );
+                    false
+                }
+                crate::state::LockdownRead::Unreadable => {
+                    cli_log!(
+                        warn,
+                        "consent gate: Status read failed ({status:?}); assuming lockdown off"
+                    );
+                    false
+                }
+            };
+            let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+            let consent = match hole::update::cli_consent_decision(lockdown_enabled, yes, interactive) {
+                hole::update::CliConsent::Proceed { consent } => {
+                    if consent {
+                        cli_log!(info, "update consent granted");
+                    }
+                    consent
+                }
+                hole::update::CliConsent::Refuse => {
+                    eprintln!("error: {}", hole::update::CONSENT_CLI_REFUSAL);
+                    return 1;
+                }
+                hole::update::CliConsent::Prompt => {
+                    print!("{}", hole::update::CONSENT_CLI_PROMPT);
+                    if let Err(e) = std::io::stdout().flush() {
+                        cli_log!(error, "failed to display consent prompt: {e}");
+                        return 1;
+                    }
+                    let mut line = String::new();
+                    match std::io::stdin().read_line(&mut line) {
+                        Err(e) => {
+                            cli_log!(warn, "consent prompt read failed: {e}");
+                            return 1;
+                        }
+                        Ok(_) => {
+                            if hole::update::cli_answer_confirms(&line) {
+                                true
+                            } else {
+                                cli_log!(info, "update cancelled by user");
+                                return 0;
+                            }
+                        }
+                    }
+                }
+            };
+
             cli_log!(info, "installing...");
-            // The privileged bridge owns the cutover (swap + service restart);
-            // the GUI only hands it the verified payload + manifest. `hole
-            // upgrade` is an explicit user action, so consent is implied.
-            let apply = hole_common::protocol::BridgeRequest::ApplyUpdate {
-                payload_path: dest.clone(),
-                target_version: info.version.to_string(),
-                consent: true,
+            // The privileged bridge owns the cutover (swap + service restart); the
+            // GUI only hands it the verified payload + manifest.
+            let apply = hole::update::build_apply_update(
+                dest.clone(),
+                info.version.to_string(),
                 sha256sums,
                 sha256sums_minisig,
-                asset_name: info.asset_name.clone(),
-                app_dest: hole::update::app_dest_hint(),
-            };
+                info.asset_name.clone(),
+                hole::update::app_dest_hint(),
+                consent,
+            );
             match send_bridge_request_inner(apply) {
                 Ok(hole_common::protocol::BridgeResponse::Ack) => {}
                 Ok(hole_common::protocol::BridgeResponse::Error { message }) => {
@@ -443,6 +502,13 @@ fn handle_upgrade() -> i32 {
                 }
                 Ok(other) => {
                     cli_log!(error, "unexpected response: {other:?}");
+                    return 1;
+                }
+                Err(crate::bridge_client::ClientError::ConsentRequired { message }) => {
+                    cli_log!(
+                        error,
+                        "lockdown changed during the update; re-run to confirm: {message}"
+                    );
                     return 1;
                 }
                 Err(e) => {

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -426,7 +426,7 @@ fn handle_upgrade(yes: bool) -> i32 {
                 return 1;
             }
 
-            // Gate consent at send time: read lockdown fresh and disclose the leak.
+            // Read lockdown fresh at send time — not the cached snapshot.
             use std::io::{IsTerminal, Write};
             let status = send_bridge_request_inner(hole_common::protocol::BridgeRequest::Status);
             let lockdown_enabled = match crate::state::classify_lockdown(&status) {

--- a/crates/hole/src/cli_tests.rs
+++ b/crates/hole/src/cli_tests.rs
@@ -116,7 +116,7 @@ fn dispatch_exempts_bridge_log_from_cli_log_guard() {
 
 #[skuld::test]
 fn dispatch_installs_cli_log_guard_for_write_actions() {
-    assert!(should_install_cli_log_guard(&Command::Upgrade));
+    assert!(should_install_cli_log_guard(&Command::Upgrade { yes: false }));
     assert!(should_install_cli_log_guard(&Command::Bridge {
         action: BridgeAction::Install {
             log_dir: None,
@@ -152,6 +152,16 @@ fn dispatch_installs_cli_log_guard_for_write_actions() {
             config_file: std::path::PathBuf::from("/tmp/x.json"),
         },
     }));
+}
+
+#[skuld::test]
+fn upgrade_parses_yes_flag() {
+    let long = Cli::try_parse_from(["hole", "upgrade", "--yes"]).unwrap();
+    assert!(matches!(long.command, Some(Command::Upgrade { yes: true })));
+    let short = Cli::try_parse_from(["hole", "upgrade", "-y"]).unwrap();
+    assert!(matches!(short.command, Some(Command::Upgrade { yes: true })));
+    let default = Cli::try_parse_from(["hole", "upgrade"]).unwrap();
+    assert!(matches!(default.command, Some(Command::Upgrade { yes: false })));
 }
 
 // Tests: bridge_log_watch rotation detection ==========================================================================

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -470,17 +470,38 @@ pub(crate) fn observed_error(result: &Result<BridgeResponse, ClientError>) -> Op
     }
 }
 
-/// The lockdown (enabled, active) a Status exchange revealed, if any. Only a
-/// `Status` Ok carries them; every other exchange yields None (leave the
-/// snapshot's prior lockdown fields untouched).
-pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<(bool, bool)> {
+/// Advisory read of the bridge's lockdown intent: decides which dialog/copy and
+/// consent value to offer. The bridge's `consent_gate` 403 is the authoritative gate;
+/// `Unreadable`/`WrongReply` fail closed to require-consent.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LockdownRead {
+    Known { enabled: bool, active: bool },
+    Unreadable,
+    WrongReply,
+}
+
+pub fn classify_lockdown(result: &Result<BridgeResponse, ClientError>) -> LockdownRead {
     match result {
         Ok(BridgeResponse::Status {
             lockdown_enabled,
             lockdown_active,
             ..
-        }) => Some((*lockdown_enabled, *lockdown_active)),
-        _ => None,
+        }) => LockdownRead::Known {
+            enabled: *lockdown_enabled,
+            active: *lockdown_active,
+        },
+        Ok(_) => LockdownRead::WrongReply,
+        Err(_) => LockdownRead::Unreadable,
+    }
+}
+
+/// The lockdown (enabled, active) a Status exchange revealed, if any. Only a
+/// `Status` Ok carries them; every other exchange yields None (leave the
+/// snapshot's prior lockdown fields untouched).
+pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<(bool, bool)> {
+    match classify_lockdown(result) {
+        LockdownRead::Known { enabled, active } => Some((enabled, active)),
+        LockdownRead::Unreadable | LockdownRead::WrongReply => None,
     }
 }
 

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -803,7 +803,6 @@ fn classify_lockdown_is_fail_closed_three_state() {
         super::classify_lockdown(&Err(ClientError::PermissionDenied)),
         super::LockdownRead::Unreadable
     );
-    // observed_lockdown delegates to classify_lockdown; guard all three arms.
     assert_eq!(super::observed_lockdown(&status(true)), Some((true, true)));
     assert_eq!(super::observed_lockdown(&Ok(BridgeResponse::Ack)), None);
     assert_eq!(super::observed_lockdown(&Err(ClientError::PermissionDenied)), None);

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -766,3 +766,45 @@ fn resolve_bridge_socket_empty_override_is_not_external() {
     assert_eq!(path, hole_common::protocol::default_bridge_socket_path());
     assert!(!external, "an empty override ⇒ not externally supervised");
 }
+
+#[skuld::test]
+fn classify_lockdown_is_fail_closed_three_state() {
+    let status = |lockdown_enabled: bool| {
+        Ok(BridgeResponse::Status {
+            running: true,
+            uptime_secs: 0,
+            error: None,
+            invalid_filters: Vec::new(),
+            udp_proxy_available: true,
+            ipv6_bypass_available: true,
+            lockdown_enabled,
+            lockdown_active: lockdown_enabled,
+        })
+    };
+    assert_eq!(
+        super::classify_lockdown(&status(true)),
+        super::LockdownRead::Known {
+            enabled: true,
+            active: true
+        }
+    );
+    assert_eq!(
+        super::classify_lockdown(&status(false)),
+        super::LockdownRead::Known {
+            enabled: false,
+            active: false
+        }
+    );
+    assert_eq!(
+        super::classify_lockdown(&Ok(BridgeResponse::Ack)),
+        super::LockdownRead::WrongReply
+    );
+    assert_eq!(
+        super::classify_lockdown(&Err(ClientError::PermissionDenied)),
+        super::LockdownRead::Unreadable
+    );
+    // observed_lockdown delegates to classify_lockdown; guard all three arms.
+    assert_eq!(super::observed_lockdown(&status(true)), Some((true, true)));
+    assert_eq!(super::observed_lockdown(&Ok(BridgeResponse::Ack)), None);
+    assert_eq!(super::observed_lockdown(&Err(ClientError::PermissionDenied)), None);
+}

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -792,7 +792,7 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             info!("tray: install update requested");
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move {
-                handle_install_update_from_tray(app_handle).await;
+                handle_install_update_from_tray(app_handle, None).await;
             });
         }
         ID_LOCKDOWN => {
@@ -919,8 +919,26 @@ async fn handle_uninstall_helper(app: AppHandle) {
     }
 }
 
-async fn handle_install_update_from_tray(app: AppHandle) {
-    use tauri_plugin_dialog::DialogExt;
+/// Read the bridge's lockdown intent fresh, failing closed to `false` (⇒ require
+/// consent) on any unreadable reply, logging the transport-error and wrong-reply
+/// cases distinctly.
+async fn read_lockdown_fresh(app: &AppHandle) -> bool {
+    let status = app.state::<AppState>().bridge_send(BridgeRequest::Status).await;
+    match crate::state::classify_lockdown(&status) {
+        crate::state::LockdownRead::Known { enabled, .. } => enabled,
+        crate::state::LockdownRead::WrongReply => {
+            warn!("consent gate: Status returned an unexpected reply ({status:?}); treating lockdown as off");
+            false
+        }
+        crate::state::LockdownRead::Unreadable => {
+            warn!("consent gate: Status read failed ({status:?}); treating lockdown as off");
+            false
+        }
+    }
+}
+
+async fn handle_install_update_from_tray(app: AppHandle, precomputed_consent: Option<bool>) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 
     // Get update info from update state.
     let update_state = app.state::<hole::update::UpdateState>();
@@ -1016,20 +1034,37 @@ async fn handle_install_update_from_tray(app: AppHandle) {
         }
     }
 
-    // Hand the verified payload to the privileged bridge, which owns the cutover
-    // (binary swap + service restart). The GUI does NOT exit — it self-heals onto
-    // the new image via the version-lockstep relaunch once the bridge is back.
-    // For PR2 the tray's existing user-initiated "install update" click is the
-    // gate, so consent is passed true (PR3 wires an explicit dialog).
-    let apply = BridgeRequest::ApplyUpdate {
-        payload_path: dest.clone(),
-        target_version: info.version.to_string(),
-        consent: true,
+    let consent = match precomputed_consent {
+        Some(consent) => consent,
+        None => match hole::update::tray_consent_decision(read_lockdown_fresh(&app).await) {
+            hole::update::TrayConsent::Proceed { consent } => consent,
+            hole::update::TrayConsent::AskUser => {
+                let confirmed = app
+                    .dialog()
+                    .message(hole::update::CONSENT_DIALOG_BODY)
+                    .title(hole::update::CONSENT_DIALOG_TITLE)
+                    .buttons(MessageDialogButtons::OkCancelCustom("Install".into(), "Cancel".into()))
+                    .blocking_show();
+                if !confirmed {
+                    info!("user declined lockdown-off update consent");
+                    return;
+                }
+                true
+            }
+        },
+    };
+
+    // The privileged bridge owns the cutover (binary swap + service restart); the
+    // GUI does not exit but self-heals onto the new image via version-lockstep relaunch.
+    let apply = hole::update::build_apply_update(
+        dest.clone(),
+        info.version.to_string(),
         sha256sums,
         sha256sums_minisig,
-        asset_name: info.asset_name.clone(),
-        app_dest: hole::update::app_dest_hint(),
-    };
+        info.asset_name.clone(),
+        hole::update::app_dest_hint(),
+        consent,
+    );
     let result = app.state::<AppState>().bridge_send(apply).await;
     drop(download_dir);
 
@@ -1043,6 +1078,13 @@ async fn handle_install_update_from_tray(app: AppHandle) {
                 .blocking_show();
         }
         Ok(other) => error!("unexpected bridge response to update apply: {other:?}"),
+        Err(crate::bridge_client::ClientError::ConsentRequired { message }) => {
+            warn!("bridge 403 on update apply (lockdown raced off): {message}");
+            app.dialog()
+                .message(hole::update::CONSENT_LOCKDOWN_RACED_OFF)
+                .title("Update Error")
+                .blocking_show();
+        }
         Err(e) => {
             error!("update apply failed: {e}");
             app.dialog()
@@ -1101,21 +1143,24 @@ async fn handle_check_for_updates(app: AppHandle) {
 
     match result {
         Ok(Ok(Some(info))) => {
+            let lockdown_enabled = read_lockdown_fresh(&app).await;
             let confirmed = app
                 .dialog()
-                .message(format!(
-                    "Version {} is available.\n\nWould you like to install it now?",
-                    info.version
+                .message(hole::update::check_update_dialog_body(
+                    &info.version.to_string(),
+                    lockdown_enabled,
                 ))
                 .title("Update Available")
                 .buttons(MessageDialogButtons::OkCancelCustom("Install".into(), "Later".into()))
                 .blocking_show();
 
             if confirmed {
-                // Store the update info and reuse the install handler.
+                // Consent decided here (merged dialog); reuse the install handler.
                 let update_state = app.state::<hole::update::UpdateState>();
                 update_state.tx.send_replace(Some(info));
-                handle_install_update_from_tray(app).await;
+                handle_install_update_from_tray(app, Some(hole::update::check_update_consent(lockdown_enabled))).await;
+            } else {
+                info!("user declined the available update at the check dialog");
             }
         }
         Ok(Ok(None)) => {

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -920,8 +920,7 @@ async fn handle_uninstall_helper(app: AppHandle) {
 }
 
 /// Read the bridge's lockdown intent fresh, failing closed to `false` (⇒ require
-/// consent) on any unreadable reply, logging the transport-error and wrong-reply
-/// cases distinctly.
+/// consent) on any unreadable reply.
 async fn read_lockdown_fresh(app: &AppHandle) -> bool {
     let status = app.state::<AppState>().bridge_send(BridgeRequest::Status).await;
     match crate::state::classify_lockdown(&status) {
@@ -1155,7 +1154,7 @@ async fn handle_check_for_updates(app: AppHandle) {
                 .blocking_show();
 
             if confirmed {
-                // Consent decided here (merged dialog); reuse the install handler.
+                // Consent already decided by the merged dialog above.
                 let update_state = app.state::<hole::update::UpdateState>();
                 update_state.tx.send_replace(Some(info));
                 handle_install_update_from_tray(app, Some(hole::update::check_update_consent(lockdown_enabled))).await;

--- a/crates/hole/src/update.rs
+++ b/crates/hole/src/update.rs
@@ -3,12 +3,17 @@
 // GUI hands it the verified payload over `POST /v1/update-apply`.
 
 pub(crate) mod check;
+mod consent;
 mod download;
 mod error;
 mod periodic;
 mod verify;
 
 pub use check::{check_for_update, UpdateInfo};
+pub use consent::{
+    build_apply_update, check_update_consent, check_update_dialog_body, tray_consent_decision, TrayConsent,
+    CONSENT_DIALOG_BODY, CONSENT_DIALOG_TITLE, CONSENT_LOCKDOWN_RACED_OFF,
+};
 pub use download::download_asset;
 pub use error::UpdateError;
 pub use periodic::start_update_checker;

--- a/crates/hole/src/update.rs
+++ b/crates/hole/src/update.rs
@@ -11,8 +11,9 @@ mod verify;
 
 pub use check::{check_for_update, UpdateInfo};
 pub use consent::{
-    build_apply_update, check_update_consent, check_update_dialog_body, tray_consent_decision, TrayConsent,
-    CONSENT_DIALOG_BODY, CONSENT_DIALOG_TITLE, CONSENT_LOCKDOWN_RACED_OFF,
+    build_apply_update, check_update_consent, check_update_dialog_body, cli_answer_confirms, cli_consent_decision,
+    tray_consent_decision, CliConsent, TrayConsent, CONSENT_CLI_PROMPT, CONSENT_CLI_REFUSAL, CONSENT_DIALOG_BODY,
+    CONSENT_DIALOG_TITLE, CONSENT_LOCKDOWN_RACED_OFF,
 };
 pub use download::download_asset;
 pub use error::UpdateError;

--- a/crates/hole/src/update/consent.rs
+++ b/crates/hole/src/update/consent.rs
@@ -8,7 +8,6 @@ pub const CONSENT_DIALOG_TITLE: &str = "Install Update";
 pub const CONSENT_DIALOG_BODY: &str = "Installing this update restarts the VPN.\n\nWith Lockdown off, your internet traffic briefly goes out unencrypted while the VPN restarts.\n\nInstall this update?";
 pub const CONSENT_LOCKDOWN_RACED_OFF: &str = "Lockdown changed during the update. Please try installing again.";
 
-/// Tray consent action (badge path).
 #[derive(Debug, PartialEq, Eq)]
 pub enum TrayConsent {
     Proceed { consent: bool },
@@ -29,13 +28,12 @@ pub fn check_update_consent(lockdown_enabled: bool) -> bool {
     !lockdown_enabled
 }
 
-/// The leak disclosure the lockdown-off check dialog embeds — a single source of
-/// truth shared by `check_update_dialog_body` and its test.
+/// The leak disclosure embedded in the lockdown-off check dialog.
 const CHECK_LEAK_DISCLOSURE: &str =
     "Installing it restarts the VPN. With Lockdown off, your traffic briefly goes out unencrypted while the VPN restarts.";
 
-/// Body for the tray "Check for Updates" dialog; lockdown-off folds in the leak
-/// disclosure so that path shows one dialog.
+/// Body for the tray "Check for Updates" dialog; the lockdown-off branch folds
+/// in the leak disclosure so that path needs only one dialog.
 pub fn check_update_dialog_body(version: &str, lockdown_enabled: bool) -> String {
     if lockdown_enabled {
         format!("Version {version} is available.\n\nWould you like to install it now?")
@@ -68,7 +66,6 @@ pub fn build_apply_update(
 pub const CONSENT_CLI_PROMPT: &str = "This update restarts the VPN. With Lockdown off, your traffic briefly goes out unencrypted during the restart.\nContinue? [y/N]: ";
 pub const CONSENT_CLI_REFUSAL: &str = "this update briefly sends your traffic unencrypted during the restart unless Lockdown is on, so it needs confirmation. Re-run in a terminal, or pass --yes to confirm. (Enabling Lockdown avoids this.)";
 
-/// CLI consent action.
 #[derive(Debug, PartialEq, Eq)]
 pub enum CliConsent {
     Proceed { consent: bool },

--- a/crates/hole/src/update/consent.rs
+++ b/crates/hole/src/update/consent.rs
@@ -1,0 +1,70 @@
+//! Client-side consent surface for a lockdown-off in-place update: discloses that
+//! the bridge restart briefly egresses cleartext and obtains the user's answer.
+
+use hole_common::protocol::BridgeRequest;
+use std::path::PathBuf;
+
+pub const CONSENT_DIALOG_TITLE: &str = "Install Update";
+pub const CONSENT_DIALOG_BODY: &str = "Installing this update restarts the VPN.\n\nWith Lockdown off, your internet traffic briefly goes out unencrypted while the VPN restarts.\n\nInstall this update?";
+pub const CONSENT_LOCKDOWN_RACED_OFF: &str = "Lockdown changed during the update. Please try installing again.";
+
+/// Tray consent action (badge path).
+#[derive(Debug, PartialEq, Eq)]
+pub enum TrayConsent {
+    Proceed { consent: bool },
+    AskUser,
+}
+
+pub fn tray_consent_decision(lockdown_enabled: bool) -> TrayConsent {
+    if lockdown_enabled {
+        TrayConsent::Proceed { consent: false }
+    } else {
+        TrayConsent::AskUser
+    }
+}
+
+/// `consent` to send when the user installs from the check dialog: lockdown off ⇒
+/// the merged dialog disclosed the leak (true); lockdown on ⇒ moot (false).
+pub fn check_update_consent(lockdown_enabled: bool) -> bool {
+    !lockdown_enabled
+}
+
+/// The leak disclosure the lockdown-off check dialog embeds — a single source of
+/// truth shared by `check_update_dialog_body` and its test.
+const CHECK_LEAK_DISCLOSURE: &str =
+    "Installing it restarts the VPN. With Lockdown off, your traffic briefly goes out unencrypted while the VPN restarts.";
+
+/// Body for the tray "Check for Updates" dialog; lockdown-off folds in the leak
+/// disclosure so that path shows one dialog.
+pub fn check_update_dialog_body(version: &str, lockdown_enabled: bool) -> String {
+    if lockdown_enabled {
+        format!("Version {version} is available.\n\nWould you like to install it now?")
+    } else {
+        format!("Version {version} is available.\n\n{CHECK_LEAK_DISCLOSURE}\n\nInstall it now?")
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_apply_update(
+    payload_path: PathBuf,
+    target_version: String,
+    sha256sums: String,
+    sha256sums_minisig: String,
+    asset_name: String,
+    app_dest: Option<String>,
+    consent: bool,
+) -> BridgeRequest {
+    BridgeRequest::ApplyUpdate {
+        payload_path,
+        target_version,
+        consent,
+        sha256sums,
+        sha256sums_minisig,
+        asset_name,
+        app_dest,
+    }
+}
+
+#[cfg(test)]
+#[path = "consent_tests.rs"]
+mod consent_tests;

--- a/crates/hole/src/update/consent.rs
+++ b/crates/hole/src/update/consent.rs
@@ -65,6 +65,36 @@ pub fn build_apply_update(
     }
 }
 
+pub const CONSENT_CLI_PROMPT: &str = "This update restarts the VPN. With Lockdown off, your traffic briefly goes out unencrypted during the restart.\nContinue? [y/N]: ";
+pub const CONSENT_CLI_REFUSAL: &str = "this update briefly sends your traffic unencrypted during the restart unless Lockdown is on, so it needs confirmation. Re-run in a terminal, or pass --yes to confirm. (Enabling Lockdown avoids this.)";
+
+/// CLI consent action.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CliConsent {
+    Proceed { consent: bool },
+    Prompt,
+    Refuse,
+}
+
+pub fn cli_consent_decision(lockdown_enabled: bool, yes: bool, interactive: bool) -> CliConsent {
+    if lockdown_enabled {
+        return CliConsent::Proceed { consent: false };
+    }
+    if yes {
+        return CliConsent::Proceed { consent: true };
+    }
+    if interactive {
+        return CliConsent::Prompt;
+    }
+    CliConsent::Refuse
+}
+
+/// Whether a read prompt line is an explicit yes; anything else — a bare Enter, an
+/// EOF empty line, `n` — declines (default-deny [y/N]).
+pub fn cli_answer_confirms(line: &str) -> bool {
+    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
 #[cfg(test)]
 #[path = "consent_tests.rs"]
 mod consent_tests;

--- a/crates/hole/src/update/consent_tests.rs
+++ b/crates/hole/src/update/consent_tests.rs
@@ -64,3 +64,25 @@ fn build_apply_update_maps_every_field() {
         BridgeRequest::ApplyUpdate { consent: false, .. }
     ));
 }
+
+#[skuld::test]
+fn cli_consent_decision_carries_the_consent_value() {
+    use CliConsent::*;
+    assert_eq!(cli_consent_decision(true, false, false), Proceed { consent: false });
+    assert_eq!(cli_consent_decision(true, true, true), Proceed { consent: false });
+    assert_eq!(cli_consent_decision(false, true, false), Proceed { consent: true });
+    assert_eq!(cli_consent_decision(false, false, true), Prompt);
+    assert_eq!(cli_consent_decision(false, false, false), Refuse);
+}
+
+#[skuld::test]
+fn cli_answer_confirms_only_on_explicit_yes() {
+    // Explicit yes, incl. the LF/CRLF shapes read_line delivers.
+    for line in ["y", "yes", "Y", "YES ", " y ", "Yes", "y\n", "yes\r\n"] {
+        assert!(cli_answer_confirms(line), "{line:?} should confirm");
+    }
+    // Not an explicit yes; "" is EOF, "\n" is a bare Enter.
+    for line in ["", "\n", "\r\n", "n", "no", "yeah", "yep", "garbage"] {
+        assert!(!cli_answer_confirms(line), "{line:?} should decline");
+    }
+}

--- a/crates/hole/src/update/consent_tests.rs
+++ b/crates/hole/src/update/consent_tests.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+#[skuld::test]
+fn tray_consent_gates_on_lockdown() {
+    assert_eq!(tray_consent_decision(true), TrayConsent::Proceed { consent: false });
+    assert_eq!(tray_consent_decision(false), TrayConsent::AskUser);
+}
+
+#[skuld::test]
+fn check_update_consent_polarity() {
+    assert!(check_update_consent(false), "lockdown off ⇒ Install grants consent");
+    assert!(!check_update_consent(true), "lockdown on ⇒ consent moot (false)");
+}
+
+#[skuld::test]
+fn check_update_dialog_body_discloses_leak_only_when_lockdown_off() {
+    // Derive the expectation from the single source of truth (the disclosure const),
+    // so a rephrase can't silently drop the disclosure past the test.
+    let off = check_update_dialog_body("1.2.3", false);
+    assert!(
+        off.contains("1.2.3") && off.contains(CHECK_LEAK_DISCLOSURE),
+        "off must disclose the leak"
+    );
+    let on = check_update_dialog_body("1.2.3", true);
+    assert!(
+        on.contains("1.2.3") && !on.contains(CHECK_LEAK_DISCLOSURE),
+        "on must not disclose a leak"
+    );
+}
+
+#[skuld::test]
+fn build_apply_update_maps_every_field() {
+    use hole_common::protocol::BridgeRequest;
+    // Distinct sentinels so a positional transposition of the four String args fails.
+    let BridgeRequest::ApplyUpdate {
+        payload_path,
+        target_version,
+        consent,
+        sha256sums,
+        sha256sums_minisig,
+        asset_name,
+        app_dest,
+    } = build_apply_update(
+        "/tmp/x.msi".into(),
+        "9.9.9".into(),
+        "SUMS".into(),
+        "SIG".into(),
+        "hole.msi".into(),
+        Some("dest".into()),
+        true,
+    )
+    else {
+        panic!("expected ApplyUpdate");
+    };
+    assert_eq!(payload_path, std::path::PathBuf::from("/tmp/x.msi"));
+    assert_eq!(target_version, "9.9.9");
+    assert!(consent);
+    assert_eq!(sha256sums, "SUMS");
+    assert_eq!(sha256sums_minisig, "SIG");
+    assert_eq!(asset_name, "hole.msi");
+    assert_eq!(app_dest, Some("dest".to_string()));
+    assert!(matches!(
+        build_apply_update("/p".into(), "1".into(), "s".into(), "m".into(), "a".into(), None, false),
+        BridgeRequest::ApplyUpdate { consent: false, .. }
+    ));
+}

--- a/crates/hole/src/update/consent_tests.rs
+++ b/crates/hole/src/update/consent_tests.rs
@@ -14,8 +14,6 @@ fn check_update_consent_polarity() {
 
 #[skuld::test]
 fn check_update_dialog_body_discloses_leak_only_when_lockdown_off() {
-    // Derive the expectation from the single source of truth (the disclosure const),
-    // so a rephrase can't silently drop the disclosure past the test.
     let off = check_update_dialog_body("1.2.3", false);
     assert!(
         off.contains("1.2.3") && off.contains(CHECK_LEAK_DISCLOSURE),
@@ -25,6 +23,20 @@ fn check_update_dialog_body_discloses_leak_only_when_lockdown_off() {
     assert!(
         on.contains("1.2.3") && !on.contains(CHECK_LEAK_DISCLOSURE),
         "on must not disclose a leak"
+    );
+}
+
+#[skuld::test]
+fn check_leak_disclosure_names_the_leak() {
+    // Pin the security-relevant wording so a rephrase that stops naming the
+    // Lockdown-off condition or the cleartext leak fails the build.
+    assert!(
+        CHECK_LEAK_DISCLOSURE.contains("Lockdown"),
+        "must name the Lockdown condition"
+    );
+    assert!(
+        CHECK_LEAK_DISCLOSURE.contains("unencrypted"),
+        "must name the cleartext leak"
     );
 }
 


### PR DESCRIPTION
## What

Wires a genuine **informed-consent surface** before a lockdown-off in-place update, so `consent` reflects a real user decision instead of the hardcoded `consent: true` both callers shipped. Ratified **decision B** (#527): a lockdown-off update accepts a brief cleartext leak during the bridge restart *only after explicit informed consent*; the bridge already enforces this structurally (`consent_gate` → 403), but the 403 branch was unreachable and the default-cohort (lockdown-off) user was never told.

## How

Rust-only — the update flow is native (tray `tauri_plugin_dialog` + CLI prompt); no `ui/` changes.

- **Pure, tested seams** in `update::consent` (`tray_consent_decision`, `cli_consent_decision`, `cli_answer_confirms`, `check_update_consent`, `check_update_dialog_body`, `build_apply_update`) carry the `consent` value onto the wire, so handlers are thin translators.
- **Lockdown read**: `state::classify_lockdown` (`LockdownRead::{Known, Unreadable, WrongReply}`) — a three-state, fail-closed classifier that `observed_lockdown` now delegates to (single matcher). An unreadable Status (transport error vs wrong reply) is logged distinctly at `warn` and fails closed to require-consent. The bridge re-checks lockdown authoritatively and 403s any residual race.
- **Tray**: the badge path gates consent fresh at send time (after verify); the "Check for Updates" path folds the leak disclosure into its single availability dialog when lockdown is off (one prompt, not two). `ClientError::ConsentRequired` (403) now maps to a clear message.
- **CLI**: `hole upgrade` gains `--yes`/`-y`. Interactive TTY → `[y/N]` prompt; non-interactive without `--yes` → fail closed (exit 1), never silently consent. EOF/read-error and a failed prompt flush get distinct dispositions.
- **Disclosure copy** is conditional-safe ("With Lockdown off, …" / "unless Lockdown is on") so it stays truthful when the bridge status is briefly unreadable; static and PII-free.

Lockdown-on updates proceed unchanged (the standing cover holds the gap; `consent` is moot).

## Design notes

- Consent is resolved at three tested sites funneling into `build_apply_update`; a unified send-boundary choke point is deferred to a follow-up (the three disclosure surfaces are genuinely heterogeneous). The bridge 403 backstops the dangerous omission.
- The client lockdown read is advisory (drives dialog/copy); the bridge's `consent_gate` 403 is the authoritative gate.

Plan- and code-reviewed via the review panel (plan gate iterated to convergence; code gate: 0 must_fix on correctness/architecture/tests).

Closes #621
Refs #474, #527
