### PR TITLE
fix(ci): run test-hole's nextest steps with the feature set hole-tests built

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,8 +278,10 @@ jobs:
     # once it is. windows/amd64 has never been killed but sits at 94% of the old
     # wall, so it is raised too; darwin/arm64 has 29% margin and stays.
     #
-    # For darwin this is a stopgap: most of its TUN pass is a whole-workspace
-    # rebuild caused by a feature-set mismatch in that step (#720).
+    # The macOS TUN step's own rebuild is gone (its feature set now matches), so
+    # the darwin measurements above predate that — re-measure those legs before
+    # tightening. windows/amd64 is unaffected; its TUN step already matched. The
+    # `hole` → `hole-tests` cascade still recompiles the shared crates (#723).
     #
     # The `ci_installer_assembly_jobs_share_a_timeout_budget` conformance test
     # does not cover these: it selects jobs whose xtask cascade reaches a
@@ -327,6 +329,8 @@ jobs:
       # `--features tombstone/crash-dumps,tombstone/crash-child` + `package(tombstone)`
       # also mirror `hole-tests` so the crash-marker tests `build hole-tests`
       # compiled actually run (matching feature set → no rebuild). See #522.
+      # The `ci_test_hole_steps_match_the_hole_tests_target` conformance test
+      # holds every nextest step here equal to that target's `run:`.
       - name: Test (non-TUN)
         id: test-non-tun
         shell: bash
@@ -341,7 +345,8 @@ jobs:
               + package(handle-holders) + package(tombstone)
               + package(hole-test-observability)'
 
-      - name: Test (TUN, runs last for #200)
+      # Quoted: an unquoted ` #` opens a YAML comment and truncates the name.
+      - name: "Test (TUN, runs last for #200)"
         if: matrix.os == 'windows' && matrix.arch == 'amd64'
         id: test-tun
         shell: bash
@@ -362,6 +367,10 @@ jobs:
       # binaries are prebuilt above; nextest only re-executes them). macOS
       # runners have passwordless sudo. Windows engages WFP from the elevated
       # token above; macOS has no such token, so root is the equivalent.
+      #
+      # `--features` must match `Build hole test binaries` and the non-TUN
+      # step above (see that comment) or cargo rebuilds instead of reusing
+      # the prebuilt binaries.
       - name: Test (TUN, macOS — root for pfctl)
         if: matrix.os == 'darwin'
         id: test-tun-macos
@@ -369,10 +378,12 @@ jobs:
         run: >
           sudo env "PATH=$PATH" "HOME=$HOME" SKULD_LABELS=tun
           cargo nextest run --no-default-features
+          --features tombstone/crash-dumps,tombstone/crash-child
           -E 'package(hole) + package(hole-bridge) + package(hole-common)
               + package(tun-engine) + package(tun-engine-macros)
               + package(dump) + package(dump-macros)
-              + package(handle-holders)'
+              + package(handle-holders) + package(tombstone)
+              + package(hole-test-observability)'
 
       # Upload bridge.log produced by `DistHarness` subprocesses. Matches
       # files that the test harness redirected to `$RUNNER_TEMP` (see

--- a/xtask/src/ci_coverage.rs
+++ b/xtask/src/ci_coverage.rs
@@ -20,7 +20,7 @@
 //!     `cargo xtask run <target>` through `build.yaml` and recurses into that
 //!     target's `run:`/`build:` commands under the same per-command rule.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
@@ -195,7 +195,7 @@ fn push_command(out: &mut Vec<String>, cur: &mut String) {
 /// Does this single command RUN tests? True iff it spawns nextest with the `run`
 /// subcommand (`cargo nextest run` OR `cargo-nextest nextest run`) and is not a
 /// `--no-run` compile-only invocation.
-fn is_nextest_run(cmd: &str) -> bool {
+pub(crate) fn is_nextest_run(cmd: &str) -> bool {
     let toks: Vec<&str> = cmd.split_whitespace().collect();
     if toks.contains(&"--no-run") {
         return false;
@@ -211,10 +211,33 @@ fn xtask_run_target(cmd: &str) -> Option<&str> {
         .map(|w| w[3])
 }
 
+/// Strip one matched pair of surrounding shell quotes.
+///
+/// [`split_commands`] preserves quote characters, so `cargo xtask build
+/// "hole-msi"` yields the token `"hole-msi"`. Comparing that raw against a bare
+/// name silently drops the command out of every match — the exact invisible-miss
+/// the conformance tests exist to prevent.
+pub(crate) fn unquote(tok: &str) -> &str {
+    for q in ['"', '\''] {
+        if let Some(inner) = tok.strip_prefix(q).and_then(|t| t.strip_suffix(q)) {
+            return inner;
+        }
+    }
+    tok
+}
+
 /// The command-line text of a manifest step, for token extraction.
 pub(crate) fn step_command(step: &Step) -> String {
     match step {
         Step::Bash { command, .. } => command.clone(),
         Step::Process { args, .. } => args.join(" "),
+    }
+}
+
+/// The environment a manifest step exports, which [`step_command`] does not
+/// carry.
+pub(crate) fn step_environment(step: &Step) -> &HashMap<String, String> {
+    match step {
+        Step::Bash { environment, .. } | Step::Process { environment, .. } => environment,
     }
 }

--- a/xtask/src/ci_nextest_parity.rs
+++ b/xtask/src/ci_nextest_parity.rs
@@ -1,0 +1,222 @@
+//! Does a `.github/workflows/ci.yaml` test job run the binaries it compiled?
+//!
+//! Backs the `ci_test_hole_steps_match_the_hole_tests_target` conformance test.
+//! `test-hole` compiles once via `cargo xtask build hole-tests`, then its nextest
+//! steps are only supposed to re-execute those binaries. Cargo keys that reuse on
+//! the resolved feature set, so a step missing one `--features` flag rebuilds the
+//! whole workspace instead — silently, staying green at roughly twice the wall
+//! clock, which is how #720 went unnoticed.
+//!
+//! [`TestJob`] therefore reports the chain, not just the commands: the build.yaml
+//! target the job's `cargo xtask build` step names, and each nextest run to
+//! compare against that target's own `run:`. Hardcoding the target on the test
+//! side would let a retargeted build step empty the invariant while it still
+//! passed.
+//!
+//! The two files state the same command with different quoting, folding and
+//! environment conventions, so comparison is on a normalized form: line
+//! continuations joined, whitespace collapsed, and a leading `sudo`/`env`/
+//! `VAR=value` launcher prefix stripped (the macOS TUN step states inline what
+//! its siblings state as step-level `env:`). Only [`FINGERPRINT_NEUTRAL_ENV`]
+//! variables may be stripped or exported — anything else feeds cargo's
+//! fingerprint, and normalizing it away would hide the very rebuild being
+//! guarded against.
+
+use anyhow::{bail, Context, Result};
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::ci_coverage::{
+    is_nextest_run, join_line_continuations, split_commands, step_command, step_environment, unquote,
+};
+use crate::ci_timeouts::xtask_target;
+use crate::manifest::Manifest;
+
+/// Environment variables a compared step may set. They select which toolchain
+/// and which tests run; none reach cargo's fingerprint, so the two files are
+/// free to state them differently.
+///
+/// `RUSTFLAGS`, `RUSTC_WRAPPER`, `CARGO_TARGET_DIR` and friends do reach it —
+/// setting one on a compile or run step breaks the artifact reuse this module
+/// exists to protect, so anything outside this set is an error rather than a
+/// silent pass.
+pub const FINGERPRINT_NEUTRAL_ENV: [&str; 3] = ["HOME", "PATH", "SKULD_LABELS"];
+
+// Minimal `ci.yaml` shape — serde ignores every field we don't name, so this
+// tracks only `jobs.<id>.steps[].{name,id,run,env}`.
+
+#[derive(Deserialize)]
+struct CiYaml {
+    jobs: IndexMap<String, Job>,
+}
+
+#[derive(Deserialize)]
+struct Job {
+    #[serde(default)]
+    steps: Vec<CiStep>,
+}
+
+#[derive(Deserialize)]
+struct CiStep {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    run: Option<String>,
+    /// Values stay uninterpreted: only the variable NAMES matter here, and a
+    /// non-string scalar on an unrelated step must not abort the parse.
+    #[serde(default)]
+    env: IndexMap<String, serde_yml::Value>,
+}
+
+/// The compile-then-run chain of a ci.yaml test job.
+#[derive(Debug)]
+pub struct TestJob {
+    /// build.yaml target whose `cargo xtask build|run` step compiled the
+    /// binaries — the only defensible thing to compare the runs against.
+    pub target: String,
+    /// `(step label, normalized nextest command)` per RUN step, in workflow order.
+    pub runs: Vec<(String, String)>,
+}
+
+/// Resolve `job_id`'s chain: the single build.yaml target it compiles, and every
+/// nextest RUN command it then executes.
+///
+/// `--no-run` compiles are not runs — compiling is a separate operation, stated
+/// separately in build.yaml as `build:`.
+pub fn test_job(ci_yaml: &str, job_id: &str) -> Result<TestJob> {
+    let ci: CiYaml = serde_yml::from_str(ci_yaml).context("parsing ci.yaml")?;
+    let job = ci
+        .jobs
+        .get(job_id)
+        .with_context(|| format!("ci.yaml declares no job {job_id:?}"))?;
+
+    let mut target: Option<String> = None;
+    let mut runs = Vec::new();
+
+    for (i, step) in job.steps.iter().enumerate() {
+        let Some(run) = &step.run else { continue };
+        let label = step_label(step, i);
+        for cmd in split_commands(&join_line_continuations(run)) {
+            if is_nextest_run(&cmd) {
+                check_env(&label, step.env.keys().map(String::as_str))?;
+                runs.push((label.clone(), normalize(&cmd)?));
+                continue;
+            }
+            let Some(found) = xtask_target(&cmd)? else { continue };
+            if let Some(prev) = &target {
+                bail!("ci.yaml job {job_id:?} builds both {prev:?} and {found:?}; which one its tests re-execute is ambiguous");
+            }
+            check_env(&label, step.env.keys().map(String::as_str))?;
+            target = Some(found.to_string());
+        }
+    }
+
+    let target = target.with_context(|| {
+        format!("ci.yaml job {job_id:?} invokes no `cargo xtask build|run`, so nothing ties its test steps to a build.yaml target")
+    })?;
+    Ok(TestJob { target, runs })
+}
+
+/// The nextest-RUN command of build.yaml target `name`, normalized the same way
+/// as [`test_job`]'s. Exactly one is required: zero or several make "the command
+/// this target runs" ambiguous, and guessing would compare the CI steps against
+/// something nobody chose.
+pub fn target_nextest_run(manifest: &Manifest, name: &str) -> Result<String> {
+    let target = manifest
+        .get(name)
+        .with_context(|| format!("build.yaml declares no target {name:?}"))?;
+
+    let mut found = Vec::new();
+    for step in &target.run {
+        for cmd in split_commands(&join_line_continuations(&step_command(step))) {
+            if is_nextest_run(&cmd) {
+                check_env(name, step_environment(step).keys().map(String::as_str))?;
+                found.push(normalize(&cmd)?);
+            }
+        }
+    }
+
+    if found.len() != 1 {
+        bail!(
+            "build.yaml target {name:?} has {} nextest run commands in its `run:` steps, expected exactly one",
+            found.len()
+        );
+    }
+    Ok(found.remove(0))
+}
+
+/// Reject any exported variable outside [`FINGERPRINT_NEUTRAL_ENV`].
+fn check_env<'a>(label: &str, names: impl Iterator<Item = &'a str>) -> Result<()> {
+    for name in names {
+        if !FINGERPRINT_NEUTRAL_ENV.contains(&name) {
+            bail!(
+                "{label:?} exports {name:?}, which is outside the fingerprint-neutral set \
+                 {FINGERPRINT_NEUTRAL_ENV:?} — it can change what cargo builds, so the compiled \
+                 and executed binaries can no longer be assumed to be the same ones"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A step's identity in a failure message: its `name`, else its `id`, else its
+/// position. Every step has one of the three.
+fn step_label(step: &CiStep, index: usize) -> String {
+    step.name
+        .clone()
+        .or_else(|| step.id.clone())
+        .unwrap_or_else(|| format!("steps[{index}]"))
+}
+
+/// One command reduced to a comparable form: launcher prefix dropped, whitespace
+/// collapsed to single spaces.
+fn normalize(cmd: &str) -> Result<String> {
+    let toks: Vec<&str> = cmd.split_whitespace().collect();
+    let mut start = 0;
+    while let Some(tok) = toks.get(start) {
+        match classify(tok) {
+            Token::Launcher => start += 1,
+            Token::Command => break,
+            Token::ForeignEnv(name) => bail!(
+                "command {cmd:?} sets {name:?} inline, which is outside the fingerprint-neutral \
+                 set {FINGERPRINT_NEUTRAL_ENV:?} — stripping it would hide a cargo rebuild"
+            ),
+        }
+    }
+    Ok(toks[start..].join(" "))
+}
+
+enum Token<'a> {
+    /// Sets up the environment rather than naming the command.
+    Launcher,
+    /// An assignment of a variable cargo's fingerprint may depend on.
+    ForeignEnv(&'a str),
+    /// The command itself — everything from here on is compared.
+    Command,
+}
+
+fn classify(tok: &str) -> Token<'_> {
+    let stripped = unquote(tok);
+    if stripped == "sudo" || stripped == "env" {
+        return Token::Launcher;
+    }
+    match stripped.split_once('=') {
+        Some((key, _)) if is_env_var_name(key) => {
+            if FINGERPRINT_NEUTRAL_ENV.contains(&key) {
+                Token::Launcher
+            } else {
+                Token::ForeignEnv(key)
+            }
+        }
+        _ => Token::Command,
+    }
+}
+
+/// A POSIX environment variable name: `[A-Za-z_][A-Za-z0-9_]*`.
+fn is_env_var_name(s: &str) -> bool {
+    let mut chars = s.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}

--- a/xtask/src/ci_nextest_parity.rs
+++ b/xtask/src/ci_nextest_parity.rs
@@ -32,14 +32,16 @@ use crate::ci_coverage::{
 use crate::ci_timeouts::xtask_target;
 use crate::manifest::Manifest;
 
-/// Environment variables a compared step may set. They select which toolchain
-/// and which tests run; none reach cargo's fingerprint, so the two files are
-/// free to state them differently.
+/// Environment variables a compared step may set — the two files are free to
+/// state these differently.
 ///
-/// `RUSTFLAGS`, `RUSTC_WRAPPER`, `CARGO_TARGET_DIR` and friends do reach it —
-/// setting one on a compile or run step breaks the artifact reuse this module
-/// exists to protect, so anything outside this set is an error rather than a
-/// silent pass.
+/// Admission criterion: does it reach cargo's fingerprint, and if so does it
+/// INVALIDATE rather than corrupt it? `PATH` passes on the second clause (a
+/// different rustc changes the fingerprint's version hash, so cargo rebuilds
+/// instead of reusing stale units), `HOME` only relocates `CARGO_HOME`, and
+/// `SKULD_LABELS` is read by skuld at test runtime. `RUSTFLAGS`, `RUSTC_WRAPPER`
+/// and `CARGO_TARGET_DIR` fail it. The test is asymmetric: rejecting a neutral
+/// variable is loud and costs one line here, admitting a relevant one is silent.
 pub const FINGERPRINT_NEUTRAL_ENV: [&str; 3] = ["HOME", "PATH", "SKULD_LABELS"];
 
 // Minimal `ci.yaml` shape — serde ignores every field we don't name, so this

--- a/xtask/src/ci_nextest_parity_tests.rs
+++ b/xtask/src/ci_nextest_parity_tests.rs
@@ -1,0 +1,362 @@
+//! Unit tests for the compile-then-run chain resolver plus the
+//! `ci_test_hole_steps_match_the_hole_tests_target` structural conformance test.
+
+use std::fs;
+
+use crate::ci_nextest_parity::{target_nextest_run, test_job};
+use crate::manifest::Manifest;
+
+// ===== test_job ======================================================================================================
+
+/// A `run:` block written as a folded scalar and one written with backslash
+/// continuations must reduce to the same text.
+#[skuld::test]
+fn folded_and_continued_commands_normalize_to_one_line() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: folded
+        run: >
+          cargo nextest run --no-default-features
+          -E 'package(a)
+              + package(b)'
+      - name: continued
+        run: |
+          cargo nextest run --no-default-features \\
+            -E 'package(a) + package(b)'
+";
+    let job = test_job(ci, "j").expect("analyze");
+    let cmds: Vec<&str> = job.runs.iter().map(|(_, c)| c.as_str()).collect();
+    assert_eq!(
+        cmds,
+        vec![
+            "cargo nextest run --no-default-features -E 'package(a) + package(b)'",
+            "cargo nextest run --no-default-features -E 'package(a) + package(b)'"
+        ]
+    );
+}
+
+/// The macOS TUN step states its environment inline under `sudo env …` where its
+/// siblings use step-level `env:`. That prefix is not part of the nextest
+/// command and must not make the step look different from them.
+#[skuld::test]
+fn a_sudo_env_prefix_is_stripped() {
+    let ci = r#"
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: root
+        run: sudo env "PATH=$PATH" "HOME=$HOME" SKULD_LABELS=tun cargo nextest run -E 'package(a)'
+"#;
+    let job = test_job(ci, "j").expect("analyze");
+    assert_eq!(
+        job.runs,
+        vec![("root".into(), "cargo nextest run -E 'package(a)'".into())]
+    );
+}
+
+/// Only a *leading* prefix is stripped: an `=` inside the command's own flags is
+/// part of the command.
+#[skuld::test]
+fn flags_carrying_an_equals_sign_survive_normalization() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: s
+        run: cargo nextest run --config-file=x.toml -E 'package(a)'
+";
+    let job = test_job(ci, "j").expect("analyze");
+    assert_eq!(job.runs[0].1, "cargo nextest run --config-file=x.toml -E 'package(a)'");
+}
+
+/// `--no-run` compiles rather than runs, so it is a different operation from the
+/// `run:` command being compared against — build.yaml states it separately.
+#[skuld::test]
+fn compile_only_steps_are_not_runs() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo xtask build tests
+      - name: build
+        run: cargo nextest run --no-run -E 'package(a)'
+";
+    assert!(test_job(ci, "j").expect("analyze").runs.is_empty());
+}
+
+/// Several nextest runs in one `run:` block each get their own entry rather than
+/// collapsing onto the step's label.
+#[skuld::test]
+fn every_run_in_a_multi_command_step_is_reported() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: both
+        run: |
+          cargo nextest run -E 'package(a)'
+          cargo nextest run -E 'package(b)'
+";
+    let job = test_job(ci, "j").expect("analyze");
+    assert_eq!(job.runs.len(), 2);
+    assert_eq!(job.runs[0].1, "cargo nextest run -E 'package(a)'");
+    assert_eq!(job.runs[1].1, "cargo nextest run -E 'package(b)'");
+}
+
+/// An unnamed step still has to be identifiable in a failure message.
+#[skuld::test]
+fn unnamed_steps_fall_back_to_id_then_position() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - id: has-id
+        run: cargo nextest run -E 'package(a)'
+      - run: cargo nextest run -E 'package(b)'
+";
+    let job = test_job(ci, "j").expect("analyze");
+    assert_eq!(job.runs[0].0, "has-id");
+    assert_eq!(job.runs[1].0, "steps[2]");
+}
+
+// ----- the compiled target -------------------------------------------------------------------------------------------
+
+#[skuld::test]
+fn the_compiled_target_is_read_off_the_build_step() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - run: cargo nextest run -E 'package(a)'
+";
+    assert_eq!(test_job(ci, "j").expect("analyze").target, "tests");
+}
+
+/// Nothing ties the runs to a build.yaml target, so there is no defensible thing
+/// to compare them against — the invariant must not quietly become vacuous.
+#[skuld::test]
+fn a_job_that_builds_nothing_is_an_error() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo nextest run -E 'package(a)'
+";
+    let err = test_job(ci, "j").unwrap_err();
+    assert!(
+        format!("{err:#}").contains("no `cargo xtask"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[skuld::test]
+fn a_job_that_builds_two_targets_is_an_error() {
+    let ci = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - run: cargo xtask build other
+      - run: cargo nextest run -E 'package(a)'
+";
+    let err = test_job(ci, "j").unwrap_err();
+    assert!(format!("{err:#}").contains("ambiguous"), "unexpected error: {err:#}");
+}
+
+#[skuld::test]
+fn a_missing_job_is_an_error() {
+    let err = test_job("jobs:\n  j:\n    steps: []\n", "gone").unwrap_err();
+    assert!(
+        format!("{err:#}").contains("no job \"gone\""),
+        "unexpected error: {err:#}"
+    );
+}
+
+// ----- environment ---------------------------------------------------------------------------------------------------
+
+/// `RUSTFLAGS` reaches cargo's fingerprint, so a step carrying it no longer
+/// re-executes what the build step compiled — whether it is exported as
+/// step-level `env:` or inline, and whether it lands on the compile step or a
+/// run step.
+#[skuld::test]
+fn a_fingerprint_relevant_variable_is_an_error_wherever_it_appears() {
+    let step_level = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: s
+        env:
+          RUSTFLAGS: -C target-cpu=native
+        run: cargo nextest run -E 'package(a)'
+";
+    let on_the_build_step = "
+jobs:
+  j:
+    steps:
+      - name: b
+        env:
+          CARGO_TARGET_DIR: /tmp/t
+        run: cargo xtask build tests
+      - run: cargo nextest run -E 'package(a)'
+";
+    let inline = "
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: s
+        run: sudo env RUSTC_WRAPPER=sccache cargo nextest run -E 'package(a)'
+";
+    for (ci, needle) in [
+        (step_level, "\"RUSTFLAGS\""),
+        (on_the_build_step, "\"CARGO_TARGET_DIR\""),
+        (inline, "\"RUSTC_WRAPPER\""),
+    ] {
+        let err = test_job(ci, "j").unwrap_err();
+        assert!(format!("{err:#}").contains(needle), "unexpected error: {err:#}");
+    }
+}
+
+/// The variables the two files legitimately state differently stay allowed.
+#[skuld::test]
+fn fingerprint_neutral_variables_are_allowed() {
+    let ci = r#"
+jobs:
+  j:
+    steps:
+      - run: cargo xtask build tests
+      - name: s
+        env:
+          SKULD_LABELS: "!tun"
+        run: cargo nextest run -E 'package(a)'
+"#;
+    assert_eq!(test_job(ci, "j").expect("analyze").runs.len(), 1);
+}
+
+// ===== target_nextest_run ============================================================================================
+
+fn fixture_manifest() -> Manifest {
+    Manifest::parse(
+        r#"
+targets:
+  tests:
+    platforms: [linux/amd64]
+    build: cargo nextest run --no-run --no-default-features -E 'package(a)'
+    run: >
+      cargo nextest run --no-default-features
+      -E 'package(a)'
+  twice:
+    platforms: [linux/amd64]
+    run:
+      - cargo nextest run -E 'package(a)'
+      - cargo nextest run -E 'package(b)'
+  none:
+    platforms: [linux/amd64]
+    run: cargo xtask build tests
+  flagged:
+    platforms: [linux/amd64]
+    run:
+      - bash:
+          command: cargo nextest run -E 'package(a)'
+          environment: { RUSTFLAGS: -C target-cpu=native }
+"#,
+    )
+    .expect("fixture manifest parses")
+}
+
+/// The `build:` twin differs only by `--no-run`; taking it instead would compare
+/// the CI steps against a compile command.
+#[skuld::test]
+fn the_run_command_is_taken_not_its_no_run_twin() {
+    assert_eq!(
+        target_nextest_run(&fixture_manifest(), "tests").expect("resolve"),
+        "cargo nextest run --no-default-features -E 'package(a)'"
+    );
+}
+
+#[skuld::test]
+fn an_ambiguous_or_absent_run_command_is_an_error() {
+    for (target, needle) in [("twice", "2 nextest"), ("none", "0 nextest")] {
+        let err = target_nextest_run(&fixture_manifest(), target).unwrap_err();
+        assert!(format!("{err:#}").contains(needle), "unexpected error: {err:#}");
+    }
+}
+
+/// build.yaml's `environment:` is dropped by `step_command`, so it has to be
+/// checked separately or a fingerprint-relevant variable there is invisible.
+#[skuld::test]
+fn a_fingerprint_relevant_step_environment_is_an_error() {
+    let err = target_nextest_run(&fixture_manifest(), "flagged").unwrap_err();
+    assert!(
+        format!("{err:#}").contains("\"RUSTFLAGS\""),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[skuld::test]
+fn a_missing_target_is_an_error() {
+    let err = target_nextest_run(&fixture_manifest(), "gone").unwrap_err();
+    assert!(
+        format!("{err:#}").contains("no target \"gone\""),
+        "unexpected error: {err:#}"
+    );
+}
+
+// ===== conformance ===================================================================================================
+
+/// Steps of `ci.yaml`'s `test-hole` job that we require to be nextest runs.
+const TEST_HOLE_RUN_STEPS: [&str; 3] = [
+    "Test (non-TUN)",
+    "Test (TUN, runs last for #200)",
+    "Test (TUN, macOS — root for pfctl)",
+];
+
+/// Every nextest run in `ci.yaml`'s `test-hole` job invokes exactly the command
+/// build.yaml's `hole-tests` target runs — see [`crate::ci_nextest_parity`] for why.
+///
+/// `hole-tests` is read off the job's build step rather than assumed, and pinned
+/// here as well: `hole` and `hole-tests` do not share a resolvable feature set
+/// (#723), so a retarget is a decision to take deliberately, not to absorb.
+#[skuld::test]
+fn ci_test_hole_steps_match_the_hole_tests_target() {
+    let root = crate::repo_root().expect("repo root");
+    let manifest = Manifest::parse(&fs::read_to_string(root.join("build.yaml")).expect("read build.yaml"))
+        .expect("parse build.yaml");
+    let ci_yaml = fs::read_to_string(root.join(".github/workflows/ci.yaml")).expect("read ci.yaml");
+
+    let job = test_job(&ci_yaml, "test-hole").expect("analyze ci.yaml");
+    assert_eq!(
+        job.target, "hole-tests",
+        "ci.yaml test-hole now compiles a different build.yaml target"
+    );
+    let expected = target_nextest_run(&manifest, &job.target).expect("resolve the compiled target");
+
+    // Guard the guard by MEMBERSHIP: a step renamed out of detection would leave
+    // any count-based check green while its command drifted unwatched.
+    let labels: Vec<&str> = job.runs.iter().map(|(label, _)| label.as_str()).collect();
+    for step in TEST_HOLE_RUN_STEPS {
+        assert!(
+            labels.contains(&step),
+            "ci.yaml test-hole step {step:?} no longer resolves as a nextest run (found {labels:?})"
+        );
+    }
+
+    for (label, cmd) in &job.runs {
+        assert_eq!(
+            cmd, &expected,
+            "ci.yaml test-hole step {label:?} must run exactly what build.yaml's {:?} target runs \
+             (see module docs for why)",
+            job.target
+        );
+    }
+}

--- a/xtask/src/ci_timeouts.rs
+++ b/xtask/src/ci_timeouts.rs
@@ -23,7 +23,7 @@ use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
-use crate::ci_coverage::{join_line_continuations, split_commands, step_command};
+use crate::ci_coverage::{join_line_continuations, split_commands, step_command, unquote};
 use crate::manifest::Manifest;
 
 // Minimal `ci.yaml` shape — serde ignores every field we don't name, so this
@@ -77,21 +77,6 @@ fn resolve_timeout(id: &str, value: &serde_yml::Value) -> Result<u64> {
 struct CiStep {
     #[serde(default)]
     run: Option<String>,
-}
-
-/// Strip one matched pair of surrounding shell quotes.
-///
-/// [`split_commands`] preserves quote characters, so `cargo xtask build
-/// "hole-msi"` yields the token `"hole-msi"`. Comparing that raw against a
-/// target name silently drops the command out of every match below — the exact
-/// invisible-miss the conformance test exists to prevent.
-fn unquote(tok: &str) -> &str {
-    for q in ['"', '\''] {
-        if let Some(inner) = tok.strip_prefix(q).and_then(|t| t.strip_suffix(q)) {
-            return inner;
-        }
-    }
-    tok
 }
 
 /// Does `cmd` assemble an installer package?

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -15,6 +15,7 @@ use crate::orchestrate::{execute, execute_run, relocate_self_if_windows, render_
 
 pub mod bindir;
 pub mod ci_coverage;
+pub mod ci_nextest_parity;
 pub mod ci_timeouts;
 // macOS-only: renders with the system font via the Typst library (a macOS-only
 // dependency — the DMG background is a darwin feature).
@@ -41,6 +42,9 @@ mod bindir_tests;
 #[cfg(test)]
 #[path = "ci_coverage_tests.rs"]
 mod ci_coverage_tests;
+#[cfg(test)]
+#[path = "ci_nextest_parity_tests.rs"]
+mod ci_nextest_parity_tests;
 #[cfg(test)]
 #[path = "ci_timeouts_tests.rs"]
 mod ci_timeouts_tests;


### PR DESCRIPTION
Closes #720.

`test-hole` compiles once with `cargo xtask build hole-tests`, then its nextest steps are supposed to only re-execute those binaries. The macOS TUN step ran a different feature and package set, so cargo resolved a different fingerprint and rebuilt the whole workspace — green, at roughly twice the wall clock.

## The fix

The macOS TUN step gains `--features tombstone/crash-dumps,tombstone/crash-child` and the `package(tombstone)` + `package(hole-test-observability)` filters, matching `hole-tests` and its two sibling steps.

## The guard

`xtask/src/ci_nextest_parity.rs` + its conformance test assert that every nextest **run** step in `test-hole` invokes exactly what `hole-tests`' `run:` invokes. The two files state the same command with different quoting, folding and environment conventions, so comparison is on a normalized form: continuations joined, whitespace collapsed, leading `sudo`/`env`/`VAR=value` prefix stripped.

Three things are checked structurally rather than assumed:

- the build.yaml target is **read off the job's `cargo xtask build` step**, not hardcoded, so a retargeted build step cannot empty the invariant;
- only `HOME`/`PATH`/`SKULD_LABELS` may be exported or stripped — `RUSTFLAGS`, `RUSTC_WRAPPER`, `CARGO_TARGET_DIR` and friends reach cargo's fingerprint, so they are an error wherever they appear on a step in the chain (inline, step-level `env:`, or build.yaml `environment:`);
- step membership, so a renamed step fails loudly instead of dropping out of the comparison.

`hole-tests` rather than `hole`: those two do not share a resolvable feature set (#723), so asserting against `hole` would encode a false invariant.

Mutation-checked in four directions — dropping `--features`, perturbing the `-E` package list, retargeting the build step, and adding `RUSTFLAGS` — each fails naming the offending step.

## Also here

- `Test (TUN, runs last for #200)` is now quoted: unquoted ` #` opens a YAML comment, so GitHub was displaying the step as `Test (TUN, runs last for`. Found by the guard.
- `unquote` moved from `ci_timeouts.rs` to `ci_coverage.rs` beside the other shared shell primitives; `is_nextest_run` widened to `pub(crate)`.
- The `test-hole` timeout rationale now scopes its rebuild claim to the darwin legs and points at #723 for the residual `hole` → `hole-tests` recompile, which this PR does not address.
