### PR TITLE
fix(lint): pin ty to 0.0.61 and fix sorted() type error

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,13 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+\\w+:\\s*[\"'](?<currentValue>[^\"']+)[\"']"
       ],
       "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^prek\\.toml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+additional_dependencies\\s*=\\s*\\[\"[^\"=]+==(?<currentValue>[^\"]+)\"\\]"
+      ]
     }
   ],
   "packageRules": [

--- a/msi-installer/tests/test_hole_msi.py
+++ b/msi-installer/tests/test_hole_msi.py
@@ -253,7 +253,7 @@ def test_arp_product_icon_in_msi(decompiled_tree: ET.ElementTree) -> None:
     pkg = decompiled_tree.getroot().find("wix:Package", NS)
     assert pkg is not None
 
-    icon_ids = {icon.get("Id") for icon in pkg.iter(f"{{{NS['wix']}}}Icon")}
+    icon_ids = {icon.get("Id", "") for icon in pkg.iter(f"{{{NS['wix']}}}Icon")}
     assert icon_ids, "Decompiled MSI has no <Icon> entries — ARPPRODUCTICON has nothing to reference"
 
     arp_property = None

--- a/msi-installer/tests/test_hole_wxs.py
+++ b/msi-installer/tests/test_hole_wxs.py
@@ -292,7 +292,7 @@ def test_arp_product_icon_defined(package: ET.Element) -> None:
     Without this property, Windows's Add/Remove Programs UI falls back
     to a generic gray installer-box icon for the Hole entry (#359).
     """
-    icon_ids = {icon.get("Id") for icon in package.iter(f"{{{NS['wix']}}}Icon")}
+    icon_ids = {icon.get("Id", "") for icon in package.iter(f"{{{NS['wix']}}}Icon")}
     arp_property = None
     for prop in package.iter(f"{{{NS['wix']}}}Property"):
         if prop.get("Id") == "ARPPRODUCTICON":

--- a/prek.toml
+++ b/prek.toml
@@ -150,7 +150,12 @@ entry = "ty check"
 language = "python"
 types = ["python"]
 pass_filenames = false
-additional_dependencies = ["ty"]
+# ty 0.0.62 regressed `unresolved-import` (ignores `ty.toml`'s
+# `rules.unresolved-import = "ignore"`) and added false-positive
+# `invalid-argument-type` findings — see #667. Pinned so a new release can't
+# break every push.
+# renovate: datasource=pypi depName=ty
+additional_dependencies = ["ty==0.0.61"]
 
 # External hooks =======================================================================================================
 


### PR DESCRIPTION
## Summary
- Pin `ty` to `0.0.61` in `prek.toml` (was unpinned) — `0.0.62` regressed `unresolved-import` handling and added false-positive `invalid-argument-type` findings, breaking `Lint` on every push since 2026-07-22.
- Add a Renovate custom manager for the `prek.toml` pin so future `ty` releases land as a normal version-bump PR (verified via CI) instead of silently breaking `main`.
- Fix the 2 real `invalid-argument-type` findings: `icon_ids` in the MSI/WXS tests could contain `None` from `Element.get("Id")`; default to `""`.

Closes #667.

## Test plan
- [x] `uvx ty@0.0.61 check` → clean; `uvx ty@0.0.62 check` → reproduces the 8 CI diagnostics exactly.
- [x] `prek run ty --all-files` → Passed.
- [x] Renovate config validated with `renovate-config-validator`.
- [ ] CI green on this PR.