### PR TITLE
feat(galoshes)!: disable the embedded ex-ray's redundant Mux.Cool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ before editing; the sections linked below are the authoritative source.
   whole interval and deadline, so an un-upgraded peer's tag rejection reads as
   liveness and a busy tunnel is never probed at all. →
   [CONTRIBUTING.md#yamux-transport-self-heal](CONTRIBUTING.md#yamux-transport-self-heal)
+- **galoshes mux default.** galoshes appends `mux=0` for its embedded ex-ray —
+  its yamux already collapsed every stream onto one connection, so Mux.Cool is
+  pure overhead. ex-ray is first-wins on duplicate SIP003 keys, so an operator's
+  earlier `mux=` overrides it. `mux` also picks the server's dokodemo
+  destination, so a `mux=0` client cannot reach a `mux=1` server. →
+  [CONTRIBUTING.md#galoshes-mux-default](CONTRIBUTING.md#galoshes-mux-default)
 - **Fail-closed covers.** The **standing lockdown** cover
   (`Routing::install_lockdown`, opt-in kill switch) holds the update-cutover gap:
   the bridge **disarms-not-drops** it across the restart and the new bridge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,6 +299,30 @@ reconnects after a transport reset instead of wedging the tunnel:
   healthy-but-slow server off the fatal path. `const` assertions pin both
   relations at the constants.
 
+### galoshes mux default
+
+galoshes appends `mux=0` to the `SS_PLUGIN_OPTIONS` it hands its embedded
+ex-ray ([`crates/galoshes/src/exray_options.rs`](crates/galoshes/src/exray_options.rs)).
+Its yamux layer has already collapsed every logical stream onto one connection,
+so v2ray-core's Mux.Cool has nothing left to multiplex — it only adds framing
+and a second connection lifecycle that can fail on its own.
+
+ex-ray is **first-wins** on duplicate SIP003 keys
+([`crates/ex-ray/args.go`](crates/ex-ray/args.go)), so the appended pair is a
+*default*: an operator's own earlier `mux=` overrides it.
+
+`mux` also selects the server's dokodemo destination (`v1.mux.cool` when
+enabled), so **a `mux=0` client cannot talk to a `mux=1` server**. Both ends
+must run a galoshes that agrees; during a version-skew window, pinning `mux=1`
+in the plugin options on both ends restores the old wire format.
+
+The append goes through `garter::{split_plugin_options, join_plugin_options}`
+so the escaping cannot drift from the parser's: a naive strip-then-append turns
+`path=/a\;` into `path=/a\;mux=0`, which ex-ray reads as one pair with no `mux`
+key at all. Two shapes have no correct output and are refused at startup — a
+dangling final escape, and a segment with an empty key — because ex-ray rejects
+either string wholesale and silently falls back to every flag default.
+
 ### Fail-closed cover
 
 Two egress-block covers share the platform `Cover` guard (kind-aware `Drop`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,6 +316,14 @@ enabled), so **a `mux=0` client cannot talk to a `mux=1` server**. Both ends
 must run a galoshes that agrees; during a version-skew window, pinning `mux=1`
 in the plugin options on both ends restores the old wire format.
 
+A skewed pair **stalls before it breaks**: the `mux=1` server's worker cannot
+unmarshal the client's first frame, so it poisons its inbound pipe and stops
+reading — but nothing is reset, because no further byte is due. The
+[yamux keepalive](#yamux-transport-self-heal) is what converts the stall into a
+teardown: its next probe hits the poisoned pipe, the server closes, and the
+client sees the transport die. Skew therefore surfaces as a connection that
+lasts one keepalive interval, not as an immediate refusal.
+
 The append goes through `garter::{split_plugin_options, join_plugin_options}`
 so the escaping cannot drift from the parser's: a naive strip-then-append turns
 `path=/a\;` into `path=/a\;mux=0`, which ex-ray reads as one pair with no `mux`

--- a/crates/ex-ray/config_test.go
+++ b/crates/ex-ray/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
+	"github.com/v2fly/v2ray-core/v5/proxy/dokodemo"
 	"github.com/v2fly/v2ray-core/v5/transport/internet"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tls"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tls/utls"
@@ -517,5 +518,94 @@ func TestGenerateConfigRejectsOutOfRangeKeepAlive(t *testing.T) {
 		if !strings.Contains(err.Error(), "tcp-keepalive") {
 			t.Errorf("server=%v: error %q does not mention tcp-keepalive", srv, err.Error())
 		}
+	}
+}
+
+// The declared default is what makes galoshes' appended mux=0 necessary at all.
+func TestMuxFlagDefault(t *testing.T) {
+	if *mux != 1 {
+		t.Errorf("mux flag default = %d, want 1", *mux)
+	}
+}
+
+// Inputs mirror what galoshes hands its embedded ex-ray; expectations come from
+// the grammar in args.go (first-wins, escapes), not from running galoshes.
+func TestParseOptsIntoFlagsMux(t *testing.T) {
+	cases := []struct {
+		desc string
+		opts string
+		want int
+	}{
+		{"appended alone", "mux=0", 0},
+		{"appended after directives", "host=cloudfront.com;path=/;mux=0", 0},
+		{"appended after an escaped semicolon", `path=/a\;;mux=0`, 0},
+		{"operator override wins (first-wins)", "mux=8;path=/;mux=0", 8},
+		{"no mux key keeps the flag default", "host=cloudfront.com;path=/", 1},
+		// The shapes galoshes' ex_ray_options refuses to emit. Each leaves mux at
+		// 1 -- Mux.Cool silently ON -- which is precisely why it refuses.
+		{"one trailing backslash is a dangling escape", `a=b\;mux=0`, 1},
+		{"two are a literal backslash, so the separator holds", `a=b\\;mux=0`, 0},
+		{"three are a literal backslash plus a dangling escape", `a=b\\\;mux=0`, 1},
+		{"an empty segment voids the whole string", "mode=websocket;;mux=0", 1},
+		{"an empty key voids the whole string", "host=h;=v;mux=0", 1},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			orig := *mux
+			defer func() { *mux = orig }()
+			*mux = 1
+			withEnv(t, c.opts)
+			parseOptsIntoFlags()
+			if *mux != c.want {
+				t.Errorf("%s: *mux = %d, want %d", c.desc, *mux, c.want)
+			}
+		})
+	}
+}
+
+// mux=0 must disable Mux.Cool on BOTH ends of a websocket chain: the client
+// stops attaching MultiplexSettings, and the server stops pointing dokodemo at
+// the v1.mux.cool sentinel. The server half is why a mux=0 client cannot talk
+// to a mux=1 server.
+func TestGenerateConfigMuxDisablesMultiplexing(t *testing.T) {
+	cases := []struct {
+		desc          string
+		mux           int
+		wantMultiplex bool
+		wantSrvAddr   string
+	}{
+		{"mux=1 keeps Mux.Cool", 1, true, "v1.mux.cool"},
+		{"mux=0 disables Mux.Cool", 0, false, "127.0.0.1"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			restore := withFlags(t, c.mux, 0, false)
+			clientCfg, err := generateConfig()
+			restore()
+			if err != nil {
+				t.Fatalf("client generateConfig(): %v", err)
+			}
+			sender := new(proxyman.SenderConfig)
+			if err := clientCfg.Outbound[0].SenderSettings.UnmarshalTo(sender); err != nil {
+				t.Fatalf("unmarshal sender settings: %v", err)
+			}
+			if got := sender.MultiplexSettings != nil; got != c.wantMultiplex {
+				t.Errorf("client: MultiplexSettings present = %v, want %v", got, c.wantMultiplex)
+			}
+
+			restore = withFlags(t, c.mux, 0, true)
+			serverCfg, err := generateConfig()
+			restore()
+			if err != nil {
+				t.Fatalf("server generateConfig(): %v", err)
+			}
+			dk := new(dokodemo.Config)
+			if err := serverCfg.Inbound[0].ProxySettings.UnmarshalTo(dk); err != nil {
+				t.Fatalf("unmarshal dokodemo settings: %v", err)
+			}
+			if got := dk.Address.AsAddress().String(); got != c.wantSrvAddr {
+				t.Errorf("server: dokodemo address = %q, want %q", got, c.wantSrvAddr)
+			}
+		})
 	}
 }

--- a/crates/galoshes/src/exray_options.rs
+++ b/crates/galoshes/src/exray_options.rs
@@ -1,0 +1,34 @@
+//! Options handed to the embedded ex-ray.
+
+use anyhow::{Context, Result};
+
+const MUX_OFF: &str = "mux=0";
+
+/// Build the embedded ex-ray's `SS_PLUGIN_OPTIONS`, appending `mux=0`.
+///
+/// galoshes' yamux already collapsed every stream onto one connection, so
+/// Mux.Cool has nothing left to multiplex. ex-ray is first-wins, so an earlier
+/// `mux=` overrides this; `mux` also picks the server's dokodemo destination.
+pub fn ex_ray_options(plugin_options: Option<&str>) -> Result<String> {
+    let Some(opts) = plugin_options.filter(|s| !s.is_empty()) else {
+        return Ok(MUX_OFF.to_string());
+    };
+    // A rejected string is fatal here because ex-ray does not reject it: it
+    // discards every option and reports `ready` on the flag-default port. The
+    // reason comes from the error's own Display, which names the shape without
+    // echoing options that may carry a secret.
+    let segments = garter::split_plugin_options(opts).context("cannot build plugin options for the embedded ex-ray")?;
+    let out = garter::join_plugin_options(segments.iter().map(|s| s.raw).chain([MUX_OFF]));
+    // Contract, not input validation: the split accepts exactly what ex-ray
+    // accepts, so a miss means garter's escaping drifted from ex-ray's. Checked
+    // on the appended pair, which is always last — an operator's own `mux=`
+    // would satisfy a mere presence check while the append was being swallowed.
+    debug_assert_eq!(
+        garter::parse_plugin_options(&out)
+            .last()
+            .map(|(k, v)| (k.as_str(), v.as_str())),
+        Some(("mux", "0")),
+        "appended mux directive vanished: {out:?}"
+    );
+    Ok(out)
+}

--- a/crates/galoshes/src/exray_options_tests.rs
+++ b/crates/galoshes/src/exray_options_tests.rs
@@ -1,0 +1,79 @@
+use crate::exray_options::ex_ray_options;
+
+#[skuld::test]
+fn mux_is_disabled_by_default() {
+    assert_eq!(ex_ray_options(None).unwrap(), "mux=0");
+    assert_eq!(ex_ray_options(Some("")).unwrap(), "mux=0");
+    assert_eq!(
+        ex_ray_options(Some("host=cloudfront.com;path=/")).unwrap(),
+        "host=cloudfront.com;path=/;mux=0"
+    );
+}
+
+#[skuld::test]
+fn server_mode_and_other_directives_survive() {
+    // `Mode::from_plugin_options` keys off `server`; appending must not disturb it.
+    let out = ex_ray_options(Some("server;host=cloudfront.com;path=/;tls")).unwrap();
+    assert_eq!(out, "server;host=cloudfront.com;path=/;tls;mux=0");
+    assert_eq!(garter::Mode::from_plugin_options(Some(&out)), garter::Mode::Server);
+}
+
+#[skuld::test]
+fn an_operator_mux_wins() {
+    // ex-ray is first-wins, so an earlier `mux=` overrides the appended default.
+    let out = ex_ray_options(Some("mux=8;path=/")).unwrap();
+    let pairs = garter::parse_plugin_options(&out);
+    let first_mux = pairs.iter().find(|(k, _)| k == "mux").expect("mux key present");
+    assert_eq!(first_mux.1, "8");
+}
+
+#[skuld::test]
+fn an_escaped_spelling_of_mux_still_overrides() {
+    // ex-ray unescapes `mu\x` to `mux`, so this is a duplicate key to it. Segments
+    // are appended raw and never deduplicated, so first-wins still resolves it.
+    let out = ex_ray_options(Some(r"mu\x=8;path=/")).unwrap();
+    assert_eq!(out, r"mu\x=8;path=/;mux=0");
+    let segments = garter::split_plugin_options(&out).unwrap();
+    assert_eq!(segments[0].key, "mux");
+}
+
+#[skuld::test]
+fn an_escaped_trailing_semicolon_is_not_swallowed() {
+    // A naive strip-then-append yields `path=/a\;mux=0`, which ex-ray reads as
+    // ONE pair with no mux key at all.
+    let out = ex_ray_options(Some(r"path=/a\;")).unwrap();
+    assert_eq!(out, r"path=/a\;;mux=0");
+    assert_eq!(
+        garter::parse_plugin_options(&out),
+        vec![("path".into(), "/a;".into()), ("mux".into(), "0".into())]
+    );
+}
+
+#[skuld::test]
+fn a_trailing_separator_does_not_make_an_empty_segment() {
+    // `mode=websocket;;mux=0` makes ex-ray reject the WHOLE string ("empty key")
+    // and fall back to every flag default.
+    let out = ex_ray_options(Some("mode=websocket;")).unwrap();
+    assert_eq!(out, "mode=websocket;mux=0");
+}
+
+// These two assert galoshes' OWN disposition, not garter's classification: on a
+// string ex-ray would silently discard, `ex_ray_options` must not hand back
+// something that looks usable.
+#[skuld::test]
+fn a_dangling_final_escape_is_rejected() {
+    // `path=/a\` + `;mux=0` = `path=/a\;mux=0`: the escape swallows the separator
+    // and mux disappears. Odd/even trailing runs are pinned Go-side in
+    // `TestParseOptsIntoFlagsMux`.
+    assert!(ex_ray_options(Some(r"path=/a\")).is_err());
+    assert!(ex_ray_options(Some(r"path=/a\\\")).is_err());
+    assert!(ex_ray_options(Some(r"path=/a\\")).is_ok());
+}
+
+#[skuld::test]
+fn an_empty_key_segment_is_rejected() {
+    assert!(ex_ray_options(Some("=v")).is_err());
+    assert!(ex_ray_options(Some("host=cloudfront.com;=v")).is_err());
+    // An empty interior segment is the same input class.
+    assert!(ex_ray_options(Some("host=cloudfront.com;;path=/")).is_err());
+}

--- a/crates/galoshes/src/lib.rs
+++ b/crates/galoshes/src/lib.rs
@@ -1,11 +1,14 @@
 #![cfg_attr(ex_ray_missing, allow(dead_code, unused_imports))]
 
 pub mod embedded;
+pub mod exray_options;
 pub mod sitrep_out;
 pub mod yamux;
 
 #[cfg(test)]
 mod embedded_tests;
+#[cfg(test)]
+mod exray_options_tests;
 #[cfg(test)]
 mod sitrep_out_tests;
 #[cfg(test)]

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -81,8 +81,11 @@ async fn main() -> anyhow::Result<()> {
     // at startup. ex-ray ignores unrecognized keys (it only reads keys it knows).
     let udp_timeout = galoshes::yamux::parse_udp_timeout(env.plugin_options.as_deref())?;
     let yamux_plugin = galoshes::yamux::YamuxPlugin::new(mode == Mode::Server, udp_timeout);
+    // The embedded ex-ray gets its own options; the yamux hop keeps the caller's,
+    // since `mux` means nothing to it.
+    let ex_ray_options = galoshes::exray_options::ex_ray_options(env.plugin_options.as_deref())?;
     let ex_ray_plugin =
-        BinaryPlugin::new(verified.exec_path(), env.plugin_options.as_deref()).readiness(ReadinessMode::ExpectSitrep);
+        BinaryPlugin::new(verified.exec_path(), Some(&ex_ray_options)).readiness(ReadinessMode::ExpectSitrep);
 
     // Bridge-facing readiness: galoshes' OWN ChainRunner aggregates the
     // per-plugin readiness of [yamux, ex-ray] and fires this channel with

--- a/crates/plugin-e2e/Cargo.toml
+++ b/crates/plugin-e2e/Cargo.toml
@@ -18,7 +18,7 @@ util = { path = "../util" }
 xtask = { path = "../../xtask" }
 shadowsocks = "=1.24.0"
 shadowsocks-service = { version = "1", features = ["server", "local", "aead-cipher-2022"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "net", "time", "process"] }
 tokio-util = "0.7"
 tracing = "0.1"
 rcgen = "0.14"

--- a/crates/plugin-e2e/src/ssserver.rs
+++ b/crates/plugin-e2e/src/ssserver.rs
@@ -87,6 +87,10 @@ pub async fn start_real_ss_server(method: CipherKind, password: &str) -> (Socket
     (addr, handle)
 }
 
+/// Server-mode options for the plain-WS fixture. Tests that need to pin an
+/// extra directive build on this.
+pub const WS_SERVER_OPTS: &str = "server;host=cloudfront.com;path=/";
+
 /// Front a held ss-server with a SERVER-mode plugin (websocket, no TLS) and
 /// return the public address external clients connect to. The public port is
 /// allocated for `Protocols::TCP` only — WS is TCP per RFC 6455.
@@ -95,14 +99,18 @@ pub async fn start_real_ss_server_with_plugin_ws(
     password: &str,
     plugin_path: &str,
 ) -> (SocketAddr, PluginServer) {
-    spawn_ss_with_plugin(
-        method,
-        password,
-        Protocols::TCP,
-        plugin_path,
-        "server;host=cloudfront.com;path=/",
-    )
-    .await
+    start_real_ss_server_with_plugin_ws_opts(method, password, plugin_path, WS_SERVER_OPTS).await
+}
+
+/// [`start_real_ss_server_with_plugin_ws`] with the server-mode options string
+/// supplied by the caller, for tests that pin a specific plugin directive.
+pub async fn start_real_ss_server_with_plugin_ws_opts(
+    method: CipherKind,
+    password: &str,
+    plugin_path: &str,
+    opts: &str,
+) -> (SocketAddr, PluginServer) {
+    spawn_ss_with_plugin(method, password, Protocols::TCP, plugin_path, opts).await
 }
 
 /// Front a held ss-server with a SERVER-mode plugin (websocket + TLS). Same

--- a/crates/plugin-e2e/tests/roundtrip.rs
+++ b/crates/plugin-e2e/tests/roundtrip.rs
@@ -51,11 +51,12 @@ mod launcher_smoke {
 
 mod roundtrips {
     use plugin_e2e::locators::locate_built_galoshes;
-    #[cfg(not(target_os = "windows"))]
-    use plugin_e2e::roundtrip::NotReachableKind;
-    use plugin_e2e::roundtrip::{run_roundtrip, Roundtrip, RoundtripConfig};
+    use plugin_e2e::roundtrip::{run_roundtrip, NotReachableKind, Roundtrip, RoundtripConfig};
     use plugin_e2e::sentinel::start_fake_sentinel;
-    use plugin_e2e::ssserver::{start_real_ss_server_with_plugin_ws, TEST_METHOD, TEST_PASSWORD};
+    use plugin_e2e::ssserver::{
+        start_real_ss_server_with_plugin_ws, start_real_ss_server_with_plugin_ws_opts, TEST_METHOD, TEST_PASSWORD,
+        WS_SERVER_OPTS,
+    };
     use plugin_e2e::util::{require_binary, rt};
 
     // WS-TLS + QUIC present a self-signed cert; v2ray-core's getCertPool drops
@@ -96,6 +97,62 @@ mod roundtrips {
             )
             .await;
             assert!(matches!(outcome, Roundtrip::Reachable { .. }), "ws: {outcome:?}");
+        });
+    }
+
+    /// Client options for the plain-WS fixture, mirroring `WS_SERVER_OPTS`.
+    const WS_CLIENT_OPTS: &str = "host=cloudfront.com;path=/";
+
+    /// `mux` also selects the server's dokodemo destination, so a default client
+    /// and a `mux=1` server no longer speak the same wire format. Proving the
+    /// tunnel BREAKS is what shows the default actually changed.
+    #[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
+    fn galoshes_ws_mux_default_cannot_reach_a_mux1_server() {
+        let g = require_galoshes();
+        rt().block_on(async {
+            let server_opts = format!("{WS_SERVER_OPTS};mux=1");
+            let (svr, _h) =
+                start_real_ss_server_with_plugin_ws_opts(TEST_METHOD, TEST_PASSWORD, &g, &server_opts).await;
+            let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+            let outcome = run_roundtrip(
+                &g,
+                Some(&format!("mux=1;{WS_CLIENT_OPTS}")),
+                &svr.ip().to_string(),
+                svr.port(),
+                TEST_METHOD,
+                TEST_PASSWORD,
+                sentinel,
+                &RoundtripConfig::default(),
+            )
+            .await;
+            assert!(
+                matches!(outcome, Roundtrip::Reachable { .. }),
+                "mux=1 on both ends must still tunnel (control): {outcome:?}"
+            );
+
+            let (svr, _h) =
+                start_real_ss_server_with_plugin_ws_opts(TEST_METHOD, TEST_PASSWORD, &g, &server_opts).await;
+            let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+            let outcome = run_roundtrip(
+                &g,
+                Some(WS_CLIENT_OPTS),
+                &svr.ip().to_string(),
+                svr.port(),
+                TEST_METHOD,
+                TEST_PASSWORD,
+                sentinel,
+                &RoundtripConfig::default(),
+            )
+            .await;
+            // Torn down via common/mux/server.go:204-208, not a hang (ReadTimeout)
+            // or a broken harness (ChainFailed) — hence PeerClosed specifically.
+            let Roundtrip::NotReachable { kind, detail } = &outcome else {
+                panic!("a mux=0 client must NOT reach a mux=1 server, and must fail by peer close: {outcome:?}");
+            };
+            assert!(
+                matches!(kind, NotReachableKind::PeerClosed),
+                "mux mismatch must tear the connection down, not hang or misreply, got {kind:?}: {detail}"
+            );
         });
     }
 

--- a/crates/plugin-e2e/tests/roundtrip.rs
+++ b/crates/plugin-e2e/tests/roundtrip.rs
@@ -49,6 +49,71 @@ mod launcher_smoke {
     }
 }
 
+/// A malformed options string must stop galoshes at startup with a diagnosable
+/// message. ex-ray would not: it discards every option and reports `ready` on
+/// the flag-default port, so galoshes is the last place the operator can be
+/// told. The bridge relays this stderr into its own log.
+mod malformed_options {
+    use plugin_e2e::locators::locate_built_galoshes;
+    use plugin_e2e::util::{require_binary, rt};
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Duration;
+    use tokio::net::TcpListener;
+    use tokio::process::Command;
+    use util::port_alloc::{self, Protocols};
+
+    const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    /// Class-2 subprocess failure bound, matching `spawn_ss_with_plugin`'s. If the
+    /// guard regresses galoshes binds and runs forever; this names that instead of
+    /// hanging the suite with no captured output.
+    const EXIT_BUDGET: Duration = Duration::from_secs(60);
+
+    /// A port that was free a moment ago. The refused path never binds — the guard
+    /// runs before the chain starts — so this only has to be plausible; it exists
+    /// so an occupied port cannot masquerade as the guard firing.
+    async fn free_tcp_port() -> u16 {
+        let (port, _listener) = port_alloc::bind_ephemeral(LOOPBACK, Protocols::TCP, |p| async move {
+            TcpListener::bind((Ipv4Addr::LOCALHOST, p)).await
+        })
+        .await
+        .expect("allocate a loopback tcp port");
+        port
+    }
+
+    #[skuld::test]
+    fn a_dangling_escape_stops_galoshes_with_a_named_reason() {
+        let g = locate_built_galoshes();
+        require_binary(&g, "run `cargo xtask ex-ray && cargo xtask galoshes`");
+        rt().block_on(async {
+            let (local, remote) = (free_tcp_port().await, free_tcp_port().await);
+            let child = Command::new(&g)
+                .env("SS_LOCAL_HOST", "127.0.0.1")
+                .env("SS_LOCAL_PORT", local.to_string())
+                .env("SS_REMOTE_HOST", "127.0.0.1")
+                .env("SS_REMOTE_PORT", remote.to_string())
+                .env("SS_PLUGIN_OPTIONS", "host=cloudfront.com;path=/a\\")
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+                .expect("galoshes must be spawnable");
+
+            let out = tokio::time::timeout(EXIT_BUDGET, child.wait_with_output())
+                .await
+                .expect("galoshes did not exit within the budget — the malformed-options guard did not fire")
+                .expect("galoshes output");
+
+            assert!(!out.status.success(), "galoshes must refuse to start: {:?}", out.status);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                stderr.contains("embedded ex-ray") && stderr.contains("unpaired backslash"),
+                "stderr must name the malformed options as the reason, got: {stderr}"
+            );
+        });
+    }
+}
+
 mod roundtrips {
     use plugin_e2e::locators::locate_built_galoshes;
     use plugin_e2e::roundtrip::{run_roundtrip, NotReachableKind, Roundtrip, RoundtripConfig};
@@ -58,6 +123,7 @@ mod roundtrips {
         WS_SERVER_OPTS,
     };
     use plugin_e2e::util::{require_binary, rt};
+    use std::time::Duration;
 
     // WS-TLS + QUIC present a self-signed cert; v2ray-core's getCertPool drops
     // custom certs on Windows, so those two transports are gated off Windows (see
@@ -133,6 +199,15 @@ mod roundtrips {
             let (svr, _h) =
                 start_real_ss_server_with_plugin_ws_opts(TEST_METHOD, TEST_PASSWORD, &g, &server_opts).await;
             let (sentinel, _s) = start_fake_sentinel(b"HTTP/1.0 200 OK\r\n\r\n".to_vec()).await;
+            // The teardown here is slower than the default read budget: the server
+            // stops reading without closing, and the close only follows once the
+            // keepalive errors the poisoned pipe — see
+            // CONTRIBUTING.md#galoshes-mux-default. Outlive that bound so the
+            // assertion observes the teardown instead of racing it.
+            let config = RoundtripConfig {
+                read_timeout: Duration::from_secs(90),
+                ..RoundtripConfig::default()
+            };
             let outcome = run_roundtrip(
                 &g,
                 Some(WS_CLIENT_OPTS),
@@ -141,17 +216,18 @@ mod roundtrips {
                 TEST_METHOD,
                 TEST_PASSWORD,
                 sentinel,
-                &RoundtripConfig::default(),
+                &config,
             )
             .await;
-            // Torn down via common/mux/server.go:204-208, not a hang (ReadTimeout)
-            // or a broken harness (ChainFailed) — hence PeerClosed specifically.
+            // ReadTimeout is excluded on purpose: it is the driver's transient
+            // signal, so accepting it would let a slow-but-working tunnel stand in
+            // for the break this test exists to prove.
             let Roundtrip::NotReachable { kind, detail } = &outcome else {
-                panic!("a mux=0 client must NOT reach a mux=1 server, and must fail by peer close: {outcome:?}");
+                panic!("a mux=0 client must NOT reach a mux=1 server: {outcome:?}");
             };
             assert!(
                 matches!(kind, NotReachableKind::PeerClosed),
-                "mux mismatch must tear the connection down, not hang or misreply, got {kind:?}: {detail}"
+                "mux mismatch must tear the connection down, got {kind:?}: {detail}"
             );
         });
     }


### PR DESCRIPTION
galoshes multiplexes every logical stream onto one connection with its own yamux
layer, then hands that single connection to its embedded ex-ray — which was
running v2ray-core's Mux.Cool on top of it. The inner layer had nothing left to
multiplex; it only added framing and a second connection lifecycle that fails on
its own. During the #655 field verification the failures driving galoshes'
reconnect cycling were exactly that inner worker dying:
`failed to handler mux client connection` / `common/mux: failed to fetch all input`.

galoshes now appends `mux=0` to the options it gives ex-ray.

## Breaking: a `mux=0` client cannot talk to a `mux=1` server

`mux` also selects the *server's* dokodemo destination — `v1.mux.cool` when
enabled, plain loopback when not — so both ends must agree. Both ends running
this version agree. During a version-skew window, pinning `mux=1` in the plugin
options on **both** ends restores the old wire format: ex-ray is first-wins on
duplicate SIP003 keys, so an operator's earlier `mux=` overrides the appended
default. That overridability is deliberate, and it is what the behavioural test
uses to stand up a `mux=1` peer.

Skew does not fail fast. The `mux=1` server cannot unmarshal the client's first
frame, poisons its inbound pipe and stops reading, but resets nothing — no
further byte is due. The yamux keepalive converts the stall into a teardown when
its next probe hits the poisoned pipe. Measured at ~25 s, deterministic.

## Why the append is not a one-liner

A naive strip-then-append is wrong in two ways, both verified against ex-ray's
real Go parser:

- `path=/a\;` ends in an *escaped* semicolon. Trimming it and appending yields
  `path=/a\;mux=0`, which parses as **one** pair with no `mux` key at all —
  Mux.Cool silently stays on.
- Appending after an unescaped trailing `;` yields `a=b;;mux=0`, which ex-ray
  rejects wholesale with `empty key`.

So this goes through `garter::{split_plugin_options, join_plugin_options}` from
#736, which accept exactly what ex-ray accepts.

A string those reject is fatal here rather than forwarded, because **ex-ray does
not reject it**: `parseOptsIntoFlags` swallows the parse error, discards every
option including the `SS_*` address assignment, and reports sitrep `ready` on the
flag-default port 1984. That is #733; this guard is the mitigation until ex-ray
emits `fatal` itself.

## Tests

- `crates/ex-ray/config_test.go` — `mux=0` ⇒ no `MultiplexSettings` on the client
  sender and no `v1.mux.cool` on the server inbound, plus the parse table
  (first-wins, escaped semicolons, and the malformed shapes that leave `mux` at 1).
- `galoshes_ws_mux_default_cannot_reach_a_mux1_server` — real binaries both ends:
  a default client against a `mux=1` server is torn down (`PeerClosed`), bracketed
  by a `mux=1`-on-both-ends control that still tunnels. Fails on `main`, where the
  default client reaches with `Reachable { latency_ms: 567 }`.
- `a_dangling_escape_stops_galoshes_with_a_named_reason` — the refusal reaches the
  operator: nonzero exit and a stderr line naming the malformed options.
- `galoshes_ws_roundtrip` (default both ends, now `mux=0`) and the three
  ex-ray↔stock-v2ray-plugin interop tests are unaffected.

Closes #691. Relates to #733.

Note for readers coming from #692: that issue's text says #691 narrows it to
standalone deployments. That is obsolete — #709 implemented #692 as socket-layer
TCP keepalive, which sits below Mux.Cool and applies at `mux=0` too.
