### PR TITLE
fix(cli): hole bridge log defaults to the service log dir (#649)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -865,6 +865,9 @@ Default dir is `dirs::state_dir()/hole/logs` (`gui.log`, `bridge.log`):
 - Windows `%LOCALAPPDATA%\hole\logs\`, macOS `~/Library/Application Support/hole/logs/`
 - Installed service: Windows `C:\ProgramData\hole\logs\`, macOS `/var/log/hole/`
 
+`hole bridge log` defaults to the installed-service dir; override with `--log-dir`
+or `HOLE_LOG_DIR` to read a foreground/dev bridge's log.
+
 ### WebView2 and Chromium logs
 
 Windows WebView2 writes Chromium-format lines (`[MMDD/HHMMSS.mmm:LEVEL:file:line]`)
@@ -942,7 +945,7 @@ User-facing commands are in [README.md](README.md#commands). The rest:
 hole bridge run [--socket-path P] [--log-dir DIR] [--state-dir DIR]   run bridge (foreground, needs elevation)
 hole bridge run --service [--log-dir DIR] [--state-dir DIR]           run as service (invoked by SCM/launchd)
 hole bridge install | uninstall | status                             register/start | stop/remove | status (elevation)
-hole bridge log [path | watch [--tail N]] [--log-dir DIR]            print | locate | stream the bridge log
+hole bridge log [path | watch [--tail N]] [--log-dir DIR]            print | locate | stream the bridge log (defaults to the service log dir)
 hole bridge grant-access [--then-send B64 | --then-send-file PATH]    create hole group, add user, write SID file
 hole bridge ipc-send (--base64 B64 | --request-file PATH)            proxy a single IPC command (elevation)
 hole proxy start --config-file PATH [--local-port PORT] [--local-port-http PORT] [--no-socks5] [--http] [--tunnel-mode MODE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -945,7 +945,7 @@ User-facing commands are in [README.md](README.md#commands). The rest:
 hole bridge run [--socket-path P] [--log-dir DIR] [--state-dir DIR]   run bridge (foreground, needs elevation)
 hole bridge run --service [--log-dir DIR] [--state-dir DIR]           run as service (invoked by SCM/launchd)
 hole bridge install | uninstall | status                             register/start | stop/remove | status (elevation)
-hole bridge log [path | watch [--tail N]] [--log-dir DIR]            print | locate | stream the bridge log (defaults to the service log dir)
+hole bridge log [path | watch [--tail N]] [--log-dir DIR]            print | locate | stream the bridge log
 hole bridge grant-access [--then-send B64 | --then-send-file PATH]    create hole group, add user, write SID file
 hole bridge ipc-send (--base64 B64 | --request-file PATH)            proxy a single IPC command (elevation)
 hole proxy start --config-file PATH [--local-port PORT] [--local-port-http PORT] [--no-socks5] [--http] [--tunnel-mode MODE]

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -142,17 +142,30 @@ pub fn default_log_dir() -> PathBuf {
     crate::paths::default_user_subdir("logs")
 }
 
-/// Resolve the log directory: explicit `override_dir`, else `HOLE_LOG_DIR`,
-/// else [`default_log_dir`]. A blank `HOLE_LOG_DIR` is ignored.
-pub fn resolve_log_dir(override_dir: Option<PathBuf>) -> PathBuf {
-    let env_dir = std::env::var_os("HOLE_LOG_DIR")
+/// Read `HOLE_LOG_DIR` as an override directory; a blank value is treated as
+/// unset. The one impure seam behind the log-dir resolvers, so their pure cores
+/// stay table-testable.
+pub fn hole_log_dir_env() -> Option<PathBuf> {
+    std::env::var_os("HOLE_LOG_DIR")
         .filter(|v| !v.is_empty())
-        .map(PathBuf::from);
-    resolve_log_dir_from(override_dir, env_dir)
+        .map(PathBuf::from)
 }
 
-fn resolve_log_dir_from(override_dir: Option<PathBuf>, env_dir: Option<PathBuf>) -> PathBuf {
-    override_dir.or(env_dir).unwrap_or_else(default_log_dir)
+/// Resolve the log directory: explicit `override_dir`, else `HOLE_LOG_DIR`,
+/// else [`default_log_dir`].
+pub fn resolve_log_dir(override_dir: Option<PathBuf>) -> PathBuf {
+    resolve_log_dir_from(override_dir, hole_log_dir_env(), default_log_dir)
+}
+
+/// Pure resolution core: `override_dir`, else `env_dir`, else `fallback()`. The
+/// `fallback` distinguishes the per-user resolver ([`default_log_dir`]) from the
+/// `hole bridge log` reader, which passes the installed service's dir.
+pub fn resolve_log_dir_from(
+    override_dir: Option<PathBuf>,
+    env_dir: Option<PathBuf>,
+    fallback: impl FnOnce() -> PathBuf,
+) -> PathBuf {
+    override_dir.or(env_dir).unwrap_or_else(fallback)
 }
 
 // Per-sink directive resolution =======================================================================================

--- a/crates/common/src/logging.rs
+++ b/crates/common/src/logging.rs
@@ -143,12 +143,15 @@ pub fn default_log_dir() -> PathBuf {
 }
 
 /// Read `HOLE_LOG_DIR` as an override directory; a blank value is treated as
-/// unset. The one impure seam behind the log-dir resolvers, so their pure cores
-/// stay table-testable.
+/// unset. The one impure seam behind the log-dir resolvers.
 pub fn hole_log_dir_env() -> Option<PathBuf> {
-    std::env::var_os("HOLE_LOG_DIR")
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
+    nonblank_dir(std::env::var_os("HOLE_LOG_DIR"))
+}
+
+/// Drop a blank value so an empty `HOLE_LOG_DIR=` falls through to the next
+/// resolution tier instead of resolving to a bare relative path.
+fn nonblank_dir(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    raw.filter(|v| !v.is_empty()).map(PathBuf::from)
 }
 
 /// Resolve the log directory: explicit `override_dir`, else `HOLE_LOG_DIR`,
@@ -157,9 +160,9 @@ pub fn resolve_log_dir(override_dir: Option<PathBuf>) -> PathBuf {
     resolve_log_dir_from(override_dir, hole_log_dir_env(), default_log_dir)
 }
 
-/// Pure resolution core: `override_dir`, else `env_dir`, else `fallback()`. The
-/// `fallback` distinguishes the per-user resolver ([`default_log_dir`]) from the
-/// `hole bridge log` reader, which passes the installed service's dir.
+/// Pure resolution core: `override_dir`, else `env_dir`, else `fallback()`.
+/// `fallback` is a closure so callers can supply something other than
+/// [`default_log_dir`].
 pub fn resolve_log_dir_from(
     override_dir: Option<PathBuf>,
     env_dir: Option<PathBuf>,

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -604,20 +604,28 @@ fn resolve_log_dir_prefers_explicit_override() {
     let got = super::resolve_log_dir_from(
         Some(std::path::PathBuf::from("/explicit")),
         Some(std::path::PathBuf::from("/env")),
+        super::default_log_dir,
     );
     assert_eq!(got, std::path::PathBuf::from("/explicit"));
 }
 
 #[skuld::test]
 fn resolve_log_dir_uses_env_when_no_override() {
-    let got = super::resolve_log_dir_from(None, Some(std::path::PathBuf::from("/env")));
+    let got = super::resolve_log_dir_from(None, Some(std::path::PathBuf::from("/env")), super::default_log_dir);
     assert_eq!(got, std::path::PathBuf::from("/env"));
 }
 
 #[skuld::test]
 fn resolve_log_dir_falls_back_to_default() {
-    let got = super::resolve_log_dir_from(None, None);
+    let got = super::resolve_log_dir_from(None, None, super::default_log_dir);
     assert_eq!(got, super::default_log_dir());
+}
+
+#[skuld::test]
+fn resolve_log_dir_from_uses_supplied_fallback() {
+    // With no override and no env, the supplied fallback wins.
+    let got = super::resolve_log_dir_from(None, None, || std::path::PathBuf::from("/service"));
+    assert_eq!(got, std::path::PathBuf::from("/service"));
 }
 
 // Per-sink composition ------------------------------------------------------------------------------------------------

--- a/crates/common/src/logging/logging_tests.rs
+++ b/crates/common/src/logging/logging_tests.rs
@@ -623,9 +623,27 @@ fn resolve_log_dir_falls_back_to_default() {
 
 #[skuld::test]
 fn resolve_log_dir_from_uses_supplied_fallback() {
-    // With no override and no env, the supplied fallback wins.
     let got = super::resolve_log_dir_from(None, None, || std::path::PathBuf::from("/service"));
     assert_eq!(got, std::path::PathBuf::from("/service"));
+}
+
+#[skuld::test]
+fn nonblank_dir_keeps_nonempty() {
+    assert_eq!(
+        super::nonblank_dir(Some("/x".into())),
+        Some(std::path::PathBuf::from("/x"))
+    );
+}
+
+#[skuld::test]
+fn nonblank_dir_drops_blank() {
+    // An empty HOLE_LOG_DIR= must fall through, not resolve to a bare path.
+    assert_eq!(super::nonblank_dir(Some("".into())), None);
+}
+
+#[skuld::test]
+fn nonblank_dir_drops_absent() {
+    assert_eq!(super::nonblank_dir(None), None);
 }
 
 // Per-sink composition ------------------------------------------------------------------------------------------------

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -158,8 +158,9 @@ pub(crate) enum BridgeAction {
     Status,
     /// View bridge logs
     Log {
-        /// Override the log directory
-        #[arg(long)]
+        /// Override the log directory. Global so it parses before or after the
+        /// nested `watch`/`path` subcommand.
+        #[arg(long, global = true)]
         log_dir: Option<std::path::PathBuf>,
         #[command(subcommand)]
         action: Option<LogAction>,

--- a/crates/hole/src/cli.rs
+++ b/crates/hole/src/cli.rs
@@ -712,8 +712,24 @@ fn handle_bridge(action: BridgeAction) -> i32 {
     }
 }
 
+/// Resolve where `hole bridge log` reads: explicit `--log-dir`, else
+/// `HOLE_LOG_DIR`, else the installed service's log dir. The service is where
+/// the bridge writes in production; the per-user default never matches it.
+fn resolve_bridge_log_dir(log_dir: Option<std::path::PathBuf>) -> std::path::PathBuf {
+    resolve_bridge_log_dir_from(log_dir, hole_common::logging::hole_log_dir_env())
+}
+
+/// Pure seam for [`resolve_bridge_log_dir`]: the service log dir is baked in as
+/// the fallback so tests can pin it without reading the process environment.
+fn resolve_bridge_log_dir_from(
+    log_dir: Option<std::path::PathBuf>,
+    env_dir: Option<std::path::PathBuf>,
+) -> std::path::PathBuf {
+    hole_common::logging::resolve_log_dir_from(log_dir, env_dir, hole_common::update_marker::service_log_dir)
+}
+
 fn handle_bridge_log(log_dir: Option<std::path::PathBuf>, action: Option<LogAction>) -> i32 {
-    let log_dir = log_dir.unwrap_or_else(hole_common::logging::default_log_dir);
+    let log_dir = resolve_bridge_log_dir(log_dir);
     let log_path = log_dir.join("bridge.log");
 
     match action {

--- a/crates/hole/src/cli_tests.rs
+++ b/crates/hole/src/cli_tests.rs
@@ -524,9 +524,7 @@ fn bridge_log_dir_flag_still_accepted_before_subcommand() {
 
 // `hole bridge log` reader default ====================================================================================
 //
-// With no --log-dir and no HOLE_LOG_DIR, the reader resolves to the installed
-// service's log dir — where the bridge writes in production — not the per-user
-// default that never matches it.
+// Falls back to the installed service's log dir, not the per-user default.
 
 #[skuld::test]
 fn resolve_bridge_log_dir_falls_back_to_service_dir() {

--- a/crates/hole/src/cli_tests.rs
+++ b/crates/hole/src/cli_tests.rs
@@ -457,6 +457,71 @@ fn bridge_install_parses_both_flags() {
     assert_eq!(repair_user_data_dir, Some(std::path::PathBuf::from("/tmp/R")));
 }
 
+// `bridge log --log-dir` position-independence ========================================================================
+//
+// --log-dir applies to `bridge log` regardless of position relative to the
+// nested watch/path subcommand.
+
+#[skuld::test]
+fn bridge_log_dir_flag_accepted_after_watch_subcommand() {
+    let cli = Cli::try_parse_from([
+        "hole",
+        "bridge",
+        "log",
+        "watch",
+        "--tail",
+        "50",
+        "--log-dir",
+        "/tmp/svc",
+    ])
+    .expect("--log-dir should be accepted after the watch subcommand");
+    let Some(Command::Bridge {
+        action: BridgeAction::Log { log_dir, action },
+    }) = cli.command
+    else {
+        panic!("expected Bridge::Log");
+    };
+    assert_eq!(log_dir, Some(std::path::PathBuf::from("/tmp/svc")));
+    assert!(matches!(action, Some(LogAction::Watch { tail: 50 })));
+}
+
+#[skuld::test]
+fn bridge_log_dir_flag_accepted_after_path_subcommand() {
+    let cli = Cli::try_parse_from(["hole", "bridge", "log", "path", "--log-dir", "/tmp/svc"])
+        .expect("--log-dir should be accepted after the path subcommand");
+    let Some(Command::Bridge {
+        action: BridgeAction::Log { log_dir, action },
+    }) = cli.command
+    else {
+        panic!("expected Bridge::Log");
+    };
+    assert_eq!(log_dir, Some(std::path::PathBuf::from("/tmp/svc")));
+    assert!(matches!(action, Some(LogAction::Path)));
+}
+
+#[skuld::test]
+fn bridge_log_dir_flag_still_accepted_before_subcommand() {
+    let cli = Cli::try_parse_from([
+        "hole",
+        "bridge",
+        "log",
+        "--log-dir",
+        "/tmp/svc",
+        "watch",
+        "--tail",
+        "50",
+    ])
+    .expect("--log-dir before the subcommand must still parse");
+    let Some(Command::Bridge {
+        action: BridgeAction::Log { log_dir, action },
+    }) = cli.command
+    else {
+        panic!("expected Bridge::Log");
+    };
+    assert_eq!(log_dir, Some(std::path::PathBuf::from("/tmp/svc")));
+    assert!(matches!(action, Some(LogAction::Watch { tail: 50 })));
+}
+
 #[skuld::test]
 fn resolve_cli_log_dir_honors_install_log_dir_override() {
     let custom = std::path::PathBuf::from("/tmp/hole-install-XYZ");

--- a/crates/hole/src/cli_tests.rs
+++ b/crates/hole/src/cli_tests.rs
@@ -522,6 +522,38 @@ fn bridge_log_dir_flag_still_accepted_before_subcommand() {
     assert!(matches!(action, Some(LogAction::Watch { tail: 50 })));
 }
 
+// `hole bridge log` reader default ====================================================================================
+//
+// With no --log-dir and no HOLE_LOG_DIR, the reader resolves to the installed
+// service's log dir — where the bridge writes in production — not the per-user
+// default that never matches it.
+
+#[skuld::test]
+fn resolve_bridge_log_dir_falls_back_to_service_dir() {
+    // Pins the load-bearing wiring: the baked fallback is the service dir, not
+    // the per-user default. A revert to default_log_dir would fail this.
+    assert_eq!(
+        super::resolve_bridge_log_dir_from(None, None),
+        hole_common::update_marker::service_log_dir()
+    );
+    assert_ne!(
+        super::resolve_bridge_log_dir_from(None, None),
+        hole_common::logging::default_log_dir()
+    );
+}
+
+#[skuld::test]
+fn resolve_bridge_log_dir_prefers_explicit_override() {
+    let custom = std::path::PathBuf::from("/tmp/custom-logs");
+    assert_eq!(super::resolve_bridge_log_dir_from(Some(custom.clone()), None), custom);
+}
+
+#[skuld::test]
+fn resolve_bridge_log_dir_uses_env_when_no_override() {
+    let env = std::path::PathBuf::from("/tmp/env-logs");
+    assert_eq!(super::resolve_bridge_log_dir_from(None, Some(env.clone())), env);
+}
+
 #[skuld::test]
 fn resolve_cli_log_dir_honors_install_log_dir_override() {
     let custom = std::path::PathBuf::from("/tmp/hole-install-XYZ");


### PR DESCRIPTION
Closes #649.

## Problem

`hole bridge log` (no `--log-dir`) resolved its read dir via `default_log_dir()` → per-user `%LOCALAPPDATA%\hole\logs` (macOS `~/Library/Application Support/hole/logs`), but the installed service is registered with `--log-dir service_log_dir()` → `%ProgramData%\hole\logs` (macOS `/var/log/hole`). So the obvious `hole bridge log watch` hit ENOENT and never found the installed service's log.

Secondary: `--log-dir` was rejected when placed after the nested `watch`/`path` subcommand.

## Change

- Reader default is now the installed service's log dir; full order is explicit `--log-dir` → `HOLE_LOG_DIR` → `service_log_dir()`. The reader now honors `HOLE_LOG_DIR`, which it silently ignored before.
- `--log-dir` on `bridge log` is a clap global arg, so it parses in any position.
- `common::logging::resolve_log_dir_from` gains an injectable `fallback`; the generic per-user resolver is unchanged, and the `hole` crate injects `service_log_dir` at the call site (no new `logging → update_marker` coupling).

## Verify

Built the CLI and drove `hole bridge log path`:

| Invocation | Resolved path |
| --- | --- |
| `bridge log path` | `C:\ProgramData\hole\logs\bridge.log` |
| `bridge log path --log-dir X` | `X\bridge.log` (was rejected before) |
| `HOLE_LOG_DIR=Y bridge log path` | `Y\bridge.log` |

Unit tests pin the fallback wiring (revert to `default_log_dir` fails), the blank-`HOLE_LOG_DIR` filter, and all three `--log-dir` positions. `cargo nextest run -p hole-common -p hole --no-default-features`: 803 pass.
