### PR TITLE
fix(galoshes): reconnect the yamux client after a transport reset (#655)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,13 @@ before editing; the sections linked below are the authoritative source.
 - **Crash-recovery sweep.** `bridge-{routes,plugins,dns}.json` + ETW sessions are
   replayed/cleaned on next startup after the IPC socket binds. →
   [CONTRIBUTING.md#crash-recovery](CONTRIBUTING.md#crash-recovery)
+- **Yamux transport self-heal.** The galoshes yamux client reconnects after a
+  transport reset instead of wedging; death is detected via the driver's
+  inbound channel closing, and reconnect backoff is floored and resets on
+  transport-level liveness (any inbound yamux frame). `driver.abort()`
+  teardown deliberately truncates in-flight relays; a silent (no-RST)
+  black-hole is out of scope (→ #660). →
+  [CONTRIBUTING.md#yamux-transport-self-heal](CONTRIBUTING.md#yamux-transport-self-heal)
 - **Fail-closed covers.** The **standing lockdown** cover
   (`Routing::install_lockdown`, opt-in kill switch) holds the update-cutover gap:
   the bridge **disarms-not-drops** it across the restart and the new bridge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,36 @@ installed service `C:\ProgramData\hole\state\` / `/var/db/hole/state/`;
 If in-bridge recovery can't run, [`scripts/network-reset.py`](scripts/network-reset.py)
 performs equivalent cleanup from outside.
 
+### Yamux transport self-heal
+
+The galoshes yamux client ([`crates/galoshes/src/yamux.rs`](crates/galoshes/src/yamux.rs))
+reconnects after a transport reset instead of wedging the tunnel:
+
+- **Death detection.** The driver task owns the yamux `Connection` and drops its
+  inbound-stream sender when the connection ends; `run_client_session` seeing
+  `inbound_rx.recv() == None` is the transport-death signal — no separate
+  liveness poll is needed.
+- **Reconnect backoff.** Every reconnect waits at least `REMOTE_BACKOFF_BASE`
+  (a floor bounding a peer flapping right after one byte) and escalates
+  exponentially to `REMOTE_BACKOFF_MAX` on repeated failures.
+  "Productive" is **transport-level**, not application-level: `TransportLivenessTap`
+  sits below yamux framing and flags any inbound byte — relayed data or a bare
+  keepalive/flow-control frame alike — as liveness, which resets the backoff to
+  the floor. A session that never received a single inbound byte counts as a
+  failure and escalates.
+- **Teardown tradeoff.** On session end the driver is `abort()`-ed rather than
+  drained, so any relay stream still in flight is truncated. This trades a
+  handful of interrupted flows for a bounded, deterministic teardown instead of
+  hanging on a chain drain-timeout.
+- **Local errors don't tear down the tunnel.** A local `accept`/`recv` error on
+  the client's loopback listener, or the server's inbound listener, is logged
+  and the accept loop continues — reconnecting the transport wouldn't fix a
+  local socket error, and a broken listener is not what these errors indicate
+  (they're transient: a stray `ECONNABORTED`, momentary `EMFILE`).
+- **Scope boundary.** This detects a transport that visibly dies (FIN/RST,
+  yamux protocol error). A peer that goes silent without ever resetting the
+  connection (a black-holed link) is not detected by this mechanism — see #660.
+
 ### Fail-closed cover
 
 Two egress-block covers share the platform `Cover` guard (kind-aware `Drop`):

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -52,6 +52,10 @@ hole-test-observability = { path = "../test-observability" }
 # Enable garter's `test_utils::WaitableWriter` for the E2E relay tests
 # (the module is gated behind garter's `test-utils` feature).
 garter = { path = "../garter", features = ["test-utils"] }
+# Enable `tokio::time::pause` for tests that need virtual-clock control.
+# Cargo unions this with the main deps `full` feature set; production
+# builds do NOT get test-util.
+tokio = { version = "1", features = ["test-util"] }
 
 [build-dependencies]
 sha2 = "0.11"

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -114,13 +114,13 @@ impl FrameAccumulator {
 
 // Driver ==============================================================================================================
 
-type OpenStreamReply = tokio::sync::oneshot::Sender<Result<yamux::Stream, yamux::ConnectionError>>;
+pub(crate) type OpenStreamReply = tokio::sync::oneshot::Sender<Result<yamux::Stream, yamux::ConnectionError>>;
 
 /// Central driver loop that owns the yamux `Connection`.
 ///
 /// All interaction with the connection goes through channels because `Connection`
 /// requires `&mut self` for every poll method.
-async fn drive_connection<T: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static>(
+pub(crate) async fn drive_connection<T: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + 'static>(
     mut conn: yamux::Connection<T>,
     mut open_rx: mpsc::Receiver<OpenStreamReply>,
     inbound_tx: mpsc::Sender<yamux::Stream>,
@@ -599,7 +599,7 @@ pub(crate) struct ClientBoundAddrs {
 /// `inbound_tx` and so is indistinguishable from a clean transport death at the
 /// `inbound_rx` seam, so the caller uses this to escalate instead of retrying.
 #[must_use]
-fn driver_panicked(result: std::result::Result<(), tokio::task::JoinError>) -> bool {
+pub(crate) fn driver_panicked(result: std::result::Result<(), tokio::task::JoinError>) -> bool {
     match result {
         Ok(()) => false,
         Err(e) if e.is_cancelled() => false,

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -362,6 +362,34 @@ pub(crate) fn connect_delay(remote: SocketAddr, attempt: u32) -> Duration {
     }
 }
 
+/// Consecutive-failure count after a session ends. A **productive** session (the
+/// server sent bytes back) resets the count so the next reconnect is at the floor;
+/// an unproductive one increments it so repeated failures escalate. Saturating.
+// Wired into the reconnect loop in a later change; only `#[cfg(test)]` calls it
+// today, so the non-test lib build sees it as unused.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn next_failures(prev: u32, productive: bool) -> u32 {
+    if productive {
+        0
+    } else {
+        prev.saturating_add(1)
+    }
+}
+
+/// Backoff before reconnecting after `failures` consecutive failed sessions.
+/// Every reconnect waits at least `REMOTE_BACKOFF_BASE` — a floor that bounds a
+/// peer flapping right after delivering one byte — and sustained failures
+/// escalate exponentially to `REMOTE_BACKOFF_MAX`.
+// Same as `next_failures` above: only exercised by tests until the reconnect
+// loop lands.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn session_reconnect_backoff(failures: u32) -> Duration {
+    let step = failures.max(1) - 1;
+    REMOTE_BACKOFF_BASE
+        .saturating_mul(1u32.checked_shl(step).unwrap_or(u32::MAX))
+        .min(REMOTE_BACKOFF_MAX)
+}
+
 /// Connect to `addr`, retrying until it succeeds or `shutdown` fires. Retries
 /// are unbounded by design — the peer (a chain sibling or a real server) is
 /// expected to come up. While it is down, work sent to the client's local

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+// `Context` alone would collide with `anyhow::Context` (the `.context()` combinator, used
+// throughout this file); the tap's poll methods spell out `std::task::Context` instead.
+use std::task::Poll;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -277,6 +282,61 @@ fn disable_udp_connreset(sock: &std::net::UdpSocket) -> std::io::Result<()> {
 async fn write_tag(stream: &mut yamux::Stream, tag: StreamTag) -> std::io::Result<()> {
     stream.write_all(&[tag.to_byte()]).await?;
     stream.flush().await
+}
+
+// Liveness tap ========================================================================================================
+
+/// Wraps the yamux transport and sets `productive` on the first inbound byte.
+///
+/// `run_client` gives this to `yamux::Connection::new`, so the tap is polled only
+/// by the driver task; reading `productive` after `driver.await` therefore has a
+/// happens-before edge to every write here (no cross-task race). It sits *below*
+/// yamux framing, so any inbound frame counts — relayed data or flow-control /
+/// keepalive frames alike. That is deliberate: it measures *transport*-level
+/// liveness (the far yamux peer responded), which is the correct signal for a
+/// transport reconnect, not end-to-end application relay.
+// Wired into `run_client` in a later change; only `#[cfg(test)]` calls it today,
+// so the non-test lib build sees the struct and constructor as unused.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) struct TransportLivenessTap<T> {
+    inner: T,
+    productive: Arc<AtomicBool>,
+}
+
+impl<T> TransportLivenessTap<T> {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new(inner: T, productive: Arc<AtomicBool>) -> Self {
+        Self { inner, productive }
+    }
+}
+
+impl<T: futures::AsyncRead + Unpin> futures::AsyncRead for TransportLivenessTap<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let me = self.get_mut();
+        let r = Pin::new(&mut me.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(n)) = &r {
+            if *n > 0 {
+                me.productive.store(true, Ordering::Relaxed);
+            }
+        }
+        r
+    }
+}
+
+impl<T: futures::AsyncWrite + Unpin> futures::AsyncWrite for TransportLivenessTap<T> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+    fn poll_close(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_close(cx)
+    }
 }
 
 /// Relay between a tokio TCP stream and a yamux stream (bidirectional),

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -158,7 +158,7 @@ async fn drive_connection<T: futures::AsyncRead + futures::AsyncWrite + Unpin + 
                     }
                 }
                 std::task::Poll::Ready(Some(Err(e))) => {
-                    tracing::error!(error = %e, "yamux inbound stream error");
+                    tracing::debug!(error = %e, "yamux inbound stream error (connection ended)");
                     return std::task::Poll::Ready(());
                 }
                 std::task::Poll::Ready(None) => {
@@ -295,16 +295,12 @@ async fn write_tag(stream: &mut yamux::Stream, tag: StreamTag) -> std::io::Resul
 /// keepalive frames alike. That is deliberate: it measures *transport*-level
 /// liveness (the far yamux peer responded), which is the correct signal for a
 /// transport reconnect, not end-to-end application relay.
-// Wired into `run_client` in a later change; only `#[cfg(test)]` calls it today,
-// so the non-test lib build sees the struct and constructor as unused.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct TransportLivenessTap<T> {
     inner: T,
     productive: Arc<AtomicBool>,
 }
 
 impl<T> TransportLivenessTap<T> {
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(inner: T, productive: Arc<AtomicBool>) -> Self {
         Self { inner, productive }
     }
@@ -425,9 +421,6 @@ pub(crate) fn connect_delay(remote: SocketAddr, attempt: u32) -> Duration {
 /// Consecutive-failure count after a session ends. A **productive** session (the
 /// server sent bytes back) resets the count so the next reconnect is at the floor;
 /// an unproductive one increments it so repeated failures escalate. Saturating.
-// Wired into the reconnect loop in a later change; only `#[cfg(test)]` calls it
-// today, so the non-test lib build sees it as unused.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn next_failures(prev: u32, productive: bool) -> u32 {
     if productive {
         0
@@ -440,9 +433,6 @@ pub(crate) fn next_failures(prev: u32, productive: bool) -> u32 {
 /// Every reconnect waits at least `REMOTE_BACKOFF_BASE` — a floor that bounds a
 /// peer flapping right after delivering one byte — and sustained failures
 /// escalate exponentially to `REMOTE_BACKOFF_MAX`.
-// Same as `next_failures` above: only exercised by tests until the reconnect
-// loop lands.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn session_reconnect_backoff(failures: u32) -> Duration {
     let step = failures.max(1) - 1;
     REMOTE_BACKOFF_BASE
@@ -506,14 +496,19 @@ async fn run_udp_association(
 ) {
     let mut stream = match open_stream(&open_tx).await {
         Ok(s) => s,
+        Err(::yamux::ConnectionError::Closed) => {
+            tracing::debug!(peer = %peer, "failed to open yamux stream for UDP: connection closed");
+            let _ = cleanup_tx.send((peer, generation)).await;
+            return;
+        }
         Err(e) => {
-            tracing::error!(peer = %peer, error = %e, "failed to open yamux stream for UDP");
+            tracing::warn!(peer = %peer, error = %e, "failed to open yamux stream for UDP");
             let _ = cleanup_tx.send((peer, generation)).await;
             return;
         }
     };
     if let Err(e) = write_tag(&mut stream, StreamTag::Udp).await {
-        tracing::error!(peer = %peer, error = %e, "failed to write UDP tag");
+        tracing::warn!(peer = %peer, error = %e, "failed to write UDP tag");
         let _ = cleanup_tx.send((peer, generation)).await;
         return;
     }
@@ -598,6 +593,138 @@ pub(crate) struct ClientBoundAddrs {
     pub udp: SocketAddr,
 }
 
+/// Join an aborted driver task. Returns `true` iff it ended by a genuine panic (a
+/// code bug, distinct from our own `abort()`), logging it. A panic must be
+/// fatal, not folded into ordinary reconnect churn — a driver panic drops
+/// `inbound_tx` and so is indistinguishable from a clean transport death at the
+/// `inbound_rx` seam, so the caller uses this to escalate instead of retrying.
+#[must_use]
+fn driver_panicked(result: std::result::Result<(), tokio::task::JoinError>) -> bool {
+    match result {
+        Ok(()) => false,
+        Err(e) if e.is_cancelled() => false,
+        Err(e) => {
+            tracing::error!(error = %e, "yamux driver task panicked");
+            true
+        }
+    }
+}
+
+/// Why a single yamux client session ended, deciding what `run_client` does next.
+enum SessionOutcome {
+    /// Shutdown requested — stop for good.
+    Shutdown,
+    /// The transport (yamux) connection died — reconnect.
+    TransportDied,
+    /// A local listener/socket error — fatal (a broken local listener is not
+    /// fixed by reconnecting the transport, so escalate to a process restart,
+    /// matching `run_server`).
+    LocalError(anyhow::Error),
+}
+
+/// Serve one yamux connection until it ends. The local TCP+UDP listeners are
+/// owned by `run_client` and persist across reconnects; only the yamux connection
+/// (its `open_tx` / `inbound_rx`) is per-session.
+async fn run_client_session(
+    tcp_listener: &TcpListener,
+    udp_socket: &Arc<UdpSocket>,
+    open_tx: &mpsc::Sender<OpenStreamReply>,
+    inbound_rx: &mut mpsc::Receiver<yamux::Stream>,
+    udp_timeout: Duration,
+    shutdown: &CancellationToken,
+) -> SessionOutcome {
+    let mut associations: HashMap<SocketAddr, (u64, mpsc::Sender<Vec<u8>>)> = HashMap::new();
+    let (cleanup_tx, mut cleanup_rx) = mpsc::channel::<(SocketAddr, u64)>(64);
+    let mut next_gen: u64 = 0;
+    let mut udp_buf = [0u8; 65536];
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => return SessionOutcome::Shutdown,
+            // Transport death: the driver dropped its inbound sender. A `Some` is a
+            // protocol violation (the server never opens streams to the client);
+            // untrusted remote input — log and drop, never panic.
+            inbound = inbound_rx.recv() => {
+                match inbound {
+                    None => return SessionOutcome::TransportDied,
+                    Some(_stream) => tracing::warn!("unexpected server-initiated yamux stream on client; dropping"),
+                }
+            }
+            accept = tcp_listener.accept() => {
+                let (tcp_stream, _peer) = match accept {
+                    Ok(v) => v,
+                    Err(e) => return SessionOutcome::LocalError(anyhow::Error::new(e).context("tcp accept")),
+                };
+                let open_tx = open_tx.clone();
+                tokio::spawn(async move {
+                    match open_stream(&open_tx).await {
+                        Ok(mut yamux_stream) => {
+                            if let Err(e) = write_tag(&mut yamux_stream, StreamTag::Tcp).await {
+                                tracing::warn!(error = %e, "failed to write TCP tag");
+                                return;
+                            }
+                            if let Err(e) = relay_tcp(yamux_stream, tcp_stream).await {
+                                tracing::debug!(error = %e, "tcp relay ended");
+                            }
+                        }
+                        // A closed connection is expected reconnect-window churn (the
+                        // driver is gone); any other error is a transport-alive
+                        // failure (e.g. a stream cap) worth surfacing.
+                        Err(yamux::ConnectionError::Closed) => {
+                            tracing::debug!("failed to open yamux stream for TCP: connection closed")
+                        }
+                        Err(e) => tracing::warn!(error = %e, "failed to open yamux stream for TCP"),
+                    }
+                });
+            }
+            recv = udp_socket.recv_from(&mut udp_buf) => {
+                let (n, peer) = match recv {
+                    Ok(v) => v,
+                    Err(e) => return SessionOutcome::LocalError(anyhow::Error::new(e).context("udp recv")),
+                };
+                let payload = udp_buf[..n].to_vec();
+
+                let payload = match associations.get(&peer) {
+                    Some((_, tx)) => match tx.try_send(payload) {
+                        Ok(()) => continue,
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            tracing::debug!(peer = %peer, "udp association buffer full, dropping datagram");
+                            continue;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(payload)) => {
+                            associations.remove(&peer);
+                            payload
+                        }
+                    },
+                    None => payload,
+                };
+
+                let generation = next_gen;
+                next_gen += 1;
+                let (tx, rx) = mpsc::channel::<Vec<u8>>(UDP_ASSOC_CHANNEL_CAPACITY);
+                let _ = tx.try_send(payload);
+                associations.insert(peer, (generation, tx));
+                tokio::spawn(run_udp_association(
+                    open_tx.clone(),
+                    Arc::clone(udp_socket),
+                    peer,
+                    generation,
+                    rx,
+                    cleanup_tx.clone(),
+                    udp_timeout,
+                ));
+            }
+            Some((peer, generation)) = cleanup_rx.recv() => {
+                if let Some((current, _)) = associations.get(&peer) {
+                    if *current == generation {
+                        associations.remove(&peer);
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub(crate) async fn run_client(
     config: yamux::Config,
     local: SocketAddr,
@@ -605,6 +732,9 @@ pub(crate) async fn run_client(
     udp_timeout: Duration,
     shutdown: CancellationToken,
     bound_addr_tx: Option<oneshot::Sender<ClientBoundAddrs>>,
+    // Test seam (mirrors `bound_addr_tx`): each reconnect decision `(failures,
+    // productive)` after a session ends. Production passes `None`.
+    reconnect_events: Option<mpsc::UnboundedSender<(u32, bool)>>,
 ) -> Result<()> {
     // Bind the local TCP + UDP listeners once for the client's lifetime. They
     // belong to `local` (the SS_LOCAL address), not to any single upstream
@@ -623,8 +753,11 @@ pub(crate) async fn run_client(
         });
     }
 
+    let mut failures: u32 = 0;
     loop {
-        // Connect to the remote yamux server.
+        // Connect to the remote yamux server (retries a down peer itself). No
+        // delay on the first attempt; a reconnect's backoff is slept at the end
+        // of the prior iteration.
         let tcp = match connect_retrying(remote, &shutdown).await {
             Some(s) => s,
             None => return Ok(()), // shutdown requested
@@ -632,115 +765,63 @@ pub(crate) async fn run_client(
 
         tracing::info!(remote = %remote, "connected to yamux server");
 
-        let compat_tcp = tcp.compat();
-        let conn = yamux::Connection::new(compat_tcp, config.clone(), yamux::Mode::Client);
+        // Tap the transport for inbound liveness. The tap is owned by the driver
+        // (inside the Connection), so reading `productive` after `driver.await`
+        // is race-free.
+        let productive = Arc::new(AtomicBool::new(false));
+        let tapped = TransportLivenessTap::new(tcp.compat(), Arc::clone(&productive));
+        let conn = yamux::Connection::new(tapped, config.clone(), yamux::Mode::Client);
 
         let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(32);
-        let (_inbound_tx, _inbound_rx) = mpsc::channel::<yamux::Stream>(32);
+        // The client never expects server-initiated streams; this channel is the
+        // transport-death signal — the driver drops `inbound_tx` when the yamux
+        // connection ends, so `inbound_rx.recv()` yields `None`.
+        let (inbound_tx, mut inbound_rx) = mpsc::channel::<yamux::Stream>(32);
 
-        let driver = tokio::spawn(drive_connection(conn, open_rx, _inbound_tx));
+        let driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
 
-        let result: Result<()> = async {
-            // NAT association table: local peer -> (generation, outbound sender).
-            // Owned solely by this loop (no shared mutex) and scoped to this
-            // connection — on reconnect it drops, every association task sees
-            // its `outbound_rx` close and exits, and the next iteration starts
-            // empty. `generation` closes the re-create-during-teardown race:
-            // a stale cleanup only removes an entry whose generation matches.
-            let mut associations: HashMap<SocketAddr, (u64, mpsc::Sender<Vec<u8>>)> = HashMap::new();
-            let (cleanup_tx, mut cleanup_rx) = mpsc::channel::<(SocketAddr, u64)>(64);
-            let mut next_gen: u64 = 0;
-            let mut udp_buf = [0u8; 65536];
-
-            loop {
-                tokio::select! {
-                    _ = shutdown.cancelled() => break,
-                    // Accept local TCP connections.
-                    accept = tcp_listener.accept() => {
-                        let (tcp_stream, _peer) = accept.context("tcp accept")?;
-                        let open_tx = open_tx.clone();
-                        tokio::spawn(async move {
-                            match open_stream(&open_tx).await {
-                                Ok(mut yamux_stream) => {
-                                    if let Err(e) = write_tag(&mut yamux_stream, StreamTag::Tcp).await {
-                                        tracing::error!(error = %e, "failed to write TCP tag");
-                                        return;
-                                    }
-                                    if let Err(e) = relay_tcp(yamux_stream, tcp_stream).await {
-                                        tracing::debug!(error = %e, "tcp relay ended");
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::error!(error = %e, "failed to open yamux stream for TCP");
-                                }
-                            }
-                        });
-                    }
-                    // Receive local UDP datagrams; route each to its peer's association.
-                    recv = udp_socket.recv_from(&mut udp_buf) => {
-                        let (n, peer) = recv.context("udp recv")?;
-                        let payload = udp_buf[..n].to_vec();
-
-                        // Forward to an existing association if one is live.
-                        // `Closed` returns the payload so we can re-create
-                        // without cloning on the hot path; `Full` drops it
-                        // (correct lossy-UDP semantics).
-                        let payload = match associations.get(&peer) {
-                            Some((_, tx)) => match tx.try_send(payload) {
-                                Ok(()) => continue,
-                                Err(mpsc::error::TrySendError::Full(_)) => {
-                                    tracing::debug!(peer = %peer, "udp association buffer full, dropping datagram");
-                                    continue;
-                                }
-                                Err(mpsc::error::TrySendError::Closed(payload)) => {
-                                    associations.remove(&peer);
-                                    payload
-                                }
-                            },
-                            None => payload,
-                        };
-
-                        // Create a new association.
-                        let generation = next_gen;
-                        next_gen += 1;
-                        let (tx, rx) = mpsc::channel::<Vec<u8>>(UDP_ASSOC_CHANNEL_CAPACITY);
-                        // First datagram always fits the fresh buffer.
-                        let _ = tx.try_send(payload);
-                        associations.insert(peer, (generation, tx));
-                        tokio::spawn(run_udp_association(
-                            open_tx.clone(),
-                            Arc::clone(&udp_socket),
-                            peer,
-                            generation,
-                            rx,
-                            cleanup_tx.clone(),
-                            udp_timeout,
-                        ));
-                    }
-                    // An association task exited; drop its entry iff still current.
-                    Some((peer, generation)) = cleanup_rx.recv() => {
-                        if let Some((current, _)) = associations.get(&peer) {
-                            if *current == generation {
-                                associations.remove(&peer);
-                            }
-                        }
-                    }
-                }
-            }
-
-            Ok(())
-        }
+        let outcome = run_client_session(
+            &tcp_listener,
+            &udp_socket,
+            &open_tx,
+            &mut inbound_rx,
+            udp_timeout,
+            &shutdown,
+        )
         .await;
 
-        // Drop the open channel to let the driver finish.
-        drop(open_tx);
-        let _ = driver.await;
+        // Tear down the driver deterministically. On `TransportDied` it already
+        // finished (abort is a no-op); otherwise abort ends it instead of hanging
+        // until the chain drain-timeout (`drive_connection` has no shutdown hook).
+        // On `Shutdown`/`LocalError` this abruptly severs any in-flight relay
+        // stream — accepted, since those paths tear the client down anyway.
+        // `open_tx` is dropped by scope exit and is NOT load-bearing for teardown.
+        // A driver *panic* is a code bug, not a transport event — escalate to a
+        // fatal exit instead of reconnecting forever.
+        driver.abort();
+        if driver_panicked(driver.await) {
+            return Err(anyhow::anyhow!("yamux driver task panicked"));
+        }
 
-        match result {
-            Ok(()) => return Ok(()),
-            Err(e) => {
-                tracing::warn!(error = %e, "client session ended, reconnecting");
-                // Loop back to reconnect.
+        match outcome {
+            SessionOutcome::Shutdown => return Ok(()),
+            SessionOutcome::LocalError(e) => return Err(e),
+            SessionOutcome::TransportDied => {
+                let was_productive = productive.load(Ordering::Relaxed);
+                failures = next_failures(failures, was_productive);
+                tracing::warn!(
+                    failures,
+                    was_productive,
+                    "yamux transport connection ended, reconnecting"
+                );
+                if let Some(tx) = &reconnect_events {
+                    let _ = tx.send((failures, was_productive));
+                }
+                let delay = session_reconnect_backoff(failures);
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = shutdown.cancelled() => return Ok(()),
+                }
             }
         }
     }
@@ -927,7 +1008,7 @@ impl garter::ChainPlugin for YamuxPlugin {
         let result = if self.is_server {
             run_server(self.config, local, remote, shutdown, None).await
         } else {
-            run_client(self.config, local, remote, self.udp_timeout, shutdown, None).await
+            run_client(self.config, local, remote, self.udp_timeout, shutdown, None, None).await
         };
 
         result.map_err(|e| garter::Error::Chain(e.to_string()))

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -406,15 +406,21 @@ pub(crate) const LOOPBACK_CONNECT_RETRY: Duration = Duration::from_millis(10);
 pub(crate) const REMOTE_BACKOFF_BASE: Duration = Duration::from_millis(100);
 pub(crate) const REMOTE_BACKOFF_MAX: Duration = Duration::from_secs(30);
 
+/// Exponential backoff for a 0-based `step`: `REMOTE_BACKOFF_BASE` doubling,
+/// capped at `REMOTE_BACKOFF_MAX`.
+fn exponential_backoff(step: u32) -> Duration {
+    REMOTE_BACKOFF_BASE
+        .saturating_mul(1u32.checked_shl(step).unwrap_or(u32::MAX))
+        .min(REMOTE_BACKOFF_MAX)
+}
+
 /// Delay before connect attempt `attempt` to `remote`: loopback peers poll on
 /// a fixed tight cadence; routable peers back off exponentially, capped.
 pub(crate) fn connect_delay(remote: SocketAddr, attempt: u32) -> Duration {
     if remote.ip().is_loopback() {
         LOOPBACK_CONNECT_RETRY
     } else {
-        REMOTE_BACKOFF_BASE
-            .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
-            .min(REMOTE_BACKOFF_MAX)
+        exponential_backoff(attempt)
     }
 }
 
@@ -434,10 +440,7 @@ pub(crate) fn next_failures(prev: u32, productive: bool) -> u32 {
 /// peer flapping right after delivering one byte — and sustained failures
 /// escalate exponentially to `REMOTE_BACKOFF_MAX`.
 pub(crate) fn session_reconnect_backoff(failures: u32) -> Duration {
-    let step = failures.max(1) - 1;
-    REMOTE_BACKOFF_BASE
-        .saturating_mul(1u32.checked_shl(step).unwrap_or(u32::MAX))
-        .min(REMOTE_BACKOFF_MAX)
+    exponential_backoff(failures.max(1) - 1)
 }
 
 /// Connect to `addr`, retrying until it succeeds or `shutdown` fires. Retries
@@ -616,10 +619,6 @@ enum SessionOutcome {
     Shutdown,
     /// The transport (yamux) connection died — reconnect.
     TransportDied,
-    /// A local listener/socket error — fatal (a broken local listener is not
-    /// fixed by reconnecting the transport, so escalate to a process restart,
-    /// matching `run_server`).
-    LocalError(anyhow::Error),
 }
 
 /// Serve one yamux connection until it ends. The local TCP+UDP listeners are
@@ -651,9 +650,17 @@ async fn run_client_session(
                 }
             }
             accept = tcp_listener.accept() => {
+                // The listener is the loopback SS_LOCAL socket accepting from the
+                // trusted local ss-service: a real accept error is rare and transient
+                // (a stray ECONNABORTED, or momentary EMFILE that clears as flows
+                // finish), not a permanently-broken listener — and reconnecting the
+                // transport would not fix a local error anyway.
                 let (tcp_stream, _peer) = match accept {
                     Ok(v) => v,
-                    Err(e) => return SessionOutcome::LocalError(anyhow::Error::new(e).context("tcp accept")),
+                    Err(e) => {
+                        tracing::debug!(error = %e, "local tcp accept error; continuing");
+                        continue;
+                    }
                 };
                 let open_tx = open_tx.clone();
                 tokio::spawn(async move {
@@ -678,9 +685,14 @@ async fn run_client_session(
                 });
             }
             recv = udp_socket.recv_from(&mut udp_buf) => {
+                // Same rationale as the accept arm above: a local recv error is
+                // transient, not a broken socket, and the transport isn't at fault.
                 let (n, peer) = match recv {
                     Ok(v) => v,
-                    Err(e) => return SessionOutcome::LocalError(anyhow::Error::new(e).context("udp recv")),
+                    Err(e) => {
+                        tracing::debug!(error = %e, "local udp recv error; continuing");
+                        continue;
+                    }
                 };
                 let payload = udp_buf[..n].to_vec();
 
@@ -793,11 +805,10 @@ pub(crate) async fn run_client(
         // Tear down the driver deterministically. On `TransportDied` it already
         // finished (abort is a no-op); otherwise abort ends it instead of hanging
         // until the chain drain-timeout (`drive_connection` has no shutdown hook).
-        // On `Shutdown`/`LocalError` this abruptly severs any in-flight relay
-        // stream — accepted, since those paths tear the client down anyway.
-        // `open_tx` is dropped by scope exit and is NOT load-bearing for teardown.
-        // A driver *panic* is a code bug, not a transport event — escalate to a
-        // fatal exit instead of reconnecting forever.
+        // On `Shutdown` this abruptly severs any in-flight relay stream — accepted,
+        // since that path tears the client down anyway. `open_tx` is dropped by
+        // scope exit and is NOT load-bearing for teardown.
+        // A driver panic is a code bug, not a transport event — exit rather than reconnect.
         driver.abort();
         if driver_panicked(driver.await) {
             return Err(anyhow::anyhow!("yamux driver task panicked"));
@@ -805,7 +816,6 @@ pub(crate) async fn run_client(
 
         match outcome {
             SessionOutcome::Shutdown => return Ok(()),
-            SessionOutcome::LocalError(e) => return Err(e),
             SessionOutcome::TransportDied => {
                 let was_productive = productive.load(Ordering::Relaxed);
                 failures = next_failures(failures, was_productive);
@@ -848,13 +858,22 @@ pub(crate) async fn run_server(
     }
 
     loop {
-        // Accept one underlying TCP connection.
+        // Accept one underlying TCP connection. A real accept error is rare and
+        // transient (see `run_client_session`'s local-accept rationale); log and
+        // keep serving rather than tearing down the whole plugin.
         let tcp = tokio::select! {
             _ = shutdown.cancelled() => return Ok(()),
             accept = listener.accept() => {
-                let (stream, peer) = accept.context("accept")?;
-                tracing::info!(peer = %peer, "accepted underlying connection");
-                stream
+                match accept {
+                    Ok((stream, peer)) => {
+                        tracing::info!(peer = %peer, "accepted underlying connection");
+                        stream
+                    }
+                    Err(e) => {
+                        tracing::debug!(error = %e, "server accept error; continuing");
+                        continue;
+                    }
+                }
             }
         };
 

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -650,15 +650,13 @@ async fn run_client_session(
                 }
             }
             accept = tcp_listener.accept() => {
-                // The listener is the loopback SS_LOCAL socket accepting from the
-                // trusted local ss-service: a real accept error is rare and transient
-                // (a stray ECONNABORTED, or momentary EMFILE that clears as flows
-                // finish), not a permanently-broken listener — and reconnecting the
-                // transport would not fix a local error anyway.
+                // A local accept error on the loopback listener is transient and
+                // not fixed by reconnecting the transport; log and continue.
                 let (tcp_stream, _peer) = match accept {
                     Ok(v) => v,
                     Err(e) => {
                         tracing::debug!(error = %e, "local tcp accept error; continuing");
+                        tokio::task::yield_now().await;
                         continue;
                     }
                 };
@@ -691,6 +689,7 @@ async fn run_client_session(
                     Ok(v) => v,
                     Err(e) => {
                         tracing::debug!(error = %e, "local udp recv error; continuing");
+                        tokio::task::yield_now().await;
                         continue;
                     }
                 };
@@ -805,9 +804,6 @@ pub(crate) async fn run_client(
         // Tear down the driver deterministically. On `TransportDied` it already
         // finished (abort is a no-op); otherwise abort ends it instead of hanging
         // until the chain drain-timeout (`drive_connection` has no shutdown hook).
-        // On `Shutdown` this abruptly severs any in-flight relay stream — accepted,
-        // since that path tears the client down anyway. `open_tx` is dropped by
-        // scope exit and is NOT load-bearing for teardown.
         // A driver panic is a code bug, not a transport event — exit rather than reconnect.
         driver.abort();
         if driver_panicked(driver.await) {
@@ -871,6 +867,7 @@ pub(crate) async fn run_server(
                     }
                     Err(e) => {
                         tracing::debug!(error = %e, "server accept error; continuing");
+                        tokio::task::yield_now().await;
                         continue;
                     }
                 }

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -889,7 +889,10 @@ pub(crate) async fn run_server(
             });
         }
 
-        let _ = driver.await;
+        driver.abort();
+        if driver_panicked(driver.await) {
+            return Err(anyhow::anyhow!("yamux driver task panicked"));
+        }
         tracing::info!("underlying connection closed, waiting for next");
     }
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use garter::test_utils::WaitableWriter;
@@ -234,6 +234,7 @@ async fn setup_relay_inner(upstream: SocketAddr, udp_timeout: Duration) -> (Clie
         udp_timeout,
         shutdown.clone(),
         Some(cli_tx),
+        None,
     ));
     let addrs = cli_rx.await.expect("client bound");
 
@@ -569,4 +570,187 @@ async fn transport_tap_delegates_writes() {
     b.read_exact(&mut buf).await.unwrap();
     assert_eq!(&buf, b"ping");
     assert!(!productive.load(Ordering::Relaxed), "writes never set productive");
+}
+
+// Transport-reset reconnect -------------------------------------------------------------------------------------------
+
+/// Fire a one-shot reset on a relay connection.
+struct ResetHandle {
+    tx: Option<oneshot::Sender<()>>,
+}
+impl ResetHandle {
+    fn trigger(&mut self) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// A TCP relay in front of `upstream`. Its first `immediate_resets` connections
+/// are RST on accept (before any data → unproductive sessions); the next
+/// connection is armed with the returned `ResetHandle` (RST on `trigger()`);
+/// later connections pass through.
+// `set_linger` is deprecated over blocking-on-drop with a nonzero timeout; a
+// zero timeout is the opposite (an immediate abortive close, no blocking) and
+// is exactly the RST this test needs — not the case the deprecation warns about.
+#[allow(deprecated)]
+async fn spawn_controllable_relay(upstream: SocketAddr, immediate_resets: usize) -> (SocketAddr, ResetHandle) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind relay");
+    let addr = listener.local_addr().expect("relay addr");
+    let (reset_tx, reset_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let mut seen = 0usize;
+        let mut trigger = Some(reset_rx);
+        while let Ok((client_conn, _)) = listener.accept().await {
+            if seen < immediate_resets {
+                seen += 1;
+                let _ = client_conn.set_linger(Some(Duration::ZERO));
+                drop(client_conn); // RST, no upstream
+                continue;
+            }
+            let server_conn = match TcpStream::connect(upstream).await {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            tokio::spawn(pump_with_optional_reset(client_conn, server_conn, trigger.take()));
+        }
+    });
+    (addr, ResetHandle { tx: Some(reset_tx) })
+}
+
+/// Pump both ways; if `reset` fires first, RST both sockets.
+#[allow(deprecated)] // see `spawn_controllable_relay`
+async fn pump_with_optional_reset(mut client: TcpStream, mut server: TcpStream, reset: Option<oneshot::Receiver<()>>) {
+    match reset {
+        Some(rx) => {
+            tokio::select! {
+                _ = tokio::io::copy_bidirectional(&mut client, &mut server) => {}
+                _ = rx => {
+                    let _ = client.set_linger(Some(Duration::ZERO));
+                    let _ = server.set_linger(Some(Duration::ZERO));
+                }
+            }
+        }
+        None => {
+            let _ = tokio::io::copy_bidirectional(&mut client, &mut server).await;
+        }
+    }
+}
+
+/// Spawn a yamux server relaying to `upstream`; returns its listen address.
+async fn spawn_yamux_server(upstream: SocketAddr, shutdown: CancellationToken) -> SocketAddr {
+    let (srv_tx, srv_rx) = oneshot::channel();
+    tokio::spawn(run_server(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        upstream,
+        shutdown,
+        Some(srv_tx),
+    ));
+    srv_rx.await.expect("server bound")
+}
+
+/// Spawn a yamux client pointed at `remote`, with a typed reconnect observer.
+/// Returns the client's local addresses and the observer receiver.
+async fn spawn_yamux_client(
+    remote: SocketAddr,
+    udp_timeout: Duration,
+    shutdown: CancellationToken,
+) -> (ClientBoundAddrs, mpsc::UnboundedReceiver<(u32, bool)>) {
+    let (events_tx, events_rx) = mpsc::unbounded_channel();
+    let (cli_tx, cli_rx) = oneshot::channel();
+    tokio::spawn(run_client(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        remote,
+        udp_timeout,
+        shutdown,
+        Some(cli_tx),
+        Some(events_tx),
+    ));
+    (cli_rx.await.expect("client bound"), events_rx)
+}
+
+/// One TCP request/response through the client's local listener.
+async fn tcp_round_trip(client_tcp: SocketAddr, request: &[u8]) -> Vec<u8> {
+    let mut app = TcpStream::connect(client_tcp).await.expect("connect client TCP");
+    app.write_all(request).await.expect("write request");
+    app.shutdown().await.expect("half-close write");
+    let mut got = Vec::new();
+    app.read_to_end(&mut got).await.expect("read to EOF");
+    got
+}
+
+const HTTP_RESPONSE: &[u8] = b"HTTP/1.0 200 OK\r\nContent-Length: 3\r\n\r\nabc";
+
+#[skuld::test]
+async fn tcp_transport_reset_reconnects() {
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+    let (relay_addr, mut reset) = spawn_controllable_relay(server_addr, 0).await;
+    let (addrs, mut events) = spawn_yamux_client(relay_addr, DEFAULT_UDP_TIMEOUT, shutdown.clone()).await;
+
+    // #1 proves the tunnel works and (via the transport tap) marks it productive.
+    assert_eq!(
+        tcp_round_trip(addrs.tcp, b"GET /1 HTTP/1.0\r\n\r\n").await,
+        HTTP_RESPONSE
+    );
+
+    reset.trigger();
+    // Rendezvous: the client observed transport death and is reconnecting. The
+    // session was productive, so it resets to the floor.
+    assert_eq!(events.recv().await.unwrap(), (0, true));
+
+    // #2 must succeed on the reconnected session.
+    assert_eq!(
+        tcp_round_trip(addrs.tcp, b"GET /2 HTTP/1.0\r\n\r\n").await,
+        HTTP_RESPONSE
+    );
+
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn udp_transport_reset_reconnects() {
+    let echo = spawn_udp_echo("127.0.0.1".parse().unwrap()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(echo, shutdown.clone()).await;
+    let (relay_addr, mut reset) = spawn_controllable_relay(server_addr, 0).await;
+    let (addrs, mut events) = spawn_yamux_client(relay_addr, DEFAULT_UDP_TIMEOUT, shutdown.clone()).await;
+    let app = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+    assert_eq!(round_trip(&app, addrs.udp, b"one").await, b"one");
+
+    reset.trigger();
+    assert_eq!(events.recv().await.unwrap(), (0, true));
+
+    assert_eq!(round_trip(&app, addrs.udp, b"two").await, b"two");
+
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn backoff_escalates_then_resets_on_productive() {
+    // Two immediate resets escalate failures 1→2 (unproductive), then a
+    // passthrough session round-trips (productive), then a triggered reset resets
+    // failures to 0 — proving both escalation and the productive reset.
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+    let (relay_addr, mut reset) = spawn_controllable_relay(server_addr, 2).await;
+    let (addrs, mut events) = spawn_yamux_client(relay_addr, DEFAULT_UDP_TIMEOUT, shutdown.clone()).await;
+
+    assert_eq!(events.recv().await.unwrap(), (1, false)); // reset #1 (unproductive)
+    assert_eq!(events.recv().await.unwrap(), (2, false)); // reset #2 (unproductive)
+
+    // The 3rd connection passes through; a round trip makes it productive.
+    assert_eq!(
+        tcp_round_trip(addrs.tcp, b"GET / HTTP/1.0\r\n\r\n").await,
+        HTTP_RESPONSE
+    );
+    reset.trigger();
+    assert_eq!(events.recv().await.unwrap(), (0, true)); // productive → reset to floor
+
+    shutdown.cancel();
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -11,15 +11,17 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::TokioAsyncReadCompatExt as _;
 use tokio_util::sync::CancellationToken;
 
 use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    connect_delay, connect_retrying, deframe_udp_datagram, frame_udp_datagram, next_failures, parse_udp_timeout,
-    run_client, run_server, session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, StreamTag,
-    TransportLivenessTap, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
+    connect_delay, connect_retrying, deframe_udp_datagram, drive_connection, driver_panicked, frame_udp_datagram,
+    next_failures, parse_udp_timeout, run_client, run_server, session_reconnect_backoff, ClientBoundAddrs,
+    FrameAccumulator, OpenStreamReply, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY,
+    REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
 // Only the Windows-gated CONNRESET regression test uses this.
 #[cfg(windows)]
@@ -559,7 +561,6 @@ async fn transport_tap_silent_on_eof() {
 #[skuld::test]
 async fn transport_tap_delegates_writes() {
     use futures::{AsyncReadExt as _, AsyncWriteExt as _};
-    use tokio_util::compat::TokioAsyncReadCompatExt as _;
     let productive = Arc::new(AtomicBool::new(false));
     let (a, b) = tokio::io::duplex(64);
     let mut tap = TransportLivenessTap::new(a.compat(), Arc::clone(&productive));
@@ -753,4 +754,143 @@ async fn backoff_escalates_then_resets_on_productive() {
     assert_eq!(events.recv().await.unwrap(), (0, true)); // productive → reset to floor
 
     shutdown.cancel();
+}
+
+// Remaining branch coverage -------------------------------------------------------------------------------------------
+
+/// Install a per-test tracing subscriber that captures log lines for
+/// [`wait_for_log`] rendezvous, plus the `DefaultGuard` keeping it active.
+fn capture_logs() -> (WaitableWriter, tracing::subscriber::DefaultGuard) {
+    let writer = WaitableWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .with_ansi(false)
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    let guard = set_default_in_current_thread(subscriber);
+    (writer, guard)
+}
+
+/// Park until a log line containing `needle` is captured — a real event
+/// rendezvous, not a timed guess.
+async fn wait_for_log(writer: &WaitableWriter, needle: &str) {
+    let rx = writer.wait_for(needle);
+    tokio::task::spawn_blocking(move || rx.recv().expect("log event never arrived"))
+        .await
+        .unwrap();
+}
+
+/// Strip the 1-byte stream tag, then echo everything else back.
+async fn echo_yamux_stream(mut stream: yamux::Stream) {
+    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+    let mut tag = [0u8; 1];
+    if stream.read_exact(&mut tag).await.is_err() {
+        return;
+    }
+    let mut buf = vec![0u8; 4096];
+    loop {
+        match stream.read(&mut buf).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                if stream.write_all(&buf[..n]).await.is_err() {
+                    break;
+                }
+                let _ = stream.flush().await;
+            }
+        }
+    }
+    let _ = stream.close().await;
+}
+
+#[skuld::test]
+async fn server_initiated_stream_dropped_client_keeps_serving() {
+    let (writer, _g) = capture_logs();
+    let srv_shutdown = CancellationToken::new();
+    let srv_shutdown2 = srv_shutdown.clone();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        let conn = ::yamux::Connection::new(tcp.compat(), ::yamux::Config::default(), ::yamux::Mode::Server);
+        let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(1);
+        let (inbound_tx, mut inbound_rx) = mpsc::channel::<yamux::Stream>(16);
+        tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+        // A server-initiated stream (protocol violation on the client).
+        let (tx, rx) = oneshot::channel();
+        let _ = open_tx.send(tx).await;
+        if let Ok(Ok(mut s)) = rx.await {
+            use futures::AsyncWriteExt as _;
+            let _ = s.write_all(&[0xFF]).await;
+            let _ = s.flush().await;
+        }
+        // Echo client-initiated streams so a normal round trip works.
+        loop {
+            tokio::select! {
+                _ = srv_shutdown2.cancelled() => break,
+                s = inbound_rx.recv() => match s {
+                    Some(stream) => { tokio::spawn(echo_yamux_stream(stream)); }
+                    None => break,
+                },
+            }
+        }
+    });
+
+    let client_shutdown = CancellationToken::new();
+    let (addrs, _events) = spawn_yamux_client(server_addr, DEFAULT_UDP_TIMEOUT, client_shutdown.clone()).await;
+
+    // The bogus stream is warned-and-dropped...
+    wait_for_log(&writer, "unexpected server-initiated yamux stream").await;
+    // ...and the client keeps serving: a normal TCP round trip still echoes.
+    assert_eq!(tcp_round_trip(addrs.tcp, b"still here").await, b"still here");
+
+    client_shutdown.cancel();
+    srv_shutdown.cancel();
+}
+
+#[skuld::test]
+async fn driver_panicked_detects_panic_not_cancel() {
+    // Normal completion (the ordinary TransportDied reconnect path) → not a panic.
+    let h = tokio::spawn(async {});
+    assert!(!driver_panicked(h.await));
+
+    // Our own abort → cancelled JoinError → not a panic.
+    let h = tokio::spawn(std::future::pending::<()>());
+    h.abort();
+    assert!(!driver_panicked(h.await));
+
+    // A real panic → panic JoinError → detected (and logged as a side effect).
+    let h = tokio::spawn(async { panic!("boom") });
+    assert!(driver_panicked(h.await));
+}
+
+#[skuld::test]
+async fn shutdown_during_backoff_exits_promptly() {
+    tokio::time::pause();
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+    let (relay_addr, _reset) = spawn_controllable_relay(server_addr, 1).await; // one unproductive reset
+    let (events_tx, mut events_rx) = mpsc::unbounded_channel();
+    let (cli_tx, cli_rx) = oneshot::channel();
+    let client = tokio::spawn(run_client(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        relay_addr,
+        DEFAULT_UDP_TIMEOUT,
+        shutdown.clone(),
+        Some(cli_tx),
+        Some(events_tx),
+    ));
+    let _ = cli_rx.await.unwrap();
+
+    // Rendezvous (not the assertion): the observer event means the client has
+    // reached the reconnect decision and is entering the backoff sleep.
+    assert_eq!(events_rx.recv().await.unwrap(), (1, false));
+
+    // The external assertion: shutdown must win the paused sleep, so the client
+    // task returns `Ok` promptly. Without the select! shutdown branch the paused
+    // sleep never elapses and this `await` hangs → framework timeout.
+    shutdown.cancel();
+    client.await.unwrap().unwrap();
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -587,15 +587,20 @@ impl ResetHandle {
     }
 }
 
-/// A TCP relay in front of `upstream`. Its first `immediate_resets` connections
-/// are RST on accept (before any data → unproductive sessions); the next
+/// A TCP relay in front of `upstream`. Its first `immediate_closes` connections
+/// are closed with a graceful FIN right after accept (before any yamux frame, so
+/// the client establishes an unproductive session that then dies); the next
 /// connection is armed with the returned `ResetHandle` (RST on `trigger()`);
 /// later connections pass through.
-// `set_linger` is deprecated over blocking-on-drop with a nonzero timeout; a
-// zero timeout is the opposite (an immediate abortive close, no blocking) and
-// is exactly the RST this test needs — not the case the deprecation warns about.
-#[allow(deprecated)]
-async fn spawn_controllable_relay(upstream: SocketAddr, immediate_resets: usize) -> (SocketAddr, ResetHandle) {
+///
+/// The immediate closes are a FIN, not an RST, on purpose. An RST on accept
+/// races the client's `connect()` on loopback and, on Linux/macOS, makes the
+/// connect itself fail with `ECONNRESET` (nondeterministically); `connect_retrying`
+/// then retries silently, so no *session* death occurs and the reconnect these
+/// tests await never fires — the test hangs. A FIN never fails a completed
+/// connect, so the client always establishes, then deterministically observes
+/// transport death on every platform.
+async fn spawn_controllable_relay(upstream: SocketAddr, immediate_closes: usize) -> (SocketAddr, ResetHandle) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind relay");
     let addr = listener.local_addr().expect("relay addr");
     let (reset_tx, reset_rx) = oneshot::channel::<()>();
@@ -603,10 +608,9 @@ async fn spawn_controllable_relay(upstream: SocketAddr, immediate_resets: usize)
         let mut seen = 0usize;
         let mut trigger = Some(reset_rx);
         while let Ok((client_conn, _)) = listener.accept().await {
-            if seen < immediate_resets {
+            if seen < immediate_closes {
                 seen += 1;
-                let _ = client_conn.set_linger(Some(Duration::ZERO));
-                drop(client_conn); // RST, no upstream
+                drop(client_conn); // graceful FIN, no upstream → unproductive session death
                 continue;
             }
             let server_conn = match TcpStream::connect(upstream).await {
@@ -620,7 +624,11 @@ async fn spawn_controllable_relay(upstream: SocketAddr, immediate_resets: usize)
 }
 
 /// Pump both ways; if `reset` fires first, RST both sockets.
-#[allow(deprecated)] // see `spawn_controllable_relay`
+// `set_linger` is deprecated in favour of blocking-on-drop with a nonzero
+// timeout; a zero timeout is the opposite — an immediate abortive close (RST),
+// no blocking — which is exactly the reset this path needs, not the case the
+// deprecation warns about.
+#[allow(deprecated)]
 async fn pump_with_optional_reset(mut client: TcpStream, mut server: TcpStream, reset: Option<oneshot::Receiver<()>>) {
     match reset {
         Some(rx) => {
@@ -732,7 +740,7 @@ async fn udp_transport_reset_reconnects() {
 
 #[skuld::test]
 async fn backoff_escalates_then_resets_on_productive() {
-    // Two immediate resets escalate failures 1→2 (unproductive), then a
+    // Two immediate closes escalate failures 1→2 (unproductive), then a
     // passthrough session round-trips (productive), then a triggered reset resets
     // failures to 0 — proving both escalation and the productive reset.
     let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
@@ -741,8 +749,8 @@ async fn backoff_escalates_then_resets_on_productive() {
     let (relay_addr, mut reset) = spawn_controllable_relay(server_addr, 2).await;
     let (addrs, mut events) = spawn_yamux_client(relay_addr, DEFAULT_UDP_TIMEOUT, shutdown.clone()).await;
 
-    assert_eq!(events.recv().await.unwrap(), (1, false)); // reset #1 (unproductive)
-    assert_eq!(events.recv().await.unwrap(), (2, false)); // reset #2 (unproductive)
+    assert_eq!(events.recv().await.unwrap(), (1, false)); // close #1 (unproductive)
+    assert_eq!(events.recv().await.unwrap(), (2, false)); // close #2 (unproductive)
 
     // The 3rd connection passes through; a round trip makes it productive.
     assert_eq!(
@@ -869,7 +877,7 @@ async fn shutdown_during_backoff_exits_promptly() {
     let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
     let shutdown = CancellationToken::new();
     let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
-    let (relay_addr, _reset) = spawn_controllable_relay(server_addr, 1).await; // one unproductive reset
+    let (relay_addr, _reset) = spawn_controllable_relay(server_addr, 1).await; // one unproductive close
     let (events_tx, mut events_rx) = mpsc::unbounded_channel();
     let (cli_tx, cli_rx) = oneshot::channel();
     let client = tokio::spawn(run_client(

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -894,3 +894,27 @@ async fn shutdown_during_backoff_exits_promptly() {
     shutdown.cancel();
     client.await.unwrap().unwrap();
 }
+
+#[skuld::test]
+async fn server_shutdown_is_prompt_while_client_connected() {
+    // A connected client keeps the driver live; shutdown must still complete
+    // promptly (the driver is aborted, not awaited-to-natural-close).
+    let (writer, _g) = capture_logs();
+    let upstream = spawn_tcp_responder(b"hi".to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let (srv_tx, srv_rx) = oneshot::channel();
+    let server = tokio::spawn(run_server(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        upstream,
+        shutdown.clone(),
+        Some(srv_tx),
+    ));
+    let server_addr = srv_rx.await.expect("server bound");
+
+    let _conn = TcpStream::connect(server_addr).await.expect("connect server");
+    wait_for_log(&writer, "accepted underlying connection").await;
+
+    shutdown.cancel();
+    server.await.expect("server task joined").expect("run_server ok");
+}

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::disallowed_methods)]
 
 use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -17,7 +19,7 @@ use garter::tracing_test::set_default_in_current_thread;
 use crate::yamux::{
     connect_delay, connect_retrying, deframe_udp_datagram, frame_udp_datagram, next_failures, parse_udp_timeout,
     run_client, run_server, session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, StreamTag,
-    DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
+    TransportLivenessTap, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
 // Only the Windows-gated CONNRESET regression test uses this.
 #[cfg(windows)]
@@ -529,4 +531,42 @@ fn session_reconnect_backoff_schedule() {
             "@ {failures}"
         );
     }
+}
+
+// TransportLivenessTap ------------------------------------------------------------------------------------------------
+
+#[skuld::test]
+async fn transport_tap_sets_on_inbound_bytes() {
+    use futures::AsyncReadExt as _;
+    let productive = Arc::new(AtomicBool::new(false));
+    let mut tap = TransportLivenessTap::new(futures::io::Cursor::new(b"data".to_vec()), Arc::clone(&productive));
+    let mut buf = [0u8; 8];
+    assert_eq!(tap.read(&mut buf).await.unwrap(), 4);
+    assert!(productive.load(Ordering::Relaxed));
+}
+
+#[skuld::test]
+async fn transport_tap_silent_on_eof() {
+    use futures::AsyncReadExt as _;
+    let productive = Arc::new(AtomicBool::new(false));
+    let mut tap = TransportLivenessTap::new(futures::io::Cursor::new(Vec::new()), Arc::clone(&productive));
+    let mut buf = [0u8; 8];
+    assert_eq!(tap.read(&mut buf).await.unwrap(), 0);
+    assert!(!productive.load(Ordering::Relaxed));
+}
+
+#[skuld::test]
+async fn transport_tap_delegates_writes() {
+    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio_util::compat::TokioAsyncReadCompatExt as _;
+    let productive = Arc::new(AtomicBool::new(false));
+    let (a, b) = tokio::io::duplex(64);
+    let mut tap = TransportLivenessTap::new(a.compat(), Arc::clone(&productive));
+    tap.write_all(b"ping").await.unwrap();
+    tap.flush().await.unwrap();
+    let mut b = b.compat();
+    let mut buf = [0u8; 4];
+    b.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"ping");
+    assert!(!productive.load(Ordering::Relaxed), "writes never set productive");
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -638,7 +638,6 @@ async fn pump_with_optional_reset(mut client: TcpStream, mut server: TcpStream, 
     }
 }
 
-/// Spawn a yamux server relaying to `upstream`; returns its listen address.
 async fn spawn_yamux_server(upstream: SocketAddr, shutdown: CancellationToken) -> SocketAddr {
     let (srv_tx, srv_rx) = oneshot::channel();
     tokio::spawn(run_server(

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -15,9 +15,9 @@ use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    connect_delay, connect_retrying, deframe_udp_datagram, frame_udp_datagram, parse_udp_timeout, run_client,
-    run_server, ClientBoundAddrs, FrameAccumulator, StreamTag, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY,
-    REMOTE_BACKOFF_MAX,
+    connect_delay, connect_retrying, deframe_udp_datagram, frame_udp_datagram, next_failures, parse_udp_timeout,
+    run_client, run_server, session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, StreamTag,
+    DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
 // Only the Windows-gated CONNRESET regression test uses this.
 #[cfg(windows)]
@@ -492,4 +492,41 @@ async fn connect_retrying_retries_until_the_peer_listens() {
         "must connect once the peer starts listening"
     );
     shutdown.cancel();
+}
+
+// Reconnect backoff ---------------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn next_failures_resets_on_productive_and_increments_otherwise() {
+    assert_eq!(next_failures(0, true), 0);
+    assert_eq!(next_failures(5, true), 0);
+    assert_eq!(next_failures(0, false), 1);
+    assert_eq!(next_failures(3, false), 4);
+    assert_eq!(next_failures(u32::MAX, false), u32::MAX);
+}
+
+#[skuld::test]
+fn session_reconnect_backoff_schedule() {
+    // Contract properties (independent of any literal table): a floor at the base,
+    // doubling per failure, capped at the max.
+    assert_eq!(session_reconnect_backoff(0), REMOTE_BACKOFF_BASE);
+    assert_eq!(session_reconnect_backoff(1), REMOTE_BACKOFF_BASE);
+    for n in 1..14u32 {
+        assert_eq!(
+            session_reconnect_backoff(n + 1),
+            (session_reconnect_backoff(n) * 2).min(REMOTE_BACKOFF_MAX),
+            "doubling @ {n}"
+        );
+    }
+    assert_eq!(session_reconnect_backoff(u32::MAX), REMOTE_BACKOFF_MAX);
+
+    // Golden literals as a readable cross-check (mirrors the connect_delay tests).
+    let expected_ms = [100u64, 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 30000, 30000];
+    for (failures, ms) in expected_ms.iter().enumerate() {
+        assert_eq!(
+            session_reconnect_backoff(failures as u32),
+            Duration::from_millis(*ms),
+            "@ {failures}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

A single TCP reset of the tunnel's transport connection permanently wedged the Hole tunnel — the SOCKS data plane instant-refused every request until the proxy was restarted (surfacing in the field as "won't connect from Russia": packet loss aborts the sustained transport, and nothing rebuilt the chain). `connect_retrying` covered only the *initial* connect to the chain sibling; there was no recovery path for a mid-session transport abort.

This makes the galoshes yamux client **reconnect** instead of wedging.

## How

- `run_client_session` observes transport death via the driver's inbound channel closing (`inbound_rx.recv() == None`) — the same signal `run_server` already uses — and returns a typed `SessionOutcome`.
- The driver is torn down deterministically with `abort()` (no more hang until the chain drain-timeout); a genuine driver **panic** is fatal (`driver_panicked`), not folded into reconnect churn.
- Reconnect uses a floored exponential backoff (`REMOTE_BACKOFF_BASE` … `REMOTE_BACKOFF_MAX`, shared with `connect_delay` via one `exponential_backoff` helper) that resets when the session was *productive*.
- Productivity is **transport-level** liveness: a byte-tap (`TransportLivenessTap`) inside the driver-owned yamux `Connection`, read after `driver.await` — race-free by happens-before. Any inbound yamux frame (data or flow-control) means the far end responded, which is the correct signal for a *transport* reconnect.
- Local accept/recv errors log-and-continue (with a cooperative `yield_now` so a persistent local error can't busy-spin); `run_server` gets the symmetric abort teardown.

Architecture-map notes added to `CLAUDE.md` / `CONTRIBUTING.md`.

## Scope

A *silent* (no-RST) black-hole is out of scope and tracked in #660: it is not a permanent wedge (ex-ray's default 300 s `ConnectionIdle`, or the ~12 s TCP write-abort when active, closes the loopback, which this fix reconnects on); the follow-up adds a proactive keepalive to shrink the idle worst case.

## Tests

`cargo nextest run -p galoshes` — 55/55. New coverage: E2E transport-reset reconnect (TCP + UDP, via a Rust port of the driver-free reset relay), backoff escalation + productive-reset (typed reconnect observer, no log-text oracles), protocol-violation warn-drop-and-keep-serving (echo round trip), `driver_panicked` panic/cancel/ok classification, and shutdown-during-backoff (`tokio::time::pause`). Backoff/accounting helpers have golden + property tests.

Closes #655.
