### PR TITLE
fix(galoshes): proactively detect a silently black-holed transport (#660)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,11 @@ before editing; the sections linked below are the authoritative source.
   transport reset instead of wedging; death is detected via the driver's
   inbound channel closing, and reconnect backoff is floored and resets on
   transport-level liveness (any inbound yamux frame). `driver.abort()`
-  teardown deliberately truncates in-flight relays; a silent (no-RST)
-  black-hole is out of scope (→ #660). →
+  teardown deliberately truncates in-flight relays. A silent (no-RST) black
+  hole is caught by an idle-gated client keepalive on a `Keepalive` substream:
+  a cycle is fatal only when the transport tap counted no inbound read across a
+  whole interval and deadline, so an un-upgraded peer's tag rejection reads as
+  liveness and a busy tunnel is never probed at all. →
   [CONTRIBUTING.md#yamux-transport-self-heal](CONTRIBUTING.md#yamux-transport-self-heal)
 - **Fail-closed covers.** The **standing lockdown** cover
   (`Routing::install_lockdown`, opt-in kill switch) holds the update-cutover gap:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,10 +264,9 @@ reconnects after a transport reset instead of wedging the tunnel:
   (a floor bounding a peer flapping right after one byte) and escalates
   exponentially to `REMOTE_BACKOFF_MAX` on repeated failures.
   "Productive" is **transport-level**, not application-level: `TransportLivenessTap`
-  sits below yamux framing and flags any inbound byte — relayed data or a bare
-  keepalive/flow-control frame alike — as liveness, which resets the backoff to
-  the floor. A session that never received a single inbound byte counts as a
-  failure and escalates.
+  sits below yamux framing and counts every inbound read — relayed data or a bare
+  ping/flow-control frame alike — as liveness, which resets the backoff to the
+  floor. A session whose count never moved counts as a failure and escalates.
 - **Teardown tradeoff.** On session end the driver is `abort()`-ed rather than
   drained, so any relay stream still in flight is truncated. This trades a
   handful of interrupted flows for a bounded, deterministic teardown instead of
@@ -277,9 +276,28 @@ reconnects after a transport reset instead of wedging the tunnel:
   and the accept loop continues — reconnecting the transport wouldn't fix a
   local socket error, and a broken listener is not what these errors indicate
   (they're transient: a stray `ECONNABORTED`, momentary `EMFILE`).
-- **Scope boundary.** This detects a transport that visibly dies (FIN/RST,
-  yamux protocol error). A peer that goes silent without ever resetting the
-  connection (a black-holed link) is not detected by this mechanism — see #660.
+- **Proactive keepalive**
+  ([`yamux/keepalive.rs`](crates/galoshes/src/yamux/keepalive.rs)). A visible
+  death (FIN/RST, yamux protocol error) is caught by the inbound-channel signal
+  above. A peer that goes silent without resetting — a black-holed link — is
+  caught instead by a client keepalive. Every `KEEPALIVE_INTERVAL` in which
+  `TransportLivenessTap` counted nothing, the client opens a
+  `StreamTag::Keepalive` substream and writes an 8-byte nonce, purely to give an
+  idle transport a reason to speak; a transport that delivered anything is not
+  probed at all, so a busy tunnel carries no keepalive traffic. The verdict is
+  not "did the echo come back" — the client reads the substream exactly once and
+  never inspects what it got — but "did the tap count *any* inbound read before
+  `KEEPALIVE_TIMEOUT` was up". That is what makes the wire addition safe against
+  version skew: an un-upgraded server resets the unknown tag, and the reset is
+  inbound traffic that is necessarily read *before* the probe's read can end, so
+  the tunnel behaves exactly as it did before. The whole cycle including the
+  substream open sits inside the deadline, because opening parks indefinitely
+  once enough substreams await an ACK. Detection is bounded by
+  `2 × KEEPALIVE_INTERVAL + KEEPALIVE_TIMEOUT` from the last inbound byte, which
+  holds only while the deadline is no longer than the interval; the interval may
+  also not drop below yamux's own 10 s ping cadence, which is what keeps a
+  healthy-but-slow server off the fatal path. `const` assertions pin both
+  relations at the constants.
 
 ### Fail-closed cover
 

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 // `Context` alone would collide with `anyhow::Context` (the `.context()` combinator, used
 // throughout this file); the tap's poll methods spell out `std::task::Context` instead.
@@ -294,23 +294,27 @@ async fn write_tag(stream: &mut yamux::Stream, tag: StreamTag) -> std::io::Resul
 
 // Liveness tap ========================================================================================================
 
-/// Wraps the yamux transport and sets `productive` on the first inbound byte.
+/// Wraps the yamux transport and counts inbound reads — this crate's single
+/// transport-liveness signal.
 ///
-/// `run_client` gives this to `yamux::Connection::new`, so the tap is polled only
-/// by the driver task; reading `productive` after `driver.await` therefore has a
-/// happens-before edge to every write here (no cross-task race). It sits *below*
-/// yamux framing, so any inbound frame counts — relayed data or flow-control /
-/// keepalive frames alike. That is deliberate: it measures *transport*-level
-/// liveness (the far yamux peer responded), which is the correct signal for a
-/// transport reconnect, not end-to-end application relay.
+/// `SessionTransport::spawn` gives this to `yamux::Connection::new`, so the tap
+/// is written only by the driver task. It sits *below* yamux framing, so any
+/// inbound frame counts — relayed data, a flow-control window update, a yamux
+/// pong, or a peer's stream reset alike. That is deliberate: it measures
+/// *transport*-level liveness (the far yamux peer responded), which is the right
+/// signal both for the reconnect backoff and for the keepalive's verdict, neither
+/// of which is about application relay.
+///
+/// `Relaxed` is sufficient: two samples of a monotonic counter are compared for
+/// inequality and no other memory is published through it.
 pub(crate) struct TransportLivenessTap<T> {
     inner: T,
-    productive: Arc<AtomicBool>,
+    inbound_reads: Arc<AtomicU64>,
 }
 
 impl<T> TransportLivenessTap<T> {
-    pub(crate) fn new(inner: T, productive: Arc<AtomicBool>) -> Self {
-        Self { inner, productive }
+    pub(crate) fn new(inner: T, inbound_reads: Arc<AtomicU64>) -> Self {
+        Self { inner, inbound_reads }
     }
 }
 
@@ -324,7 +328,7 @@ impl<T: futures::AsyncRead + Unpin> futures::AsyncRead for TransportLivenessTap<
         let r = Pin::new(&mut me.inner).poll_read(cx, buf);
         if let Poll::Ready(Ok(n)) = &r {
             if *n > 0 {
-                me.productive.store(true, Ordering::Relaxed);
+                me.inbound_reads.fetch_add(1, Ordering::Relaxed);
             }
         }
         r
@@ -636,24 +640,72 @@ pub(crate) fn driver_panicked(result: std::result::Result<(), tokio::task::JoinE
 }
 
 /// Why a single yamux client session ended, deciding what `run_client` does next.
-enum SessionOutcome {
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SessionOutcome {
     /// Shutdown requested — stop for good.
     Shutdown,
     /// The transport (yamux) connection died — reconnect.
     TransportDied,
 }
 
+/// Everything one yamux connection owns, re-created on every reconnect. The
+/// local listeners and the shutdown token outlive it, so they stay separate.
+pub(crate) struct SessionTransport {
+    open_tx: mpsc::Sender<OpenStreamReply>,
+    /// Server-initiated substreams. The client expects none: the channel closing
+    /// is how the driver reports that the connection ended.
+    inbound_rx: mpsc::Receiver<yamux::Stream>,
+    /// Inbound reads counted below yamux framing.
+    inbound_reads: Arc<AtomicU64>,
+}
+
+impl SessionTransport {
+    /// Wrap `tcp` in a tapped yamux client connection and spawn its driver.
+    ///
+    /// The tap is owned by the driver (inside the `Connection`), so reading the
+    /// counter after the driver is joined is race-free.
+    pub(crate) fn spawn(tcp: TcpStream, config: &yamux::Config) -> (Self, tokio::task::JoinHandle<()>) {
+        let inbound_reads = Arc::new(AtomicU64::new(0));
+        let tapped = TransportLivenessTap::new(tcp.compat(), Arc::clone(&inbound_reads));
+        let conn = yamux::Connection::new(tapped, config.clone(), yamux::Mode::Client);
+
+        let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(32);
+        let (inbound_tx, inbound_rx) = mpsc::channel::<yamux::Stream>(32);
+        let driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+
+        (
+            Self {
+                open_tx,
+                inbound_rx,
+                inbound_reads,
+            },
+            driver,
+        )
+    }
+
+    /// Whether the far peer sent anything at all during this session — the
+    /// reconnect backoff's reset condition.
+    pub(crate) fn was_productive(&self) -> bool {
+        self.inbound_reads.load(Ordering::Relaxed) > 0
+    }
+}
+
 /// Serve one yamux connection until it ends. The local TCP+UDP listeners are
-/// owned by `run_client` and persist across reconnects; only the yamux connection
-/// (its `open_tx` / `inbound_rx`) is per-session.
-async fn run_client_session(
+/// owned by `run_client` and persist across reconnects; only the `session` is
+/// per-connection.
+pub(crate) async fn run_client_session(
     tcp_listener: &TcpListener,
     udp_socket: &Arc<UdpSocket>,
-    open_tx: &mpsc::Sender<OpenStreamReply>,
-    inbound_rx: &mut mpsc::Receiver<yamux::Stream>,
+    session: &mut SessionTransport,
     udp_timeout: Duration,
     shutdown: &CancellationToken,
 ) -> SessionOutcome {
+    let SessionTransport {
+        open_tx,
+        inbound_rx,
+        inbound_reads: _,
+    } = session;
+
     let mut associations: HashMap<SocketAddr, (u64, mpsc::Sender<Vec<u8>>)> = HashMap::new();
     let (cleanup_tx, mut cleanup_rx) = mpsc::channel::<(SocketAddr, u64)>(64);
     let mut next_gen: u64 = 0;
@@ -798,30 +850,9 @@ pub(crate) async fn run_client(
 
         tracing::info!(remote = %remote, "connected to yamux server");
 
-        // Tap the transport for inbound liveness. The tap is owned by the driver
-        // (inside the Connection), so reading `productive` after `driver.await`
-        // is race-free.
-        let productive = Arc::new(AtomicBool::new(false));
-        let tapped = TransportLivenessTap::new(tcp.compat(), Arc::clone(&productive));
-        let conn = yamux::Connection::new(tapped, config.clone(), yamux::Mode::Client);
+        let (mut session, driver) = SessionTransport::spawn(tcp, &config);
 
-        let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(32);
-        // The client never expects server-initiated streams; this channel is the
-        // transport-death signal — the driver drops `inbound_tx` when the yamux
-        // connection ends, so `inbound_rx.recv()` yields `None`.
-        let (inbound_tx, mut inbound_rx) = mpsc::channel::<yamux::Stream>(32);
-
-        let driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
-
-        let outcome = run_client_session(
-            &tcp_listener,
-            &udp_socket,
-            &open_tx,
-            &mut inbound_rx,
-            udp_timeout,
-            &shutdown,
-        )
-        .await;
+        let outcome = run_client_session(&tcp_listener, &udp_socket, &mut session, udp_timeout, &shutdown).await;
 
         // Tear down the driver deterministically. On `TransportDied` it already
         // finished (abort is a no-op); otherwise abort ends it instead of hanging
@@ -835,7 +866,7 @@ pub(crate) async fn run_client(
         match outcome {
             SessionOutcome::Shutdown => return Ok(()),
             SessionOutcome::TransportDied => {
-                let was_productive = productive.load(Ordering::Relaxed);
+                let was_productive = session.was_productive();
                 failures = next_failures(failures, was_productive);
                 tracing::warn!(
                     failures,

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -35,6 +35,9 @@ pub const DEFAULT_UDP_TIMEOUT: Duration = Duration::from_secs(300);
 pub enum StreamTag {
     Tcp = 0x01,
     Udp = 0x02,
+    /// Client-opened liveness probe: the client writes `KEEPALIVE_NONCE_LEN`
+    /// bytes and the server echoes them back and closes.
+    Keepalive = 0x03,
 }
 
 impl StreamTag {
@@ -46,10 +49,14 @@ impl StreamTag {
         match b {
             0x01 => Some(Self::Tcp),
             0x02 => Some(Self::Udp),
+            0x03 => Some(Self::Keepalive),
             _ => None,
         }
     }
 }
+
+/// Payload size of one keepalive probe: a big-endian `u64` nonce.
+pub(crate) const KEEPALIVE_NONCE_LEN: usize = 8;
 
 /// Frame a UDP datagram with a 2-byte big-endian length prefix.
 pub fn frame_udp_datagram(payload: &[u8]) -> Vec<u8> {
@@ -1052,9 +1059,24 @@ async fn handle_inbound_stream(mut stream: yamux::Stream, remote: SocketAddr) ->
         StreamTag::Udp => {
             relay_udp_server(stream, remote).await?;
         }
+        StreamTag::Keepalive => echo_keepalive(stream).await?,
     }
 
     Ok(())
+}
+
+/// Echo one keepalive nonce back to the client, then close the substream.
+///
+/// Exactly `KEEPALIVE_NONCE_LEN` bytes are read and written — never an open-ended
+/// echo, so a probe substream cannot be used to make the server relay arbitrary
+/// traffic. The client opens a fresh substream per probe, so one round is the
+/// whole exchange.
+async fn echo_keepalive(mut stream: yamux::Stream) -> Result<()> {
+    let mut nonce = [0u8; KEEPALIVE_NONCE_LEN];
+    stream.read_exact(&mut nonce).await.context("read keepalive nonce")?;
+    stream.write_all(&nonce).await.context("write keepalive echo")?;
+    stream.flush().await.context("flush keepalive echo")?;
+    stream.close().await.context("close keepalive substream")
 }
 
 // Plugin ==============================================================================================================

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -18,6 +18,12 @@ use tokio::time::Instant;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tokio_util::sync::CancellationToken;
 
+pub(crate) mod keepalive;
+#[cfg(test)]
+mod keepalive_tests;
+
+use keepalive::Cadence;
+
 /// Maximum buffered outbound datagrams per UDP association before new ones are
 /// dropped. Bounded (not unbounded) so a stalled association — e.g. yamux
 /// backpressure while the app floods UDP — can't grow without limit; dropping
@@ -688,6 +694,15 @@ impl SessionTransport {
     pub(crate) fn was_productive(&self) -> bool {
         self.inbound_reads.load(Ordering::Relaxed) > 0
     }
+
+    /// The client-side liveness loop for *this* connection.
+    ///
+    /// Both halves come from `self`, so a caller cannot hand the keepalive a
+    /// counter other than the one this session's tap feeds — which would declare
+    /// a perfectly healthy tunnel dead every cycle.
+    pub(crate) fn keepalive(&self, cadence: Cadence) -> impl std::future::Future<Output = ()> {
+        keepalive::run_keepalive(self.open_tx.clone(), Arc::clone(&self.inbound_reads), cadence)
+    }
 }
 
 /// Serve one yamux connection until it ends. The local TCP+UDP listeners are
@@ -698,8 +713,14 @@ pub(crate) async fn run_client_session(
     udp_socket: &Arc<UdpSocket>,
     session: &mut SessionTransport,
     udp_timeout: Duration,
+    cadence: Cadence,
     shutdown: &CancellationToken,
 ) -> SessionOutcome {
+    // Pinned outside the loop so the cadence survives every other select arm
+    // firing, and so an in-flight probe is not restarted by unrelated traffic.
+    let keepalive = session.keepalive(cadence);
+    tokio::pin!(keepalive);
+
     let SessionTransport {
         open_tx,
         inbound_rx,
@@ -714,6 +735,9 @@ pub(crate) async fn run_client_session(
     loop {
         tokio::select! {
             _ = shutdown.cancelled() => return SessionOutcome::Shutdown,
+            // A transport that has gone silent: black-holed with no RST or FIN,
+            // so no other arm here would ever notice.
+            () = &mut keepalive => return SessionOutcome::TransportDied,
             // Transport death: the driver dropped its inbound sender. A `Some` is a
             // protocol violation (the server never opens streams to the client);
             // untrusted remote input — log and drop, never panic.
@@ -852,7 +876,15 @@ pub(crate) async fn run_client(
 
         let (mut session, driver) = SessionTransport::spawn(tcp, &config);
 
-        let outcome = run_client_session(&tcp_listener, &udp_socket, &mut session, udp_timeout, &shutdown).await;
+        let outcome = run_client_session(
+            &tcp_listener,
+            &udp_socket,
+            &mut session,
+            udp_timeout,
+            Cadence::default(),
+            &shutdown,
+        )
+        .await;
 
         // Tear down the driver deterministically. On `TransportDied` it already
         // finished (abort is a no-op); otherwise abort ends it instead of hanging

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -886,9 +886,12 @@ pub(crate) async fn run_client(
         )
         .await;
 
-        // Tear down the driver deterministically. On `TransportDied` it already
-        // finished (abort is a no-op); otherwise abort ends it instead of hanging
-        // until the chain drain-timeout (`drive_connection` has no shutdown hook).
+        // Tear down the driver deterministically. When the driver itself observed
+        // the death it has already returned and the abort is a no-op; when the
+        // keepalive declared it, or on shutdown, the driver is still live and the
+        // abort is what ends it — truncating any in-flight relay, per the teardown
+        // tradeoff — instead of hanging until the chain drain-timeout
+        // (`drive_connection` has no shutdown hook).
         // A driver panic is a code bug, not a transport event — exit rather than reconnect.
         driver.abort();
         if driver_panicked(driver.await) {

--- a/crates/galoshes/src/yamux/keepalive.rs
+++ b/crates/galoshes/src/yamux/keepalive.rs
@@ -4,8 +4,8 @@
 //! RST/FIN — produces no death signal of its own, so an idle tunnel otherwise
 //! waits out ex-ray's inherited 300 s `ConnectionIdle`
 //! (`third_party/v2ray-core/features/policy/policy.go`, `SessionDefault`) before
-//! anything notices. This module bounds that recovery here instead, without
-//! relying on any timer further down the stack.
+//! anything notices. This module bounds that recovery instead, without relying
+//! on any timer further down the stack.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/crates/galoshes/src/yamux/keepalive.rs
+++ b/crates/galoshes/src/yamux/keepalive.rs
@@ -1,0 +1,220 @@
+//! Client-side liveness for one yamux transport connection.
+//!
+//! A silently black-holed transport — a middlebox dropping packets with no
+//! RST/FIN — produces no death signal of its own, so an idle tunnel otherwise
+//! waits out ex-ray's inherited 300 s `ConnectionIdle`
+//! (`third_party/v2ray-core/features/policy/policy.go`, `SessionDefault`) before
+//! anything notices. This module bounds that recovery here instead, without
+//! relying on any timer further down the stack.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::AsyncReadExt as _;
+use futures::AsyncWriteExt as _;
+use tokio::sync::mpsc;
+
+use super::{open_stream, OpenStreamReply, StreamTag, KEEPALIVE_NONCE_LEN};
+
+/// How long the transport may stay silent before the client gives it a reason to
+/// speak.
+pub(crate) const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// How long the transport may stay completely silent after a probe before it is
+/// declared dead.
+///
+/// The probe is a full round trip through the local ex-ray hop, the wire, the
+/// remote ex-ray hop and the remote yamux server, so this is sized for a bad day
+/// on a long path, not a median RTT: a false positive tears the session down and
+/// `driver.abort()` truncates whatever relays were in flight.
+pub(crate) const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The margin that keeps a healthy-but-slow server off the fatal path.
+///
+/// Detection itself needs no help: a black-holed transport delivers neither an
+/// echo nor anything else. But a server whose echo task is merely slow would be
+/// silent too, and what covers it is yamux's own RTT ping — due again 10 s after
+/// the last pong, and emitted the moment our probe wakes the driver. That holds
+/// only while a probe cannot come due sooner than a ping is, so the interval may
+/// not drop below yamux's cadence. `PING_INTERVAL` is private to that crate, so
+/// the relation is pinned here rather than imported.
+const _: () = assert!(KEEPALIVE_INTERVAL.as_nanos() >= Duration::from_secs(10).as_nanos());
+
+/// Worst-case detection is `2 × KEEPALIVE_INTERVAL + KEEPALIVE_TIMEOUT` from the
+/// last inbound byte, and there are two ways to reach it. A byte landing just
+/// after a cycle boundary makes the next cycle skip, so the probe lands a cycle
+/// later. A byte landing just after a probe went out instead costs the rest of
+/// that window before the next interval even starts — which stays inside the
+/// same bound only while the deadline is no longer than an interval.
+const _: () = assert!(KEEPALIVE_TIMEOUT.as_nanos() <= KEEPALIVE_INTERVAL.as_nanos());
+
+/// The keepalive's timings.
+///
+/// Production always passes [`Cadence::default()`] and nothing configures it; the
+/// type exists so a session-level test can drive a real socket on the real clock,
+/// which a virtual clock cannot do (tokio's auto-advance polls the I/O driver for
+/// 0 ms and then jumps to the next timer, firing a deadline while the answer is
+/// still in the kernel).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Cadence {
+    interval: Duration,
+    timeout: Duration,
+}
+
+impl Cadence {
+    /// The deadline may not exceed the interval: the `2 × interval + timeout`
+    /// detection bound holds only while it does not. The `const` assertion above
+    /// pins that for the shipped values; this is the only way to build any other
+    /// pair, so none can be built inconsistent.
+    pub(crate) fn new(interval: Duration, timeout: Duration) -> Self {
+        debug_assert!(timeout <= interval, "a keepalive deadline must fit inside its interval");
+        Self { interval, timeout }
+    }
+}
+
+impl Default for Cadence {
+    /// The shipped cadence — the only one production ever uses.
+    fn default() -> Self {
+        Self::new(KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT)
+    }
+}
+
+/// Open a keepalive substream and put `tag || nonce` on it.
+///
+/// The tag and the nonce share one write so there is exactly one failure path
+/// between opening and having asked the peer something.
+pub(crate) async fn open_probe(open_tx: &mpsc::Sender<OpenStreamReply>, nonce: u64) -> Option<yamux::Stream> {
+    let mut stream = match open_stream(open_tx).await {
+        Ok(s) => s,
+        // A closed connection is expected reconnect-window churn; anything else
+        // is a transport-alive failure worth surfacing.
+        Err(yamux::ConnectionError::Closed) => {
+            tracing::debug!("no keepalive substream: connection closed");
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open the keepalive substream");
+            return None;
+        }
+    };
+
+    let mut request = [0u8; 1 + KEEPALIVE_NONCE_LEN];
+    request[0] = StreamTag::Keepalive.to_byte();
+    request[1..].copy_from_slice(&nonce.to_be_bytes());
+    if let Err(e) = stream.write_all(&request).await {
+        tracing::debug!(nonce, error = %e, "keepalive probe could not be written");
+        return None;
+    }
+    if let Err(e) = stream.flush().await {
+        tracing::debug!(nonce, error = %e, "keepalive probe could not be flushed");
+        return None;
+    }
+    Some(stream)
+}
+
+/// Give an idle transport a reason to speak, then wait for the probe substream to
+/// say anything at all. Never resolves when the probe could not be sent — the
+/// caller's deadline ends the cycle either way.
+///
+/// One `read` is the whole client-side protocol. Every outcome — the echo, a peer
+/// FIN, a peer reset — required a frame the connection read off the socket, and
+/// the tap counted that read; the echo's *value* is never part of the verdict.
+/// `read` is also cancel-safe where `read_exact` is not, and the substream is
+/// dropped when the cycle ends, so a deadline firing here costs nothing.
+async fn elicit(open_tx: &mpsc::Sender<OpenStreamReply>, nonce: u64) {
+    let Some(mut stream) = open_probe(open_tx, nonce).await else {
+        return std::future::pending().await;
+    };
+    tracing::debug!(nonce, "keepalive probe sent");
+
+    let mut sink = [0u8; KEEPALIVE_NONCE_LEN];
+    match stream.read(&mut sink).await {
+        Ok(0) => tracing::debug!(nonce, "keepalive probe substream ended"),
+        Ok(_) => {}
+        Err(e) => tracing::debug!(nonce, error = %e, "keepalive probe read failed"),
+    }
+}
+
+/// What one keepalive cycle concluded about the transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeepaliveCycle {
+    /// The transport spoke during the interval, so nothing was asked of it.
+    Skipped,
+    /// Something arrived before the deadline was up.
+    Answered,
+    /// Nothing at all arrived across the whole deadline.
+    Silent,
+}
+
+/// One cycle against a transport whose tap last read `*last_seen`, re-baselining
+/// it whenever the transport speaks.
+///
+/// A cycle is fatal only when the tap did not move across a whole deadline that
+/// began with a probe *attempt*. If the probe could not be sent, the reading is
+/// the same: a connection whose substream budget is exhausted while delivering
+/// nothing is, at this layer, indistinguishable from a dead one, and reconnecting
+/// is the fail-safe choice for a VPN.
+pub(crate) async fn keepalive_cycle(
+    open_tx: &mpsc::Sender<OpenStreamReply>,
+    nonce: u64,
+    inbound_reads: &AtomicU64,
+    last_seen: &mut u64,
+    timeout: Duration,
+) -> KeepaliveCycle {
+    let seen = inbound_reads.load(Ordering::Relaxed);
+    if seen != *last_seen {
+        *last_seen = seen;
+        return KeepaliveCycle::Skipped;
+    }
+
+    // The deadline IS how long silence is tolerated, not synchronization between
+    // our own code paths. It covers the substream open too, which parks
+    // indefinitely once enough substreams await an ACK — exactly what a black
+    // hole produces.
+    tokio::select! {
+        () = elicit(open_tx, nonce) => {}
+        () = tokio::time::sleep(timeout) => {}
+    }
+
+    let seen = inbound_reads.load(Ordering::Relaxed);
+    if seen != *last_seen {
+        *last_seen = seen;
+        return KeepaliveCycle::Answered;
+    }
+    KeepaliveCycle::Silent
+}
+
+/// Client-side liveness for one yamux session.
+///
+/// Every `cadence.interval` in which the transport delivered nothing, it gives the
+/// peer a reason to speak and then asks the tap whether *anything* arrived before
+/// `cadence.timeout` was up. Resolves only when the answer is no, so the caller
+/// can park on it as a plain `select!` arm.
+pub(crate) async fn run_keepalive(
+    open_tx: mpsc::Sender<OpenStreamReply>,
+    inbound_reads: Arc<AtomicU64>,
+    cadence: Cadence,
+) {
+    let mut last_seen = inbound_reads.load(Ordering::Relaxed);
+    let mut nonce: u64 = 0;
+
+    loop {
+        // The cadence IS the behavior (a keepalive interval), not
+        // synchronization between our own code paths.
+        tokio::time::sleep(cadence.interval).await;
+        nonce = nonce.wrapping_add(1);
+
+        match keepalive_cycle(&open_tx, nonce, &inbound_reads, &mut last_seen, cadence.timeout).await {
+            KeepaliveCycle::Skipped => tracing::debug!("transport still active; skipping the keepalive probe"),
+            KeepaliveCycle::Answered => tracing::debug!(nonce, "transport answered inside the keepalive deadline"),
+            KeepaliveCycle::Silent => {
+                tracing::warn!(
+                    nonce,
+                    "transport silent across the keepalive deadline; declaring it dead"
+                );
+                return;
+            }
+        }
+    }
+}

--- a/crates/galoshes/src/yamux/keepalive_tests.rs
+++ b/crates/galoshes/src/yamux/keepalive_tests.rs
@@ -1,0 +1,412 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio_util::compat::TokioAsyncReadCompatExt as _;
+
+use super::keepalive::{
+    keepalive_cycle, open_probe, run_keepalive, Cadence, KeepaliveCycle, KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT,
+};
+use crate::yamux::{drive_connection, OpenStreamReply, StreamTag, TransportLivenessTap, KEEPALIVE_NONCE_LEN};
+use crate::yamux_tests::{capture_logs, echo_yamux_stream_body, open_test_stream};
+
+/// How a stub peer treats the client's keepalive substream. Non-keepalive
+/// substreams are always echoed, so a test can generate ordinary traffic.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StubPeer {
+    /// Echoes the nonce, like the production server.
+    Echo,
+    /// What a pre-keepalive galoshes server does: the tag is unknown, the
+    /// handler errors, the substream is dropped — which yamux turns into a reset
+    /// the client will read.
+    RejectTag,
+    /// Answers, but with bytes that are not the nonce.
+    Corrupt,
+    /// Reads the nonce and half-closes without answering: a graceful FIN, which
+    /// the client's probe read sees as `Ok(0)`.
+    FinWithoutEcho,
+    /// Reads every nonce and never answers any of them, holding the substream
+    /// open. Models a busy-but-alive peer whose probe stalls.
+    StallProbe,
+    /// A raw byte sink: reads and discards, never writes a single byte. NOT a
+    /// yamux peer — a real `Connection` would answer yamux's own pings and so
+    /// could not model a black hole.
+    Blackhole,
+}
+
+/// A live yamux client whose transport is an in-process pipe to `peer`.
+///
+/// Both yamux peers ping on their driver's first poll, so the harness quiesces
+/// before handing the client back: one `chatter` round trip. Frames are ordered,
+/// so the pong is necessarily read before the echo; ten bytes are far below the
+/// window-update threshold, so no trailing frame follows; and the substream is
+/// dropped, whose reset the peer answers with nothing at all (its own stream is
+/// already `Closed`, and `on_drop_stream` emits no frame for that state). After
+/// it the connection is silent until a test touches it, and yamux's next ping is
+/// 10 s of *real* time away — which a virtual clock never reaches. Without this,
+/// the setup pong would land during a test's own cycle and make every `Answered`
+/// verdict true regardless of what the stub peer did.
+struct PipedClient {
+    open_tx: mpsc::Sender<OpenStreamReply>,
+    inbound_reads: Arc<AtomicU64>,
+    /// The nonce of every keepalive probe the peer read.
+    probes: mpsc::UnboundedReceiver<u64>,
+    _client_driver: tokio::task::JoinHandle<()>,
+    _client_inbound: mpsc::Receiver<yamux::Stream>,
+    _peer: tokio::task::JoinHandle<()>,
+}
+
+impl PipedClient {
+    /// The tap's current value — a cycle's `last_seen` starting point.
+    fn seen(&self) -> u64 {
+        self.inbound_reads.load(Ordering::Relaxed)
+    }
+
+    async fn cycle(&self, nonce: u64, last_seen: &mut u64) -> KeepaliveCycle {
+        keepalive_cycle(&self.open_tx, nonce, &self.inbound_reads, last_seen, KEEPALIVE_TIMEOUT).await
+    }
+}
+
+async fn piped_client(peer: StubPeer) -> PipedClient {
+    piped_client_with_max_streams(peer, 512).await
+}
+
+/// `max_streams` is the substream budget available to the test. The quiesce
+/// substream is dropped before the client is handed back, so it costs none of it.
+async fn piped_client_with_max_streams(peer: StubPeer, max_streams: usize) -> PipedClient {
+    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    let (client_io, peer_io) = tokio::io::duplex(256 * 1024);
+
+    // `Blackhole` never answers, so it can neither be quiesced nor needs to be:
+    // it sends nothing to quiesce away.
+    let quiesces = peer != StubPeer::Blackhole;
+
+    let mut config = ::yamux::Config::default();
+    config.set_max_num_streams(max_streams);
+
+    let inbound_reads = Arc::new(AtomicU64::new(0));
+    let tapped = TransportLivenessTap::new(client_io.compat(), Arc::clone(&inbound_reads));
+    let conn = ::yamux::Connection::new(tapped, config, ::yamux::Mode::Client);
+    let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(32);
+    let (inbound_tx, client_inbound) = mpsc::channel::<yamux::Stream>(32);
+    let client_driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+
+    let (probe_tx, probes) = mpsc::unbounded_channel::<u64>();
+    let peer_task = tokio::spawn(async move {
+        if peer == StubPeer::Blackhole {
+            let mut sink = peer_io;
+            let mut buf = [0u8; 4096];
+            while matches!(tokio::io::AsyncReadExt::read(&mut sink, &mut buf).await, Ok(n) if n > 0) {}
+            return;
+        }
+
+        let conn = ::yamux::Connection::new(peer_io.compat(), ::yamux::Config::default(), ::yamux::Mode::Server);
+        let (_open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(1);
+        let (inbound_tx, mut inbound_rx) = mpsc::channel::<yamux::Stream>(32);
+        tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+
+        while let Some(mut stream) = inbound_rx.recv().await {
+            let probe_tx = probe_tx.clone();
+            tokio::spawn(async move {
+                let mut tag = [0u8; 1];
+                if stream.read_exact(&mut tag).await.is_err() {
+                    return;
+                }
+                if tag[0] != StreamTag::Keepalive.to_byte() {
+                    echo_yamux_stream_body(stream).await;
+                    return;
+                }
+                if peer == StubPeer::RejectTag {
+                    return;
+                }
+                let mut nonce = [0u8; KEEPALIVE_NONCE_LEN];
+                while stream.read_exact(&mut nonce).await.is_ok() {
+                    let _ = probe_tx.send(u64::from_be_bytes(nonce));
+                    match peer {
+                        StubPeer::StallProbe => continue,
+                        StubPeer::FinWithoutEcho => {
+                            let _ = stream.close().await;
+                            return;
+                        }
+                        StubPeer::Corrupt => nonce.iter_mut().for_each(|b| *b ^= 0xFF),
+                        _ => {}
+                    }
+                    if stream.write_all(&nonce).await.is_err() || stream.flush().await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+
+    if quiesces {
+        chatter(&open_tx).await;
+    }
+
+    PipedClient {
+        open_tx,
+        inbound_reads,
+        probes,
+        _client_driver: client_driver,
+        _client_inbound: client_inbound,
+        _peer: peer_task,
+    }
+}
+
+/// Assert how much *virtual* time a path consumed, allowing tokio's timer wheel
+/// one millisecond of rounding per `sleep` on it: `deadline_to_tick` rounds a
+/// deadline up to the next whole millisecond, and `pause()` leaves a
+/// sub-millisecond offset between the clock base and the driver's start time, so
+/// an exact equality would fail on all but a measure-zero alignment.
+fn assert_elapsed(started: tokio::time::Instant, expected: Duration, sleeps: u32) {
+    let elapsed = tokio::time::Instant::now() - started;
+    let slack = Duration::from_millis(u64::from(sleeps));
+    assert!(
+        (expected..=expected + slack).contains(&elapsed),
+        "expected {expected:?} (+{slack:?} of timer-wheel rounding), got {elapsed:?}"
+    );
+}
+
+/// Await the next `count` nonces read by the peer, in order. An in-runtime
+/// rendezvous, so a paused clock only advances between cycles and never
+/// mid-exchange.
+async fn expect_probes(client: &mut PipedClient, count: usize) -> Vec<u64> {
+    let mut nonces = Vec::with_capacity(count);
+    for probe in 1..=count {
+        nonces.push(
+            client
+                .probes
+                .recv()
+                .await
+                .unwrap_or_else(|| panic!("probe {probe} never reached the peer")),
+        );
+    }
+    nonces
+}
+
+/// One echoed round trip on an ordinary substream, generating inbound traffic.
+/// Every step is a ready-task hand-off, so a paused clock cannot advance
+/// mid-exchange. The substream is dropped when this returns — the peer answers
+/// the resulting reset with nothing, and an unread substream left open would
+/// wedge every later substream on this in-process pipe.
+async fn chatter(open_tx: &mpsc::Sender<OpenStreamReply>) {
+    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+    let mut stream = open_test_stream(open_tx).await;
+    stream.write_all(&[StreamTag::Tcp.to_byte()]).await.unwrap();
+    stream.write_all(b"still here").await.unwrap();
+    stream.flush().await.unwrap();
+    let mut buf = [0u8; 10];
+    stream.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"still here");
+}
+
+#[skuld::test]
+async fn opening_a_probe_fails_when_the_substream_budget_is_exhausted() {
+    // The `TooManyStreams` arm: a refused open must be reported, not pass
+    // silently — the two open-failure arms are deliberately logged at different
+    // levels, and this is the one that warns.
+    let (writer, _g) = capture_logs();
+    let client = piped_client_with_max_streams(StubPeer::Echo, 1).await;
+    let _hog = open_test_stream(&client.open_tx).await;
+    assert!(open_probe(&client.open_tx, 1).await.is_none());
+    assert!(
+        writer.snapshot().contains("failed to open the keepalive substream"),
+        "a refused open must warn, not pass silently"
+    );
+}
+
+#[skuld::test]
+async fn opening_a_probe_fails_when_the_connection_is_gone() {
+    let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(1);
+    drop(open_rx);
+    assert!(open_probe(&open_tx, 1).await.is_none());
+}
+
+#[skuld::test]
+async fn opening_a_probe_tags_it_and_delivers_the_nonce() {
+    let mut client = piped_client(StubPeer::Echo).await;
+    assert!(
+        open_probe(&client.open_tx, 7).await.is_some(),
+        "a healthy connection must yield a probe substream"
+    );
+    assert_eq!(expect_probes(&mut client, 1).await, vec![7]);
+}
+
+#[skuld::test]
+async fn a_cycle_skips_the_probe_while_the_transport_is_busy() {
+    // A transport that delivered something has already answered the question a
+    // probe asks, so the cycle sends nothing at all and never touches a timer.
+    // The peer would stall any probe, so a probe reaching it could not be
+    // mistaken for an answer.
+    let mut client = piped_client(StubPeer::StallProbe).await;
+    let mut last_seen = client.seen();
+    client.inbound_reads.fetch_add(1, Ordering::Relaxed); // the transport spoke
+
+    assert_eq!(client.cycle(1, &mut last_seen).await, KeepaliveCycle::Skipped);
+    assert_eq!(last_seen, client.seen(), "a skip must re-baseline the sample");
+    assert!(
+        matches!(client.probes.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        "a skipped cycle must not put a nonce on the wire"
+    );
+}
+
+#[skuld::test]
+async fn a_cycle_the_peer_echoes_is_not_fatal() {
+    let mut client = piped_client(StubPeer::Echo).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    assert_eq!(client.cycle(4, &mut last_seen).await, KeepaliveCycle::Answered);
+    assert_eq!(expect_probes(&mut client, 1).await, vec![4], "the cycle's own nonce");
+    assert_eq!(last_seen, client.seen(), "an answer must re-baseline the sample");
+}
+
+#[skuld::test]
+async fn a_cycle_a_peer_rejects_the_tag_on_is_not_fatal() {
+    // An un-upgraded server. Its reset is inbound traffic, necessarily read off
+    // the socket before the probe's own read can end, so the cycle is answered —
+    // and the probe read reports the substream ending, which is what proves the
+    // reset travelled the whole way rather than the verdict resting on some
+    // other frame.
+    let (writer, _g) = capture_logs();
+    let client = piped_client(StubPeer::RejectTag).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    assert_eq!(client.cycle(1, &mut last_seen).await, KeepaliveCycle::Answered);
+    assert!(
+        writer.snapshot().contains("keepalive probe substream ended"),
+        "the peer's rejection must have reached the probe's own read"
+    );
+}
+
+#[skuld::test]
+async fn a_cycle_a_peer_half_closes_is_not_fatal() {
+    // A graceful FIN rather than a reset: the client's probe read sees `Ok(0)`
+    // and the FIN frame itself is the liveness.
+    let (writer, _g) = capture_logs();
+    let mut client = piped_client(StubPeer::FinWithoutEcho).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    assert_eq!(client.cycle(1, &mut last_seen).await, KeepaliveCycle::Answered);
+    assert_eq!(expect_probes(&mut client, 1).await, vec![1]);
+    assert!(writer.snapshot().contains("keepalive probe substream ended"));
+}
+
+#[skuld::test]
+async fn a_cycle_answered_with_garbage_is_not_fatal() {
+    // The verdict is "did anything arrive", never "was it the nonce".
+    let mut client = piped_client(StubPeer::Corrupt).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    assert_eq!(client.cycle(1, &mut last_seen).await, KeepaliveCycle::Answered);
+    assert_eq!(expect_probes(&mut client, 1).await, vec![1]);
+}
+
+#[skuld::test]
+async fn a_cycle_whose_probe_stalls_survives_on_other_traffic() {
+    // The peer holds the probe substream open and answers nothing, so only
+    // traffic elsewhere can save the cycle. `chatter` is pure ready-task work
+    // over the duplex, so it lands before the paused clock can reach the
+    // deadline.
+    let client = piped_client(StubPeer::StallProbe).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    let (verdict, ()) = tokio::join!(client.cycle(1, &mut last_seen), chatter(&client.open_tx));
+    assert_eq!(verdict, KeepaliveCycle::Answered);
+}
+
+#[skuld::test]
+async fn a_cycle_nothing_answers_is_fatal_after_one_deadline() {
+    // The peer swallows everything and answers nothing, with no reset and no
+    // FIN. Only timers can make progress, so the paused clock advances
+    // deterministically to the verdict — and to one deadline's worth of it,
+    // which a stray extra sleep would break.
+    let client = piped_client(StubPeer::Blackhole).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    let started = tokio::time::Instant::now();
+    assert_eq!(client.cycle(1, &mut last_seen).await, KeepaliveCycle::Silent);
+    assert_eq!(client.seen(), 0, "nothing came back — that silence is the verdict");
+    assert_elapsed(started, KEEPALIVE_TIMEOUT, 1);
+}
+
+#[skuld::test]
+async fn a_cycle_that_cannot_open_a_probe_still_waits_the_whole_deadline() {
+    // A refused open plus a whole silent window is, at this layer,
+    // observationally identical to a dead transport: substreams that delivered
+    // nothing. Reconnecting is the fail-safe reading — but only after the full
+    // window, never on the open failure alone.
+    let client = piped_client_with_max_streams(StubPeer::Blackhole, 1).await;
+    let _hog = open_test_stream(&client.open_tx).await;
+    tokio::time::pause();
+    let mut last_seen = client.seen();
+    let started = tokio::time::Instant::now();
+    assert_eq!(client.cycle(1, &mut last_seen).await, KeepaliveCycle::Silent);
+    assert_elapsed(started, KEEPALIVE_TIMEOUT, 1);
+}
+
+#[skuld::test]
+async fn keepalive_keeps_probing_a_healthy_peer_with_a_fresh_nonce_each_time() {
+    // Three delivered probes prove the loop took the non-fatal path twice and
+    // came back for more, which a fatal verdict would have prevented. Their
+    // nonces must differ: a probe is meant to be distinguishable in the logs and
+    // on the wire, which a constant would not be. They need not be consecutive —
+    // a skipped cycle consumes a nonce without sending one.
+    let mut client = piped_client(StubPeer::Echo).await;
+    tokio::time::pause();
+    let keepalive = tokio::spawn(run_keepalive(
+        client.open_tx.clone(),
+        Arc::clone(&client.inbound_reads),
+        Cadence::default(),
+    ));
+    let nonces = expect_probes(&mut client, 3).await;
+    assert!(
+        nonces.windows(2).all(|w| w[0] < w[1]),
+        "each cycle must carry its own nonce, got {nonces:?}"
+    );
+    assert!(!keepalive.is_finished(), "a healthy peer must never be declared dead");
+    keepalive.abort();
+}
+
+#[skuld::test]
+async fn keepalive_declares_a_silent_transport_dead() {
+    // The loop's fatal exit at its fastest: a whole interval of silence before
+    // the probe, then a whole deadline after it, and nothing else.
+    let client = piped_client(StubPeer::Blackhole).await;
+    tokio::time::pause();
+    let started = tokio::time::Instant::now();
+    run_keepalive(
+        client.open_tx.clone(),
+        Arc::clone(&client.inbound_reads),
+        Cadence::default(),
+    )
+    .await;
+    assert_elapsed(started, KEEPALIVE_INTERVAL + KEEPALIVE_TIMEOUT, 2);
+}
+
+#[skuld::test]
+async fn keepalive_declares_a_transport_dead_two_intervals_after_the_last_inbound_byte() {
+    // The documented worst case, driven end to end: a byte lands just before a
+    // cycle boundary, that cycle skips, and the next one runs a full deadline
+    // before the verdict. `2 × INTERVAL + TIMEOUT`, which is the bound CLAUDE.md
+    // and CONTRIBUTING.md state.
+    let client = piped_client(StubPeer::Blackhole).await;
+    tokio::time::pause();
+    let started = tokio::time::Instant::now();
+
+    let mut keepalive = Box::pin(run_keepalive(
+        client.open_tx.clone(),
+        Arc::clone(&client.inbound_reads),
+        Cadence::default(),
+    ));
+    // One poll runs `run_keepalive` up to its baseline sample and parks it on the
+    // first interval. The byte has to land after that: incremented earlier it
+    // would be folded into the baseline and the cycle would probe instead of
+    // skipping.
+    assert!(futures::poll!(keepalive.as_mut()).is_pending());
+    client.inbound_reads.fetch_add(1, Ordering::Relaxed);
+    keepalive.await;
+
+    assert_elapsed(started, 2 * KEEPALIVE_INTERVAL + KEEPALIVE_TIMEOUT, 3);
+}

--- a/crates/galoshes/src/yamux/keepalive_tests.rs
+++ b/crates/galoshes/src/yamux/keepalive_tests.rs
@@ -389,8 +389,7 @@ async fn keepalive_declares_a_silent_transport_dead() {
 async fn keepalive_declares_a_transport_dead_two_intervals_after_the_last_inbound_byte() {
     // The documented worst case, driven end to end: a byte lands just before a
     // cycle boundary, that cycle skips, and the next one runs a full deadline
-    // before the verdict. `2 × INTERVAL + TIMEOUT`, which is the bound CLAUDE.md
-    // and CONTRIBUTING.md state.
+    // before the verdict: `2 × INTERVAL + TIMEOUT`.
     let client = piped_client(StubPeer::Blackhole).await;
     tokio::time::pause();
     let started = tokio::time::Instant::now();
@@ -409,4 +408,13 @@ async fn keepalive_declares_a_transport_dead_two_intervals_after_the_last_inboun
     keepalive.await;
 
     assert_elapsed(started, 2 * KEEPALIVE_INTERVAL + KEEPALIVE_TIMEOUT, 3);
+}
+
+#[skuld::test]
+#[should_panic(expected = "a keepalive deadline must fit inside its interval")]
+fn a_cadence_whose_deadline_outlasts_its_interval_is_rejected() {
+    // The detection bound is only `2 × interval + timeout` while the deadline
+    // fits inside the interval, and `new` is the only way to build a pair other
+    // than the shipped one.
+    Cadence::new(Duration::from_secs(1), Duration::from_secs(2));
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -18,15 +18,12 @@ use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram, drive_connection, driver_panicked,
-    enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client, run_server,
+    bind_udp, connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram, drive_connection,
+    driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client, run_server,
     run_server_with_connections, serve_driven_connection, session_reconnect_backoff, ClientBoundAddrs,
-    FrameAccumulator, OpenStreamReply, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY,
-    REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
+    FrameAccumulator, OpenStreamReply, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN,
+    LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
-// Only the Windows-gated CONNRESET regression test uses this.
-#[cfg(windows)]
-use crate::yamux::bind_udp;
 
 #[skuld::test]
 fn stream_tag_tcp_roundtrip() {
@@ -38,6 +35,12 @@ fn stream_tag_tcp_roundtrip() {
 fn stream_tag_udp_roundtrip() {
     assert_eq!(StreamTag::Udp.to_byte(), 0x02);
     assert_eq!(StreamTag::from_byte(0x02).unwrap(), StreamTag::Udp);
+}
+
+#[skuld::test]
+fn stream_tag_keepalive_roundtrip() {
+    assert_eq!(StreamTag::Keepalive.to_byte(), 0x03);
+    assert_eq!(StreamTag::from_byte(0x03).unwrap(), StreamTag::Keepalive);
 }
 
 #[skuld::test]
@@ -1079,4 +1082,109 @@ async fn server_exits_when_the_yamux_driver_panics() {
         .expect("server task joined")
         .expect_err("a panicking driver must fail the plugin");
     assert!(err.to_string().contains("panicked"), "unexpected error: {err}");
+}
+
+// Keepalive wire protocol ---------------------------------------------------------------------------------------------
+
+/// Open one substream through `open_tx`. Panics if the connection is gone.
+pub(crate) async fn open_test_stream(open_tx: &mpsc::Sender<OpenStreamReply>) -> yamux::Stream {
+    let (tx, rx) = oneshot::channel();
+    open_tx.send(tx).await.expect("driver alive");
+    rx.await.expect("open reply").expect("stream opened")
+}
+
+/// Write `payload` to `stream` and read exactly `expect_len` bytes back.
+/// `None` if the peer ended the substream instead of answering.
+async fn write_and_read(stream: &mut yamux::Stream, payload: &[u8], expect_len: usize) -> Option<Vec<u8>> {
+    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+    stream.write_all(payload).await.ok()?;
+    stream.flush().await.ok()?;
+    let mut echo = vec![0u8; expect_len];
+    stream.read_exact(&mut echo).await.ok().map(|()| echo)
+}
+
+/// A raw yamux client over a real TCP connection, kept alive so a test can send
+/// several substreams down the *same* session.
+struct RawYamuxClient {
+    open_tx: mpsc::Sender<OpenStreamReply>,
+    _inbound_rx: mpsc::Receiver<yamux::Stream>,
+    driver: tokio::task::JoinHandle<()>,
+}
+
+impl RawYamuxClient {
+    async fn connect(server_addr: SocketAddr) -> Self {
+        let tcp = TcpStream::connect(server_addr).await.expect("connect yamux server");
+        let conn = ::yamux::Connection::new(tcp.compat(), ::yamux::Config::default(), ::yamux::Mode::Client);
+        let (open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(4);
+        let (inbound_tx, _inbound_rx) = mpsc::channel::<yamux::Stream>(4);
+        let driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+        Self {
+            open_tx,
+            _inbound_rx,
+            driver,
+        }
+    }
+
+    /// Send `tag` + `payload` on a fresh substream and read `expect_len` bytes
+    /// back. `None` if the peer ended the substream first.
+    async fn exchange(&self, tag: u8, payload: &[u8], expect_len: usize) -> Option<Vec<u8>> {
+        use futures::AsyncWriteExt as _;
+        let mut stream = open_test_stream(&self.open_tx).await;
+        stream.write_all(&[tag]).await.expect("write tag");
+        write_and_read(&mut stream, payload, expect_len).await
+    }
+}
+
+impl Drop for RawYamuxClient {
+    fn drop(&mut self) {
+        self.driver.abort();
+    }
+}
+
+#[skuld::test]
+async fn the_server_echoes_a_keepalive_nonce_verbatim() {
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+
+    let client = RawYamuxClient::connect(server_addr).await;
+    let nonce: u64 = 0x0123_4567_89AB_CDEF;
+    assert_eq!(
+        client
+            .exchange(
+                StreamTag::Keepalive.to_byte(),
+                &nonce.to_be_bytes(),
+                KEEPALIVE_NONCE_LEN
+            )
+            .await,
+        Some(nonce.to_be_bytes().to_vec())
+    );
+
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn an_unknown_stream_tag_costs_one_substream_not_the_session() {
+    // The version-skew property in mirror image, asserted on the SAME session:
+    // the server rejects the substream and keeps serving the connection. This is
+    // exactly what an un-upgraded server does to a keepalive probe.
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+
+    let client = RawYamuxClient::connect(server_addr).await;
+    assert_eq!(
+        client.exchange(0x7F, b"whatever", 1).await,
+        None,
+        "unknown tag rejected"
+    );
+    assert_eq!(
+        client
+            .exchange(0x01, b"GET / HTTP/1.0\r\n\r\n", HTTP_RESPONSE.len())
+            .await,
+        Some(HTTP_RESPONSE.to_vec()),
+        "the session must survive a rejected substream"
+    );
+
+    shutdown.cancel();
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -543,38 +543,40 @@ fn session_reconnect_backoff_schedule() {
 // TransportLivenessTap ------------------------------------------------------------------------------------------------
 
 #[skuld::test]
-async fn transport_tap_sets_on_inbound_bytes() {
+async fn transport_tap_counts_inbound_reads() {
     use futures::AsyncReadExt as _;
-    let productive = Arc::new(AtomicBool::new(false));
-    let mut tap = TransportLivenessTap::new(futures::io::Cursor::new(b"data".to_vec()), Arc::clone(&productive));
-    let mut buf = [0u8; 8];
+    let reads = Arc::new(AtomicU64::new(0));
+    let mut tap = TransportLivenessTap::new(futures::io::Cursor::new(b"datadata".to_vec()), Arc::clone(&reads));
+    let mut buf = [0u8; 4];
     assert_eq!(tap.read(&mut buf).await.unwrap(), 4);
-    assert!(productive.load(Ordering::Relaxed));
+    assert_eq!(reads.load(Ordering::Relaxed), 1);
+    assert_eq!(tap.read(&mut buf).await.unwrap(), 4);
+    assert_eq!(reads.load(Ordering::Relaxed), 2, "each non-empty read must be counted");
 }
 
 #[skuld::test]
 async fn transport_tap_silent_on_eof() {
     use futures::AsyncReadExt as _;
-    let productive = Arc::new(AtomicBool::new(false));
-    let mut tap = TransportLivenessTap::new(futures::io::Cursor::new(Vec::new()), Arc::clone(&productive));
+    let reads = Arc::new(AtomicU64::new(0));
+    let mut tap = TransportLivenessTap::new(futures::io::Cursor::new(Vec::new()), Arc::clone(&reads));
     let mut buf = [0u8; 8];
     assert_eq!(tap.read(&mut buf).await.unwrap(), 0);
-    assert!(!productive.load(Ordering::Relaxed));
+    assert_eq!(reads.load(Ordering::Relaxed), 0);
 }
 
 #[skuld::test]
 async fn transport_tap_delegates_writes() {
     use futures::{AsyncReadExt as _, AsyncWriteExt as _};
-    let productive = Arc::new(AtomicBool::new(false));
+    let reads = Arc::new(AtomicU64::new(0));
     let (a, b) = tokio::io::duplex(64);
-    let mut tap = TransportLivenessTap::new(a.compat(), Arc::clone(&productive));
+    let mut tap = TransportLivenessTap::new(a.compat(), Arc::clone(&reads));
     tap.write_all(b"ping").await.unwrap();
     tap.flush().await.unwrap();
     let mut b = b.compat();
     let mut buf = [0u8; 4];
     b.read_exact(&mut buf).await.unwrap();
     assert_eq!(&buf, b"ping");
-    assert!(!productive.load(Ordering::Relaxed), "writes never set productive");
+    assert_eq!(reads.load(Ordering::Relaxed), 0, "writes are never inbound liveness");
 }
 
 // Transport-reset reconnect -------------------------------------------------------------------------------------------

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -17,12 +17,14 @@ use tokio_util::sync::CancellationToken;
 use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
+use crate::yamux::keepalive::Cadence;
 use crate::yamux::{
     bind_udp, connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram, drive_connection,
-    driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client, run_server,
-    run_server_with_connections, serve_driven_connection, session_reconnect_backoff, ClientBoundAddrs,
-    FrameAccumulator, OpenStreamReply, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN,
-    LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
+    driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client,
+    run_client_session, run_server, run_server_with_connections, serve_driven_connection, session_reconnect_backoff,
+    ClientBoundAddrs, FrameAccumulator, OpenStreamReply, SessionOutcome, SessionTransport, StreamTag,
+    TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE,
+    REMOTE_BACKOFF_MAX,
 };
 
 #[skuld::test]
@@ -773,7 +775,7 @@ async fn backoff_escalates_then_resets_on_productive() {
 
 /// Install a per-test tracing subscriber that captures log lines for
 /// [`wait_for_log`] rendezvous, plus the `DefaultGuard` keeping it active.
-fn capture_logs() -> (WaitableWriter, tracing::subscriber::DefaultGuard) {
+pub(crate) fn capture_logs() -> (WaitableWriter, tracing::subscriber::DefaultGuard) {
     let writer = WaitableWriter::new();
     let subscriber = tracing_subscriber::fmt()
         .with_writer(writer.clone())
@@ -793,13 +795,19 @@ async fn wait_for_log(writer: &WaitableWriter, needle: &str) {
         .unwrap();
 }
 
-/// Strip the 1-byte stream tag, then echo everything else back.
 async fn echo_yamux_stream(mut stream: yamux::Stream) {
-    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
+    use futures::AsyncReadExt as _;
     let mut tag = [0u8; 1];
     if stream.read_exact(&mut tag).await.is_err() {
         return;
     }
+    echo_yamux_stream_body(stream).await;
+}
+
+/// Echo every byte back until the peer goes away. Any stream tag must already
+/// have been consumed.
+pub(crate) async fn echo_yamux_stream_body(mut stream: yamux::Stream) {
+    use futures::{AsyncReadExt as _, AsyncWriteExt as _};
     let mut buf = vec![0u8; 4096];
     loop {
         match stream.read(&mut buf).await {
@@ -879,7 +887,6 @@ async fn driver_panicked_detects_panic_not_cancel() {
 
 #[skuld::test]
 async fn shutdown_during_backoff_exits_promptly() {
-    tokio::time::pause();
     let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
     let shutdown = CancellationToken::new();
     let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
@@ -900,6 +907,13 @@ async fn shutdown_during_backoff_exits_promptly() {
     // Rendezvous (not the assertion): the observer event means the client has
     // reached the reconnect decision and is entering the backoff sleep.
     assert_eq!(events_rx.recv().await.unwrap(), (1, false));
+
+    // Pause only here, over the backoff window, where nothing but a timer can
+    // progress. Held from the top it would also span the first session, letting
+    // auto-advance resolve a whole keepalive interval and deadline while that
+    // session's frames were still in the kernel — so the reconnect awaited above
+    // could be the keepalive's rather than the relay's close.
+    tokio::time::pause();
 
     // The external assertion: shutdown must win the paused sleep, so the client
     // task returns `Ok` promptly. Without the select! shutdown branch the paused
@@ -1189,4 +1203,165 @@ async fn an_unknown_stream_tag_costs_one_substream_not_the_session() {
     );
 
     shutdown.cancel();
+}
+
+/// Fire a one-shot silent black hole on a relay connection.
+struct BlackholeHandle {
+    tx: Option<oneshot::Sender<()>>,
+}
+
+impl BlackholeHandle {
+    fn trigger(&mut self) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// A TCP relay in front of `upstream` whose first connection can be silently
+/// black-holed: on `trigger()` it stops forwarding both ways but holds both
+/// sockets open forever, so neither peer sees a FIN or an RST and neither peer's
+/// TCP stack times out (the relay's kernel keeps ACKing). That is strictly
+/// harsher than the field condition, where the client's retransmits do
+/// eventually abort.
+async fn spawn_blackholing_relay(upstream: SocketAddr) -> (SocketAddr, BlackholeHandle) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind relay");
+    let addr = listener.local_addr().expect("relay addr");
+    let (hole_tx, hole_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let mut trigger = Some(hole_rx);
+        while let Ok((client_conn, _)) = listener.accept().await {
+            let server_conn = match TcpStream::connect(upstream).await {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            tokio::spawn(pump_with_optional_blackhole(client_conn, server_conn, trigger.take()));
+        }
+    });
+    (addr, BlackholeHandle { tx: Some(hole_tx) })
+}
+
+async fn pump_with_optional_blackhole(
+    mut client: TcpStream,
+    mut server: TcpStream,
+    hole: Option<oneshot::Receiver<()>>,
+) {
+    match hole {
+        Some(rx) => {
+            tokio::select! {
+                _ = tokio::io::copy_bidirectional(&mut client, &mut server) => {}
+                // `client` and `server` stay alive in this frame, so both
+                // sockets stay open: a true silent black hole.
+                _ = rx => std::future::pending::<()>().await,
+            }
+        }
+        None => {
+            let _ = tokio::io::copy_bidirectional(&mut client, &mut server).await;
+        }
+    }
+}
+
+#[skuld::test]
+async fn a_silently_blackholed_session_is_declared_dead() {
+    let (writer, _g) = capture_logs();
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+    let (relay_addr, mut hole) = spawn_blackholing_relay(server_addr).await;
+    let (addrs, mut events) = spawn_yamux_client(relay_addr, DEFAULT_UDP_TIMEOUT, shutdown.clone()).await;
+
+    // #1 proves the tunnel works and marks the session productive.
+    assert_eq!(
+        tcp_round_trip(addrs.tcp, b"GET /1 HTTP/1.0\r\n\r\n").await,
+        HTTP_RESPONSE
+    );
+
+    hole.trigger();
+    // From here nothing but a timer can make progress, and nothing that could
+    // ever come back is in flight, so where the paused clock jumps cannot change
+    // the outcome. Nothing in this window uses `spawn_blocking`, which would
+    // inhibit the advance.
+    tokio::time::pause();
+
+    // Productive before the hole, so failures reset to the floor. `run_client`
+    // emits this before any backoff or reconnect, so nothing else has started.
+    assert_eq!(events.recv().await.unwrap(), (0, true));
+    tokio::time::resume();
+
+    // Naming the mechanism: the fatal line is written by `run_keepalive`, which
+    // returns before `run_client_session` returns and therefore before the event
+    // above — same task, so the ordering is program order, not a race.
+    assert!(
+        writer
+            .snapshot()
+            .contains("transport silent across the keepalive deadline"),
+        "the reconnect must have been caused by the keepalive, not by anything else"
+    );
+
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn a_healthy_session_is_kept_alive_by_its_own_probe() {
+    // The complementary direction, and the one that would otherwise ship green
+    // while tearing down every idle tunnel: the probe must travel the whole
+    // client path to the real server's `echo_keepalive` and come back as
+    // liveness on this session's own tap. The short cadence IS the behavior
+    // under test (mirroring the NAT idle-eviction test's short `udp_timeout`);
+    // the rendezvous is the log event, never a duration.
+    let (writer, _g) = capture_logs();
+    let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+    let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
+
+    let tcp = TcpStream::connect(server_addr).await.expect("connect yamux server");
+    let (mut session, _driver) = SessionTransport::spawn(tcp, &::yamux::Config::default());
+    let tcp_listener = TcpListener::bind("127.0.0.1:0").await.expect("bind local TCP");
+    let udp_socket = Arc::new(bind_udp("127.0.0.1:0".parse().unwrap()).expect("bind local UDP"));
+    // Short enough that the test does not idle, long enough that a loaded runner
+    // cannot miss a loopback round trip; `Cadence::new` requires the deadline to
+    // fit inside the interval, so they are equal rather than lopsided.
+    let cadence = Cadence::new(Duration::from_millis(500), Duration::from_millis(500));
+
+    // End the session as soon as the keepalive has reported a live transport, so
+    // the assertion below is on how the session ended, not on how long it ran.
+    let ender = {
+        let writer = writer.clone();
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            wait_for_log(&writer, "transport answered inside the keepalive deadline").await;
+            shutdown.cancel();
+        })
+    };
+
+    let outcome = run_client_session(
+        &tcp_listener,
+        &udp_socket,
+        &mut session,
+        DEFAULT_UDP_TIMEOUT,
+        cadence,
+        &shutdown,
+    )
+    .await;
+
+    ender.await.expect("ender joined");
+    assert_eq!(
+        outcome,
+        SessionOutcome::Shutdown,
+        "a session whose probe is answered must end only on shutdown"
+    );
+    assert!(
+        !writer
+            .snapshot()
+            .contains("transport silent across the keepalive deadline"),
+        "a healthy transport must never be declared dead"
+    );
+    // And the liveness came from the server's *echo*, not from some other frame:
+    // a rejected or reset probe substream would end the probe's read, which logs.
+    // A coalesced data+FIN still reads as `Ok(8)`, since `poll_read` drains the
+    // buffer before consulting `can_read`.
+    assert!(
+        !writer.snapshot().contains("keepalive probe substream ended"),
+        "the probe must have been answered by `echo_keepalive`, not rejected"
+    );
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -887,6 +887,13 @@ async fn driver_panicked_detects_panic_not_cancel() {
 
 #[skuld::test]
 async fn shutdown_during_backoff_exits_promptly() {
+    // Paused for the whole test so no wall-clock window exists between the
+    // rendezvous below and the backoff sleep it is supposed to freeze. The
+    // keepalive timer inside the span cannot change what is observed: the first
+    // session never receives a byte, so whether it dies from the relay's close
+    // or from a keepalive verdict, the reconnect event is `(1, false)` either
+    // way.
+    tokio::time::pause();
     let upstream = spawn_tcp_responder(HTTP_RESPONSE.to_vec()).await;
     let shutdown = CancellationToken::new();
     let server_addr = spawn_yamux_server(upstream, shutdown.clone()).await;
@@ -907,13 +914,6 @@ async fn shutdown_during_backoff_exits_promptly() {
     // Rendezvous (not the assertion): the observer event means the client has
     // reached the reconnect decision and is entering the backoff sleep.
     assert_eq!(events_rx.recv().await.unwrap(), (1, false));
-
-    // Pause only here, over the backoff window, where nothing but a timer can
-    // progress. Held from the top it would also span the first session, letting
-    // auto-advance resolve a whole keepalive interval and deadline while that
-    // session's frames were still in the kernel — so the reconnect awaited above
-    // could be the keepalive's rather than the relay's close.
-    tokio::time::pause();
 
     // The external assertion: shutdown must win the paused sleep, so the client
     // task returns `Ok` promptly. Without the select! shutdown branch the paused
@@ -1323,13 +1323,17 @@ async fn a_healthy_session_is_kept_alive_by_its_own_probe() {
     // fit inside the interval, so they are equal rather than lopsided.
     let cadence = Cadence::new(Duration::from_millis(500), Duration::from_millis(500));
 
-    // End the session as soon as the keepalive has reported a live transport, so
-    // the assertion below is on how the session ended, not on how long it ran.
+    // End the session as soon as the keepalive has reached *a* verdict, so the
+    // assertions below are on which verdict it was, not on how long it ran. The
+    // needle is the substring both verdict lines share ("transport answered
+    // inside the keepalive deadline" / "transport silent across the keepalive
+    // deadline") on purpose: waiting for the good one alone would hang here
+    // instead of failing, and the diagnosis would be lost.
     let ender = {
         let writer = writer.clone();
         let shutdown = shutdown.clone();
         tokio::spawn(async move {
-            wait_for_log(&writer, "transport answered inside the keepalive deadline").await;
+            wait_for_log(&writer, "the keepalive deadline").await;
             shutdown.cancel();
         })
     };


### PR DESCRIPTION
Closes #660.

An **idle** tunnel whose transport is silently black-holed — a middlebox dropping
packets with no RST or FIN — took up to 5 minutes to notice, because nothing in
the stack was watching: yamux sends nothing on an idle connection, so recovery
fell through to ex-ray's inherited 300 s `ConnectionIdle`. #655 covers the
visible-reset case; this covers the silent one, bounding idle recovery to **40 s**.

## How

Two halves, deliberately separated.

**Elicit.** A new `StreamTag::Keepalive = 0x03` substream. The client opens one
per probe, writes `tag || nonce`, reads once, and drops it; the server echoes the
nonce and closes. It probes only when the transport has been silent for a whole
interval — a transport that delivered anything has already answered the only
question a probe asks, so **a busy tunnel carries no keepalive traffic at all**.

**Judge.** `TransportLivenessTap` — already this crate's transport-liveness
authority — becomes a monotonic inbound-read counter instead of a latching bool.
A cycle is fatal only when the counter did not move across the whole deadline
that began with the probe attempt. Anything inbound counts: the echo, a yamux
window update, a yamux pong, relayed data on another substream. A missed cycle
trips the same `TransportDied` reconnect path #655 added.

The client never inspects the echo, so a single cancel-safe `read` is the whole
client protocol, and a deadline firing mid-read costs nothing.

## The wire change is additive, in both directions

`StreamTag::Keepalive = 0x03` is new on the wire, and version skew is safe
without negotiation:

- **New client, old server.** The old server rejects the unknown tag and resets
  the substream. That reset *is* inbound traffic, and yamux surfaces a reset to a
  reader only after the frame carrying it was read off the socket — which the tap
  counted. So the rejection reads as liveness and the tunnel behaves exactly as
  it does today.
- **Old client, new server.** The server arm is only reachable from a tag no old
  client sends.

## The 40 s bound, and the two relations that pin it

Worst case is `2 × KEEPALIVE_INTERVAL + KEEPALIVE_TIMEOUT` = 15 + 15 + 10 from
the last inbound byte. The extra interval is what the idle gate costs when
traffic lands just after a cycle boundary. Two relations hold it up, and both are
`const` assertions at the constants:

- `KEEPALIVE_TIMEOUT <= KEEPALIVE_INTERVAL` — otherwise a byte landing just after
  a probe went out pushes the next verdict past the bound.
- `KEEPALIVE_INTERVAL >= 10 s`, yamux's own ping cadence — the margin that keeps a
  healthy-but-slow server off the fatal path, since our probe wakes the driver and
  yamux pings too.

Both are also driven end to end:
`keepalive_declares_a_transport_dead_two_intervals_after_the_last_inbound_byte`
asserts the compound skip-then-silent path takes exactly that long on a virtual
clock, and `Cadence::new` `debug_assert`s the first relation for any other cadence.

## Tests, and which fail without the fix

Both directions are covered, because the dangerous regression is not "fails to
detect" but "tears down every healthy idle tunnel":

- `a_silently_blackholed_session_is_declared_dead` — a relay that stops forwarding
  while holding both sockets open, so neither peer ever sees a FIN or an RST.
  Without the session's keepalive arm this test fails; nothing else in the stack
  notices.
- `a_healthy_session_is_kept_alive_by_its_own_probe` — the probe travels the whole
  client path to the real server's `echo_keepalive` and back, and the session ends
  only on shutdown.
- Cycle-level verdicts against stub peers over an in-process pipe: echo, tag
  rejection, graceful FIN, garbled echo, a stalled probe rescued by other traffic,
  the idle-gate skip, and the two fatal paths (silence, and a substream budget
  that refuses the probe).

The cycle tests run against a harness that **quiesces** first — one echoed round
trip whose substream is then dropped. That step is load-bearing twice over. Both
yamux peers ping on their driver's first poll, so without it the setup pong moves
the tap *during* the test's own cycle and every "Answered" verdict is true
regardless of what the stub peer did; and the substream must be dropped rather
than retained, because a held, unread substream wedges every later one over
`tokio::io::duplex` (#735 — a harness trap, not a product bug).

The cycle tests run on a paused clock with typed rendezvous. The healthy-session
test cannot: tokio's auto-advance polls the I/O driver for 0 ms and then jumps to
the next armed timer, so a paused clock would fire the deadline while the loopback
echo was still in the kernel. It runs on the real clock with an injected short
cadence and parks on a log event, mirroring `udp_idle_eviction_and_recreation`'s
short `udp_timeout`. `Cadence` is a test seam only — nothing configures it, and
production always passes `Cadence::default()`.

## Also in here

- `SessionTransport` folds the three artifacts `run_client` re-creates on every
  reconnect (`open_tx`, `inbound_rx`, the tap counter) into one type. Its
  `keepalive()` takes both halves from `self`, so a caller cannot hand the
  keepalive a counter other than the one its own tap feeds.
- The server echo is single-round by design: the client sends one nonce per
  substream, and a future reusing client would work against this server anyway,
  since a substream ending after one echo reads as liveness and costs a re-open.

Jitter for the residual idle-case timing signature is deferred to #704 — no `rand`
dependency here.
