### PR TITLE
fix(galoshes): tight connect cadence for the loopback chain sibling (#550)

### DIFF
--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -337,20 +337,59 @@ async fn relay_udp_server(mut yamux_stream: yamux::Stream, remote: SocketAddr) -
 
 // Client mode =========================================================================================================
 
-async fn connect_with_backoff(addr: SocketAddr, shutdown: &CancellationToken) -> Option<TcpStream> {
-    let mut delay = Duration::from_millis(100);
-    let max_delay = Duration::from_secs(30);
+/// Retry cadence for a **loopback** peer — a hop on the same host (e.g.
+/// ex-ray's local listener). A loopback connect is cheap and its peer comes up
+/// within startup, so poll on a fixed tight cadence: backoff exists to spare a
+/// *network*, and there is none here. Small enough that the first stream isn't
+/// stalled once the peer binds, large enough not to busy-spin on the immediate
+/// `ECONNREFUSED` a loopback returns.
+pub(crate) const LOOPBACK_CONNECT_RETRY: Duration = Duration::from_millis(10);
 
+/// Exponential-backoff bounds for a **routable** peer that may be genuinely
+/// down for a while, so repeated attempts don't hammer the network.
+pub(crate) const REMOTE_BACKOFF_BASE: Duration = Duration::from_millis(100);
+pub(crate) const REMOTE_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Delay before connect attempt `attempt` to `remote`: loopback peers poll on
+/// a fixed tight cadence; routable peers back off exponentially, capped.
+pub(crate) fn connect_delay(remote: SocketAddr, attempt: u32) -> Duration {
+    if remote.ip().is_loopback() {
+        LOOPBACK_CONNECT_RETRY
+    } else {
+        REMOTE_BACKOFF_BASE
+            .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
+            .min(REMOTE_BACKOFF_MAX)
+    }
+}
+
+/// Connect to `addr`, retrying until it succeeds or `shutdown` fires. Retries
+/// are unbounded by design — the peer (a chain sibling or a real server) is
+/// expected to come up. While it is down, work sent to the client's local
+/// listener waits in the OS accept backlog / UDP recv buffer (bounded by the
+/// retry cadence) until the connection is established; nothing is dropped here.
+pub(crate) async fn connect_retrying(addr: SocketAddr, shutdown: &CancellationToken) -> Option<TcpStream> {
+    let mut attempt: u32 = 0;
     loop {
         match TcpStream::connect(addr).await {
             Ok(stream) => return Some(stream),
             Err(e) => {
-                tracing::warn!(error = %e, delay_ms = delay.as_millis(), "connection failed, retrying");
+                let delay = connect_delay(addr, attempt);
+                match (addr.ip().is_loopback(), attempt) {
+                    // A loopback sibling a beat late is normal startup: log once,
+                    // then stay quiet at the tight cadence (no log storm).
+                    (true, 0) => tracing::debug!(%addr, error = %e, "peer not up yet, retrying"),
+                    (true, _) => {}
+                    // A routable peer may be genuinely down: warn each attempt
+                    // (the backoff throttles this to at most ~one line per 30 s).
+                    (false, _) => {
+                        tracing::warn!(%addr, error = %e, delay_ms = delay.as_millis(), "connection failed, retrying")
+                    }
+                }
                 tokio::select! {
                     _ = tokio::time::sleep(delay) => {}
                     _ = shutdown.cancelled() => return None,
                 }
-                delay = (delay * 2).min(max_delay);
+                attempt = attempt.saturating_add(1);
             }
         }
     }
@@ -498,7 +537,7 @@ pub(crate) async fn run_client(
 
     loop {
         // Connect to the remote yamux server.
-        let tcp = match connect_with_backoff(remote, &shutdown).await {
+        let tcp = match connect_retrying(remote, &shutdown).await {
             Some(s) => s,
             None => return Ok(()), // shutdown requested
         };

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -15,8 +15,9 @@ use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client, run_server, ClientBoundAddrs,
-    FrameAccumulator, StreamTag, DEFAULT_UDP_TIMEOUT,
+    connect_delay, connect_retrying, deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client,
+    run_server, ClientBoundAddrs, FrameAccumulator, StreamTag, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY,
+    REMOTE_BACKOFF_MAX,
 };
 // Only the Windows-gated CONNRESET regression test uses this.
 #[cfg(windows)]
@@ -407,5 +408,88 @@ async fn tcp_full_response_survives_client_half_close() {
     app.read_to_end(&mut got).await.expect("read response to EOF");
     assert_eq!(got, RESPONSE, "the full response must survive a client half-close");
 
+    shutdown.cancel();
+}
+
+// Connect-cadence policy (#550) ---------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn connect_delay_is_tight_and_constant_for_a_loopback_peer() {
+    // A loopback peer is a co-located hop that comes up within startup; every
+    // attempt polls on the same tight cadence, so nothing is stalled behind a
+    // grown backoff once it binds.
+    for addr in ["127.0.0.1:9000", "[::1]:9000"] {
+        let remote: SocketAddr = addr.parse().unwrap();
+        for attempt in [0u32, 1, 5, 20, 1000] {
+            assert_eq!(
+                connect_delay(remote, attempt),
+                LOOPBACK_CONNECT_RETRY,
+                "{addr} @ {attempt}"
+            );
+        }
+    }
+}
+
+#[skuld::test]
+fn connect_delay_backs_off_exponentially_for_a_routable_remote() {
+    // Golden literals, independent of the impl's formula: 100 ms doubling,
+    // capped at 30 s.
+    let remote: SocketAddr = "203.0.113.7:443".parse().unwrap();
+    let expected_ms = [
+        100u64, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 30000, 30000, 30000,
+    ];
+    for (attempt, ms) in expected_ms.iter().enumerate() {
+        assert_eq!(
+            connect_delay(remote, attempt as u32),
+            Duration::from_millis(*ms),
+            "@ {attempt}"
+        );
+    }
+    // Saturates at the cap for huge attempt counts (no overflow panic).
+    assert_eq!(connect_delay(remote, u32::MAX), REMOTE_BACKOFF_MAX);
+}
+
+#[skuld::test]
+async fn connect_retrying_returns_the_stream_when_the_peer_is_up() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shutdown = CancellationToken::new();
+    assert!(connect_retrying(addr, &shutdown).await.is_some());
+}
+
+#[skuld::test]
+async fn connect_retrying_returns_none_when_shutdown_fires() {
+    // Bound-but-not-listening: connects are refused (so the loop is in its
+    // retry path) and the port can't be stolen by a parallel test. A
+    // pre-cancelled token makes the loop take its shutdown branch — no clock.
+    let sock = tokio::net::TcpSocket::new_v4().unwrap();
+    sock.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = sock.local_addr().unwrap();
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+    assert!(connect_retrying(addr, &shutdown).await.is_none());
+}
+
+#[skuld::test]
+async fn connect_retrying_retries_until_the_peer_listens() {
+    // Reserve the port bound-but-not-listening so early connects refuse (and
+    // no parallel test can steal it), then `listen` to bring the peer up. The
+    // client must retry across the gap and connect — a real event rendezvous
+    // (await the task), never a timed guess.
+    let sock = tokio::net::TcpSocket::new_v4().unwrap();
+    sock.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = sock.local_addr().unwrap();
+
+    let shutdown = CancellationToken::new();
+    let token = shutdown.clone();
+    let handle = tokio::spawn(async move { connect_retrying(addr, &token).await });
+
+    tokio::task::yield_now().await; // bias the first attempt to fail before listen
+    let _listener = sock.listen(1024).unwrap();
+
+    assert!(
+        handle.await.unwrap().is_some(),
+        "must connect once the peer starts listening"
+    );
     shutdown.cancel();
 }


### PR DESCRIPTION
## Problem

galoshes' yamux client reconnects to its next hop with an exponential backoff (100 ms → ×2 → 30 s) built for a flaky *remote*. In the bundled chain that hop is **always a loopback sibling** — ex-ray's local listener, wired by garter as `plugin[i].remote = plugin[i+1].local`. Chain readiness fires once the local listeners bind, *before* the yamux→ex-ray connect completes; if that first connect refuses (sibling a beat late), the client sleeps out a grown backoff before retrying. Under CI contention the first stream/datagram stalled for seconds — past the 20 s roundtrip read budget — surfacing as the cross-platform cold-start flakes (darwin `ReadTimeout` / truncation, UDP reply lag; the #542/#543 family).

## Fix

Key the connect cadence on the peer's transport nature. A loopback peer is a cheap same-host connection whose peer comes up within startup, so poll it on a fixed tight cadence (`connect_delay` → 10 ms); a routable peer keeps the exponential backoff (a network genuinely worth sparing). This bounds the post-bind first-connect lag from up-to-seconds down to ~10 ms.

## Scope

Option (a) from #550. The residual `ready`-before-connected window remains (~10 ms; work waits in the OS accept backlog / UDP recv buffer until the connection establishes — nothing is dropped). Closing it structurally (option c, honest readiness) is deliberately out of scope.

## Verify

- Golden-literal table test pins the delay policy (loopback constant; routable 100 ms→30 s, capped, no overflow).
- Event-rendezvous tests over the stateful retry loop (connects / retries-then-connects / returns on shutdown), race-free via bound-but-not-listening ports — no wall-clock.
- Real-world validation: the previously-flaky darwin `plugin-e2e` / bridge-e2e roundtrip suites on CI ceasing to flake.

Closes #550
