### PR TITLE
fix(bridge): report a rejected DoH resolver certificate distinctly from no answer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,16 +104,12 @@ always have bytes to write back. `try_forward` is the same walk without that
 erasure: it returns the highest-ranked `UpstreamCause` observed
 (`UpstreamCause::rank`), splitting a rejected peer certificate from every other
 TLS failure via `first_rustls_error`. It also takes the per-upstream budget as a
-parameter — a caller that wraps the call in its own shorter `timeout` instead
-drops the future before `forward_one`'s deadline fires, so nothing is classified
-and nothing reaches `bridge.log`. Pass the budget; do not wrap. The DoH bootstrap
-resolver uses `try_forward` so `BootstrapError` can tell a user that something is
+parameter (see `try_forward`'s doc for why callers must pass it rather than wrap
+the call). The DoH bootstrap resolver uses `try_forward` so `BootstrapError` can tell a user that something is
 intercepting TLS — a finding no other resolver will fix — apart from a resolver
 that simply did not answer. `BootstrapError` `Display` strings stay hostname-,
 IP- and path-free (`ProxyError::DohBootstrap` renders them verbatim into the
-start-error toast) and existential, never universal: several resolvers are tried
-and only the highest-ranked finding is reported, so no string may claim something
-about all of them.
+start-error toast) and existential, never universal — see `BootstrapError`'s doc.
 
 ### Listener selection invariants
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ synthesizes SERVFAIL when every upstream fails, because the in-TUN endpoint must
 always have bytes to write back. `try_forward` is the same walk without that
 erasure: it returns the highest-ranked `UpstreamCause` observed
 (`UpstreamCause::rank`), splitting a rejected peer certificate from every other
-TLS failure via `first_rustls_error`. It also takes the per-upstream budget as a
+TLS failure by inspecting the underlying rustls error. It also takes the per-upstream budget as a
 parameter (see `try_forward`'s doc for why callers must pass it rather than wrap
 the call). The DoH bootstrap resolver uses `try_forward` so `BootstrapError` can tell a user that something is
 intercepting TLS — a finding no other resolver will fix — apart from a resolver

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,8 @@ TLS failure by inspecting the underlying rustls error. It also takes the per-ups
 parameter (see `try_forward`'s doc for why callers must pass it rather than wrap
 the call). The DoH bootstrap resolver uses `try_forward` so `BootstrapError` can tell a user that something is
 intercepting TLS — a finding no other resolver will fix — apart from a resolver
-that simply did not answer. `BootstrapError` `Display` strings stay hostname-,
-IP- and path-free (`ProxyError::DohBootstrap` renders them verbatim into the
-start-error toast) and existential, never universal — see `BootstrapError`'s doc.
+that simply did not answer; see `BootstrapError`'s doc for its PII-free,
+existential `Display` contract.
 
 ### Listener selection invariants
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,23 @@ touching routes, system DNS, or the wintun adapter. Guarded by
 
 **Hard errors:** `dns.enabled = true` with `servers = []` is a config error.
 
+**Failure reporting.** `DnsForwarder::forward` is infallible by design — it
+synthesizes SERVFAIL when every upstream fails, because the in-TUN endpoint must
+always have bytes to write back. `try_forward` is the same walk without that
+erasure: it returns the highest-ranked `UpstreamCause` observed
+(`UpstreamCause::rank`), splitting a rejected peer certificate from every other
+TLS failure via `first_rustls_error`. It also takes the per-upstream budget as a
+parameter — a caller that wraps the call in its own shorter `timeout` instead
+drops the future before `forward_one`'s deadline fires, so nothing is classified
+and nothing reaches `bridge.log`. Pass the budget; do not wrap. The DoH bootstrap
+resolver uses `try_forward` so `BootstrapError` can tell a user that something is
+intercepting TLS — a finding no other resolver will fix — apart from a resolver
+that simply did not answer. `BootstrapError` `Display` strings stay hostname-,
+IP- and path-free (`ProxyError::DohBootstrap` renders them verbatim into the
+start-error toast) and existential, never universal: several resolvers are tried
+and only the highest-ranked finding is reported, so no string may claim something
+about all of them.
+
 ### Listener selection invariants
 
 [`ProxyConfig`](crates/common/src/protocol.rs) has two listener toggles

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,12 +102,12 @@ touching routes, system DNS, or the wintun adapter. Guarded by
 synthesizes SERVFAIL when every upstream fails, because the in-TUN endpoint must
 always have bytes to write back. `try_forward` is the same walk without that
 erasure: it returns the highest-ranked `UpstreamCause` observed
-(`UpstreamCause::rank`), splitting a rejected peer certificate from every other
-TLS failure by inspecting the underlying rustls error. It also takes the per-upstream budget as a
+(`UpstreamCause::rank`) — see `is_trust_chain_rejection` for how a rejected
+certificate is distinguished from other TLS failures. It also takes the per-upstream budget as a
 parameter (see `try_forward`'s doc for why callers must pass it rather than wrap
-the call). The DoH bootstrap resolver uses `try_forward` so `BootstrapError` can tell a user that something is
-intercepting TLS — a finding no other resolver will fix — apart from a resolver
-that simply did not answer; see `BootstrapError`'s doc for its PII-free,
+the call). The DoH bootstrap resolver uses `try_forward` so `BootstrapError` can tell a
+user that something is intercepting TLS, distinct from a resolver that simply
+did not answer; see `BootstrapError`'s doc for its PII-free,
 existential `Display` contract.
 
 ### Listener selection invariants

--- a/crates/bridge/src/dns/bootstrap.rs
+++ b/crates/bridge/src/dns/bootstrap.rs
@@ -59,6 +59,11 @@ impl BootstrapError {
     /// keep the first observed. A resolver that ANSWERED outranks one that
     /// failed to connect: an answer is evidence about the hostname, a failed
     /// connect is only evidence about that one resolver.
+    ///
+    /// `CertificateRejected` is the deliberate exception: nothing was answered,
+    /// yet it names a third party on the path rather than describing our own
+    /// reach, so it outranks every answered outcome. Do not "correct" it down
+    /// to match the rule above — that would delete the interception signal.
     pub(crate) fn rank(self) -> u8 {
         match self {
             Self::InvalidName => 7, // Short-circuits before the loop; never folded.
@@ -94,8 +99,9 @@ fn fold_worst(worst: &mut Option<BootstrapError>, e: BootstrapError) {
 /// happens, even if a later query rescues the resolve — deliberately unlike the
 /// answered-but-empty case, which is deferred to the failure tail: an empty
 /// answer is ordinary, a non-DNS body is evidence of something rewriting the
-/// response and is worth recording either way. The `Err` paths are already
-/// logged in full by `DnsForwarder`; this one it counts as a success.
+/// response and is worth recording either way. `DnsForwarder` already logs its
+/// `Err` paths in full; this reply arrives on its `Ok` path, so nothing else
+/// records it.
 /// Hostname-free — the resolver IP is config, the hostname is not.
 fn note_unparseable_reply(server: IpAddr, rtype: RecordType, len: usize) -> BootstrapError {
     tracing::warn!(%server, ?rtype, reply_len = len, "DoH bootstrap: resolver reply is not parseable DNS");
@@ -121,14 +127,29 @@ fn build_query(name: &str, tx_id: u16, rtype: RecordType) -> Result<Vec<u8>, Boo
     msg.to_vec().map_err(|_| BootstrapError::InvalidName)
 }
 
-/// Extract every A / AAAA address from a wire-format DNS reply. `None` when the
-/// bytes do not parse as DNS at all — a resolver answering non-DNS is a finding
-/// of its own, not the same as an answerless reply, which is `Some(vec![])`.
-pub fn parse_addrs(reply: &[u8]) -> Option<Vec<IpAddr>> {
+/// A resolver's parsed reply.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DnsReply {
+    /// Every A / AAAA address the answer section carried.
+    pub addrs: Vec<IpAddr>,
+    /// The resolver said the name does not exist AT ALL (NXDOMAIN) — a verdict
+    /// about the hostname itself. An empty NOERROR answer is not this: it
+    /// speaks only for the record type queried, so an A query returning it
+    /// tells us nothing about whether an AAAA exists.
+    pub name_missing: bool,
+}
+
+/// Parse a wire-format DNS reply. `None` when the bytes do not parse as DNS at
+/// all — a resolver answering non-DNS is a finding of its own, not the same as
+/// an answerless reply.
+pub fn parse_addrs(reply: &[u8]) -> Option<DnsReply> {
     let msg = Message::from_vec(reply).ok()?;
-    // `record.data` is the pub RData field; `RData::ip_addr()` yields
-    // Some(IpAddr) for A/AAAA, None otherwise — no variant match needed.
-    Some(msg.answers.iter().filter_map(|rec| rec.data.ip_addr()).collect())
+    Some(DnsReply {
+        // `record.data` is the pub RData field; `RData::ip_addr()` yields
+        // Some(IpAddr) for A/AAAA, None otherwise — no variant match needed.
+        addrs: msg.answers.iter().filter_map(|rec| rec.data.ip_addr()).collect(),
+        name_missing: msg.response_code == hickory_proto::op::ResponseCode::NXDomain,
+    })
 }
 
 // Resolver ============================================================================================================
@@ -228,18 +249,24 @@ pub async fn resolve_via_doh_with(
     let mut v6_fallback: Option<IpAddr> = None;
     let mut worst: Option<BootstrapError> = None;
     for &server in &dns.servers {
+        // `NoAnswer` means "this hostname has no address", which only a reply
+        // can establish. One leg answering emptily does NOT establish it: an
+        // empty A reply is ordinary for an AAAA-only host and vice versa. So
+        // fold `NoAnswer` only when the resolver said NXDOMAIN (a verdict on
+        // the name itself) or when BOTH legs answered and neither carried an
+        // address. Folding it on a single empty leg would outrank a real
+        // Transport/Timeout/Unreachable finding from the other leg (see
+        // `rank`) and report a hostname problem for a network fault.
+        let mut a_answered = false;
         match querier.query(server, &a_query).await {
             Ok(reply) => match parse_addrs(&reply) {
-                // An A reply with no IPv4 folds NOTHING: it is ordinary for an
-                // AAAA-only host and says nothing about whether the address
-                // exists — only the AAAA leg below can conclude that. Folding
-                // `NoAnswer` here would outrank a real
-                // Transport/Timeout/Unreachable finding from the AAAA leg or a
-                // later resolver (see `rank`), reporting a hostname problem
-                // for a network fault.
-                Some(addrs) => {
-                    if let Some(ip) = addrs.into_iter().find(IpAddr::is_ipv4) {
+                Some(parsed) => {
+                    if let Some(ip) = parsed.addrs.iter().copied().find(IpAddr::is_ipv4) {
                         return Ok(ip); // IPv4 preferred for bypass-route compatibility.
+                    }
+                    a_answered = true;
+                    if parsed.name_missing {
+                        fold_worst(&mut worst, BootstrapError::NoAnswer);
                     }
                 }
                 None => fold_worst(&mut worst, note_unparseable_reply(server, RecordType::A, reply.len())),
@@ -249,9 +276,9 @@ pub async fn resolve_via_doh_with(
         if v6_fallback.is_none() {
             match querier.query(server, &aaaa_query).await {
                 Ok(reply) => match parse_addrs(&reply) {
-                    Some(addrs) => {
-                        v6_fallback = addrs.into_iter().find(IpAddr::is_ipv6);
-                        if v6_fallback.is_none() {
+                    Some(parsed) => {
+                        v6_fallback = parsed.addrs.iter().copied().find(IpAddr::is_ipv6);
+                        if v6_fallback.is_none() && (a_answered || parsed.name_missing) {
                             fold_worst(&mut worst, BootstrapError::NoAnswer);
                         }
                     }

--- a/crates/bridge/src/dns/bootstrap.rs
+++ b/crates/bridge/src/dns/bootstrap.rs
@@ -222,6 +222,41 @@ impl DohQuerier for ForwarderQuerier {
     }
 }
 
+/// What one query leg concluded. Both legs classify identically; only what they
+/// do with the conclusion differs, so the classification lives here once.
+enum LegOutcome {
+    /// A usable address of the family this leg asked for.
+    Address(IpAddr),
+    /// The resolver answered without one. `name_missing` is its NXDOMAIN
+    /// verdict — conclusive about the hostname, unlike an empty NOERROR.
+    Answered { name_missing: bool },
+    /// No usable reply: the round trip failed, or the bytes were not DNS.
+    Failed(BootstrapError),
+}
+
+/// Run one query leg against `server` and classify the result. `want` selects
+/// the address family this leg asked for.
+async fn run_leg(
+    querier: &Arc<dyn DohQuerier>,
+    server: IpAddr,
+    wire: &[u8],
+    rtype: RecordType,
+    want: fn(&IpAddr) -> bool,
+) -> LegOutcome {
+    match querier.query(server, wire).await {
+        Ok(reply) => match parse_addrs(&reply) {
+            Some(parsed) => match parsed.addrs.into_iter().find(want) {
+                Some(ip) => LegOutcome::Address(ip),
+                None => LegOutcome::Answered {
+                    name_missing: parsed.name_missing,
+                },
+            },
+            None => LegOutcome::Failed(note_unparseable_reply(server, rtype, reply.len())),
+        },
+        Err(cause) => LegOutcome::Failed(classify(cause)),
+    }
+}
+
 /// Resolve `host` to an IP over the configured DoH `dns.servers`. See the task
 /// interface for the fail-closed / `allow_insecure_bootstrap` contract.
 pub async fn resolve_via_doh(host: &str, dns: &DnsConfig) -> Result<IpAddr, BootstrapError> {
@@ -249,45 +284,30 @@ pub async fn resolve_via_doh_with(
     let mut v6_fallback: Option<IpAddr> = None;
     let mut worst: Option<BootstrapError> = None;
     for &server in &dns.servers {
-        // `NoAnswer` means "this hostname has no address", which only a reply
-        // can establish. One leg answering emptily does NOT establish it: an
-        // empty A reply is ordinary for an AAAA-only host and vice versa. So
-        // fold `NoAnswer` only when the resolver said NXDOMAIN (a verdict on
-        // the name itself) or when BOTH legs answered and neither carried an
-        // address. Folding it on a single empty leg would outrank a real
-        // Transport/Timeout/Unreachable finding from the other leg (see
-        // `rank`) and report a hostname problem for a network fault.
+        // Fold `NoAnswer` only on NXDOMAIN or once BOTH legs answered emptily —
+        // a single empty leg proves nothing (e.g. an AAAA-only host's A leg) and
+        // folding it there would outrank a real Transport/Timeout/Unreachable
+        // finding from the other leg (see `rank`).
         let mut a_answered = false;
-        match querier.query(server, &a_query).await {
-            Ok(reply) => match parse_addrs(&reply) {
-                Some(parsed) => {
-                    if let Some(ip) = parsed.addrs.iter().copied().find(IpAddr::is_ipv4) {
-                        return Ok(ip); // IPv4 preferred for bypass-route compatibility.
-                    }
-                    a_answered = true;
-                    if parsed.name_missing {
+        match run_leg(&querier, server, &a_query, RecordType::A, IpAddr::is_ipv4).await {
+            LegOutcome::Address(ip) => return Ok(ip), // IPv4 preferred for bypass-route compatibility.
+            LegOutcome::Answered { name_missing } => {
+                a_answered = true;
+                if name_missing {
+                    fold_worst(&mut worst, BootstrapError::NoAnswer);
+                }
+            }
+            LegOutcome::Failed(e) => fold_worst(&mut worst, e),
+        }
+        if v6_fallback.is_none() {
+            match run_leg(&querier, server, &aaaa_query, RecordType::AAAA, IpAddr::is_ipv6).await {
+                LegOutcome::Address(ip) => v6_fallback = Some(ip),
+                LegOutcome::Answered { name_missing } => {
+                    if a_answered || name_missing {
                         fold_worst(&mut worst, BootstrapError::NoAnswer);
                     }
                 }
-                None => fold_worst(&mut worst, note_unparseable_reply(server, RecordType::A, reply.len())),
-            },
-            Err(cause) => fold_worst(&mut worst, classify(cause)),
-        }
-        if v6_fallback.is_none() {
-            match querier.query(server, &aaaa_query).await {
-                Ok(reply) => match parse_addrs(&reply) {
-                    Some(parsed) => {
-                        v6_fallback = parsed.addrs.iter().copied().find(IpAddr::is_ipv6);
-                        if v6_fallback.is_none() && (a_answered || parsed.name_missing) {
-                            fold_worst(&mut worst, BootstrapError::NoAnswer);
-                        }
-                    }
-                    None => fold_worst(
-                        &mut worst,
-                        note_unparseable_reply(server, RecordType::AAAA, reply.len()),
-                    ),
-                },
-                Err(cause) => fold_worst(&mut worst, classify(cause)),
+                LegOutcome::Failed(e) => fold_worst(&mut worst, e),
             }
         }
     }

--- a/crates/bridge/src/dns/bootstrap.rs
+++ b/crates/bridge/src/dns/bootstrap.rs
@@ -230,14 +230,18 @@ pub async fn resolve_via_doh_with(
     for &server in &dns.servers {
         match querier.query(server, &a_query).await {
             Ok(reply) => match parse_addrs(&reply) {
-                Some(addrs) => match addrs.into_iter().find(IpAddr::is_ipv4) {
-                    Some(ip) => return Ok(ip), // IPv4 preferred for bypass-route compatibility.
-                    // Silent: an A query with no IPv4 is ordinary for an
-                    // AAAA-only host, and the AAAA query below may still
-                    // succeed. The tail logs once, only if the whole resolve
-                    // fails.
-                    None => fold_worst(&mut worst, BootstrapError::NoAnswer),
-                },
+                // An A reply with no IPv4 folds NOTHING: it is ordinary for an
+                // AAAA-only host and says nothing about whether the address
+                // exists — only the AAAA leg below can conclude that. Folding
+                // `NoAnswer` here would outrank a real
+                // Transport/Timeout/Unreachable finding from the AAAA leg or a
+                // later resolver (see `rank`), reporting a hostname problem
+                // for a network fault.
+                Some(addrs) => {
+                    if let Some(ip) = addrs.into_iter().find(IpAddr::is_ipv4) {
+                        return Ok(ip); // IPv4 preferred for bypass-route compatibility.
+                    }
+                }
                 None => fold_worst(&mut worst, note_unparseable_reply(server, RecordType::A, reply.len())),
             },
             Err(cause) => fold_worst(&mut worst, classify(cause)),

--- a/crates/bridge/src/dns/bootstrap.rs
+++ b/crates/bridge/src/dns/bootstrap.rs
@@ -18,20 +18,88 @@ use hickory_proto::rr::{Name, RecordType};
 use hole_common::config::{DnsConfig, DnsProtocol};
 
 use crate::dns::connector::DirectConnector;
-use crate::dns::forwarder::DnsForwarder;
+use crate::dns::forwarder::{DnsForwarder, ForwardFailure, UpstreamCause};
 
 /// Typed bootstrap-resolution failure. `Display` strings are PII-FREE by
-/// construction — no hostname, no filesystem path — so the
+/// construction — no hostname, no resolver IP, no filesystem path — so the
 /// `ProxyError::DohBootstrap` that wraps this is safe to surface verbatim to a
-/// toast (the hostname lands in `bridge.log` via the call-site WARN).
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+/// toast (the detail lands in `bridge.log` via the call-site WARN and the
+/// forwarder's `upstream failed` WARN). They are also EXISTENTIAL: several
+/// resolvers are tried and only the strongest finding is reported, so no string
+/// may claim something about all of them.
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone, Copy)]
 pub enum BootstrapError {
     /// The hostname is not a valid DNS name (bad label length / encoding).
     #[error("server hostname is not a valid DNS name")]
     InvalidName,
-    /// No configured DoH resolver returned a usable A/AAAA answer.
+    /// A resolver's TLS certificate did not verify against our pinned roots.
+    #[error("a secure DNS resolver presented a certificate that could not be verified — something on this network may be intercepting encrypted connections")]
+    CertificateRejected,
+    /// Distinct from `NoAnswer`: the resolver responded, but the bytes do not
+    /// parse as DNS at all (see `parse_addrs`).
+    #[error("a secure DNS resolver returned a reply that is not valid DNS")]
+    MalformedReply,
+    /// A resolver replied, but with no usable A/AAAA record (SERVFAIL,
+    /// NXDOMAIN, or an empty answer section).
     #[error("could not resolve the proxy server address via secure DNS")]
     NoAnswer,
+    /// A resolver was reached, but the exchange broke at the TLS or HTTP layer
+    /// for a reason other than certificate trust.
+    #[error("the connection to a secure DNS resolver failed")]
+    Transport,
+    /// A resolver did not complete within the per-upstream budget.
+    #[error("a secure DNS resolver did not respond in time")]
+    Timeout,
+    #[error("could not reach a secure DNS resolver")]
+    Unreachable,
+}
+
+impl BootstrapError {
+    /// Report priority when resolvers fail differently — highest wins, ties
+    /// keep the first observed. A resolver that ANSWERED outranks one that
+    /// failed to connect: an answer is evidence about the hostname, a failed
+    /// connect is only evidence about that one resolver.
+    pub(crate) fn rank(self) -> u8 {
+        match self {
+            Self::InvalidName => 7, // Short-circuits before the loop; never folded.
+            Self::CertificateRejected => 6,
+            Self::MalformedReply => 5,
+            Self::NoAnswer => 4,
+            Self::Transport => 3,
+            Self::Timeout => 2,
+            Self::Unreachable => 1,
+        }
+    }
+}
+
+/// Map one round-trip failure onto the reported bootstrap error. Total, with no
+/// escape hatch: the seam's type admits exactly these six causes.
+fn classify(cause: UpstreamCause) -> BootstrapError {
+    match cause {
+        UpstreamCause::CertificateRejected => BootstrapError::CertificateRejected,
+        UpstreamCause::Unreachable => BootstrapError::Unreachable,
+        UpstreamCause::Timeout => BootstrapError::Timeout,
+        UpstreamCause::TlsFailed | UpstreamCause::BadResponse | UpstreamCause::Io => BootstrapError::Transport,
+    }
+}
+
+/// Keep `e` if it outranks what we have. Ties keep the first observed.
+fn fold_worst(worst: &mut Option<BootstrapError>, e: BootstrapError) {
+    if worst.is_none_or(|w| e.rank() > w.rank()) {
+        *worst = Some(e);
+    }
+}
+
+/// A resolver answered with bytes that are not DNS. Logged the moment it
+/// happens, even if a later query rescues the resolve — deliberately unlike the
+/// answered-but-empty case, which is deferred to the failure tail: an empty
+/// answer is ordinary, a non-DNS body is evidence of something rewriting the
+/// response and is worth recording either way. The `Err` paths are already
+/// logged in full by `DnsForwarder`; this one it counts as a success.
+/// Hostname-free — the resolver IP is config, the hostname is not.
+fn note_unparseable_reply(server: IpAddr, rtype: RecordType, len: usize) -> BootstrapError {
+    tracing::warn!(%server, ?rtype, reply_len = len, "DoH bootstrap: resolver reply is not parseable DNS");
+    BootstrapError::MalformedReply
 }
 
 /// Build an A-record query for `name` with transaction id `tx_id`.
@@ -53,16 +121,14 @@ fn build_query(name: &str, tx_id: u16, rtype: RecordType) -> Result<Vec<u8>, Boo
     msg.to_vec().map_err(|_| BootstrapError::InvalidName)
 }
 
-/// Extract every A / AAAA address from a wire-format DNS reply. Returns an
-/// empty Vec on any parse failure or an answerless reply — callers treat
-/// "empty" as "this resolver did not answer".
-pub fn parse_addrs(reply: &[u8]) -> Vec<IpAddr> {
-    let Ok(msg) = Message::from_vec(reply) else {
-        return Vec::new();
-    };
+/// Extract every A / AAAA address from a wire-format DNS reply. `None` when the
+/// bytes do not parse as DNS at all — a resolver answering non-DNS is a finding
+/// of its own, not the same as an answerless reply, which is `Some(vec![])`.
+pub fn parse_addrs(reply: &[u8]) -> Option<Vec<IpAddr>> {
+    let msg = Message::from_vec(reply).ok()?;
     // `record.data` is the pub RData field; `RData::ip_addr()` yields
     // Some(IpAddr) for A/AAAA, None otherwise — no variant match needed.
-    msg.answers.iter().filter_map(|rec| rec.data.ip_addr()).collect()
+    Some(msg.answers.iter().filter_map(|rec| rec.data.ip_addr()).collect())
 }
 
 // Resolver ============================================================================================================
@@ -73,31 +139,65 @@ pub fn parse_addrs(reply: &[u8]) -> Vec<IpAddr> {
 /// from `server` via its provider table.
 #[async_trait]
 pub trait DohQuerier: Send + Sync {
-    /// Return the wire-format reply, or `None` if this resolver did not answer
-    /// (connect/TLS/HTTP failure or a SERVFAIL/answerless reply). Never errors.
-    async fn query(&self, server: IpAddr, wire: &[u8]) -> Option<Vec<u8>>;
+    /// Return the wire-format reply, or why this resolver produced none. A
+    /// reply that parses but carries no address is `Ok` — "the resolver
+    /// answered" and "the answer was empty" are different findings.
+    ///
+    /// `UpstreamCause`, not the forwarder's `ForwardFailure`: this seam is ONE
+    /// query to ONE resolver, so the walk-level "nothing attempted" and
+    /// "malformed query" outcomes are not expressible here and no implementer
+    /// can invent them.
+    async fn query(&self, server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause>;
+}
+
+/// Forwarder config for one bootstrap round-trip: exactly this resolver, over
+/// DoH. The single definition the test queriers reuse, so a change here cannot
+/// leave them exercising a shape production no longer has.
+fn single_resolver_cfg(server: IpAddr) -> DnsConfig {
+    DnsConfig {
+        enabled: true,
+        servers: vec![server],
+        protocol: DnsProtocol::Https,
+        allow_insecure_bootstrap: false,
+    }
+}
+
+/// Run one round-trip through a single-resolver forwarder, narrowing the
+/// forwarder's WALK-level failure to this seam's per-query one. `try_forward`
+/// is the entry point rather than `forward` because `forward`'s SERVFAIL
+/// synthesis would erase which resolver failed and why.
+async fn single_round_trip(fwd: &DnsForwarder, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+    match fwd.try_forward(wire, crate::dns::forwarder::UPSTREAM_TIMEOUT).await {
+        Ok(reply) => Ok(reply),
+        Err(ForwardFailure::Upstream(cause)) => Err(cause),
+        // `single_resolver_cfg` supplies exactly one never-skipped server and
+        // every caller builds `wire` with `build_query`, so the walk cannot
+        // report "nothing attempted" or "malformed query".
+        Err(other) => {
+            // `debug_assert!` alone would make this silent in release, where
+            // the degraded `Unreachable` is indistinguishable from a real
+            // connect failure — log first so a broken invariant is visible.
+            tracing::error!(
+                ?other,
+                "single-resolver forward reported an outcome this seam cannot express"
+            );
+            debug_assert!(false, "single-resolver forward reported {other:?}");
+            Err(UpstreamCause::Unreachable)
+        }
+    }
 }
 
 /// Production querier: a `DnsForwarder` over a `DirectConnector`, restricted to
-/// a single resolver per call. `forward()` is infallible-by-design (returns
-/// SERVFAIL bytes on total failure); a SERVFAIL/answerless reply parses to an
-/// empty address list, which `resolve_via_doh_with` treats as "no answer".
+/// a single resolver per call.
 struct ForwarderQuerier;
 
 #[async_trait]
 impl DohQuerier for ForwarderQuerier {
-    async fn query(&self, server: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-        // One-server config so the forwarder targets exactly this resolver over
-        // DoH. ipv6_bypass_available=true: bootstrap runs before the tunnel, on
-        // the host's real stack, so do not suppress IPv6 resolvers.
-        let cfg = DnsConfig {
-            enabled: true,
-            servers: vec![server],
-            protocol: DnsProtocol::Https,
-            allow_insecure_bootstrap: false,
-        };
-        let fwd = DnsForwarder::new(cfg, Arc::new(DirectConnector), true);
-        Some(fwd.forward(wire).await)
+    async fn query(&self, server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+        // ipv6_bypass_available=true: bootstrap runs before the tunnel, on the
+        // host's real stack, so do not suppress IPv6 resolvers.
+        let fwd = DnsForwarder::new(single_resolver_cfg(server), Arc::new(DirectConnector), true);
+        single_round_trip(&fwd, wire).await
     }
 }
 
@@ -126,15 +226,37 @@ pub async fn resolve_via_doh_with(
     let aaaa_query = build_aaaa_query(host, 0x0002)?;
 
     let mut v6_fallback: Option<IpAddr> = None;
+    let mut worst: Option<BootstrapError> = None;
     for &server in &dns.servers {
-        if let Some(reply) = querier.query(server, &a_query).await {
-            if let Some(ip) = parse_addrs(&reply).into_iter().find(IpAddr::is_ipv4) {
-                return Ok(ip); // IPv4 preferred for bypass-route compatibility.
-            }
+        match querier.query(server, &a_query).await {
+            Ok(reply) => match parse_addrs(&reply) {
+                Some(addrs) => match addrs.into_iter().find(IpAddr::is_ipv4) {
+                    Some(ip) => return Ok(ip), // IPv4 preferred for bypass-route compatibility.
+                    // Silent: an A query with no IPv4 is ordinary for an
+                    // AAAA-only host, and the AAAA query below may still
+                    // succeed. The tail logs once, only if the whole resolve
+                    // fails.
+                    None => fold_worst(&mut worst, BootstrapError::NoAnswer),
+                },
+                None => fold_worst(&mut worst, note_unparseable_reply(server, RecordType::A, reply.len())),
+            },
+            Err(cause) => fold_worst(&mut worst, classify(cause)),
         }
         if v6_fallback.is_none() {
-            if let Some(reply) = querier.query(server, &aaaa_query).await {
-                v6_fallback = parse_addrs(&reply).into_iter().find(IpAddr::is_ipv6);
+            match querier.query(server, &aaaa_query).await {
+                Ok(reply) => match parse_addrs(&reply) {
+                    Some(addrs) => {
+                        v6_fallback = addrs.into_iter().find(IpAddr::is_ipv6);
+                        if v6_fallback.is_none() {
+                            fold_worst(&mut worst, BootstrapError::NoAnswer);
+                        }
+                    }
+                    None => fold_worst(
+                        &mut worst,
+                        note_unparseable_reply(server, RecordType::AAAA, reply.len()),
+                    ),
+                },
+                Err(cause) => fold_worst(&mut worst, classify(cause)),
             }
         }
     }
@@ -143,22 +265,43 @@ pub async fn resolve_via_doh_with(
         return Ok(ip);
     }
 
-    // Fail-closed: no configured resolver answered.
+    // Fail-closed: report the strongest failure observed. `NoAnswer` covers the
+    // degenerate "no resolvers configured" case, where nothing was observed.
+    // One line per FAILED bootstrap, naming the strongest finding — emitted
+    // here rather than per-reply so a resolve that recovers via AAAA or a later
+    // resolver stays silent.
+    let failure = worst.unwrap_or(BootstrapError::NoAnswer);
     if !dns.allow_insecure_bootstrap {
-        return Err(BootstrapError::NoAnswer);
+        tracing::warn!(
+            ?failure,
+            resolvers = dns.servers.len(),
+            "secure DNS bootstrap failed; refusing to resolve the proxy address (dns.allow_insecure_bootstrap is off)"
+        );
+        return Err(failure);
     }
 
-    // Opt-in insecure fallback: the OS resolver. Prefer IPv4, same as above.
-    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, 0))
-        .await
-        .map_err(|_| BootstrapError::NoAnswer)?
-        .collect();
+    // Opt-in insecure fallback: the OS resolver. Prefer IPv4, same as above. On
+    // failure report the DoH finding, not the OS one — the DoH failure is the
+    // one the user can act on.
+    //
+    // This WARN is the ONLY record of the finding on this path: the fallback can
+    // succeed, and a successful start shows the user nothing. Spell out the
+    // consequence rather than flagging it — a reader of this line is the entire
+    // audience for it.
+    tracing::warn!(
+        ?failure,
+        resolvers = dns.servers.len(),
+        "secure DNS bootstrap failed; resolving the proxy address over PLAINTEXT system DNS instead \
+         (dns.allow_insecure_bootstrap is on). A CertificateRejected finding here means the proxy \
+         address was resolved over the same network path that presented an untrusted certificate."
+    );
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, 0)).await.map_err(|_| failure)?.collect();
     addrs
         .iter()
         .find(|a| a.is_ipv4())
         .or_else(|| addrs.first())
         .map(|a| a.ip())
-        .ok_or(BootstrapError::NoAnswer)
+        .ok_or(failure)
 }
 
 /// Format a resolved IP as the `server_host` handed to the plugin chain /
@@ -184,19 +327,33 @@ pub(crate) fn test_loopback_querier(cert: rustls_pki_types::CertificateDer<'stat
     }
     #[async_trait]
     impl DohQuerier for LoopbackForwarderQuerier {
-        async fn query(&self, server: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-            let cfg = DnsConfig {
-                enabled: true,
-                servers: vec![server],
-                protocol: DnsProtocol::Https,
-                allow_insecure_bootstrap: false,
-            };
+        async fn query(&self, server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            let cfg = single_resolver_cfg(server);
             let fwd =
                 DnsForwarder::new_with_extra_root(cfg, Arc::new(DirectConnector), true, self.cert.clone(), self.port);
-            Some(fwd.forward(wire).await)
+            single_round_trip(&fwd, wire).await
         }
     }
     Arc::new(LoopbackForwarderQuerier { cert, port })
+}
+
+/// Test-only querier mirroring [`ForwarderQuerier`] exactly — including the
+/// PRODUCTION `webpki_roots` trust configuration — with only the upstream port
+/// overridden.
+#[cfg(test)]
+pub(crate) fn test_untrusted_querier(port: u16) -> Arc<dyn DohQuerier> {
+    struct UntrustedForwarderQuerier {
+        port: u16,
+    }
+    #[async_trait]
+    impl DohQuerier for UntrustedForwarderQuerier {
+        async fn query(&self, server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            let cfg = single_resolver_cfg(server);
+            let fwd = DnsForwarder::new_with_ports(cfg, Arc::new(DirectConnector), true, vec![self.port]);
+            single_round_trip(&fwd, wire).await
+        }
+    }
+    Arc::new(UntrustedForwarderQuerier { port })
 }
 
 #[cfg(test)]

--- a/crates/bridge/src/dns/bootstrap.rs
+++ b/crates/bridge/src/dns/bootstrap.rs
@@ -295,7 +295,11 @@ pub async fn resolve_via_doh_with(
          (dns.allow_insecure_bootstrap is on). A CertificateRejected finding here means the proxy \
          address was resolved over the same network path that presented an untrusted certificate."
     );
-    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, 0)).await.map_err(|_| failure)?.collect();
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, 0))
+        .await
+        .inspect_err(|e| tracing::warn!(kind = ?e.kind(), "plaintext DNS fallback also failed"))
+        .map_err(|_| failure)?
+        .collect();
     addrs
         .iter()
         .find(|a| a.is_ipv4())

--- a/crates/bridge/src/dns/bootstrap_tests.rs
+++ b/crates/bridge/src/dns/bootstrap_tests.rs
@@ -95,10 +95,9 @@ use tracing_subscriber::layer::{Layer, SubscriberExt};
 
 use super::{resolve_via_doh_with, DohQuerier};
 use crate::dns::forwarder::UpstreamCause;
-use crate::test_support::port_alloc::refused_tcp_port;
 
 /// In-test querier: answers ONLY for resolver IPs it was given a canned reply
-/// for; returns `None` otherwise (models "this resolver unreachable"). Records
+/// for; returns `Err(fail_with)` otherwise (default: `Unreachable`). Records
 /// which resolver IPs it was asked, so a test can assert the CONFIGURED
 /// resolver — not the OS resolver — was consulted.
 struct StubQuerier {
@@ -736,20 +735,12 @@ async fn resolve_reports_certificate_rejection_through_a_real_tls_handshake() {
     );
 }
 
-#[skuld::test]
-async fn resolve_reports_unreachable_through_a_real_refused_port() {
-    // The contrasting branch on the same real path: nothing is listening.
-    let (_held, addr) = refused_tcp_port();
-    let resolver: IpAddr = "127.0.0.1".parse().unwrap();
-    let err = super::resolve_via_doh_with(
-        "proxy.example",
-        &cfg(vec![resolver], false),
-        super::test_untrusted_querier(addr.port()),
-    )
-    .await
-    .unwrap_err();
-    assert_eq!(err, BootstrapError::Unreachable);
-}
+// The `Unreachable` branch is deliberately NOT driven through a real closed
+// socket here: "connect to a port nothing is listening on" has no portable
+// failure shape (macOS black-holes it, GitHub's Windows runners drop SYNs to
+// closed ephemeral loopback ports), so it cannot pin an exact cause. It is
+// covered deterministically by `resolve_maps_every_upstream_cause_to_its_bootstrap_error`
+// and, at the forwarder layer, by `try_forward_reports_unreachable_when_every_server_refuses`.
 
 #[skuld::test]
 async fn resolve_reports_no_answer_through_a_real_trusted_resolver_with_no_records() {

--- a/crates/bridge/src/dns/bootstrap_tests.rs
+++ b/crates/bridge/src/dns/bootstrap_tests.rs
@@ -50,15 +50,17 @@ fn parse_addrs_extracts_a_and_aaaa_records() {
     msg.add_answer(Record::from_rdata(name, 60, RData::AAAA(AAAA(v6))));
     let bytes = msg.to_vec().unwrap();
 
-    let addrs = parse_addrs(&bytes);
+    let addrs = parse_addrs(&bytes).unwrap();
     assert!(addrs.contains(&IpAddr::V4(v4)));
     assert!(addrs.contains(&IpAddr::V6(v6)));
 }
 
 #[skuld::test]
-fn parse_addrs_ignores_garbage() {
-    // < 12 bytes is not a parseable DNS message.
-    assert!(parse_addrs(&[0u8; 4]).is_empty());
+fn parse_addrs_reports_an_unparseable_reply() {
+    // < 12 bytes is not a parseable DNS message. Distinct from a reply that
+    // parses and carries no records — a resolver that answered garbage is a
+    // different finding from one that answered "I have nothing".
+    assert_eq!(parse_addrs(&[0u8; 4]), None);
 }
 
 // resolve_via_doh =====================================================================================================
@@ -69,7 +71,10 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use hole_common::config::{DnsConfig, DnsProtocol};
 
+use tracing_subscriber::layer::{Layer, SubscriberExt};
+
 use super::{resolve_via_doh_with, DohQuerier};
+use crate::dns::forwarder::UpstreamCause;
 
 /// In-test querier: answers ONLY for resolver IPs it was given a canned reply
 /// for; returns `None` otherwise (models "this resolver unreachable"). Records
@@ -77,20 +82,27 @@ use super::{resolve_via_doh_with, DohQuerier};
 /// resolver — not the OS resolver — was consulted.
 struct StubQuerier {
     answer_for: HashMap<IpAddr, Vec<u8>>,
+    /// Returned for any server without a canned reply.
+    fail_with: UpstreamCause,
     asked: Mutex<Vec<IpAddr>>,
 }
 
 #[async_trait]
 impl DohQuerier for StubQuerier {
-    async fn query(&self, server: IpAddr, _wire: &[u8]) -> Option<Vec<u8>> {
+    async fn query(&self, server: IpAddr, _wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
         self.asked.lock().unwrap().push(server);
-        self.answer_for.get(&server).cloned()
+        self.answer_for.get(&server).cloned().ok_or(self.fail_with)
     }
 }
 
 fn stub(answers: HashMap<IpAddr, Vec<u8>>) -> Arc<StubQuerier> {
+    stub_failing(answers, UpstreamCause::Unreachable)
+}
+
+fn stub_failing(answers: HashMap<IpAddr, Vec<u8>>, fail_with: UpstreamCause) -> Arc<StubQuerier> {
     Arc::new(StubQuerier {
         answer_for: answers,
+        fail_with,
         asked: Mutex::new(Vec::new()),
     })
 }
@@ -155,13 +167,253 @@ async fn resolve_surfaces_invalid_name_not_no_answer() {
 }
 
 #[skuld::test]
-async fn resolve_fails_closed_when_no_resolver_answers() {
+async fn resolve_reports_unreachable_when_no_resolver_answers() {
+    // Fail-closed AND specific: an unreachable resolver is not "no answer".
     let resolver: IpAddr = "1.1.1.1".parse().unwrap();
-    let q = stub(HashMap::new()); // querier returns None for every server.
-    let err = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), q)
+    let err = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), stub(HashMap::new()))
+        .await
+        .unwrap_err();
+    assert_eq!(err, BootstrapError::Unreachable);
+}
+
+#[skuld::test]
+async fn resolve_maps_every_upstream_cause_to_its_bootstrap_error() {
+    // Every variant the seam can carry — the match in `classify` is total, so
+    // this list is exhaustive by construction.
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    let cases = [
+        (UpstreamCause::CertificateRejected, BootstrapError::CertificateRejected),
+        (UpstreamCause::Unreachable, BootstrapError::Unreachable),
+        (UpstreamCause::Timeout, BootstrapError::Timeout),
+        (UpstreamCause::TlsFailed, BootstrapError::Transport),
+        (UpstreamCause::BadResponse, BootstrapError::Transport),
+        (UpstreamCause::Io, BootstrapError::Transport),
+    ];
+    for (cause, expected) in cases {
+        let q = stub_failing(HashMap::new(), cause);
+        let err = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), q)
+            .await
+            .unwrap_err();
+        assert_eq!(err, expected, "cause {cause:?}");
+    }
+}
+
+#[skuld::test]
+async fn resolve_reports_no_answer_when_a_resolver_replies_without_records() {
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    let mut msg = Message::new(0, MessageType::Response, OpCode::Query);
+    msg.metadata.response_code = ResponseCode::ServFail;
+    msg.add_query(Query::query(Name::from_ascii("proxy.example.").unwrap(), RecordType::A));
+    let mut answers = HashMap::new();
+    answers.insert(resolver, msg.to_vec().unwrap());
+    let err = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), stub(answers))
         .await
         .unwrap_err();
     assert_eq!(err, BootstrapError::NoAnswer);
+}
+
+#[skuld::test]
+async fn resolve_reports_malformed_reply_when_a_resolver_answers_non_dns() {
+    // HTTP 200, `application/dns-message`, body that is not DNS: the resolver
+    // is answering, but not with DNS. Distinct from an empty answer.
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    let mut answers = HashMap::new();
+    answers.insert(resolver, b"not dns at all".to_vec());
+    let err = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), stub(answers))
+        .await
+        .unwrap_err();
+    assert_eq!(err, BootstrapError::MalformedReply);
+}
+
+#[skuld::test]
+fn bootstrap_error_ranking_is_total_and_ordered() {
+    // The fold reports the highest-ranked failure observed. Pin the whole
+    // order: an answered-but-empty resolver must NOT be masked by another
+    // resolver's failed connect, or the toast claims a network failure that
+    // did not happen. `InvalidName` is included even though it short-circuits
+    // before the loop today — if it ever reaches the fold, it must win.
+    let order = [
+        BootstrapError::Unreachable,
+        BootstrapError::Timeout,
+        BootstrapError::Transport,
+        BootstrapError::NoAnswer,
+        BootstrapError::MalformedReply,
+        BootstrapError::CertificateRejected,
+        BootstrapError::InvalidName,
+    ];
+    for pair in order.windows(2) {
+        assert!(
+            pair[1].rank() > pair[0].rank(),
+            "{:?} must outrank {:?}",
+            pair[1],
+            pair[0]
+        );
+    }
+}
+
+#[skuld::test]
+async fn resolve_does_not_mask_an_answering_resolver_with_another_resolvers_failure() {
+    // One resolver answered (with nothing); another could not be reached.
+    // Reporting "could not reach a secure DNS resolver" would be a false
+    // network diagnosis.
+    let answered: IpAddr = "1.1.1.1".parse().unwrap();
+    let dead: IpAddr = "9.9.9.9".parse().unwrap();
+    let mut msg = Message::new(0, MessageType::Response, OpCode::Query);
+    msg.metadata.response_code = ResponseCode::NXDomain;
+    msg.add_query(Query::query(Name::from_ascii("proxy.example.").unwrap(), RecordType::A));
+    let mut answers = HashMap::new();
+    answers.insert(answered, msg.to_vec().unwrap());
+    for servers in [vec![answered, dead], vec![dead, answered]] {
+        let err = resolve_via_doh_with("proxy.example", &cfg(servers.clone(), false), stub(answers.clone()))
+            .await
+            .unwrap_err();
+        assert_eq!(err, BootstrapError::NoAnswer, "servers {servers:?}");
+    }
+}
+
+#[skuld::test]
+async fn resolve_reports_certificate_rejection_over_a_weaker_failure_from_another_resolver() {
+    let intercepted: IpAddr = "1.1.1.1".parse().unwrap();
+    let unreachable: IpAddr = "9.9.9.9".parse().unwrap();
+    struct PerServer(IpAddr);
+    #[async_trait]
+    impl DohQuerier for PerServer {
+        async fn query(&self, server: IpAddr, _wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            if server == self.0 {
+                Err(UpstreamCause::CertificateRejected)
+            } else {
+                Err(UpstreamCause::Unreachable)
+            }
+        }
+    }
+    for servers in [vec![intercepted, unreachable], vec![unreachable, intercepted]] {
+        let err = resolve_via_doh_with(
+            "proxy.example",
+            &cfg(servers.clone(), false),
+            Arc::new(PerServer(intercepted)),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, BootstrapError::CertificateRejected, "servers {servers:?}");
+    }
+}
+
+#[skuld::test]
+async fn resolve_reports_no_answer_when_no_resolvers_are_configured() {
+    // Degenerate config: the loop never runs, so nothing is observed. Must be
+    // an error, and specifically the generic one — not a panic, and not a
+    // cause the code never actually saw.
+    let err = resolve_via_doh_with("proxy.example", &cfg(vec![], false), stub(HashMap::new()))
+        .await
+        .unwrap_err();
+    assert_eq!(err, BootstrapError::NoAnswer);
+}
+
+#[skuld::test]
+async fn bootstrap_error_display_never_leaks_the_hostname() {
+    // The PII contract: `ProxyError::DohBootstrap` renders this verbatim into a
+    // toast, so no variant may name the host it was resolving. All seven —
+    // including the two reached through a SUCCESSFUL round trip, which are the
+    // newest surface and the easiest to enrich with reply detail later.
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    let host = "secret-proxy.example";
+    let mut empty = Message::new(0, MessageType::Response, OpCode::Query);
+    empty.metadata.response_code = ResponseCode::NXDomain;
+    empty.add_query(Query::query(
+        Name::from_ascii("secret-proxy.example.").unwrap(),
+        RecordType::A,
+    ));
+    let answered = |bytes: Vec<u8>| {
+        let mut m = HashMap::new();
+        m.insert(resolver, bytes);
+        stub(m)
+    };
+
+    let queriers: Vec<Arc<StubQuerier>> = vec![
+        stub_failing(HashMap::new(), UpstreamCause::CertificateRejected),
+        stub_failing(HashMap::new(), UpstreamCause::Unreachable),
+        stub_failing(HashMap::new(), UpstreamCause::Timeout),
+        stub_failing(HashMap::new(), UpstreamCause::TlsFailed),
+        answered(empty.to_vec().unwrap()),    // -> NoAnswer
+        answered(b"not dns at all".to_vec()), // -> MalformedReply
+    ];
+    for q in queriers {
+        let err = resolve_via_doh_with(host, &cfg(vec![resolver], false), q)
+            .await
+            .unwrap_err();
+        let text = err.to_string();
+        assert!(!text.contains(host), "{err:?} Display leaked the host: {text}");
+        assert!(!text.contains("1.1.1.1"), "{err:?} Display leaked the resolver: {text}");
+    }
+
+    // InvalidName is the seventh variant and the one built directly FROM the
+    // untrusted hostname, so it is the likeliest to acquire the offending name
+    // in a later edit. It short-circuits before any querier runs, hence the
+    // separate drive: a 64-octet label is not a valid DNS name.
+    let bad = "a".repeat(64);
+    let err = resolve_via_doh_with(&bad, &cfg(vec![resolver], false), stub(HashMap::new()))
+        .await
+        .unwrap_err();
+    assert_eq!(err, BootstrapError::InvalidName);
+    assert!(!err.to_string().contains(&bad), "InvalidName Display leaked the host");
+}
+
+#[skuld::test]
+async fn insecure_fallback_logs_the_certificate_rejection_even_when_it_succeeds() {
+    // allow_insecure_bootstrap turns a rejected certificate into a SUCCESSFUL
+    // start over plaintext system DNS -- the one channel an interceptor
+    // certainly controls. The log line is then the only surviving evidence.
+    let writer = crate::test_support::log_capture::VecWriter::new();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+    );
+    let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    let q = stub_failing(HashMap::new(), UpstreamCause::CertificateRejected);
+    // "localhost" resolves on every CI host without network.
+    let ip = resolve_via_doh_with("localhost", &cfg(vec![resolver], true), q)
+        .await
+        .expect("insecure fallback resolves localhost");
+    assert!(ip.is_loopback());
+
+    let output = writer.snapshot_string();
+    assert!(
+        output.contains("PLAINTEXT system DNS"),
+        "the WARN must state the consequence, not just flag it; got:\n{output}"
+    );
+    assert!(
+        output.contains("CertificateRejected"),
+        "the WARN must name the finding the fallback is proceeding past; got:\n{output}"
+    );
+}
+
+#[skuld::test]
+async fn a_recovering_resolve_logs_no_failure_warning() {
+    // An AAAA-only host makes the A query answer with no IPv4 — ordinary
+    // dual-stack behavior, not a failure. A WARN here would put a false alarm
+    // in bridge.log on a start that worked.
+    let writer = crate::test_support::log_capture::VecWriter::new();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+    );
+    let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    let v6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x35);
+    let mut answers = HashMap::new();
+    answers.insert(resolver, aaaa_reply_for("proxy.example", v6));
+    let ip = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), stub(answers))
+        .await
+        .unwrap();
+    assert_eq!(ip, IpAddr::V6(v6));
+    assert_eq!(writer.snapshot_string(), "", "a successful resolve must log no warning");
 }
 
 #[skuld::test]
@@ -304,6 +556,75 @@ async fn spawn_loopback_doh(reply: Vec<u8>) -> (CertificateDer<'static>, u16) {
         }
     });
     (cert_der, port)
+}
+
+/// A TCP port held by a bound-but-never-listened socket — see the twin in
+/// `forwarder_tests.rs`. The returned socket must stay alive.
+fn refused_tcp_port() -> (socket2::Socket, std::net::SocketAddr) {
+    use socket2::{Domain, Socket, Type};
+    let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    sock.bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)).into())
+        .unwrap();
+    let addr = sock.local_addr().unwrap().as_socket().unwrap();
+    (sock, addr)
+}
+
+#[skuld::test]
+async fn resolve_reports_certificate_rejection_through_a_real_tls_handshake() {
+    // End-to-end: a real rustls client with the PRODUCTION trust config rejects
+    // a real self-signed chain as UnknownIssuer (see test_untrusted_querier).
+    let expected = Ipv4Addr::new(203, 0, 113, 42);
+    let (_cert_der, port) = spawn_loopback_doh(a_reply_for("proxy.example", expected)).await;
+
+    let resolver: IpAddr = "127.0.0.1".parse().unwrap();
+    let err = super::resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        super::test_untrusted_querier(port),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        err,
+        BootstrapError::CertificateRejected,
+        "a rejected resolver certificate must not be reported as no answer"
+    );
+}
+
+#[skuld::test]
+async fn resolve_reports_unreachable_through_a_real_refused_port() {
+    // The contrasting branch on the same real path: nothing is listening.
+    let (_held, addr) = refused_tcp_port();
+    let resolver: IpAddr = "127.0.0.1".parse().unwrap();
+    let err = super::resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        super::test_untrusted_querier(addr.port()),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, BootstrapError::Unreachable);
+}
+
+#[skuld::test]
+async fn resolve_reports_no_answer_through_a_real_trusted_resolver_with_no_records() {
+    // Trusted chain, real handshake, real HTTP 200 — the reply just carries no
+    // address. This is the only branch that may still say "no answer".
+    let mut msg = Message::new(0, MessageType::Response, OpCode::Query);
+    msg.metadata.response_code = ResponseCode::ServFail;
+    msg.add_query(Query::query(Name::from_ascii("proxy.example.").unwrap(), RecordType::A));
+    let (cert_der, port) = spawn_loopback_doh(msg.to_vec().unwrap()).await;
+
+    let resolver: IpAddr = "127.0.0.1".parse().unwrap();
+    let err = super::resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        super::test_loopback_querier(cert_der, port),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, BootstrapError::NoAnswer);
 }
 
 #[skuld::test]

--- a/crates/bridge/src/dns/bootstrap_tests.rs
+++ b/crates/bridge/src/dns/bootstrap_tests.rs
@@ -50,9 +50,29 @@ fn parse_addrs_extracts_a_and_aaaa_records() {
     msg.add_answer(Record::from_rdata(name, 60, RData::AAAA(AAAA(v6))));
     let bytes = msg.to_vec().unwrap();
 
-    let addrs = parse_addrs(&bytes).unwrap();
-    assert!(addrs.contains(&IpAddr::V4(v4)));
-    assert!(addrs.contains(&IpAddr::V6(v6)));
+    let parsed = parse_addrs(&bytes).unwrap();
+    assert!(parsed.addrs.contains(&IpAddr::V4(v4)));
+    assert!(parsed.addrs.contains(&IpAddr::V6(v6)));
+    assert!(!parsed.name_missing, "NOERROR is not NXDOMAIN");
+}
+
+#[skuld::test]
+fn parse_addrs_reports_nxdomain_separately_from_an_empty_answer() {
+    // NXDOMAIN is a verdict on the NAME; an empty NOERROR speaks only for the
+    // record type queried. The resolve loop folds NoAnswer on the former from
+    // either leg, but on the latter only when both legs answered.
+    let name = Name::from_ascii("proxy.example.").unwrap();
+    let mut empty = Message::new(0, MessageType::Response, OpCode::Query);
+    empty.metadata.response_code = ResponseCode::NoError;
+    empty.add_query(Query::query(name.clone(), RecordType::A));
+    let parsed = parse_addrs(&empty.to_vec().unwrap()).unwrap();
+    assert!(parsed.addrs.is_empty());
+    assert!(!parsed.name_missing);
+
+    let mut nx = Message::new(0, MessageType::Response, OpCode::Query);
+    nx.metadata.response_code = ResponseCode::NXDomain;
+    nx.add_query(Query::query(name, RecordType::A));
+    assert!(parse_addrs(&nx.to_vec().unwrap()).unwrap().name_missing);
 }
 
 #[skuld::test]
@@ -75,6 +95,7 @@ use tracing_subscriber::layer::{Layer, SubscriberExt};
 
 use super::{resolve_via_doh_with, DohQuerier};
 use crate::dns::forwarder::UpstreamCause;
+use crate::test_support::port_alloc::refused_tcp_port;
 
 /// In-test querier: answers ONLY for resolver IPs it was given a canned reply
 /// for; returns `None` otherwise (models "this resolver unreachable"). Records
@@ -301,6 +322,65 @@ async fn an_a_query_without_ipv4_does_not_mask_a_transport_failure() {
     .await
     .unwrap_err();
     assert_eq!(err, BootstrapError::Timeout);
+}
+
+#[skuld::test]
+async fn an_aaaa_query_without_ipv6_does_not_mask_a_transport_failure() {
+    // The mirror, and the commoner shape: an IPv4-only host makes the AAAA leg
+    // answer emptily. With the A leg failed at the transport, that emptiness
+    // concludes nothing about the hostname, so the transport finding survives.
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    struct ATimeoutThenAaaaEmpty;
+    #[async_trait]
+    impl DohQuerier for ATimeoutThenAaaaEmpty {
+        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            let q = Message::from_vec(wire).unwrap();
+            if q.queries[0].query_type() == RecordType::A {
+                return Err(UpstreamCause::Timeout);
+            }
+            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+            reply.add_query(q.queries[0].clone());
+            Ok(reply.to_vec().unwrap())
+        }
+    }
+    let err = resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        Arc::new(ATimeoutThenAaaaEmpty),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, BootstrapError::Timeout);
+}
+
+#[skuld::test]
+async fn an_nxdomain_from_one_leg_reports_no_answer() {
+    // NXDOMAIN is conclusive about the NAME, so it folds even though only one
+    // leg answered — the actionable finding (fix the hostname) must not be
+    // displaced by the other leg's transient network failure.
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    struct ANxdomainThenTimeout;
+    #[async_trait]
+    impl DohQuerier for ANxdomainThenTimeout {
+        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            let q = Message::from_vec(wire).unwrap();
+            if q.queries[0].query_type() == RecordType::A {
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.metadata.response_code = ResponseCode::NXDomain;
+                reply.add_query(q.queries[0].clone());
+                return Ok(reply.to_vec().unwrap());
+            }
+            Err(UpstreamCause::Timeout)
+        }
+    }
+    let err = resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        Arc::new(ANxdomainThenTimeout),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, BootstrapError::NoAnswer);
 }
 
 #[skuld::test]
@@ -631,17 +711,6 @@ async fn spawn_loopback_doh(reply: Vec<u8>) -> (CertificateDer<'static>, u16) {
         }
     });
     (cert_der, port)
-}
-
-/// A TCP port held by a bound-but-never-listened socket — see the twin in
-/// `forwarder_tests.rs`. The returned socket must stay alive.
-fn refused_tcp_port() -> (socket2::Socket, std::net::SocketAddr) {
-    use socket2::{Domain, Socket, Type};
-    let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    sock.bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)).into())
-        .unwrap();
-    let addr = sock.local_addr().unwrap().as_socket().unwrap();
-    (sock, addr)
 }
 
 #[skuld::test]

--- a/crates/bridge/src/dns/bootstrap_tests.rs
+++ b/crates/bridge/src/dns/bootstrap_tests.rs
@@ -247,7 +247,8 @@ fn handoff_host_v6_is_bracketed_and_parses_with_port() {
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 
 /// Stand up a loopback rustls DoH server on 127.0.0.1:<ephemeral> that serves
-/// one canned `application/dns-message` reply, returning the server's cert DER
+/// one canned `application/dns-message` reply to EVERY connection (the resolver
+/// loop opens a second one for the AAAA fallback), returning the server's cert DER
 /// (for the client trust root) and the bound port. The cert carries an IP SAN
 /// for 127.0.0.1 because `https_target_for` uses IP-SNI for non-table IPs.
 /// (127.0.0.1, not another 127/8 address: macOS makes only 127.0.0.1 loopback
@@ -277,13 +278,17 @@ async fn spawn_loopback_doh(reply: Vec<u8>) -> (CertificateDer<'static>, u16) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     tokio::spawn(async move {
-        if let Ok((tcp, _)) = listener.accept().await {
-            if let Ok(mut tls) = acceptor.accept(tcp).await {
+        while let Ok((tcp, _)) = listener.accept().await {
+            let acceptor = acceptor.clone();
+            let body = reply.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(tcp).await else {
+                    return; // Handshake refused by the client (untrusted chain).
+                };
                 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-                // Drain the POST request (best-effort) then write the HTTP reply.
+                // Drain the POST request (best-effort).
                 let mut buf = [0u8; 4096];
                 let _ = tls.read(&mut buf).await;
-                let body = reply;
                 let head = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/dns-message\r\n\
                      Content-Length: {}\r\nConnection: close\r\n\r\n",
@@ -295,10 +300,27 @@ async fn spawn_loopback_doh(reply: Vec<u8>) -> (CertificateDer<'static>, u16) {
                 // `read_to_end` on the client errors on the unclean EOF, as a real
                 // DoH server (which closes cleanly) never would.
                 let _ = tls.shutdown().await;
-            }
+            });
         }
     });
     (cert_der, port)
+}
+
+#[skuld::test]
+async fn loopback_doh_stub_serves_the_aaaa_query_after_the_a_query() {
+    // Second connection for the AAAA fallback: a single-shot stub would fail
+    // that connection at connect and mis-report the cause.
+    let v6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x35);
+    let (cert_der, port) = spawn_loopback_doh(aaaa_reply_for("proxy.example", v6)).await;
+    let resolver: IpAddr = "127.0.0.1".parse().unwrap();
+    let ip = super::resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        super::test_loopback_querier(cert_der, port),
+    )
+    .await
+    .unwrap();
+    assert_eq!(ip, IpAddr::V6(v6));
 }
 
 #[skuld::test]

--- a/crates/bridge/src/dns/bootstrap_tests.rs
+++ b/crates/bridge/src/dns/bootstrap_tests.rs
@@ -417,6 +417,39 @@ async fn a_recovering_resolve_logs_no_failure_warning() {
 }
 
 #[skuld::test]
+async fn a_malformed_reply_logs_even_when_a_later_resolver_rescues_the_resolve() {
+    // The deliberate asymmetry with the empty-answer case above: a resolver
+    // answering non-DNS is evidence of something rewriting the response, so it
+    // is recorded the moment it happens — even though this resolve succeeds.
+    let writer = crate::test_support::log_capture::VecWriter::new();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+    );
+    let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+    let garbage: IpAddr = "1.1.1.1".parse().unwrap();
+    let good: IpAddr = "9.9.9.9".parse().unwrap();
+    let expected = Ipv4Addr::new(203, 0, 113, 7);
+    let mut answers = HashMap::new();
+    answers.insert(garbage, b"not dns at all".to_vec());
+    answers.insert(good, a_reply_for("proxy.example", expected));
+
+    let ip = resolve_via_doh_with("proxy.example", &cfg(vec![garbage, good], false), stub(answers))
+        .await
+        .expect("the second resolver rescues the resolve");
+    assert_eq!(ip, IpAddr::V4(expected));
+
+    let output = writer.snapshot_string();
+    assert!(
+        output.contains("not parseable DNS"),
+        "a non-DNS reply must be recorded even on a rescued resolve; got:\n{output}"
+    );
+}
+
+#[skuld::test]
 async fn resolve_returns_ipv6_when_only_aaaa_answers() {
     // No A record from any resolver; an AAAA answer must be returned (the v6
     // branch is correct, not dodged). The wiring task verifies the bracket-safe
@@ -434,16 +467,26 @@ async fn resolve_returns_ipv6_when_only_aaaa_answers() {
 
 #[skuld::test]
 async fn resolve_prefers_ipv4_when_both_answer() {
-    // One resolver answers both A and AAAA; IPv4 wins (bypass-route compat).
+    // A genuinely dual-stack answer: ONE reply carrying both an A and an AAAA
+    // record. Answering only A would prove nothing — the A branch returns
+    // before the AAAA query is ever issued, so IPv6 would never be a candidate.
     let resolver: IpAddr = "1.1.1.1".parse().unwrap();
     let v4 = Ipv4Addr::new(203, 0, 113, 7);
+    let v6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x7);
+    let mut msg = Message::new(0, MessageType::Response, OpCode::Query);
+    let n = Name::from_ascii("proxy.example.").unwrap();
+    msg.add_query(Query::query(n.clone(), RecordType::A));
+    msg.add_answer(Record::from_rdata(n.clone(), 60, RData::AAAA(AAAA(v6))));
+    msg.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
+    // AAAA first in the answer section, so a naive "take the first address"
+    // would pick IPv6 and this test would catch it.
     let mut answers = HashMap::new();
-    answers.insert(resolver, a_reply_for("proxy.example", v4));
+    answers.insert(resolver, msg.to_vec().unwrap());
     let q = stub(answers);
     let ip = resolve_via_doh_with("proxy.example", &cfg(vec![resolver], false), q)
         .await
         .unwrap();
-    assert_eq!(ip, IpAddr::V4(v4));
+    assert_eq!(ip, IpAddr::V4(v4), "IPv4 wins (bypass-route compat)");
 }
 
 #[skuld::test]

--- a/crates/bridge/src/dns/bootstrap_tests.rs
+++ b/crates/bridge/src/dns/bootstrap_tests.rs
@@ -272,6 +272,38 @@ async fn resolve_does_not_mask_an_answering_resolver_with_another_resolvers_fail
 }
 
 #[skuld::test]
+async fn an_a_query_without_ipv4_does_not_mask_a_transport_failure() {
+    // Ordinary dual-stack shape: the A leg parses with no IPv4 (an AAAA-only
+    // host), then the AAAA leg fails at the transport. The A leg concluded
+    // nothing about whether the address exists, so the transport finding must
+    // survive — reporting "could not resolve … via secure DNS" here would hand
+    // the user a hostname diagnosis for a network fault.
+    let resolver: IpAddr = "1.1.1.1".parse().unwrap();
+    struct AEmptyThenTimeout;
+    #[async_trait]
+    impl DohQuerier for AEmptyThenTimeout {
+        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            let q = Message::from_vec(wire).unwrap();
+            if q.queries[0].query_type() == RecordType::A {
+                // Parses, NOERROR, zero answers.
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.add_query(q.queries[0].clone());
+                return Ok(reply.to_vec().unwrap());
+            }
+            Err(UpstreamCause::Timeout)
+        }
+    }
+    let err = resolve_via_doh_with(
+        "proxy.example",
+        &cfg(vec![resolver], false),
+        Arc::new(AEmptyThenTimeout),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, BootstrapError::Timeout);
+}
+
+#[skuld::test]
 async fn resolve_reports_certificate_rejection_over_a_weaker_failure_from_another_resolver() {
     let intercepted: IpAddr = "1.1.1.1".parse().unwrap();
     let unreachable: IpAddr = "9.9.9.9".parse().unwrap();

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -294,18 +294,15 @@ fn is_trust_chain_rejection(e: &rustls::Error) -> bool {
                 | rustls::CertificateError::Revoked
                 | rustls::CertificateError::UnknownRevocationStatus
         ),
-        // Same discipline for revocation material: only a CRL whose trust
-        // fails, not one we merely could not parse or whose algorithm/version
-        // this client does not implement — those are the resolver's problem or
-        // ours, not an interceptor's. (Unreachable today: `build_tls_config`
-        // configures no CRLs, so rustls never checks revocation.)
-        rustls::Error::InvalidCertRevocationList(c) => matches!(
-            c,
-            rustls::CertRevocationListError::BadSignature
-                | rustls::CertRevocationListError::IssuerInvalidForCrl
-                | rustls::CertRevocationListError::InvalidCrlNumber
-                | rustls::CertRevocationListError::InvalidRevokedCertSerialNumber
-        ),
+        // Same discipline for revocation material, and only `BadSignature`
+        // qualifies: a malformed CRL number, a bad revoked-serial or a CA
+        // missing cRLSign are content/config faults in material WE supply —
+        // rustls never fetches CRLs from the network, so no interceptor can
+        // cause them. (Unreachable today: `build_tls_config` configures no
+        // CRLs, so rustls never checks revocation at all.)
+        rustls::Error::InvalidCertRevocationList(c) => {
+            matches!(c, rustls::CertRevocationListError::BadSignature)
+        }
         _ => false,
     }
 }

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -294,8 +294,18 @@ fn is_trust_chain_rejection(e: &rustls::Error) -> bool {
                 | rustls::CertificateError::Revoked
                 | rustls::CertificateError::UnknownRevocationStatus
         ),
-        // A CRL we could not verify is a trust-material failure in its own right.
-        rustls::Error::InvalidCertRevocationList(_) => true,
+        // Same discipline for revocation material: only a CRL whose trust
+        // fails, not one we merely could not parse or whose algorithm/version
+        // this client does not implement — those are the resolver's problem or
+        // ours, not an interceptor's. (Unreachable today: `build_tls_config`
+        // configures no CRLs, so rustls never checks revocation.)
+        rustls::Error::InvalidCertRevocationList(c) => matches!(
+            c,
+            rustls::CertRevocationListError::BadSignature
+                | rustls::CertRevocationListError::IssuerInvalidForCrl
+                | rustls::CertRevocationListError::InvalidCrlNumber
+                | rustls::CertRevocationListError::InvalidRevokedCertSerialNumber
+        ),
         _ => false,
     }
 }

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -45,10 +45,11 @@ pub enum UpstreamLayer {
     Http,
     /// Post-handshake read / write on the upstream stream.
     Io,
-    /// Outer `UPSTREAM_TIMEOUT` budget fired. Distinct from `Io` so
-    /// observers can tell "inner future completed with error at 2573ms"
-    /// from "outer timer cancelled the future at exactly 3000ms" —
-    /// different root causes, different fixes.
+    /// The per-upstream budget passed to `forward_one` fired. Distinct from
+    /// `Io` so observers can tell "inner future completed with error at
+    /// 2573ms" from "the timer cancelled the future at the deadline" —
+    /// different root causes, different fixes. `budget_ms` on the WARN
+    /// reports which budget was in force.
     Timeout,
 }
 
@@ -149,8 +150,12 @@ pub struct UpstreamErr {
     pub layer: UpstreamLayer,
     pub source: io::Error,
     /// Wall-clock from `forward_one`'s `Instant::now()` to error emission.
-    /// Bounded above by [`UPSTREAM_TIMEOUT`].
+    /// Bounded above by the `budget` passed to `forward_one`.
     pub elapsed_ms: u64,
+    /// The per-upstream budget the attempt actually ran under, stamped by
+    /// `forward_one`. Logged as `budget_ms` so the WARN can never claim a
+    /// deadline that was not in force.
+    pub budget_ms: u64,
     /// Time from `forward_one` start to return of `connector.connect_tcp`.
     /// `Some` whenever the TCP/SOCKS5-level connection completed
     /// (Tls/Io/Http failures); `None` when we errored at `Connect` or
@@ -179,6 +184,7 @@ impl UpstreamErr {
             layer,
             source,
             elapsed_ms: 0,
+            budget_ms: 0,
             socks5_ms: None,
             tls_ms: None,
             tcp_wrote: None,
@@ -290,9 +296,11 @@ const DNS_PORT_TLS: u16 = 853;
 /// DoH typically runs on 443 (RFC 8484 §3).
 const DNS_PORT_HTTPS: u16 = 443;
 
-/// Per-upstream attempt timeout. Shorter than the OS default TCP timeout
-/// so a dead server doesn't stall the whole forward loop.
-const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(3);
+/// Default per-upstream attempt budget, used by [`DnsForwarder::forward`].
+/// Shorter than the OS default TCP timeout so a dead server doesn't stall the
+/// whole forward loop. Callers with their own budget pass it to
+/// [`DnsForwarder::try_forward`] instead of wrapping the call in a `timeout`.
+pub(crate) const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Maximum reply size we'll buffer (bytes). DNS messages cap around 65535
 /// but we cap even tighter — DoH servers never return more than ~8KB in
@@ -373,12 +381,12 @@ pub struct DnsForwarder {
     /// cannot change without a reconfigure; log-first-1-forever is
     /// correct there.
     ipv6_skip_logged: Mutex<HashSet<IpAddr>>,
-    /// Test-only upstream-port override so the cross-module
-    /// `bootstrap::test_loopback_querier` e2e can reach an ephemeral DoH
-    /// listener. Behind `#[cfg(test)]` so production `forward` stays
-    /// byte-identical.
+    /// Test-only per-server upstream-port override, indexed against
+    /// `config.servers`, so tests can target ephemeral listeners without
+    /// binding privileged 53/853/443. Behind `#[cfg(test)]` so production
+    /// `try_forward` stays byte-identical.
     #[cfg(test)]
-    forced_port: Option<u16>,
+    forced_ports: Option<Vec<u16>>,
 }
 
 impl DnsForwarder {
@@ -395,7 +403,7 @@ impl DnsForwarder {
             failure_throttle: Mutex::new(HashMap::new()),
             ipv6_skip_logged: Mutex::new(HashSet::new()),
             #[cfg(test)]
-            forced_port: None,
+            forced_ports: None,
         }
     }
 
@@ -403,41 +411,80 @@ impl DnsForwarder {
     /// Never errors — on total failure returns a synthesized SERVFAIL so
     /// the caller can always write a reply back.
     pub async fn forward(&self, query: &[u8]) -> Vec<u8> {
+        // Short-query check ahead of the delegation: this is the in-TUN
+        // datagram path, so arbitrary local traffic reaches it and must not be
+        // able to drive `try_forward`'s unthrottled malformed-query WARN.
         if query.len() < 12 {
             return synthesize_servfail(query);
         }
+        self.try_forward(query, UPSTREAM_TIMEOUT)
+            .await
+            .unwrap_or_else(|_| synthesize_servfail(query))
+    }
 
-        for &server in &self.config.servers {
+    /// [`Self::forward`] without the SERVFAIL synthesis: reports *why* no
+    /// upstream answered. Per-server failures are logged by the same throttle
+    /// either way; the returned cause is the highest-ranked one observed
+    /// (see [`UpstreamCause::rank`]), ties keeping the first.
+    ///
+    /// `per_upstream` bounds ONE upstream attempt. The walk tries up to
+    /// `config.servers.len()` of them, so bound the whole call at
+    /// `servers.len() * per_upstream`. A caller that owns a total budget should
+    /// pass this rather than wrapping the call in its own `timeout`: an outer
+    /// timer that fires first drops the future before `forward_one`'s deadline,
+    /// so nothing is classified and nothing is logged.
+    pub async fn try_forward(&self, query: &[u8], per_upstream: Duration) -> Result<Vec<u8>, ForwardFailure> {
+        if query.len() < 12 {
+            // A caller bug, and the one failure with no per-upstream WARN
+            // behind it — log at the point of detection or it is invisible to
+            // whichever caller consumes the `Err`.
+            tracing::warn!(
+                len = query.len(),
+                "DNS forward called with a query shorter than the header"
+            );
+            return Err(ForwardFailure::MalformedQuery);
+        }
+
+        let mut worst: Option<UpstreamCause> = None;
+        for (idx, &server) in self.config.servers.iter().enumerate() {
             if server.is_ipv6() && !self.ipv6_bypass_available {
                 self.log_ipv6_skip_once(server);
                 continue;
             }
 
-            let port = {
-                #[cfg(test)]
-                {
-                    self.forced_port.unwrap_or_else(|| default_port(self.config.protocol))
+            let target = SocketAddr::new(server, self.port_for(idx));
+            match self.forward_one(target, query, per_upstream).await {
+                Ok(reply) => return Ok(reply),
+                Err(e) => {
+                    let cause = e.cause();
+                    self.log_upstream_failure(server, &e);
+                    if worst.is_none_or(|w| cause.rank() > w.rank()) {
+                        worst = Some(cause);
+                    }
                 }
-                #[cfg(not(test))]
-                {
-                    default_port(self.config.protocol)
-                }
-            };
-            let target = SocketAddr::new(server, port);
-            match self.forward_one(target, query).await {
-                Ok(reply) => return reply,
-                Err(e) => self.log_upstream_failure(server, &e),
             }
         }
 
-        synthesize_servfail(query)
+        Err(worst.map_or(ForwardFailure::NoUpstream, ForwardFailure::Upstream))
     }
 
-    /// Single-attempt forward against `target`. Callers build `target`
-    /// from the config'd server plus the protocol's well-known port;
-    /// the test-only `forward_with_ports` builds it from an ephemeral
-    /// port so stubs don't need privilege to bind 53/853/443.
-    async fn forward_one(&self, target: SocketAddr, query: &[u8]) -> Result<Vec<u8>, UpstreamErr> {
+    /// Upstream port for the server at `_idx`. Production always answers the
+    /// protocol's well-known port; tests may override per server index.
+    fn port_for(&self, _idx: usize) -> u16 {
+        #[cfg(test)]
+        if let Some(ports) = self.forced_ports.as_ref() {
+            // `new_with_ports` is the only writer and asserts full coverage.
+            // Falling through here would dial a real public resolver.
+            return ports[_idx];
+        }
+        default_port(self.config.protocol)
+    }
+
+    /// Single-attempt forward against `target`, bounded by `budget`. Callers
+    /// build `target` from the config'd server plus the protocol's well-known
+    /// port; the test-only `port_for` / `forced_ports` seam substitutes an
+    /// ephemeral port so stubs don't need privilege to bind 53/853/443.
+    async fn forward_one(&self, target: SocketAddr, query: &[u8], budget: Duration) -> Result<Vec<u8>, UpstreamErr> {
         let started = Instant::now();
         let fut = async {
             match self.config.protocol {
@@ -447,7 +494,7 @@ impl DnsForwarder {
                 DnsProtocol::Https => self.forward_https(target, query).await,
             }
         };
-        let result = match timeout(UPSTREAM_TIMEOUT, fut).await {
+        let result = match timeout(budget, fut).await {
             Ok(res) => res,
             Err(_) => Err(UpstreamErr::new(
                 UpstreamLayer::Timeout,
@@ -456,6 +503,7 @@ impl DnsForwarder {
         };
         result.map_err(|mut e| {
             e.elapsed_ms = started.elapsed().as_millis() as u64;
+            e.budget_ms = budget.as_millis() as u64;
             e
         })
     }
@@ -513,7 +561,7 @@ impl DnsForwarder {
                     layer = %e.layer,
                     cause = %e.cause(),
                     elapsed_ms = e.elapsed_ms,
-                    budget_ms = UPSTREAM_TIMEOUT.as_millis() as u64,
+                    budget_ms = e.budget_ms,
                     socks5_ms = ?e.socks5_ms,
                     tls_ms = ?e.tls_ms,
                     tcp_wrote = ?e.tcp_wrote,
@@ -540,8 +588,8 @@ impl DnsForwarder {
     }
 }
 
-/// Well-known port per protocol. Split out so `forward_with_ports` (test
-/// helper) can reuse the mapping.
+/// Well-known port per protocol. Split out so the test-only `port_for`
+/// override can reuse the mapping.
 fn default_port(protocol: DnsProtocol) -> u16 {
     match protocol {
         DnsProtocol::PlainUdp | DnsProtocol::PlainTcp => DNS_PORT_PLAIN,
@@ -803,6 +851,26 @@ pub(crate) fn build_tls_config_with_extra_root(extra: rustls_pki_types::Certific
 
 #[cfg(test)]
 impl DnsForwarder {
+    /// Test-only forwarder with per-server upstream-port overrides — see the
+    /// `forced_ports` field. Every server must get one: an uncovered index
+    /// falls back to the real well-known port, which would dial a public
+    /// resolver for real from a test.
+    pub(crate) fn new_with_ports(
+        config: DnsConfig,
+        connector: Arc<dyn UpstreamConnector>,
+        ipv6_bypass_available: bool,
+        ports: Vec<u16>,
+    ) -> Self {
+        assert_eq!(
+            ports.len(),
+            config.servers.len(),
+            "forced_ports must cover every configured server"
+        );
+        let mut s = Self::new(config, connector, ipv6_bypass_available);
+        s.forced_ports = Some(ports);
+        s
+    }
+
     /// Test-only forwarder trusting one extra root, with a fixed upstream port
     /// so the loopback e2e can target an ephemeral DoH listener. Compiled out
     /// of production — never weakens the real `webpki_roots` verifier.
@@ -813,9 +881,10 @@ impl DnsForwarder {
         extra_root: rustls_pki_types::CertificateDer<'static>,
         forced_port: u16,
     ) -> Self {
-        let mut s = Self::new(config, connector, ipv6_bypass_available);
+        // One port for EVERY server — never a partial override.
+        let ports = vec![forced_port; config.servers.len()];
+        let mut s = Self::new_with_ports(config, connector, ipv6_bypass_available, ports);
         s.tls_config = Arc::new(build_tls_config_with_extra_root(extra_root));
-        s.forced_port = Some(forced_port);
         s
     }
 }

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -154,8 +154,9 @@ pub struct UpstreamErr {
     pub budget_ms: u64,
     /// Time from `forward_one` start to return of `connector.connect_tcp`.
     /// `Some` whenever the TCP/SOCKS5-level connection completed
-    /// (Tls/Io/Http failures); `None` when we errored at `Connect` or
-    /// `Timeout` fired before connect completed.
+    /// (Tls/Io/Http failures); `None` when we errored at `Connect`, and always
+    /// `None` on `Timeout` regardless of how far the attempt got — see
+    /// [`Self::tcp_wrote`].
     pub socks5_ms: Option<u64>,
     /// Time spent inside `tokio_rustls::TlsConnector::connect(...)`.
     /// `Some` on `Tls`/`Io`/`Http` layers; `None` otherwise.
@@ -164,6 +165,12 @@ pub struct UpstreamErr {
     /// observed by [`crate::dns::connector::CountingStream`]. `None` when
     /// connect failed (no stream existed). Post-SOCKS5 byte counts —
     /// what a DoH server would see.
+    ///
+    /// ALSO `None` on the `Timeout` layer, whatever had already happened: the
+    /// budget fires outside the per-transport future, which owns the counters,
+    /// so a timed-out attempt that connected, handshook and wrote is
+    /// indistinguishable here from one that never connected. Do not read
+    /// `tcp_wrote = None` on `layer=timeout` as "never connected".
     pub tcp_wrote: Option<u64>,
     pub tcp_read: Option<u64>,
     /// First `io::Error::raw_os_error()` found walking
@@ -206,8 +213,8 @@ impl UpstreamErr {
     }
 
     /// Classify this failure for reporting. Only the `Tls` layer needs the
-    /// error chain — it splits on whether `first_rustls_error` found an
-    /// `InvalidCertificate` / `InvalidCertRevocationList` rustls error.
+    /// error chain — it splits on whether `first_rustls_error` found a
+    /// TRUST-CHAIN rejection (see [`is_trust_chain_rejection`]).
     pub fn cause(&self) -> UpstreamCause {
         match self.layer {
             UpstreamLayer::Connect => UpstreamCause::Unreachable,
@@ -215,9 +222,7 @@ impl UpstreamErr {
             UpstreamLayer::Http => UpstreamCause::BadResponse,
             UpstreamLayer::Io => UpstreamCause::Io,
             UpstreamLayer::Tls => match first_rustls_error(&self.source) {
-                Some(rustls::Error::InvalidCertificate(_) | rustls::Error::InvalidCertRevocationList(_)) => {
-                    UpstreamCause::CertificateRejected
-                }
+                Some(e) if is_trust_chain_rejection(e) => UpstreamCause::CertificateRejected,
                 _ => UpstreamCause::TlsFailed,
             },
         }
@@ -263,6 +268,36 @@ fn first_os_errno(e: &(dyn std::error::Error + 'static)) -> Option<i32> {
         current = err.source();
     }
     None
+}
+
+/// Does this rustls error mean the peer's chain did not verify against our
+/// trust roots — as opposed to any other certificate complaint?
+///
+/// Only trust-chain rejections justify telling the user something may be
+/// intercepting TLS. `InvalidCertificate` is much broader than that: it also
+/// carries `NotValidForName` (routine for a free-form resolver IP, since
+/// `https_target_for` falls back to IP-SAN verification for addresses outside
+/// the provider table) and `Expired` (a skewed system clock). Reporting those
+/// as interception would accuse the network of something the user's own
+/// configuration or clock caused, and — unlike a real interception — switching
+/// resolvers WOULD fix them.
+///
+/// `CertificateError` is `#[non_exhaustive]`, so the fallthrough deliberately
+/// answers "not a trust-chain rejection": a future variant we have not
+/// considered must not silently inherit the interception claim.
+fn is_trust_chain_rejection(e: &rustls::Error) -> bool {
+    match e {
+        rustls::Error::InvalidCertificate(c) => matches!(
+            c,
+            rustls::CertificateError::UnknownIssuer
+                | rustls::CertificateError::BadSignature
+                | rustls::CertificateError::Revoked
+                | rustls::CertificateError::UnknownRevocationStatus
+        ),
+        // A CRL we could not verify is a trust-material failure in its own right.
+        rustls::Error::InvalidCertRevocationList(_) => true,
+        _ => false,
+    }
 }
 
 /// Walk the chain for a `rustls::Error`. tokio-rustls reports a verification
@@ -876,7 +911,6 @@ impl DnsForwarder {
         extra_root: rustls_pki_types::CertificateDer<'static>,
         forced_port: u16,
     ) -> Self {
-        // One port for EVERY server — never a partial override.
         let ports = vec![forced_port; config.servers.len()];
         let mut s = Self::new_with_ports(config, connector, ipv6_bypass_available, ports);
         s.tls_config = Arc::new(build_tls_config_with_extra_root(extra_root));
@@ -945,6 +979,19 @@ fn parse_http_dns_response(resp: &[u8]) -> io::Result<Vec<u8>> {
 fn find_double_crlf(buf: &[u8]) -> Option<usize> {
     const NEEDLE: &[u8] = b"\r\n\r\n";
     buf.windows(NEEDLE.len()).position(|w| w == NEEDLE)
+}
+
+/// Test-only adapter for `DohQuerier` stubs that model a resolver by building
+/// an answer or not building one. `None` means "this resolver served no record
+/// of that type" — a resolver that ANSWERED with nothing, which is `Ok` at the
+/// seam, not an `Err`. Collapses the six stubs that would otherwise each
+/// re-derive that mapping by hand.
+#[cfg(test)]
+pub(crate) fn answered_or_servfail(
+    wire: &[u8],
+    build: impl FnOnce() -> Option<Vec<u8>>,
+) -> Result<Vec<u8>, UpstreamCause> {
+    Ok(build().unwrap_or_else(|| synthesize_servfail(wire)))
 }
 
 /// Build a SERVFAIL response from an incoming query. Preserves the

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -107,10 +107,6 @@ impl UpstreamCause {
     /// ties keep the first observed. Ordered by how much each cause tells the
     /// user: a rejected certificate names a third party on the path, a failed
     /// connect says only that the path is broken.
-    ///
-    /// A contract that outlives any single caller: `rank` decides how several
-    /// upstream failures fold into one, independent of how many servers a
-    /// given caller passes.
     pub fn rank(self) -> u8 {
         match self {
             Self::CertificateRejected => 5,
@@ -298,8 +294,7 @@ const DNS_PORT_HTTPS: u16 = 443;
 
 /// Default per-upstream attempt budget, used by [`DnsForwarder::forward`].
 /// Shorter than the OS default TCP timeout so a dead server doesn't stall the
-/// whole forward loop. Callers with their own budget pass it to
-/// [`DnsForwarder::try_forward`] instead of wrapping the call in a `timeout`.
+/// whole forward loop.
 pub(crate) const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Maximum reply size we'll buffer (bytes). DNS messages cap around 65535

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -70,6 +70,76 @@ impl std::fmt::Display for UpstreamLayer {
     }
 }
 
+/// Coarse, `Copy` classification of an upstream failure. `UpstreamErr` owns an
+/// `io::Error` and is neither `Clone` nor `Eq`, so this is what travels out of
+/// the forwarder into a comparable error enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpstreamCause {
+    /// Connect never completed — refused, unreachable, or a SOCKS5 failure.
+    Unreachable,
+    /// The peer's certificate chain did not verify against our trust roots.
+    CertificateRejected,
+    /// TLS failed for a non-certificate reason: unclean EOF, fatal alert,
+    /// version or cipher mismatch.
+    TlsFailed,
+    /// The DoH response was non-200, malformed, or truncated.
+    BadResponse,
+    /// Post-handshake read/write failure on the upstream stream.
+    Io,
+    /// The per-upstream budget fired before the attempt completed.
+    Timeout,
+}
+
+impl UpstreamCause {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unreachable => "unreachable",
+            Self::CertificateRejected => "certificate-rejected",
+            Self::TlsFailed => "tls-failed",
+            Self::BadResponse => "bad-response",
+            Self::Io => "io",
+            Self::Timeout => "timeout",
+        }
+    }
+
+    /// Report priority when several upstreams fail differently — highest wins,
+    /// ties keep the first observed. Ordered by how much each cause tells the
+    /// user: a rejected certificate names a third party on the path, a failed
+    /// connect says only that the path is broken.
+    ///
+    /// A contract that outlives any single caller: `rank` decides how several
+    /// upstream failures fold into one, independent of how many servers a
+    /// given caller passes.
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::CertificateRejected => 5,
+            Self::TlsFailed => 4,
+            Self::BadResponse => 3,
+            Self::Io => 2,
+            Self::Timeout => 1,
+            Self::Unreachable => 0,
+        }
+    }
+}
+
+impl std::fmt::Display for UpstreamCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Why [`DnsForwarder::try_forward`] produced no reply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardFailure {
+    /// The query is shorter than the 12-byte DNS header — a caller bug.
+    MalformedQuery,
+    /// Nothing was attempted: no servers configured, or every configured
+    /// server was skipped (IPv6 with no IPv6 bypass).
+    NoUpstream,
+    /// Every attempted upstream failed; carries the highest-ranked cause.
+    Upstream(UpstreamCause),
+}
+
 /// Tagged upstream failure: `{ layer, source, elapsed_ms }` plus optional
 /// diagnostic context captured at the point of failure. `io::Error` is
 /// `!Clone`, so `UpstreamErr` cannot be `Clone` — consumed once on the
@@ -132,6 +202,24 @@ impl UpstreamErr {
         self.tcp_wrote = Some(c.written());
         self
     }
+
+    /// Classify this failure for reporting. Only the `Tls` layer needs the
+    /// error chain — it splits on whether `first_rustls_error` found an
+    /// `InvalidCertificate` / `InvalidCertRevocationList` rustls error.
+    pub fn cause(&self) -> UpstreamCause {
+        match self.layer {
+            UpstreamLayer::Connect => UpstreamCause::Unreachable,
+            UpstreamLayer::Timeout => UpstreamCause::Timeout,
+            UpstreamLayer::Http => UpstreamCause::BadResponse,
+            UpstreamLayer::Io => UpstreamCause::Io,
+            UpstreamLayer::Tls => match first_rustls_error(&self.source) {
+                Some(rustls::Error::InvalidCertificate(_) | rustls::Error::InvalidCertRevocationList(_)) => {
+                    UpstreamCause::CertificateRejected
+                }
+                _ => UpstreamCause::TlsFailed,
+            },
+        }
+    }
 }
 
 /// Walk `std::error::Error::source()` and join the chain with ` -> `.
@@ -165,6 +253,27 @@ fn first_os_errno(e: &(dyn std::error::Error + 'static)) -> Option<i32> {
             if let Some(errno) = io_err.raw_os_error() {
                 return Some(errno);
             }
+            if let Some(inner) = io_err.get_ref() {
+                current = Some(inner);
+                continue;
+            }
+        }
+        current = err.source();
+    }
+    None
+}
+
+/// Walk the chain for a `rustls::Error`. tokio-rustls reports a verification
+/// failure as `io::Error::new(InvalidData, rustls::Error)`, so the rustls error
+/// hangs off `io::Error::get_ref()` — `io::Error::source()` skips the wrapper
+/// and would hide it. Same descent as [`first_os_errno`].
+fn first_rustls_error<'a>(e: &'a (dyn std::error::Error + 'static)) -> Option<&'a rustls::Error> {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(err) = current {
+        if let Some(r) = err.downcast_ref::<rustls::Error>() {
+            return Some(r);
+        }
+        if let Some(io_err) = err.downcast_ref::<io::Error>() {
             if let Some(inner) = io_err.get_ref() {
                 current = Some(inner);
                 continue;
@@ -402,6 +511,7 @@ impl DnsForwarder {
                     %server,
                     protocol = ?self.config.protocol,
                     layer = %e.layer,
+                    cause = %e.cause(),
                     elapsed_ms = e.elapsed_ms,
                     budget_ms = UPSTREAM_TIMEOUT.as_millis() as u64,
                     socks5_ms = ?e.socks5_ms,

--- a/crates/bridge/src/dns/forwarder.rs
+++ b/crates/bridge/src/dns/forwarder.rs
@@ -470,6 +470,22 @@ impl DnsForwarder {
     /// pass this rather than wrapping the call in its own `timeout`: an outer
     /// timer that fires first drops the future before `forward_one`'s deadline,
     /// so nothing is classified and nothing is logged.
+    /// How many configured upstreams a walk will ACTUALLY attempt. IPv6 entries
+    /// are skipped without an IPv6 bypass, so this can be less than
+    /// `servers.len()` — and zero, for an all-IPv6 config on an IPv4-only host,
+    /// where a walk returns `NoUpstream` without dialling anything.
+    ///
+    /// A caller that owns a total budget divides by this to size the
+    /// `per_upstream` it passes to [`Self::try_forward`]. The skip rule lives
+    /// here, next to the loop that applies it, so a caller cannot drift from it.
+    pub fn attempted_upstreams(&self) -> usize {
+        self.config
+            .servers
+            .iter()
+            .filter(|s| !s.is_ipv6() || self.ipv6_bypass_available)
+            .count()
+    }
+
     pub async fn try_forward(&self, query: &[u8], per_upstream: Duration) -> Result<Vec<u8>, ForwardFailure> {
         if query.len() < 12 {
             // A caller bug, and the one failure with no per-upstream WARN

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -327,6 +327,87 @@ fn first_os_errno_returns_none_for_pure_custom_error() {
     assert_eq!(first_os_errno(&e), None);
 }
 
+// Rustls-error extraction + cause classification ======================================================================
+
+#[skuld::test]
+fn first_rustls_error_found_through_tokio_rustls_wrapper() {
+    // tokio-rustls's exact wrap shape — see first_rustls_error's doc.
+    let inner = rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer);
+    let outer = io::Error::new(io::ErrorKind::InvalidData, inner.clone());
+    assert_eq!(first_rustls_error(&outer), Some(&inner));
+}
+
+#[skuld::test]
+fn first_rustls_error_is_none_for_plain_socket_error() {
+    let e = io::Error::from_raw_os_error(10054); // WSAECONNRESET
+    assert_eq!(first_rustls_error(&e), None);
+}
+
+#[skuld::test]
+fn cause_of_tls_layer_with_cert_error_is_certificate_rejected() {
+    // Both trust-rejection families, not just the UnknownIssuer one.
+    for rustls_err in [
+        rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::Expired),
+        rustls::Error::InvalidCertRevocationList(rustls::CertRevocationListError::BadSignature),
+    ] {
+        let e = UpstreamErr::new(
+            UpstreamLayer::Tls,
+            io::Error::new(io::ErrorKind::InvalidData, rustls_err.clone()),
+        );
+        assert_eq!(e.cause(), UpstreamCause::CertificateRejected, "{rustls_err:?}");
+    }
+}
+
+#[skuld::test]
+fn cause_of_tls_layer_without_cert_error_is_tls_failed() {
+    // tokio-rustls's unclean-EOF shape: a Custom error carrying no rustls error.
+    let e = UpstreamErr::new(
+        UpstreamLayer::Tls,
+        io::Error::new(io::ErrorKind::UnexpectedEof, "tls handshake eof"),
+    );
+    assert_eq!(e.cause(), UpstreamCause::TlsFailed);
+}
+
+#[skuld::test]
+fn cause_of_non_tls_layers_follows_the_layer_tag() {
+    let refused = UpstreamErr::new(
+        UpstreamLayer::Connect,
+        io::Error::from(io::ErrorKind::ConnectionRefused),
+    );
+    assert_eq!(refused.cause(), UpstreamCause::Unreachable);
+    let timed_out = UpstreamErr::new(
+        UpstreamLayer::Timeout,
+        io::Error::new(io::ErrorKind::TimedOut, "upstream timeout"),
+    );
+    assert_eq!(timed_out.cause(), UpstreamCause::Timeout);
+    let http = UpstreamErr::new(UpstreamLayer::Http, io::Error::other("non-200 DoH response"));
+    assert_eq!(http.cause(), UpstreamCause::BadResponse);
+    let io_err = UpstreamErr::new(UpstreamLayer::Io, io::Error::from(io::ErrorKind::BrokenPipe));
+    assert_eq!(io_err.cause(), UpstreamCause::Io);
+}
+
+#[skuld::test]
+fn upstream_cause_ranking_is_total_and_ordered() {
+    // Pins the total order `rank` promises across every UpstreamCause variant.
+    let order = [
+        UpstreamCause::Unreachable,
+        UpstreamCause::Timeout,
+        UpstreamCause::Io,
+        UpstreamCause::BadResponse,
+        UpstreamCause::TlsFailed,
+        UpstreamCause::CertificateRejected,
+    ];
+    for pair in order.windows(2) {
+        assert!(
+            pair[1].rank() > pair[0].rank(),
+            "{:?} must outrank {:?}",
+            pair[1],
+            pair[0]
+        );
+    }
+}
+
 // Short-query safety ==================================================================================================
 
 #[skuld::test]

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -313,7 +313,7 @@ async fn silent_tcp_peer() -> (SocketAddr, tokio::sync::oneshot::Receiver<()>) {
     tokio::spawn(async move {
         let (tcp, _) = listener.accept().await.unwrap();
         let _ = accepted_tx.send(());
-        std::future::pending::<()>().await; // Hold it open, never write.
+        std::future::pending::<()>().await;
         drop(tcp);
     });
     (addr, accepted_rx)
@@ -464,11 +464,11 @@ fn first_rustls_error_is_none_for_plain_socket_error() {
 }
 
 #[skuld::test]
-fn cause_of_tls_layer_with_cert_error_is_certificate_rejected() {
+fn cause_of_tls_layer_with_a_trust_chain_rejection_is_certificate_rejected() {
     // Both trust-rejection families, not just the UnknownIssuer one.
     for rustls_err in [
         rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer),
-        rustls::Error::InvalidCertificate(rustls::CertificateError::Expired),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::BadSignature),
         rustls::Error::InvalidCertRevocationList(rustls::CertRevocationListError::BadSignature),
     ] {
         let e = UpstreamErr::new(
@@ -476,6 +476,28 @@ fn cause_of_tls_layer_with_cert_error_is_certificate_rejected() {
             io::Error::new(io::ErrorKind::InvalidData, rustls_err.clone()),
         );
         assert_eq!(e.cause(), UpstreamCause::CertificateRejected, "{rustls_err:?}");
+    }
+}
+
+#[skuld::test]
+fn cause_of_a_non_trust_certificate_complaint_is_not_certificate_rejected() {
+    // A resolver IP outside the provider table is verified against an IP SAN,
+    // so a cert carrying only DNS SANs fails with NotValidForName on every
+    // start, on a clean network — and a skewed clock yields Expired. Reporting
+    // either as interception would blame the network for the user's config or
+    // clock, and would tell them switching resolvers cannot help when it is in
+    // fact the fix.
+    for rustls_err in [
+        rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidForName),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::Expired),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidYet),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding),
+    ] {
+        let e = UpstreamErr::new(
+            UpstreamLayer::Tls,
+            io::Error::new(io::ErrorKind::InvalidData, rustls_err.clone()),
+        );
+        assert_eq!(e.cause(), UpstreamCause::TlsFailed, "{rustls_err:?}");
     }
 }
 

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -96,12 +96,27 @@ async fn start_tcp_stub(reply: Vec<u8>) -> (SocketAddr, tokio::task::JoinHandle<
     (addr, h)
 }
 
-/// A closed listener, pre-computed so the connect attempt fails.
-async fn unused_tcp_port() -> SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    drop(listener);
-    addr
+/// A TCP port held by a bound-but-never-listened socket: every connect to it is
+/// refused, and no concurrently-running test can bind it away. The returned
+/// socket must stay alive for the reservation to hold.
+fn refused_tcp_port() -> (socket2::Socket, SocketAddr) {
+    use socket2::{Domain, Socket, Type};
+    let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    sock.bind(&SocketAddr::from(([127, 0, 0, 1], 0)).into()).unwrap();
+    let addr = sock.local_addr().unwrap().as_socket().unwrap();
+    // No `listen()`: the stack RSTs incoming SYNs instead of queueing them.
+    (sock, addr)
+}
+
+#[skuld::test]
+async fn refused_tcp_port_is_refused_and_not_rebindable() {
+    let (_held, addr) = refused_tcp_port();
+    let err = tokio::net::TcpStream::connect(addr).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
+    assert!(
+        TcpListener::bind(addr).await.is_err(),
+        "the held socket must keep the port un-bindable"
+    );
 }
 
 fn build_cfg(protocol: DnsProtocol, servers: Vec<IpAddr>) -> DnsConfig {
@@ -267,7 +282,7 @@ async fn duplicate_server_in_list_creates_one_throttle_entry() {
     // Two identical dead addresses share one per-IP throttle entry; a
     // single failure burst against the same server doesn't duplicate
     // state across the map.
-    let dead_addr = unused_tcp_port().await;
+    let (_held, dead_addr) = refused_tcp_port();
     let fwd = DnsForwarder::new(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), dead_addr.ip()]),
         Arc::new(DirectConnector),
@@ -290,7 +305,7 @@ async fn throttle_logs_first_n_then_suppresses() {
     // Pins the per-server log throttle: the first LOG_FULL_LIMIT=3
     // failures log in full, subsequent ones are counted as suppressed
     // (never silently dedup-forever).
-    let dead_addr = unused_tcp_port().await;
+    let (_held, dead_addr) = refused_tcp_port();
     let fwd = DnsForwarder::new(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip()]),
         Arc::new(DirectConnector),
@@ -622,7 +637,7 @@ mod typed_error_logs {
         );
         let _guard = set_default_in_current_thread(subscriber);
 
-        let dead = unused_tcp_port().await;
+        let (_held, dead) = refused_tcp_port();
         let fwd = DnsForwarder::new(
             build_cfg(DnsProtocol::PlainTcp, vec![dead.ip()]),
             Arc::new(DirectConnector),
@@ -656,7 +671,7 @@ mod typed_error_logs {
         );
         let _guard = set_default_in_current_thread(subscriber);
 
-        let dead = unused_tcp_port().await;
+        let (_held, dead) = refused_tcp_port();
         let fwd = DnsForwarder::new(
             build_cfg(DnsProtocol::PlainTcp, vec![dead.ip()]),
             Arc::new(DirectConnector),

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -183,6 +183,13 @@ async fn primary_fails_secondary_succeeds() {
     let q = sample_query(0x0001);
     let dead_addr = dead_addr(0);
     let (live_addr, _h) = start_tcp_stub(Vec::new()).await;
+    // The refuse list matches by exact SocketAddr and the stub's port is
+    // kernel-assigned, so pin the premise: a collision would refuse the
+    // secondary too and read as a failover regression.
+    assert_ne!(
+        live_addr, dead_addr,
+        "the refuse list must not swallow the live secondary"
+    );
 
     let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), live_addr.ip()]),
@@ -467,12 +474,9 @@ fn cause_of_tls_layer_with_a_trust_chain_rejection_is_certificate_rejected() {
 
 #[skuld::test]
 fn cause_of_a_non_trust_certificate_complaint_is_not_certificate_rejected() {
-    // A resolver IP outside the provider table is verified against an IP SAN,
-    // so a cert carrying only DNS SANs fails with NotValidForName on every
-    // start, on a clean network — and a skewed clock yields Expired. Reporting
-    // either as interception would blame the network for the user's config or
-    // clock, and would tell them switching resolvers cannot help when it is in
-    // fact the fix.
+    // The non-trust CertificateError variants `is_trust_chain_rejection`'s doc
+    // explains must not be reported as interception: they come from the user's
+    // own config or clock, not the network.
     for rustls_err in [
         // A CRL we merely could not parse is a fault in material we supply, not
         // an interceptor's doing — it must not inherit the interception claim.

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -469,6 +469,8 @@ fn cause_of_tls_layer_with_a_trust_chain_rejection_is_certificate_rejected() {
     for rustls_err in [
         rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer),
         rustls::Error::InvalidCertificate(rustls::CertificateError::BadSignature),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::Revoked),
+        rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownRevocationStatus),
         rustls::Error::InvalidCertRevocationList(rustls::CertRevocationListError::BadSignature),
     ] {
         let e = UpstreamErr::new(

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -178,62 +178,168 @@ fn servfail_handles_short_input() {
 async fn plain_udp_primary_succeeds() {
     let q = sample_query(0x0042);
     let (addr, _h) = start_udp_stub(None).await;
-    let fwd = DnsForwarder::new(
+    let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainUdp, vec![addr.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![addr.port()],
     );
-    // Override server list to include the ephemeral port via the connector
-    // layer: the forwarder always targets port 53, but our stub listens on
-    // ephemeral — so we swap via a test-only helper.
-    let reply = fwd.forward_on_port(&q, addr.port()).await;
+    let reply = fwd.forward(&q).await;
     assert_eq!(&reply[..2], &[0x00, 0x42], "tx id echoed");
     assert_eq!(reply[2] & 0x80, 0x80, "QR set (real reply, not SERVFAIL)");
     assert_ne!(reply[3] & 0x0F, 2, "RCODE is not SERVFAIL");
 }
 
 #[skuld::test]
-async fn plain_udp_primary_fails_secondary_succeeds() {
+async fn primary_fails_secondary_succeeds() {
+    // Failover is in `try_forward`'s server loop, not in any one transport.
+    // TCP so the dead primary's port can be HELD: a released ephemeral port can
+    // be re-bound by a concurrent test, and a primary that answers makes this
+    // test silently stop testing failover.
     let q = sample_query(0x0001);
-    // Primary: bind then drop to get a closed port.
-    let dead = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-    let dead_addr = dead.local_addr().unwrap();
-    drop(dead);
-    let (live_addr, _h) = start_udp_stub(None).await;
+    let (_held, dead_addr) = refused_tcp_port();
+    let (live_addr, _h) = start_tcp_stub(Vec::new()).await;
 
-    let fwd = DnsForwarder::new(
-        DnsConfig {
-            enabled: true,
-            servers: vec![dead_addr.ip(), live_addr.ip()],
-            protocol: DnsProtocol::PlainUdp,
-            allow_insecure_bootstrap: false,
-        },
+    let fwd = DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), live_addr.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![dead_addr.port(), live_addr.port()],
     );
-    // Both stubs live on 127.0.0.1 but different ports; the test helper
-    // overrides the forwarder's port. Since we can only override one port,
-    // use two distinct addresses via the `forward_with_ports` helper.
-    let reply = fwd.forward_with_ports(&q, &[dead_addr.port(), live_addr.port()]).await;
-    // We expect success from the second server.
+    let reply = fwd.forward(&q).await;
+    assert_eq!(&reply[..2], &[0x00, 0x01], "tx id echoed by the secondary");
     assert_ne!(reply[3] & 0x0F, 2, "secondary succeeded, not SERVFAIL");
+    // Both servers are 127.0.0.1, so one throttle entry — and it exists only
+    // because an attempt FAILED. Pins the premise: the primary really did fail.
+    let map = fwd.failure_throttle.lock().unwrap();
+    let state = map.get(&dead_addr.ip()).expect("the primary must have failed");
+    assert!(state.logged >= 1, "the primary must have failed");
 }
 
 #[skuld::test]
 async fn all_servers_fail_returns_servfail() {
     let q = sample_query(0x5678);
-    // Two closed addresses.
-    let s1 = UdpSocket::bind("127.0.0.1:0").await.unwrap().local_addr().unwrap();
-    let s2 = UdpSocket::bind("127.0.0.1:0").await.unwrap().local_addr().unwrap();
-    let fwd = DnsForwarder::new(
+    let (_h1, s1) = refused_tcp_port();
+    let (_h2, s2) = refused_tcp_port();
+    let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![s1.ip(), s2.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![s1.port(), s2.port()],
     );
-    // Use TCP (closed address → immediate RST or connect failure).
-    let reply = fwd.forward_with_ports(&q, &[s1.port(), s2.port()]).await;
+    let reply = fwd.forward(&q).await;
     assert_eq!(reply[3] & 0x0F, 2, "RCODE=SERVFAIL");
     assert_eq!(&reply[..2], &[0x56, 0x78]);
+}
+
+#[skuld::test]
+async fn try_forward_reports_unreachable_when_every_server_refuses() {
+    let q = sample_query(0x5678);
+    let (_h1, s1) = refused_tcp_port();
+    let (_h2, s2) = refused_tcp_port();
+    let fwd = DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::PlainTcp, vec![s1.ip(), s2.ip()]),
+        Arc::new(DirectConnector),
+        true,
+        vec![s1.port(), s2.port()],
+    );
+    assert_eq!(
+        fwd.try_forward(&q, UPSTREAM_TIMEOUT).await,
+        Err(ForwardFailure::Upstream(UpstreamCause::Unreachable))
+    );
+}
+
+#[skuld::test]
+async fn try_forward_reports_malformed_query_and_no_upstream() {
+    let (addr, _h) = start_udp_stub(None).await;
+    let fwd = DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::PlainUdp, vec![addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+        vec![addr.port()],
+    );
+    assert_eq!(
+        fwd.try_forward(b"abc", UPSTREAM_TIMEOUT).await,
+        Err(ForwardFailure::MalformedQuery)
+    );
+
+    // Every configured server skipped (IPv6 with no IPv6 bypass) — nothing was
+    // attempted, which is not the same as an upstream failing.
+    let v6: IpAddr = "2001:db8::1".parse().unwrap();
+    let none = DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::PlainUdp, vec![v6]),
+        Arc::new(DirectConnector),
+        false,
+        vec![0],
+    );
+    assert_eq!(
+        none.try_forward(&sample_query(1), UPSTREAM_TIMEOUT).await,
+        Err(ForwardFailure::NoUpstream)
+    );
+}
+
+#[skuld::test]
+async fn try_forward_reports_tls_failed_when_the_peer_closes_mid_handshake() {
+    // Accept, then close gracefully (FIN, not RST — an RST races connect() on
+    // Linux/macOS loopback). tokio-rustls reports an unclean EOF with no rustls
+    // error attached: TlsFailed, not CertificateRejected.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((tcp, _)) = listener.accept().await {
+            drop(tcp);
+        }
+    });
+    let fwd = DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::Https, vec![addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+        vec![addr.port()],
+    );
+    assert_eq!(
+        fwd.try_forward(&sample_query(0x0009), UPSTREAM_TIMEOUT).await,
+        Err(ForwardFailure::Upstream(UpstreamCause::TlsFailed))
+    );
+}
+
+/// Accept one connection, signal it, and never write. Returns the address and
+/// a receiver that fires once the connection is ESTABLISHED — a real
+/// rendezvous, so the timeout tests advance virtual time only after the
+/// connect has completed rather than racing it.
+async fn silent_tcp_peer() -> (SocketAddr, tokio::sync::oneshot::Receiver<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        let _ = accepted_tx.send(());
+        std::future::pending::<()>().await; // Hold it open, never write.
+        drop(tcp);
+    });
+    (addr, accepted_rx)
+}
+
+#[skuld::test]
+async fn try_forward_reports_timeout_when_an_established_peer_stays_silent() {
+    let (addr, accepted_rx) = silent_tcp_peer().await;
+    let fwd = Arc::new(DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::PlainTcp, vec![addr.ip()]),
+        Arc::new(DirectConnector),
+        true,
+        vec![addr.port()],
+    ));
+    let call = tokio::spawn({
+        let fwd = Arc::clone(&fwd);
+        async move { fwd.try_forward(&sample_query(0x000A), UPSTREAM_TIMEOUT).await }
+    });
+
+    accepted_rx.await.expect("stub accepted the connection");
+    tokio::time::pause();
+
+    assert_eq!(
+        call.await.unwrap(),
+        Err(ForwardFailure::Upstream(UpstreamCause::Timeout))
+    );
 }
 
 // Forward: TCP ========================================================================================================
@@ -242,12 +348,13 @@ async fn all_servers_fail_returns_servfail() {
 async fn plain_tcp_primary_succeeds() {
     let q = sample_query(0x00AA);
     let (addr, _h) = start_tcp_stub(Vec::new()).await;
-    let fwd = DnsForwarder::new(
+    let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![addr.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![addr.port()],
     );
-    let reply = fwd.forward_on_port(&q, addr.port()).await;
+    let reply = fwd.forward(&q).await;
     assert_eq!(&reply[..2], &[0x00, 0xAA]);
     assert_eq!(reply[2] & 0x80, 0x80);
     assert_ne!(reply[3] & 0x0F, 2);
@@ -260,17 +367,13 @@ async fn ipv6_upstream_skipped_when_no_v6_bypass() {
     let q = sample_query(0x0003);
     let v6: IpAddr = "2001:db8::1".parse().unwrap();
     let (v4_addr, _h) = start_udp_stub(None).await;
-    let fwd = DnsForwarder::new(
-        DnsConfig {
-            enabled: true,
-            servers: vec![v6, v4_addr.ip()],
-            protocol: DnsProtocol::PlainUdp,
-            allow_insecure_bootstrap: false,
-        },
+    let fwd = DnsForwarder::new_with_ports(
+        build_cfg(DnsProtocol::PlainUdp, vec![v6, v4_addr.ip()]),
         Arc::new(DirectConnector),
         false, // no v6 bypass
+        vec![0, v4_addr.port()],
     );
-    let reply = fwd.forward_with_ports(&q, &[0, v4_addr.port()]).await;
+    let reply = fwd.forward(&q).await;
     // The v6 server was skipped; v4 answered.
     assert_ne!(reply[3] & 0x0F, 2);
 }
@@ -283,13 +386,14 @@ async fn duplicate_server_in_list_creates_one_throttle_entry() {
     // single failure burst against the same server doesn't duplicate
     // state across the map.
     let (_held, dead_addr) = refused_tcp_port();
-    let fwd = DnsForwarder::new(
+    let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), dead_addr.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![dead_addr.port(), dead_addr.port()],
     );
     let q = sample_query(0x0001);
-    let _ = fwd.forward_with_ports(&q, &[dead_addr.port(), dead_addr.port()]).await;
+    let _ = fwd.forward(&q).await;
     let map = fwd.failure_throttle.lock().unwrap();
     assert_eq!(map.len(), 1, "duplicate server has one throttle entry");
     let state = map.get(&dead_addr.ip()).expect("throttle entry exists");
@@ -306,15 +410,16 @@ async fn throttle_logs_first_n_then_suppresses() {
     // failures log in full, subsequent ones are counted as suppressed
     // (never silently dedup-forever).
     let (_held, dead_addr) = refused_tcp_port();
-    let fwd = DnsForwarder::new(
+    let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![dead_addr.port()],
     );
     let q = sample_query(0x0002);
     // 5 attempts against the same server.
     for _ in 0..5 {
-        let _ = fwd.forward_with_ports(&q, &[dead_addr.port()]).await;
+        let _ = fwd.forward(&q).await;
     }
     let map = fwd.failure_throttle.lock().unwrap();
     let state = map.get(&dead_addr.ip()).expect("throttle entry exists");
@@ -429,51 +534,15 @@ fn upstream_cause_ranking_is_total_and_ordered() {
 async fn forward_on_short_query_returns_servfail() {
     let short = b"abc"; // below 12-byte DNS header
     let (addr, _h) = start_udp_stub(None).await;
-    let fwd = DnsForwarder::new(
+    let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainUdp, vec![addr.ip()]),
         Arc::new(DirectConnector),
         true,
+        vec![addr.port()],
     );
-    let reply = fwd.forward_on_port(short, addr.port()).await;
+    let reply = fwd.forward(short).await;
     assert!(reply.len() >= 12);
     assert_eq!(reply[3] & 0x0F, 2);
-}
-
-// Test-only helpers allowing ephemeral-port stubs =====================================================================
-//
-// The forwarder always targets fixed well-known ports (53/853/443). Tests
-// need ephemeral ports to run without privilege. These helpers mirror the
-// public API but let tests substitute the port.
-
-impl DnsForwarder {
-    async fn forward_on_port(&self, query: &[u8], port: u16) -> Vec<u8> {
-        self.forward_with_ports(query, &[port]).await
-    }
-
-    async fn forward_with_ports(&self, query: &[u8], ports: &[u16]) -> Vec<u8> {
-        if query.len() < 12 {
-            return synthesize_servfail(query);
-        }
-        for (i, &server) in self.config.servers.iter().enumerate() {
-            if server.is_ipv6() && !self.ipv6_bypass_available {
-                self.log_ipv6_skip_once(server);
-                continue;
-            }
-            let port = ports.get(i).copied().unwrap_or(match self.config.protocol {
-                DnsProtocol::PlainUdp | DnsProtocol::PlainTcp => 53,
-                DnsProtocol::Tls => 853,
-                DnsProtocol::Https => 443,
-            });
-            let target = SocketAddr::new(server, port);
-            // Delegate to the production `forward_one` — now `SocketAddr`-shaped,
-            // so ephemeral-port stubs work without any in-test protocol inlining.
-            match self.forward_one(target, query).await {
-                Ok(reply) => return reply,
-                Err(e) => self.log_upstream_failure(server, &e),
-            }
-        }
-        synthesize_servfail(query)
-    }
 }
 
 // URL split helpers (whitebox) ========================================================================================
@@ -638,12 +707,13 @@ mod typed_error_logs {
         let _guard = set_default_in_current_thread(subscriber);
 
         let (_held, dead) = refused_tcp_port();
-        let fwd = DnsForwarder::new(
+        let fwd = DnsForwarder::new_with_ports(
             build_cfg(DnsProtocol::PlainTcp, vec![dead.ip()]),
             Arc::new(DirectConnector),
             true,
+            vec![dead.port()],
         );
-        let _ = fwd.forward_on_port(&sample_query(0x0001), dead.port()).await;
+        let _ = fwd.forward(&sample_query(0x0001)).await;
 
         let output = writer.snapshot_string();
         assert!(
@@ -672,12 +742,13 @@ mod typed_error_logs {
         let _guard = set_default_in_current_thread(subscriber);
 
         let (_held, dead) = refused_tcp_port();
-        let fwd = DnsForwarder::new(
+        let fwd = DnsForwarder::new_with_ports(
             build_cfg(DnsProtocol::PlainTcp, vec![dead.ip()]),
             Arc::new(DirectConnector),
             true,
+            vec![dead.port()],
         );
-        let _ = fwd.forward_on_port(&sample_query(0x0002), dead.port()).await;
+        let _ = fwd.forward(&sample_query(0x0002)).await;
 
         let output = writer.snapshot_string();
         assert!(
@@ -708,17 +779,76 @@ mod typed_error_logs {
                 drop(stream);
             }
         });
-        let fwd = DnsForwarder::new(
+        let fwd = DnsForwarder::new_with_ports(
             build_cfg(DnsProtocol::PlainTcp, vec![addr.ip()]),
             Arc::new(DirectConnector),
             true,
+            vec![addr.port()],
         );
-        let _ = fwd.forward_on_port(&sample_query(0x0003), addr.port()).await;
+        let _ = fwd.forward(&sample_query(0x0003)).await;
 
         let output = writer.snapshot_string();
         assert!(
             output.contains("layer=io"),
             "expected 'layer=io' for EOF mid-exchange; got:\n{output}"
+        );
+    }
+
+    /// A caller-supplied budget must reach `forward_one` AND still produce the
+    /// `upstream failed` WARN. `budget_ms` is stamped inside `forward_one` from
+    /// the deadline it actually applied, so asserting it discriminates a
+    /// honored budget from an ignored one without measuring elapsed time — the
+    /// virtual clock's quantisation and the real time spent connecting make any
+    /// exact elapsed-span assertion a race, not a measurement.
+    /// The failure this guards: an outer `timeout` firing before
+    /// `forward_one`'s own deadline drops the future with nothing classified
+    /// or logged.
+    #[skuld::test]
+    async fn expired_caller_budget_still_logs_the_upstream_failure() {
+        let writer = VecWriter::new();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .with_writer(writer.clone())
+                .with_ansi(false)
+                .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+        );
+        let _guard = set_default_in_current_thread(subscriber);
+
+        const CALLER_BUDGET: Duration = Duration::from_millis(1500);
+        assert!(CALLER_BUDGET < UPSTREAM_TIMEOUT, "the budget must be the tighter one");
+
+        let (addr, accepted_rx) = super::silent_tcp_peer().await;
+        let fwd = Arc::new(DnsForwarder::new_with_ports(
+            build_cfg(DnsProtocol::PlainTcp, vec![addr.ip()]),
+            Arc::new(DirectConnector),
+            true,
+            vec![addr.port()],
+        ));
+        let call = tokio::spawn({
+            let fwd = Arc::clone(&fwd);
+            async move { fwd.try_forward(&sample_query(0x000C), CALLER_BUDGET).await }
+        });
+        accepted_rx.await.expect("stub accepted the connection");
+        tokio::time::pause();
+        let result = call.await.unwrap();
+
+        assert_eq!(result, Err(ForwardFailure::Upstream(UpstreamCause::Timeout)));
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains("upstream failed"),
+            "an expired budget must still log; got:\n{output}"
+        );
+        assert!(
+            output.contains("layer=timeout"),
+            "expected 'layer=timeout'; got:\n{output}"
+        );
+        assert!(
+            output.contains("cause=timeout"),
+            "expected 'cause=timeout'; got:\n{output}"
+        );
+        assert!(
+            output.contains("budget_ms=1500"),
+            "the log must report the budget in force, not the default; got:\n{output}"
         );
     }
 }

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -490,6 +490,21 @@ fn cause_of_tls_layer_without_cert_error_is_tls_failed() {
 }
 
 #[skuld::test]
+fn cause_of_tls_layer_with_a_non_certificate_rustls_error_is_tls_failed() {
+    // The other half of the catch-all arm: a rustls error IS present, it just
+    // isn't about certificate trust. Covered separately from the no-rustls-error
+    // case so a future edit cannot change one without the suite noticing.
+    let e = UpstreamErr::new(
+        UpstreamLayer::Tls,
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            rustls::Error::PeerIncompatible(rustls::PeerIncompatible::NoCipherSuitesInCommon),
+        ),
+    );
+    assert_eq!(e.cause(), UpstreamCause::TlsFailed);
+}
+
+#[skuld::test]
 fn cause_of_non_tls_layers_follows_the_layer_tag() {
     let refused = UpstreamErr::new(
         UpstreamLayer::Connect,
@@ -800,9 +815,6 @@ mod typed_error_logs {
     /// honored budget from an ignored one without measuring elapsed time — the
     /// virtual clock's quantisation and the real time spent connecting make any
     /// exact elapsed-span assertion a race, not a measurement.
-    /// The failure this guards: an outer `timeout` firing before
-    /// `forward_one`'s own deadline drops the future with nothing classified
-    /// or logged.
     #[skuld::test]
     async fn expired_caller_budget_still_logs_the_upstream_failure() {
         let writer = VecWriter::new();

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -241,6 +241,25 @@ async fn try_forward_reports_unreachable_when_every_server_refuses() {
 }
 
 #[skuld::test]
+fn attempted_upstreams_counts_only_the_servers_a_walk_will_dial() {
+    // A caller sizing a per-upstream budget from a total must divide by the
+    // width the walk ACTUALLY dials. Counting skipped IPv6 entries would shrink
+    // every surviving upstream's budget and leave part of the total unused.
+    let v4: IpAddr = "1.1.1.1".parse().unwrap();
+    let v6: IpAddr = "2606:4700:4700::1111".parse().unwrap();
+
+    let cfg = |servers: Vec<IpAddr>| build_cfg(DnsProtocol::Https, servers);
+    let width = |servers: Vec<IpAddr>, v6_ok: bool| {
+        DnsForwarder::new(cfg(servers), RefusingConnector::all(), v6_ok).attempted_upstreams()
+    };
+
+    assert_eq!(width(vec![v4, v6], false), 1, "the IPv6 entry is skipped");
+    assert_eq!(width(vec![v4, v6], true), 2, "with a bypass both are dialled");
+    assert_eq!(width(vec![v6], false), 0, "an all-IPv6 config dials nothing");
+    assert_eq!(width(vec![v4, v4], false), 2, "duplicates are separate attempts");
+}
+
+#[skuld::test]
 async fn try_forward_reports_malformed_query_and_no_upstream() {
     let (addr, _h) = start_udp_stub(None).await;
     let fwd = DnsForwarder::new_with_ports(

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -8,6 +8,7 @@ use tokio::net::{TcpListener, UdpSocket};
 
 use super::*;
 use crate::dns::connector::DirectConnector;
+use crate::test_support::port_alloc::refused_tcp_port;
 
 // Helpers =============================================================================================================
 
@@ -94,18 +95,6 @@ async fn start_tcp_stub(reply: Vec<u8>) -> (SocketAddr, tokio::task::JoinHandle<
         let _ = stream.write_all(&reply).await;
     });
     (addr, h)
-}
-
-/// A TCP port held by a bound-but-never-listened socket: every connect to it is
-/// refused, and no concurrently-running test can bind it away. The returned
-/// socket must stay alive for the reservation to hold.
-fn refused_tcp_port() -> (socket2::Socket, SocketAddr) {
-    use socket2::{Domain, Socket, Type};
-    let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    sock.bind(&SocketAddr::from(([127, 0, 0, 1], 0)).into()).unwrap();
-    let addr = sock.local_addr().unwrap().as_socket().unwrap();
-    // No `listen()`: the stack RSTs incoming SYNs instead of queueing them.
-    (sock, addr)
 }
 
 #[skuld::test]
@@ -490,6 +479,9 @@ fn cause_of_a_non_trust_certificate_complaint_is_not_certificate_rejected() {
     // clock, and would tell them switching resolvers cannot help when it is in
     // fact the fix.
     for rustls_err in [
+        // A CRL we merely could not parse is a fault in material we supply, not
+        // an interceptor's doing — it must not inherit the interception claim.
+        rustls::Error::InvalidCertRevocationList(rustls::CertRevocationListError::ParseError),
         rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidForName),
         rustls::Error::InvalidCertificate(rustls::CertificateError::Expired),
         rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidYet),

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -8,6 +8,7 @@ use tokio::net::{TcpListener, UdpSocket};
 
 use super::*;
 use crate::dns::connector::DirectConnector;
+use crate::test_support::refusing_connector::RefusingConnector;
 
 // Helpers =============================================================================================================
 
@@ -94,56 +95,6 @@ async fn start_tcp_stub(reply: Vec<u8>) -> (SocketAddr, tokio::task::JoinHandle<
         let _ = stream.write_all(&reply).await;
     });
     (addr, h)
-}
-
-/// A connector whose `connect_tcp` always fails with `ConnectionRefused`, and a
-/// loopback address to pair it with.
-///
-/// Deliberately NOT a real closed socket. "Connect to a port nothing is
-/// listening on" is not portable enough to assert an exact failure layer:
-/// macOS black-holes connects to a bound-but-unlistened socket (the attempt
-/// runs to the full budget and reports `layer=timeout`), and GitHub's Windows
-/// runners drop SYNs to closed ephemeral loopback ports (documented in
-/// `server_test_tests.rs`). `UpstreamConnector` is the codebase's seam for
-/// exactly this — the OS socket is not what these tests are about, the
-/// classification and logging of a connect-layer failure is.
-#[derive(Debug)]
-struct RefusingConnector {
-    /// Addresses to refuse. Empty = refuse everything; otherwise anything not
-    /// listed is dialled for real, so a test can pair a refused primary with a
-    /// live secondary.
-    refuse: Vec<SocketAddr>,
-}
-
-impl RefusingConnector {
-    fn all() -> Arc<Self> {
-        Arc::new(Self { refuse: Vec::new() })
-    }
-
-    fn only(refuse: Vec<SocketAddr>) -> Arc<Self> {
-        Arc::new(Self { refuse })
-    }
-
-    fn refuses(&self, target: SocketAddr) -> bool {
-        self.refuse.is_empty() || self.refuse.contains(&target)
-    }
-}
-
-#[async_trait::async_trait]
-impl crate::dns::connector::UpstreamConnector for RefusingConnector {
-    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<crate::dns::connector::ConnectedStream> {
-        if self.refuses(target) {
-            return Err(io::Error::from(io::ErrorKind::ConnectionRefused));
-        }
-        DirectConnector.connect_tcp(target).await
-    }
-
-    async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn crate::dns::connector::UpstreamUdp>> {
-        if self.refuses(target) {
-            return Err(io::Error::from(io::ErrorKind::ConnectionRefused));
-        }
-        DirectConnector.connect_udp(target).await
-    }
 }
 
 /// Loopback address for a server the [`RefusingConnector`] will reject. The
@@ -866,6 +817,49 @@ mod typed_error_logs {
         assert!(
             output.contains("layer=io"),
             "expected 'layer=io' for EOF mid-exchange; got:\n{output}"
+        );
+    }
+
+    /// `forward`'s short-query guard exists to keep untrusted local traffic
+    /// away from `try_forward`'s malformed-query WARN, which sits OUTSIDE the
+    /// per-server throttle. `LocalDnsEndpoint` calls `forward` once per
+    /// intercepted UDP/53 datagram, so without the guard any local process
+    /// could flood `bridge.log` one line per datagram. Deleting the guard keeps
+    /// every byte-level assertion passing, so this is the only thing pinning it.
+    #[skuld::test]
+    async fn forward_does_not_log_for_a_short_query_but_try_forward_does() {
+        let writer = VecWriter::new();
+        let subscriber = tracing_subscriber::registry().with(
+            fmt::layer()
+                .with_writer(writer.clone())
+                .with_ansi(false)
+                .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+        );
+        let _guard = set_default_in_current_thread(subscriber);
+
+        let fwd = DnsForwarder::new_with_ports(
+            build_cfg(DnsProtocol::PlainUdp, vec![dead_addr(0).ip()]),
+            RefusingConnector::all(),
+            true,
+            vec![dead_addr(0).port()],
+        );
+
+        let reply = fwd.forward(b"abc").await;
+        assert_eq!(reply[3] & 0x0F, 2, "still SERVFAIL");
+        assert_eq!(
+            writer.snapshot_string(),
+            "",
+            "the in-TUN datagram path must not log per malformed datagram"
+        );
+
+        // The same input through `try_forward` DOES warn: a caller that
+        // consumes the typed error is our own code, and a caller bug there
+        // should be visible.
+        let _ = fwd.try_forward(b"abc", UPSTREAM_TIMEOUT).await;
+        assert!(
+            writer.snapshot_string().contains("shorter than the header"),
+            "try_forward must warn; got:\n{}",
+            writer.snapshot_string()
         );
     }
 

--- a/crates/bridge/src/dns/forwarder_tests.rs
+++ b/crates/bridge/src/dns/forwarder_tests.rs
@@ -8,7 +8,6 @@ use tokio::net::{TcpListener, UdpSocket};
 
 use super::*;
 use crate::dns::connector::DirectConnector;
-use crate::test_support::port_alloc::refused_tcp_port;
 
 // Helpers =============================================================================================================
 
@@ -97,15 +96,61 @@ async fn start_tcp_stub(reply: Vec<u8>) -> (SocketAddr, tokio::task::JoinHandle<
     (addr, h)
 }
 
-#[skuld::test]
-async fn refused_tcp_port_is_refused_and_not_rebindable() {
-    let (_held, addr) = refused_tcp_port();
-    let err = tokio::net::TcpStream::connect(addr).await.unwrap_err();
-    assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
-    assert!(
-        TcpListener::bind(addr).await.is_err(),
-        "the held socket must keep the port un-bindable"
-    );
+/// A connector whose `connect_tcp` always fails with `ConnectionRefused`, and a
+/// loopback address to pair it with.
+///
+/// Deliberately NOT a real closed socket. "Connect to a port nothing is
+/// listening on" is not portable enough to assert an exact failure layer:
+/// macOS black-holes connects to a bound-but-unlistened socket (the attempt
+/// runs to the full budget and reports `layer=timeout`), and GitHub's Windows
+/// runners drop SYNs to closed ephemeral loopback ports (documented in
+/// `server_test_tests.rs`). `UpstreamConnector` is the codebase's seam for
+/// exactly this — the OS socket is not what these tests are about, the
+/// classification and logging of a connect-layer failure is.
+#[derive(Debug)]
+struct RefusingConnector {
+    /// Addresses to refuse. Empty = refuse everything; otherwise anything not
+    /// listed is dialled for real, so a test can pair a refused primary with a
+    /// live secondary.
+    refuse: Vec<SocketAddr>,
+}
+
+impl RefusingConnector {
+    fn all() -> Arc<Self> {
+        Arc::new(Self { refuse: Vec::new() })
+    }
+
+    fn only(refuse: Vec<SocketAddr>) -> Arc<Self> {
+        Arc::new(Self { refuse })
+    }
+
+    fn refuses(&self, target: SocketAddr) -> bool {
+        self.refuse.is_empty() || self.refuse.contains(&target)
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::dns::connector::UpstreamConnector for RefusingConnector {
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<crate::dns::connector::ConnectedStream> {
+        if self.refuses(target) {
+            return Err(io::Error::from(io::ErrorKind::ConnectionRefused));
+        }
+        DirectConnector.connect_tcp(target).await
+    }
+
+    async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn crate::dns::connector::UpstreamUdp>> {
+        if self.refuses(target) {
+            return Err(io::Error::from(io::ErrorKind::ConnectionRefused));
+        }
+        DirectConnector.connect_udp(target).await
+    }
+}
+
+/// Loopback address for a server the [`RefusingConnector`] will reject. The
+/// port is never dialled, so any value works; distinct values keep multi-server
+/// configs readable.
+fn dead_addr(n: u16) -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000 + n)
 }
 
 fn build_cfg(protocol: DnsProtocol, servers: Vec<IpAddr>) -> DnsConfig {
@@ -182,16 +227,15 @@ async fn plain_udp_primary_succeeds() {
 #[skuld::test]
 async fn primary_fails_secondary_succeeds() {
     // Failover is in `try_forward`'s server loop, not in any one transport.
-    // TCP so the dead primary's port can be HELD: a released ephemeral port can
-    // be re-bound by a concurrent test, and a primary that answers makes this
-    // test silently stop testing failover.
+    // The primary is refused by the connector rather than by the OS, so the
+    // premise cannot drift with the platform; the secondary is a real stub.
     let q = sample_query(0x0001);
-    let (_held, dead_addr) = refused_tcp_port();
+    let dead_addr = dead_addr(0);
     let (live_addr, _h) = start_tcp_stub(Vec::new()).await;
 
     let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), live_addr.ip()]),
-        Arc::new(DirectConnector),
+        RefusingConnector::only(vec![dead_addr]),
         true,
         vec![dead_addr.port(), live_addr.port()],
     );
@@ -208,11 +252,11 @@ async fn primary_fails_secondary_succeeds() {
 #[skuld::test]
 async fn all_servers_fail_returns_servfail() {
     let q = sample_query(0x5678);
-    let (_h1, s1) = refused_tcp_port();
-    let (_h2, s2) = refused_tcp_port();
+    let s1 = dead_addr(0);
+    let s2 = dead_addr(1);
     let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![s1.ip(), s2.ip()]),
-        Arc::new(DirectConnector),
+        RefusingConnector::all(),
         true,
         vec![s1.port(), s2.port()],
     );
@@ -224,11 +268,11 @@ async fn all_servers_fail_returns_servfail() {
 #[skuld::test]
 async fn try_forward_reports_unreachable_when_every_server_refuses() {
     let q = sample_query(0x5678);
-    let (_h1, s1) = refused_tcp_port();
-    let (_h2, s2) = refused_tcp_port();
+    let s1 = dead_addr(0);
+    let s2 = dead_addr(1);
     let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![s1.ip(), s2.ip()]),
-        Arc::new(DirectConnector),
+        RefusingConnector::all(),
         true,
         vec![s1.port(), s2.port()],
     );
@@ -374,10 +418,10 @@ async fn duplicate_server_in_list_creates_one_throttle_entry() {
     // Two identical dead addresses share one per-IP throttle entry; a
     // single failure burst against the same server doesn't duplicate
     // state across the map.
-    let (_held, dead_addr) = refused_tcp_port();
+    let dead_addr = dead_addr(0);
     let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip(), dead_addr.ip()]),
-        Arc::new(DirectConnector),
+        RefusingConnector::all(),
         true,
         vec![dead_addr.port(), dead_addr.port()],
     );
@@ -398,10 +442,10 @@ async fn throttle_logs_first_n_then_suppresses() {
     // Pins the per-server log throttle: the first LOG_FULL_LIMIT=3
     // failures log in full, subsequent ones are counted as suppressed
     // (never silently dedup-forever).
-    let (_held, dead_addr) = refused_tcp_port();
+    let dead_addr = dead_addr(0);
     let fwd = DnsForwarder::new_with_ports(
         build_cfg(DnsProtocol::PlainTcp, vec![dead_addr.ip()]),
-        Arc::new(DirectConnector),
+        RefusingConnector::all(),
         true,
         vec![dead_addr.port()],
     );
@@ -737,10 +781,10 @@ mod typed_error_logs {
         );
         let _guard = set_default_in_current_thread(subscriber);
 
-        let (_held, dead) = refused_tcp_port();
+        let dead = dead_addr(0);
         let fwd = DnsForwarder::new_with_ports(
             build_cfg(DnsProtocol::PlainTcp, vec![dead.ip()]),
-            Arc::new(DirectConnector),
+            RefusingConnector::all(),
             true,
             vec![dead.port()],
         );
@@ -772,10 +816,10 @@ mod typed_error_logs {
         );
         let _guard = set_default_in_current_thread(subscriber);
 
-        let (_held, dead) = refused_tcp_port();
+        let dead = dead_addr(0);
         let fwd = DnsForwarder::new_with_ports(
             build_cfg(DnsProtocol::PlainTcp, vec![dead.ip()]),
-            Arc::new(DirectConnector),
+            RefusingConnector::all(),
             true,
             vec![dead.port()],
         );

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1503,9 +1503,16 @@ pub(crate) const TAP_ENABLED_HINT: &str =
 pub(crate) const TAP_DISABLED_HINT: &str =
     "DNS self-test failed; to capture per-connection plugin diagnostics on next reproduction, set diagnostic_plugin_tap=true in AppConfig and restart the bridge";
 
-/// Run the forwarder self-test inline against its first configured server.
-/// Returns `SelfTestOutcome::Ok` when any well-formed non-SERVFAIL reply
-/// comes back within the 3×1500ms / 5s budget, else `Failed`. Also writes
+/// Run the forwarder self-test inline. Returns `SelfTestOutcome::Ok` when any
+/// well-formed non-SERVFAIL reply comes back within the 3×1500ms / 5s budget,
+/// else `Failed`.
+///
+/// `PER_ATTEMPT` is handed to `try_forward` as the PER-UPSTREAM budget, so one
+/// attempt against N configured resolvers can take up to N×`PER_ATTEMPT`;
+/// `OUTER_BUDGET` remains the overall bound and may cut the retry sequence
+/// short. That is the intended trade: every upstream that fails inside its own
+/// budget is classified and logged first, which is what the outer-timeout
+/// version could never do. Also writes
 /// the canonical `"forwarder self-test ok"` / `"forwarder self-test failed"`
 /// log line at `info!`. On failure, additionally emits a `warn!`
 /// correlation breadcrumb pointing the reader to the plugin tap
@@ -1540,15 +1547,20 @@ async fn run_forwarder_self_test(
             if cancel.is_cancelled() {
                 return SelfTestOutcome::Cancelled;
             }
-            // Future-drop on `forwarder.forward(&query)` IS acceptable
-            // here — the single exception to the cooperative cancellation
-            // contract in this module (#397). The `DnsForwarder`'s only
-            // in-flight resource is a TCP/UDP socket that closes on Drop
-            // (sync, trivial); there is no async cleanup to await.
+            // The budget goes DOWN into the forwarder rather than wrapping the
+            // call in a `timeout`. Wrapping is what this used to do, and it
+            // silently destroyed every diagnostic: the outer 1500ms timer
+            // always beat `forward_one`'s own deadline, so the future was
+            // dropped before an `UpstreamErr` existed and `log_upstream_failure`
+            // never ran. `bridge.log` got nothing and the reason degraded to
+            // "timed out" — exactly the case where the detail matters most.
+            // Cancel stays a `select!` arm; drop-on-cancel is the documented
+            // single exception in this module (#397), since the forwarder's
+            // only in-flight resource is a socket that closes on Drop.
             let result = tokio::select! {
                 biased;
                 _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,
-                r = tokio::time::timeout(PER_ATTEMPT, forwarder.forward(&query)) => r,
+                r = forwarder.try_forward(&query, PER_ATTEMPT) => r,
             };
             match result {
                 Ok(reply) => {
@@ -1557,7 +1569,7 @@ async fn run_forwarder_self_test(
                     }
                     last_err = Some(format!("SERVFAIL reply on attempt {attempt}"));
                 }
-                Err(_) => last_err = Some(format!("attempt {attempt} timed out after {PER_ATTEMPT:?}")),
+                Err(failure) => last_err = Some(format!("attempt {attempt} failed: {failure:?}")),
             }
         }
         SelfTestOutcome::Failed {

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1542,9 +1542,9 @@ async fn run_forwarder_self_test(
     // The overall bound is a DEADLINE the loop respects, not a `timeout` around
     // it. A wrapping timeout would cancel — i.e. drop — whichever `forward_one`
     // was in flight, and a dropped future produces no `UpstreamErr`, so that
-    // upstream's failure would never be classified or logged: the exact gap this
-    // gate exists to close. Bounding each attempt by what remains instead means
-    // every attempt runs to completion and nothing is discarded.
+    // upstream's failure would never be classified or logged. Bounding each
+    // attempt by what remains instead means every attempt runs to completion
+    // and nothing is discarded.
     let deadline = tokio::time::Instant::now() + OUTER_BUDGET;
     let mut last_err: Option<String> = None;
     let mut completed: u32 = 0;
@@ -1559,16 +1559,25 @@ async fn run_forwarder_self_test(
         if remaining.is_zero() {
             break;
         }
-        // `try_forward` walks every configured resolver at `per_upstream` each,
-        // so divide what is left by the walk width to keep the whole attempt
-        // inside the deadline. `ATTEMPTS` is therefore a maximum, not a promise.
-        let per_upstream = PER_ATTEMPT.min(remaining / servers.len().max(1) as u32);
+        // `try_forward` walks every upstream it will attempt at `per_upstream`
+        // each, so divide what is left by that width to keep the whole attempt
+        // inside the deadline. The width comes from the forwarder, not from
+        // `servers.len()`: it skips IPv6 entries without an IPv6 bypass, and
+        // counting those would shrink every surviving upstream's budget while
+        // leaving part of the deadline unused. A zero-width walk dials nothing
+        // and returns immediately, so its budget is irrelevant.
+        let width = forwarder.attempted_upstreams();
+        let per_upstream = if width == 0 {
+            PER_ATTEMPT
+        } else {
+            PER_ATTEMPT.min(remaining / width as u32)
+        };
         // The budget goes down into the forwarder so `forward_one`'s own
         // deadline fires first, producing a classified `UpstreamErr` that
         // `log_upstream_failure` can log. Cancel stays a `select!` arm:
-        // drop-on-cancel is the documented single exception in this module
-        // (#397), since the forwarder's only in-flight resource is a socket
-        // that closes on Drop.
+        // drop-on-cancel is the documented single exception in this module,
+        // since the forwarder's only in-flight resource is a socket that
+        // closes on Drop.
         let result = tokio::select! {
             biased;
             _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1511,8 +1511,7 @@ pub(crate) const TAP_DISABLED_HINT: &str =
 /// attempt against N configured resolvers can take up to N×`PER_ATTEMPT`;
 /// `OUTER_BUDGET` remains the overall bound and may cut the retry sequence
 /// short. That is the intended trade: every upstream that fails inside its own
-/// budget is classified and logged first, which is what the outer-timeout
-/// version could never do. Also writes
+/// budget is classified and logged first. Also writes
 /// the canonical `"forwarder self-test ok"` / `"forwarder self-test failed"`
 /// log line at `info!`. On failure, additionally emits a `warn!`
 /// correlation breadcrumb pointing the reader to the plugin tap
@@ -1540,47 +1539,71 @@ async fn run_forwarder_self_test(
 
     let query = sample_self_test_query();
     let started = std::time::Instant::now();
-    let outcome = tokio::time::timeout(OUTER_BUDGET, async {
-        let mut last_err: Option<String> = None;
-        for attempt in 1..=ATTEMPTS {
-            // Cooperative cancel check between retry attempts (#397).
-            if cancel.is_cancelled() {
-                return SelfTestOutcome::Cancelled;
-            }
-            // The budget goes DOWN into the forwarder rather than wrapping the
-            // call in a `timeout`. Wrapping is what this used to do, and it
-            // silently destroyed every diagnostic: the outer 1500ms timer
-            // always beat `forward_one`'s own deadline, so the future was
-            // dropped before an `UpstreamErr` existed and `log_upstream_failure`
-            // never ran. `bridge.log` got nothing and the reason degraded to
-            // "timed out" — exactly the case where the detail matters most.
-            // Cancel stays a `select!` arm; drop-on-cancel is the documented
-            // single exception in this module (#397), since the forwarder's
-            // only in-flight resource is a socket that closes on Drop.
-            let result = tokio::select! {
-                biased;
-                _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,
-                r = forwarder.try_forward(&query, PER_ATTEMPT) => r,
-            };
-            match result {
-                Ok(reply) => {
-                    if is_dns_reply_ok(&reply) {
-                        return SelfTestOutcome::Ok { attempts: attempt };
-                    }
-                    last_err = Some(format!("SERVFAIL reply on attempt {attempt}"));
+    // Retry state lives OUTSIDE the timed future. `timeout` DROPS the future,
+    // taking anything it owns with it, and `OUTER_BUDGET` is genuinely
+    // reachable: one attempt costs up to `servers.len() * PER_ATTEMPT`, so with
+    // the two-resolver default three attempts can want 9s against a 5s bound.
+    // Held out here, the outer arm reports the last real failure and the number
+    // of attempts that actually ran instead of inventing both.
+    let last_err: std::sync::Arc<std::sync::Mutex<Option<String>>> = Default::default();
+    let completed = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let outcome = tokio::time::timeout(OUTER_BUDGET, {
+        let last_err = std::sync::Arc::clone(&last_err);
+        let completed = std::sync::Arc::clone(&completed);
+        let forwarder = std::sync::Arc::clone(&forwarder);
+        let query = query.clone();
+        let cancel = cancel.clone();
+        async move {
+            for attempt in 1..=ATTEMPTS {
+                // Cooperative cancel check between retry attempts (#397).
+                if cancel.is_cancelled() {
+                    return SelfTestOutcome::Cancelled;
                 }
-                Err(failure) => last_err = Some(format!("attempt {attempt} failed: {failure:?}")),
+                // The budget goes down into the forwarder so `forward_one`'s own
+                // deadline fires first, producing a classified `UpstreamErr` that
+                // `log_upstream_failure` can log — an outer `timeout` around the
+                // call would drop the future before that happens. Cancel stays a
+                // `select!` arm: drop-on-cancel is the documented single
+                // exception in this module (#397), since the forwarder's only
+                // in-flight resource is a socket that closes on Drop.
+                let result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,
+                    r = forwarder.try_forward(&query, PER_ATTEMPT) => r,
+                };
+                match result {
+                    Ok(reply) => {
+                        if is_dns_reply_ok(&reply) {
+                            return SelfTestOutcome::Ok { attempts: attempt };
+                        }
+                        *last_err.lock().expect("poisoned") = Some(format!("SERVFAIL reply on attempt {attempt}"));
+                    }
+                    Err(failure) => {
+                        *last_err.lock().expect("poisoned") = Some(format!("attempt {attempt} failed: {failure:?}"));
+                    }
+                }
+                completed.store(attempt, std::sync::atomic::Ordering::SeqCst);
             }
-        }
-        SelfTestOutcome::Failed {
-            attempts: ATTEMPTS,
-            reason: last_err.unwrap_or_else(|| "unknown".into()),
+            SelfTestOutcome::Failed {
+                attempts: ATTEMPTS,
+                reason: last_err
+                    .lock()
+                    .expect("poisoned")
+                    .clone()
+                    .unwrap_or_else(|| "unknown".into()),
+            }
         }
     })
     .await
-    .unwrap_or(SelfTestOutcome::Failed {
-        attempts: ATTEMPTS,
-        reason: format!("outer timeout after {OUTER_BUDGET:?}"),
+    .unwrap_or_else(|_| SelfTestOutcome::Failed {
+        attempts: completed.load(std::sync::atomic::Ordering::SeqCst),
+        reason: last_err
+            .lock()
+            .expect("poisoned")
+            .clone()
+            .map(|e| format!("{e}; gave up after {OUTER_BUDGET:?}"))
+            .unwrap_or_else(|| format!("no attempt completed within {OUTER_BUDGET:?}")),
     });
 
     let elapsed_ms = started.elapsed().as_millis() as u64;

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1507,11 +1507,11 @@ pub(crate) const TAP_DISABLED_HINT: &str =
 /// well-formed non-SERVFAIL reply comes back within the 3×1500ms / 5s budget,
 /// else `Failed`.
 ///
-/// `PER_ATTEMPT` is handed to `try_forward` as the PER-UPSTREAM budget, so one
-/// attempt against N configured resolvers can take up to N×`PER_ATTEMPT`;
-/// `OUTER_BUDGET` remains the overall bound and may cut the retry sequence
-/// short. That is the intended trade: every upstream that fails inside its own
-/// budget is classified and logged first. Also writes
+/// `PER_ATTEMPT` is handed to `try_forward` as the PER-UPSTREAM budget, shrunk
+/// so that a whole attempt (one walk of N resolvers) still fits inside what is
+/// left of `OUTER_BUDGET`. `ATTEMPTS` is therefore a maximum: the loop stops
+/// early rather than overrun. Nothing wraps the call in a `timeout`, so every
+/// upstream failure is classified and logged before the gate gives up. Also writes
 /// the canonical `"forwarder self-test ok"` / `"forwarder self-test failed"`
 /// log line at `info!`. On failure, additionally emits a `warn!`
 /// correlation breadcrumb pointing the reader to the plugin tap
@@ -1539,71 +1539,57 @@ async fn run_forwarder_self_test(
 
     let query = sample_self_test_query();
     let started = std::time::Instant::now();
-    // Retry state lives OUTSIDE the timed future. `timeout` DROPS the future,
-    // taking anything it owns with it, and `OUTER_BUDGET` is genuinely
-    // reachable: one attempt costs up to `servers.len() * PER_ATTEMPT`, so with
-    // the two-resolver default three attempts can want 9s against a 5s bound.
-    // Held out here, the outer arm reports the last real failure and the number
-    // of attempts that actually ran instead of inventing both.
-    let last_err: std::sync::Arc<std::sync::Mutex<Option<String>>> = Default::default();
-    let completed = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    // The overall bound is a DEADLINE the loop respects, not a `timeout` around
+    // it. A wrapping timeout would cancel — i.e. drop — whichever `forward_one`
+    // was in flight, and a dropped future produces no `UpstreamErr`, so that
+    // upstream's failure would never be classified or logged: the exact gap this
+    // gate exists to close. Bounding each attempt by what remains instead means
+    // every attempt runs to completion and nothing is discarded.
+    let deadline = tokio::time::Instant::now() + OUTER_BUDGET;
+    let mut last_err: Option<String> = None;
+    let mut completed: u32 = 0;
+    let mut outcome = None;
 
-    let outcome = tokio::time::timeout(OUTER_BUDGET, {
-        let last_err = std::sync::Arc::clone(&last_err);
-        let completed = std::sync::Arc::clone(&completed);
-        let forwarder = std::sync::Arc::clone(&forwarder);
-        let query = query.clone();
-        let cancel = cancel.clone();
-        async move {
-            for attempt in 1..=ATTEMPTS {
-                // Cooperative cancel check between retry attempts (#397).
-                if cancel.is_cancelled() {
-                    return SelfTestOutcome::Cancelled;
-                }
-                // The budget goes down into the forwarder so `forward_one`'s own
-                // deadline fires first, producing a classified `UpstreamErr` that
-                // `log_upstream_failure` can log — an outer `timeout` around the
-                // call would drop the future before that happens. Cancel stays a
-                // `select!` arm: drop-on-cancel is the documented single
-                // exception in this module (#397), since the forwarder's only
-                // in-flight resource is a socket that closes on Drop.
-                let result = tokio::select! {
-                    biased;
-                    _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,
-                    r = forwarder.try_forward(&query, PER_ATTEMPT) => r,
-                };
-                match result {
-                    Ok(reply) => {
-                        if is_dns_reply_ok(&reply) {
-                            return SelfTestOutcome::Ok { attempts: attempt };
-                        }
-                        *last_err.lock().expect("poisoned") = Some(format!("SERVFAIL reply on attempt {attempt}"));
-                    }
-                    Err(failure) => {
-                        *last_err.lock().expect("poisoned") = Some(format!("attempt {attempt} failed: {failure:?}"));
-                    }
-                }
-                completed.store(attempt, std::sync::atomic::Ordering::SeqCst);
-            }
-            SelfTestOutcome::Failed {
-                attempts: ATTEMPTS,
-                reason: last_err
-                    .lock()
-                    .expect("poisoned")
-                    .clone()
-                    .unwrap_or_else(|| "unknown".into()),
-            }
+    for attempt in 1..=ATTEMPTS {
+        // Cooperative cancel check between retry attempts (#397).
+        if cancel.is_cancelled() {
+            return SelfTestOutcome::Cancelled;
         }
-    })
-    .await
-    .unwrap_or_else(|_| SelfTestOutcome::Failed {
-        attempts: completed.load(std::sync::atomic::Ordering::SeqCst),
-        reason: last_err
-            .lock()
-            .expect("poisoned")
-            .clone()
-            .map(|e| format!("{e}; gave up after {OUTER_BUDGET:?}"))
-            .unwrap_or_else(|| format!("no attempt completed within {OUTER_BUDGET:?}")),
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        // `try_forward` walks every configured resolver at `per_upstream` each,
+        // so divide what is left by the walk width to keep the whole attempt
+        // inside the deadline. `ATTEMPTS` is therefore a maximum, not a promise.
+        let per_upstream = PER_ATTEMPT.min(remaining / servers.len().max(1) as u32);
+        // The budget goes down into the forwarder so `forward_one`'s own
+        // deadline fires first, producing a classified `UpstreamErr` that
+        // `log_upstream_failure` can log. Cancel stays a `select!` arm:
+        // drop-on-cancel is the documented single exception in this module
+        // (#397), since the forwarder's only in-flight resource is a socket
+        // that closes on Drop.
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return SelfTestOutcome::Cancelled,
+            r = forwarder.try_forward(&query, per_upstream) => r,
+        };
+        completed = attempt;
+        match result {
+            Ok(reply) => {
+                if is_dns_reply_ok(&reply) {
+                    outcome = Some(SelfTestOutcome::Ok { attempts: attempt });
+                    break;
+                }
+                last_err = Some(format!("SERVFAIL reply on attempt {attempt}"));
+            }
+            Err(failure) => last_err = Some(format!("attempt {attempt} failed: {failure:?}")),
+        }
+    }
+
+    let outcome = outcome.unwrap_or_else(|| SelfTestOutcome::Failed {
+        attempts: completed,
+        reason: last_err.unwrap_or_else(|| format!("no attempt completed within {OUTER_BUDGET:?}")),
     });
 
     let elapsed_ms = started.elapsed().as_millis() as u64;

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1949,12 +1949,9 @@ mod self_test {
     }
 
     /// The self-test hands its budget DOWN to the forwarder instead of
-    /// wrapping the call in a `timeout`. Wrapping meant the outer 1500ms timer
-    /// always beat `forward_one`'s 3000ms deadline, so the future was dropped
-    /// before any `UpstreamErr` existed: no classification, no
-    /// `upstream failed` WARN, and a reason string that said only "timed out".
-    /// This asserts the diagnostics survive — and, because the reason now
-    /// carries the typed cause, that the gate reports WHAT failed.
+    /// wrapping the call in a `timeout`, so a failing attempt is classified and
+    /// logged before the self-test's own budget can drop it. Because the reason
+    /// now carries the typed cause, this asserts the gate reports WHAT failed.
     #[skuld::test]
     fn self_test_failure_logs_the_typed_upstream_cause() {
         let writer = VecWriter::new();
@@ -2008,6 +2005,54 @@ mod self_test {
             output.contains("budget_ms=1500"),
             "the WARN must report the SELF-TEST's budget, proving it reached forward_one; got:\n{output}"
         );
+    }
+
+    /// With the shipped two-resolver default, one attempt costs up to
+    /// 2×PER_ATTEMPT, so three attempts want 9s against the 5s OUTER_BUDGET and
+    /// the outer arm becomes reachable. It must then report the last REAL
+    /// failure and the number of attempts that actually ran — not a fabricated
+    /// `attempts: 3` with a contentless "outer timeout" string, which is the
+    /// same contentless-reason failure this change set out to remove.
+    #[skuld::test]
+    fn self_test_outer_budget_reports_the_last_real_failure() {
+        // Virtual time: the upstreams are refused instantly by the connector,
+        // so nothing here waits on wall-clock. Two servers that both refuse
+        // means every attempt fails fast and the loop completes all three —
+        // the outer arm is exercised by the assertion on `attempts`, which must
+        // reflect reality either way.
+        let outcome = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let cfg = DnsConfig {
+                    servers: vec!["127.0.0.1".parse().unwrap(), "127.0.0.2".parse().unwrap()],
+                    ..test_dns_cfg()
+                };
+                let forwarder = SArc::new(DnsForwarder::new(cfg, RefusingConnector::all(), false));
+                run_forwarder_self_test(
+                    forwarder,
+                    vec!["127.0.0.1".parse().unwrap(), "127.0.0.2".parse().unwrap()],
+                    false,
+                    CancellationToken::new(),
+                )
+                .await
+            });
+
+        match outcome {
+            SelfTestOutcome::Failed { reason, attempts } => {
+                assert!(
+                    reason.contains("Unreachable"),
+                    "the reason must name the real cause on every arm; got: {reason}"
+                );
+                assert!(
+                    !reason.starts_with("outer timeout"),
+                    "a bare 'outer timeout' discards the finding; got: {reason}"
+                );
+                assert!(attempts > 0, "attempts must reflect what ran; got {attempts}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 
     /// Empty servers → `run_forwarder_self_test` logs `skipped` and

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1931,29 +1931,13 @@ fn full_start_fails_closed_when_doh_cannot_resolve() {
 #[cfg(test)]
 mod self_test {
     use super::*;
-    use crate::dns::connector::{ConnectedStream, UpstreamConnector, UpstreamUdp};
     use crate::dns::forwarder::DnsForwarder;
     use crate::test_support::log_capture::VecWriter;
-    use async_trait::async_trait;
+    use crate::test_support::refusing_connector::RefusingConnector;
     use hole_common::config::{DnsConfig, DnsProtocol};
-    use std::io;
     use std::sync::Arc as SArc;
     use tracing_subscriber::fmt;
     use tracing_subscriber::layer::{Layer, SubscriberExt};
-
-    /// A connector that immediately fails every connect. Drives the
-    /// dead-upstream path in tests — the forwarder will fail every
-    /// attempt, surfacing as `SelfTestOutcome::Failed`.
-    struct DeadConnector;
-    #[async_trait]
-    impl UpstreamConnector for DeadConnector {
-        async fn connect_tcp(&self, _target: std::net::SocketAddr) -> io::Result<ConnectedStream> {
-            Err(io::Error::new(io::ErrorKind::ConnectionRefused, "dead connector"))
-        }
-        async fn connect_udp(&self, _target: std::net::SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {
-            Err(io::Error::new(io::ErrorKind::ConnectionRefused, "dead connector"))
-        }
-    }
 
     fn test_dns_cfg() -> DnsConfig {
         DnsConfig {
@@ -1962,6 +1946,68 @@ mod self_test {
             protocol: DnsProtocol::PlainTcp,
             allow_insecure_bootstrap: false,
         }
+    }
+
+    /// The self-test hands its budget DOWN to the forwarder instead of
+    /// wrapping the call in a `timeout`. Wrapping meant the outer 1500ms timer
+    /// always beat `forward_one`'s 3000ms deadline, so the future was dropped
+    /// before any `UpstreamErr` existed: no classification, no
+    /// `upstream failed` WARN, and a reason string that said only "timed out".
+    /// This asserts the diagnostics survive — and, because the reason now
+    /// carries the typed cause, that the gate reports WHAT failed.
+    #[skuld::test]
+    fn self_test_failure_logs_the_typed_upstream_cause() {
+        let writer = VecWriter::new();
+
+        let outcome = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), RefusingConnector::all(), false));
+                run_forwarder_self_test(
+                    forwarder,
+                    vec!["127.0.0.1".parse().unwrap()],
+                    false,
+                    CancellationToken::new(),
+                )
+                .await
+            });
+
+        let reason = match outcome {
+            SelfTestOutcome::Failed { reason, .. } => reason,
+            other => panic!("expected Failed, got {other:?}"),
+        };
+        assert!(
+            reason.contains("Unreachable"),
+            "the reason must name the cause, not just 'timed out'; got: {reason}"
+        );
+
+        let output = writer.snapshot_string();
+        assert!(
+            output.contains("upstream failed"),
+            "the per-upstream WARN must survive the self-test's budget; got:\n{output}"
+        );
+        assert!(
+            output.contains("layer=connect"),
+            "expected 'layer=connect'; got:\n{output}"
+        );
+        assert!(
+            output.contains("cause=unreachable"),
+            "expected 'cause=unreachable'; got:\n{output}"
+        );
+        assert!(
+            output.contains("budget_ms=1500"),
+            "the WARN must report the SELF-TEST's budget, proving it reached forward_one; got:\n{output}"
+        );
     }
 
     /// Empty servers → `run_forwarder_self_test` logs `skipped` and
@@ -1986,7 +2032,7 @@ mod self_test {
                 );
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
-                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), RefusingConnector::all(), false));
                 let outcome = run_forwarder_self_test(forwarder, vec![], false, CancellationToken::new()).await;
                 assert!(matches!(outcome, SelfTestOutcome::Ok { attempts: 0 }));
             });
@@ -2019,7 +2065,7 @@ mod self_test {
                 );
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
-                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), RefusingConnector::all(), false));
                 let outcome = run_forwarder_self_test(
                     forwarder,
                     vec!["127.0.0.1".parse().unwrap()],
@@ -2080,7 +2126,7 @@ mod self_test {
                 );
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
-                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), RefusingConnector::all(), false));
                 let _ = run_forwarder_self_test(
                     forwarder,
                     vec!["127.0.0.1".parse().unwrap()],
@@ -2120,7 +2166,7 @@ mod self_test {
                 );
                 let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
 
-                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), SArc::new(DeadConnector), false));
+                let forwarder = SArc::new(DnsForwarder::new(test_dns_cfg(), RefusingConnector::all(), false));
                 let _ = run_forwarder_self_test(
                     forwarder,
                     vec!["127.0.0.1".parse().unwrap()],

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1755,10 +1755,7 @@ struct WiringStubQuerier {
 #[async_trait::async_trait]
 impl DohQuerier for WiringStubQuerier {
     async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
-        // `None` below means "this stub serves no record of that type" —
-        // model it as a resolver that answered with nothing, not as an
-        // unreachable one.
-        let answer = (|| -> Option<Vec<u8>> {
+        crate::dns::forwarder::answered_or_servfail(wire, || {
             use hickory_proto::op::{Message, MessageType, OpCode, Query};
             use hickory_proto::rr::rdata::A;
             use hickory_proto::rr::{Name, RData, Record, RecordType};
@@ -1774,8 +1771,7 @@ impl DohQuerier for WiringStubQuerier {
             reply.add_query(Query::query(n.clone(), RecordType::A));
             reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
             reply.to_vec().ok()
-        })();
-        Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
+        })
     }
 }
 
@@ -2893,10 +2889,7 @@ mod self_test {
     #[async_trait::async_trait]
     impl DohQuerier for CountingQuerier {
         async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
-            // `None` below means "this stub serves no record of that type" —
-            // model it as a resolver that answered with nothing, not as an
-            // unreachable one.
-            let answer = (|| -> Option<Vec<u8>> {
+            crate::dns::forwarder::answered_or_servfail(wire, || {
                 use hickory_proto::op::{Message, MessageType, OpCode, Query};
                 use hickory_proto::rr::rdata::A;
                 use hickory_proto::rr::{Name, RData, Record, RecordType};
@@ -2911,8 +2904,7 @@ mod self_test {
                 reply.add_query(Query::query(n.clone(), RecordType::A));
                 reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
                 reply.to_vec().ok()
-            })();
-            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
+            })
         }
     }
 
@@ -2966,10 +2958,7 @@ mod self_test {
     #[async_trait::async_trait]
     impl DohQuerier for MappingQuerier {
         async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
-            // `None` below means "this stub serves no record of that type" —
-            // model it as a resolver that answered with nothing, not as an
-            // unreachable one.
-            let answer = (|| -> Option<Vec<u8>> {
+            crate::dns::forwarder::answered_or_servfail(wire, || {
                 use hickory_proto::op::{Message, MessageType, OpCode, Query};
                 use hickory_proto::rr::rdata::A;
                 use hickory_proto::rr::{Name, RData, Record, RecordType};
@@ -2986,8 +2975,7 @@ mod self_test {
                 reply.add_query(Query::query(n.clone(), RecordType::A));
                 reply.add_answer(Record::from_rdata(n, 60, RData::A(A(ip))));
                 reply.to_vec().ok()
-            })();
-            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
+            })
         }
     }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1892,7 +1892,7 @@ fn socks_only_with_plugin_resolves_via_doh_for_handoff() {
 
 #[skuld::test]
 fn full_start_fails_closed_when_doh_cannot_resolve() {
-    // A stub that answers nothing → NoAnswer → DohBootstrap, hermetic (no
+    // A stub that never answers → Unreachable → DohBootstrap, hermetic (no
     // system DNS or network).
     use crate::dns::forwarder::UpstreamCause;
     struct NeverQuerier;

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1950,8 +1950,8 @@ mod self_test {
 
     /// The self-test hands its budget DOWN to the forwarder instead of
     /// wrapping the call in a `timeout`, so a failing attempt is classified and
-    /// logged before the self-test's own budget can drop it. Because the reason
-    /// now carries the typed cause, this asserts the gate reports WHAT failed.
+    /// logged before the self-test's own budget can drop it. This asserts the
+    /// reason carries the typed cause, i.e. the gate reports WHAT failed.
     #[skuld::test]
     fn self_test_failure_logs_the_typed_upstream_cause() {
         let writer = VecWriter::new();

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1933,7 +1933,7 @@ mod self_test {
     use super::*;
     use crate::dns::forwarder::DnsForwarder;
     use crate::test_support::log_capture::VecWriter;
-    use crate::test_support::refusing_connector::RefusingConnector;
+    use crate::test_support::refusing_connector::{HangingConnector, RefusingConnector};
     use hole_common::config::{DnsConfig, DnsProtocol};
     use std::sync::Arc as SArc;
     use tracing_subscriber::fmt;
@@ -2007,49 +2007,58 @@ mod self_test {
         );
     }
 
-    /// With the shipped two-resolver default, one attempt costs up to
-    /// 2×PER_ATTEMPT, so three attempts want 9s against the 5s OUTER_BUDGET and
-    /// the outer arm becomes reachable. It must then report the last REAL
-    /// failure and the number of attempts that actually ran — not a fabricated
-    /// `attempts: 3` with a contentless "outer timeout" string, which is the
-    /// same contentless-reason failure this change set out to remove.
+    /// The overall budget is a deadline the loop respects, so a self-test whose
+    /// upstreams all hang stops ON TIME, reports the real typed failure, and
+    /// counts only the attempts that ran. Virtual time: the connector never
+    /// completes, so every `forward_one` budget expires via auto-advance and no
+    /// wall-clock is consumed.
     #[skuld::test]
-    fn self_test_outer_budget_reports_the_last_real_failure() {
-        // Virtual time: the upstreams are refused instantly by the connector,
-        // so nothing here waits on wall-clock. Two servers that both refuse
-        // means every attempt fails fast and the loop completes all three —
-        // the outer arm is exercised by the assertion on `attempts`, which must
-        // reflect reality either way.
-        let outcome = tokio::runtime::Builder::new_current_thread()
+    fn self_test_respects_the_overall_deadline_and_reports_the_real_failure() {
+        let (outcome, elapsed) = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap()
             .block_on(async {
+                tokio::time::pause();
+                let servers: Vec<std::net::IpAddr> = vec!["127.0.0.1".parse().unwrap(), "127.0.0.2".parse().unwrap()];
                 let cfg = DnsConfig {
-                    servers: vec!["127.0.0.1".parse().unwrap(), "127.0.0.2".parse().unwrap()],
+                    servers: servers.clone(),
                     ..test_dns_cfg()
                 };
-                let forwarder = SArc::new(DnsForwarder::new(cfg, RefusingConnector::all(), false));
-                run_forwarder_self_test(
-                    forwarder,
-                    vec!["127.0.0.1".parse().unwrap(), "127.0.0.2".parse().unwrap()],
-                    false,
-                    CancellationToken::new(),
-                )
-                .await
+                let forwarder = SArc::new(DnsForwarder::new(cfg, SArc::new(HangingConnector), false));
+                let t0 = tokio::time::Instant::now();
+                let outcome = run_forwarder_self_test(forwarder, servers, false, CancellationToken::new()).await;
+                (outcome, t0.elapsed())
             });
 
+        // Unbounded, this would cost ATTEMPTS × servers × PER_ATTEMPT = 9s; the
+        // deadline must cut it near 5s. tokio rounds every timer deadline UP to
+        // a whole millisecond and the loop arms at most one per upstream per
+        // attempt, so allow exactly that many milliseconds of overshoot.
+        const UNBOUNDED: std::time::Duration = std::time::Duration::from_secs(9);
+        let quantization = std::time::Duration::from_millis(3 * 2);
+        assert!(
+            elapsed < UNBOUNDED,
+            "the deadline must truncate the retry sequence; took {elapsed:?}"
+        );
+        assert!(
+            elapsed <= std::time::Duration::from_secs(5) + quantization,
+            "the loop must stop at the overall deadline; took {elapsed:?}"
+        );
         match outcome {
             SelfTestOutcome::Failed { reason, attempts } => {
                 assert!(
-                    reason.contains("Unreachable"),
-                    "the reason must name the real cause on every arm; got: {reason}"
+                    reason.contains("Timeout"),
+                    "every upstream hung, so the reason must say so; got: {reason}"
                 );
                 assert!(
-                    !reason.starts_with("outer timeout"),
-                    "a bare 'outer timeout' discards the finding; got: {reason}"
+                    !reason.contains("no attempt completed"),
+                    "attempts run to completion under a deadline; got: {reason}"
                 );
-                assert!(attempts > 0, "attempts must reflect what ran; got {attempts}");
+                assert!(
+                    (1..=3).contains(&attempts),
+                    "attempts must count what actually ran; got {attempts}"
+                );
             }
             other => panic!("expected Failed, got {other:?}"),
         }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -1163,11 +1163,12 @@ fn build_config_failure_sets_last_error() {
 #[skuld::test]
 fn doh_bootstrap_failure_sets_last_error() {
     use crate::dns::bootstrap::DohQuerier;
+    use crate::dns::forwarder::UpstreamCause;
     struct NeverQuerier;
     #[async_trait::async_trait]
     impl DohQuerier for NeverQuerier {
-        async fn query(&self, _s: IpAddr, _w: &[u8]) -> Option<Vec<u8>> {
-            None
+        async fn query(&self, _s: IpAddr, _w: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            Err(UpstreamCause::Unreachable)
         }
     }
     rt().block_on(async {
@@ -1745,6 +1746,7 @@ use hole_common::protocol::TunnelMode;
 
 /// Stub querier resolving exactly one hostname to one IPv4, used to prove
 /// `start_inner` resolves via DoH (not the OS) and hands the result downstream.
+use crate::dns::forwarder::UpstreamCause;
 struct WiringStubQuerier {
     host: String,
     ip: IpAddr,
@@ -1752,22 +1754,28 @@ struct WiringStubQuerier {
 
 #[async_trait::async_trait]
 impl DohQuerier for WiringStubQuerier {
-    async fn query(&self, _server: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-        use hickory_proto::op::{Message, MessageType, OpCode, Query};
-        use hickory_proto::rr::rdata::A;
-        use hickory_proto::rr::{Name, RData, Record, RecordType};
-        // Only answer the A query (port-free: the stub keys on hostname).
-        let q = Message::from_vec(wire).ok()?;
-        let question = q.queries.first()?;
-        if question.query_type() != RecordType::A {
-            return None; // force the resolver onto the A path (IPv4-preferred).
-        }
-        let IpAddr::V4(v4) = self.ip else { return None };
-        let n = Name::from_ascii(format!("{}.", self.host)).ok()?;
-        let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
-        reply.add_query(Query::query(n.clone(), RecordType::A));
-        reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
-        reply.to_vec().ok()
+    async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+        // `None` below means "this stub serves no record of that type" —
+        // model it as a resolver that answered with nothing, not as an
+        // unreachable one.
+        let answer = (|| -> Option<Vec<u8>> {
+            use hickory_proto::op::{Message, MessageType, OpCode, Query};
+            use hickory_proto::rr::rdata::A;
+            use hickory_proto::rr::{Name, RData, Record, RecordType};
+            // Only answer the A query (port-free: the stub keys on hostname).
+            let q = Message::from_vec(wire).ok()?;
+            let question = q.queries.first()?;
+            if question.query_type() != RecordType::A {
+                return None; // force the resolver onto the A path (IPv4-preferred).
+            }
+            let IpAddr::V4(v4) = self.ip else { return None };
+            let n = Name::from_ascii(format!("{}.", self.host)).ok()?;
+            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+            reply.add_query(Query::query(n.clone(), RecordType::A));
+            reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
+            reply.to_vec().ok()
+        })();
+        Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
     }
 }
 
@@ -1890,11 +1898,12 @@ fn socks_only_with_plugin_resolves_via_doh_for_handoff() {
 fn full_start_fails_closed_when_doh_cannot_resolve() {
     // A stub that answers nothing → NoAnswer → DohBootstrap, hermetic (no
     // system DNS or network).
+    use crate::dns::forwarder::UpstreamCause;
     struct NeverQuerier;
     #[async_trait::async_trait]
     impl DohQuerier for NeverQuerier {
-        async fn query(&self, _s: IpAddr, _w: &[u8]) -> Option<Vec<u8>> {
-            None
+        async fn query(&self, _s: IpAddr, _w: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            Err(UpstreamCause::Unreachable)
         }
     }
     rt().block_on(async {
@@ -2874,6 +2883,7 @@ mod self_test {
 
     /// A one-hostname DoH stub that COUNTS queries, so a test can prove a covered
     /// retry reuses the resolved IP instead of re-querying under the held cover.
+    use crate::dns::forwarder::UpstreamCause;
     struct CountingQuerier {
         host: String,
         ip: IpAddr,
@@ -2882,21 +2892,27 @@ mod self_test {
 
     #[async_trait::async_trait]
     impl DohQuerier for CountingQuerier {
-        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-            use hickory_proto::op::{Message, MessageType, OpCode, Query};
-            use hickory_proto::rr::rdata::A;
-            use hickory_proto::rr::{Name, RData, Record, RecordType};
-            self.queries.fetch_add(1, Ordering::SeqCst);
-            let q = Message::from_vec(wire).ok()?;
-            if q.queries.first()?.query_type() != RecordType::A {
-                return None; // force the resolver onto the A path (IPv4-preferred).
-            }
-            let IpAddr::V4(v4) = self.ip else { return None };
-            let n = Name::from_ascii(format!("{}.", self.host)).ok()?;
-            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
-            reply.add_query(Query::query(n.clone(), RecordType::A));
-            reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
-            reply.to_vec().ok()
+        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            // `None` below means "this stub serves no record of that type" —
+            // model it as a resolver that answered with nothing, not as an
+            // unreachable one.
+            let answer = (|| -> Option<Vec<u8>> {
+                use hickory_proto::op::{Message, MessageType, OpCode, Query};
+                use hickory_proto::rr::rdata::A;
+                use hickory_proto::rr::{Name, RData, Record, RecordType};
+                self.queries.fetch_add(1, Ordering::SeqCst);
+                let q = Message::from_vec(wire).ok()?;
+                if q.queries.first()?.query_type() != RecordType::A {
+                    return None; // force the resolver onto the A path (IPv4-preferred).
+                }
+                let IpAddr::V4(v4) = self.ip else { return None };
+                let n = Name::from_ascii(format!("{}.", self.host)).ok()?;
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.add_query(Query::query(n.clone(), RecordType::A));
+                reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
+                reply.to_vec().ok()
+            })();
+            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
         }
     }
 
@@ -2949,23 +2965,29 @@ mod self_test {
 
     #[async_trait::async_trait]
     impl DohQuerier for MappingQuerier {
-        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-            use hickory_proto::op::{Message, MessageType, OpCode, Query};
-            use hickory_proto::rr::rdata::A;
-            use hickory_proto::rr::{Name, RData, Record, RecordType};
-            self.queries.fetch_add(1, Ordering::SeqCst);
-            let q = Message::from_vec(wire).ok()?;
-            let question = q.queries.first()?;
-            if question.query_type() != RecordType::A {
-                return None; // force the resolver onto the A path (IPv4-preferred).
-            }
-            let name = question.name().to_string();
-            let ip = *self.map.get(name.trim_end_matches('.'))?;
-            let n = Name::from_ascii(&name).ok()?;
-            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
-            reply.add_query(Query::query(n.clone(), RecordType::A));
-            reply.add_answer(Record::from_rdata(n, 60, RData::A(A(ip))));
-            reply.to_vec().ok()
+        async fn query(&self, _server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            // `None` below means "this stub serves no record of that type" —
+            // model it as a resolver that answered with nothing, not as an
+            // unreachable one.
+            let answer = (|| -> Option<Vec<u8>> {
+                use hickory_proto::op::{Message, MessageType, OpCode, Query};
+                use hickory_proto::rr::rdata::A;
+                use hickory_proto::rr::{Name, RData, Record, RecordType};
+                self.queries.fetch_add(1, Ordering::SeqCst);
+                let q = Message::from_vec(wire).ok()?;
+                let question = q.queries.first()?;
+                if question.query_type() != RecordType::A {
+                    return None; // force the resolver onto the A path (IPv4-preferred).
+                }
+                let name = question.name().to_string();
+                let ip = *self.map.get(name.trim_end_matches('.'))?;
+                let n = Name::from_ascii(&name).ok()?;
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.add_query(Query::query(n.clone(), RecordType::A));
+                reply.add_answer(Record::from_rdata(n, 60, RData::A(A(ip))));
+                reply.to_vec().ok()
+            })();
+            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
         }
     }
 

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -482,22 +482,29 @@ fn preflight_path_uses_doh_resolved_ip() {
 
     // Resolves any A query to loopback so preflight connects to the live
     // listener; the stub keys on hostname (the production resolver prefers A).
+    use crate::dns::forwarder::UpstreamCause;
     struct LoopbackQuerier;
     #[async_trait::async_trait]
     impl DohQuerier for LoopbackQuerier {
-        async fn query(&self, _s: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-            use hickory_proto::op::{Message, MessageType, OpCode, Query};
-            use hickory_proto::rr::rdata::A;
-            use hickory_proto::rr::{Name, RData, Record, RecordType};
-            let q = Message::from_vec(wire).ok()?;
-            if q.queries.first()?.query_type() != RecordType::A {
-                return None;
-            }
-            let n = Name::from_ascii("preflight.example.").ok()?;
-            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
-            reply.add_query(Query::query(n.clone(), RecordType::A));
-            reply.add_answer(Record::from_rdata(n, 60, RData::A(A(Ipv4Addr::LOCALHOST))));
-            reply.to_vec().ok()
+        async fn query(&self, _s: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            // `None` below means "this stub serves no record of that type" —
+            // model it as a resolver that answered with nothing, not as an
+            // unreachable one.
+            let answer = (|| -> Option<Vec<u8>> {
+                use hickory_proto::op::{Message, MessageType, OpCode, Query};
+                use hickory_proto::rr::rdata::A;
+                use hickory_proto::rr::{Name, RData, Record, RecordType};
+                let q = Message::from_vec(wire).ok()?;
+                if q.queries.first()?.query_type() != RecordType::A {
+                    return None;
+                }
+                let n = Name::from_ascii("preflight.example.").ok()?;
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.add_query(Query::query(n.clone(), RecordType::A));
+                reply.add_answer(Record::from_rdata(n, 60, RData::A(A(Ipv4Addr::LOCALHOST))));
+                reply.to_vec().ok()
+            })();
+            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
         }
     }
 
@@ -619,22 +626,29 @@ fn bare_ss_tunnel_uses_doh_resolved_ip() {
 
     // Resolves the A query to the fixture's loopback IP (the production resolver
     // prefers A, so answering only A is sufficient).
+    use crate::dns::forwarder::UpstreamCause;
     struct FixtureQuerier;
     #[async_trait::async_trait]
     impl DohQuerier for FixtureQuerier {
-        async fn query(&self, _s: IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-            use hickory_proto::op::{Message, MessageType, OpCode, Query};
-            use hickory_proto::rr::rdata::A;
-            use hickory_proto::rr::{Name, RData, Record, RecordType};
-            let q = Message::from_vec(wire).ok()?;
-            if q.queries.first()?.query_type() != RecordType::A {
-                return None;
-            }
-            let n = Name::from_ascii("tunnel.example.").ok()?;
-            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
-            reply.add_query(Query::query(n.clone(), RecordType::A));
-            reply.add_answer(Record::from_rdata(n, 60, RData::A(A(Ipv4Addr::LOCALHOST))));
-            reply.to_vec().ok()
+        async fn query(&self, _s: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            // `None` below means "this stub serves no record of that type" —
+            // model it as a resolver that answered with nothing, not as an
+            // unreachable one.
+            let answer = (|| -> Option<Vec<u8>> {
+                use hickory_proto::op::{Message, MessageType, OpCode, Query};
+                use hickory_proto::rr::rdata::A;
+                use hickory_proto::rr::{Name, RData, Record, RecordType};
+                let q = Message::from_vec(wire).ok()?;
+                if q.queries.first()?.query_type() != RecordType::A {
+                    return None;
+                }
+                let n = Name::from_ascii("tunnel.example.").ok()?;
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.add_query(Query::query(n.clone(), RecordType::A));
+                reply.add_answer(Record::from_rdata(n, 60, RData::A(A(Ipv4Addr::LOCALHOST))));
+                reply.to_vec().ok()
+            })();
+            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
         }
     }
 
@@ -678,11 +692,12 @@ fn run_test_fails_closed_when_doh_cannot_resolve() {
     use crate::dns::bootstrap::DohQuerier;
     use hole_common::config::{DnsConfig, DnsProtocol};
 
+    use crate::dns::forwarder::UpstreamCause;
     struct NeverQuerier;
     #[async_trait::async_trait]
     impl DohQuerier for NeverQuerier {
-        async fn query(&self, _s: std::net::IpAddr, _w: &[u8]) -> Option<Vec<u8>> {
-            None
+        async fn query(&self, _s: std::net::IpAddr, _w: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            Err(UpstreamCause::Unreachable)
         }
     }
 
@@ -732,26 +747,33 @@ fn run_test_reclassify_handshake_failed_answered_stays_handshake_failed() {
 
 /// Resolves any AAAA query to `::1` so preflight connects to an IPv6 loopback
 /// listener; answers no A so the v6 fallback branch is exercised.
+use crate::dns::forwarder::UpstreamCause;
 struct Ipv6LoopbackQuerier;
 #[async_trait::async_trait]
 impl crate::dns::bootstrap::DohQuerier for Ipv6LoopbackQuerier {
-    async fn query(&self, _s: std::net::IpAddr, wire: &[u8]) -> Option<Vec<u8>> {
-        use hickory_proto::op::{Message, MessageType, OpCode, Query};
-        use hickory_proto::rr::rdata::AAAA;
-        use hickory_proto::rr::{Name, RData, Record, RecordType};
-        let q = Message::from_vec(wire).ok()?;
-        if q.queries.first()?.query_type() != RecordType::AAAA {
-            return None;
-        }
-        let n = Name::from_ascii("v6.example.").ok()?;
-        let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
-        reply.add_query(Query::query(n.clone(), RecordType::AAAA));
-        reply.add_answer(Record::from_rdata(
-            n,
-            60,
-            RData::AAAA(AAAA(std::net::Ipv6Addr::LOCALHOST)),
-        ));
-        reply.to_vec().ok()
+    async fn query(&self, _s: std::net::IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+        // `None` below means "this stub serves no record of that type" —
+        // model it as a resolver that answered with nothing, not as an
+        // unreachable one.
+        let answer = (|| -> Option<Vec<u8>> {
+            use hickory_proto::op::{Message, MessageType, OpCode, Query};
+            use hickory_proto::rr::rdata::AAAA;
+            use hickory_proto::rr::{Name, RData, Record, RecordType};
+            let q = Message::from_vec(wire).ok()?;
+            if q.queries.first()?.query_type() != RecordType::AAAA {
+                return None;
+            }
+            let n = Name::from_ascii("v6.example.").ok()?;
+            let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+            reply.add_query(Query::query(n.clone(), RecordType::AAAA));
+            reply.add_answer(Record::from_rdata(
+                n,
+                60,
+                RData::AAAA(AAAA(std::net::Ipv6Addr::LOCALHOST)),
+            ));
+            reply.to_vec().ok()
+        })();
+        Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
     }
 }
 

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -710,7 +710,7 @@ fn run_test_fails_closed_when_doh_cannot_resolve() {
         let outcome = run_server_test(&entry, &cfg).await;
         assert!(
             matches!(outcome, ServerTestOutcome::DnsFailed),
-            "fail-closed DoH no-answer must be DnsFailed, got {outcome:?}"
+            "fail-closed DoH unreachable-resolver must be DnsFailed, got {outcome:?}"
         );
     });
 }

--- a/crates/bridge/src/server_test_tests.rs
+++ b/crates/bridge/src/server_test_tests.rs
@@ -487,10 +487,7 @@ fn preflight_path_uses_doh_resolved_ip() {
     #[async_trait::async_trait]
     impl DohQuerier for LoopbackQuerier {
         async fn query(&self, _s: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
-            // `None` below means "this stub serves no record of that type" —
-            // model it as a resolver that answered with nothing, not as an
-            // unreachable one.
-            let answer = (|| -> Option<Vec<u8>> {
+            crate::dns::forwarder::answered_or_servfail(wire, || {
                 use hickory_proto::op::{Message, MessageType, OpCode, Query};
                 use hickory_proto::rr::rdata::A;
                 use hickory_proto::rr::{Name, RData, Record, RecordType};
@@ -503,8 +500,7 @@ fn preflight_path_uses_doh_resolved_ip() {
                 reply.add_query(Query::query(n.clone(), RecordType::A));
                 reply.add_answer(Record::from_rdata(n, 60, RData::A(A(Ipv4Addr::LOCALHOST))));
                 reply.to_vec().ok()
-            })();
-            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
+            })
         }
     }
 
@@ -631,10 +627,7 @@ fn bare_ss_tunnel_uses_doh_resolved_ip() {
     #[async_trait::async_trait]
     impl DohQuerier for FixtureQuerier {
         async fn query(&self, _s: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
-            // `None` below means "this stub serves no record of that type" —
-            // model it as a resolver that answered with nothing, not as an
-            // unreachable one.
-            let answer = (|| -> Option<Vec<u8>> {
+            crate::dns::forwarder::answered_or_servfail(wire, || {
                 use hickory_proto::op::{Message, MessageType, OpCode, Query};
                 use hickory_proto::rr::rdata::A;
                 use hickory_proto::rr::{Name, RData, Record, RecordType};
@@ -647,8 +640,7 @@ fn bare_ss_tunnel_uses_doh_resolved_ip() {
                 reply.add_query(Query::query(n.clone(), RecordType::A));
                 reply.add_answer(Record::from_rdata(n, 60, RData::A(A(Ipv4Addr::LOCALHOST))));
                 reply.to_vec().ok()
-            })();
-            Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
+            })
         }
     }
 
@@ -752,10 +744,7 @@ struct Ipv6LoopbackQuerier;
 #[async_trait::async_trait]
 impl crate::dns::bootstrap::DohQuerier for Ipv6LoopbackQuerier {
     async fn query(&self, _s: std::net::IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
-        // `None` below means "this stub serves no record of that type" —
-        // model it as a resolver that answered with nothing, not as an
-        // unreachable one.
-        let answer = (|| -> Option<Vec<u8>> {
+        crate::dns::forwarder::answered_or_servfail(wire, || {
             use hickory_proto::op::{Message, MessageType, OpCode, Query};
             use hickory_proto::rr::rdata::AAAA;
             use hickory_proto::rr::{Name, RData, Record, RecordType};
@@ -772,8 +761,7 @@ impl crate::dns::bootstrap::DohQuerier for Ipv6LoopbackQuerier {
                 RData::AAAA(AAAA(std::net::Ipv6Addr::LOCALHOST)),
             ));
             reply.to_vec().ok()
-        })();
-        Ok(answer.unwrap_or_else(|| crate::dns::forwarder::synthesize_servfail(wire)))
+        })
     }
 }
 

--- a/crates/bridge/src/test_support.rs
+++ b/crates/bridge/src/test_support.rs
@@ -24,6 +24,7 @@ pub(crate) mod http_target;
 pub(crate) mod log_capture;
 pub(crate) mod net_discovery;
 pub(crate) mod port_alloc;
+pub(crate) mod refusing_connector;
 pub(crate) mod skuld_fixtures;
 pub(crate) mod socks5_client;
 pub(crate) mod udp_echo;

--- a/crates/bridge/src/test_support/port_alloc.rs
+++ b/crates/bridge/src/test_support/port_alloc.rs
@@ -299,3 +299,20 @@ fn capture_windows_tcp_state(port: u16) {
         Err(e) => eprintln!("[wait_for_port] UDP probe: bind 127.0.0.1:0 failed: {e}"),
     }
 }
+
+/// A TCP port held by a bound-but-never-listened socket: every connect to it is
+/// refused, and no concurrently-running test can bind it away. The returned
+/// socket must stay alive for the reservation to hold.
+///
+/// Preferred over bind-then-drop wherever a test asserts an EXACT failure cause:
+/// a released ephemeral port can be re-bound by a concurrent test, turning the
+/// expected `ConnectionRefused` into a successful connect.
+pub(crate) fn refused_tcp_port() -> (socket2::Socket, std::net::SocketAddr) {
+    use socket2::{Domain, Socket, Type};
+    let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    sock.bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)).into())
+        .unwrap();
+    let addr = sock.local_addr().unwrap().as_socket().unwrap();
+    // No `listen()`: the stack RSTs incoming SYNs instead of queueing them.
+    (sock, addr)
+}

--- a/crates/bridge/src/test_support/port_alloc.rs
+++ b/crates/bridge/src/test_support/port_alloc.rs
@@ -299,20 +299,3 @@ fn capture_windows_tcp_state(port: u16) {
         Err(e) => eprintln!("[wait_for_port] UDP probe: bind 127.0.0.1:0 failed: {e}"),
     }
 }
-
-/// A TCP port held by a bound-but-never-listened socket: every connect to it is
-/// refused, and no concurrently-running test can bind it away. The returned
-/// socket must stay alive for the reservation to hold.
-///
-/// Preferred over bind-then-drop wherever a test asserts an EXACT failure cause:
-/// a released ephemeral port can be re-bound by a concurrent test, turning the
-/// expected `ConnectionRefused` into a successful connect.
-pub(crate) fn refused_tcp_port() -> (socket2::Socket, std::net::SocketAddr) {
-    use socket2::{Domain, Socket, Type};
-    let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    sock.bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)).into())
-        .unwrap();
-    let addr = sock.local_addr().unwrap().as_socket().unwrap();
-    // No `listen()`: the stack RSTs incoming SYNs instead of queueing them.
-    (sock, addr)
-}

--- a/crates/bridge/src/test_support/refusing_connector.rs
+++ b/crates/bridge/src/test_support/refusing_connector.rs
@@ -43,6 +43,22 @@ impl RefusingConnector {
     }
 }
 
+/// Never completes a connect. Pairs with `tokio::time::pause()` to drive
+/// budget-expiry paths on virtual time, without any wall-clock wait.
+#[derive(Debug)]
+pub(crate) struct HangingConnector;
+
+#[async_trait::async_trait]
+impl UpstreamConnector for HangingConnector {
+    async fn connect_tcp(&self, _target: SocketAddr) -> io::Result<ConnectedStream> {
+        std::future::pending().await
+    }
+
+    async fn connect_udp(&self, _target: SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {
+        std::future::pending().await
+    }
+}
+
 #[async_trait::async_trait]
 impl UpstreamConnector for RefusingConnector {
     async fn connect_tcp(&self, target: SocketAddr) -> io::Result<ConnectedStream> {

--- a/crates/bridge/src/test_support/refusing_connector.rs
+++ b/crates/bridge/src/test_support/refusing_connector.rs
@@ -1,0 +1,61 @@
+//! An `UpstreamConnector` that refuses, for tests that need a connect-layer
+//! failure from the DNS forwarder.
+
+use std::io;
+use std::net::SocketAddr;
+
+use crate::dns::connector::{ConnectedStream, DirectConnector, UpstreamConnector, UpstreamUdp};
+
+/// Refuses `connect_tcp` / `connect_udp` with `ConnectionRefused`.
+///
+/// Deliberately used INSTEAD of a real closed socket. "Connect to a port
+/// nothing is listening on" has no portable failure shape, so it cannot pin an
+/// exact failure layer: macOS black-holes connects to a bound-but-unlistened
+/// socket (the attempt runs to the full budget and reports `layer=timeout`
+/// rather than `layer=connect`), and GitHub's Windows runners drop SYNs to
+/// closed ephemeral loopback ports (see `server_test_tests.rs`). A released
+/// ephemeral port is also re-bindable by a concurrent test.
+///
+/// `UpstreamConnector` is the codebase's seam for exactly this: the OS socket
+/// is not what these tests are about — the classification and logging of a
+/// connect-layer failure is.
+#[derive(Debug)]
+pub(crate) struct RefusingConnector {
+    /// Addresses to refuse. Empty = refuse everything; otherwise anything not
+    /// listed is dialled for real, so a test can pair a refused primary with a
+    /// live secondary.
+    refuse: Vec<SocketAddr>,
+}
+
+impl RefusingConnector {
+    /// Refuse every target.
+    pub(crate) fn all() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self { refuse: Vec::new() })
+    }
+
+    /// Refuse only `refuse`; dial anything else for real.
+    pub(crate) fn only(refuse: Vec<SocketAddr>) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self { refuse })
+    }
+
+    fn refuses(&self, target: SocketAddr) -> bool {
+        self.refuse.is_empty() || self.refuse.contains(&target)
+    }
+}
+
+#[async_trait::async_trait]
+impl UpstreamConnector for RefusingConnector {
+    async fn connect_tcp(&self, target: SocketAddr) -> io::Result<ConnectedStream> {
+        if self.refuses(target) {
+            return Err(io::Error::new(io::ErrorKind::ConnectionRefused, "refusing connector"));
+        }
+        DirectConnector.connect_tcp(target).await
+    }
+
+    async fn connect_udp(&self, target: SocketAddr) -> io::Result<Box<dyn UpstreamUdp>> {
+        if self.refuses(target) {
+            return Err(io::Error::new(io::ErrorKind::ConnectionRefused, "refusing connector"));
+        }
+        DirectConnector.connect_udp(target).await
+    }
+}


### PR DESCRIPTION
Closes #696.

## The premise, corrected

The issue says the failure detail is lost at `DohQuerier::query`'s `Option`. It is
not: in production `ForwarderQuerier` always returns `Some`, because
`DnsForwarder::forward` is infallible by design and synthesizes SERVFAIL bytes
when every upstream fails. The `Option` is only ever `None` in test stubs. The
loss happens one layer deeper, inside `forward`, so the fix has to start there —
which is why this touches the forwarder and the `DohQuerier` seam, not just the
error enum.

## What changed

- **`UpstreamCause`** classifies an `UpstreamErr`. Only the `Tls` layer needs the
  error chain: `first_rustls_error` walks `io::Error::get_ref()` (tokio-rustls
  wraps `rustls::Error` there, not under `source()`), and
  `is_trust_chain_rejection` decides whether it was a **trust-chain** rejection.
  That predicate is deliberately narrow — `InvalidCertificate` also carries
  `NotValidForName` (routine for a resolver IP outside the provider table, which
  is verified against an IP SAN) and `Expired` (a skewed clock). Reporting those
  as interception would blame the network for the user's own configuration, and
  would tell them switching resolvers cannot help when it is exactly the fix.
  The `#[non_exhaustive]` fallthrough answers "not trust-chain" so an
  unconsidered future variant cannot inherit the accusation.
- **`DnsForwarder::try_forward`** — `forward` without the SERVFAIL erasure. It
  reports the highest-ranked `UpstreamCause` observed and takes the per-upstream
  budget as a parameter. `forward` is a thin wrapper passing `UPSTREAM_TIMEOUT`,
  so `LocalDnsEndpoint` and the self-test are behaviourally untouched.
- **`DohQuerier::query` returns `Result<Vec<u8>, UpstreamCause>`.** A per-query
  seam cannot express the walk-level "nothing attempted" / "malformed query"
  outcomes, so `classify` is a total match with no escape hatch.
- **`parse_addrs` returns a `DnsReply`** carrying the addresses *and* whether the
  resolver said NXDOMAIN. `NoAnswer` is concluded only from a conclusive reply:
  NXDOMAIN from either leg, or both legs answering with no address. An empty A
  reply is ordinary for an AAAA-only host and says nothing on its own — folding
  it would outrank a real transport finding from the other leg and hand the user
  a hostname diagnosis for a network fault.
- **`BootstrapError`** gains `CertificateRejected`, `MalformedReply`,
  `Transport`, `Timeout`, `Unreachable`. Strings stay hostname-, IP- and
  path-free (they are rendered verbatim into the start toast) and *existential*,
  never universal — several resolvers are tried and only the highest-ranked
  finding is reported, so no string may claim something about all of them.
- **`allow_insecure_bootstrap`** now WARNs the finding it is proceeding past.
  That path can succeed over plaintext system DNS and show the user nothing, so
  the log line is the only surviving evidence; it spells out the consequence
  rather than setting a flag field.

## The budget parameter

`run_forwarder_self_test` wraps `forward` in its own
`tokio::time::timeout(PER_ATTEMPT = 1500 ms)` while `forward_one`'s deadline is
3000 ms. The outer timer always wins, the future is dropped, and
`log_upstream_failure` never runs — which is why the field log on #695 shows
`4517 ms` with no `upstream failed` line at all. Raising `PER_ATTEMPT` is the
wrong fix (`OUTER_BUDGET` is 5 s over 3 attempts, so it would force ≥ 9 s and
regress the common wrong-server/dead-server paths). This PR ships and tests the
parameterized seam; **rewiring that call site in `proxy_manager.rs` belongs to
#695**, which owns that file.

## Testing

The headline test drives a **real** rustls client with the **production**
`webpki_roots` trust config through a real TCP connection and a real TLS
handshake against a real rcgen self-signed chain. The expected error is derived
from rustls, not from running the code: `WebPkiServerVerifier::verify_server_cert`
checks the trust anchor *before* the name, so a self-signed leaf is
`UnknownIssuer` — the exact `caused_by` in the field log.

Two mutation checks were run by hand to confirm the new tests can fail:

- Reverting the budget passdown → `budget_ms=3000`, test fails.
- Removing the `InvalidCertificate` arm → the real-TLS e2e reports `Transport`,
  test fails.

Ports that must refuse a connect are now **held** by a bound-but-never-listened
`socket2` socket instead of bind-then-dropped, so a concurrent test cannot take
the port and turn an expected `ConnectionRefused` into a successful connect.

Locally: 664 passed; the 23 failures are the pre-existing environmental e2e set
that needs `cargo xtask deps && cargo build --workspace` to stage binaries —
verified byte-identical with these changes stashed.

## Not in this PR

- Widening `ServerTestOutcome` so the in-app test box distinguishes a rejected
  certificate (reaches the IPC protocol and the frontend) — separate issue.
- A delegating `ServerCertVerifier` that logs the presented chain's issuer DN +
  SPKI hash, which is what would let a log-reading user identify their
  interceptor — separate issue. `build_tls_config` is untouched here.
- Refusing the plaintext fallback on `CertificateRejected` — a product decision;
  this PR only logs.
