### PR TITLE
chore(release): bump galoshes to 0.3.1 and hole to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dump"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "dump-macros",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "dump-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dump",
  "hole-test-observability",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "galoshes"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "handle-holders"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hole-test-observability",
  "skuld",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "hole"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "hole-bridge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "hole-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dirs 6.0.0",
  "file-rotate",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "hole-test-observability"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ctor 1.0.7",
  "hole-common",
@@ -8960,7 +8960,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8988,7 +8988,7 @@ dependencies = [
 
 [[package]]
 name = "tun-engine-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hole-test-observability",
  "proc-macro2",

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-bridge"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-common"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 

--- a/crates/dump-macros/Cargo.toml
+++ b/crates/dump-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the dump crate (provides #[derive(Dump)])."

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 description = "YAML-shaped representation for logging, analogous to Python's dump() alongside str()/repr()."

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "galoshes"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license = "Apache-2.0"
 publish = false

--- a/crates/handle-holders/Cargo.toml
+++ b/crates/handle-holders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handle-holders"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 

--- a/crates/hole/Cargo.toml
+++ b/crates/hole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 

--- a/crates/test-observability/Cargo.toml
+++ b/crates/test-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hole-test-observability"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license = "GPL-3.0-or-later"
 publish = false

--- a/crates/tun-engine-macros/Cargo.toml
+++ b/crates/tun-engine-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 description = "Proc-macro support for the tun-engine crate (provides #[freeze])."

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tun-engine"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 publish = false
 description = "Cross-platform TUN device, OS routing, gateway discovery, and a smoltcp-backed packet-loop engine for building split-tunnel VPN/proxy daemons."


### PR DESCRIPTION
Closes the first step of #674.

| Track | From | To |
| --- | --- | --- |
| `galoshes` | 0.3.0 | 0.3.1 |
| `hole` (9 crates) | 0.4.0 | 0.5.0 |

`galoshes` takes a patch (fixes only: #642, #662). `hole` takes a minor because the batch carries a feature — in-process archive update-payload extraction (#659).

Version fields plus the `Cargo.lock` sync from `cargo update --workspace`; no other changes. Both groups validate under the same command the draft workflow runs (`cargo xtask version --check --exact --group <g>`, against a local tag at the target version).

Rationale for the two tracks that sit out this cycle — `ex-ray` (unchanged binary) and `garter` (blocked on `kill-group` reaching crates.io) — is in #674.
