### PR TITLE
chore(release): bump ex-ray 0.2.0, galoshes 0.3.0, hole 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dump"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "dump-macros",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "dump-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dump",
  "hole-test-observability",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "galoshes"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "handle-holders"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hole-test-observability",
  "skuld",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "hole"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "hole-bridge"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "hole-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dirs 6.0.0",
  "file-rotate",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "hole-test-observability"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ctor 1.0.7",
  "hole-common",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8148,7 +8148,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hole-test-observability",
  "proc-macro2",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-bridge"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-common"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the dump crate (provides #[derive(Dump)])."

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 description = "YAML-shaped representation for logging, analogous to Python's dump() alongside str()/repr()."

--- a/crates/ex-ray/version.toml
+++ b/crates/ex-ray/version.toml
@@ -2,4 +2,4 @@
 # rather than in a Cargo.toml because the crate has no Rust manifest. It is
 # a NEW product and does NOT inherit the retired v2ray-plugin group's
 # version lineage — it starts fresh at 0.1.0. Plain strict semver only.
-version = "0.1.0"
+version = "0.2.0"

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "galoshes"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handle-holders"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-test-observability"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license = "GPL-3.0-or-later"
 publish = false

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the tun-engine crate (provides #[freeze])."

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 publish = false
 description = "Cross-platform TUN device, OS routing, gateway discovery, and a smoltcp-backed packet-loop engine for building split-tunnel VPN/proxy daemons."


### PR DESCRIPTION
Bumps the three release tracks whose shipped artifacts changed since their last tag, ahead of drafting the releases.

- **ex-ray** 0.1.0 → 0.2.0 (minor) — ECH + private-DoH bootstrap (#593), ECH through the uTLS engine (#622), typed bind error (#620).
- **galoshes** 0.2.1 → 0.3.0 (minor) — gains ECH via the refreshed embedded ex-ray (`include_bytes!` of the built binary); internal yamux 0.13→0.14.
- **hole** group (9 crates) 0.3.0 → 0.4.0 (minor) — block-until-connected (#636), Windows cutover recovery (#628), informed-consent dialog (#626), ECH (#593/#622), latency-const codegen (#610), macOS menu-bar/DMG, network-blocked diagnostics.

garter sits out — only test files changed since its tag. `cargo update --workspace` synced Cargo.lock to the 10 workspace-member bumps only; `cargo xtask version --group {hole,galoshes,ex-ray} --check` passes locally.

Version bump only. Draft (this cycle) and publish (later, with signing + `/releases/latest` flip) follow after merge.

Part of #637.