### PR TITLE
fix(ci): give test-dmg-signing the installer-assembly timeout budget

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -615,7 +615,11 @@ jobs:
   test-dmg-signing:
     name: Test DMG signing (${{ matrix.os }}/${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    # The installer-assembly budget, held equal to `test-installer` by
+    # `ci_installer_assembly_jobs_share_a_timeout_budget`. The darwin/amd64 leg
+    # is what needs it: `macos-15-intel` runs ~1.7x slower than the arm64 runner
+    # across every phase, and legitimately takes up to 29 min.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -638,8 +642,10 @@ jobs:
 
       # hdiutil DMG creation/mounting is a non-deterministic macOS
       # DiskArbitration race; capture system state on any failure (build or the
-      # pytest mount) to diagnose the next occurrence (#446). `--last 30m` spans
-      # the job's whole lifetime (timeout-minutes: 30).
+      # pytest mount) to diagnose the next occurrence (#446). Note `if: failure()`
+      # does not fire when a timeout kills the job — that surfaces as `cancelled`,
+      # so a budget overrun leaves no diagnostics here.
+      # `--last 45m` spans the job's whole lifetime (timeout-minutes: 45).
       - name: Capture DiskArbitration/hdiutil state on failure
         if: failure()
         shell: bash
@@ -650,7 +656,7 @@ jobs:
           hdiutil info    > "$OUT/hdiutil-info.txt" 2>&1
           ls -la /Volumes > "$OUT/volumes.txt"      2>&1
           mount           > "$OUT/mount.txt"        2>&1
-          log show --last 30m --predicate \
+          log show --last 45m --predicate \
             'process == "diskarbitrationd" OR process == "diskimagesiod" OR process == "mds" OR process == "mds_stores"' \
             > "$OUT/diskarb-log.txt" 2>&1
           echo "captured DMG-flake diagnostics to $OUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -433,10 +433,11 @@ jobs:
   test-installer:
     name: Test installer (windows/amd64)
     runs-on: windows-latest
-    # 45m (was 20m): this job intermittently hit the 20m ceiling during the
-    # post-job cache save with the actual work already green, cancelling a
-    # would-be pass. The extra headroom absorbs slow cold-sccache/cache runs.
-    timeout-minutes: 45
+    # The installer-assembly budget, held equal to `test-dmg-signing` by
+    # `ci_installer_assembly_jobs_share_a_timeout_budget`. Sized for a cold
+    # sccache: GitHub evicts cache entries untouched for 7 days, so the first
+    # run after a quiet week compiles the workspace from scratch.
+    timeout-minutes: 60
     env:
       # renovate: datasource=github-releases depName=gerardog/gsudo
       GSUDO_VERSION: "2.6.1"
@@ -617,9 +618,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     # The installer-assembly budget, held equal to `test-installer` by
     # `ci_installer_assembly_jobs_share_a_timeout_budget`. The darwin/amd64 leg
-    # is what needs it: `macos-15-intel` runs ~1.7x slower than the arm64 runner
-    # across every phase, and legitimately takes up to 29 min.
-    timeout-minutes: 45
+    # sets the requirement: `macos-15-intel` runs ~1.7x slower than the arm64
+    # runner across every phase — ~25 min on a warm sccache, and 45m45s measured
+    # on a fully cold one (5% hit rate, the first run after a 7-day cache
+    # eviction). Roughly 8 min of that is the duplicated Rust build in #714.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -645,7 +648,7 @@ jobs:
       # pytest mount) to diagnose the next occurrence (#446). Note `if: failure()`
       # does not fire when a timeout kills the job — that surfaces as `cancelled`,
       # so a budget overrun leaves no diagnostics here.
-      # `--last 45m` spans the job's whole lifetime (timeout-minutes: 45).
+      # `--last 60m` spans the job's whole lifetime (timeout-minutes: 60).
       - name: Capture DiskArbitration/hdiutil state on failure
         if: failure()
         shell: bash
@@ -656,7 +659,7 @@ jobs:
           hdiutil info    > "$OUT/hdiutil-info.txt" 2>&1
           ls -la /Volumes > "$OUT/volumes.txt"      2>&1
           mount           > "$OUT/mount.txt"        2>&1
-          log show --last 45m --predicate \
+          log show --last 60m --predicate \
             'process == "diskarbitrationd" OR process == "diskimagesiod" OR process == "mds" OR process == "mds_stores"' \
             > "$OUT/diskarb-log.txt" 2>&1
           echo "captured DMG-flake diagnostics to $OUT"

--- a/xtask/src/ci_coverage.rs
+++ b/xtask/src/ci_coverage.rs
@@ -116,7 +116,7 @@ pub fn ci_run_packages(ci_yaml: &str, manifest: &Manifest) -> Result<BTreeSet<St
 /// Collapse shell backslash-newline line continuations into spaces, so a command
 /// written across several lines (as the archive-lane nextest invocations are)
 /// is one logical command before [`split_commands`] runs.
-fn join_line_continuations(script: &str) -> String {
+pub(crate) fn join_line_continuations(script: &str) -> String {
     script.replace("\\\r\n", " ").replace("\\\n", " ")
 }
 
@@ -154,7 +154,7 @@ fn collect_from_command(
 /// nextest `-E '…'` filter expression (folded YAML) carries newlines inside its
 /// single quotes. Tokens within a command stay whitespace-separated, so
 /// downstream `split_whitespace` matching is unaffected.
-fn split_commands(script: &str) -> Vec<String> {
+pub(crate) fn split_commands(script: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut cur = String::new();
     let mut quote: Option<char> = None;
@@ -212,7 +212,7 @@ fn xtask_run_target(cmd: &str) -> Option<&str> {
 }
 
 /// The command-line text of a manifest step, for token extraction.
-fn step_command(step: &Step) -> String {
+pub(crate) fn step_command(step: &Step) -> String {
     match step {
         Step::Bash { command, .. } => command.clone(),
         Step::Process { args, .. } => args.join(" "),

--- a/xtask/src/ci_timeouts.rs
+++ b/xtask/src/ci_timeouts.rs
@@ -1,0 +1,170 @@
+//! Which `.github/workflows/ci.yaml` jobs assemble a release installer, and what
+//! timeout budget does each one carry?
+//!
+//! Backs the `ci_installer_assembly_jobs_share_a_timeout_budget` conformance
+//! test. Assembling an installer is the most expensive thing CI does — a full
+//! release build of `hole`, then the bundler, then the package's own test suite
+//! — so those jobs sit closest to their `timeout-minutes` wall. When two jobs do
+//! that same work but disagree on the budget, the smaller one is killed
+//! mid-compile on the slower runner while its sibling passes.
+//!
+//! The test asserts EQUALITY, not a floor: there is no defensible magic number
+//! for "long enough", but there is a defensible invariant that sibling jobs
+//! doing the same work on the same runner matrix get the same budget. Raising
+//! the class budget stays a one-line edit; under-budgeting one member does not.
+//!
+//! Scope is `ci.yaml` deliberately. The release workflows also assemble
+//! installers, but on a cold cache and with extra packaging work, so their
+//! budget is a separate question and equality with the CI jobs would be wrong.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{bail, Context, Result};
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::ci_coverage::{join_line_continuations, split_commands, step_command};
+use crate::manifest::Manifest;
+
+// Minimal `ci.yaml` shape — serde ignores every field we don't name, so this
+// tracks only `jobs.<id>.{timeout-minutes,steps[].run}`.
+
+#[derive(Deserialize)]
+struct CiYaml {
+    jobs: IndexMap<String, Job>,
+}
+
+#[derive(Deserialize)]
+struct Job {
+    #[serde(rename = "timeout-minutes")]
+    timeout_minutes: Option<u64>,
+    #[serde(default)]
+    steps: Vec<CiStep>,
+}
+
+#[derive(Deserialize)]
+struct CiStep {
+    #[serde(default)]
+    run: Option<String>,
+}
+
+/// Strip one matched pair of surrounding shell quotes.
+///
+/// [`split_commands`] preserves quote characters, so `cargo xtask build
+/// "hole-msi"` yields the token `"hole-msi"`. Comparing that raw against a
+/// target name silently drops the command out of every match below — the exact
+/// invisible-miss the conformance test exists to prevent.
+fn unquote(tok: &str) -> &str {
+    for q in ['"', '\''] {
+        if let Some(inner) = tok.strip_prefix(q).and_then(|t| t.strip_suffix(q)) {
+            return inner;
+        }
+    }
+    tok
+}
+
+/// Does `cmd` assemble an installer package?
+///
+/// The signature is `uv run --directory <name>-installer build` — the entry
+/// point both `hole-msi` and `hole-dmg` use to hand off to their packaging
+/// project. The trailing `build` is load-bearing: `hole-dmg-tests` runs
+/// `uv run --directory dmg-installer pytest`, which consumes the package rather
+/// than assembling it, and must not be credited on its own.
+pub fn assembles_installer(cmd: &str) -> bool {
+    let toks: Vec<&str> = cmd.split_whitespace().map(unquote).collect();
+    toks.windows(3)
+        .any(|w| w[0] == "--directory" && w[1].ends_with("-installer") && w[2] == "build")
+}
+
+/// The build.yaml target of a `cargo xtask run <target>` / `cargo xtask build
+/// <target>` command, if `cmd` is one. Both spellings enter the same cascade;
+/// `test-installer` uses `build`, `test-dmg-signing` uses `run`.
+///
+/// Errors on a target name carrying a `${{ … }}` expression: it cannot be
+/// resolved against build.yaml statically, and silently treating it as
+/// "not an installer job" is how a job disappears from the class unnoticed.
+pub fn xtask_target(cmd: &str) -> Result<Option<&str>> {
+    let toks: Vec<&str> = cmd.split_whitespace().map(unquote).collect();
+    let Some(target) = toks
+        .windows(4)
+        .find(|w| w[0] == "cargo" && w[1] == "xtask" && matches!(w[2], "run" | "build"))
+        .map(|w| w[3])
+    else {
+        return Ok(None);
+    };
+    if target.contains("${{") {
+        bail!(
+            "cannot resolve templated xtask target {target:?} in command {cmd:?} — \
+             a workflow-expression target defeats static analysis of the build graph"
+        );
+    }
+    Ok(Some(target))
+}
+
+/// CI job id → declared `timeout-minutes`, for every job whose xtask cascade
+/// transitively assembles an installer package. A `None` value means the job
+/// declares no timeout at all (GitHub then applies its 6-hour default, which is
+/// never what this class wants).
+pub fn installer_assembly_job_timeouts(ci_yaml: &str, manifest: &Manifest) -> Result<BTreeMap<String, Option<u64>>> {
+    let ci: CiYaml = serde_yml::from_str(ci_yaml).context("parsing ci.yaml")?;
+    let mut out = BTreeMap::new();
+
+    for (id, job) in &ci.jobs {
+        let mut assembles = false;
+        for run in job.steps.iter().filter_map(|s| s.run.as_ref()) {
+            for cmd in split_commands(&join_line_continuations(run)) {
+                if command_reaches_installer(&cmd, manifest, &mut BTreeSet::new())
+                    .with_context(|| format!("in job {id:?}"))?
+                {
+                    assembles = true;
+                }
+            }
+        }
+        if assembles {
+            out.insert(id.clone(), job.timeout_minutes);
+        }
+    }
+
+    Ok(out)
+}
+
+/// Does `cmd` — directly, or through the build.yaml target it invokes and that
+/// target's transitive `depends` and nested `cargo xtask` steps — assemble an
+/// installer package?
+fn command_reaches_installer(cmd: &str, manifest: &Manifest, visited: &mut BTreeSet<String>) -> Result<bool> {
+    if assembles_installer(cmd) {
+        return Ok(true);
+    }
+    let Some(target) = xtask_target(cmd)? else {
+        return Ok(false);
+    };
+    target_reaches_installer(target, manifest, visited)
+}
+
+/// Walk `target`'s own steps (recursing into any `cargo xtask run|build` they
+/// invoke) and its transitive `depends`. `visited` guards against a manifest
+/// cycle and against re-walking a diamond dependency.
+fn target_reaches_installer(target: &str, manifest: &Manifest, visited: &mut BTreeSet<String>) -> Result<bool> {
+    if !visited.insert(target.to_string()) {
+        return Ok(false);
+    }
+    let Some(t) = manifest.get(target) else {
+        return Ok(false);
+    };
+
+    for step in t.run.iter().chain(t.build.iter()) {
+        for cmd in split_commands(&join_line_continuations(&step_command(step))) {
+            if command_reaches_installer(&cmd, manifest, visited)? {
+                return Ok(true);
+            }
+        }
+    }
+
+    for dep in &t.depends {
+        if target_reaches_installer(dep, manifest, visited)? {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/xtask/src/ci_timeouts_tests.rs
+++ b/xtask/src/ci_timeouts_tests.rs
@@ -1,0 +1,278 @@
+//! Unit tests for the installer-assembly detectors plus the
+//! `ci_installer_assembly_jobs_share_a_timeout_budget` structural conformance
+//! test.
+
+use std::collections::BTreeSet;
+use std::fs;
+
+use crate::ci_timeouts::{assembles_installer, installer_assembly_job_timeouts, xtask_target};
+use crate::manifest::Manifest;
+
+// ===== assembles_installer ===========================================================================================
+
+#[skuld::test]
+fn msi_and_dmg_assembly_commands_are_detected() {
+    assert!(assembles_installer("uv run --directory msi-installer build"));
+    assert!(assembles_installer("uv run --directory dmg-installer build"));
+}
+
+#[skuld::test]
+fn quoted_assembly_commands_are_detected() {
+    assert!(assembles_installer(r#"uv run --directory "msi-installer" build"#));
+    assert!(assembles_installer("uv run --directory 'dmg-installer' build"));
+}
+
+#[skuld::test]
+fn consuming_the_package_is_not_assembling_it() {
+    assert!(!assembles_installer("uv run --directory dmg-installer pytest -v"));
+}
+
+#[skuld::test]
+fn unrelated_uv_projects_are_ignored() {
+    assert!(!assembles_installer("uv run --directory tools build"));
+}
+
+#[skuld::test]
+fn plain_commands_are_ignored() {
+    assert!(!assembles_installer("cargo build --release -p hole"));
+    assert!(!assembles_installer(""));
+}
+
+// ===== xtask_target ==================================================================================================
+
+#[skuld::test]
+fn both_run_and_build_spellings_resolve() {
+    assert_eq!(
+        xtask_target("cargo xtask run hole-dmg-tests").unwrap(),
+        Some("hole-dmg-tests")
+    );
+    assert_eq!(xtask_target("cargo xtask build hole-msi").unwrap(), Some("hole-msi"));
+}
+
+#[skuld::test]
+fn quoted_targets_resolve() {
+    assert_eq!(
+        xtask_target(r#"cargo xtask build "hole-msi""#).unwrap(),
+        Some("hole-msi")
+    );
+}
+
+#[skuld::test]
+fn non_xtask_commands_resolve_to_nothing() {
+    assert_eq!(xtask_target("cargo build --release").unwrap(), None);
+    assert_eq!(xtask_target("cargo xtask deps").unwrap(), None);
+}
+
+/// A workflow-expression target can't be resolved against build.yaml, so it must
+/// fail loudly rather than drop the job out of the class.
+#[skuld::test]
+fn templated_targets_are_an_error() {
+    let err = xtask_target(r#"cargo xtask build "hole-${{ matrix.ext }}""#).unwrap_err();
+    assert!(
+        err.to_string().contains("templated xtask target"),
+        "unexpected error: {err}"
+    );
+}
+
+// ===== installer_assembly_job_timeouts ===============================================================================
+
+fn fixture_manifest() -> Manifest {
+    Manifest::parse(
+        r#"
+targets:
+  pkg:
+    platforms: [linux/amd64]
+    build:
+      - cargo build --release -p thing
+      - cargo xtask render-background
+      - uv run --directory pkg-installer build
+  pkg-tests:
+    depends: pkg
+    platforms: [linux/amd64]
+    run: uv run --directory pkg-installer pytest -v
+  render-background:
+    platforms: [linux/amd64]
+    build: cargo run -p renderer
+  nested:
+    platforms: [linux/amd64]
+    build: cargo xtask build pkg
+  unrelated:
+    platforms: [linux/amd64]
+    build: cargo build --release
+"#,
+    )
+    .expect("fixture manifest parses")
+}
+
+#[skuld::test]
+fn assembly_is_found_through_a_transitive_depends_edge() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 45
+    steps:
+      - run: cargo xtask run pkg-tests
+  b:
+    timeout-minutes: 10
+    steps:
+      - run: cargo xtask run unrelated
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got.keys().collect::<Vec<_>>(), vec!["a"]);
+    assert_eq!(got["a"], Some(45));
+}
+
+/// The assembling command is the third of three build steps — `hole-dmg`'s real
+/// shape, where the `uv run … build` handoff is neither first nor alone.
+#[skuld::test]
+fn assembly_is_found_mid_way_through_a_multi_step_build_list() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 45
+    steps:
+      - run: cargo xtask build pkg
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got["a"], Some(45));
+}
+
+/// A target that composes the installer build as a nested `cargo xtask` step
+/// rather than a `depends` edge is still in the class.
+#[skuld::test]
+fn assembly_is_found_through_a_nested_xtask_step() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 45
+    steps:
+      - run: cargo xtask build nested
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got["a"], Some(45));
+}
+
+#[skuld::test]
+fn a_job_without_a_declared_timeout_is_reported_as_none() {
+    let ci = r#"
+jobs:
+  a:
+    steps:
+      - run: cargo xtask build pkg
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got["a"], None);
+}
+
+#[skuld::test]
+fn steps_without_run_blocks_do_not_panic() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo xtask build pkg
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got["a"], Some(45));
+}
+
+/// The `visited` guard must stop a `depends` cycle rather than recurse forever.
+/// `Manifest::parse` accepts the cycle, so the walk is what has to terminate.
+#[skuld::test]
+fn a_depends_cycle_terminates() {
+    let cyclic = Manifest::parse(
+        r#"
+targets:
+  a:
+    depends: b
+    platforms: [linux/amd64]
+    build: cargo build -p a
+  b:
+    depends: a
+    platforms: [linux/amd64]
+    build: cargo build -p b
+"#,
+    )
+    .expect("cyclic fixture parses");
+
+    let ci = r#"
+jobs:
+  j:
+    timeout-minutes: 10
+    steps:
+      - run: cargo xtask build a
+"#;
+    let got = installer_assembly_job_timeouts(ci, &cyclic).expect("analyze");
+    assert!(got.is_empty(), "no target in the cycle assembles an installer");
+}
+
+/// A self-referential `cargo xtask` step must terminate too — the nested-step
+/// recursion shares the same `visited` set as the `depends` walk.
+#[skuld::test]
+fn a_self_referential_xtask_step_terminates() {
+    let looping = Manifest::parse(
+        r#"
+targets:
+  a:
+    platforms: [linux/amd64]
+    build: cargo xtask build a
+"#,
+    )
+    .expect("self-referential fixture parses");
+
+    let ci = r#"
+jobs:
+  j:
+    timeout-minutes: 10
+    steps:
+      - run: cargo xtask build a
+"#;
+    let got = installer_assembly_job_timeouts(ci, &looping).expect("analyze");
+    assert!(got.is_empty());
+}
+
+// ===== conformance ===================================================================================================
+
+/// Every `ci.yaml` job that assembles a release installer carries the same
+/// `timeout-minutes`.
+///
+/// Assembling an installer is the heaviest work CI does, so these jobs run
+/// closest to their wall — and the slowest runner in the matrix sets the real
+/// requirement. A member budgeted below its siblings does not fail cleanly; it
+/// gets SIGKILLed mid-compile and reads as a flake.
+#[skuld::test]
+fn ci_installer_assembly_jobs_share_a_timeout_budget() {
+    let root = crate::repo_root().expect("repo root");
+    let manifest = Manifest::parse(&fs::read_to_string(root.join("build.yaml")).expect("read build.yaml"))
+        .expect("parse build.yaml");
+    let ci_yaml = fs::read_to_string(root.join(".github/workflows/ci.yaml")).expect("read ci.yaml");
+
+    let timeouts = installer_assembly_job_timeouts(&ci_yaml, &manifest).expect("analyze ci.yaml");
+
+    // Guard the guard by MEMBERSHIP, not count: a job silently dropping out of
+    // detection while another drops in would keep any count-based check green.
+    for id in ["test-installer", "test-dmg-signing"] {
+        assert!(
+            timeouts.contains_key(id),
+            "{id:?} no longer resolves as an installer-assembly job (found {:?}) — \
+             the detector in ci_timeouts.rs has drifted from ci.yaml/build.yaml",
+            timeouts.keys().collect::<Vec<_>>()
+        );
+    }
+
+    let undeclared: Vec<&String> = timeouts.iter().filter(|(_, t)| t.is_none()).map(|(id, _)| id).collect();
+    assert!(
+        undeclared.is_empty(),
+        "installer-assembly jobs must declare timeout-minutes, these do not: {undeclared:?}"
+    );
+
+    let distinct: BTreeSet<u64> = timeouts.values().flatten().copied().collect();
+    assert_eq!(
+        distinct.len(),
+        1,
+        "installer-assembly jobs disagree on timeout-minutes: {timeouts:?} — \
+         they do the same class of work, so they get the same budget; change all of them together"
+    );
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -15,6 +15,7 @@ use crate::orchestrate::{execute, execute_run, relocate_self_if_windows, render_
 
 pub mod bindir;
 pub mod ci_coverage;
+pub mod ci_timeouts;
 // macOS-only: renders with the system font via the Typst library (a macOS-only
 // dependency — the DMG background is a darwin feature).
 #[cfg(target_os = "macos")]
@@ -40,6 +41,9 @@ mod bindir_tests;
 #[cfg(test)]
 #[path = "ci_coverage_tests.rs"]
 mod ci_coverage_tests;
+#[cfg(test)]
+#[path = "ci_timeouts_tests.rs"]
+mod ci_timeouts_tests;
 // These tests render with the macOS system font (/System/Library/Fonts/SFNS.ttf);
 // the DMG background is a darwin-only feature, so gate them to macOS. They fail
 // loudly on macOS if the font is missing — other platforms simply lack the feature.


### PR DESCRIPTION
Closes #669.

## Problem

`Test DMG signing (darwin/amd64)` was killed at exactly its 30-minute
`timeout-minutes` in **17 of 38** `main` runs. The sibling `darwin/arm64` leg —
same code, same steps — never timed out in 38 runs.

The job's own comment attributed this to the `hdiutil` DiskArbitration race
(#446). That is not what was happening, and three measurements rule it out:

- **All 17 kills landed mid-`Compiling`**, actively progressing. Only one ever
  reached `hdiutil` at all, and that run had already finished the build, the
  bundler and codesign — it was killed 6 seconds into the pytest.
- **No stall signature.** Max idle gap between log lines is statistically
  identical for successes (168–457s) and timeouts (128–476s). Nothing hangs;
  cargo is just quiet while compiling a large crate.
- **sccache hit rate does not discriminate.** An 85%-hit run timed out; a
  4%-hit arm64 run passed.

`macos-15-intel` is uniformly ~1.7x slower than the arm64 runner across every
phase (setup, deps, frontend, bundle, test). amd64 successes ran 17m55s–28m52s
against a 30m wall — a P100 at 96% of budget. The budget was simply smaller than
the legitimate work.

`test-installer` — the structural analogue, which builds the MSI and then runs
the installer test suite — already carried 45 minutes. `test-dmg-signing` builds
the DMG and then runs the signing test suite, and carried 30.

### The cold-cache tail

The first push of this PR raised the budget to 45 and CI **still cancelled the
amd64 leg, at 45m14s**. That run is the most informative datapoint in the whole
investigation, so it is worth recording rather than hiding:

| phase | cold run (job `91556002848`) |
|---|---|
| setup | 36s |
| `cargo xtask deps` | 10m56s |
| frontend + ex-ray + galoshes | 1m51s |
| `hole-dmg` cargo build | 21m59s |
| `npx tauri build`'s cargo build | **8m02s** |
| bundle + dmgbuild | ~42s |
| pytest | killed 25s in (needs 11–56s) |
| **needed** | **~45m45s** |

sccache hit rate on that run was **5%** (91 hits, 1907 misses) — by far the
coldest of the 78 jobs measured, because GitHub evicts cache entries untouched
for 7 days and `main` had last run a week earlier. That is a recurring condition,
not a freak, so the budget has to cover it.

## Fix

Set the installer-assembly budget to **60 minutes** — ~31% headroom over the
measured cold-cache requirement — and add a conformance test that holds the class
together:
`ci_installer_assembly_jobs_share_a_timeout_budget` resolves each `ci.yaml` job's
`cargo xtask run|build <target>` through `build.yaml` (following `depends` and
nested `xtask` steps) and asserts every job that assembles an installer declares
the *same* budget.

`test-installer` moves to 60 with it. That is not merely mechanical: its own
comment already recorded a 20m→45m raise for "slow cold-sccache runs", and its
warm P100 of 23m26s would face the same cold-cache multiplier.

It asserts equality, not a numeric floor — there is no defensible magic number
for "long enough", but there is a defensible invariant that sibling jobs doing
the same work get the same budget. Raising the class budget stays a one-line
edit; under-budgeting one member does not.

The `if: failure()` diagnostics comment is corrected too: a timeout kill surfaces
as `cancelled`, not `failure`, so that step never ran for any of these 17
failures.

## Verification

TDD — the conformance test was written first and failed on `main`'s state:

```
installer-assembly jobs disagree on timeout-minutes:
{"test-dmg-signing": Some(30), "test-installer": Some(45)}
```

Re-checked in both directions by reverting one job's budget: the gate fails with
`{"test-dmg-signing": Some(60), "test-installer": Some(45)}`, then passes when
both read 60. Full `xtask` suite: 125 passed (all 6 `Test tooling` legs green on
the first CI run). Workspace clippy `-D warnings` and `cargo fmt --check` clean.

## Follow-ups filed

Two real defects surfaced while measuring this; neither is fixed here.

- The release workflows declare **no `timeout-minutes` at all**, so
  `draft-release-hole.yaml`'s installer build on `macos-15-intel` (observed up to
  38m07s) runs to GitHub's 6-hour default if it wedges.
- `hole-dmg` compiles the Rust release build **twice**: `npx tauri build`
  re-compiles 44 crates the pre-build already built (`ring`, `aws-lc-sys`,
  `shadowsocks*`, the whole tauri/objc2/wry stack), costing 3m54s–7m57s on amd64
  on every run — 8m02s on the cold run above, which alone would have brought it
  inside 45m. build.yaml calls this "an incremental no-op"; it is not, on any of
  the 78 jobs measured. When #714 lands, this budget can come back down — the
  conformance test makes that a one-line change in one place.
- xtask's `ci_coverage` and `ci_timeouts` now duplicate the ci.yaml/build.yaml
  traversal and have already drifted (#715).

> [!NOTE]
> This touches `.github/workflows/ci.yaml`, confined to the `test-dmg-signing`
> job block (~L615–660). #692's PR also edits `ci.yaml`, in the `test-ex-ray`
> job (~L424) — different blocks, so no textual conflict is expected.
