### PR TITLE
fix(release): derive SHA256SUMS expectations from release assets and run scripts tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,14 @@ jobs:
       - name: Run linters
         run: cargo xtask run prek
 
+      # `scripts/*.py` keep their tests inline, and the filenames are
+      # hyphenated, so pytest's default `test_*.py` collection finds nothing —
+      # which is why sign-release.py's stale asset-count check reached a release
+      # unnoticed (#682). `python_files` collects every script rather than a
+      # hand-listed set, so a new script's tests run without touching CI.
+      - name: Test release scripts
+        run: uv run --with pytest --with PyYAML --with pathspec pytest -o python_files="*.py" scripts/
+
   # Per-platform build job: compiles clippy + test binaries once and publishes
   # them as a platform-scoped artifact (`build-<os>-<arch>`). Test jobs below
   # download the archive and run filtered tests without invoking the Rust

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -115,7 +115,7 @@ def git(repo_root: Path, *args: str) -> str:
         ["git", *args],
         cwd=repo_root,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:
@@ -394,7 +394,7 @@ def main() -> int:
             subprocess.run(
                 ["git", "rev-parse", "--show-toplevel"],
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
                 check=True,
             ).stdout.strip()
         )
@@ -710,7 +710,7 @@ def test_integration_filtering_against_real_history():
         ],
         cwd=repo_root,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=False,
     )
     # Surface the child's stderr: `check=True` raises with only the exit status,
@@ -733,7 +733,7 @@ def test_integration_filtering_against_real_history():
         ["git", "log", "--format=%H", "--no-merges", f"{prev_tag}..HEAD"],
         cwd=repo_root,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=True,
     ).stdout.splitlines()
     for sha in all_commits:
@@ -741,7 +741,7 @@ def test_integration_filtering_against_real_history():
             ["git", "show", "--no-renames", "--name-only", "--format=", sha],
             cwd=repo_root,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
             check=True,
         ).stdout.splitlines()
         files = [f for f in files if f.strip()]
@@ -754,7 +754,7 @@ def test_integration_filtering_against_real_history():
             ["git", "log", "--format=%s", "-1", sha],
             cwd=repo_root,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
             check=True,
         ).stdout.strip()
         m = re.search(r"\(#(\d+)\)\s*$", subject)
@@ -836,7 +836,7 @@ def _commit(repo: Path, message: str) -> str:
         ["git", "rev-parse", "HEAD"],
         cwd=repo,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=True,
     ).stdout.strip()
 

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -351,6 +351,17 @@ def render_notes(
 # Entry point ==========================================================================================================
 
 
+def emit(text: str) -> None:
+    """Write to stdout as UTF-8 regardless of the console's code page.
+
+    Category titles carry emoji, so the output is UTF-8 by contract; going
+    through the text layer dies on cp1252 (stock Windows) — invisible while
+    this only ran on ubuntu (#682).
+    """
+    sys.stdout.buffer.write(text.encode("utf-8"))
+    sys.stdout.buffer.flush()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("track", choices=["hole", "galoshes", "garter", "ex-ray"])
@@ -398,7 +409,7 @@ def main() -> int:
         # First-of-track release: emit the configured stub instead of
         # walking history. Avoids the "every PR ever merged" problem.
         body = config.initial_release or f"Initial release of the `{args.track}` track."
-        sys.stdout.write(downloads_table + "\n" + body.rstrip() + "\n")
+        emit(downloads_table + "\n" + body.rstrip() + "\n")
         return 0
 
     range_spec = f"{previous_tag}..{args.head}"
@@ -407,7 +418,7 @@ def main() -> int:
     filtered = [c for c in commits if any(path_spec.match_file(f) for f in c.files)]
     grouped = categorize(filtered, config.categories)
     body = render_notes(grouped, new_tag=args.new_tag, previous_tag=previous_tag, repo_url=args.repo_url)
-    sys.stdout.write(downloads_table + "\n" + body)
+    emit(downloads_table + "\n" + body)
     return 0
 
 
@@ -700,8 +711,11 @@ def test_integration_filtering_against_real_history():
         cwd=repo_root,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
+    # Surface the child's stderr: `check=True` raises with only the exit status,
+    # which left a CI failure undiagnosable (#682).
+    assert result.returncode == 0, f"generate-release-notes exited {result.returncode}:\n{result.stderr}"
     out = result.stdout
     assert out.strip(), "Empty output"
     assert "## Downloads" in out, f"Missing Downloads table: {out[:200]}"
@@ -758,7 +772,7 @@ def test_integration_filtering_against_real_history():
 def test_shared_categories_file_loaded():
     """load_config returns categories from the shared file for every track."""
     repo_root = Path(__file__).resolve().parent.parent
-    shared = yaml.safe_load((repo_root / ".github" / "release-categories.yaml").read_text())
+    shared = yaml.safe_load((repo_root / ".github" / "release-categories.yaml").read_text(encoding="utf-8"))
     expected_titles = [c["title"] for c in shared["categories"]]
     for track in ["hole", "galoshes", "garter", "ex-ray"]:
         config = load_config(repo_root, track)
@@ -770,7 +784,7 @@ def test_per_track_configs_dont_duplicate_categories():
     """Per-track files must not redeclare categories (single source of truth)."""
     repo_root = Path(__file__).resolve().parent.parent
     for track in ["hole", "galoshes", "garter", "ex-ray"]:
-        raw = yaml.safe_load((repo_root / ".github" / f"release-{track}.yaml").read_text())
+        raw = yaml.safe_load((repo_root / ".github" / f"release-{track}.yaml").read_text(encoding="utf-8"))
         assert "categories" not in raw, (
             f"release-{track}.yaml must not declare `categories:`; "
             f"shared schema lives in .github/release-categories.yaml"
@@ -787,11 +801,11 @@ def test_categories_cover_all_semantic_pr_types():
     type must have an explicit category.
     """
     repo_root = Path(__file__).resolve().parent.parent
-    semantic = yaml.safe_load((repo_root / ".github/workflows/semantic-pr.yaml").read_text())
+    semantic = yaml.safe_load((repo_root / ".github/workflows/semantic-pr.yaml").read_text(encoding="utf-8"))
     types_block = semantic["jobs"]["validate"]["steps"][0]["with"]["types"]
     declared_types = {t.strip() for t in types_block.splitlines() if t.strip()}
 
-    shared = yaml.safe_load((repo_root / ".github" / "release-categories.yaml").read_text())
+    shared = yaml.safe_load((repo_root / ".github" / "release-categories.yaml").read_text(encoding="utf-8"))
     explicit_types = {t for cat in shared["categories"] for t in cat.get("types", [])}
     has_catchall = any(not cat.get("types") for cat in shared["categories"])
 

--- a/scripts/sign-release.py
+++ b/scripts/sign-release.py
@@ -27,8 +27,9 @@ import tempfile
 from pathlib import Path
 
 REPO = "bindreams/hole"
-EXPECTED_INSTALLER_COUNT = 3
 TAG_PREFIX = "releases/hole/v"
+# Assets that carry signing metadata rather than being covered by it.
+SIGNATURE_ASSETS = frozenset({"SHA256SUMS", "SHA256SUMS.minisig"})
 
 
 def normalize_tag(tag: str) -> str:
@@ -40,22 +41,42 @@ def normalize_tag(tag: str) -> str:
     return f"{TAG_PREFIX}{version}"
 
 
-def validate_sha256sums(path: Path) -> None:
-    """Validate that the SHA256SUMS file has the expected format."""
-    content = path.read_text()
-    lines = [line for line in content.splitlines() if line.strip()]
+def signable_asset_names(asset_names) -> set:
+    """Release assets that SHA256SUMS must cover: everything but the signing metadata."""
+    return {name for name in asset_names if name not in SIGNATURE_ASSETS}
 
-    if len(lines) != EXPECTED_INSTALLER_COUNT:
-        print(
-            f"error: SHA256SUMS has {len(lines)} entries, expected {EXPECTED_INSTALLER_COUNT}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
+def validate_sha256sums(path: Path, expected: set) -> None:
+    """Assert SHA256SUMS covers exactly `expected`, one well-formed line each.
+
+    Derived from the release's own asset list rather than a count, so adding a
+    platform or artifact needs no change here (#682).
+    """
+    lines = [line for line in path.read_text().splitlines() if line.strip()]
+
+    listed = []
     for i, line in enumerate(lines, 1):
-        if not re.fullmatch(r"[0-9a-fA-F]{64}  .+", line):
+        match = re.fullmatch(r"([0-9a-fA-F]{64})  (.+)", line)
+        if not match:
             print(f"error: SHA256SUMS line {i} is malformed: {line!r}", file=sys.stderr)
             sys.exit(1)
+        listed.append(match.group(2))
+
+    duplicates = sorted({name for name in listed if listed.count(name) > 1})
+    if duplicates:
+        print(f"error: SHA256SUMS lists {', '.join(duplicates)} more than once", file=sys.stderr)
+        sys.exit(1)
+
+    if set(listed) != expected:
+        missing = sorted(expected - set(listed))
+        unknown = sorted(set(listed) - expected)
+        detail = []
+        if missing:
+            detail.append(f"release assets absent from SHA256SUMS: {', '.join(missing)}")
+        if unknown:
+            detail.append(f"SHA256SUMS entries not on the release: {', '.join(unknown)}")
+        print(f"error: {'; '.join(detail)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def main() -> None:
@@ -102,7 +123,7 @@ def main() -> None:
         )
 
         sha256sums_path = tmpdir / "SHA256SUMS"
-        validate_sha256sums(sha256sums_path)
+        validate_sha256sums(sha256sums_path, signable_asset_names(asset_names))
 
         sign_cmd = ["minisign", "-Sm", str(sha256sums_path)]
         if args.secret_key:
@@ -157,6 +178,86 @@ def test_normalize_tag_invalid():
         normalize_tag("abc")
 
 
+# The 0.5.0 asset set: three installers plus the three update archives added in
+# #659. A hardcoded count went stale on exactly this change (#682).
+SIGNABLE_ASSETS = [
+    "hole-0.5.0-darwin-amd64.dmg",
+    "hole-0.5.0-darwin-amd64.tar.gz",
+    "hole-0.5.0-darwin-arm64.dmg",
+    "hole-0.5.0-darwin-arm64.tar.gz",
+    "hole-0.5.0-windows-amd64.msi",
+    "hole-0.5.0-windows-amd64.zip",
+]
+
+
+def _sums(names):
+    return "".join(f"{i:064x}  {name}\n" for i, name in enumerate(names, 1))
+
+
+def test_accepts_sums_covering_every_release_asset(tmp_path):
+    path = tmp_path / "SHA256SUMS"
+    path.write_text(_sums(SIGNABLE_ASSETS))
+
+    validate_sha256sums(path, set(SIGNABLE_ASSETS))
+
+
+def test_asset_count_is_not_fixed(tmp_path):
+    """Adding an asset to the release must not require touching this script."""
+    extended = [*SIGNABLE_ASSETS, "hole-0.5.0-linux-amd64.tar.gz"]
+    path = tmp_path / "SHA256SUMS"
+    path.write_text(_sums(extended))
+
+    validate_sha256sums(path, set(extended))
+
+
+def test_rejects_asset_missing_from_sums(tmp_path):
+    import pytest
+
+    path = tmp_path / "SHA256SUMS"
+    path.write_text(_sums(SIGNABLE_ASSETS[:-1]))
+
+    with pytest.raises(SystemExit):
+        validate_sha256sums(path, set(SIGNABLE_ASSETS))
+
+
+def test_rejects_sums_line_for_unknown_asset(tmp_path):
+    import pytest
+
+    path = tmp_path / "SHA256SUMS"
+    path.write_text(_sums([*SIGNABLE_ASSETS, "hole-0.5.0-windows-arm64.msi"]))
+
+    with pytest.raises(SystemExit):
+        validate_sha256sums(path, set(SIGNABLE_ASSETS))
+
+
+def test_rejects_duplicate_entry(tmp_path):
+    import pytest
+
+    path = tmp_path / "SHA256SUMS"
+    path.write_text(_sums(SIGNABLE_ASSETS) + f"{7:064x}  {SIGNABLE_ASSETS[0]}\n")
+
+    with pytest.raises(SystemExit):
+        validate_sha256sums(path, set(SIGNABLE_ASSETS))
+
+
+def test_rejects_malformed_line(tmp_path):
+    import pytest
+
+    path = tmp_path / "SHA256SUMS"
+    path.write_text("not-a-hash  hole-0.5.0-windows-amd64.msi\n")
+
+    with pytest.raises(SystemExit):
+        validate_sha256sums(path, {"hole-0.5.0-windows-amd64.msi"})
+
+
+def test_signature_assets_are_not_themselves_hashed(tmp_path):
+    """`SHA256SUMS`/`.minisig` are release assets but never entries."""
+    path = tmp_path / "SHA256SUMS"
+    path.write_text(_sums(SIGNABLE_ASSETS))
+
+    validate_sha256sums(path, signable_asset_names(SIGNABLE_ASSETS + ["SHA256SUMS"]))
+
+
 def test_validate_sha256sums_valid(tmp_path: Path):
     p = tmp_path / "SHA256SUMS"
     p.write_text(
@@ -164,16 +265,23 @@ def test_validate_sha256sums_valid(tmp_path: Path):
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  hole-1.0.0-darwin-arm64.dmg\n"
         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  hole-1.0.0-darwin-amd64.dmg\n"
     )
-    validate_sha256sums(p)  # should not raise
+    validate_sha256sums(
+        p,
+        {
+            "hole-1.0.0-windows-amd64.msi",
+            "hole-1.0.0-darwin-arm64.dmg",
+            "hole-1.0.0-darwin-amd64.dmg",
+        },
+    )  # should not raise
 
 
-def test_validate_sha256sums_wrong_line_count(tmp_path: Path):
+def test_validate_sha256sums_short_of_the_release_assets(tmp_path: Path):
     import pytest
 
     p = tmp_path / "SHA256SUMS"
     p.write_text("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  hole-1.0.0-windows-amd64.msi\n")
     with pytest.raises(SystemExit):
-        validate_sha256sums(p)
+        validate_sha256sums(p, {"hole-1.0.0-windows-amd64.msi", "hole-1.0.0-darwin-arm64.dmg"})
 
 
 def test_validate_sha256sums_malformed_hash(tmp_path: Path):
@@ -186,4 +294,11 @@ def test_validate_sha256sums_malformed_hash(tmp_path: Path):
         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  hole-1.0.0-darwin-amd64.dmg\n"
     )
     with pytest.raises(SystemExit):
-        validate_sha256sums(p)
+        validate_sha256sums(
+            p,
+            {
+                "hole-1.0.0-windows-amd64.msi",
+                "hole-1.0.0-darwin-arm64.dmg",
+                "hole-1.0.0-darwin-amd64.dmg",
+            },
+        )


### PR DESCRIPTION
Closes #682.

`scripts/sign-release.py` refuses to sign the 0.5.0 draft: it asserts a hardcoded `EXPECTED_INSTALLER_COUNT = 3`, but since #659 the release also ships the three update archives, so `SHA256SUMS` has 6 entries. Signing is the one manual release step, so this blocked publishing.

`validate_sha256sums` now takes the expected names, derived from the release's own asset list minus `SHA256SUMS`/`SHA256SUMS.minisig` — a set the script already fetches. Adding a platform or artifact needs no change here. It is also strictly stronger than the count it replaces: a 6-line file naming the wrong six files passed before and fails now, and duplicate entries are rejected.

**The reason it reached a release:** `scripts/*.py` keep their tests inline and the filenames are hyphenated, so pytest's default `test_*.py` collection matches none of them. CI only ran pytest under `msi-installer/` and `dmg-installer/`, leaving four scripts' tests — 104 of them — never executed, one load-bearing for every hole release. The `lint` job now runs them with `python_files="*.py"`, which collects any script rather than a hand-listed set, so this can't silently regrow. `lint` was chosen over a new job because it's already a required check, so a failure actually blocks.

Verify: `uv run --with pytest --with PyYAML --with pathspec pytest -o python_files="*.py" scripts/` — 104 pass. The signing tests were written first against the real 0.5.0 asset set and failed before the change.
