### PR TITLE
fix(galoshes): serve every underlying yamux server connection concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "skuld",
+ "socket2",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1420,13 +1420,11 @@ mod proxy_manager_tests;
 //   listener-selection tests) run on every Hole platform (Win+mac).
 // - **galoshes-fronted** tests front a galoshes *server* via the garter
 //   `ChainRunner` launcher (`plugin_e2e::ssserver`), which the `SsServerHandle`
-//   fixture keeps alive for the test's lifetime. The SOCKS5 UDP-associate test
-//   runs on **Win+mac** (its reply-leg flake was fixed in #543). The rest run on
-//   **macOS** only, gated off Windows pending fixes: the socks-only WS/IPv6
-//   roundtrips hit an intermittent Windows bridge-e2e stall (#542), the
-//   full-tunnel TUN test hangs (#541), and WS-TLS/QUIC are macOS-only anyway
-//   (Windows custom-cert limit). Broader galoshes transport coverage on Windows
-//   lives in the `plugin-e2e` crate.
+//   fixture keeps alive for the test's lifetime. The socks-only WS/IPv6
+//   roundtrips run on **Win+mac**; WS-TLS and QUIC are macOS-only (Windows
+//   custom-cert limit), and the full-tunnel TUN variants are Windows-only
+//   (`mod tun` is `cfg(target_os = "windows")` and needs elevation). Broader
+//   galoshes transport coverage on Windows lives in the `plugin-e2e` crate.
 #[cfg(test)]
 #[path = "proxy_manager_e2e_tests.rs"]
 mod proxy_manager_e2e_tests;

--- a/crates/bridge/src/proxy_manager_e2e_tests.rs
+++ b/crates/bridge/src/proxy_manager_e2e_tests.rs
@@ -231,16 +231,7 @@ fn e2e_metrics_report_tunnel_traffic(
 }
 
 /// Test 2: SocksOnly mode with galoshes (websocket, no TLS).
-///
-/// Gated off Windows: the Windows bridge-e2e lane intermittently stalls
-/// 600–740s, and the galoshes/ex-ray chain's internal timeouts fire under the
-/// stall → truncated response. Reliable on macOS; the galoshes WS transport is
-/// covered on Windows by `plugin-e2e`. See bindreams/hole#542.
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC])]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "galoshes bridge e2e truncates under the Windows bridge-e2e stall — see bindreams/hole#542"
-)]
 fn e2e_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,
@@ -729,15 +720,7 @@ fn cipher_2022_blake3_aes_256_gcm_roundtrip(
 // IPv6 axis ===========================================================================================================
 
 /// Test 13: ws plugin, SocksOnly mode, IPv6 HTTP target on `[::1]`.
-///
-/// Gated off Windows for the same reason as `e2e_ws_socks_only_roundtrip` (the
-/// intermittent Windows bridge-e2e stall truncates the galoshes chain). Runs on
-/// macOS. See bindreams/hole#542.
 #[skuld::test(labels = [DIST_BIN, PORT_ALLOC, IPV6], serial = IPV6)]
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "galoshes bridge e2e truncates under the Windows bridge-e2e stall — see bindreams/hole#542"
-)]
 fn ipv6_ws_socks_only_roundtrip(
     #[fixture(dist_dir)] dist: &Path,
     #[fixture(ssserver_ws)] ss: &SsServerHandle,

--- a/crates/galoshes/Cargo.toml
+++ b/crates/galoshes/Cargo.toml
@@ -34,6 +34,7 @@ contracts = { workspace = true }
 async-trait = { workspace = true }
 futures = "0.3"
 yamux = "0.14"
+socket2 = "0.6"
 sha2 = "0.11"
 tempfile = "3"
 tombstone = { path = "../tombstone" }

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -13,6 +13,7 @@ use futures::AsyncReadExt as _;
 use futures::AsyncWriteExt as _;
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tokio_util::sync::CancellationToken;
@@ -584,29 +585,43 @@ async fn run_udp_association(
     let _ = cleanup_tx.send((peer, generation)).await;
 }
 
-/// The client's bound local listener addresses, reported via the `run_client`
-/// test seam. The TCP listener and UDP socket are bound separately, so on a
-/// `:0` (ephemeral) `local` they land on different ports — tests need both.
-/// Production passes `None` and never observes this.
-// The fields are read only from `#[cfg(test)]` code (the relay tests), so the
-// non-test lib build sees them as write-only; allow that, keep the lint in tests.
-#[cfg_attr(not(test), allow(dead_code))]
+/// The client's bound local listener addresses. `YamuxPlugin::run` reports
+/// readiness at `tcp`; the relay tests need both.
+///
+/// The TCP listener and UDP socket are bound separately, so on a `:0`
+/// (ephemeral) `local` they land on different ports — only the relay tests,
+/// which call `run_client` directly, ever pass `:0`. Reporting `tcp` as the
+/// hop's single `listen` is sound because the yamux client is chain position 0,
+/// so its `local` is `PluginEnv::local_addr()` — `SS_LOCAL_HOST`/`SS_LOCAL_PORT`,
+/// which shadowsocks-rust always sets to a concrete allocated port.
 pub(crate) struct ClientBoundAddrs {
     pub tcp: SocketAddr,
+    // Read only from `#[cfg(test)]` code, so the non-test lib build sees it as
+    // write-only; allow that, keep the lint in tests.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub udp: SocketAddr,
 }
 
-/// Join an aborted driver task. Returns `true` iff it ended by a genuine panic (a
-/// code bug, distinct from our own `abort()`), logging it. A panic must be
-/// fatal, not folded into ordinary reconnect churn — a driver panic drops
-/// `inbound_tx` and so is indistinguishable from a clean transport death at the
-/// `inbound_rx` seam, so the caller uses this to escalate instead of retrying.
+/// The sole definition of "this task ended by a genuine panic": a code bug,
+/// distinct from our own `abort()`. Every escalation path classifies through it.
+fn task_panic(result: std::result::Result<(), tokio::task::JoinError>) -> Option<tokio::task::JoinError> {
+    match result {
+        Ok(()) => None,
+        Err(e) if e.is_cancelled() => None,
+        Err(e) => Some(e),
+    }
+}
+
+/// Join an aborted driver task. Returns `true` iff it panicked, logging it. A
+/// panic must be fatal, not folded into ordinary reconnect churn — a driver
+/// panic drops `inbound_tx` and so is indistinguishable from a clean transport
+/// death at the `inbound_rx` seam, so the caller uses this to escalate instead
+/// of retrying.
 #[must_use]
 pub(crate) fn driver_panicked(result: std::result::Result<(), tokio::task::JoinError>) -> bool {
-    match result {
-        Ok(()) => false,
-        Err(e) if e.is_cancelled() => false,
-        Err(e) => {
+    match task_panic(result) {
+        None => false,
+        Some(e) => {
             tracing::error!(error = %e, "yamux driver task panicked");
             true
         }
@@ -756,7 +771,7 @@ pub(crate) async fn run_client(
     let tcp_listener = TcpListener::bind(local).await.context("bind local TCP")?;
     let udp_socket = Arc::new(bind_udp(local).context("bind local UDP")?);
 
-    // Report the actual bound listener addresses (test seam). Production passes `None`.
+    // Readiness signal: both listeners are up, so the hop is serving.
     if let Some(tx) = bound_addr_tx {
         let _ = tx.send(ClientBoundAddrs {
             tcp: tcp_listener.local_addr().context("local tcp addr")?,
@@ -842,29 +857,60 @@ pub(crate) async fn run_server(
     shutdown: CancellationToken,
     bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
 ) -> Result<()> {
+    run_server_with_connections(config, local, remote, shutdown, bound_addr_tx, serve_underlying).await
+}
+
+/// [`run_server`] over an injectable per-connection handler; tests substitute
+/// `serve` to drive the supervision policy without a real yamux peer.
+pub(crate) async fn run_server_with_connections<S, F>(
+    config: yamux::Config,
+    local: SocketAddr,
+    remote: SocketAddr,
+    shutdown: CancellationToken,
+    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+    serve: S,
+) -> Result<()>
+where
+    S: Fn(TcpStream, SocketAddr, yamux::Config, SocketAddr, CancellationToken) -> F,
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
     let listener = TcpListener::bind(local)
         .await
         .with_context(|| format!("bind yamux server on {local}"))?;
     tracing::info!(local = %local, "yamux server listening");
 
-    // Signal the actual bound listen address (test seam). Production passes `None`.
+    // Readiness signal: the listener is up, so the hop is serving.
     if let Some(tx) = bound_addr_tx {
         let addr = listener.local_addr().context("local tcp addr")?;
         let _ = tx.send(addr);
     }
 
-    loop {
-        // Accept one underlying TCP connection. A real accept error is rare and
-        // transient (see `run_client_session`'s local-accept rationale); log and
-        // keep serving rather than tearing down the whole plugin.
-        let tcp = tokio::select! {
-            _ = shutdown.cancelled() => return Ok(()),
+    // Every connection task is owned here, never detached: joining them is what
+    // makes a panic fatal (below) and what makes `run_server` returning mean
+    // their drivers really were aborted and their sockets closed.
+    let mut connections: JoinSet<()> = JoinSet::new();
+
+    // Connection tasks wind down on this child token, so the fatal path below
+    // can stop them the same cooperative way an external shutdown does. Aborting
+    // them instead would drop each task at an await point, detaching its driver
+    // and leaking the socket the driver owns.
+    let connections_shutdown = shutdown.child_token();
+
+    let mut fatal = loop {
+        // A real accept error is rare and transient (see `run_client_session`'s
+        // local-accept rationale); log and keep serving rather than tearing down
+        // the whole plugin.
+        let (tcp, peer) = tokio::select! {
+            _ = shutdown.cancelled() => break false,
+            Some(joined) = connections.join_next() => {
+                if connection_task_fatal(joined) {
+                    break true;
+                }
+                continue;
+            }
             accept = listener.accept() => {
                 match accept {
-                    Ok((stream, peer)) => {
-                        tracing::info!(peer = %peer, "accepted underlying connection");
-                        stream
-                    }
+                    Ok(v) => v,
                     Err(e) => {
                         tracing::debug!(error = %e, "server accept error; continuing");
                         tokio::task::yield_now().await;
@@ -873,43 +919,120 @@ pub(crate) async fn run_server(
                 }
             }
         };
+        tracing::info!(peer = %peer, "accepted underlying connection");
 
-        let compat_tcp = tcp.compat();
-        let conn = yamux::Connection::new(compat_tcp, config.clone(), yamux::Mode::Server);
+        // Each underlying connection is served on its own task. A server plugin
+        // fronts every client of its ss-server, and a reconnecting client opens
+        // its next transport before the previous one is reaped — so serving them
+        // one at a time leaves later connections accepted by the kernel but never
+        // read, black-holing their traffic.
+        connections.spawn(serve(tcp, peer, config.clone(), remote, connections_shutdown.clone()));
+    };
 
-        let (_open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(32);
-        let (inbound_tx, mut inbound_rx) = mpsc::channel::<yamux::Stream>(64);
+    // A fatal exit cancels the child token so peers wind down cooperatively; an
+    // external shutdown already cancelled the parent. Either way we drain here,
+    // so a second panic racing the teardown is still escalated.
+    if fatal {
+        connections_shutdown.cancel();
+    }
+    while let Some(joined) = connections.join_next().await {
+        fatal |= connection_task_fatal(joined);
+    }
 
-        let driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+    if fatal {
+        return Err(anyhow::anyhow!("yamux connection task panicked"));
+    }
+    Ok(())
+}
 
-        let server_shutdown = shutdown.clone();
-        let remote_addr = remote;
-
-        // Handle inbound streams until the connection closes.
-        loop {
-            let stream = tokio::select! {
-                _ = server_shutdown.cancelled() => break,
-                stream = inbound_rx.recv() => {
-                    match stream {
-                        Some(s) => s,
-                        None => break, // driver closed
-                    }
-                }
-            };
-
-            let remote = remote_addr;
-            tokio::spawn(async move {
-                if let Err(e) = handle_inbound_stream(stream, remote).await {
-                    tracing::debug!(error = %e, "inbound stream handler ended");
-                }
-            });
+/// Whether a joined connection task means the plugin must exit. A panic is a
+/// code bug, so it is fatal rather than folded into ordinary connection churn;
+/// an aborted task is our own teardown, not a bug.
+#[must_use]
+pub(crate) fn connection_task_fatal(joined: std::result::Result<(), tokio::task::JoinError>) -> bool {
+    match task_panic(joined) {
+        None => false,
+        Some(e) => {
+            tracing::error!(error = %e, "yamux connection task panicked");
+            true
         }
+    }
+}
 
-        driver.abort();
-        if driver_panicked(driver.await) {
-            return Err(anyhow::anyhow!("yamux driver task panicked"));
-        }
-        tracing::info!("underlying connection closed, waiting for next");
+/// Enable OS keepalive on an accepted connection: a peer whose path dies
+/// silently (no FIN, no RST) would otherwise hold its task, driver and socket
+/// for the plugin's lifetime, since yamux carries no liveness of its own.
+///
+/// `SO_KEEPALIVE` only — the kernel owns the cadence. socket2's
+/// `set_tcp_keepalive` would additionally issue `SIO_KEEPALIVE_VALS` on Windows
+/// and overwrite the system defaults with zeros.
+pub(crate) fn enable_keepalive(tcp: &TcpStream) {
+    if let Err(e) = socket2::SockRef::from(tcp).set_keepalive(true) {
+        tracing::debug!(error = %e, "could not enable TCP keepalive on the accepted connection");
+    }
+}
+
+/// Serve one underlying yamux connection until it ends.
+async fn serve_underlying(
+    tcp: TcpStream,
+    peer: SocketAddr,
+    config: yamux::Config,
+    remote: SocketAddr,
+    shutdown: CancellationToken,
+) {
+    enable_keepalive(&tcp);
+
+    let conn = yamux::Connection::new(tcp.compat(), config, yamux::Mode::Server);
+
+    let (_open_tx, open_rx) = mpsc::channel::<OpenStreamReply>(32);
+    let (inbound_tx, inbound_rx) = mpsc::channel::<yamux::Stream>(64);
+
+    let driver = tokio::spawn(drive_connection(conn, open_rx, inbound_tx));
+
+    serve_driven_connection(peer, remote, shutdown, driver, inbound_rx).await;
+}
+
+/// [`serve_underlying`] once its driver is spawned; tests substitute a panicking
+/// driver to drive the escalation without provoking a panic inside yamux.
+///
+/// A driver panic is re-raised here so that the supervisor's join is the single
+/// route by which a code bug reaches [`run_server`].
+pub(crate) async fn serve_driven_connection(
+    peer: SocketAddr,
+    remote: SocketAddr,
+    shutdown: CancellationToken,
+    driver: tokio::task::JoinHandle<()>,
+    mut inbound_rx: mpsc::Receiver<yamux::Stream>,
+) {
+    // Handle inbound streams until the connection closes.
+    loop {
+        let stream = tokio::select! {
+            _ = shutdown.cancelled() => break,
+            stream = inbound_rx.recv() => {
+                match stream {
+                    Some(s) => s,
+                    None => break, // driver closed
+                }
+            }
+        };
+
+        // Detached by design: one stream's bug must not take down every other
+        // client's traffic, so a panic here stays isolated to its stream and
+        // surfaces on stderr through the default hook rather than escalating.
+        tokio::spawn(async move {
+            if let Err(e) = handle_inbound_stream(stream, remote).await {
+                tracing::debug!(error = %e, "inbound stream handler ended");
+            }
+        });
+    }
+
+    driver.abort();
+    let panic = task_panic(driver.await);
+    tracing::info!(peer = %peer, "underlying connection closed");
+
+    if let Some(e) = panic {
+        tracing::error!(error = %e, "yamux driver task panicked");
+        std::panic::resume_unwind(e.into_panic());
     }
 }
 
@@ -997,64 +1120,49 @@ impl garter::ChainPlugin for YamuxPlugin {
         shutdown: CancellationToken,
         ready: tokio::sync::oneshot::Sender<std::result::Result<garter::PluginReady, garter::StartError>>,
     ) -> garter::Result<()> {
-        // Self-probe readiness: a YAMUX plugin serves both TCP and UDP at
-        // its local listener. Spawn a TCP-connect probe against `local`; on
-        // success report TCP|UDP readiness, on shutdown-first drop `ready`
-        // unsent (RecvError — the "shutdown before ready" semantics).
+        // Readiness comes from the bind point itself, over the same channel the
+        // tests use: `run_server`/`run_client` send their bound address once
+        // their listeners are up, and a YAMUX plugin serves both TCP and UDP
+        // there. A failed bind drops `ready` unsent (RecvError). Startup is not
+        // gated on `shutdown` here — garter's readiness aggregator is `biased` on
+        // it and owns the "shutdown before ready" outcome for the whole chain.
         //
-        // This is galoshes' INTERNAL hop-readiness signal: it feeds
-        // galoshes' OWN `ChainRunner` aggregator, which intersects it with
-        // the inner ex-ray hop and fires the chain-level `on_ready`. The
-        // PROCESS-level sitrep the bridge reads is emitted separately in
-        // `main.rs` off that `on_ready` outcome (see `galoshes::sitrep_out`).
-        // This probe knows only its own hop, not the chain, so it cannot
-        // own the process-stdout contract.
-        //
-        // A future refinement could replace the TCP-connect probe with a
-        // structured `ready` emitted from inside run_server/run_client at
-        // the exact bind point; the probe is the current pragmatic stand-in.
-        let probe_local = local;
-        let probe_shutdown = shutdown.clone();
-        tokio::spawn(async move {
-            if probe_tcp_ready(probe_local, &probe_shutdown).await {
-                let _ = ready.send(Ok(garter::PluginReady {
-                    listen: probe_local,
-                    transports: garter::Transports::TCP | garter::Transports::UDP,
-                }));
-            }
-        });
-
+        // This is galoshes' INTERNAL hop-readiness signal: it feeds galoshes'
+        // OWN `ChainRunner` aggregator, which intersects it with the inner
+        // ex-ray hop and fires the chain-level `on_ready`. The PROCESS-level
+        // sitrep the bridge reads is emitted separately in `main.rs` off that
+        // `on_ready` outcome (see `galoshes::sitrep_out`). This signal knows
+        // only its own hop, not the chain, so it cannot own the process-stdout
+        // contract.
+        let transports = garter::Transports::TCP | garter::Transports::UDP;
         let result = if self.is_server {
-            run_server(self.config, local, remote, shutdown, None).await
+            let (bound_tx, bound_rx) = oneshot::channel();
+            tokio::spawn(async move {
+                let Ok(listen) = bound_rx.await else { return };
+                let _ = ready.send(Ok(garter::PluginReady { listen, transports }));
+            });
+            run_server(self.config, local, remote, shutdown, Some(bound_tx)).await
         } else {
-            run_client(self.config, local, remote, self.udp_timeout, shutdown, None, None).await
+            let (bound_tx, bound_rx) = oneshot::channel::<ClientBoundAddrs>();
+            tokio::spawn(async move {
+                let Ok(addrs) = bound_rx.await else { return };
+                let _ = ready.send(Ok(garter::PluginReady {
+                    listen: addrs.tcp,
+                    transports,
+                }));
+            });
+            run_client(
+                self.config,
+                local,
+                remote,
+                self.udp_timeout,
+                shutdown,
+                Some(bound_tx),
+                None,
+            )
+            .await
         };
 
         result.map_err(|e| garter::Error::Chain(e.to_string()))
-    }
-}
-
-/// TCP-connect probe with exponential backoff. Returns `true` once `addr`
-/// accepts a connection, `false` if shutdown fires first. Mirrors garter's
-/// internal `poll_ready` (not exported), used to detect the YAMUX local
-/// listener coming up.
-async fn probe_tcp_ready(addr: SocketAddr, shutdown: &CancellationToken) -> bool {
-    let mut delay = Duration::from_millis(10);
-    let max_delay = Duration::from_secs(1);
-    loop {
-        tokio::select! {
-            result = TcpStream::connect(addr) => {
-                if result.is_ok() {
-                    return true;
-                }
-            }
-            () = shutdown.cancelled() => return false,
-        }
-        tokio::select! {
-            () = tokio::time::sleep(delay) => {
-                delay = (delay * 2).min(max_delay);
-            }
-            () = shutdown.cancelled() => return false,
-        }
     }
 }

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -18,8 +18,9 @@ use garter::test_utils::WaitableWriter;
 use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::{
-    connect_delay, connect_retrying, deframe_udp_datagram, drive_connection, driver_panicked, frame_udp_datagram,
-    next_failures, parse_udp_timeout, run_client, run_server, session_reconnect_backoff, ClientBoundAddrs,
+    connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram, drive_connection, driver_panicked,
+    enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client, run_server,
+    run_server_with_connections, serve_driven_connection, session_reconnect_backoff, ClientBoundAddrs,
     FrameAccumulator, OpenStreamReply, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, LOOPBACK_CONNECT_RETRY,
     REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
@@ -924,4 +925,158 @@ async fn server_shutdown_is_prompt_while_client_connected() {
 
     shutdown.cancel();
     server.await.expect("server task joined").expect("run_server ok");
+}
+
+#[skuld::test]
+async fn server_serves_a_client_while_an_idle_connection_is_open() {
+    // An idle connection must not starve a real client sharing the server (see
+    // `run_server_with_connections`'s per-connection-task comment).
+    const RESPONSE: &[u8] = b"HTTP/1.0 200 OK\r\n\r\nok";
+    let (writer, _g) = capture_logs();
+    let upstream = spawn_tcp_responder(RESPONSE.to_vec()).await;
+    let shutdown = CancellationToken::new();
+
+    let (srv_tx, srv_rx) = oneshot::channel();
+    tokio::spawn(run_server(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        upstream,
+        shutdown.clone(),
+        Some(srv_tx),
+    ));
+    let server_addr = srv_rx.await.expect("server bound");
+
+    // The idle connection. Held for the whole test; never writes a frame.
+    let _idle = TcpStream::connect(server_addr).await.expect("connect idle");
+    wait_for_log(&writer, "accepted underlying connection").await;
+
+    let (cli_tx, cli_rx) = oneshot::channel();
+    tokio::spawn(run_client(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        server_addr,
+        DEFAULT_UDP_TIMEOUT,
+        shutdown.clone(),
+        Some(cli_tx),
+        None,
+    ));
+    let addrs = cli_rx.await.expect("client bound");
+
+    let mut app = TcpStream::connect(addrs.tcp).await.expect("connect client TCP");
+    app.write_all(b"GET / HTTP/1.0\r\n\r\n").await.expect("write request");
+    let mut got = Vec::new();
+    app.read_to_end(&mut got).await.expect("read response to EOF");
+    assert_eq!(got, RESPONSE, "the relay must serve a client past an idle connection");
+
+    shutdown.cancel();
+}
+
+#[skuld::test]
+async fn connection_task_fatal_escalates_panics_not_aborts() {
+    assert!(!connection_task_fatal(tokio::spawn(async {}).await));
+
+    // Our own teardown abort → cancelled JoinError → not a bug.
+    let h = tokio::spawn(std::future::pending::<()>());
+    h.abort();
+    assert!(!connection_task_fatal(h.await));
+
+    // A panic — the single route by which a code bug reaches the supervisor,
+    // including a driver panic, which `serve_underlying` re-raises.
+    assert!(connection_task_fatal(tokio::spawn(async { panic!("boom") }).await));
+}
+
+#[skuld::test]
+async fn served_connection_gets_os_keepalive() {
+    // Without it a peer whose path dies silently is never reaped.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let _client = TcpStream::connect(addr).await.expect("connect");
+    let (accepted, _) = listener.accept().await.expect("accept");
+
+    let sock = socket2::SockRef::from(&accepted);
+    assert!(!sock.keepalive().expect("read keepalive"), "off before");
+    enable_keepalive(&accepted);
+    assert!(sock.keepalive().expect("read keepalive"), "on after");
+}
+
+#[skuld::test]
+async fn server_exits_on_a_panic_and_winds_down_its_other_connections() {
+    // A code bug must stop the whole plugin rather than let it limp on — and the
+    // surviving connections must be wound down cooperatively, so their drivers
+    // are aborted and their sockets closed before `run_server` returns.
+    let shutdown = CancellationToken::new();
+    let (srv_tx, srv_rx) = oneshot::channel();
+    let (serving_tx, mut serving_rx) = mpsc::channel::<()>(1);
+    let sibling_wound_down = Arc::new(AtomicBool::new(false));
+
+    let seen = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&sibling_wound_down);
+    let server = tokio::spawn(run_server_with_connections(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        "127.0.0.1:9".parse().unwrap(),
+        shutdown.clone(),
+        Some(srv_tx),
+        move |_tcp, _peer, _config, _remote, shutdown| {
+            // First connection is the well-behaved sibling; the second panics.
+            let is_sibling = !seen.swap(true, Ordering::SeqCst);
+            let serving_tx = serving_tx.clone();
+            let flag = Arc::clone(&flag);
+            async move {
+                assert!(is_sibling, "boom");
+                let _ = serving_tx.send(()).await;
+                shutdown.cancelled().await;
+                flag.store(true, Ordering::SeqCst);
+            }
+        },
+    ));
+    let server_addr = srv_rx.await.expect("server bound");
+
+    let _sibling = TcpStream::connect(server_addr).await.expect("connect sibling");
+    serving_rx.recv().await.expect("sibling is being served");
+    let _bad = TcpStream::connect(server_addr).await.expect("connect panicking");
+
+    let err = server
+        .await
+        .expect("server task joined")
+        .expect_err("a panicking connection task must fail the plugin");
+    assert!(err.to_string().contains("panicked"), "unexpected error: {err}");
+    assert!(
+        sibling_wound_down.load(Ordering::SeqCst),
+        "the surviving connection must be wound down, not abandoned"
+    );
+}
+
+#[skuld::test]
+async fn server_exits_when_the_yamux_driver_panics() {
+    // The driver runs on a task of its own, so its panic must be re-raised in
+    // the connection task to reach the supervisor. The injected driver drops
+    // `inbound_tx` while unwinding exactly as the real one does, so the
+    // connection observes the close only after the driver has finished.
+    let shutdown = CancellationToken::new();
+    let (srv_tx, srv_rx) = oneshot::channel();
+    let server = tokio::spawn(run_server_with_connections(
+        ::yamux::Config::default(),
+        "127.0.0.1:0".parse().unwrap(),
+        "127.0.0.1:9".parse().unwrap(),
+        shutdown.clone(),
+        Some(srv_tx),
+        |_tcp, peer, _config, remote, shutdown| {
+            let (inbound_tx, inbound_rx) = mpsc::channel::<::yamux::Stream>(1);
+            let driver = tokio::spawn(async move {
+                let _inbound_tx = inbound_tx;
+                panic!("driver boom");
+            });
+            serve_driven_connection(peer, remote, shutdown, driver, inbound_rx)
+        },
+    ));
+    let server_addr = srv_rx.await.expect("server bound");
+
+    let _conn = TcpStream::connect(server_addr).await.expect("connect server");
+
+    let err = server
+        .await
+        .expect("server task joined")
+        .expect_err("a panicking driver must fail the plugin");
+    assert!(err.to_string().contains("panicked"), "unexpected error: {err}");
 }


### PR DESCRIPTION
Closes #711. Closes #542.

`run_server` served one underlying TCP connection at a time: the outer loop
accepted, and the inner loop ran to completion before `accept()` was called
again. galoshes' own readiness self-probe opened a connection to that listener
1 ms after the bind, and when it occupied the slot the real client's connection
was completed by the kernel backlog but never `accept()`ed — the chain came up,
the request was dispatched, and no byte ever came back.

## Evidence

Three failures share one log signature: exactly one `accepted underlying
connection` right after `yamux server listening`, no `underlying connection
closed`, no second accept, then a wedge until an upstream timeout.

| Run | Job | Test | Duration |
|---|---|---|---|
| [30213282404](https://github.com/bindreams/hole/actions/runs/30213282404) | plugin-e2e (windows/amd64) | `galoshes_ws_roundtrip` | 25.3 s |
| [30213282404](https://github.com/bindreams/hole/actions/runs/30213282404) | hole (darwin/amd64) | `e2e_ws_tls_socks_only_roundtrip` | 635.4 s |
| [27772927089](https://github.com/bindreams/hole/actions/runs/27772927089) | hole (windows/amd64) | `e2e_ws_socks_only_roundtrip` | 619.7 s |

Reproduced locally on Windows: 2 failures in 30 runs of `galoshes_ws_roundtrip`.
A passing run logs `underlying connection closed, waiting for next` 0.25 ms
after the probe's accept and then accepts the real client; a failing run logs
neither.

## This subsumes #542

#542 read the same failure as an intermittent *Windows-wide* bridge-e2e stall
(600–740 s across many tests) and blamed NDIS / Azure loopback. That was a
misreading of `serial = DIST_BIN`: skuld holds the coordination guard for the
whole test body cross-process, so every other DistHarness test queues behind
the one wedged galoshes test and nextest counts its queue time as run time. In
#542's own cited run the three "stalled" tests all completed in a staircase
immediately after the wedged one released the lock (690 s / 731 s / 740 s
against a wedge that failed at 620 s). Nothing was stalled; one test was
wedged. The `cfg_attr(windows, ignore)` gates it introduced are removed here —
#542's stated acceptance criterion.

## Changes

- `run_server` owns every connection task in a `JoinSet` and serves them
  concurrently. Tasks run on a shutdown child token, so a fatal exit winds them
  down the same cooperative way an external shutdown does and both paths share
  one drain — returning means the drivers were aborted and the sockets closed.
- A panic is escalated by one mechanism: `serve_driven_connection` re-raises a
  driver panic, and the supervisor's join classifies it.
- Readiness is reported from the bind point over the existing `bound_addr_tx`
  channel. This deletes the self-connect probe that triggered the bug, and with
  it a poll-with-backoff on a locally-owned condition.
- `SO_KEEPALIVE` on accepted sockets, so a silently-dead path is reaped by the
  kernel rather than accumulating (`set_tcp_keepalive` is avoided: on Windows it
  issues `SIO_KEEPALIVE_VALS` with zeros instead of leaving system defaults).

## Verification

`server_serves_a_client_while_an_idle_connection_is_open` hangs indefinitely on
`main` and passes in ~0.1 s here. `server_exits_when_the_yamux_driver_panics`
and `server_exits_on_a_panic_and_winds_down_its_other_connections` were each
mutation-checked — removing the `resume_unwind` or the child token makes them
fail.

Locally on Windows: 130 consecutive green `plugin-e2e` runs against a ~7 %
pre-fix failure rate, plus 27 green runs of the four galoshes bridge e2e tests
(two of which this PR un-gates on Windows).

## Likely also explained by this

`galoshes_quic_roundtrip` on darwin (#498) and
`e2e_socks_only_udp_associate_galoshes` on Windows (#543) both show the same
signature — one `accepted underlying connection` sub-millisecond after
`yamux server listening`, no `underlying connection closed`, no second accept.
Both were previously attributed to the transport (QUIC) and to the UDP reply
leg. Left open deliberately: the evidence is n=1 each, so they want post-merge
confirmation rather than closing on this PR.

## Review

`running-the-review-panel` (code mode), 3 rounds: `rejected` → `rejected` →
**`conditionally-approved`**. Round 1 rejected the first shape (detached
connection tasks lost the driver-panic-is-fatal contract); round 2 rejected the
`JoinSet::shutdown()` fatal path (force-abort orphaned sibling drivers and
discarded concurrent panics) and the Windows keepalive ioctl. Every `must_fix`
was addressed; one item — per-stream relay tasks staying detached — was
recorded `by_design`, since escalating one stream's panic would tear down every
other client's traffic and joining relay tasks would contradict the deliberate
truncate-in-flight-relays teardown contract.
