### PR TITLE
fix(ci): install uv on darwin draft-release-hole builds so the DMG builds

### DIFF
--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -59,8 +59,9 @@ jobs:
       - name: Create local tag for build
         run: git tag "releases/hole/v${{ needs.validate.outputs.version }}"
 
+      # Required by both bundle builds — hole-msi (Windows) and hole-dmg
+      # (Darwin dmg-installer) — so it must run on every matrix target.
       - uses: astral-sh/setup-uv@v8.2.0
-        if: matrix.os == 'windows'
 
       - uses: ./.github/actions/setup-build
 


### PR DESCRIPTION
`draft-release-hole`'s build job gated `astral-sh/setup-uv` with `if: matrix.os == 'windows'`, so uv was never installed on the darwin runners. The DMG build now runs `uv run --directory dmg-installer build` (redesigned installer window, #609/#613) → `uv: command not found` → exit 127 on both darwin legs. The MSI build was unaffected.

CI's own `test-dmg-signing` job installs uv **unconditionally**, so it builds the DMG fine and structurally can't catch this — the gap lives only in the release-draft path (a separate workflow with its own uv step). uv is not in the shared `setup-build` composite, which is how the two drifted.

Drop the windows-only `if:` so uv runs on every build target (the `release` job already installs it unconditionally).

Closes #639. Anti-drift follow-up (consolidate uv provisioning into `setup-build`) to be filed separately.