### PR TITLE
fix(ci): de-elevate installer E2E to dodge WebView2 150 elevated regression (#661)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,14 @@
         "version\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\n.*github\\.com/(?<depName>[^/]+/[^/]+)/"
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+\\w+:\\s*[\"'](?<currentValue>[^\"']+)[\"']"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -66,6 +74,11 @@
       "description": "Major updates: one PR per package (API breaks reviewed individually). groupName: null overrides any inherited monorepo group from config:recommended's group:monorepos / group:recommended presets. Applies to customManagers (WiX) as well — by design; the customManagers block has no groupName, so this just reasserts the default.",
       "matchUpdateTypes": ["major"],
       "groupName": null,
+      "automerge": true
+    },
+    {
+      "description": "gsudo (installer-E2E de-elevation): auto-merge; the required Test installer check gates it.",
+      "matchDepNames": ["gerardog/gsudo"],
       "automerge": true
     }
   ]

--- a/.github/scripts/e2e-medium.ps1
+++ b/.github/scripts/e2e-medium.ps1
@@ -1,0 +1,18 @@
+# Runs inside the gsudo Medium child (via run-at-medium.ps1). Guards the
+# installed-binary target where wdio actually reads it -- proving
+# HOLE_TEST_APP_PATH survived de-elevation and points at a real binary, rather
+# than letting wdio.conf.ts fall back to the uninstalled workspace build --
+# then runs the dashboard E2E and forwards its exit code.
+if ([string]::IsNullOrEmpty($env:HOLE_TEST_APP_PATH)) {
+  throw "HOLE_TEST_APP_PATH not set in the de-elevated child (env did not forward)"
+}
+if (-not (Test-Path $env:HOLE_TEST_APP_PATH)) {
+  throw "installed hole.exe not found at '$env:HOLE_TEST_APP_PATH'"
+}
+# Fail closed if npm can't even start: a not-found npm leaves $LASTEXITCODE
+# $null, and `exit $null` coerces to 0 -- a green with zero tests run.
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+  throw "npm not resolvable on PATH inside the de-elevated child"
+}
+npm run test:e2e
+exit $LASTEXITCODE

--- a/.github/scripts/run-at-medium.ps1
+++ b/.github/scripts/run-at-medium.ps1
@@ -1,0 +1,14 @@
+# Runs a PowerShell script at Medium integrity via gsudo (direct mode).
+#
+# GitHub runners run every process at High integrity (admin + UAC disabled),
+# and WebView2 Runtime 150 broke the DevTools loopback for High-integrity hosts
+# (MicrosoftEdge/WebView2Feedback#5640), so the WebView2 host must run Medium
+# (where real users run it). Single source of truth for the de-elevation
+# launcher: the installer E2E and its self-test both call this, so they cannot
+# drift. `-d` skips gsudo's shell detection so `powershell -File $Script` runs
+# directly; without it gsudo, invoked from a PowerShell parent, re-wraps the
+# command under PowerShell-shell semantics, which collapses a non-zero child
+# exit code to 1 (exit-code forwarding is otherwise gsudo's default).
+param([Parameter(Mandatory)][string]$Script)
+gsudo -d -i Medium -- powershell -NoProfile -File $Script
+exit $LASTEXITCODE

--- a/.github/scripts/verify-gsudo-deelevation.ps1
+++ b/.github/scripts/verify-gsudo-deelevation.ps1
@@ -1,0 +1,20 @@
+# Runs inside the gsudo Medium child (via run-at-medium.ps1) to prove the
+# de-elevation contract the installer E2E relies on: Medium integrity (by the
+# locale-invariant SID, not a localized whoami label), a forwarded env var,
+# npm on PATH, and streamed stdout. Exits 7 only when all hold -- a nonzero
+# sentinel that also proves the exit code survives the launcher -- otherwise
+# writes a distinct message and exits 1.
+$g = try { (& "$env:SystemRoot\System32\whoami.exe" /groups 2>$null | Out-String) } catch { "" }
+$il =
+  if ([string]::IsNullOrWhiteSpace($g)) { "WhoamiError" }
+  elseif ($g -match "S-1-16-8192") { "Medium" }
+  elseif ($g -match "S-1-16-12288") { "High" }
+  else { "Unknown" }
+$npm = if (Get-Command npm -ErrorAction SilentlyContinue) { "yes" } else { "no" }
+Write-Output "IL=$il ENV=$env:HOLE_SELFTEST_CANARY NPM=$npm PROBE_OK"
+if ($il -eq "WhoamiError") { Write-Host "whoami.exe failed inside the de-elevated child"; exit 1 }
+if ($il -eq "High")        { Write-Host "child still High integrity (gsudo did not lower it)"; exit 1 }
+if ($il -ne "Medium")      { Write-Host "could not confirm Medium integrity (IL=$il)"; exit 1 }
+if ($env:HOLE_SELFTEST_CANARY -ne "canary-ok") { Write-Host "env var not forwarded into the de-elevated child"; exit 1 }
+if ($npm -ne "yes")        { Write-Host "npm not resolvable on PATH inside the de-elevated child"; exit 1 }
+exit 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -541,12 +541,16 @@ jobs:
         shell: pwsh
         run: |
           $env:HOLE_SELFTEST_CANARY = "canary-ok"
-          $out = (pwsh -NoProfile -File .github/scripts/run-at-medium.ps1 -Script .github/scripts/verify-gsudo-deelevation.ps1 *>&1 | Out-String)
+          # The child streams its IL=.../PROBE_OK line straight to the log and
+          # exits 7 only when every contract check passes -- a nonzero sentinel
+          # that also proves the exit code survives the launcher. Gate on that
+          # and set the step's exit code explicitly (a lingering $LASTEXITCODE=7
+          # would otherwise fail the step under GitHub's pwsh wrapper).
+          pwsh -NoProfile -File .github/scripts/run-at-medium.ps1 -Script .github/scripts/verify-gsudo-deelevation.ps1
           $code = $LASTEXITCODE
-          Write-Host $out
-          if ($code -ne 7)               { throw "gsudo de-elevation contract failed (exit $code); see child output above" }
-          if ($out -notmatch 'PROBE_OK') { throw "child stdout did not stream back to the runner" }
-          Write-Host "OK: Medium integrity + env + PATH + stdout + exit code verified"
+          if ($code -ne 7) { Write-Host "::error::gsudo de-elevation contract failed (exit $code); see child output above"; exit 1 }
+          Write-Host "OK: de-elevation verified (Medium + env + PATH + stdout + exit code)"
+          exit 0
 
       # Run the dashboard E2E at Medium integrity through the shared launcher.
       # The installed-binary guard lives in e2e-medium.ps1 (inside the child),
@@ -558,7 +562,7 @@ jobs:
           HOLE_TEST_APP_PATH: 'C:\Program Files\hole\bin\hole.exe'
         run: |
           pwsh -NoProfile -File .github/scripts/run-at-medium.ps1 -Script .github/scripts/e2e-medium.ps1
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          exit $LASTEXITCODE
 
       - name: Kill hole.exe after E2E
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,6 +429,9 @@ jobs:
     # post-job cache save with the actual work already green, cancelling a
     # would-be pass. The extra headroom absorbs slow cold-sccache/cache runs.
     timeout-minutes: 45
+    env:
+      # renovate: datasource=github-releases depName=gerardog/gsudo
+      GSUDO_VERSION: "2.6.1"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -514,14 +517,48 @@ jobs:
           Get-Process hole -ErrorAction SilentlyContinue | Stop-Process -Force
           Wait-Process -Name hole -ErrorAction SilentlyContinue
 
-      # Reuse the `node_modules/` left by `frontend-build` during
-      # `cargo xtask build hole-msi`. WDIO is in devDependencies; the
-      # configured `tauri:options.application` is overridden via env var
-      # to point at the installed binary, not the workspace's release.
-      - name: E2E dashboard test
+      # gsudo runs the dashboard E2E at Medium integrity. GitHub runners run
+      # every process at High integrity (admin + UAC disabled), and WebView2
+      # Runtime 150 broke the DevTools loopback for High-integrity hosts
+      # (MicrosoftEdge/WebView2Feedback#5640) so tauri-driver can't attach.
+      # Real users run the GUI unprivileged (Medium), where 150 works.
+      - name: Install gsudo (de-elevation for the E2E)
+        shell: pwsh
+        run: |
+          $zip = "$env:RUNNER_TEMP\gsudo.zip"
+          $dir = "$env:RUNNER_TEMP\gsudo"
+          Invoke-WebRequest -Uri "https://github.com/gerardog/gsudo/releases/download/v$env:GSUDO_VERSION/gsudo.portable.zip" -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dir -Force
+          $exe = "$dir\x64\gsudo.exe"
+          if (-not (Test-Path $exe)) { throw "gsudo.exe not found at $exe after extract" }
+          "$dir\x64" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      # Prove on the real runner that de-elevation preserves everything the E2E
+      # needs — integrity (Medium), env vars, PATH (npm), streamed stdout, and
+      # the exact exit code — via the SAME gsudo -> powershell -File launcher
+      # the E2E uses. Fails loud here rather than as an opaque session timeout.
+      - name: Verify gsudo de-elevation contract
+        shell: pwsh
+        run: |
+          $env:HOLE_SELFTEST_CANARY = "canary-ok"
+          $out = (pwsh -NoProfile -File .github/scripts/run-at-medium.ps1 -Script .github/scripts/verify-gsudo-deelevation.ps1 *>&1 | Out-String)
+          $code = $LASTEXITCODE
+          Write-Host $out
+          if ($code -ne 7)               { throw "gsudo de-elevation contract failed (exit $code); see child output above" }
+          if ($out -notmatch 'PROBE_OK') { throw "child stdout did not stream back to the runner" }
+          Write-Host "OK: Medium integrity + env + PATH + stdout + exit code verified"
+
+      # Run the dashboard E2E at Medium integrity through the shared launcher.
+      # The installed-binary guard lives in e2e-medium.ps1 (inside the child),
+      # so it runs where wdio actually reads HOLE_TEST_APP_PATH. `node_modules/`
+      # is reused from the `frontend-build` that produced the MSI.
+      - name: E2E dashboard test (Medium integrity)
+        shell: pwsh
         env:
           HOLE_TEST_APP_PATH: 'C:\Program Files\hole\bin\hole.exe'
-        run: npm run test:e2e
+        run: |
+          pwsh -NoProfile -File .github/scripts/run-at-medium.ps1 -Script .github/scripts/e2e-medium.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Kill hole.exe after E2E
         if: always()


### PR DESCRIPTION
Closes #661.

## Root cause

The installer E2E's `session not created: DevToolsActivePort file doesn't exist` is a **WebView2 Runtime 150 regression** ([WebView2Feedback#5640](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5640)): 150 broke the DevTools remote-debugging loopback **for processes running at High Integrity**. GitHub runners run everything at High Integrity (admin + UAC disabled), so `tauri-driver`→`msedgedriver` can no longer attach once the runner's evergreen WebView2 auto-updated 149→150. It is **not** the version-mismatch the issue guessed, and **real users are unaffected** — they run the GUI unprivileged (Medium), where 150 works.

## Fix: de-elevate the E2E to Medium integrity

Run the dashboard E2E through a `gsudo -d -i Medium -- powershell -File` launcher so the whole tree (`npm`→`wdio`→`tauri-driver`→`msedgedriver`→`hole.exe`) runs at Medium — the same level users run at. Everything else is unchanged: CI keeps testing the runner's **real evergreen** WebView2, and `msedgedriver` keeps matching the live runtime.

Three checked-in scripts in `.github/scripts/`:
- **`run-at-medium.ps1`** — the single shared de-elevation launcher (both the E2E and its self-test call it, so they can't drift).
- **`verify-gsudo-deelevation.ps1`** — a self-test run *before* the E2E that proves, on the real runner, that de-elevation preserves integrity (Medium, by locale-invariant SID), env vars, `npm` on PATH, streamed stdout, and the exact exit code — each with a distinct error.
- **`e2e-medium.ps1`** — guards the installed-binary target *inside* the Medium child (where wdio reads it) and fails closed if `npm` can't start, then runs the E2E.

`gsudo` is pinned (`GSUDO_VERSION`) and Renovate-tracked; the `Test installer` check is a required status check, so its auto-merge is E2E-gated.

## What was considered and dropped

Pinning the WebView2 runtime for determinism was considered and **deliberately dropped**: the only programmatic source is a third-party NuGet package that lags evergreen (1–5 days, and skips builds), so a pin can't track what users run and would *hide* real evergreen regressions instead of surfacing them. De-elevation is what actually prevents the #5640-class recurrence (it only bites at High integrity).

## Verification

Reviewed via the plan panel (4 rounds → conditionally-approved) and the code panel (conditionally-approved, both must_fix applied). The gsudo mechanics were validated locally: the full launcher chain returns the exit-code sentinel, and every reachable throw branch fires (integrity/env/PATH/stdout, plus the installed-binary and npm guards). The High→Medium lowering and WebView2 window creation are CI-only and verified by this job going green.
