### PR TITLE
fix(bridge): recover a wedged Windows in-place-update cutover

### DIFF
--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -118,6 +118,7 @@ windows = { version = "0.62", features = [
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_Etw",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_JobObjects",
     "Win32_System_RemoteDesktop",
     "Win32_System_Services",

--- a/crates/bridge/src/cutover.rs
+++ b/crates/bridge/src/cutover.rs
@@ -54,7 +54,23 @@ pub fn run_detached(payload: &Path, target_version: &str) -> std::io::Result<()>
         images,
         target_version: target_version.to_string(),
     };
-    run_cutover(&mut os)
+    let result = run_cutover(&mut os);
+    clear_marker_on_cutover_failure(&result, &hole_common::update_marker::service_log_dir());
+    result
+}
+
+/// On a graceful cutover failure clear the marker so a retry is not blocked by
+/// the single-occupancy claim. Load-bearing for the stop/swap sub-case (no new
+/// bridge binds to sweep it); an idempotent second clear for the start-failure
+/// sub-case (Part A's restart also sweeps post-bind). A crash is covered by the
+/// GUI liveness net.
+#[cfg(target_os = "windows")]
+fn clear_marker_on_cutover_failure(result: &std::io::Result<()>, log_dir: &Path) {
+    if result.is_err() {
+        if let Err(e) = hole_common::update_marker::clear(log_dir) {
+            tracing::warn!(error = %e, "cutover child: failed to clear marker on graceful failure");
+        }
+    }
 }
 
 /// Build the rename-swap plan for every bundled binary: each `name` maps from

--- a/crates/bridge/src/cutover.rs
+++ b/crates/bridge/src/cutover.rs
@@ -44,6 +44,13 @@ pub fn run_detached(payload: &Path, target_version: &str) -> std::io::Result<()>
     use crate::cutover::os::run_cutover;
     use crate::cutover::os::windows::WindowsCutoverOs;
 
+    // Bring an install base predating the restart-on-failure SCM config up to date
+    // as part of the update itself. Best-effort: a failure here must not abort the
+    // cutover (the swap + restart still proceed), so log and continue.
+    if let Err(e) = crate::platform::os::ensure_failure_actions() {
+        tracing::warn!(error = %e, "cutover: could not ensure SCM restart-on-failure config");
+    }
+
     let install_dir = std::env::current_exe()?
         .parent()
         .ok_or_else(|| std::io::Error::other("current_exe has no parent dir"))?
@@ -62,8 +69,8 @@ pub fn run_detached(payload: &Path, target_version: &str) -> std::io::Result<()>
 /// On a graceful cutover failure clear the marker so a retry is not blocked by
 /// the single-occupancy claim. Load-bearing for the stop/swap sub-case (no new
 /// bridge binds to sweep it); an idempotent second clear for the start-failure
-/// sub-case (Part A's restart also sweeps post-bind). A crash is covered by the
-/// GUI liveness net.
+/// sub-case (the SCM's restart-on-failure also sweeps post-bind). A crash is
+/// covered by the GUI liveness net.
 #[cfg(target_os = "windows")]
 fn clear_marker_on_cutover_failure(result: &std::io::Result<()>, log_dir: &Path) {
     if result.is_err() {

--- a/crates/bridge/src/cutover/apply.rs
+++ b/crates/bridge/src/cutover/apply.rs
@@ -82,8 +82,24 @@ pub fn spawn_actor(
 ) -> std::io::Result<()> {
     #[cfg(target_os = "windows")]
     {
-        let _ = (app_dest, log_dir);
-        windows::spawn_detached_child(&staged, target_version)
+        let _ = app_dest;
+        // Spawn the detached child SUSPENDED, stamp the frozen child's identity
+        // into the marker, then resume it — the marker names the driver before the
+        // child can act. Any pre-resume failure kills the child (logged) and
+        // returns Err so the ipc.rs caller clears the marker and 500s; the child
+        // never ran.
+        let mut child = windows::spawn_suspended_child(&staged, target_version)?;
+        let pid = child.id();
+        if let Err(e) = windows::record_spawned_driver(log_dir, pid, hole_common::process::process_start_time(pid))
+            .and_then(|()| windows::resume_main_thread(pid))
+        {
+            if let Err(ke) = child.kill() {
+                tracing::warn!(pid, error = %ke, "failed to kill the suspended cutover child after a pre-resume failure");
+            }
+            return Err(e);
+        }
+        // Dropping `child` closes our handle without killing the now-running process.
+        Ok(())
     }
     #[cfg(target_os = "macos")]
     {
@@ -112,8 +128,10 @@ pub fn breakaway_decision(in_job: bool, job_permits_breakaway: bool) -> bool {
 
 #[cfg(target_os = "windows")]
 mod windows {
-    //! Detached-child spawn with the conditional job-breakaway probe. Raw
-    //! JobObject FFI is sanctioned here per the #165 isolation contract.
+    //! Suspended-child spawn (so the initiator can stamp the frozen child's
+    //! identity into the marker before it can act), the conditional job-breakaway
+    //! probe, and the ToolHelp thread-resume. Raw JobObject/ToolHelp FFI is
+    //! sanctioned here per the #165 isolation contract.
     #![allow(clippy::disallowed_methods)]
 
     use std::os::windows::process::CommandExt;
@@ -125,30 +143,139 @@ mod windows {
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_BREAKAWAY_OK,
     };
     use windows::Win32::System::Threading::{
-        GetCurrentProcess, CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW, DETACHED_PROCESS,
+        GetCurrentProcess, CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW, CREATE_SUSPENDED, DETACHED_PROCESS,
     };
 
     use super::breakaway_decision;
     use crate::cutover::extract::ExtractedImages;
 
-    pub fn spawn_detached_child(staged: &ExtractedImages, target_version: &str) -> std::io::Result<()> {
-        let exe = std::env::current_exe()?;
-        let mut flags = DETACHED_PROCESS.0 | CREATE_NO_WINDOW.0;
+    /// Overwrite the marker's driver identity with the freshly-spawned child's
+    /// PID + start time. A real Windows creation FILETIME is never 0; a stamped
+    /// `0` is the poisoned sentinel the GUI reads as unassessed (a permanent mask
+    /// on a dead driver), so treat `Some(0)` (and `None`) as a failure — the
+    /// caller then kills the child and clears the marker rather than stamping a
+    /// poisoned identity. Table-testable.
+    pub(super) fn record_spawned_driver(
+        log_dir: &std::path::Path,
+        child_pid: u32,
+        start: Option<u64>,
+    ) -> std::io::Result<()> {
+        match start {
+            Some(s) if s != 0 => hole_common::update_marker::stamp_driver(log_dir, child_pid, s),
+            _ => Err(std::io::Error::other(
+                "could not record a valid cutover child start time",
+            )),
+        }
+    }
+
+    /// The suspended-spawn creation flags: DETACHED + NO_WINDOW + SUSPENDED, plus
+    /// CREATE_BREAKAWAY_FROM_JOB only when this process's job permits it.
+    fn suspended_creation_flags() -> u32 {
+        let mut flags = DETACHED_PROCESS.0 | CREATE_NO_WINDOW.0 | CREATE_SUSPENDED.0;
         if breakaway_decision(process_in_job(), job_permits_breakaway()) {
             flags |= CREATE_BREAKAWAY_FROM_JOB.0;
         }
-        std::process::Command::new(exe)
-            .args([
-                "bridge",
-                "cutover",
-                "--payload",
-                &staged.staging_dir.to_string_lossy(),
-                "--target-version",
-                target_version,
-            ])
-            .creation_flags(flags)
-            .spawn()?;
-        Ok(())
+        flags
+    }
+
+    /// Apply the suspended creation flags to `cmd` and spawn it. The single main
+    /// thread is left suspended; the caller stamps the marker, then resumes it via
+    /// [`resume_main_thread`].
+    fn spawn_suspended(mut cmd: std::process::Command) -> std::io::Result<std::process::Child> {
+        cmd.creation_flags(suspended_creation_flags()).spawn()
+    }
+
+    /// Spawn the detached LocalSystem `hole bridge cutover` child SUSPENDED. It
+    /// outlives this process and drives stop -> swap -> start once resumed.
+    pub(super) fn spawn_suspended_child(
+        staged: &ExtractedImages,
+        target_version: &str,
+    ) -> std::io::Result<std::process::Child> {
+        let exe = std::env::current_exe()?;
+        let mut cmd = std::process::Command::new(exe);
+        cmd.args([
+            "bridge",
+            "cutover",
+            "--payload",
+            &staged.staging_dir.to_string_lossy(),
+            "--target-version",
+            target_version,
+        ]);
+        spawn_suspended(cmd)
+    }
+
+    /// Spawn an arbitrary command line SUSPENDED. The first whitespace-delimited
+    /// token is the program; the remainder is appended verbatim (`raw_arg`, no
+    /// re-quoting). A test seam so the suspend->resume ordering can be driven with
+    /// an observable command; the real cutover payload goes through
+    /// [`spawn_suspended_child`].
+    #[cfg(test)]
+    pub(super) fn spawn_suspended_command(cmdline: &str) -> std::io::Result<std::process::Child> {
+        let (program, rest) = match cmdline.split_once(char::is_whitespace) {
+            Some((p, r)) => (p, r.trim_start()),
+            None => (cmdline, ""),
+        };
+        let mut cmd = std::process::Command::new(program);
+        if !rest.is_empty() {
+            cmd.raw_arg(rest);
+        }
+        spawn_suspended(cmd)
+    }
+
+    /// Resume the (single) suspended main thread of `pid`. A `CREATE_SUSPENDED`
+    /// process has exactly one thread, itself suspended; find it by owner PID via
+    /// a ToolHelp thread snapshot, open it with `THREAD_SUSPEND_RESUME`, and
+    /// `ResumeThread` (which returns `u32::MAX` on failure). `OpenThread` errors
+    /// are surfaced too, so a resume that could not fire returns `Err` (the caller
+    /// kills the still-suspended child rather than leaking it).
+    pub(super) fn resume_main_thread(pid: u32) -> std::io::Result<()> {
+        use windows::Win32::Foundation::CloseHandle;
+        use windows::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+        };
+        use windows::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+        // SAFETY: the snapshot handle is checked and closed below.
+        let snap = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) }
+            .map_err(|e| std::io::Error::other(format!("thread snapshot: {e}")))?;
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            ..Default::default()
+        };
+        let mut outcome: std::io::Result<()> = Err(std::io::Error::other("cutover child's main thread not found"));
+        // SAFETY: `snap` is a live snapshot; `entry.dwSize` is set per contract.
+        if unsafe { Thread32First(snap, &mut entry) }.is_ok() {
+            loop {
+                if entry.th32OwnerProcessID == pid {
+                    // SAFETY: a valid thread id from the snapshot.
+                    match unsafe { OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID) } {
+                        Ok(h) => {
+                            // SAFETY: `h` is a live thread handle; closed right after.
+                            let prev = unsafe { ResumeThread(h) };
+                            unsafe {
+                                let _ = CloseHandle(h);
+                            }
+                            outcome = if prev == u32::MAX {
+                                Err(std::io::Error::last_os_error())
+                            } else {
+                                Ok(())
+                            };
+                        }
+                        Err(e) => outcome = Err(std::io::Error::other(format!("OpenThread: {e}"))),
+                    }
+                    break;
+                }
+                // SAFETY: `snap`/`entry` stay valid across the enumeration.
+                if unsafe { Thread32Next(snap, &mut entry) }.is_err() {
+                    break;
+                }
+            }
+        }
+        // SAFETY: `snap` is a live handle opened above.
+        unsafe {
+            let _ = CloseHandle(snap);
+        }
+        outcome
     }
 
     fn current_process() -> HANDLE {

--- a/crates/bridge/src/cutover/apply.rs
+++ b/crates/bridge/src/cutover/apply.rs
@@ -369,7 +369,9 @@ mod macos {
             return;
         };
         tracing::error!(error = %e, "macOS cutover failed before restart; clearing marker");
-        let _ = hole_common::update_marker::clear(log_dir);
+        if let Err(ce) = hole_common::update_marker::clear(log_dir) {
+            tracing::warn!(error = %ce, "failed to clear cutover marker on error path");
+        }
     }
 }
 

--- a/crates/bridge/src/cutover/apply.rs
+++ b/crates/bridge/src/cutover/apply.rs
@@ -64,11 +64,12 @@ pub fn preflight_app_dest(app_dest: Option<&Path>) -> std::io::Result<std::path:
 
 /// Kick off the cutover actor and return immediately, BEFORE any self-restart.
 ///
-/// - Windows: spawn the DETACHED LocalSystem `hole bridge cutover` child (a
-///   service cannot SCM-restart itself); it outlives this process and drives
-///   stop → swap → start. Returns once the child is spawned. `app_dest`/`log_dir`
-///   are unused (the SCM install dir is canonical; the detached child leaves the
-///   marker for the next bridge's post-bind sweep).
+/// - Windows: spawn the DETACHED LocalSystem `hole bridge cutover` child SUSPENDED
+///   (a service cannot SCM-restart itself), stamp its identity into `log_dir`'s
+///   marker, then resume it; it outlives this process and drives stop → swap →
+///   start. Returns once the child is running. `app_dest` is unused (the SCM
+///   install dir is canonical); the marker is left for the next bridge's post-bind
+///   sweep.
 /// - macOS: build the inline actor and run it on a DETACHED tokio task so the
 ///   200 flushes before the actor SIGTERMs this very process. The task is never
 ///   joined — the process is about to be killed and the new bridge takes over.
@@ -86,18 +87,12 @@ pub fn spawn_actor(
         // Spawn the detached child SUSPENDED, stamp the frozen child's identity
         // into the marker, then resume it — the marker names the driver before the
         // child can act. Any pre-resume failure kills the child (logged) and
-        // returns Err so the ipc.rs caller clears the marker and 500s; the child
+        // returns Err so the caller clears the marker and returns 500; the child
         // never ran.
         let mut child = windows::spawn_suspended_child(&staged, target_version)?;
         let pid = child.id();
-        if let Err(e) = windows::record_spawned_driver(log_dir, pid, hole_common::process::process_start_time(pid))
-            .and_then(|()| windows::resume_main_thread(pid))
-        {
-            if let Err(ke) = child.kill() {
-                tracing::warn!(pid, error = %ke, "failed to kill the suspended cutover child after a pre-resume failure");
-            }
-            return Err(e);
-        }
+        let record = windows::record_spawned_driver(log_dir, pid, hole_common::process::process_start_time(pid));
+        windows::record_resume_or_kill(&mut child, record, || windows::resume_main_thread(pid))?;
         // Dropping `child` closes our handle without killing the now-running process.
         Ok(())
     }
@@ -154,7 +149,7 @@ mod windows {
     /// `0` is the poisoned sentinel the GUI reads as unassessed (a permanent mask
     /// on a dead driver), so treat `Some(0)` (and `None`) as a failure — the
     /// caller then kills the child and clears the marker rather than stamping a
-    /// poisoned identity. Table-testable.
+    /// poisoned identity.
     pub(super) fn record_spawned_driver(
         log_dir: &std::path::Path,
         child_pid: u32,
@@ -166,6 +161,27 @@ mod windows {
                 "could not record a valid cutover child start time",
             )),
         }
+    }
+
+    /// Post-spawn composition for the suspended cutover child: apply `record`
+    /// (stamp the marker), then `resume`. On ANY failure kill the still-suspended
+    /// child (logged) and return the Err — the child never ran. Extracted so the
+    /// spawn->stamp->resume->kill-on-failure sequence is testable with an injected
+    /// record/resume.
+    pub(super) fn record_resume_or_kill(
+        child: &mut std::process::Child,
+        record: std::io::Result<()>,
+        resume: impl FnOnce() -> std::io::Result<()>,
+    ) -> std::io::Result<()> {
+        let outcome = record.and_then(|()| resume());
+        if let Err(e) = &outcome {
+            let pid = child.id();
+            if let Err(ke) = child.kill() {
+                tracing::warn!(pid, error = %ke, "failed to kill the suspended cutover child after a pre-resume failure");
+            }
+            tracing::warn!(pid, error = %e, "cutover child pre-resume failure; child killed");
+        }
+        outcome
     }
 
     /// The suspended-spawn creation flags: DETACHED + NO_WINDOW + SUSPENDED, plus

--- a/crates/bridge/src/cutover/apply_tests.rs
+++ b/crates/bridge/src/cutover/apply_tests.rs
@@ -5,8 +5,9 @@ fn sample_marker() -> hole_common::update_marker::MarkerInfo {
         version: hole_common::update_marker::MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: "0.3.0".into(),
-        pid: 4242,
+        driver_pid: 4242,
         started_at_unix: 1_700_000_000,
+        driver_start_unix_ms: 0,
     }
 }
 

--- a/crates/bridge/src/cutover/apply_tests.rs
+++ b/crates/bridge/src/cutover/apply_tests.rs
@@ -113,6 +113,23 @@ fn record_spawned_driver_fails_when_child_vanished_or_zero() {
     );
 }
 
+// The post-spawn composition (record->resume, kill-on-any-failure): an injected
+// record failure must terminate the still-suspended child AND return Err.
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn record_resume_or_kill_kills_on_record_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel = dir.path().join("ran.txt");
+    let mut child = windows::spawn_suspended_command(&format!("cmd /c echo x > \"{}\"", sentinel.display())).unwrap();
+    let out = windows::record_resume_or_kill(&mut child, Err(std::io::Error::other("record failed")), || {
+        panic!("resume must not run after a record failure")
+    });
+    assert!(out.is_err(), "a record failure returns Err");
+    // The child was killed while suspended: it never ran, and wait() returns.
+    child.wait().unwrap();
+    assert!(!sentinel.exists(), "the killed suspended child never ran");
+}
+
 // The suspend->resume ordering primitive, asserted POSITIVELY: a suspended child
 // does not run (its sentinel is absent) until resumed, then it runs (sentinel
 // appears). Driven through the `spawn_suspended_command` inner seam so the

--- a/crates/bridge/src/cutover/apply_tests.rs
+++ b/crates/bridge/src/cutover/apply_tests.rs
@@ -90,3 +90,44 @@ fn breakaway_only_when_in_job_and_job_permits() {
     );
     assert!(!breakaway_decision(false, false));
 }
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn record_spawned_driver_stamps_when_alive() {
+    let dir = tempfile::tempdir().unwrap();
+    hole_common::update_marker::write(dir.path(), &sample_marker(), None).unwrap();
+    windows::record_spawned_driver(dir.path(), 4242, Some(1_700_000_000_123)).unwrap();
+    let got = hole_common::update_marker::read(dir.path()).unwrap();
+    assert_eq!((got.driver_pid, got.driver_start_unix_ms), (4242, 1_700_000_000_123));
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn record_spawned_driver_fails_when_child_vanished_or_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    hole_common::update_marker::write(dir.path(), &sample_marker(), None).unwrap();
+    assert!(windows::record_spawned_driver(dir.path(), 4242, None).is_err());
+    assert!(
+        windows::record_spawned_driver(dir.path(), 4242, Some(0)).is_err(),
+        "a poisoned 0 start time is rejected"
+    );
+}
+
+// The suspend->resume ordering primitive, asserted POSITIVELY: a suspended child
+// does not run (its sentinel is absent) until resumed, then it runs (sentinel
+// appears). Driven through the `spawn_suspended_command` inner seam so the
+// ordering is testable with an arbitrary observable command.
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn spawn_suspended_child_is_frozen_until_resumed() {
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel = dir.path().join("ran.txt");
+    let mut child = windows::spawn_suspended_command(&format!("cmd /c echo x > \"{}\"", sentinel.display())).unwrap();
+    let pid = child.id();
+    assert!(!sentinel.exists(), "a suspended child must not run before resume");
+    windows::resume_main_thread(pid).unwrap();
+    // Sanctioned external-event wait: a broken resume leaves the child suspended
+    // forever, which the test harness surfaces as a timeout, not a hang here.
+    child.wait().unwrap();
+    assert!(sentinel.exists(), "the child ran only after resume");
+}

--- a/crates/bridge/src/cutover/scm_wait.rs
+++ b/crates/bridge/src/cutover/scm_wait.rs
@@ -63,8 +63,8 @@ pub fn start_via_notify<A: ScmActor>(a: &mut A) -> std::io::Result<()> {
         match a.wait_callback()? {
             Observed::Running => return Ok(()),
             // A terminal Stopped means the service stopped instead of reaching
-            // Running — a failed start. Give up (the cutover child then clears
-            // the marker + exits; Part A's restart re-drives a transient failure).
+            // Running — a failed start. Give up (the cutover child then clears the
+            // marker + exits; the SCM's restart-on-failure re-drives a transient one).
             Observed::Stopped => {
                 return Err(std::io::Error::other(
                     "service stopped before reaching Running (failed start)",

--- a/crates/bridge/src/cutover/scm_wait.rs
+++ b/crates/bridge/src/cutover/scm_wait.rs
@@ -10,6 +10,19 @@ pub enum WantState {
     Running,
 }
 
+/// The service state a `wait_callback` observed. Distinct from `WantState`: a
+/// callback can report a state that is neither what the caller wants nor its
+/// opposite. `Running`/`Stopped` are terminal; `Pending` is any intermediate
+/// (`StartPending`/`StopPending`) and re-arms. `start_via_notify` treats a
+/// terminal `Stopped` as a FAILED start (the swapped-in bridge stopped instead
+/// of reaching Running), so it returns `Err` rather than blocking forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Observed {
+    Running,
+    Stopped,
+    Pending,
+}
+
 /// The granular SCM operations the restart sequence needs, isolated so the
 /// ordering can be unit-tested with a fake.
 pub trait ScmActor {
@@ -19,10 +32,8 @@ pub trait ScmActor {
     fn control_stop(&mut self) -> std::io::Result<()>;
     fn start(&mut self) -> std::io::Result<()>;
     /// Block in an alertable wait until the armed notification fires; return the
-    /// service's current terminal state read from the callback buffer. A
-    /// non-terminal (pending) state is reported as the opposite of the awaited
-    /// state so the caller re-arms and waits again.
-    fn wait_callback(&mut self) -> std::io::Result<WantState>;
+    /// service's observed state from the callback buffer.
+    fn wait_callback(&mut self) -> std::io::Result<Observed>;
 }
 
 /// Stop the service, gated strictly on a real STOPPED callback from
@@ -32,10 +43,11 @@ pub fn stop_via_notify<A: ScmActor>(a: &mut A) -> std::io::Result<()> {
     a.arm(WantState::Stopped)?;
     a.control_stop()?;
     loop {
-        if a.wait_callback()? == WantState::Stopped {
-            return Ok(());
+        match a.wait_callback()? {
+            Observed::Stopped => return Ok(()),
+            // Running/Pending are non-terminal for a stop wait — re-arm and wait.
+            Observed::Running | Observed::Pending => a.arm(WantState::Stopped)?,
         }
-        a.arm(WantState::Stopped)?; // re-arm after a non-terminal callback
     }
 }
 
@@ -48,10 +60,18 @@ pub fn start_via_notify<A: ScmActor>(a: &mut A) -> std::io::Result<()> {
     a.arm(WantState::Running)?;
     a.start()?;
     loop {
-        if a.wait_callback()? == WantState::Running {
-            return Ok(());
+        match a.wait_callback()? {
+            Observed::Running => return Ok(()),
+            // A terminal Stopped means the service stopped instead of reaching
+            // Running — a failed start. Give up (the cutover child then clears
+            // the marker + exits; Part A's restart re-drives a transient failure).
+            Observed::Stopped => {
+                return Err(std::io::Error::other(
+                    "service stopped before reaching Running (failed start)",
+                ))
+            }
+            Observed::Pending => a.arm(WantState::Running)?,
         }
-        a.arm(WantState::Running)?; // re-arm after a non-terminal callback
     }
 }
 
@@ -71,12 +91,13 @@ mod system {
     use windows::Win32::System::Services::{
         CloseServiceHandle, ControlService, NotifyServiceStatusChangeW, OpenSCManagerW, OpenServiceW, StartServiceW,
         SC_HANDLE, SC_MANAGER_CONNECT, SERVICE_CONTROL_STOP, SERVICE_NOTIFY, SERVICE_NOTIFY_2W, SERVICE_NOTIFY_RUNNING,
-        SERVICE_NOTIFY_STATUS_CHANGE, SERVICE_NOTIFY_STOPPED, SERVICE_QUERY_STATUS, SERVICE_RUNNING, SERVICE_START,
-        SERVICE_STATUS, SERVICE_STOP, SERVICE_STOPPED,
+        SERVICE_NOTIFY_START_PENDING, SERVICE_NOTIFY_STATUS_CHANGE, SERVICE_NOTIFY_STOPPED,
+        SERVICE_NOTIFY_STOP_PENDING, SERVICE_QUERY_STATUS, SERVICE_RUNNING, SERVICE_START, SERVICE_STATUS,
+        SERVICE_STOP, SERVICE_STOPPED,
     };
     use windows::Win32::System::Threading::SleepEx;
 
-    use super::WantState;
+    use super::{Observed, WantState};
 
     /// Receives the callback-reported current state across the `SleepEx` wait.
     /// Heap-pinned (its address is handed to the SCM as `pContext`). Atomics:
@@ -109,10 +130,24 @@ mod system {
         }
     }
 
-    fn want_to_mask(want: WantState) -> SERVICE_NOTIFY {
+    /// The `NotifyServiceStatusChangeW` mask for `want`, given whether `start()`
+    /// has already been issued (`started`).
+    ///
+    /// For a start wait the STOPPED bit is included ONLY after `start()`: the
+    /// service is `Stopped` at the initial arm (the cutover ran
+    /// `stop_service_wait_stopped` first), and `NotifyServiceStatusChangeW`
+    /// immediate-fires on the current state — so arming STOPPED before `start()`
+    /// would misclassify that pre-start `Stopped` as a failed start. After
+    /// `start()` the service has entered `StartPending`, so a later
+    /// `StartPending -> Stopped` (or an already-`Stopped` immediate-fire) delivers
+    /// a real `Stopped` callback that terminates the wait with `Err`.
+    fn want_to_mask(want: WantState, started: bool) -> SERVICE_NOTIFY {
         match want {
-            WantState::Stopped => SERVICE_NOTIFY_STOPPED,
-            WantState::Running => SERVICE_NOTIFY_RUNNING,
+            WantState::Stopped => SERVICE_NOTIFY_STOPPED | SERVICE_NOTIFY_STOP_PENDING,
+            WantState::Running if started => {
+                SERVICE_NOTIFY_RUNNING | SERVICE_NOTIFY_STOPPED | SERVICE_NOTIFY_START_PENDING
+            }
+            WantState::Running => SERVICE_NOTIFY_RUNNING | SERVICE_NOTIFY_START_PENDING,
         }
     }
 
@@ -125,9 +160,11 @@ mod system {
         service_name: Vec<u16>,
         status: Box<LastStatus>,
         notify: Box<SERVICE_NOTIFY_2W>,
-        /// The state most recently awaited, so a pending callback can be mapped
-        /// to "not yet there" (the opposite variant) for a re-arm.
+        /// The state most recently awaited (for the debug trace).
         awaiting: WantState,
+        /// Whether `start()` has been issued. Gates the two-phase arm: the STOPPED
+        /// notify bit is added only after start (see `want_to_mask`).
+        started: bool,
     }
 
     impl SystemScmActor {
@@ -159,6 +196,7 @@ mod system {
                 }),
                 notify: Box::new(SERVICE_NOTIFY_2W::default()),
                 awaiting: WantState::Stopped,
+                started: false,
             })
         }
 
@@ -204,8 +242,9 @@ mod system {
                 pContext: (&mut *self.status as *mut LastStatus) as *mut c_void,
                 ..Default::default()
             };
+            let mask = want_to_mask(want, self.started);
             loop {
-                let rc = unsafe { NotifyServiceStatusChangeW(self.service, want_to_mask(want), &*self.notify) };
+                let rc = unsafe { NotifyServiceStatusChangeW(self.service, mask, &*self.notify) };
                 if rc == 0 {
                     return Ok(());
                 }
@@ -230,10 +269,14 @@ mod system {
         }
 
         fn start(&mut self) -> io::Result<()> {
-            unsafe { StartServiceW(self.service, None) }.map_err(io::Error::other)
+            let r = unsafe { StartServiceW(self.service, None) }.map_err(io::Error::other);
+            // Mark started even if StartServiceW errored: the two-phase arm keys on
+            // "start was attempted", and the caller propagates the error anyway.
+            self.started = true;
+            r
         }
 
-        fn wait_callback(&mut self) -> io::Result<WantState> {
+        fn wait_callback(&mut self) -> io::Result<Observed> {
             // Alertable wait: blocks until the SCM delivers the notify APC, which
             // runs `notify_callback` and sets `status.fired`. A spurious early
             // wake (an unrelated APC) re-enters the wait.
@@ -244,17 +287,14 @@ mod system {
             // Trace here, NOT in `notify_callback`: that runs in an APC where any
             // allocation/lock (which `tracing` may take) is a hazard.
             tracing::debug!(scm_current_state = state, awaiting = ?self.awaiting, "SCM status callback fired");
-            if state == SERVICE_RUNNING.0 {
-                return Ok(WantState::Running);
-            }
-            if state == SERVICE_STOPPED.0 {
-                return Ok(WantState::Stopped);
-            }
-            // Pending/intermediate: report "not yet at the awaited state" so the
-            // caller re-arms and waits for the real transition.
-            Ok(match self.awaiting {
-                WantState::Stopped => WantState::Running,
-                WantState::Running => WantState::Stopped,
+            // Map the raw SCM state to an observation. RUNNING/STOPPED are terminal;
+            // everything else (START_PENDING/STOP_PENDING/…) is Pending → re-arm.
+            Ok(if state == SERVICE_RUNNING.0 {
+                Observed::Running
+            } else if state == SERVICE_STOPPED.0 {
+                Observed::Stopped
+            } else {
+                Observed::Pending
             })
         }
     }

--- a/crates/bridge/src/cutover/scm_wait_tests.rs
+++ b/crates/bridge/src/cutover/scm_wait_tests.rs
@@ -1,17 +1,34 @@
 use super::*;
 use std::cell::RefCell;
 
-/// Records the granular SCM steps in call order and replays a scripted state for
-/// each `wait_callback`. The script asserts the pure ordering of
+/// Records the granular SCM steps in call order and replays a scripted `Observed`
+/// for each `wait_callback`. The script asserts the pure ordering of
 /// `stop_via_notify` / `start_via_notify` without touching the real SCM.
 struct FakeScm<'a> {
     log: &'a RefCell<Vec<&'static str>>,
-    /// States the next `wait_callback` calls return, front to back.
-    waits: std::collections::VecDeque<WantState>,
+    /// `Observed`s the next `wait_callback` calls return, front to back.
+    waits: std::collections::VecDeque<Observed>,
+    /// Total `arm` calls, so the two-phase-arm re-arm behavior is checkable.
+    arms: usize,
+}
+
+impl<'a> FakeScm<'a> {
+    fn new(log: &'a RefCell<Vec<&'static str>>, waits: std::collections::VecDeque<Observed>) -> Self {
+        Self { log, waits, arms: 0 }
+    }
+
+    /// A scripted actor with no call log, for the terminal-state assertions.
+    fn scripted(waits: Vec<Observed>) -> ScriptedScm {
+        ScriptedScm {
+            waits: waits.into(),
+            arms: 0,
+        }
+    }
 }
 
 impl ScmActor for FakeScm<'_> {
     fn arm(&mut self, want: WantState) -> std::io::Result<()> {
+        self.arms += 1;
         self.log.borrow_mut().push(match want {
             WantState::Stopped => "arm_stopped",
             WantState::Running => "arm_running",
@@ -26,24 +43,51 @@ impl ScmActor for FakeScm<'_> {
         self.log.borrow_mut().push("start");
         Ok(())
     }
-    fn wait_callback(&mut self) -> std::io::Result<WantState> {
+    fn wait_callback(&mut self) -> std::io::Result<Observed> {
         self.log.borrow_mut().push("wait");
         let state = self.waits.pop_front().expect("script ran dry");
         self.log.borrow_mut().push(match state {
-            WantState::Stopped => "got_stopped",
-            WantState::Running => "got_running",
+            Observed::Stopped => "got_stopped",
+            Observed::Running => "got_running",
+            Observed::Pending => "got_pending",
         });
         Ok(state)
+    }
+}
+
+/// A minimal scripted actor (no call log) that counts `arm`s — for the
+/// terminal-state and re-arm-count assertions.
+struct ScriptedScm {
+    waits: std::collections::VecDeque<Observed>,
+    arms: usize,
+}
+
+impl ScriptedScm {
+    fn arm_count(&self) -> usize {
+        self.arms
+    }
+}
+
+impl ScmActor for ScriptedScm {
+    fn arm(&mut self, _want: WantState) -> std::io::Result<()> {
+        self.arms += 1;
+        Ok(())
+    }
+    fn control_stop(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+    fn start(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+    fn wait_callback(&mut self) -> std::io::Result<Observed> {
+        Ok(self.waits.pop_front().expect("script ran dry"))
     }
 }
 
 #[skuld::test]
 fn stop_via_notify_arms_stopped_then_gates_on_stopped() {
     let log: RefCell<Vec<&'static str>> = RefCell::new(vec![]);
-    let mut fake = FakeScm {
-        log: &log,
-        waits: [WantState::Stopped].into(),
-    };
+    let mut fake = FakeScm::new(&log, [Observed::Stopped].into());
     stop_via_notify(&mut fake).unwrap();
     assert_eq!(
         *log.borrow(),
@@ -54,12 +98,9 @@ fn stop_via_notify_arms_stopped_then_gates_on_stopped() {
 #[skuld::test]
 fn stop_re_arms_after_a_non_terminal_callback() {
     let log: RefCell<Vec<&'static str>> = RefCell::new(vec![]);
-    let mut fake = FakeScm {
-        log: &log,
-        // A spurious RUNNING fires while waiting for STOPPED, then STOPPED; the
-        // non-terminal callback must trigger a re-arm.
-        waits: [WantState::Running, WantState::Stopped].into(),
-    };
+    // A pending (intermediate) callback fires while waiting for STOPPED, then
+    // STOPPED; the non-terminal callback must trigger a re-arm.
+    let mut fake = FakeScm::new(&log, [Observed::Pending, Observed::Stopped].into());
     stop_via_notify(&mut fake).unwrap();
     assert_eq!(
         *log.borrow(),
@@ -67,7 +108,7 @@ fn stop_re_arms_after_a_non_terminal_callback() {
             "arm_stopped",
             "control_stop",
             "wait",
-            "got_running",
+            "got_pending",
             "arm_stopped", // re-arm: still waiting for STOPPED
             "wait",
             "got_stopped",
@@ -78,10 +119,7 @@ fn stop_re_arms_after_a_non_terminal_callback() {
 #[skuld::test]
 fn start_via_notify_arms_running_before_start_then_gates_on_running() {
     let log: RefCell<Vec<&'static str>> = RefCell::new(vec![]);
-    let mut fake = FakeScm {
-        log: &log,
-        waits: [WantState::Running].into(),
-    };
+    let mut fake = FakeScm::new(&log, [Observed::Running].into());
     start_via_notify(&mut fake).unwrap();
     // The critical ordering: arm RUNNING strictly BEFORE start, else a RUNNING
     // reached before the arm fires only on the NEXT entry — a hang.
@@ -91,12 +129,9 @@ fn start_via_notify_arms_running_before_start_then_gates_on_running() {
 #[skuld::test]
 fn start_re_arms_after_a_non_terminal_callback() {
     let log: RefCell<Vec<&'static str>> = RefCell::new(vec![]);
-    let mut fake = FakeScm {
-        log: &log,
-        // A spurious STOPPED fires while waiting for RUNNING, then RUNNING; the
-        // non-terminal callback must trigger a re-arm.
-        waits: [WantState::Stopped, WantState::Running].into(),
-    };
+    // A StartPending/StopPending intermediate (Pending) fires while waiting for
+    // RUNNING, then RUNNING; the non-terminal callback must trigger a re-arm.
+    let mut fake = FakeScm::new(&log, [Observed::Pending, Observed::Running].into());
     start_via_notify(&mut fake).unwrap();
     assert_eq!(
         *log.borrow(),
@@ -104,10 +139,30 @@ fn start_re_arms_after_a_non_terminal_callback() {
             "arm_running",
             "start",
             "wait",
-            "got_stopped",
+            "got_pending",
             "arm_running", // re-arm: still waiting for RUNNING
             "wait",
             "got_running",
         ]
     );
+}
+
+#[skuld::test]
+fn start_via_notify_errs_when_service_stops_instead_of_running() {
+    let mut fake = FakeScm::scripted(vec![Observed::Pending, Observed::Stopped]);
+    assert!(start_via_notify(&mut fake).is_err());
+}
+
+#[skuld::test]
+fn start_via_notify_ok_when_service_runs() {
+    let mut fake = FakeScm::scripted(vec![Observed::Pending, Observed::Running]);
+    assert!(start_via_notify(&mut fake).is_ok());
+}
+
+#[skuld::test]
+fn start_via_notify_rearms_on_pending_not_errs() {
+    // A StartPending/StopPending intermediate (Pending) must RE-ARM, not fail.
+    let mut fake = FakeScm::scripted(vec![Observed::Pending, Observed::Pending, Observed::Running]);
+    assert!(start_via_notify(&mut fake).is_ok());
+    assert_eq!(fake.arm_count(), 3); // initial + 2 re-arms
 }

--- a/crates/bridge/src/cutover_tests.rs
+++ b/crates/bridge/src/cutover_tests.rs
@@ -49,6 +49,25 @@ fn unlock_successful_disengage_flips_intent_off() {
 
 #[cfg(target_os = "windows")]
 #[skuld::test]
+fn clear_marker_on_failure_clears_only_on_err() {
+    let dir = tempfile::tempdir().unwrap();
+    let m = hole_common::update_marker::MarkerInfo {
+        version: hole_common::update_marker::MARKER_VERSION,
+        from_version: "0.2.0".into(),
+        to_version: "0.3.0".into(),
+        driver_pid: 1,
+        started_at_unix: 0,
+        driver_start_unix_ms: 0,
+    };
+    hole_common::update_marker::write(dir.path(), &m, None).unwrap();
+    clear_marker_on_cutover_failure(&Ok(()), dir.path());
+    assert!(hole_common::update_marker::read(dir.path()).is_some());
+    clear_marker_on_cutover_failure(&Err(std::io::Error::other("boom")), dir.path());
+    assert!(hole_common::update_marker::read(dir.path()).is_none());
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
 fn find_staged_exe_locates_hole_exe_in_nested_tree() {
     // An MSI admin-install lays the exe into a versioned subtree, so the finder
     // must recurse, not look at a fixed depth.

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -61,8 +61,9 @@ fn post_bind_sweep_clears_marker() {
         version: hole_common::update_marker::MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: "0.3.0".into(),
-        pid: 1,
+        driver_pid: 1,
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     };
     let dir = tempfile::tempdir().unwrap();
     hole_common::update_marker::write(dir.path(), &marker, None).unwrap();

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -1132,8 +1132,8 @@ fn apply_socket_permissions(path: &Path) {
     }
 }
 
-/// Build the cutover marker. Extracted so the driver-identity field mapping —
-/// the anchor of Part B's liveness net — is unit-testable.
+/// Build the cutover marker; extracted so the driver-identity field mapping is
+/// unit-testable.
 fn build_cutover_marker(
     from_version: String,
     to_version: String,

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -547,7 +547,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
     let private_dir = match crate::cutover::extract::private_payload_dir(&state.state_dir) {
         Ok(d) => d,
         Err(e) => {
-            let _ = hole_common::update_marker::clear(log_dir);
+            if let Err(e) = hole_common::update_marker::clear(log_dir) {
+                tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+            }
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
@@ -576,7 +578,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
     let payload = match staged_copy {
         Ok(Ok(copy)) => copy,
         Ok(Err(StageError::Verify(e))) => {
-            let _ = hole_common::update_marker::clear(log_dir);
+            if let Err(e) = hole_common::update_marker::clear(log_dir) {
+                tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+            }
             let _ = std::fs::remove_dir_all(&private_dir);
             return Err((
                 StatusCode::UNPROCESSABLE_ENTITY,
@@ -586,7 +590,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
             ));
         }
         Ok(Err(StageError::Io(e))) => {
-            let _ = hole_common::update_marker::clear(log_dir);
+            if let Err(e) = hole_common::update_marker::clear(log_dir) {
+                tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+            }
             let _ = std::fs::remove_dir_all(&private_dir);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -596,7 +602,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
             ));
         }
         Err(e) => {
-            let _ = hole_common::update_marker::clear(log_dir);
+            if let Err(e) = hole_common::update_marker::clear(log_dir) {
+                tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+            }
             let _ = std::fs::remove_dir_all(&private_dir);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -616,7 +624,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
     let staged = match extracted {
         Ok(Ok(s)) => s,
         Ok(Err(e)) => {
-            let _ = hole_common::update_marker::clear(log_dir);
+            if let Err(e) = hole_common::update_marker::clear(log_dir) {
+                tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+            }
             let _ = std::fs::remove_dir_all(&private_dir);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -626,7 +636,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
             ));
         }
         Err(e) => {
-            let _ = hole_common::update_marker::clear(log_dir);
+            if let Err(e) = hole_common::update_marker::clear(log_dir) {
+                tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+            }
             let _ = std::fs::remove_dir_all(&private_dir);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -641,7 +653,9 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
     // a detached child (returns naturally); macOS runs the actor on a detached
     // task that SIGTERMs THIS process only after this 200 is on the wire.
     if let Err(e) = crate::cutover::apply::spawn_actor(staged, &req.target_version, app_dest.as_deref(), log_dir) {
-        let _ = hole_common::update_marker::clear(log_dir);
+        if let Err(e) = hole_common::update_marker::clear(log_dir) {
+            tracing::warn!(error = %e, "failed to clear cutover marker on error path");
+        }
         let _ = std::fs::remove_dir_all(&private_dir);
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -502,16 +502,28 @@ async fn handle_update_apply<P: Proxy + 'static, R: Routing + 'static>(
     // dir — otherwise its `stage_payload` (which clears+rewrites the fixed dir)
     // could clobber the winner's already-verified copy mid-extract, reopening the
     // verify/use TOCTOU via a privileged write on the loser's behalf.
-    let marker = hole_common::update_marker::MarkerInfo {
-        version: hole_common::update_marker::MARKER_VERSION,
-        from_version: state.version.clone(),
-        to_version: req.target_version.clone(),
-        pid: std::process::id(),
-        started_at_unix: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs(),
-    };
+    let self_pid = std::process::id();
+    // A None self-probe is a contract-level surprise (a process can always read
+    // its own creation time), so warn; the stored 0 is treated downstream as an
+    // unassessed identity, never confirmed-dead.
+    let driver_start_unix_ms = hole_common::process::process_start_time(self_pid).unwrap_or_else(|| {
+        tracing::warn!(
+            pid = self_pid,
+            "could not read own process start time for the cutover marker"
+        );
+        0
+    });
+    let started_at_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let marker = build_cutover_marker(
+        state.version.clone(),
+        req.target_version.clone(),
+        self_pid,
+        started_at_unix,
+        driver_start_unix_ms,
+    );
     if let Err(e) = hole_common::update_marker::write_new(log_dir, &marker, state.owner) {
         let (code, message) = if e.kind() == std::io::ErrorKind::AlreadyExists {
             (StatusCode::CONFLICT, "a cutover is already in progress".to_string())
@@ -1103,6 +1115,25 @@ fn apply_socket_permissions(path: &Path) {
         if libc::chmod(c_path.as_ptr(), 0o660) != 0 {
             warn!("chmod failed, socket may have incorrect permissions");
         }
+    }
+}
+
+/// Build the cutover marker. Extracted so the driver-identity field mapping —
+/// the anchor of Part B's liveness net — is unit-testable.
+fn build_cutover_marker(
+    from_version: String,
+    to_version: String,
+    self_pid: u32,
+    started_at_unix: u64,
+    driver_start_unix_ms: u64,
+) -> hole_common::update_marker::MarkerInfo {
+    hole_common::update_marker::MarkerInfo {
+        version: hole_common::update_marker::MARKER_VERSION,
+        from_version,
+        to_version,
+        driver_pid: self_pid,
+        started_at_unix,
+        driver_start_unix_ms,
     }
 }
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -714,8 +714,9 @@ fn update_apply_with_existing_marker_is_409() {
                 version: hole_common::update_marker::MARKER_VERSION,
                 from_version: "0.2.0".into(),
                 to_version: "0.3.0".into(),
-                pid: 1,
+                driver_pid: 1,
                 started_at_unix: 0,
+                driver_start_unix_ms: 0,
             },
             None,
         )
@@ -1987,4 +1988,20 @@ fn socket_removed_on_drop() {
         drop(server);
         assert!(!path.exists(), "socket file should be removed after drop");
     });
+}
+
+#[skuld::test]
+fn build_cutover_marker_maps_driver_identity() {
+    let m = super::build_cutover_marker("0.2.0".into(), "0.3.0".into(), 4242, 1_700_000_000, 1_700_000_000_123);
+    assert_eq!(
+        (m.driver_pid, m.driver_start_unix_ms, m.version),
+        (4242, 1_700_000_000_123, hole_common::update_marker::MARKER_VERSION)
+    );
+    assert_eq!((m.from_version.as_str(), m.to_version.as_str()), ("0.2.0", "0.3.0"));
+}
+
+#[skuld::test]
+fn own_process_start_time_is_nonzero() {
+    // The fallback-to-0 poison sentinel must not be hit for a live self-probe.
+    assert_ne!(hole_common::process::process_start_time(std::process::id()), Some(0));
 }

--- a/crates/bridge/src/platform/macos.rs
+++ b/crates/bridge/src/platform/macos.rs
@@ -337,8 +337,9 @@ fn test_marker() -> hole_common::update_marker::MarkerInfo {
         version: hole_common::update_marker::MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: "0.3.0".into(),
-        pid: 1,
+        driver_pid: 1,
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     }
 }
 

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -4,7 +4,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use windows_service::service::{
     ServiceAccess, ServiceAction, ServiceActionType, ServiceControl, ServiceControlAccept, ServiceErrorControl,
     ServiceExitCode, ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType, ServiceState,
@@ -403,8 +403,13 @@ pub fn install(binary_path: &Path) -> Result<(), windows_service::Error> {
     let service = manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG | ServiceAccess::START)?;
 
     service.set_description(SERVICE_DESCRIPTION)?;
-    drop(service);
-    ensure_failure_actions()?;
+    // Auto-restart is hardening, applied on the just-created handle (no re-open,
+    // which can race SCM propagation right after create_service). Best-effort: the
+    // service is installed regardless — failing the whole install (an MSI custom
+    // action) over the restart config would be worse than shipping without it.
+    if let Err(e) = apply_failure_actions(&service) {
+        warn!(error = %e, "could not configure SCM restart-on-failure; service installed without auto-restart");
+    }
     info!("Windows service installed");
     Ok(())
 }
@@ -424,19 +429,23 @@ fn restart_failure_actions() -> ServiceFailureActions {
     }
 }
 
-/// Apply the restart-on-failure SCM config to the installed `HoleBridge` service:
-/// the `Restart` action plus the non-crash-failures flag (so a graceful
-/// `Stopped(1)` from a failed bind is restarted too, while a clean `Stopped(0)`
-/// user/cutover stop is not). Idempotent — a re-apply just re-writes the same
-/// config. Called by `install()` for a fresh install and by the cutover child so
-/// an install base predating this config is brought up to date as part of the
-/// update itself.
+/// Write the restart-on-failure SCM config to an open `HoleBridge` handle (needs
+/// `CHANGE_CONFIG`): the `Restart` action plus the non-crash-failures flag (so a
+/// graceful `Stopped(1)` from a failed bind is restarted too, while a clean
+/// `Stopped(0)` user/cutover stop is not).
+fn apply_failure_actions(service: &windows_service::service::Service) -> Result<(), windows_service::Error> {
+    service.update_failure_actions(restart_failure_actions())?;
+    service.set_failure_actions_on_non_crash_failures(true)
+}
+
+/// Open the installed `HoleBridge` service and apply the restart-on-failure
+/// config. Idempotent (a re-apply re-writes the same config). Called by the
+/// cutover child so an install base predating this config is brought up to date
+/// as part of the update itself.
 pub fn ensure_failure_actions() -> Result<(), windows_service::Error> {
     let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
     let service = manager.open_service(SERVICE_NAME, ServiceAccess::CHANGE_CONFIG)?;
-    service.update_failure_actions(restart_failure_actions())?;
-    service.set_failure_actions_on_non_crash_failures(true)?;
-    Ok(())
+    apply_failure_actions(&service)
 }
 
 /// Stop and uninstall the bridge Windows Service.

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -362,10 +362,14 @@ fn service_state_dir() -> PathBuf {
 ///
 /// The service is registered to run
 /// `<binary_path> bridge run --service --log-dir <log> --state-dir <state>`
-/// with auto-start, then `ensure_failure_actions` applies the restart-on-failure
-/// SCM config. An install base that predates that config picks it up on the next
-/// update instead (the cutover child re-applies it — see `cutover::run_detached`),
-/// so a bare `install()` is not the only path that provisions it.
+/// with auto-start, then `apply_failure_actions` writes the restart-on-failure
+/// SCM config directly on the just-created handle — best-effort (warn-and-continue),
+/// since a SCM hiccup must not fail the install itself. This deliberately avoids
+/// `ensure_failure_actions` (which re-opens the service and propagates errors);
+/// that stricter re-open path is reserved for the cutover child's post-update
+/// refresh (see `cutover::run_detached`), which also brings an install base that
+/// predates this config up to date — so a bare `install()` is not the only path
+/// that provisions it.
 pub fn install(binary_path: &Path) -> Result<(), windows_service::Error> {
     let manager = ServiceManager::local_computer(
         None::<&str>,

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -132,11 +132,7 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
             state_dir.clone(),
             None,
         )?;
-        // Socket is bound: sweep the cutover marker, then report SCM `Running`. The
-        // cutover child exits on the `Running` edge, so it exits only once the
-        // marker is gone — no "marker present + dead driver" window in a healthy
-        // update. If the sweep somehow fails, the start fails (SCM restarts + retries)
-        // rather than reporting Running with a stale marker.
+        // Socket is bound: sweep the marker, then report Running (see sweep_marker_then_ready).
         sweep_marker_then_ready(&log_dir, || {
             status_handle_ready
                 .set_service_status(ServiceStatus {
@@ -177,8 +173,6 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
         if let Err(e) = tokio::task::spawn_blocking(move || tombstone::sweep(&log_dir_sweep)).await {
             tracing::warn!(error = %e, "crash sweep task panicked");
         }
-        // The marker was already swept before the `Running` report above (so the
-        // cutover child exits only once it is gone). No second sweep needed here.
         // Sweep `hole.exe.old-*` left by a prior cutover swap's best-effort delete
         // (it fails while an old process still maps the renamed inode).
         if let Err(e) = tokio::task::spawn_blocking(sweep_old_binaries_in_install_dir).await {
@@ -274,16 +268,25 @@ pub(crate) fn sweep_marker(log_dir: &Path) {
 /// driver dead" — before this the child is alive (Mask), after it the marker is
 /// already swept (PassThrough).
 ///
-/// The `read().is_some()` re-check is defense-in-depth. A remove failure should
-/// never happen (Rust opens files with `FILE_SHARE_DELETE`), yet reporting
+/// The `read().is_some()` re-check guards the reachable case of an external
+/// process holding the marker open without `FILE_SHARE_DELETE`: reporting
 /// `Running` with a stale marker would false-fail the healthy update, so the start
-/// fails instead (SCM restarts and retries the sweep). That impossible branch is
-/// acceptance-observed, not unit-tested.
+/// fails instead (SCM restarts and retries the sweep).
 fn sweep_marker_then_ready<R: FnOnce() -> std::io::Result<()>>(
     log_dir: &Path,
     report_running: R,
 ) -> std::io::Result<()> {
-    sweep_marker(log_dir);
+    sweep_marker_then_ready_with(|| sweep_marker(log_dir), log_dir, report_running)
+}
+
+/// [`sweep_marker_then_ready`] with the sweep injected so the marker-survives-sweep
+/// branch is unit-testable (a no-op sweep leaves the marker present).
+fn sweep_marker_then_ready_with<S: FnOnce(), R: FnOnce() -> std::io::Result<()>>(
+    sweep: S,
+    log_dir: &Path,
+    report_running: R,
+) -> std::io::Result<()> {
+    sweep();
     if hole_common::update_marker::read(log_dir).is_some() {
         return Err(std::io::Error::other(
             "cutover marker still present after sweep; refusing to report Running",
@@ -359,7 +362,10 @@ fn service_state_dir() -> PathBuf {
 ///
 /// The service is registered to run
 /// `<binary_path> bridge run --service --log-dir <log> --state-dir <state>`
-/// with auto-start.
+/// with auto-start, then `ensure_failure_actions` applies the restart-on-failure
+/// SCM config. An install base that predates that config picks it up on the next
+/// update instead (the cutover child re-applies it — see `cutover::run_detached`),
+/// so a bare `install()` is not the only path that provisions it.
 pub fn install(binary_path: &Path) -> Result<(), windows_service::Error> {
     let manager = ServiceManager::local_computer(
         None::<&str>,
@@ -397,12 +403,8 @@ pub fn install(binary_path: &Path) -> Result<(), windows_service::Error> {
     let service = manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG | ServiceAccess::START)?;
 
     service.set_description(SERVICE_DESCRIPTION)?;
-    service.update_failure_actions(restart_failure_actions())?;
-    // Also restart on a graceful Stopped with a NON-ZERO exit — run_service reports
-    // Stopped(1) on any bind/runtime failure, which SCM would otherwise NOT treat
-    // as a failure. This covers the failed-start wedge (a swapped-in bridge that
-    // fails to bind). A clean Stopped(0) (user stop / cutover stop) is not restarted.
-    service.set_failure_actions_on_non_crash_failures(true)?;
+    drop(service);
+    ensure_failure_actions()?;
     info!("Windows service installed");
     Ok(())
 }
@@ -420,6 +422,21 @@ fn restart_failure_actions() -> ServiceFailureActions {
             delay: std::time::Duration::from_secs(1),
         }]),
     }
+}
+
+/// Apply the restart-on-failure SCM config to the installed `HoleBridge` service:
+/// the `Restart` action plus the non-crash-failures flag (so a graceful
+/// `Stopped(1)` from a failed bind is restarted too, while a clean `Stopped(0)`
+/// user/cutover stop is not). Idempotent — a re-apply just re-writes the same
+/// config. Called by `install()` for a fresh install and by the cutover child so
+/// an install base predating this config is brought up to date as part of the
+/// update itself.
+pub fn ensure_failure_actions() -> Result<(), windows_service::Error> {
+    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+    let service = manager.open_service(SERVICE_NAME, ServiceAccess::CHANGE_CONFIG)?;
+    service.update_failure_actions(restart_failure_actions())?;
+    service.set_failure_actions_on_non_crash_failures(true)?;
+    Ok(())
 }
 
 /// Stop and uninstall the bridge Windows Service.

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -76,22 +76,28 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
 
     let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)?;
 
-    // Report running
+    // Report StartPending, NOT Running: the cutover child exits on the SCM
+    // `Running` edge, so `Running` is deferred until after the socket binds AND
+    // the marker is swept (`sweep_marker_then_ready`) — so a healthy update never
+    // presents "marker present + dead driver". No controls accepted while starting.
     status_handle.set_service_status(ServiceStatus {
         service_type: ServiceType::OWN_PROCESS,
-        current_state: ServiceState::Running,
-        controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
+        current_state: ServiceState::StartPending,
+        controls_accepted: ServiceControlAccept::empty(),
         exit_code: ServiceExitCode::Win32(0),
         checkpoint: 0,
-        wait_hint: Duration::ZERO,
+        wait_hint: Duration::from_secs(30),
         process_id: None,
     })?;
 
-    info!("Windows service started");
+    info!("Windows service starting");
 
     // Build and run the tokio runtime
     let rt = tokio::runtime::Runtime::new()?;
-    let run_result: Result<(), Box<dyn std::error::Error>> = rt.block_on(async {
+    // `ServiceStatusHandle` is Copy (a raw SCM handle wrapper); capture it for the
+    // deferred `Running` report inside the async block.
+    let status_handle_ready = status_handle;
+    let run_result: Result<(), Box<dyn std::error::Error>> = rt.block_on(async move {
         let state_dir = STATE_DIR_OVERRIDE
             .get()
             .cloned()
@@ -126,6 +132,25 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
             state_dir.clone(),
             None,
         )?;
+        // Socket is bound: sweep the cutover marker, then report SCM `Running`. The
+        // cutover child exits on the `Running` edge, so it exits only once the
+        // marker is gone — no "marker present + dead driver" window in a healthy
+        // update. If the sweep somehow fails, the start fails (SCM restarts + retries)
+        // rather than reporting Running with a stale marker.
+        sweep_marker_then_ready(&log_dir, || {
+            status_handle_ready
+                .set_service_status(ServiceStatus {
+                    service_type: ServiceType::OWN_PROCESS,
+                    current_state: ServiceState::Running,
+                    controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
+                    exit_code: ServiceExitCode::Win32(0),
+                    checkpoint: 0,
+                    wait_hint: Duration::ZERO,
+                    process_id: None,
+                })
+                .map_err(std::io::Error::other)
+        })?;
+        info!("Windows service started");
         // DNS recovery runs first; see crate::dns::recovery docs for ordering.
         let state_dir_for_dns = state_dir.clone();
         if let Err(e) =
@@ -152,12 +177,8 @@ fn run_service() -> Result<(), Box<dyn std::error::Error>> {
         if let Err(e) = tokio::task::spawn_blocking(move || tombstone::sweep(&log_dir_sweep)).await {
             tracing::warn!(error = %e, "crash sweep task panicked");
         }
-        // The new bridge is authoritative once it has bound: any update marker is
-        // a completed cutover, so clear it unconditionally (remove-by-path).
-        let log_dir_marker = log_dir.clone();
-        if let Err(e) = tokio::task::spawn_blocking(move || sweep_marker(&log_dir_marker)).await {
-            tracing::warn!(error = %e, "marker sweep task panicked");
-        }
+        // The marker was already swept before the `Running` report above (so the
+        // cutover child exits only once it is gone). No second sweep needed here.
         // Sweep `hole.exe.old-*` left by a prior cutover swap's best-effort delete
         // (it fails while an old process still maps the renamed inode).
         if let Err(e) = tokio::task::spawn_blocking(sweep_old_binaries_in_install_dir).await {
@@ -245,6 +266,30 @@ pub(crate) fn sweep_marker(log_dir: &Path) {
     if let Err(e) = hole_common::update_marker::clear(log_dir) {
         tracing::warn!(error = %e, "failed to clear update-in-progress marker");
     }
+}
+
+/// Sweep the completed cutover's marker, verify it is gone, THEN report `Running`
+/// so the cutover child (which exits on the `Running` edge) exits only after the
+/// marker is gone. A healthy update therefore never presents "marker present plus
+/// driver dead" — before this the child is alive (Mask), after it the marker is
+/// already swept (PassThrough).
+///
+/// The `read().is_some()` re-check is defense-in-depth. A remove failure should
+/// never happen (Rust opens files with `FILE_SHARE_DELETE`), yet reporting
+/// `Running` with a stale marker would false-fail the healthy update, so the start
+/// fails instead (SCM restarts and retries the sweep). That impossible branch is
+/// acceptance-observed, not unit-tested.
+fn sweep_marker_then_ready<R: FnOnce() -> std::io::Result<()>>(
+    log_dir: &Path,
+    report_running: R,
+) -> std::io::Result<()> {
+    sweep_marker(log_dir);
+    if hole_common::update_marker::read(log_dir).is_some() {
+        return Err(std::io::Error::other(
+            "cutover marker still present after sweep; refusing to report Running",
+        ));
+    }
+    report_running()
 }
 
 /// Prefix of a rename-away leftover from a cutover swap (`<file>.old-<ver>`); see

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -6,8 +6,9 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::{error, info};
 use windows_service::service::{
-    ServiceAccess, ServiceControl, ServiceControlAccept, ServiceErrorControl, ServiceExitCode, ServiceInfo,
-    ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+    ServiceAccess, ServiceAction, ServiceActionType, ServiceControl, ServiceControlAccept, ServiceErrorControl,
+    ServiceExitCode, ServiceFailureActions, ServiceFailureResetPeriod, ServiceInfo, ServiceStartType, ServiceState,
+    ServiceStatus, ServiceType,
 };
 use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 use windows_service::service_dispatcher;
@@ -351,8 +352,29 @@ pub fn install(binary_path: &Path) -> Result<(), windows_service::Error> {
     let service = manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG | ServiceAccess::START)?;
 
     service.set_description(SERVICE_DESCRIPTION)?;
+    service.update_failure_actions(restart_failure_actions())?;
+    // Also restart on a graceful Stopped with a NON-ZERO exit — run_service reports
+    // Stopped(1) on any bind/runtime failure, which SCM would otherwise NOT treat
+    // as a failure. This covers the failed-start wedge (a swapped-in bridge that
+    // fails to bind). A clean Stopped(0) (user stop / cutover stop) is not restarted.
+    service.set_failure_actions_on_non_crash_failures(true)?;
     info!("Windows service installed");
     Ok(())
+}
+
+/// Restart-on-failure SCM actions. Fires on a crash / non-zero exit, not a
+/// graceful `Stopped(0)`. `reset_period` is finite so a run of crashes keeps
+/// restarting (the counter resets after a day without a failure).
+fn restart_failure_actions() -> ServiceFailureActions {
+    ServiceFailureActions {
+        reset_period: ServiceFailureResetPeriod::After(std::time::Duration::from_secs(86_400)),
+        reboot_msg: None,
+        command: None,
+        actions: Some(vec![ServiceAction {
+            action_type: ServiceActionType::Restart,
+            delay: std::time::Duration::from_secs(1),
+        }]),
+    }
 }
 
 /// Stop and uninstall the bridge Windows Service.

--- a/crates/bridge/src/platform/windows.rs
+++ b/crates/bridge/src/platform/windows.rs
@@ -427,8 +427,9 @@ fn test_marker() -> hole_common::update_marker::MarkerInfo {
         version: hole_common::update_marker::MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: "0.3.0".into(),
-        pid: 1,
+        driver_pid: 1,
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     }
 }
 

--- a/crates/bridge/src/platform/windows_tests.rs
+++ b/crates/bridge/src/platform/windows_tests.rs
@@ -32,6 +32,22 @@ fn post_bind_sweep_clears_marker() {
 }
 
 #[skuld::test]
+fn sweep_marker_then_ready_sweeps_before_reporting() {
+    let dir = tempfile::tempdir().unwrap();
+    hole_common::update_marker::write(dir.path(), &super::test_marker(), None).unwrap();
+    let marker_gone_when_reported = std::cell::Cell::new(false);
+    super::sweep_marker_then_ready(dir.path(), || {
+        marker_gone_when_reported.set(hole_common::update_marker::read(dir.path()).is_none());
+        Ok(())
+    })
+    .unwrap();
+    assert!(
+        marker_gone_when_reported.get(),
+        "the marker must be swept before Running is reported"
+    );
+}
+
+#[skuld::test]
 fn restart_failure_actions_configures_restart_on_failure() {
     use windows_service::service::{ServiceActionType, ServiceFailureResetPeriod};
     let fa = super::restart_failure_actions();

--- a/crates/bridge/src/platform/windows_tests.rs
+++ b/crates/bridge/src/platform/windows_tests.rs
@@ -48,6 +48,26 @@ fn sweep_marker_then_ready_sweeps_before_reporting() {
 }
 
 #[skuld::test]
+fn sweep_marker_then_ready_errs_when_marker_survives_sweep() {
+    // An external holder can leave the marker present after the sweep attempt.
+    // Inject a no-op sweep so the marker survives: the helper must return Err and
+    // NEVER report Running (which would false-fail a healthy update).
+    let dir = tempfile::tempdir().unwrap();
+    hole_common::update_marker::write(dir.path(), &super::test_marker(), None).unwrap();
+    let reported = std::cell::Cell::new(false);
+    let out = super::sweep_marker_then_ready_with(
+        || {}, // no-op sweep: the marker is NOT removed
+        dir.path(),
+        || {
+            reported.set(true);
+            Ok(())
+        },
+    );
+    assert!(out.is_err(), "a surviving marker must fail the start");
+    assert!(!reported.get(), "Running must never be reported with a stale marker");
+}
+
+#[skuld::test]
 fn restart_failure_actions_configures_restart_on_failure() {
     use windows_service::service::{ServiceActionType, ServiceFailureResetPeriod};
     let fa = super::restart_failure_actions();

--- a/crates/bridge/src/platform/windows_tests.rs
+++ b/crates/bridge/src/platform/windows_tests.rs
@@ -32,6 +32,19 @@ fn post_bind_sweep_clears_marker() {
 }
 
 #[skuld::test]
+fn restart_failure_actions_configures_restart_on_failure() {
+    use windows_service::service::{ServiceActionType, ServiceFailureResetPeriod};
+    let fa = super::restart_failure_actions();
+    assert!(fa
+        .actions
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .any(|a| a.action_type == ServiceActionType::Restart));
+    assert!(matches!(fa.reset_period, ServiceFailureResetPeriod::After(d) if !d.is_zero()));
+}
+
+#[skuld::test]
 fn sweep_old_binaries_removes_old_suffixed_and_spares_live() {
     let dir = tempfile::tempdir().unwrap();
     let old1 = dir.path().join("hole.exe.old-0.0.0");

--- a/crates/bridge/src/plugin_recovery.rs
+++ b/crates/bridge/src/plugin_recovery.rs
@@ -61,10 +61,8 @@ pub fn kill_pid(pid: u32) -> std::io::Result<()> {
 }
 
 /// Read the start time of a process as Unix milliseconds. Returns `None`
-/// if the process doesn't exist.
-pub fn process_start_time(pid: u32) -> Option<u64> {
-    platform::process_start_time_impl(pid)
-}
+/// if the process doesn't exist. Shared with the GUI via `hole_common::process`.
+pub use hole_common::process::process_start_time;
 
 #[cfg(target_os = "windows")]
 mod platform {
@@ -104,30 +102,6 @@ mod platform {
             }
         }
     }
-
-    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
-        use windows::Win32::Foundation::CloseHandle;
-        use windows::Win32::Foundation::FILETIME;
-        use windows::Win32::System::Threading::{GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-
-        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
-
-        let mut creation = FILETIME::default();
-        let mut exit = FILETIME::default();
-        let mut kernel = FILETIME::default();
-        let mut user = FILETIME::default();
-
-        let ok = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
-        let _ = unsafe { CloseHandle(handle) };
-        ok.ok()?;
-
-        // FILETIME is 100-nanosecond intervals since 1601-01-01.
-        // Convert to Unix ms: subtract the epoch diff, divide by 10_000.
-        let ft = ((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64;
-        const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
-        let unix_ms = ft.checked_sub(EPOCH_DIFF_100NS)? / 10_000;
-        Some(unix_ms)
-    }
 }
 
 #[cfg(target_os = "macos")]
@@ -147,29 +121,6 @@ mod platform {
             Err(err)
         }
     }
-
-    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
-        // Use proc_pidinfo(PROC_PIDTBSDINFO) to get process start time.
-        let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
-        let size = std::mem::size_of::<libc::proc_bsdinfo>() as i32;
-
-        let ret = unsafe {
-            libc::proc_pidinfo(
-                pid as i32,
-                libc::PROC_PIDTBSDINFO,
-                0,
-                &mut info as *mut _ as *mut libc::c_void,
-                size,
-            )
-        };
-
-        if ret <= 0 {
-            return None;
-        }
-
-        let ms = info.pbi_start_tvsec * 1000 + info.pbi_start_tvusec / 1000;
-        Some(ms)
-    }
 }
 
 #[cfg(target_os = "linux")]
@@ -188,31 +139,6 @@ mod platform {
         } else {
             Err(err)
         }
-    }
-
-    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
-        // Read /proc/<pid>/stat, field 22 (starttime in clock ticks since boot).
-        // Then read /proc/stat btime (boot time in seconds since epoch).
-        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-
-        // Field 22 is after the comm field (which can contain spaces and parens).
-        // Find the closing paren, then split the rest.
-        let after_comm = stat.rfind(')')?.checked_add(2)?;
-        let fields: Vec<&str> = stat[after_comm..].split_whitespace().collect();
-        // Field index 0 after comm = field 3 in stat; field 19 after comm = field 22 (starttime)
-        let starttime_ticks: u64 = fields.get(19)?.parse().ok()?;
-
-        let btime_line = std::fs::read_to_string("/proc/stat")
-            .ok()?
-            .lines()
-            .find(|l| l.starts_with("btime "))?
-            .to_string();
-        let btime_secs: u64 = btime_line.split_whitespace().nth(1)?.parse().ok()?;
-
-        let ticks_per_sec = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64;
-        let start_secs = btime_secs + starttime_ticks / ticks_per_sec;
-        let start_ms = start_secs * 1000 + (starttime_ticks % ticks_per_sec) * 1000 / ticks_per_sec;
-        Some(start_ms)
     }
 }
 

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod import;
 pub mod logging;
 pub mod paths;
 pub mod plugin;
+pub mod process;
 pub mod protocol;
 pub mod update_marker;
 pub mod verify;

--- a/crates/common/src/process.rs
+++ b/crates/common/src/process.rs
@@ -10,10 +10,13 @@ pub fn process_start_time(pid: u32) -> Option<u64> {
     platform::process_start_time_impl(pid)
 }
 
-/// Whether `pid` is a RUNNING process (not exited or a handle-retained zombie)
-/// whose creation time equals `expected_start_unix_ms`. Windows only; `false`
-/// elsewhere (Part B liveness is Windows-scoped).
-pub fn process_matches_and_alive(pid: u32, expected_start_unix_ms: u64) -> bool {
+/// Liveness of `pid` against a stamped creation time: `Some(true)` a running
+/// process (not exited or a handle-retained zombie) whose creation time equals
+/// `expected_start_unix_ms`; `Some(false)` a genuinely gone / reused / exited
+/// process; `None` unassessed (a transient/access-denied open failure — never
+/// treated as dead, which would false-wedge a healthy update). Windows only;
+/// `None` elsewhere.
+pub fn process_matches_and_alive(pid: u32, expected_start_unix_ms: u64) -> Option<bool> {
     platform::process_matches_and_alive_impl(pid, expected_start_unix_ms)
 }
 
@@ -37,8 +40,50 @@ mod platform {
     /// (grantable across privilege levels, so the unprivileged GUI can query the
     /// SYSTEM cutover child). `None` if the PID does not resolve.
     fn process_times(pid: u32) -> Option<(FILETIME, FILETIME)> {
-        // SAFETY: the handle is checked and closed below.
+        // SAFETY: the handle is checked and closed by `read_process_times`.
         let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+        read_process_times(handle)
+    }
+
+    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
+        let (creation, _exit) = process_times(pid)?;
+        filetime_to_unix_ms(creation)
+    }
+
+    pub fn process_matches_and_alive_impl(pid: u32, expected: u64) -> Option<bool> {
+        use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+        // SAFETY: the handle is checked and closed below (via `read_process_times`).
+        let handle = match unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) } {
+            Ok(h) => h,
+            Err(e) => {
+                // Disambiguate "no such process" (confirmed-dead) from a transient
+                // open failure (access-denied etc. → unassessed). Same codes as
+                // `plugin_recovery::kill_pid`: 87/E_INVALIDARG mean an invalid/absent PID.
+                let code = e.code().0 as u32;
+                return if code == 0x8007_0057 || code == 87 {
+                    Some(false) // genuinely gone/reused
+                } else {
+                    None // access-denied / transient → unassessed, NOT dead
+                };
+            }
+        };
+        let times = read_process_times(handle);
+        let Some((creation, exit)) = times else {
+            // The open succeeded but reading times failed — treat as unassessed.
+            return None;
+        };
+        // A RUNNING process has a zero exit FILETIME; an exited process (even one
+        // kept unreaped by an open handle) has a non-zero exit time. Unambiguous
+        // (no GetExitCodeProcess/STILL_ACTIVE-259 collision). Identity: the
+        // creation FILETIME must match the stamped value.
+        Some(zero(exit) && filetime_to_unix_ms(creation) == Some(expected))
+    }
+
+    /// `GetProcessTimes` on an already-open handle, closing it. Split from the
+    /// PID-open path so `process_matches_and_alive_impl` can disambiguate the
+    /// open failure itself.
+    fn read_process_times(handle: windows::Win32::Foundation::HANDLE) -> Option<(FILETIME, FILETIME)> {
         let (mut creation, mut exit, mut kernel, mut user) = (
             FILETIME::default(),
             FILETIME::default(),
@@ -49,22 +94,6 @@ mod platform {
         let _ = unsafe { CloseHandle(handle) };
         ok.ok()?;
         Some((creation, exit))
-    }
-
-    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
-        let (creation, _exit) = process_times(pid)?;
-        filetime_to_unix_ms(creation)
-    }
-
-    pub fn process_matches_and_alive_impl(pid: u32, expected: u64) -> bool {
-        let Some((creation, exit)) = process_times(pid) else {
-            return false; // reaped/absent → dead
-        };
-        // A RUNNING process has a zero exit FILETIME; an exited process (even one
-        // kept unreaped by an open handle) has a non-zero exit time. Unambiguous
-        // (no GetExitCodeProcess/STILL_ACTIVE-259 collision). Identity: the
-        // creation FILETIME must match the stamped value.
-        zero(exit) && filetime_to_unix_ms(creation) == Some(expected)
     }
 }
 
@@ -88,8 +117,8 @@ mod platform {
         Some(info.pbi_start_tvsec * 1000 + info.pbi_start_tvusec / 1000)
     }
 
-    pub fn process_matches_and_alive_impl(_pid: u32, _expected: u64) -> bool {
-        false // Part B liveness is Windows-only
+    pub fn process_matches_and_alive_impl(_pid: u32, _expected: u64) -> Option<bool> {
+        None
     }
 }
 
@@ -113,8 +142,8 @@ mod platform {
         Some(start_secs * 1000 + (starttime_ticks % ticks_per_sec) * 1000 / ticks_per_sec)
     }
 
-    pub fn process_matches_and_alive_impl(_pid: u32, _expected: u64) -> bool {
-        false
+    pub fn process_matches_and_alive_impl(_pid: u32, _expected: u64) -> Option<bool> {
+        None
     }
 }
 

--- a/crates/common/src/process.rs
+++ b/crates/common/src/process.rs
@@ -1,0 +1,123 @@
+//! Cross-platform process probes for the cutover marker driver identity: the
+//! privileged bridge stamps a child's start time into the marker and the GUI
+//! verifies it, so both share one impl (byte-identical values). `process_start_time`
+//! is the creation-time source; `process_matches_and_alive` adds the exit-state
+//! check the GUI's liveness needs (a terminated-but-unreaped process stays
+//! openable with its original creation time).
+
+/// Start time of a process as Unix milliseconds; `None` if it does not exist.
+pub fn process_start_time(pid: u32) -> Option<u64> {
+    platform::process_start_time_impl(pid)
+}
+
+/// Whether `pid` is a RUNNING process (not exited or a handle-retained zombie)
+/// whose creation time equals `expected_start_unix_ms`. Windows only; `false`
+/// elsewhere (Part B liveness is Windows-scoped).
+pub fn process_matches_and_alive(pid: u32, expected_start_unix_ms: u64) -> bool {
+    platform::process_matches_and_alive_impl(pid, expected_start_unix_ms)
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use windows::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows::Win32::System::Threading::{GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    /// FILETIME (100-ns intervals since 1601) → Unix milliseconds.
+    fn filetime_to_unix_ms(ft: FILETIME) -> Option<u64> {
+        let raw = ((ft.dwHighDateTime as u64) << 32) | ft.dwLowDateTime as u64;
+        const EPOCH_DIFF_100NS: u64 = 116_444_736_000_000_000;
+        Some(raw.checked_sub(EPOCH_DIFF_100NS)? / 10_000)
+    }
+
+    fn zero(ft: FILETIME) -> bool {
+        (ft.dwLowDateTime | ft.dwHighDateTime) == 0
+    }
+
+    /// Read a process's creation + exit FILETIMEs via `PROCESS_QUERY_LIMITED_INFORMATION`
+    /// (grantable across privilege levels, so the unprivileged GUI can query the
+    /// SYSTEM cutover child). `None` if the PID does not resolve.
+    fn process_times(pid: u32) -> Option<(FILETIME, FILETIME)> {
+        // SAFETY: the handle is checked and closed below.
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+        let (mut creation, mut exit, mut kernel, mut user) = (
+            FILETIME::default(),
+            FILETIME::default(),
+            FILETIME::default(),
+            FILETIME::default(),
+        );
+        let ok = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+        let _ = unsafe { CloseHandle(handle) };
+        ok.ok()?;
+        Some((creation, exit))
+    }
+
+    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
+        let (creation, _exit) = process_times(pid)?;
+        filetime_to_unix_ms(creation)
+    }
+
+    pub fn process_matches_and_alive_impl(pid: u32, expected: u64) -> bool {
+        let Some((creation, exit)) = process_times(pid) else {
+            return false; // reaped/absent → dead
+        };
+        // A RUNNING process has a zero exit FILETIME; an exited process (even one
+        // kept unreaped by an open handle) has a non-zero exit time. Unambiguous
+        // (no GetExitCodeProcess/STILL_ACTIVE-259 collision). Identity: the
+        // creation FILETIME must match the stamped value.
+        zero(exit) && filetime_to_unix_ms(creation) == Some(expected)
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
+        let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+        let size = std::mem::size_of::<libc::proc_bsdinfo>() as i32;
+        let ret = unsafe {
+            libc::proc_pidinfo(
+                pid as i32,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut libc::c_void,
+                size,
+            )
+        };
+        if ret <= 0 {
+            return None;
+        }
+        Some(info.pbi_start_tvsec * 1000 + info.pbi_start_tvusec / 1000)
+    }
+
+    pub fn process_matches_and_alive_impl(_pid: u32, _expected: u64) -> bool {
+        false // Part B liveness is Windows-only
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    pub fn process_start_time_impl(pid: u32) -> Option<u64> {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let after_comm = stat.rfind(')')?.checked_add(2)?;
+        let fields: Vec<&str> = stat[after_comm..].split_whitespace().collect();
+        let starttime_ticks: u64 = fields.get(19)?.parse().ok()?;
+        let btime_secs: u64 = std::fs::read_to_string("/proc/stat")
+            .ok()?
+            .lines()
+            .find(|l| l.starts_with("btime "))?
+            .split_whitespace()
+            .nth(1)?
+            .parse()
+            .ok()?;
+        let ticks_per_sec = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64;
+        let start_secs = btime_secs + starttime_ticks / ticks_per_sec;
+        Some(start_secs * 1000 + (starttime_ticks % ticks_per_sec) * 1000 / ticks_per_sec)
+    }
+
+    pub fn process_matches_and_alive_impl(_pid: u32, _expected: u64) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+#[path = "process_tests.rs"]
+mod process_tests;

--- a/crates/common/src/process_tests.rs
+++ b/crates/common/src/process_tests.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[skuld::test]
+fn own_process_has_a_start_time() {
+    assert!(process_start_time(std::process::id()).is_some());
+}
+
+#[skuld::test]
+fn absent_pid_has_no_start_time() {
+    // PID 0 is never a real process (Windows reserves it; Unix uses it for the group).
+    assert_eq!(process_start_time(0), None);
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn live_process_matches_and_alive() {
+    let me = std::process::id();
+    let start = process_start_time(me).unwrap();
+    assert!(process_matches_and_alive(me, start));
+    assert!(!process_matches_and_alive(me, start + 1)); // PID-reuse guard
+    assert!(!process_matches_and_alive(0, 0));
+}
+
+// A terminated child whose handle is still open (zombie) reads as NOT alive —
+// for exit code 0 AND a non-zero exit (the exit-FILETIME check is code-agnostic).
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn zombie_process_is_not_alive() {
+    for args in [["/c", "exit"].as_slice(), ["/c", "exit 5"].as_slice()] {
+        let mut child = std::process::Command::new("cmd").args(args).spawn().unwrap();
+        let pid = child.id();
+        let start = process_start_time(pid).unwrap();
+        child.wait().unwrap(); // dead; `child` (handle) kept in scope → unreaped zombie
+        assert!(
+            !process_matches_and_alive(pid, start),
+            "an exited-but-unreaped process must read as dead"
+        );
+        drop(child);
+    }
+}

--- a/crates/common/src/process_tests.rs
+++ b/crates/common/src/process_tests.rs
@@ -16,13 +16,13 @@ fn absent_pid_has_no_start_time() {
 fn live_process_matches_and_alive() {
     let me = std::process::id();
     let start = process_start_time(me).unwrap();
-    assert!(process_matches_and_alive(me, start));
-    assert!(!process_matches_and_alive(me, start + 1)); // PID-reuse guard
-    assert!(!process_matches_and_alive(0, 0));
+    assert_eq!(process_matches_and_alive(me, start), Some(true));
+    assert_eq!(process_matches_and_alive(me, start + 1), Some(false)); // PID-reuse guard
+    assert_eq!(process_matches_and_alive(0, 0), Some(false)); // no such process
 }
 
-// A terminated child whose handle is still open (zombie) reads as NOT alive —
-// for exit code 0 AND a non-zero exit (the exit-FILETIME check is code-agnostic).
+// A terminated child whose handle is still open (zombie) reads as confirmed-dead
+// — for exit code 0 AND a non-zero exit (the exit-FILETIME check is code-agnostic).
 #[cfg(target_os = "windows")]
 #[skuld::test]
 fn zombie_process_is_not_alive() {
@@ -31,9 +31,10 @@ fn zombie_process_is_not_alive() {
         let pid = child.id();
         let start = process_start_time(pid).unwrap();
         child.wait().unwrap(); // dead; `child` (handle) kept in scope → unreaped zombie
-        assert!(
-            !process_matches_and_alive(pid, start),
-            "an exited-but-unreaped process must read as dead"
+        assert_eq!(
+            process_matches_and_alive(pid, start),
+            Some(false),
+            "an exited-but-unreaped process must read as confirmed-dead"
         );
         drop(child);
     }

--- a/crates/common/src/update_marker.rs
+++ b/crates/common/src/update_marker.rs
@@ -18,7 +18,7 @@ pub const MARKER_FILE: &str = "update-in-progress.json";
 /// Schema version. Bump on a breaking shape change; `read` returns None on an
 /// unknown version (load-None-on-mismatch), but `clear` is remove-by-path and
 /// ignores the schema entirely.
-pub const MARKER_VERSION: u32 = 1;
+pub const MARKER_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -26,8 +26,14 @@ pub struct MarkerInfo {
     pub version: u32,
     pub from_version: String,
     pub to_version: String,
-    pub pid: u32,
+    /// PID of the cutover DRIVER — the process whose death means the cutover is
+    /// abandoned (the detached child on Windows; the inline actor on macOS).
+    pub driver_pid: u32,
+    /// Wall-clock Unix seconds when the cutover was claimed.
     pub started_at_unix: u64,
+    /// OS creation time of `driver_pid`, Unix ms. PID-reuse guard by exact
+    /// equality; a stored `0` is a failed-probe sentinel treated as unassessed.
+    pub driver_start_unix_ms: u64,
 }
 
 /// The SERVICE log directory (where the privileged bridge writes its logs and
@@ -133,6 +139,19 @@ pub fn clear(log_dir: &Path) -> io::Result<()> {
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
     }
+}
+
+/// Overwrite the marker's `driver_pid` + `driver_start_unix_ms` in place,
+/// preserving the rest. The Windows cutover initiator stamps the frozen child's
+/// identity here so the marker names the driver, not the initiator. An absent
+/// marker is a no-op (`Ok`).
+pub fn stamp_driver(log_dir: &Path, driver_pid: u32, driver_start_unix_ms: u64) -> io::Result<()> {
+    let Some(mut info) = read(log_dir) else {
+        return Ok(());
+    };
+    info.driver_pid = driver_pid;
+    info.driver_start_unix_ms = driver_start_unix_ms;
+    write(log_dir, &info, None)
 }
 
 #[cfg(test)]

--- a/crates/common/src/update_marker.rs
+++ b/crates/common/src/update_marker.rs
@@ -147,6 +147,9 @@ pub fn clear(log_dir: &Path) -> io::Result<()> {
 /// marker is a no-op (`Ok`).
 pub fn stamp_driver(log_dir: &Path, driver_pid: u32, driver_start_unix_ms: u64) -> io::Result<()> {
     let Some(mut info) = read(log_dir) else {
+        // Unreachable in the normal sequence (the initiator wrote the marker
+        // before stamping); a warn surfaces the anomaly rather than swallowing it.
+        tracing::warn!(driver_pid, "stamp_driver: no marker present to stamp");
         return Ok(());
     };
     info.driver_pid = driver_pid;

--- a/crates/common/src/update_marker_tests.rs
+++ b/crates/common/src/update_marker_tests.rs
@@ -9,8 +9,9 @@ fn roundtrip_write_read_clear() {
         version: MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: "0.3.0".into(),
-        pid: 4242,
+        driver_pid: 4242,
         started_at_unix: 1_700_000_000,
+        driver_start_unix_ms: 0,
     };
     write(dir.path(), &info, None).unwrap();
 
@@ -35,8 +36,9 @@ fn schema_mismatch_reads_none() {
         "version": MARKER_VERSION + 1,
         "from_version": "0.3.0",
         "to_version": "0.4.0",
-        "pid": 7,
+        "driver_pid": 7,
         "started_at_unix": 1,
+        "driver_start_unix_ms": 0,
     });
     std::fs::write(dir.path().join(MARKER_FILE), serde_json::to_vec(&future).unwrap()).unwrap();
     assert!(read(dir.path()).is_none(), "unknown schema version -> None");
@@ -55,8 +57,9 @@ fn marker_mode_is_world_readable() {
         version: MARKER_VERSION,
         from_version: "a".into(),
         to_version: "b".into(),
-        pid: 1,
+        driver_pid: 1,
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     };
     write(dir.path(), &info, None).unwrap();
     let mode = std::fs::metadata(dir.path().join(MARKER_FILE))
@@ -73,8 +76,9 @@ fn write_new_is_an_atomic_single_occupancy_claim() {
         version: MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: "0.3.0".into(),
-        pid: 1,
+        driver_pid: 1,
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     };
     // First claim wins and the full content is readable (never a partial file).
     write_new(dir.path(), &info, None).unwrap();
@@ -112,8 +116,9 @@ fn write_new_marker_mode_is_world_readable() {
         version: MARKER_VERSION,
         from_version: "a".into(),
         to_version: "b".into(),
-        pid: 1,
+        driver_pid: 1,
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     };
     write_new(dir.path(), &info, None).unwrap();
     let mode = std::fs::metadata(dir.path().join(MARKER_FILE))
@@ -128,6 +133,38 @@ fn write_new_marker_mode_is_world_readable() {
 // file to another uid; a self-chown here would be vacuous (the temp is already
 // self-owned). It rides the root lane in
 // `crates/hole/tests/elevated_ownership_privileged.rs`.
+
+#[skuld::test]
+fn stamp_driver_overwrites_only_driver_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        &MarkerInfo {
+            version: MARKER_VERSION,
+            from_version: "0.2.0".into(),
+            to_version: "0.3.0".into(),
+            driver_pid: 111,
+            started_at_unix: 1_700_000_000,
+            driver_start_unix_ms: 0,
+        },
+        None,
+    )
+    .unwrap();
+    stamp_driver(dir.path(), 222, 1_700_000_123_456).unwrap();
+    let got = read(dir.path()).unwrap();
+    assert_eq!((got.driver_pid, got.driver_start_unix_ms), (222, 1_700_000_123_456));
+    assert_eq!(
+        (got.from_version.as_str(), got.started_at_unix),
+        ("0.2.0", 1_700_000_000)
+    );
+}
+
+#[skuld::test]
+fn stamp_driver_absent_marker_is_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    stamp_driver(dir.path(), 1, 1).unwrap();
+    assert!(read(dir.path()).is_none());
+}
 
 #[skuld::test]
 fn service_log_dir_matches_log_collector_constants() {

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -133,6 +133,40 @@ fn resolve_bridge_socket(override_path: Option<PathBuf>) -> (PathBuf, bool) {
 /// testable and holds no `AppHandle` of its own.
 pub type SelfHealHook = std::sync::Arc<dyn Fn(Option<String>) + Send + Sync>;
 
+/// The path-free failure reason surfaced when a Windows update cutover wedges —
+/// its driver died mid-swap with the marker still present. GUI-set (not a bridge
+/// death reason), so it flows through `map_status_response` unchanged and cannot
+/// leak PII.
+pub(crate) const UPDATE_FAILED: &str = "The update didn't finish and the connection was lost.";
+
+/// Resolves the cutover DRIVER's liveness from its marker identity: `Some(true)`
+/// alive, `Some(false)` confirmed dead, `None` unassessed. Injected so `BridgeLink`
+/// stays testable and the masking decision stays `#[cfg]`-free.
+pub type DriverLiveness = std::sync::Arc<dyn Fn(&hole_common::update_marker::MarkerInfo) -> Option<bool> + Send + Sync>;
+
+/// Windows: the driver is alive iff its PID is a running process whose creation
+/// time matches (exit-state + exact-equality). A stored `0` is a poisoned/absent
+/// identity → `None` (unassessed, never confirmed-dead). Off Windows there is no
+/// trackable persistent driver → `None`.
+fn production_driver_liveness() -> DriverLiveness {
+    #[cfg(target_os = "windows")]
+    {
+        std::sync::Arc::new(|m: &hole_common::update_marker::MarkerInfo| {
+            if m.driver_start_unix_ms == 0 {
+                return None;
+            }
+            Some(hole_common::process::process_matches_and_alive(
+                m.driver_pid,
+                m.driver_start_unix_ms,
+            ))
+        })
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::sync::Arc::new(|_m| None)
+    }
+}
+
 pub struct BridgeLink {
     socket_path: PathBuf,
     /// SERVICE log dir where the privileged bridge writes the update-in-progress
@@ -142,6 +176,9 @@ pub struct BridgeLink {
     client: tokio::sync::Mutex<Option<BridgeClient>>,
     cell: ProxyStateCell,
     self_heal: SelfHealHook,
+    /// Resolves the cutover driver's liveness (Part B). Production self-wires
+    /// `production_driver_liveness`; tests inject a stub.
+    driver_liveness: DriverLiveness,
 }
 
 impl BridgeLink {
@@ -152,12 +189,25 @@ impl BridgeLink {
     /// Construct with an explicit service log dir (tests inject a temp dir so
     /// per-test markers don't collide across the shared skuld process).
     pub fn with_service_log_dir(socket_path: PathBuf, service_log_dir: PathBuf, self_heal: SelfHealHook) -> Self {
+        Self::with_service_log_dir_and_liveness(socket_path, service_log_dir, self_heal, production_driver_liveness())
+    }
+
+    /// Construct with an explicit service log dir AND driver-liveness resolver.
+    /// Tests inject a stub liveness so the mask/unmask/failure arms are driven
+    /// without a real process to probe.
+    pub fn with_service_log_dir_and_liveness(
+        socket_path: PathBuf,
+        service_log_dir: PathBuf,
+        self_heal: SelfHealHook,
+        driver_liveness: DriverLiveness,
+    ) -> Self {
         Self {
             socket_path,
             service_log_dir,
             client: tokio::sync::Mutex::new(None),
             cell: ProxyStateCell::new(),
             self_heal,
+            driver_liveness,
         }
     }
 
@@ -165,11 +215,46 @@ impl BridgeLink {
         &self.cell
     }
 
-    /// Whether the privileged bridge has a cutover in flight (its marker is
-    /// present). Read fresh per exchange so the no-surprise-Disconnected window
-    /// opens and closes with the marker.
-    fn update_in_progress(&self) -> bool {
-        hole_common::update_marker::read(&self.service_log_dir).is_some()
+    /// Read the cutover marker and (if present) resolve its driver's liveness,
+    /// fresh per exchange so the masking window opens and closes with the marker.
+    fn cutover_state(&self) -> (Option<hole_common::update_marker::MarkerInfo>, Option<bool>) {
+        let marker = hole_common::update_marker::read(&self.service_log_dir);
+        let driver_alive = marker.as_ref().and_then(|m| (self.driver_liveness)(m));
+        (marker, driver_alive)
+    }
+
+    /// Commit an exchange's observation under the current cutover decision. On a
+    /// wedged cutover (`UnmaskFailed` + not running) surface `UPDATE_FAILED` —
+    /// but only if the marker FILE is still present at commit: a swept marker
+    /// means the successor won (a completed cutover), so pass through. Any other
+    /// resolved observation retracts a stale `UPDATE_FAILED`.
+    fn commit_observation(
+        &self,
+        decision: CutoverDecision,
+        running: bool,
+        result: &Result<BridgeResponse, ClientError>,
+    ) {
+        if !running && decision == CutoverDecision::UnmaskFailed {
+            // "Successor won" ⇒ the marker FILE is gone. Use `exists()`, not
+            // `read()` (which also returns None for a present-but-corrupt marker)
+            // — a present-but-unparsable marker with a dead driver is a real
+            // wedge, not a completed cutover, so it must still surface the failure.
+            if self
+                .service_log_dir
+                .join(hole_common::update_marker::MARKER_FILE)
+                .exists()
+            {
+                self.cell.commit_update_failed(UPDATE_FAILED);
+                return;
+            }
+            tracing::debug!("cutover marker file gone before commit; treating as a completed cutover");
+        }
+        // A resolved observation retracts any stale wedge failure.
+        self.cell.clear_update_failed(UPDATE_FAILED);
+        match observed_lockdown(result) {
+            Some((le, la)) => self.cell.commit_status(running, observed_error(result), le, la),
+            None => self.cell.commit(running),
+        }
     }
 
     /// Drive the self-heal hook if the exchange revealed a version mismatch.
@@ -186,14 +271,11 @@ impl BridgeLink {
     pub async fn send(&self, req: BridgeRequest) -> Result<BridgeResponse, ClientError> {
         let kind = ReqKind::of(&req);
         let mut guard = self.client.lock().await;
+        let (marker, driver_alive) = self.cutover_state();
+        let decision = cutover_decision(marker.as_ref(), driver_alive);
         let result = Self::send_locked(&mut guard, &self.socket_path, req).await;
-        if let Some(running) = observed_running(kind, &result, self.update_in_progress()) {
-            // A Status exchange reveals error + lockdown too — commit all three
-            // atomically under this lock; other exchanges know only `running`.
-            match observed_lockdown(&result) {
-                Some((le, la)) => self.cell.commit_status(running, observed_error(&result), le, la),
-                None => self.cell.commit(running),
-            }
+        if let Some(running) = observed_running(kind, &result, matches!(decision, CutoverDecision::Mask)) {
+            self.commit_observation(decision, running, &result);
         }
         self.note_mismatch(&result);
         result
@@ -270,13 +352,12 @@ impl BridgeLink {
     /// successful reload.
     pub async fn reload_if_running(&self, config: hole_common::protocol::ProxyConfig) -> Result<bool, String> {
         let mut guard = self.client.lock().await;
+        let (marker, driver_alive) = self.cutover_state();
+        let decision = cutover_decision(marker.as_ref(), driver_alive);
         let status = Self::send_locked(&mut guard, &self.socket_path, BridgeRequest::Status).await;
         self.note_mismatch(&status);
-        if let Some(running) = observed_running(ReqKind::Status, &status, self.update_in_progress()) {
-            match observed_lockdown(&status) {
-                Some((le, la)) => self.cell.commit_status(running, observed_error(&status), le, la),
-                None => self.cell.commit(running),
-            }
+        if let Some(running) = observed_running(ReqKind::Status, &status, matches!(decision, CutoverDecision::Mask)) {
+            self.commit_observation(decision, running, &status);
         }
         if !matches!(status, Ok(BridgeResponse::Status { running: true, .. })) {
             return Ok(false); // Not running; changes apply on next start.
@@ -305,9 +386,11 @@ pub struct ProxySnapshot {
     /// Reason for the most recent running transition, when the bridge reported
     /// one (#470). Carried on BOTH the poll and the `proxy-state-changed` event
     /// so whichever channel wins the death-seq race surfaces the same string.
-    /// Only ever the path-free out-of-band-death sentinel or `None` (set by
-    /// `commit_status` from a Status response; cleared by `commit`), so a toast
-    /// of this value cannot leak PII — see `commands::map_status_response`.
+    /// Only ever a path-free sentinel or `None`: the bridge's out-of-band-death
+    /// reason (set by `commit_status`; cleared by `commit`) OR the GUI-set
+    /// `UPDATE_FAILED` for a wedged update cutover (set by `commit_update_failed`;
+    /// cleared by `clear_update_failed`). A toast of this value cannot leak PII —
+    /// see `commands::map_status_response`.
     pub error: Option<String>,
     /// Standing kill-switch intent (#527), from the bridge's StatusResponse.
     pub lockdown_enabled: bool,
@@ -384,12 +467,77 @@ impl ProxyStateCell {
         });
     }
 
+    /// Commit a wedged-cutover failure: Disconnected + the path-free reason.
+    /// Idempotent — re-committing the same failure does not bump `seq`.
+    pub fn commit_update_failed(&self, reason: &'static str) {
+        self.tx.send_if_modified(|snap| {
+            if !snap.running && snap.error.as_deref() == Some(reason) {
+                return false;
+            }
+            *snap = ProxySnapshot {
+                seq: snap.seq + 1,
+                running: false,
+                error: Some(reason.to_string()),
+                lockdown_enabled: snap.lockdown_enabled,
+                lockdown_active: snap.lockdown_active,
+            };
+            true
+        });
+    }
+
+    /// Clear the sticky wedge reason from the backend snapshot once the cutover
+    /// resolves, even if `running` is unchanged, so subsequent `get_proxy_status`
+    /// polls no longer carry the stale error. The toast itself is transient (fired
+    /// once on the true→false death edge and faded); this is snapshot hygiene, not
+    /// a toast-dismiss. `commit`/`commit_status` don't key change-detection on
+    /// `error`, so this dedicated clear is what retracts it.
+    pub fn clear_update_failed(&self, reason: &'static str) {
+        self.tx.send_if_modified(|snap| {
+            if snap.error.as_deref() != Some(reason) {
+                return false;
+            }
+            snap.seq += 1;
+            snap.error = None;
+            true
+        });
+    }
+
     pub fn snapshot(&self) -> ProxySnapshot {
         self.tx.borrow().clone()
     }
 
     pub fn subscribe(&self) -> tokio::sync::watch::Receiver<ProxySnapshot> {
         self.tx.subscribe()
+    }
+}
+
+// Cutover masking decision (Part B) ===================================================================================
+
+/// What the GUI should do with an exchange's observation while a cutover marker
+/// is (or is not) present, given the cutover DRIVER's liveness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CutoverDecision {
+    /// No cutover in flight (or it resolved) — commit the observation as usual.
+    PassThrough,
+    /// A cutover is in flight and the driver is alive (or unassessed) — hold the
+    /// last snapshot so the restart gap is not a surprise Disconnected.
+    Mask,
+    /// A cutover marker is present but the driver is CONFIRMED dead — the cutover
+    /// is abandoned; unmask and surface the wedged-update failure.
+    UnmaskFailed,
+}
+
+/// Single source of truth for the cutover masking decision. `driver_alive`:
+/// `Some(true)` alive, `Some(false)` confirmed dead, `None` unassessed (macOS or
+/// a poisoned/absent identity). No marker ⇒ PassThrough regardless of liveness.
+pub(crate) fn cutover_decision(
+    marker: Option<&hole_common::update_marker::MarkerInfo>,
+    driver_alive: Option<bool>,
+) -> CutoverDecision {
+    match (marker, driver_alive) {
+        (None, _) => CutoverDecision::PassThrough,
+        (Some(_), Some(false)) => CutoverDecision::UnmaskFailed,
+        (Some(_), _) => CutoverDecision::Mask,
     }
 }
 
@@ -422,9 +570,11 @@ impl ReqKind {
 ///   says nothing about the tunnel.
 /// - Transport errors on tracked kinds commit false: an unreachable
 ///   bridge tunnels nothing (the mapping `get_proxy_status` always used).
-/// - A transport error WHILE an update cutover is in progress commits
+/// - While the cutover mask is active (a marker present with a live/unassessed
+///   driver) both a transport error AND a reachable running:false commit
 ///   nothing: the bridge is mid-restart, so the gap is expected, not a
-///   Disconnected — hold the last snapshot.
+///   Disconnected — hold the last snapshot. The mask is dropped (decision
+///   PassThrough) once the marker is swept or the driver is confirmed dead.
 pub(crate) fn observed_running(
     kind: ReqKind,
     result: &Result<BridgeResponse, ClientError>,
@@ -446,6 +596,11 @@ pub(crate) fn observed_running(
         // it arrives only after the new bridge answers.
         (_, Err(_)) if update_in_progress => None,
         (_, Err(_)) => Some(false),
+        // A reachable running:false DURING a cutover is held (no surprise
+        // Disconnected — e.g. the proxy self-dies via `check_health` while the old
+        // bridge still serves); released once the marker is swept (the decision is
+        // then PassThrough, not Mask). Must precede the general Status-Ok arm.
+        (Status, Ok(BridgeResponse::Status { running: false, .. })) if update_in_progress => None,
         (Status, Ok(BridgeResponse::Status { running, .. })) => Some(*running),
         (Start, Ok(BridgeResponse::Ack)) => Some(true),
         (Start, Ok(BridgeResponse::StartFailed(e))) => match e {

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -145,9 +145,10 @@ pub(crate) const UPDATE_FAILED: &str = "The update didn't finish and the connect
 pub type DriverLiveness = std::sync::Arc<dyn Fn(&hole_common::update_marker::MarkerInfo) -> Option<bool> + Send + Sync>;
 
 /// Windows: the driver is alive iff its PID is a running process whose creation
-/// time matches (exit-state + exact-equality). A stored `0` is a poisoned/absent
-/// identity → `None` (unassessed, never confirmed-dead). Off Windows there is no
-/// trackable persistent driver → `None`.
+/// time matches (exit-state + exact-equality); an access-denied/transient probe
+/// failure is `None` (unassessed, never confirmed-dead). A stored `0` is a
+/// poisoned/absent identity → `None`. Off Windows there is no trackable
+/// persistent driver → `None`.
 fn production_driver_liveness() -> DriverLiveness {
     #[cfg(target_os = "windows")]
     {
@@ -155,10 +156,7 @@ fn production_driver_liveness() -> DriverLiveness {
             if m.driver_start_unix_ms == 0 {
                 return None;
             }
-            Some(hole_common::process::process_matches_and_alive(
-                m.driver_pid,
-                m.driver_start_unix_ms,
-            ))
+            hole_common::process::process_matches_and_alive(m.driver_pid, m.driver_start_unix_ms)
         })
     }
     #[cfg(not(target_os = "windows"))]
@@ -176,7 +174,7 @@ pub struct BridgeLink {
     client: tokio::sync::Mutex<Option<BridgeClient>>,
     cell: ProxyStateCell,
     self_heal: SelfHealHook,
-    /// Resolves the cutover driver's liveness (Part B). Production self-wires
+    /// Resolves the cutover driver's liveness. Production self-wires
     /// `production_driver_liveness`; tests inject a stub.
     driver_liveness: DriverLiveness,
 }
@@ -244,7 +242,9 @@ impl BridgeLink {
                 .join(hole_common::update_marker::MARKER_FILE)
                 .exists()
             {
-                self.cell.commit_update_failed(UPDATE_FAILED);
+                // Carry any lockdown fields the triggering Status revealed so a
+                // reachable running:false wedge does not drop a fresh lockdown edge.
+                self.cell.commit_update_failed(UPDATE_FAILED, observed_lockdown(result));
                 return;
             }
             tracing::debug!("cutover marker file gone before commit; treating as a completed cutover");
@@ -468,18 +468,26 @@ impl ProxyStateCell {
     }
 
     /// Commit a wedged-cutover failure: Disconnected + the path-free reason.
-    /// Idempotent — re-committing the same failure does not bump `seq`.
-    pub fn commit_update_failed(&self, reason: &'static str) {
+    /// `lockdown` is `Some((enabled, active))` when the triggering Status carried
+    /// fresh lockdown fields (apply them) and `None` otherwise (preserve prior).
+    /// Idempotent — bumps `seq` only when running, error, or a lockdown field
+    /// actually changes.
+    pub fn commit_update_failed(&self, reason: &'static str, lockdown: Option<(bool, bool)>) {
         self.tx.send_if_modified(|snap| {
-            if !snap.running && snap.error.as_deref() == Some(reason) {
+            let (le, la) = lockdown.unwrap_or((snap.lockdown_enabled, snap.lockdown_active));
+            if !snap.running
+                && snap.error.as_deref() == Some(reason)
+                && snap.lockdown_enabled == le
+                && snap.lockdown_active == la
+            {
                 return false;
             }
             *snap = ProxySnapshot {
                 seq: snap.seq + 1,
                 running: false,
                 error: Some(reason.to_string()),
-                lockdown_enabled: snap.lockdown_enabled,
-                lockdown_active: snap.lockdown_active,
+                lockdown_enabled: le,
+                lockdown_active: la,
             };
             true
         });
@@ -511,7 +519,7 @@ impl ProxyStateCell {
     }
 }
 
-// Cutover masking decision (Part B) ===================================================================================
+// Cutover masking decision ============================================================================================
 
 /// What the GUI should do with an exchange's observation while a cutover marker
 /// is (or is not) present, given the cutover DRIVER's liveness.

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -235,10 +235,10 @@ impl BridgeLink {
         result: &Result<BridgeResponse, ClientError>,
     ) {
         if !running && decision == CutoverDecision::UnmaskFailed {
-            // "Successor won" ⇒ the marker FILE is gone. Use `exists()`, not
-            // `read()` (which also returns None for a present-but-corrupt marker)
-            // — a present-but-unparsable marker with a dead driver is a real
-            // wedge, not a completed cutover, so it must still surface the failure.
+            // "Successor won" ⇒ the marker FILE is gone. A presence check, not
+            // `read()`: the wedge test is "did a cutover complete", which is the
+            // file's existence, not a parseable schema — robust across a from->to
+            // version bump mid-cutover (matching `clear`'s remove-by-path).
             if self
                 .service_log_dir
                 .join(hole_common::update_marker::MARKER_FILE)

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -596,7 +596,7 @@ async fn cutover_marker_suppresses_then_resumes_disconnected_flash() {
     );
 }
 
-// Part B: wedged-cutover surface + clear path =========================================================================
+// Wedged-cutover surface + clear path =================================================================================
 
 // Wedge via transport error → UPDATE_FAILED.
 #[skuld::test]
@@ -626,6 +626,39 @@ async fn wedge_reachable_not_running_surfaces_failure() {
     let _ = link.send(BridgeRequest::Status).await;
     let s = link.cell().snapshot();
     assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
+}
+
+// A reachable running:false wedge whose Status reports a lockdown change must
+// surface UPDATE_FAILED AND the new lockdown fields (not the stale prior ones).
+#[skuld::test]
+async fn wedge_reachable_carries_lockdown_change() {
+    let path = test_socket_path("wedge-lockdown");
+    let _m = serve_router(
+        &path,
+        axum::Router::new().route(
+            ROUTE_STATUS,
+            get(|| async {
+                Json(StatusResponse {
+                    running: false,
+                    lockdown_enabled: true,
+                    lockdown_active: false,
+                    ..status_response(false)
+                })
+            }),
+        ),
+    )
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = link_with(path, dir.path(), Some(false));
+    link.cell().commit(true);
+    let _ = link.send(BridgeRequest::Status).await;
+    let s = link.cell().snapshot();
+    assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
+    assert!(
+        s.lockdown_enabled && !s.lockdown_active,
+        "the wedge Status's lockdown fields must apply, not the stale prior ones"
+    );
 }
 
 // HEALTHY re-read race: marker PRESENT at decision (→ UnmaskFailed) but the
@@ -699,7 +732,7 @@ async fn update_failed_clears_when_marker_gone() {
     let swept = std::env::temp_dir().join(format!("hole-616-clears-nonexistent-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&swept);
     let link = super::BridgeLink::with_service_log_dir_and_liveness(path, swept, noop_hook(), liveness_stub(None));
-    link.cell().commit_update_failed(super::UPDATE_FAILED); // seed a prior wedge
+    link.cell().commit_update_failed(super::UPDATE_FAILED, None); // seed a prior wedge
     let _ = link.send(BridgeRequest::Status).await;
     assert!(
         link.cell().snapshot().error.is_none(),
@@ -723,11 +756,34 @@ async fn wedge_via_reload_surfaces_failure() {
 fn commit_update_failed_is_idempotent() {
     let cell = super::ProxyStateCell::new();
     cell.commit(true);
-    cell.commit_update_failed(super::UPDATE_FAILED);
+    cell.commit_update_failed(super::UPDATE_FAILED, None);
     let a = cell.snapshot();
     assert!(!a.running && a.error.as_deref() == Some(super::UPDATE_FAILED));
-    cell.commit_update_failed(super::UPDATE_FAILED);
+    cell.commit_update_failed(super::UPDATE_FAILED, None);
     assert_eq!(cell.snapshot().seq, a.seq);
+}
+
+#[skuld::test]
+fn commit_update_failed_applies_a_lockdown_change() {
+    // A wedge whose Status carried a lockdown change must surface UPDATE_FAILED
+    // AND the new lockdown fields — not preserve the stale prior ones.
+    let cell = super::ProxyStateCell::new();
+    cell.commit_status(true, None, false, false); // connected, no lockdown
+    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false)));
+    let s = cell.snapshot();
+    assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
+    assert!(
+        s.lockdown_enabled && !s.lockdown_active,
+        "the wedge's lockdown fields apply"
+    );
+    // Re-committing the same wedge + lockdown is idempotent.
+    let seq = s.seq;
+    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false)));
+    assert_eq!(cell.snapshot().seq, seq);
+    // A lockdown change bumps seq even though running/error are unchanged.
+    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, true)));
+    let s2 = cell.snapshot();
+    assert!(s2.lockdown_active && s2.seq == seq + 1);
 }
 
 // Real seam, alive, through send(): held.

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -377,9 +377,9 @@ fn noop_hook() -> SelfHealHook {
 
 /// Build a `BridgeLink` whose update-marker dir is a unique, never-created temp
 /// path. `BridgeLink::new` would otherwise read the real system service log dir,
-/// where a stray cutover marker would make `update_in_progress()` hold the
-/// snapshot and break these transport-error assertions. A non-existent dir reads
-/// as "no marker" (the `read` ENOENT path), keeping every test hermetic.
+/// where a stray cutover marker would make the cutover decision `Mask` and hold
+/// the snapshot, breaking these transport-error assertions. A non-existent dir
+/// reads as "no marker" (the `read` ENOENT path), keeping every test hermetic.
 fn test_link(socket_path: PathBuf, self_heal: SelfHealHook) -> BridgeLink {
     let marker_dir = std::env::temp_dir().join(format!(
         "hole-link-marker-{}-{}",

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -1,6 +1,32 @@
 use super::*;
 use crate::bridge_client::ClientError;
 use hole_common::protocol::{BridgeResponse, StartError};
+use hole_common::update_marker::{MarkerInfo, MARKER_VERSION};
+
+fn sample_marker() -> MarkerInfo {
+    MarkerInfo {
+        version: MARKER_VERSION,
+        from_version: "0.2.0".into(),
+        to_version: "0.3.0".into(),
+        driver_pid: 4242,
+        started_at_unix: 0,
+        driver_start_unix_ms: 0,
+    }
+}
+
+// CutoverDecision =====================================================================================================
+
+#[skuld::test]
+fn cutover_decision_truth_table() {
+    use super::CutoverDecision::*;
+    let m = sample_marker();
+    assert_eq!(super::cutover_decision(None, None), PassThrough);
+    assert_eq!(super::cutover_decision(None, Some(false)), PassThrough);
+    assert_eq!(super::cutover_decision(None, Some(true)), PassThrough);
+    assert_eq!(super::cutover_decision(Some(&m), Some(true)), Mask);
+    assert_eq!(super::cutover_decision(Some(&m), None), Mask);
+    assert_eq!(super::cutover_decision(Some(&m), Some(false)), UnmaskFailed);
+}
 
 // ProxyStateCell ======================================================================================================
 
@@ -276,9 +302,18 @@ fn observed_running_update_in_progress_holds_snapshot() {
     });
     assert_eq!(observed_running(ReqKind::Status, &vm, false), None);
     assert_eq!(observed_running(ReqKind::Status, &vm, true), None);
-    // A successful Status still reports truth (marker irrelevant on Ok).
+    // A successful Status still reports truth (marker irrelevant on Ok{running:true}).
     let ok: Result<BridgeResponse, ClientError> = Ok(status_resp(true));
     assert_eq!(observed_running(ReqKind::Status, &ok, true), Some(true));
+    // A reachable Ok{running:false} DURING a cutover is masked (held), but flips
+    // to Disconnected once the marker is gone (Step 6b).
+    let ok_false: Result<BridgeResponse, ClientError> = Ok(status_resp(false));
+    assert_eq!(observed_running(ReqKind::Status, &ok_false, true), None, "masking");
+    assert_eq!(
+        observed_running(ReqKind::Status, &ok_false, false),
+        Some(false),
+        "not masking"
+    );
 }
 
 // BridgeLink ==========================================================================================================
@@ -352,6 +387,31 @@ fn test_link(socket_path: PathBuf, self_heal: SelfHealHook) -> BridgeLink {
         socket_path.file_name().and_then(|s| s.to_str()).unwrap_or("x")
     ));
     BridgeLink::with_service_log_dir(socket_path, marker_dir, self_heal)
+}
+
+/// A driver-liveness stub reporting a fixed `Option<bool>` regardless of the marker.
+fn liveness_stub(a: Option<bool>) -> DriverLiveness {
+    std::sync::Arc::new(move |_m: &MarkerInfo| a)
+}
+
+/// A `BridgeLink` with an explicit service-log dir AND a stubbed driver liveness.
+fn link_with(path: PathBuf, dir: &std::path::Path, a: Option<bool>) -> BridgeLink {
+    BridgeLink::with_service_log_dir_and_liveness(path, dir.to_path_buf(), noop_hook(), liveness_stub(a))
+}
+
+/// Write the sample cutover marker into `dir`.
+fn marker_in(dir: &std::path::Path) {
+    hole_common::update_marker::write(dir, &sample_marker(), None).unwrap();
+}
+
+/// A liveness stub that reports the driver dead AND sweeps the marker as a side
+/// effect — simulating the successor sweeping the marker between the decision
+/// read and the commit re-read (the "successor won" race the re-read guard covers).
+fn sweeping_dead_stub(dir: PathBuf) -> DriverLiveness {
+    std::sync::Arc::new(move |_m| {
+        let _ = hole_common::update_marker::clear(&dir);
+        Some(false)
+    })
 }
 
 /// Serve `router` on `path`, accepting connections in a loop (BridgeLink
@@ -483,20 +543,8 @@ async fn transport_error_holds_snapshot_while_marker_present() {
     let path = test_socket_path("dead-marker");
     let _ = std::fs::remove_file(&path);
     let marker_dir = tempfile::tempdir().unwrap();
-    hole_common::update_marker::write(
-        marker_dir.path(),
-        &hole_common::update_marker::MarkerInfo {
-            version: hole_common::update_marker::MARKER_VERSION,
-            from_version: "0.2.0".into(),
-            to_version: "0.3.0".into(),
-            driver_pid: std::process::id(),
-            started_at_unix: 0,
-            driver_start_unix_ms: 0,
-        },
-        None,
-    )
-    .unwrap();
-    let link = BridgeLink::with_service_log_dir(path, marker_dir.path().to_path_buf(), noop_hook());
+    marker_in(marker_dir.path());
+    let link = link_with(path, marker_dir.path(), Some(true));
     link.cell().commit(true); // believed running before the cutover gap
     let _ = link.send(BridgeRequest::Status).await.unwrap_err();
     assert_eq!(
@@ -522,24 +570,12 @@ async fn cutover_marker_suppresses_then_resumes_disconnected_flash() {
     let path = test_socket_path("cutover-flash");
     let _ = std::fs::remove_file(&path); // dead socket: every send is a transport error
     let marker_dir = tempfile::tempdir().unwrap();
-    let link = BridgeLink::with_service_log_dir(path, marker_dir.path().to_path_buf(), noop_hook());
+    let link = link_with(path, marker_dir.path(), Some(true));
     link.cell().commit(true); // believed Connected before the cutover
     let seq_connected = link.cell().snapshot().seq;
 
     // Marker SET: the failing Status must hold the Connected snapshot.
-    hole_common::update_marker::write(
-        marker_dir.path(),
-        &hole_common::update_marker::MarkerInfo {
-            version: hole_common::update_marker::MARKER_VERSION,
-            from_version: "0.2.0".into(),
-            to_version: "0.3.0".into(),
-            driver_pid: std::process::id(),
-            started_at_unix: 0,
-            driver_start_unix_ms: 0,
-        },
-        None,
-    )
-    .unwrap();
+    marker_in(marker_dir.path());
     let _ = link.send(BridgeRequest::Status).await.unwrap_err();
     assert_eq!(
         link.cell().snapshot().seq,
@@ -558,6 +594,203 @@ async fn cutover_marker_suppresses_then_resumes_disconnected_flash() {
         !link.cell().snapshot().running,
         "Disconnected commits once the marker is gone"
     );
+}
+
+// Part B: wedged-cutover surface + clear path =========================================================================
+
+// Wedge via transport error → UPDATE_FAILED.
+#[skuld::test]
+async fn wedge_transport_error_surfaces_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = link_with("/nonexistent/socket".into(), dir.path(), Some(false));
+    link.cell().commit(true);
+    let _ = link.send(BridgeRequest::Status).await;
+    let s = link.cell().snapshot();
+    assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
+}
+
+// Reachable Ok{running:false}, driver dead, marker STILL PRESENT → UPDATE_FAILED.
+#[skuld::test]
+async fn wedge_reachable_not_running_surfaces_failure() {
+    let path = test_socket_path("wedge-reachable");
+    let _m = serve_router(
+        &path,
+        axum::Router::new().route(ROUTE_STATUS, get(|| async { Json(status_response(false)) })),
+    )
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = link_with(path, dir.path(), Some(false));
+    link.cell().commit(true);
+    let _ = link.send(BridgeRequest::Status).await;
+    let s = link.cell().snapshot();
+    assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
+}
+
+// HEALTHY re-read race: marker PRESENT at decision (→ UnmaskFailed) but the
+// successor sweeps it before commit → the commit-time re-read finds it gone →
+// PassThrough, NO UPDATE_FAILED. Exercises the "successor won" guard: a transport
+// error (dead socket) reaches the failure branch, and a stub that clears the
+// marker when consulted.
+#[skuld::test]
+async fn healthy_swept_before_commit_no_false_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = super::BridgeLink::with_service_log_dir_and_liveness(
+        "/nonexistent/socket".into(),
+        dir.path().to_path_buf(),
+        noop_hook(),
+        sweeping_dead_stub(dir.path().to_path_buf()),
+    );
+    link.cell().commit(true);
+    let _ = link.send(BridgeRequest::Status).await;
+    let s = link.cell().snapshot();
+    assert!(
+        !s.running && s.error.is_none(),
+        "swept marker at commit → no UPDATE_FAILED"
+    );
+}
+
+// Reachable running:false DURING a cutover with a live driver → HELD (masked),
+// no Disconnected flash (observed_running masks Ok{running:false} under Mask).
+#[skuld::test]
+async fn reachable_not_running_during_cutover_holds() {
+    let path = test_socket_path("reachable-live");
+    let _m = serve_router(
+        &path,
+        axum::Router::new().route(ROUTE_STATUS, get(|| async { Json(status_response(false)) })),
+    )
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = link_with(path, dir.path(), Some(true));
+    link.cell().commit(true);
+    let before = link.cell().snapshot().seq;
+    let _ = link.send(BridgeRequest::Status).await;
+    let s = link.cell().snapshot();
+    assert!(
+        s.running && s.seq == before,
+        "reachable running:false is held during a cutover"
+    );
+}
+
+// Healthy gap, driver alive → hold, no commit.
+#[skuld::test]
+async fn healthy_gap_holds_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = link_with("/nonexistent/socket".into(), dir.path(), Some(true));
+    link.cell().commit(true);
+    let before = link.cell().snapshot().seq;
+    let _ = link.send(BridgeRequest::Status).await;
+    assert!(link.cell().snapshot().running && link.cell().snapshot().seq == before);
+}
+
+// A stale UPDATE_FAILED is retracted once the cutover resolves (marker gone).
+#[skuld::test]
+async fn update_failed_clears_when_marker_gone() {
+    let path = test_socket_path("failed-clears");
+    let _m = serve_router(
+        &path,
+        axum::Router::new().route(ROUTE_STATUS, get(|| async { Json(status_response(false)) })),
+    )
+    .await;
+    let swept = std::env::temp_dir().join(format!("hole-616-clears-nonexistent-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&swept);
+    let link = super::BridgeLink::with_service_log_dir_and_liveness(path, swept, noop_hook(), liveness_stub(None));
+    link.cell().commit_update_failed(super::UPDATE_FAILED); // seed a prior wedge
+    let _ = link.send(BridgeRequest::Status).await;
+    assert!(
+        link.cell().snapshot().error.is_none(),
+        "resolved cutover retracts the failure"
+    );
+}
+
+// reload_if_running Status leg also surfaces the wedge.
+#[skuld::test]
+async fn wedge_via_reload_surfaces_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    marker_in(dir.path());
+    let link = link_with("/nonexistent/socket".into(), dir.path(), Some(false));
+    link.cell().commit(true);
+    let _ = link.reload_if_running(test_proxy_config()).await;
+    let s = link.cell().snapshot();
+    assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
+}
+
+#[skuld::test]
+fn commit_update_failed_is_idempotent() {
+    let cell = super::ProxyStateCell::new();
+    cell.commit(true);
+    cell.commit_update_failed(super::UPDATE_FAILED);
+    let a = cell.snapshot();
+    assert!(!a.running && a.error.as_deref() == Some(super::UPDATE_FAILED));
+    cell.commit_update_failed(super::UPDATE_FAILED);
+    assert_eq!(cell.snapshot().seq, a.seq);
+}
+
+// Real seam, alive, through send(): held.
+#[cfg(target_os = "windows")]
+#[skuld::test]
+async fn real_live_driver_holds_via_send() {
+    let me = std::process::id();
+    let start = hole_common::process::process_start_time(me).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    hole_common::update_marker::write(
+        dir.path(),
+        &MarkerInfo {
+            driver_pid: me,
+            driver_start_unix_ms: start,
+            ..sample_marker()
+        },
+        None,
+    )
+    .unwrap();
+    let link = super::BridgeLink::with_service_log_dir_and_liveness(
+        "/nonexistent/socket".into(),
+        dir.path().to_path_buf(),
+        noop_hook(),
+        super::production_driver_liveness(),
+    );
+    link.cell().commit(true);
+    let before = link.cell().snapshot().seq;
+    let _ = link.send(BridgeRequest::Status).await;
+    assert!(link.cell().snapshot().running && link.cell().snapshot().seq == before);
+}
+
+// Real seam, dead (zombie handle retained), through send(): UnmaskFailed once.
+#[cfg(target_os = "windows")]
+#[skuld::test]
+async fn real_dead_driver_unmasks_once() {
+    let mut child = std::process::Command::new("cmd").args(["/c", "exit"]).spawn().unwrap();
+    let pid = child.id();
+    let start = hole_common::process::process_start_time(pid).unwrap();
+    child.wait().unwrap(); // dead; `child` (handle) kept in scope below → zombie
+    let dir = tempfile::tempdir().unwrap();
+    hole_common::update_marker::write(
+        dir.path(),
+        &MarkerInfo {
+            driver_pid: pid,
+            driver_start_unix_ms: start,
+            ..sample_marker()
+        },
+        None,
+    )
+    .unwrap();
+    let link = super::BridgeLink::with_service_log_dir_and_liveness(
+        "/nonexistent/socket".into(),
+        dir.path().to_path_buf(),
+        noop_hook(),
+        super::production_driver_liveness(),
+    );
+    link.cell().commit(true);
+    let _ = link.send(BridgeRequest::Status).await;
+    let first = link.cell().snapshot();
+    assert!(!first.running && first.error.as_deref() == Some(super::UPDATE_FAILED));
+    let _ = link.send(BridgeRequest::Status).await;
+    assert_eq!(link.cell().snapshot().seq, first.seq);
+    drop(child);
 }
 
 #[skuld::test]

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -489,8 +489,9 @@ async fn transport_error_holds_snapshot_while_marker_present() {
             version: hole_common::update_marker::MARKER_VERSION,
             from_version: "0.2.0".into(),
             to_version: "0.3.0".into(),
-            pid: std::process::id(),
+            driver_pid: std::process::id(),
             started_at_unix: 0,
+            driver_start_unix_ms: 0,
         },
         None,
     )
@@ -532,8 +533,9 @@ async fn cutover_marker_suppresses_then_resumes_disconnected_flash() {
             version: hole_common::update_marker::MARKER_VERSION,
             from_version: "0.2.0".into(),
             to_version: "0.3.0".into(),
-            pid: std::process::id(),
+            driver_pid: std::process::id(),
             started_at_unix: 0,
+            driver_start_unix_ms: 0,
         },
         None,
     )

--- a/crates/hole/tests/elevated_ownership_privileged.rs
+++ b/crates/hole/tests/elevated_ownership_privileged.rs
@@ -60,8 +60,9 @@ fn cutover_marker_is_chowned_to_owner_under_root() {
         version: MARKER_VERSION,
         from_version: "0.2.0".into(),
         to_version: to.into(),
-        pid: std::process::id(),
+        driver_pid: std::process::id(),
         started_at_unix: 0,
+        driver_start_unix_ms: 0,
     };
     let root = unsafe { libc::geteuid() } == 0;
     let (nuid, ngid) = nobody();

--- a/ui/power-button.test.ts
+++ b/ui/power-button.test.ts
@@ -297,18 +297,18 @@ describe("power-button state machine", () => {
     expect(showToastMock).toHaveBeenCalledWith("proxy task exited unexpectedly", "error");
   });
 
-  // Wedged update cutover (#616): the GUI-set UPDATE_FAILED sentinel arrives as
-  // the `error` on a connected -> disconnected observation and must surface as a
-  // toast exactly like a bridge death reason (it flows through
-  // commands::map_status_response unchanged).
-  it("toasts the update-failed sentinel on a wedged cutover (connected -> disconnected)", async () => {
-    const UPDATE_FAILED = "The update didn't finish and the connection was lost.";
+  // Wedged update cutover: the GUI-set failure sentinel arrives as the `error`
+  // on a connected -> disconnected observation and must surface as a toast
+  // exactly like a bridge death reason. This tests the PLUMBING (the string is
+  // passed through unchanged), so it uses a local error, not the Rust constant.
+  it("toasts the wedged-cutover error on a connected -> disconnected observation", async () => {
+    const err = "test update-failed message";
     const { initPowerButton, applyProxyStateObservation } = await import("./power-button");
     initPowerButton();
     applyProxyStateObservation(1, true); // connected
-    applyProxyStateObservation(2, false, UPDATE_FAILED); // driver died mid-cutover
+    applyProxyStateObservation(2, false, err); // driver died mid-cutover
     expect(showToastMock).toHaveBeenCalledTimes(1);
-    expect(showToastMock).toHaveBeenCalledWith(UPDATE_FAILED, "error");
+    expect(showToastMock).toHaveBeenCalledWith(err, "error");
   });
 
   it("does not re-toast on a re-observation of the same death (frozen seq)", async () => {

--- a/ui/power-button.test.ts
+++ b/ui/power-button.test.ts
@@ -297,6 +297,20 @@ describe("power-button state machine", () => {
     expect(showToastMock).toHaveBeenCalledWith("proxy task exited unexpectedly", "error");
   });
 
+  // Wedged update cutover (#616): the GUI-set UPDATE_FAILED sentinel arrives as
+  // the `error` on a connected -> disconnected observation and must surface as a
+  // toast exactly like a bridge death reason (it flows through
+  // commands::map_status_response unchanged).
+  it("toasts the update-failed sentinel on a wedged cutover (connected -> disconnected)", async () => {
+    const UPDATE_FAILED = "The update didn't finish and the connection was lost.";
+    const { initPowerButton, applyProxyStateObservation } = await import("./power-button");
+    initPowerButton();
+    applyProxyStateObservation(1, true); // connected
+    applyProxyStateObservation(2, false, UPDATE_FAILED); // driver died mid-cutover
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+    expect(showToastMock).toHaveBeenCalledWith(UPDATE_FAILED, "error");
+  });
+
   it("does not re-toast on a re-observation of the same death (frozen seq)", async () => {
     const { initPowerButton, updateProxyStatus } = await import("./power-button");
     initPowerButton();


### PR DESCRIPTION
Closes #616.

## What this fixes

The Windows in-place-update cutover ran **stop → swap → start** from a detached child with **no automatic recovery** for two failure modes, and the GUI masked a false **"Connected"** indefinitely (recovery = reboot). This adds two complementary, **structural** recoveries — **no time thresholds** anywhere.

## Part A — SCM restart-on-failure

`platform/windows.rs::install()` configures `Service::update_failure_actions` with an `SC_ACTION_RESTART` (finite `reset_period`) **plus** `set_failure_actions_on_non_crash_failures(true)` — so a crash **and** a failed-start `Stopped(1)` both auto-restart. A clean `Stopped(0)` (user/cutover stop) is not restarted.

`install()` writes this on the just-created service handle **best-effort** (warn-and-continue): the SCM config is hardening and must not fail the install itself (the MSI runs `hole bridge install` as a custom action). An install base predating this config picks it up on the next update — the cutover child re-applies it via `ensure_failure_actions()` (the re-open + strict-propagate path) from `cutover::run_detached`.

## Part B — marker driver-liveness unmask

The update marker's liveness identity is re-pointed from the **initiator** bridge (stopped as cutover step 1 — dead during *every* healthy update, so keying on it would flash Disconnected + a death toast on success) to the **cutover driver** (the detached child that drives the restart):

- The initiator spawns the child `CREATE_SUSPENDED`, stamps the frozen child's PID + creation time into the marker, then resumes it — an ordering primitive, so the marker names the child before it can act.
- The new bridge sweeps the marker, **then** reports SCM `Running` (after `bind`) — the child exits on the `Running` edge, so a healthy update never presents "marker present + dead driver".
- The GUI resolves liveness by process **exit-time** (`GetProcessTimes`; a handle-retained zombie is *not* alive) via `PROCESS_QUERY_LIMITED_INFORMATION` (cross-privilege-safe), keyed by an exact creation-time equality (no time window). When the driver is confirmed dead it unmasks and surfaces a **path-free** `UPDATE_FAILED` toast; it re-reads the marker at commit (a swept marker = the successor won) and clears the stale error once the cutover resolves.
- `start_via_notify` now fails fast on a `Stopped` transition (never a permanent hang), so a swapped-in bridge that can't reach `Running` cleans up the marker + exits instead of wedging.

**Scope:** Windows only (issue title). macOS keeps presence-masking — its inline actor SIGTERMs itself every update (no trackable driver PID); the wedge is covered by launchd `KeepAlive` + `clear_marker_on_actor_failure`.

## Testing

Unit + integration coverage for the marker schema/stamp, the zombie-aware liveness probe, the `cutover_decision` table, the transport-error / reachable-`running:false` / swept-marker / reload-path / real live-and-dead(zombie)-PID arms, the SCM sweep-before-`Running` ordering, the `start_via_notify` fail-fast, and the frontend `UPDATE_FAILED` toast. The live SCM `NotifyServiceStatusChangeW` immediate-fire behavior and the failed-start composition are covered by the manual elevated acceptance steps below.

**Manual (elevated Windows) — done before merge:**
1. `sc qfailure HoleBridge` shows `RESTART` (+ non-crash flag).
2. Healthy update never flashes Disconnected / UPDATE_FAILED.
3. Kill the cutover child mid-swap → Disconnected + `UPDATE_FAILED` within one 5s tick; repair → error clears.
4. Force a failed successor start → the child exits (no hang), marker cleared, no permanent masked "Connected".

Plan-reviewed across 6 rounds (running-the-review-panel) + code-reviewed across 2 passes to `conditionally-approved`, every `must_fix` applied.
