### PR TITLE
fix(setup): macOS elevation emits valid AppleScript literal (#651)

### DIFF
--- a/crates/hole/src/setup.rs
+++ b/crates/hole/src/setup.rs
@@ -287,17 +287,7 @@ fn cmdline_roundtrips(cmdline: &str, expected: &[&str]) -> bool {
 /// see [`prompt_bridge_install`], which layers a temp-log capture on top.
 #[cfg(target_os = "macos")]
 pub fn run_elevated(program: &Path, args: &[&str]) -> Result<(), SetupError> {
-    // Build the shell command with proper escaping
-    let mut cmd_parts = vec![shell_escape(program.to_string_lossy().as_ref())];
-    for arg in args {
-        cmd_parts.push(shell_escape(arg));
-    }
-    let shell_cmd = cmd_parts.join(" ");
-
-    let script = format!(
-        "do shell script {} with administrator privileges",
-        shell_escape(&shell_cmd)
-    );
+    let script = build_elevation_script(program, args);
 
     let output = std::process::Command::new("osascript").args(["-e", &script]).output()?;
 
@@ -323,10 +313,37 @@ pub fn run_elevated(program: &Path, args: &[&str]) -> Result<(), SetupError> {
     })
 }
 
+/// Build the AppleScript that runs `program args…` with administrator
+/// privileges. Two escaping layers: each argv element is POSIX-shell-quoted
+/// (the command line is executed by `/bin/sh` via `do shell script`), then
+/// the whole line is wrapped as an AppleScript string literal.
+#[cfg(target_os = "macos")]
+fn build_elevation_script(program: &Path, args: &[&str]) -> String {
+    let mut cmd_parts = vec![shell_escape(program.to_string_lossy().as_ref())];
+    for arg in args {
+        cmd_parts.push(shell_escape(arg));
+    }
+    let shell_cmd = cmd_parts.join(" ");
+
+    format!(
+        "do shell script {} with administrator privileges",
+        applescript_quote(&shell_cmd)
+    )
+}
+
 #[cfg(target_os = "macos")]
 fn shell_escape(s: &str) -> String {
     // Single-quote escaping for POSIX shell
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Quote a string as an AppleScript string literal. Distinct from
+/// [`shell_escape`], which produces a POSIX **single**-quoted token for
+/// `/bin/sh`. Using the latter for the AppleScript layer emits
+/// `do shell script '…'`, which the AppleScript compiler rejects with `-2741`.
+#[cfg(target_os = "macos")]
+fn applescript_quote(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 // Install/uninstall orchestration =====================================================================================

--- a/crates/hole/src/setup_tests.rs
+++ b/crates/hole/src/setup_tests.rs
@@ -246,3 +246,57 @@ fn exit_code_display_with_unicode_output() {
     assert!(rendered.contains("Привет"));
     assert!(rendered.contains("世界"));
 }
+
+// macOS AppleScript elevation quoting =================================================================================
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn applescript_quote_wraps_and_escapes() {
+    assert_eq!(applescript_quote("plain"), "\"plain\"");
+    assert_eq!(applescript_quote(r#"a"b"#), r#""a\"b""#);
+    assert_eq!(applescript_quote(r"a\b"), r#""a\\b""#);
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn build_elevation_script_uses_double_quoted_applescript_literal() {
+    let script = build_elevation_script(
+        Path::new("/Applications/Hole.app/Contents/MacOS/hole"),
+        &["bridge", "install"],
+    );
+    // A single quote after `do shell script ` is the -2741 "unknown token".
+    assert!(
+        script.starts_with("do shell script \""),
+        "outer literal must be double-quoted, got: {script}"
+    );
+    assert!(script.ends_with(" with administrator privileges"), "got: {script}");
+    assert!(script.contains("'bridge' 'install'"), "got: {script}");
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn build_elevation_script_output_compiles_and_roundtrips_via_osascript() {
+    // Feed the shipped function's own output to the real AppleScript compiler,
+    // minus the admin suffix so no password prompt appears. /bin/echo + argv
+    // with quotes, backslash, and spaces proves both compile and round-trip.
+    // The single quote in `a'b` makes shell_escape emit its own `'\''`
+    // backslash, so applescript_quote's backslash-doubling is exercised too.
+    let args = ["a\"b", "c\\d", "e f", "a'b"];
+    let full = build_elevation_script(Path::new("/bin/echo"), &args);
+    let script = full
+        .strip_suffix(" with administrator privileges")
+        .expect("script ends with the admin suffix");
+    let out = std::process::Command::new("osascript")
+        .args(["-e", script])
+        .output()
+        .expect("osascript is present on macOS");
+    assert!(
+        out.status.success(),
+        "osascript rejected build_elevation_script output: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim_end_matches('\n'),
+        "a\"b c\\d e f a'b"
+    );
+}


### PR DESCRIPTION
Closes #651.

macOS `run_elevated` built the `do shell script …` argument with `shell_escape` (POSIX **single**-quote), but AppleScript string literals must be **double**-quoted — the `'` at offset 17 (right after the 16-char `do shell script `) is an "unknown token", so every osascript-elevated operation (install, uninstall, runtime bridge start/stop) failed at compile time with `-2741`.

## Fix

Add `applescript_quote` (double-quote wrap, backslash-escape `"` and `\`) and route the outer literal through it via a new `build_elevation_script`. The inner per-arg `shell_escape` is unchanged — that string is executed by `/bin/sh` via `do shell script`, so POSIX single-quoting is correct there.

## Tests

macOS-gated, in `setup_tests.rs`:
- `applescript_quote_wraps_and_escapes` — escaping rules.
- `build_elevation_script_uses_double_quoted_applescript_literal` — regression assertion that the outer literal is double-quoted.
- `build_elevation_script_output_compiles_and_roundtrips_via_osascript` — feeds the shipped function's own output to the real `osascript` compiler over adversarial argv (double quote, backslash, spaces, single quote), asserting it compiles and round-trips. No admin prompt (admin suffix stripped, `/bin/echo` payload).
