### PR TITLE
fix(ci): budget test-hole per matrix leg from measured wall clock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,16 +263,37 @@ jobs:
   test-hole:
     name: Test hole (${{ matrix.os }}/${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    # 45min: the non-TUN pass provisions stock upstream v2ray-plugin and runs
-    # the cross-impl interop tests (~78s each).
-    timeout-minutes: 45
+    # Per-leg, because the legs differ by ~2x: one number would either
+    # under-budget darwin/amd64 or push every leg's hang-detection deadline out
+    # to suit the slowest. Whole-job wall clock, 38 runs per leg on `main`:
+    #
+    #   darwin/arm64   16m31s - 32m01s, 0 killed  -> 45
+    #   windows/amd64  23m48s - 42m06s, 0 killed  -> 60
+    #   darwin/amd64   22m22s - 44m28s, 8 killed  -> 90
+    #
+    # darwin/amd64's distribution is right-CENSORED by the 45min wall replaced
+    # here, so 44m28s is a floor, not a maximum. Reconstructing the killed runs
+    # from their phase timings puts the real requirement near 56min. 90
+    # clears the censored region so the true tail becomes observable; tighten
+    # once it is. windows/amd64 has never been killed but sits at 94% of the old
+    # wall, so it is raised too; darwin/arm64 has 29% margin and stays.
+    #
+    # For darwin this is a stopgap: most of its TUN pass is a whole-workspace
+    # rebuild caused by a feature-set mismatch in that step (#720).
+    #
+    # The `ci_installer_assembly_jobs_share_a_timeout_budget` conformance test
+    # does not cover these: it selects jobs whose xtask cascade reaches a
+    # `uv run --directory <name>-installer build` handoff, and `hole-tests`
+    # (-> hole -> galoshes -> ex-ray) reaches none. Should that cascade ever
+    # gain an installer edge, this job joins that class and must match it.
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { os: windows, arch: amd64, runner: windows-latest }
-          - { os: darwin,  arch: amd64, runner: macos-15-intel }
-          - { os: darwin,  arch: arm64, runner: macos-latest }
+          - { os: windows, arch: amd64, runner: windows-latest, timeout: 60 }
+          - { os: darwin,  arch: amd64, runner: macos-15-intel, timeout: 90 }
+          - { os: darwin,  arch: arm64, runner: macos-latest,   timeout: 45 }
     steps:
       - uses: actions/checkout@v7
         with:

--- a/xtask/src/ci_timeouts.rs
+++ b/xtask/src/ci_timeouts.rs
@@ -36,10 +36,41 @@ struct CiYaml {
 
 #[derive(Deserialize)]
 struct Job {
+    /// Left uninterpreted so an unexpected scalar on an unrelated job cannot
+    /// abort the whole document — see [`resolve_timeout`].
     #[serde(rename = "timeout-minutes")]
-    timeout_minutes: Option<u64>,
+    timeout_minutes: Option<serde_yml::Value>,
     #[serde(default)]
     steps: Vec<CiStep>,
+}
+
+/// A declared `timeout-minutes` as a literal minute count.
+///
+/// GitHub accepts a number or a workflow expression here; `test-hole` uses an
+/// expression to budget each matrix leg separately. An expression cannot be
+/// compared against a sibling statically, so it is an error for a job in the
+/// class — but only there, which is why the value is interpreted at use rather
+/// than at deserialization.
+///
+/// Classification is on the `${{` syntax, matching [`xtask_target`], not on
+/// which serde shape the scalar took: `"60"` is a quoted literal, not an
+/// expression.
+fn resolve_timeout(id: &str, value: &serde_yml::Value) -> Result<u64> {
+    if let Some(n) = value.as_u64() {
+        return Ok(n);
+    }
+    if let Some(s) = value.as_str() {
+        if s.contains("${{") {
+            bail!(
+                "job {id:?} declares timeout-minutes as the expression {s:?} — \
+                 it cannot be compared against its siblings' budgets statically"
+            );
+        }
+        if let Ok(n) = s.parse::<u64>() {
+            return Ok(n);
+        }
+    }
+    bail!("job {id:?} declares timeout-minutes as {value:?}, which is not a whole number of minutes")
 }
 
 #[derive(Deserialize)]
@@ -120,9 +151,15 @@ pub fn installer_assembly_job_timeouts(ci_yaml: &str, manifest: &Manifest) -> Re
                 }
             }
         }
-        if assembles {
-            out.insert(id.clone(), job.timeout_minutes);
+        if !assembles {
+            continue;
         }
+        let minutes = job
+            .timeout_minutes
+            .as_ref()
+            .map(|v| resolve_timeout(id, v))
+            .transpose()?;
+        out.insert(id.clone(), minutes);
     }
 
     Ok(out)

--- a/xtask/src/ci_timeouts_tests.rs
+++ b/xtask/src/ci_timeouts_tests.rs
@@ -152,6 +152,87 @@ jobs:
     assert_eq!(got["a"], Some(45));
 }
 
+/// GitHub allows an expression for `timeout-minutes` (a per-leg matrix budget,
+/// as `test-hole` uses). A job outside the class must not break the parse.
+#[skuld::test]
+fn an_expression_timeout_outside_the_class_is_ignored() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 45
+    steps:
+      - run: cargo xtask build pkg
+  b:
+    timeout-minutes: ${{ matrix.timeout }}
+    steps:
+      - run: cargo xtask run unrelated
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got.keys().collect::<Vec<_>>(), vec!["a"]);
+}
+
+/// Inside the class an expression cannot be compared against a sibling, so it
+/// must fail loudly rather than silently drop out of the equality check.
+#[skuld::test]
+fn an_expression_timeout_inside_the_class_is_an_error() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: ${{ matrix.timeout }}
+    steps:
+      - run: cargo xtask build pkg
+"#;
+    let err = installer_assembly_job_timeouts(ci, &fixture_manifest()).unwrap_err();
+    assert!(format!("{err:#}").contains("expression"), "unexpected error: {err:#}");
+}
+
+/// A YAML-quoted number is a literal, not an expression — classification is on
+/// the `${{` syntax, not on which serde shape the scalar happened to take.
+#[skuld::test]
+fn a_quoted_numeric_timeout_is_a_literal() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: "60"
+    steps:
+      - run: cargo xtask build pkg
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got["a"], Some(60));
+}
+
+/// An odd scalar on an unrelated job must not abort the whole ci.yaml parse —
+/// the failure mode the expression handling exists to prevent.
+#[skuld::test]
+fn an_odd_timeout_scalar_outside_the_class_does_not_break_parsing() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 45
+    steps:
+      - run: cargo xtask build pkg
+  b:
+    timeout-minutes: 0.5
+    steps:
+      - run: cargo xtask run unrelated
+"#;
+    let got = installer_assembly_job_timeouts(ci, &fixture_manifest()).expect("analyze");
+    assert_eq!(got.keys().collect::<Vec<_>>(), vec!["a"]);
+}
+
+#[skuld::test]
+fn a_non_integral_timeout_inside_the_class_is_an_error() {
+    let ci = r#"
+jobs:
+  a:
+    timeout-minutes: 0.5
+    steps:
+      - run: cargo xtask build pkg
+"#;
+    let err = installer_assembly_job_timeouts(ci, &fixture_manifest()).unwrap_err();
+    assert!(format!("{err:#}").contains("whole number"), "unexpected error: {err:#}");
+}
+
 #[skuld::test]
 fn a_job_without_a_declared_timeout_is_reported_as_none() {
     let ci = r#"


### PR DESCRIPTION
Closes #718.

## Problem

`Test hole (darwin/amd64)` was killed at its 45-minute `timeout-minutes` in
**8 of 38** recent `main` runs, and `main` is red on it right now.

I classified all 8 by log — they are **three different causes**:

| cause | count | disposition |
|---|---|---|
| budget exhaustion | 6 | this PR |
| galoshes wedge | 1 | #711, fixed by #717 |
| `crash_marker_abort` hang | 1 | #719 |

The most recent kill is unambiguous — not a wedge, not a hang:

```
00:43:19  Starting 1647 tests across 21 binaries
00:50:48  Summary [ 448.467s] 1647 tests run: 1647 passed (5 slow), 2 skipped
00:50:48  Run sudo env … SKULD_LABELS=tun cargo nextest run --no-default-features …
00:56:24  ##[error]The operation was canceled.
```

Every test passed; the kill landed **5m36s after** the suite went green.

## Fix: per-leg budgets, derived from whole-job wall clock

Whole-job wall clock over 38 runs per leg on `main`:

| leg | observed | killed | budget |
|---|---|---|---|
| darwin/arm64 | 16m31s – 32m01s | 0 | **45** (unchanged) |
| windows/amd64 | 23m48s – 42m06s | 0 | **60** |
| darwin/amd64 | 22m22s – 44m28s | 8 | **90** |

Per-leg rather than one number, because the legs differ by ~2x and a single
budget would either under-budget darwin/amd64 or push *every* leg's
hang-detection deadline out to suit the slowest.

Two things worth stating plainly about the derivation:

- **darwin/amd64's distribution is right-censored** by the very wall being
  replaced. 44m28s is a floor, not a maximum — 8 runs were cut off. Reconstructing
  those from their phase timings puts the real requirement near 56 min. 90 is
  chosen to clear the censored region so the true tail becomes *observable*, and
  should be tightened once it is. You cannot size a budget from a censored
  distribution.
- **windows/amd64 needed raising too.** It has never been killed, but 42m06s
  against the old 45m wall is 94% of budget — one bad run from red. That was not
  obvious until measured.

## The bug this exposed in #712

Making `timeout-minutes` a matrix expression broke
`ci_installer_assembly_jobs_share_a_timeout_budget`: the parser I added in #712
typed the field as `Option<u64>`, so a non-integer value on **any** job aborted
the whole `ci.yaml` parse. Fixed here, TDD, with the field left uninterpreted at
deserialization and resolved at use:

- an expression on a job outside the class is ignored, not fatal;
- an expression on a job *inside* the class is a loud error (it cannot be
  compared against a sibling), matching the existing treatment of templated
  xtask targets;
- classification is on the `${{` syntax, not on which serde shape the scalar
  took, so a quoted literal `"60"` is a literal;
- any other scalar shape is a precise per-job error rather than a whole-document
  parse failure.

## Verification

130 tests pass; workspace clippy `-D warnings` and `cargo fmt --check` clean.

The conformance gate was mutation-checked in both directions: setting
`test-installer` back to 45 fails it with
`{"test-dmg-signing": Some(60), "test-installer": Some(45)}`; restoring 60
passes.

Reviewed with the review panel (code mode) over two rounds — round 1 was
`rejected` and correctly caught that my first derivation summed three *steps*
while `timeout-minutes` bounds the whole *job*.

## Not fixed here

Most of darwin's TUN pass is a whole-workspace rebuild: that step omits
`--features tombstone/crash-dumps,tombstone/crash-child`, which the Windows step
passes, so the feature set differs from the build and cargo rebuilds everything
for 9 tests. Within-run control in #720: Windows TUN phase 2m20s (one crate),
macOS 5m36s+ and killed (the whole workspace). Landing #720 returns 4–8 min and
lets the darwin budget come back down.

> [!NOTE]
> Touches `.github/workflows/ci.yaml` only in the `test-hole` block — the
> `timeout-minutes` line and the matrix `include` list (`@@ -266,3 +266,24` and
> `@@ -273,3 +294,3`). PR #709 edits the `test-ex-ray` block, well clear of it.
