### PR TITLE
fix(deps): realign tauri-plugin-log with its npm package and guard the pairing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -87,6 +87,11 @@
       "description": "gsudo (installer-E2E de-elevation): auto-merge; the required Test installer check gates it.",
       "matchDepNames": ["gerardog/gsudo"],
       "automerge": true
+    },
+    {
+      "description": "Tauri ships each plugin as an npm/crate pair and `npx tauri build` refuses a major.minor mismatch (#679). The npm and cargo managers are grouped separately above, so without this a bump on one side lands alone and breaks the DMG bundle. Last rule wins, so this overrides those groups for these packages.",
+      "matchPackageNames": ["@tauri-apps/**", "tauri", "tauri-build", "tauri-plugin-**"],
+      "groupName": "Tauri"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,17 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +135,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -157,7 +146,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -575,18 +564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,30 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,44 +661,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
-name = "byte-unit"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
-dependencies = [
- "rust_decimal",
- "schemars 1.2.1",
- "serde",
- "utf8-width",
-]
-
-[[package]]
 name = "byte_string"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11aade7a05aa8c3a351cedc44c3fc45806430543382fcc4743a9b757a2a0b4ed"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bytemuck"
@@ -1793,7 +1712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2115,7 +2034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2406,12 +2325,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -3025,9 +2938,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3702,7 +3612,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4518,9 +4428,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -4787,7 +4694,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4994,7 +4901,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5399,7 +5306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6126,26 +6033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,12 +6138,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -6535,15 +6416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6661,35 +6533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "roman-numerals-rs"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6742,14 +6585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
- "borsh",
- "bytes",
  "num-traits",
- "rand 0.8.6",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -6786,7 +6622,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6951,12 +6787,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sealed"
@@ -7567,7 +7397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7671,7 +7501,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7997,12 +7827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8213,12 +8037,11 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-log"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
 dependencies = [
  "android_logger",
- "byte-unit",
  "fern",
  "log",
  "objc2",
@@ -8360,7 +8183,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8914,7 +8737,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9424,7 +9247,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9707,12 +9530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
-name = "utf8-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9759,12 +9576,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -10212,7 +10023,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10866,7 +10677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11031,15 +10842,6 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -28,6 +28,7 @@ pub mod manifest;
 pub mod orchestrate;
 pub mod stage;
 pub mod target;
+pub mod tauri_pairs;
 pub mod test_binaries;
 pub mod update_archive;
 pub mod upstream_v2ray;

--- a/xtask/src/tauri_pairs.rs
+++ b/xtask/src/tauri_pairs.rs
@@ -1,0 +1,77 @@
+//! Tauri ships each plugin as an npm/crate pair, and `npx tauri build` refuses
+//! to build when the two sides disagree on major.minor. Both are floating
+//! requirements resolved by different lockfiles, so a bump on one side alone is
+//! invisible until a bundle build runs — see the DMG break in #679.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+/// `@tauri-apps/plugin-X` ↔ `tauri-plugin-X` versions that disagree on
+/// major.minor, as `("plugin-X", npm, crate)`. Empty means the pair is aligned.
+pub fn plugin_version_drift(package_lock: &str, cargo_lock: &str) -> Result<Vec<(String, String, String)>> {
+    let npm = npm_plugin_versions(package_lock)?;
+    let cargo = cargo_plugin_versions(cargo_lock);
+
+    let mut drift = Vec::new();
+    for (plugin, npm_version) in npm {
+        let Some(crate_version) = cargo.get(&plugin) else {
+            continue;
+        };
+        if minor_series(&npm_version) != minor_series(crate_version) {
+            drift.push((plugin, npm_version, crate_version.clone()));
+        }
+    }
+    Ok(drift)
+}
+
+/// Leading `major.minor`, the granularity the Tauri CLI compares at.
+fn minor_series(version: &str) -> (&str, &str) {
+    let mut parts = version.split('.');
+    (parts.next().unwrap_or_default(), parts.next().unwrap_or_default())
+}
+
+fn npm_plugin_versions(package_lock: &str) -> Result<BTreeMap<String, String>> {
+    let lock: Value = serde_json::from_str(package_lock).context("parse package-lock.json")?;
+    let packages = lock.get("packages").and_then(Value::as_object);
+    let mut out = BTreeMap::new();
+    for (path, entry) in packages.into_iter().flatten() {
+        // Keys are install paths; the same package can appear nested.
+        let Some(name) = path.rsplit("node_modules/").next() else {
+            continue;
+        };
+        let Some(plugin) = name.strip_prefix("@tauri-apps/") else {
+            continue;
+        };
+        if !plugin.starts_with("plugin-") {
+            continue;
+        }
+        if let Some(version) = entry.get("version").and_then(Value::as_str) {
+            out.insert(plugin.to_string(), version.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn cargo_plugin_versions(cargo_lock: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let mut name = None;
+    for line in cargo_lock.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("name = ") {
+            name = rest.trim_matches('"').strip_prefix("tauri-").map(str::to_string);
+        } else if let Some(rest) = line.strip_prefix("version = ") {
+            if let Some(n) = name.take() {
+                if n.starts_with("plugin-") {
+                    out.insert(n, rest.trim_matches('"').to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "tauri_pairs_tests.rs"]
+mod tauri_pairs_tests;

--- a/xtask/src/tauri_pairs_tests.rs
+++ b/xtask/src/tauri_pairs_tests.rs
@@ -1,0 +1,74 @@
+use super::plugin_version_drift;
+
+const NPM_LOCK: &str = r#"{
+  "packages": {
+    "": { "name": "hole" },
+    "node_modules/@tauri-apps/api": { "version": "2.11.0" },
+    "node_modules/@tauri-apps/plugin-log": { "version": "2.9.0" },
+    "node_modules/@tauri-apps/plugin-shell": { "version": "2.3.0" }
+  }
+}"#;
+
+const CARGO_LOCK: &str = r#"
+[[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.1"
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+"#;
+
+#[skuld::test]
+fn aligned_pairs_report_no_drift() {
+    assert!(plugin_version_drift(NPM_LOCK, CARGO_LOCK).unwrap().is_empty());
+}
+
+/// Patch versions move independently on each side; only major.minor is compared.
+#[skuld::test]
+fn patch_level_difference_is_not_drift() {
+    let drift = plugin_version_drift(NPM_LOCK, CARGO_LOCK).unwrap();
+    assert!(!drift.iter().any(|(p, ..)| p == "plugin-shell"), "got: {drift:?}");
+}
+
+#[skuld::test]
+fn a_minor_bump_on_one_side_is_drift() {
+    let npm = NPM_LOCK.replace("\"version\": \"2.9.0\"", "\"version\": \"2.8.0\"");
+
+    let drift = plugin_version_drift(&npm, CARGO_LOCK).unwrap();
+
+    assert_eq!(
+        drift,
+        vec![("plugin-log".to_string(), "2.8.0".to_string(), "2.9.0".to_string())]
+    );
+}
+
+/// A crate with no npm counterpart (or vice versa) is not a pair.
+#[skuld::test]
+fn unpaired_packages_are_ignored() {
+    let drift = plugin_version_drift(NPM_LOCK, CARGO_LOCK).unwrap();
+    assert!(
+        !drift.iter().any(|(p, ..)| p == "plugin-single-instance"),
+        "got: {drift:?}"
+    );
+}
+
+/// The guard: this repo's own lockfiles must agree, or `npx tauri build` fails
+/// at bundle time (#679).
+#[skuld::test]
+fn this_repo_has_no_tauri_plugin_drift() {
+    let root = xtask_lib::repo_root::repo_root().unwrap();
+    let npm = std::fs::read_to_string(root.join("package-lock.json")).unwrap();
+    let cargo = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
+
+    let drift = plugin_version_drift(&npm, &cargo).unwrap();
+
+    assert!(
+        drift.is_empty(),
+        "npm/crate Tauri pairs disagree on major.minor; `npx tauri build` will refuse to bundle: {drift:?}"
+    );
+}


### PR DESCRIPTION
Closes #679.

`main` cannot build a DMG: `npx tauri build` refuses the pair `tauri-plugin-log` v2.8.0 : `@tauri-apps/plugin-log` v2.9.0. It blocked the hole 0.5.0 draft.

The npm side floated when #647 — a *vite* bump — regenerated `package-lock.json`. Renovate groups the npm and cargo managers separately, so an npm-side bump of a paired package structurally cannot bring its crate with it.

Three parts:

- **Realign** — `tauri-plugin-log` 2.9.0, matching the npm package.
- **Guard** — `plugin_version_drift` compares every `@tauri-apps/plugin-X` against `tauri-plugin-X` at major.minor, the granularity the Tauri CLI enforces. The repo's own lockfiles are asserted clean, so this now fails in `Test tooling` on every platform rather than at release time. Written first: it reproduced the drift as `[("plugin-log", "2.9.0", "2.8.0")]` before the bump.
- **Prevent** — a Renovate rule groups `@tauri-apps/*` with `tauri`/`tauri-plugin-*` into one PR. Last rule wins, so it overrides the per-manager groups for these packages.

Patch-level differences are allowed; the two sides publish patches independently and the CLI only compares major.minor.

Verify: `cargo nextest run -p xtask -E 'test(drift) + test(pairs) + test(unpaired) + test(bump)'`. The DMG jobs are the end-to-end check.
