### PR TITLE
fix(release): verify update archive in xtask, not a jq shell loop

### DIFF
--- a/.github/workflows/draft-release-hole.yaml
+++ b/.github/workflows/draft-release-hole.yaml
@@ -105,19 +105,12 @@ jobs:
           cargo xtask update-archive --out "$ARCHIVE"
           echo "Archive: $ARCHIVE"
 
-      - name: Verify Windows archive contents
-        if: matrix.os == 'windows'
+      - name: Verify archive contents
         shell: bash
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
           ARCHIVE="hole-${VERSION}-$(cargo xtask asset-suffix)"
-          workdir="$(mktemp -d)"
-          unzip -q "$ARCHIVE" -d "$workdir"
-          # Derive the expected set from the single source of truth.
-          cargo xtask bindir-names --os windows | jq -r '.[]' | while read -r f; do
-            test -s "$workdir/$f" || { echo "::error::missing/empty $f in $ARCHIVE"; exit 1; }
-          done
-          echo "Windows archive contents verified"
+          cargo xtask verify-update-archive --archive "$ARCHIVE"
 
       - name: Verify macOS archive app is runnable (codesign)
         if: matrix.os == 'darwin'

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -222,6 +222,14 @@ pub enum Command {
         #[arg(long)]
         out: PathBuf,
     },
+    /// Assert an update archive carries every file the bridge needs to unpack a
+    /// working BINDIR. The expected set comes from `bindir_dest_names`, so the
+    /// release workflow cannot drift from what ships.
+    VerifyUpdateArchive {
+        /// Archive to check (`.zip` on Windows, `.tar.gz` on macOS).
+        #[arg(long)]
+        archive: PathBuf,
+    },
     /// Print this host's update-archive asset suffix (e.g. `windows-amd64.zip`).
     ///
     /// The release workflow captures it to name the published archive; the
@@ -291,6 +299,11 @@ pub fn dispatch(cli: Cli) -> Result<()> {
             let repo_root = repo_root()?;
             update_archive::build_update_archive(Profile::Release, &repo_root, &out)?;
             println!("xtask: update archive written to {}", out.display());
+            Ok(())
+        }
+        Command::VerifyUpdateArchive { archive } => {
+            update_archive::verify_update_archive(&archive)?;
+            println!("xtask: update archive verified {}", archive.display());
             Ok(())
         }
         Command::AssetSuffix => {

--- a/xtask/src/update_archive.rs
+++ b/xtask/src/update_archive.rs
@@ -44,6 +44,65 @@ pub fn build_update_archive(profile: Profile, repo_root: &Path, out: &Path) -> R
     }
 }
 
+/// Assert `archive` carries a usable payload: every BINDIR entry present and
+/// non-empty on Windows, a non-empty app binary on macOS. Runs against the real
+/// built artifact in the release workflow, where the fake-tree unit tests can't
+/// reach.
+pub fn verify_update_archive(archive: &Path) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        use std::collections::HashMap;
+
+        use anyhow::{bail, Context};
+        use xtask_lib::bindir::{bindir_dest_names, Os};
+
+        let file = std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
+        let mut zip = zip::ZipArchive::new(file).with_context(|| format!("read zip {}", archive.display()))?;
+        let mut sizes = HashMap::new();
+        for i in 0..zip.len() {
+            let entry = zip.by_index(i)?;
+            sizes.insert(entry.name().to_string(), entry.size());
+        }
+        for name in bindir_dest_names(Os::Windows) {
+            match sizes.get(&name) {
+                None => bail!("{name} is missing from {}", archive.display()),
+                Some(0) => bail!("{name} is empty in {}", archive.display()),
+                Some(_) => {}
+            }
+        }
+        Ok(())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use anyhow::{bail, Context};
+
+        const BINARY: &str = ".app/Contents/MacOS/hole";
+
+        let file = std::fs::File::open(archive).with_context(|| format!("open {}", archive.display()))?;
+        let mut tar = tar::Archive::new(flate2::read::GzDecoder::new(file));
+        let mut size = None;
+        for entry in tar
+            .entries()
+            .with_context(|| format!("read tar {}", archive.display()))?
+        {
+            let entry = entry?;
+            if entry.path()?.to_string_lossy().ends_with(BINARY) {
+                size = Some(entry.size());
+            }
+        }
+        match size {
+            None => bail!("Contents/MacOS/hole is missing from {}", archive.display()),
+            Some(0) => bail!("Contents/MacOS/hole is empty in {}", archive.display()),
+            Some(_) => Ok(()),
+        }
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        let _ = archive;
+        anyhow::bail!("update-archive is only built on windows/macos")
+    }
+}
+
 /// The single built `.app` under `target/<profile>/bundle/macos`, via the shared
 /// `payload_archive::find_single_app` — bridge and xtask enforce the "exactly one
 /// .app" invariant with ONE implementation.

--- a/xtask/src/update_archive_tests.rs
+++ b/xtask/src/update_archive_tests.rs
@@ -1,4 +1,4 @@
-use crate::update_archive::build_update_archive;
+use crate::update_archive::{build_update_archive, verify_update_archive};
 use crate::Profile;
 #[cfg(target_os = "windows")]
 use std::fs;
@@ -43,6 +43,92 @@ fn windows_archive_entry_names_equal_bindir_dest_names() {
         names, expected,
         "zip entries must equal bindir_dest_names, incl. ex-ray.exe"
     );
+}
+
+/// The release workflow verifies the *real* built archive, which no fake-tree
+/// test can stand in for; these pin the checker itself.
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn verify_accepts_a_freshly_built_archive() {
+    let repo = fake_repo();
+    let out = repo.path().join("hole.zip");
+    build_update_archive(Profile::Release, repo.path(), &out).unwrap();
+
+    verify_update_archive(&out).unwrap();
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn verify_rejects_an_archive_missing_a_bindir_entry() {
+    let repo = fake_repo();
+    let out = repo.path().join("hole.zip");
+    build_update_archive(Profile::Release, repo.path(), &out).unwrap();
+    rewrite_zip_without(&out, "ex-ray.exe");
+
+    let err = verify_update_archive(&out).unwrap_err();
+    assert!(err.to_string().contains("ex-ray.exe"), "got: {err}");
+}
+
+#[cfg(target_os = "windows")]
+#[skuld::test]
+fn verify_rejects_an_empty_bindir_entry() {
+    let repo = fake_repo();
+    fs::write(repo.path().join("target/release/galoshes.exe"), b"").unwrap();
+    let out = repo.path().join("hole.zip");
+    build_update_archive(Profile::Release, repo.path(), &out).unwrap();
+
+    let err = verify_update_archive(&out).unwrap_err();
+    assert!(err.to_string().contains("galoshes.exe"), "got: {err}");
+}
+
+/// Repack `zip` keeping every entry except `drop_name`.
+#[cfg(target_os = "windows")]
+fn rewrite_zip_without(zip: &std::path::Path, drop_name: &str) {
+    let mut src = zip::ZipArchive::new(fs::File::open(zip).unwrap()).unwrap();
+    let mut kept = Vec::new();
+    for i in 0..src.len() {
+        let mut e = src.by_index(i).unwrap();
+        if e.name() == drop_name {
+            continue;
+        }
+        let name = e.name().to_string();
+        let mut bytes = Vec::new();
+        std::io::Read::read_to_end(&mut e, &mut bytes).unwrap();
+        kept.push((name, bytes));
+    }
+    let mut w = zip::ZipWriter::new(fs::File::create(zip).unwrap());
+    for (name, bytes) in kept {
+        w.start_file(name, zip::write::SimpleFileOptions::default()).unwrap();
+        std::io::Write::write_all(&mut w, &bytes).unwrap();
+    }
+    w.finish().unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn verify_accepts_a_freshly_built_archive() {
+    let repo = tempfile::tempdir().unwrap();
+    let macos = repo.path().join("target/release/bundle/macos/Hole.app/Contents/MacOS");
+    std::fs::create_dir_all(&macos).unwrap();
+    std::fs::write(macos.join("hole"), b"MACHO").unwrap();
+    let out = repo.path().join("hole.tar.gz");
+    build_update_archive(Profile::Release, repo.path(), &out).unwrap();
+
+    verify_update_archive(&out).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test]
+fn verify_rejects_an_archive_whose_app_binary_is_empty() {
+    let repo = tempfile::tempdir().unwrap();
+    let macos = repo.path().join("target/release/bundle/macos/Hole.app/Contents/MacOS");
+    std::fs::create_dir_all(&macos).unwrap();
+    std::fs::write(macos.join("hole"), b"").unwrap();
+    let out = repo.path().join("hole.tar.gz");
+    build_update_archive(Profile::Release, repo.path(), &out).unwrap();
+
+    let err = verify_update_archive(&out).unwrap_err();
+    assert!(err.to_string().contains("Contents/MacOS/hole"), "got: {err}");
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Closes #677.

The *Verify Windows archive contents* step could never pass: `jq` on the Windows runner emits CRLF, so each name read by the shell loop kept a trailing `\r` and `test -s "$workdir/hole.exe\r"` always failed. It blocked the hole 0.5.0 draft.

Rather than strip the CR, the check moves to where the expected set already lives. `cargo xtask verify-update-archive --archive <path>` asserts every `bindir_dest_names(host)` entry is present and non-empty (Windows), or that the app binary is present and non-empty (macOS). The step now runs on both platforms instead of Windows only, and no longer needs `jq` or `unzip`.

The point is coverage, not just the CR: the old check ran only inside `draft-release-hole.yaml`, so nothing exercised it until a release. The new logic has unit tests — accepts a freshly built archive, rejects a missing entry, rejects an empty one — that run in normal CI on both Windows and macOS.

Verify: `cargo nextest run -p xtask -E 'test(verify_)'`. End-to-end confirmation is the 0.5.0 draft re-run, since the failing step only exists there.
