### PR TITLE
fix(garter): recover a delivered StartError instead of forwarding a generic ExitedBeforeReady

### DIFF
--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -256,10 +256,17 @@ fn resolve_tap_source(diagnostic_tap: bool) -> TapSource {
 /// Single-attempt plugin-runner spawn. Constructs `BinaryPlugin`
 /// (with optional `pid_sink`), wraps in `TapPlugin` when
 /// `HOLE_BRIDGE_PLUGIN_TAP=1`, builds the `ChainRunner`, spawns it,
-/// and awaits readiness with a 30-second timeout. On failure runs
-/// `cancel.cancel(); handle.abort()` so a retried attempt by
-/// `bind_ephemeral` doesn't leak the previous attempt's task. On
-/// success returns `(handle, cancel, ready_addr, transports)` — the
+/// and awaits readiness with a 30-second timeout. Every failure arm runs
+/// `cancel.cancel()` first, then either `handle.abort()` (BindConflict,
+/// Fatal, and the readiness timeout, where the plugin's own report is
+/// already as specific as it gets or nothing more can be recovered) or
+/// `recover_exit_detail(handle).await` (ExitedBeforeReady and the
+/// chain-level RecvError, where joining the handle can recover a more
+/// specific reason than the generic placeholder) — see that fn's doc for
+/// why the latter is a real, `drain_timeout`-bounded join rather than an
+/// abort. Either way a retried attempt by `bind_ephemeral` never leaks the
+/// previous attempt's task. On success returns `(handle, cancel,
+/// ready_addr, transports)` — the
 /// caller wraps these in a [`PluginChain`]. The `transports` is the
 /// sitrep-reported end-to-end transport set (#414), threaded into the
 /// bridge's UDP-drop policy.

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -433,24 +433,11 @@ async fn spawn_plugin_runner_at(
 /// process mid-startup, via `garter`'s own signal handler) — the plugin is
 /// then still alive and only now begins its graceful-stop sequence, so
 /// this join is bounded by `ChainRunner`'s `drain_timeout` (5s default),
-/// not instant. Falls back to [`garter::EXITED_BEFORE_READY_DETAIL`] if
-/// `handle` has nothing better.
+/// not instant. Delegates the actual recovery (and its `EXITED_BEFORE_READY_DETAIL`
+/// fallback) to [`garter::recover_exit_detail_from_joined`] — the single
+/// implementation shared with galoshes and plugin-e2e's own identical need.
 async fn recover_exit_detail(handle: tokio::task::JoinHandle<garter::Result<()>>) -> String {
-    match handle.await {
-        Ok(Err(e)) => e.to_string(),
-        Ok(Ok(())) => garter::EXITED_BEFORE_READY_DETAIL.into(),
-        Err(join_err) => {
-            // The plugin-driving task panicked or was cancelled while we
-            // were recovering its exit detail — a bug signal, not routine
-            // diagnostic noise, so it's logged at the same level
-            // `chain.rs`'s own `record_exit` uses for an individual
-            // plugin-task panic, not silently absorbed at `debug!` into
-            // the same generic fallback text used for a genuinely clean
-            // exit.
-            tracing::error!(error = %join_err, "plugin-driving task ended abnormally while recovering exit detail");
-            garter::EXITED_BEFORE_READY_DETAIL.into()
-        }
-    }
+    garter::recover_exit_detail_from_joined(&handle.await)
 }
 
 /// Convert a [`ProxyError`] from `spawn_plugin_runner_at` into an

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -203,10 +203,12 @@ pub async fn start_plugin_chain(
                 return ProxyError::Cancelled;
             }
             // The chain never became a `PluginChain`, so nothing downstream can
-            // reach its ring. "exited before becoming ready" and "did not become
-            // ready within 30s" carry no detail of their own, and the plugin's
-            // own last lines are the only account of why — emit them here, once,
-            // after every bind retry has had its say.
+            // reach its ring. `spawn_plugin_runner_at` recovers a specific
+            // reason where one exists (`ExitedBeforeReady`, the chain-level
+            // RecvError), but "did not become ready within 30s" never has one
+            // to recover — the plugin's own last lines are the only account
+            // of why THAT case failed. Emit the ring here, once, after every
+            // bind retry has had its say, regardless of which case this is.
             crate::proxy::plugin_log::warn_recent(&log);
             ProxyError::Plugin(format!("plugin chain start failed: {e}"))
         })?;
@@ -380,16 +382,29 @@ async fn spawn_plugin_runner_at(
                 return Err(ProxyError::BindRace { errno, addr });
             }
             // Terminal start failure (config error, upstream-dial failure,
-            // bare process exit) — never retried.
+            // bare process exit) — never retried. Already as specific as it
+            // gets (plugin-reported via sitrep, including one forwarded
+            // verbatim by a nested garter) — `handle` has nothing more to
+            // add, so it is aborted unread.
             Ok(Ok(Err(garter::StartError::Fatal { detail, .. }))) => {
                 cancel.cancel();
                 handle.abort();
                 return Err(ProxyError::Plugin(format!("plugin failed to start: {detail}")));
             }
+            // See `StartError::ExitedBeforeReady`'s doc comment for why this is
+            // distinct from `Fatal` (e.g. `BinaryPlugin::sip003_env` erroring on
+            // malformed options before the child even spawns).
+            Ok(Ok(Err(garter::StartError::ExitedBeforeReady))) => {
+                cancel.cancel();
+                return Err(ProxyError::Plugin(recover_exit_detail(handle).await));
+            }
             Ok(Err(_)) => {
                 cancel.cancel();
-                handle.abort();
-                return Err(ProxyError::Plugin("plugin exited before becoming ready".into()));
+                // The chain-level ready oneshot ITSELF dropped unsent —
+                // distinct from the arm above: the aggregator never got to
+                // send at all (e.g. shutdown fired before it examined any
+                // plugin).
+                return Err(ProxyError::Plugin(recover_exit_detail(handle).await));
             }
             Err(_) => {
                 cancel.cancel();
@@ -400,6 +415,35 @@ async fn spawn_plugin_runner_at(
     };
 
     Ok((handle, cancel, chain_ready.listen, chain_ready.transports))
+}
+
+/// Join `handle` for the plugin's own terminal error when the ready-gate
+/// signal carried no diagnosis of its own — a real join (not a fixed
+/// timeout). Usually resolves promptly: the common case is the plugin
+/// itself already exited (e.g. `sip003_env` erroring before it even
+/// spawned). NOT guaranteed instant, though: `shutdown` can fire
+/// independently of the plugin (e.g. a SIGINT/SIGTERM to the bridge
+/// process mid-startup, via `garter`'s own signal handler) — the plugin is
+/// then still alive and only now begins its graceful-stop sequence, so
+/// this join is bounded by `ChainRunner`'s `drain_timeout` (5s default),
+/// not instant. Falls back to [`garter::EXITED_BEFORE_READY_DETAIL`] if
+/// `handle` has nothing better.
+async fn recover_exit_detail(handle: tokio::task::JoinHandle<garter::Result<()>>) -> String {
+    match handle.await {
+        Ok(Err(e)) => e.to_string(),
+        Ok(Ok(())) => garter::EXITED_BEFORE_READY_DETAIL.into(),
+        Err(join_err) => {
+            // The plugin-driving task panicked or was cancelled while we
+            // were recovering its exit detail — a bug signal, not routine
+            // diagnostic noise, so it's logged at the same level
+            // `chain.rs`'s own `record_exit` uses for an individual
+            // plugin-task panic, not silently absorbed at `debug!` into
+            // the same generic fallback text used for a genuinely clean
+            // exit.
+            tracing::error!(error = %join_err, "plugin-driving task ended abnormally while recovering exit detail");
+            garter::EXITED_BEFORE_READY_DETAIL.into()
+        }
+    }
 }
 
 /// Convert a [`ProxyError`] from `spawn_plugin_runner_at` into an
@@ -471,7 +515,10 @@ fn unpinned_reason(ech_doh: Option<&crate::dns::ech::EchDoh>) -> &'static str {
 /// Only the v2ray-family plugins receive these: `v2ray-plugin` resolves to the
 /// first-party `ex-ray` binary, but a config may also name `ex-ray` directly,
 /// so both spellings are covered; `galoshes` ignores the keys itself but
-/// forwards the whole options string to its inner ex-ray.
+/// forwards the whole options string to its inner ex-ray. Every OTHER plugin
+/// name still gets its options string validated (though nothing is
+/// injected) — a malformed string must not reach `BinaryPlugin` unvalidated
+/// just because the plugin isn't one of these three.
 fn inject_plugin_directives(
     plugin_name: &str,
     opts: Option<&str>,
@@ -550,7 +597,12 @@ fn inject_plugin_directives(
                     .chain(directive.as_deref()),
             )))
         }
-        _ => Ok(opts.map(String::from)),
+        _ => match opts {
+            Some(o) => garter::split_plugin_options(o)
+                .map(|_| Some(o.to_string()))
+                .map_err(|e| ProxyError::MalformedPluginOptions(format!("{plugin_name}: {e}"))),
+            None => Ok(None),
+        },
     }
 }
 
@@ -707,6 +759,11 @@ mod inject_tests {
     fn unknown_plugin_passes_through_unchanged() {
         assert_eq!(merged("some-future-plugin", Some("k=v"), None).as_deref(), Some("k=v"));
         assert_eq!(merged("some-future-plugin", None, None), None);
+    }
+
+    #[skuld::test]
+    fn unknown_plugin_with_malformed_options_is_rejected() {
+        assert!(inject_plugin_directives("obfs-local", Some(r"server;path=/a\"), None).is_err());
     }
 
     #[skuld::test]

--- a/crates/bridge/src/proxy/plugin_tests.rs
+++ b/crates/bridge/src/proxy/plugin_tests.rs
@@ -6,9 +6,152 @@
 use std::net::SocketAddr;
 
 use tokio_util::sync::CancellationToken;
+use tracing_subscriber::layer::{Layer, SubscriberExt};
 
-use super::{proxy_err_to_io_err, start_plugin_chain};
+use super::{proxy_err_to_io_err, recover_exit_detail, spawn_plugin_runner_at, start_plugin_chain};
 use crate::proxy::ProxyError;
+use crate::test_support::log_capture::VecWriter;
+
+// recover_exit_detail (the shared join-and-recover logic both new arms call) ==========================================
+
+#[skuld::test]
+async fn recover_exit_detail_surfaces_the_specific_reason() {
+    let handle = tokio::spawn(async { Err(garter::Error::Chain("the specific reason".into())) });
+    assert_eq!(recover_exit_detail(handle).await, "the specific reason");
+}
+
+#[skuld::test]
+async fn recover_exit_detail_falls_back_when_handle_has_nothing_better() {
+    let handle: tokio::task::JoinHandle<garter::Result<()>> = tokio::spawn(async { Ok(()) });
+    assert_eq!(recover_exit_detail(handle).await, garter::EXITED_BEFORE_READY_DETAIL);
+}
+
+// A panicking (or aborted) handle is distinct from "exited cleanly with no
+// diagnosis" — both fall back to the same placeholder text, but the panic
+// itself must not be silently absorbed with zero logging: this pins BOTH
+// the fallback text AND that the `tracing::error!` call actually fires
+// (the two arms are otherwise indistinguishable by their string output).
+#[skuld::test]
+async fn recover_exit_detail_falls_back_when_the_handle_panicked() {
+    let writer = VecWriter::new();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::LevelFilter::ERROR),
+    );
+    let detail = {
+        let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+        let handle: tokio::task::JoinHandle<garter::Result<()>> = tokio::spawn(async { panic!("boom") });
+        recover_exit_detail(handle).await
+    };
+    assert_eq!(detail, garter::EXITED_BEFORE_READY_DETAIL);
+    let output = writer.snapshot_string();
+    assert!(
+        output.contains("plugin-driving task ended abnormally"),
+        "expected an error-level log for the panic, got:\n{output}"
+    );
+}
+
+// `start_plugin_chain`'s own `inject_plugin_directives` pre-validates
+// SS_PLUGIN_OPTIONS for every plugin name, so a malformed string never
+// reaches `BinaryPlugin::sip003_env` through that entry point — these tests
+// call the lower-level `spawn_plugin_runner_at` directly to exercise
+// `sip003_env`'s own fallibility and pin what actually surfaces when its
+// `Err` beats the chain-level ready oneshot.
+async fn spawn_with_malformed_options(diagnostic_tap: bool) -> String {
+    let cancel = CancellationToken::new();
+    let log = crate::proxy::plugin_log::PluginLog::new();
+    let err = spawn_plugin_runner_at(
+        "v2ray-plugin",
+        "/nonexistent/binary",
+        Some(r"path=/a\"), // dangling escape
+        dummy_addr(),
+        "127.0.0.1", // a literal IP: no DNS lookup precedes the plugin spawn
+        443,
+        None,
+        None,
+        diagnostic_tap,
+        cancel,
+        &log,
+    )
+    .await
+    .unwrap_err();
+
+    let ProxyError::Plugin(detail) = err else {
+        panic!("expected ProxyError::Plugin, got: {err:?}");
+    };
+    detail
+}
+
+#[skuld::test]
+async fn spawn_plugin_runner_surfaces_the_real_reason_on_malformed_options() {
+    let detail = spawn_with_malformed_options(false).await;
+    assert!(
+        detail.contains("unpaired backslash"),
+        "expected the specific malformed-options reason, got a generic message: {detail}"
+    );
+}
+
+// `TapPlugin` synthesizes its OWN `StartError::ExitedBeforeReady` on the
+// same "inner exited before readying" race — this pins that it, like the
+// untapped path above, still surfaces the plugin's real reason rather than
+// the generic placeholder.
+#[skuld::test]
+async fn spawn_plugin_runner_surfaces_the_real_reason_on_malformed_options_through_the_tap() {
+    let detail = spawn_with_malformed_options(true).await;
+    assert!(
+        detail.contains("unpaired backslash"),
+        "expected the specific malformed-options reason through the tap, got a generic message: {detail}"
+    );
+}
+
+// The OTHER synthesis point: the chain-level ready oneshot itself dropping
+// unsent because `ChainRunner::run` errors before the readiness aggregator
+// is ever spawned (here: DNS resolution of the SS_REMOTE address fails,
+// before any plugin runs or the aggregator starts) — distinct from the
+// `ExitedBeforeReady` arm above, which requires the aggregator to have
+// started and observed a per-plugin readiness sender drop.
+#[skuld::test]
+async fn spawn_plugin_runner_surfaces_the_real_reason_when_the_chain_never_starts_the_aggregator() {
+    let cancel = CancellationToken::new();
+    let log = crate::proxy::plugin_log::PluginLog::new();
+    // A DNS label exceeding RFC 1035's 63-byte-per-label / 255-byte-total
+    // limits fails resolution PURELY through the resolver's own local
+    // wire-format validation, before any query ever reaches the network —
+    // unlike an unusual-but-syntactically-valid hostname, this cannot be
+    // answered by a captive portal or a DNS-hijacking resolver, so the
+    // failure is deterministic across network environments.
+    let bogus_host = "a".repeat(260);
+    let err = spawn_plugin_runner_at(
+        "v2ray-plugin",
+        "/nonexistent/binary",
+        None,
+        dummy_addr(),
+        &bogus_host, // fails DNS resolution before any plugin spawns
+        443,
+        None,
+        None,
+        false,
+        cancel,
+        &log,
+    )
+    .await
+    .unwrap_err();
+
+    let ProxyError::Plugin(detail) = err else {
+        panic!("expected ProxyError::Plugin, got: {err:?}");
+    };
+    // The OS's own DNS-failure wording is not portable across platforms
+    // (Windows/Linux/macOS phrase `getaddrinfo` failures differently); the
+    // portable claim is that it's NOT the generic placeholder, proving
+    // `recover_exit_detail` actually reached and used `handle`'s result.
+    assert_ne!(
+        detail,
+        garter::EXITED_BEFORE_READY_DETAIL,
+        "expected the DNS failure's own reason, not the generic placeholder: {detail}"
+    );
+}
 
 #[skuld::test]
 async fn start_with_nonexistent_binary_returns_plugin_error() {

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -49,28 +49,68 @@ pub(crate) enum ProbeTransport {
     Raw,
 }
 
-pub(crate) fn classify_transport(plugin: Option<&str>, plugin_opts: Option<&str>, server_host: &str) -> ProbeTransport {
-    if plugin.is_none() {
-        return ProbeTransport::Raw;
+/// Mirrors vendored v2ray-core's `websocket.Config::GetNormalizedPath`
+/// (`crates/ex-ray/third_party/v2ray-core/transport/internet/websocket/config.go`)
+/// byte for byte: this is what actually decides the WebSocket
+/// request-target on the wire, applied unconditionally to whatever the
+/// `path` SIP003 flag decoded to.
+fn normalize_ws_path(path: String) -> String {
+    if path.is_empty() {
+        "/".into()
+    } else if !path.starts_with('/') {
+        format!("/{path}")
+    } else {
+        path
     }
-    let opts = plugin_opts.map(garter::parse_plugin_options).unwrap_or_default();
-    let get = |k: &str| opts.iter().find(|(kk, _)| kk == k).map(|(_, v)| v.clone());
-    let has = |k: &str| opts.iter().any(|(kk, _)| kk == k);
+}
+
+pub(crate) fn classify_transport(
+    plugin: Option<&str>,
+    plugin_opts: Option<&str>,
+    server_host: &str,
+) -> Result<ProbeTransport, garter::MalformedOptions> {
+    if plugin.is_none() {
+        return Ok(ProbeTransport::Raw);
+    }
+    // `split_plugin_options`, not `parse_plugin_options`: the latter maps a
+    // bare key and an explicit `key=` to the same decoded `""`, but ex-ray's
+    // own `Args.Get`/`main.go` do NOT treat them the same for `path` (see
+    // below) — only `OptionSegment::raw` can tell bare from valued apart.
+    let segments = plugin_opts
+        .map(garter::split_plugin_options)
+        .transpose()?
+        .unwrap_or_default();
+    let get = |k: &str| segments.iter().find(|s| s.key == k).map(|s| s.value.clone());
+    let has = |k: &str| segments.iter().any(|s| s.key == k);
     // The probe's first-flight SNI/Host is the connect target (the DoH-resolved
     // IP — IP-SNI): a failure-only diagnostic must not emit the domain in
     // cleartext, and the real tunnel hides it via ECH, so a domain-SNI probe
     // would test a path the client never uses.
     let sni = server_host.to_string();
     if get("mode").as_deref() == Some("quic") {
-        return ProbeTransport::Quic { sni };
+        return Ok(ProbeTransport::Quic { sni });
     }
     if has("tls") {
-        return ProbeTransport::TlsWs { sni };
+        return Ok(ProbeTransport::TlsWs { sni });
     }
-    ProbeTransport::PlainWs {
+    Ok(ProbeTransport::PlainWs {
         host: sni,
-        path: get("path").unwrap_or_else(|| "/".into()),
-    }
+        // Mirrors what ex-ray actually puts on the wire, not a plausible
+        // guess. Two layers: (1) the flag value itself — an ABSENT `path`
+        // key uses the flag default "/"; a BARE `path` key (no `=`) decodes
+        // as "1" (`Args.Add` stores "1" for a no-equals option, args.go +
+        // main.go:70); an explicit `path=` decodes as "" — then (2)
+        // `normalize_ws_path` (above) applies vendored v2ray-core's own
+        // `GetNormalizedPath` rule. Skipping layer 2 would probe a path
+        // ex-ray never requests — for `path=` specifically, an unnormalized
+        // "" is a syntactically invalid empty request-target, not merely a
+        // different one — misreading a routed server as network-blocked.
+        path: normalize_ws_path(match segments.iter().find(|s| s.key == "path") {
+            None => "/".into(),
+            Some(s) if !s.raw.contains('=') => "1".to_string(),
+            Some(s) => s.value.clone(),
+        }),
+    })
 }
 
 pub async fn probe_server_reachability(
@@ -80,7 +120,27 @@ pub async fn probe_server_reachability(
     plugin_opts: Option<&str>,
     cancel: &CancellationToken,
 ) -> ReachabilityVerdict {
-    let transport = classify_transport(plugin, plugin_opts, host);
+    // A malformed options string means the transport can't be classified,
+    // and guessing wrong in either direction (TCP vs UDP) produces an
+    // actively false confident verdict — unlike `server_endpoint_is_udp`'s
+    // preflight-skip decision, there is no safe default transport to probe
+    // with here, so this best-effort diagnostic reports Inconclusive.
+    //
+    // Every current caller already validates `plugin_opts` before reaching
+    // here, so this path is not exercised today. Left as a graceful
+    // `Result`, not an assertion: this function's whole existence is a
+    // best-effort diagnostic, and if the two validators
+    // (`inject_plugin_directives` and `classify_transport`, independent
+    // call sites both wrapping `garter::split_plugin_options`) ever
+    // silently diverge, Inconclusive is the correct degraded behavior
+    // here, not a panic.
+    let transport = match classify_transport(plugin, plugin_opts, host) {
+        Ok(t) => t,
+        Err(e) => {
+            debug!(%e, "malformed SS_PLUGIN_OPTIONS in reachability probe");
+            return ReachabilityVerdict::Inconclusive;
+        }
+    };
     let v = tokio::select! {
         _ = cancel.cancelled() => ReachabilityVerdict::Inconclusive,
         v = probe_inner(host, port, &transport) => v,

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -46,12 +46,15 @@ async fn accept_then_answer() -> SocketAddr {
 // `nextest run … reachability_tests` substring filter only matches with it.
 #[skuld::test(name = "reachability_tests::classify_no_plugin_is_raw")]
 fn classify_no_plugin_is_raw() {
-    assert!(matches!(classify_transport(None, None, "ex.com"), ProbeTransport::Raw));
+    assert!(matches!(
+        classify_transport(None, None, "ex.com").unwrap(),
+        ProbeTransport::Raw
+    ));
 }
 #[skuld::test(name = "reachability_tests::classify_tls_ws_sni_is_connect_host_not_opt")]
 fn classify_tls_ws_sni_is_connect_host_not_opt() {
     // A failure-only diagnostic must not emit the proxy domain in cleartext.
-    match classify_transport(Some("galoshes"), Some("tls;path=/t/x;host=h.ex.com"), "srv") {
+    match classify_transport(Some("galoshes"), Some("tls;path=/t/x;host=h.ex.com"), "srv").unwrap() {
         ProbeTransport::TlsWs { sni } => {
             assert_eq!(sni, "srv", "SNI must be the connect host");
             assert_ne!(sni, "h.ex.com", "SNI must not leak the host= opt (domain)");
@@ -61,7 +64,7 @@ fn classify_tls_ws_sni_is_connect_host_not_opt() {
 }
 #[skuld::test(name = "reachability_tests::classify_plain_ws_defaults_path_and_host")]
 fn classify_plain_ws_defaults_path_and_host() {
-    match classify_transport(Some("galoshes"), Some("path=/t/x"), "srv.ex.com") {
+    match classify_transport(Some("galoshes"), Some("path=/t/x"), "srv.ex.com").unwrap() {
         ProbeTransport::PlainWs { host, path } => {
             assert_eq!(host, "srv.ex.com");
             assert_eq!(path, "/t/x");
@@ -69,16 +72,74 @@ fn classify_plain_ws_defaults_path_and_host() {
         _ => panic!(),
     }
 }
+// Mirrors classify_transport's bare-path handling (see its doc comment).
+#[skuld::test(name = "reachability_tests::classify_path_key_matches_ex_ray_for_absent_bare_and_valued")]
+fn classify_path_key_matches_ex_ray_for_absent_bare_and_valued() {
+    let cases = [
+        ("host=h", "/"),          // absent: flag default "/", already normalized
+        ("path;host=h", "/1"),    // bare: flag "1", normalized to "/1"
+        ("path=;host=h", "/"),    // explicit empty: flag "", normalized to "/"
+        ("path=x;host=h", "/x"),  // explicit, no leading slash: normalized to "/x"
+        ("path=/x;host=h", "/x"), // explicit, already slash-prefixed: unchanged
+    ];
+    for (opts, expected) in cases {
+        match classify_transport(Some("galoshes"), Some(opts), "srv.ex.com").unwrap() {
+            ProbeTransport::PlainWs { path, .. } => {
+                assert_eq!(path, expected, "opts={opts:?}");
+            }
+            _ => panic!("expected PlainWs for opts={opts:?}"),
+        }
+    }
+}
 #[skuld::test(name = "reachability_tests::classify_quic_forces_quic")]
 fn classify_quic_forces_quic() {
     // Same no-domain-leak rule as the TLS-WS probe.
-    match classify_transport(Some("galoshes"), Some("mode=quic;host=h"), "srv") {
+    match classify_transport(Some("galoshes"), Some("mode=quic;host=h"), "srv").unwrap() {
         ProbeTransport::Quic { sni } => {
             assert_eq!(sni, "srv", "SNI must be the connect host");
             assert_ne!(sni, "h", "SNI must not leak the host= opt");
         }
         _ => panic!("expected Quic"),
     }
+}
+#[skuld::test(name = "reachability_tests::classify_rejects_malformed_options")]
+fn classify_rejects_malformed_options() {
+    assert!(classify_transport(Some("galoshes"), Some(r"path=/a\"), "srv").is_err());
+}
+#[skuld::test(name = "reachability_tests::classify_recognizes_an_escaped_tls_key")]
+fn classify_recognizes_an_escaped_tls_key() {
+    // A backslash escapes whatever byte follows, so `\tls` IS `tls` — to
+    // ex-ray, and here.
+    match classify_transport(Some("galoshes"), Some(r"\tls;host=h"), "srv").unwrap() {
+        ProbeTransport::TlsWs { .. } => {}
+        _ => panic!("expected TlsWs for an escaped tls key"),
+    }
+}
+#[skuld::test(name = "reachability_tests::classify_first_wins_on_duplicate_mode_key")]
+fn classify_first_wins_on_duplicate_mode_key() {
+    // ex-ray's Args.Get is first-wins; the FIRST `mode=` must be the one
+    // consulted.
+    match classify_transport(Some("galoshes"), Some("mode=quic;mode=websocket"), "srv").unwrap() {
+        ProbeTransport::Quic { .. } => {}
+        _ => panic!("expected Quic (first mode= wins)"),
+    }
+}
+#[skuld::test(name = "reachability_tests::malformed_options_probe_is_inconclusive")]
+async fn malformed_options_probe_is_inconclusive() {
+    // Unlike `server_endpoint_is_udp`'s assume-UDP fallback, guessing wrong
+    // here produces a false confident verdict either way — Inconclusive.
+    let a = accept_then_answer().await;
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some(r"path=/a\"),
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Inconclusive
+    );
 }
 // A `.` flanked by alphanumerics on both sides — the shape of a domain label or
 // IP octet boundary (`ex.com`, `1.2.3.4`). A sentence-final `.` (followed by a

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -251,14 +251,28 @@ async fn reclassify_blocked(
 /// TCP listener to connect to — so [`run_server_test`] skips it and lets the
 /// full tunnel handshake produce the diagnosis. Covers a direct
 /// v2ray-plugin/ex-ray QUIC server AND a galoshes server (which passes
-/// `mode=quic` through to its embedded ex-ray). Shares the reachability probe's
-/// transport classifier, so the two agree on what a QUIC endpoint is. See
-/// bindreams/hole#421.
+/// `mode=quic` through to its embedded ex-ray). Shares the reachability
+/// probe's transport classifier, so the two agree on what a QUIC endpoint
+/// is.
+///
+/// A malformed options string also skips the preflight, even though the
+/// endpoint might really be TCP: the risk is asymmetric. Guessing UDP when
+/// it's actually TCP costs only diagnosis precision (the full tunnel
+/// handshake still runs and produces a correct, if vaguer, verdict).
+/// Guessing TCP when it's actually UDP-only reproduces the exact false
+/// TcpTimeout/TcpRefused verdict this asymmetry exists to avoid, and a raw
+/// TCP connect can't distinguish "genuinely TCP" from "unclassifiable" to
+/// make that guess safely.
 fn server_endpoint_is_udp(entry: &ServerEntry) -> bool {
-    matches!(
-        crate::reachability::classify_transport(entry.plugin.as_deref(), entry.plugin_opts.as_deref(), &entry.server),
-        crate::reachability::ProbeTransport::Quic { .. }
-    )
+    match crate::reachability::classify_transport(entry.plugin.as_deref(), entry.plugin_opts.as_deref(), &entry.server)
+    {
+        Ok(crate::reachability::ProbeTransport::Quic { .. }) => true,
+        Ok(_) => false,
+        Err(e) => {
+            debug!(%e, "malformed SS_PLUGIN_OPTIONS in server_endpoint_is_udp, assuming UDP");
+            true
+        }
+    }
 }
 
 /// Raw-TCP-connect to the DoH-resolved `addr`. Returns `Err(outcome)` with a

--- a/crates/bridge/src/server_test_preflight_tests.rs
+++ b/crates/bridge/src/server_test_preflight_tests.rs
@@ -57,6 +57,11 @@ fn non_quic_endpoint_is_tcp() {
     )));
 }
 
+#[skuld::test]
+fn malformed_options_endpoint_is_treated_as_udp() {
+    assert!(server_endpoint_is_udp(&entry(Some("galoshes"), Some(r"path=/a\"))));
+}
+
 // preflight ===========================================================================================================
 //
 // `preflight` takes a resolved `SocketAddr` (DoH already resolved the

--- a/crates/bridge/tests/plugin_chain.rs
+++ b/crates/bridge/tests/plugin_chain.rs
@@ -138,10 +138,10 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
 }
 
 /// A chain that never becomes ready is where the plugin's own words matter
-/// most: `spawn_plugin_runner_at`'s "exited before becoming ready" and
-/// readiness-timeout arms carry no detail of their own, and the failed attempt's
-/// ring can never be reached from outside — `PluginChain` was never built. So
-/// `start_plugin_chain` must report the ring itself before returning the error.
+/// most: the failed attempt's ring can never be reached from outside —
+/// `PluginChain` was never built. So `start_plugin_chain` must report the
+/// ring itself before returning the error, even where `spawn_plugin_runner_at`
+/// does recover a specific reason (readiness-timeout has none to recover).
 #[skuld::test]
 async fn a_failed_chain_start_reports_the_plugin_ring() {
     use tracing_subscriber::layer::{Layer, SubscriberExt};

--- a/crates/galoshes/src/exray_options.rs
+++ b/crates/galoshes/src/exray_options.rs
@@ -13,10 +13,11 @@ pub fn ex_ray_options(plugin_options: Option<&str>) -> Result<String> {
     let Some(opts) = plugin_options.filter(|s| !s.is_empty()) else {
         return Ok(MUX_OFF.to_string());
     };
-    // A rejected string is fatal here because ex-ray does not reject it: it
-    // discards every option and reports `ready` on the flag-default port. The
-    // reason comes from the error's own Display, which names the shape without
-    // echoing options that may carry a secret.
+    // Fallible because ex-ray itself does not reject a malformed string: it
+    // discards every option and reports `ready` on the flag-default port. In
+    // the real galoshes binary this Err is unreachable — `main` validates the
+    // same string via `Mode::from_plugin_options` first — but it stays live
+    // for direct callers and this module's own unit tests.
     let segments = garter::split_plugin_options(opts).context("cannot build plugin options for the embedded ex-ray")?;
     let out = garter::join_plugin_options(segments.iter().map(|s| s.raw).chain([MUX_OFF]));
     // Contract, not input validation: the split accepts exactly what ex-ray
@@ -25,6 +26,7 @@ pub fn ex_ray_options(plugin_options: Option<&str>) -> Result<String> {
     // would satisfy a mere presence check while the append was being swallowed.
     debug_assert_eq!(
         garter::parse_plugin_options(&out)
+            .expect("well-formed by construction: raw segments already validated by split_plugin_options")
             .last()
             .map(|(k, v)| (k.as_str(), v.as_str())),
         Some(("mux", "0")),

--- a/crates/galoshes/src/exray_options_tests.rs
+++ b/crates/galoshes/src/exray_options_tests.rs
@@ -15,14 +15,17 @@ fn server_mode_and_other_directives_survive() {
     // `Mode::from_plugin_options` keys off `server`; appending must not disturb it.
     let out = ex_ray_options(Some("server;host=cloudfront.com;path=/;tls")).unwrap();
     assert_eq!(out, "server;host=cloudfront.com;path=/;tls;mux=0");
-    assert_eq!(garter::Mode::from_plugin_options(Some(&out)), garter::Mode::Server);
+    assert_eq!(
+        garter::Mode::from_plugin_options(Some(&out)).unwrap(),
+        garter::Mode::Server
+    );
 }
 
 #[skuld::test]
 fn an_operator_mux_wins() {
     // ex-ray is first-wins, so an earlier `mux=` overrides the appended default.
     let out = ex_ray_options(Some("mux=8;path=/")).unwrap();
-    let pairs = garter::parse_plugin_options(&out);
+    let pairs = garter::parse_plugin_options(&out).unwrap();
     let first_mux = pairs.iter().find(|(k, _)| k == "mux").expect("mux key present");
     assert_eq!(first_mux.1, "8");
 }
@@ -44,7 +47,7 @@ fn an_escaped_trailing_semicolon_is_not_swallowed() {
     let out = ex_ray_options(Some(r"path=/a\;")).unwrap();
     assert_eq!(out, r"path=/a\;;mux=0");
     assert_eq!(
-        garter::parse_plugin_options(&out),
+        garter::parse_plugin_options(&out).unwrap(),
         vec![("path".into(), "/a;".into()), ("mux".into(), "0".into())]
     );
 }

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(ex_ray_missing, allow(dead_code, unused_imports))]
 
-use galoshes::sitrep_out::{chain_result_to_event, emit, recover_exit_detail};
+use galoshes::sitrep_out::{chain_result_to_event, emit};
 use garter::{
     BinaryPlugin, ChainReady, ChainRunner, Mode, PluginEnv, ReadinessMode, SitrepEvent, StartError, SITREP_PROTOCOL,
 };
@@ -108,8 +108,7 @@ async fn main() -> anyhow::Result<()> {
 
     // `run()` is spawned rather than awaited inline: the plugins only start
     // (and report ready) once `run` is driving them, so we cannot await
-    // `ready_rx` before calling `run`. Spawning (instead of racing a second
-    // task against an inline `.await`, as before) also gives the
+    // `ready_rx` before calling `run`. Spawning also gives the
     // `ExitedBeforeReady` arm below a handle it can join early, to recover
     // a more specific reason from the chain's own terminal result — the
     // same recovery bridge's `recover_exit_detail` performs against the
@@ -126,7 +125,7 @@ async fn main() -> anyhow::Result<()> {
         Ok(Ok(ready)) => (Some(chain_result_to_event(Ok(ready))), Pending::NotJoined(run_handle)),
         Ok(Err(StartError::ExitedBeforeReady)) => {
             let joined = run_handle.await;
-            let detail = recover_exit_detail(&joined);
+            let detail = garter::recover_exit_detail_from_joined(&joined);
             (
                 Some(chain_result_to_event(Err(StartError::Fatal { detail, errno: None }))),
                 Pending::Joined(joined),

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(ex_ray_missing, allow(dead_code, unused_imports))]
 
-use galoshes::sitrep_out::{chain_result_to_event, emit};
+use galoshes::sitrep_out::{chain_result_to_event, emit, recover_exit_detail};
 use garter::{
     BinaryPlugin, ChainReady, ChainRunner, Mode, PluginEnv, ReadinessMode, SitrepEvent, StartError, SITREP_PROTOCOL,
 };
@@ -100,30 +100,57 @@ async fn main() -> anyhow::Result<()> {
     // structured `ready`/`bind_conflict`/`fatal` on galoshes' stdout.
     let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<ChainReady, StartError>>();
 
-    // The emitter must run concurrently with `runner.run`: the plugins
-    // only start (and report ready) once `run` is driving them, so we
-    // cannot await `ready_rx` before calling `run`. On channel drop
-    // (RecvError) we emit nothing — galoshes will exit and the bridge sees
-    // stdout EOF, which is the backstop.
-    let emitter = tokio::spawn(async move {
-        if let Ok(outcome) = ready_rx.await {
-            emit(&chain_result_to_event(outcome));
-        }
-    });
-
     let runner = ChainRunner::new()
         .mode(mode)
         .on_ready(ready_tx)
         .add(Box::new(yamux_plugin))
         .add(Box::new(ex_ray_plugin));
 
+    // `run()` is spawned rather than awaited inline: the plugins only start
+    // (and report ready) once `run` is driving them, so we cannot await
+    // `ready_rx` before calling `run`. Spawning (instead of racing a second
+    // task against an inline `.await`, as before) also gives the
+    // `ExitedBeforeReady` arm below a handle it can join early, to recover
+    // a more specific reason from the chain's own terminal result — the
+    // same recovery bridge's `recover_exit_detail` performs against the
+    // plugin-driving task IT holds. `run_handle` is consumed by exactly one
+    // of the two branches below (`Pending` tracks which), never twice.
+    let run_handle = tokio::spawn(runner.run(env));
+
+    enum Pending {
+        NotJoined(tokio::task::JoinHandle<garter::Result<()>>),
+        Joined(Result<garter::Result<()>, tokio::task::JoinError>),
+    }
+
+    let (event, pending) = match ready_rx.await {
+        Ok(Ok(ready)) => (Some(chain_result_to_event(Ok(ready))), Pending::NotJoined(run_handle)),
+        Ok(Err(StartError::ExitedBeforeReady)) => {
+            let joined = run_handle.await;
+            let detail = recover_exit_detail(&joined);
+            (
+                Some(chain_result_to_event(Err(StartError::Fatal { detail, errno: None }))),
+                Pending::Joined(joined),
+            )
+        }
+        Ok(Err(other)) => (Some(chain_result_to_event(Err(other))), Pending::NotJoined(run_handle)),
+        // The ready channel itself dropped unsent (shutdown fired before the
+        // aggregator sent anything) — emit nothing; galoshes will exit and
+        // the bridge sees stdout EOF, the existing backstop.
+        Err(_) => (None, Pending::NotJoined(run_handle)),
+    };
+    if let Some(event) = &event {
+        emit(event);
+    }
+
     // `verified` must remain alive here -- its open handle prevents TOCTOU
-    // attacks on the extracted binary. It is dropped after `run()` returns.
-    let result = runner.run(env).await.map_err(|e| anyhow::anyhow!(e));
-    // The aggregator drops `ready_tx` once the chain ends (or on shutdown),
-    // so the emitter task either already emitted or sees RecvError; await
-    // it to completion rather than fire-and-forget.
-    let _ = emitter.await;
+    // attacks on the extracted binary. It is dropped after the chain's own
+    // task is fully joined (below), whichever branch above already did so.
+    let joined = match pending {
+        Pending::Joined(j) => j,
+        Pending::NotJoined(h) => h.await,
+    };
     drop(verified);
-    result
+    joined
+        .map_err(|je| anyhow::anyhow!("plugin-driving task ended abnormally: {je}"))
+        .and_then(|r| r.map_err(|e| anyhow::anyhow!(e)))
 }

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -75,7 +75,12 @@ async fn main() -> anyhow::Result<()> {
 
     let verified = ex_ray_binary.prepare()?;
 
-    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    // Validates `env.plugin_options` first, so its malformed-options `Err` is
+    // what a bad SS_PLUGIN_OPTIONS string surfaces as here — the same defect
+    // would also fail `parse_udp_timeout`/`ex_ray_options` below, but they can
+    // never reach that branch through this binary; both stay fallible for
+    // their own callers and unit tests.
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref())?;
     // Parse the galoshes-specific client UDP NAT idle-eviction timeout from the
     // shared options string before any I/O so a misconfiguration fails loudly
     // at startup. ex-ray ignores unrecognized keys (it only reads keys it knows).

--- a/crates/galoshes/src/sitrep_out.rs
+++ b/crates/galoshes/src/sitrep_out.rs
@@ -49,10 +49,10 @@ pub const GALOSHES_TRANSPORTS: Transports = Transports::TCP.union(Transports::UD
 /// corresponding sitrep event — `ExitedBeforeReady` included: `SitrepEvent`
 /// has no counterpart for it, so it downgrades to a plain `Fatal` with
 /// [`garter::EXITED_BEFORE_READY_DETAIL`] text. `main` recovers a more
-/// specific reason itself before calling this (see [`recover_exit_detail`])
-/// and passes that in as an ordinary `Fatal` instead, so a bare
-/// `ExitedBeforeReady` only ever reaches here when nothing more specific
-/// was recoverable either.
+/// specific reason itself before calling this (via
+/// [`garter::recover_exit_detail_from_joined`]) and passes that in as an
+/// ordinary `Fatal` instead, so a bare `ExitedBeforeReady` only ever
+/// reaches here when nothing more specific was recoverable either.
 pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEvent {
     match result {
         Ok(chain_ready) => SitrepEvent::Ready {
@@ -67,33 +67,6 @@ pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEv
             detail: garter::EXITED_BEFORE_READY_DETAIL.into(),
             errno: None,
         },
-    }
-}
-
-/// Recover a specific exit reason from `joined` — the outcome of joining
-/// galoshes' own plugin-driving task (its `ChainRunner::run` future) —
-/// for the case where the ready-gate signal itself carried no diagnosis
-/// (a bare `StartError::ExitedBeforeReady`). Mirrors bridge's own
-/// `recover_exit_detail`, which performs the identical join-for-detail
-/// recovery against the plugin-driving task IT holds.
-///
-/// `Ok(Err(e))` (the chain's own `run()` call returned a specific error)
-/// yields that error's `Display` text — the same text `main`'s own
-/// `anyhow::Result` return would otherwise carry, now surfaced to the
-/// bridge via the sitrep event too. `Ok(Ok(()))` (a clean exit — e.g.
-/// shutdown raced the readiness report) and `Err(_)` (the task panicked or
-/// was cancelled while being joined) both fall back to
-/// [`garter::EXITED_BEFORE_READY_DETAIL`]; the panic/cancel case is also
-/// logged at `error!`, since it signals a bug rather than routine
-/// diagnostic noise.
-pub fn recover_exit_detail(joined: &Result<garter::Result<()>, tokio::task::JoinError>) -> String {
-    match joined {
-        Ok(Err(e)) => e.to_string(),
-        Ok(Ok(())) => garter::EXITED_BEFORE_READY_DETAIL.into(),
-        Err(join_err) => {
-            tracing::error!(error = %join_err, "plugin-driving task ended abnormally while recovering exit detail");
-            garter::EXITED_BEFORE_READY_DETAIL.into()
-        }
     }
 }
 

--- a/crates/galoshes/src/sitrep_out.rs
+++ b/crates/galoshes/src/sitrep_out.rs
@@ -46,7 +46,13 @@ pub const GALOSHES_TRANSPORTS: Transports = Transports::TCP.union(Transports::UD
 /// `chain_ready.transports`. See [`GALOSHES_TRANSPORTS`] for why.
 ///
 /// On `Err(StartError)` the typed start failure maps 1:1 to the
-/// corresponding sitrep event.
+/// corresponding sitrep event — `ExitedBeforeReady` included: `SitrepEvent`
+/// has no counterpart for it, so it downgrades to a plain `Fatal` with
+/// [`garter::EXITED_BEFORE_READY_DETAIL`] text, discarding whatever specific
+/// cause `main`'s own `result` may hold. This is a real, tracked
+/// diagnostic-fidelity gap, not a costless design choice: symmetric recovery
+/// (matching `recover_exit_detail` on the bridge side) isn't a small patch
+/// here.
 pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEvent {
     match result {
         Ok(chain_ready) => SitrepEvent::Ready {
@@ -57,6 +63,10 @@ pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEv
         },
         Err(StartError::BindConflict { errno, addr }) => SitrepEvent::BindConflict { errno, addr },
         Err(StartError::Fatal { detail, errno }) => SitrepEvent::Fatal { detail, errno },
+        Err(StartError::ExitedBeforeReady) => SitrepEvent::Fatal {
+            detail: garter::EXITED_BEFORE_READY_DETAIL.into(),
+            errno: None,
+        },
     }
 }
 

--- a/crates/galoshes/src/sitrep_out.rs
+++ b/crates/galoshes/src/sitrep_out.rs
@@ -48,11 +48,13 @@ pub const GALOSHES_TRANSPORTS: Transports = Transports::TCP.union(Transports::UD
 /// On `Err(StartError)` the typed start failure maps 1:1 to the
 /// corresponding sitrep event — `ExitedBeforeReady` included: `SitrepEvent`
 /// has no counterpart for it, so it downgrades to a plain `Fatal` with
-/// [`garter::EXITED_BEFORE_READY_DETAIL`] text. `main` recovers a more
-/// specific reason itself before calling this (via
-/// [`garter::recover_exit_detail_from_joined`]) and passes that in as an
-/// ordinary `Fatal` instead, so a bare `ExitedBeforeReady` only ever
-/// reaches here when nothing more specific was recoverable either.
+/// [`garter::EXITED_BEFORE_READY_DETAIL`] text. Defense-in-depth for this
+/// function's own public contract (any caller can pass a bare
+/// `ExitedBeforeReady` directly), not something `main`'s actual control
+/// flow reaches: `main` always intercepts `Ok(Err(StartError::ExitedBeforeReady))`
+/// itself first, recovers a more specific reason (via
+/// [`garter::recover_exit_detail_from_joined`]), and passes an ordinary
+/// `Fatal` here instead — so this arm never actually fires in production.
 pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEvent {
     match result {
         Ok(chain_ready) => SitrepEvent::Ready {

--- a/crates/galoshes/src/sitrep_out.rs
+++ b/crates/galoshes/src/sitrep_out.rs
@@ -48,11 +48,11 @@ pub const GALOSHES_TRANSPORTS: Transports = Transports::TCP.union(Transports::UD
 /// On `Err(StartError)` the typed start failure maps 1:1 to the
 /// corresponding sitrep event — `ExitedBeforeReady` included: `SitrepEvent`
 /// has no counterpart for it, so it downgrades to a plain `Fatal` with
-/// [`garter::EXITED_BEFORE_READY_DETAIL`] text, discarding whatever specific
-/// cause `main`'s own `result` may hold. This is a real, tracked
-/// diagnostic-fidelity gap, not a costless design choice: symmetric recovery
-/// (matching `recover_exit_detail` on the bridge side) isn't a small patch
-/// here.
+/// [`garter::EXITED_BEFORE_READY_DETAIL`] text. `main` recovers a more
+/// specific reason itself before calling this (see [`recover_exit_detail`])
+/// and passes that in as an ordinary `Fatal` instead, so a bare
+/// `ExitedBeforeReady` only ever reaches here when nothing more specific
+/// was recoverable either.
 pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEvent {
     match result {
         Ok(chain_ready) => SitrepEvent::Ready {
@@ -67,6 +67,33 @@ pub fn chain_result_to_event(result: Result<ChainReady, StartError>) -> SitrepEv
             detail: garter::EXITED_BEFORE_READY_DETAIL.into(),
             errno: None,
         },
+    }
+}
+
+/// Recover a specific exit reason from `joined` — the outcome of joining
+/// galoshes' own plugin-driving task (its `ChainRunner::run` future) —
+/// for the case where the ready-gate signal itself carried no diagnosis
+/// (a bare `StartError::ExitedBeforeReady`). Mirrors bridge's own
+/// `recover_exit_detail`, which performs the identical join-for-detail
+/// recovery against the plugin-driving task IT holds.
+///
+/// `Ok(Err(e))` (the chain's own `run()` call returned a specific error)
+/// yields that error's `Display` text — the same text `main`'s own
+/// `anyhow::Result` return would otherwise carry, now surfaced to the
+/// bridge via the sitrep event too. `Ok(Ok(()))` (a clean exit — e.g.
+/// shutdown raced the readiness report) and `Err(_)` (the task panicked or
+/// was cancelled while being joined) both fall back to
+/// [`garter::EXITED_BEFORE_READY_DETAIL`]; the panic/cancel case is also
+/// logged at `error!`, since it signals a bug rather than routine
+/// diagnostic noise.
+pub fn recover_exit_detail(joined: &Result<garter::Result<()>, tokio::task::JoinError>) -> String {
+    match joined {
+        Ok(Err(e)) => e.to_string(),
+        Ok(Ok(())) => garter::EXITED_BEFORE_READY_DETAIL.into(),
+        Err(join_err) => {
+            tracing::error!(error = %join_err, "plugin-driving task ended abnormally while recovering exit detail");
+            garter::EXITED_BEFORE_READY_DETAIL.into()
+        }
     }
 }
 

--- a/crates/galoshes/src/sitrep_out_tests.rs
+++ b/crates/galoshes/src/sitrep_out_tests.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use garter::{ChainReady, SitrepEvent, StartError, Transports};
 
-use crate::sitrep_out::{chain_result_to_event, GALOSHES_TRANSPORTS};
+use crate::sitrep_out::{chain_result_to_event, recover_exit_detail, GALOSHES_TRANSPORTS};
 
 fn addr() -> SocketAddr {
     "127.0.0.1:1080".parse().unwrap()
@@ -120,4 +120,31 @@ fn exited_before_ready_maps_to_fatal_with_generic_detail() {
             errno: None,
         }
     );
+}
+
+#[skuld::test]
+fn recover_exit_detail_surfaces_the_chains_specific_error() {
+    let joined: Result<garter::Result<()>, tokio::task::JoinError> = Ok(Err(garter::Error::Chain(
+        "tap[ex-ray]: alloc inner port: address in use".into(),
+    )));
+    assert_eq!(
+        recover_exit_detail(&joined),
+        "tap[ex-ray]: alloc inner port: address in use"
+    );
+}
+
+#[skuld::test]
+fn recover_exit_detail_falls_back_on_a_clean_exit() {
+    // `run()` returning `Ok(())` here means shutdown raced the readiness
+    // report, not a real failure — nothing more specific to recover.
+    let joined: Result<garter::Result<()>, tokio::task::JoinError> = Ok(Ok(()));
+    assert_eq!(recover_exit_detail(&joined), garter::EXITED_BEFORE_READY_DETAIL);
+}
+
+#[skuld::test]
+async fn recover_exit_detail_falls_back_when_the_task_panicked() {
+    let handle = tokio::spawn(async { panic!("boom") });
+    let joined = handle.await;
+    assert!(joined.is_err(), "expected a real JoinError from the panicked task");
+    assert_eq!(recover_exit_detail(&joined), garter::EXITED_BEFORE_READY_DETAIL);
 }

--- a/crates/galoshes/src/sitrep_out_tests.rs
+++ b/crates/galoshes/src/sitrep_out_tests.rs
@@ -108,3 +108,16 @@ fn fatal_maps_through_without_errno() {
         }
     );
 }
+
+#[skuld::test]
+fn exited_before_ready_maps_to_fatal_with_generic_detail() {
+    // See `chain_result_to_event`'s doc comment for why.
+    let ev = chain_result_to_event(Err(StartError::ExitedBeforeReady));
+    assert_eq!(
+        ev,
+        SitrepEvent::Fatal {
+            detail: garter::EXITED_BEFORE_READY_DETAIL.into(),
+            errno: None,
+        }
+    );
+}

--- a/crates/galoshes/src/sitrep_out_tests.rs
+++ b/crates/galoshes/src/sitrep_out_tests.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use garter::{ChainReady, SitrepEvent, StartError, Transports};
 
-use crate::sitrep_out::{chain_result_to_event, recover_exit_detail, GALOSHES_TRANSPORTS};
+use crate::sitrep_out::{chain_result_to_event, GALOSHES_TRANSPORTS};
 
 fn addr() -> SocketAddr {
     "127.0.0.1:1080".parse().unwrap()
@@ -122,29 +122,6 @@ fn exited_before_ready_maps_to_fatal_with_generic_detail() {
     );
 }
 
-#[skuld::test]
-fn recover_exit_detail_surfaces_the_chains_specific_error() {
-    let joined: Result<garter::Result<()>, tokio::task::JoinError> = Ok(Err(garter::Error::Chain(
-        "tap[ex-ray]: alloc inner port: address in use".into(),
-    )));
-    assert_eq!(
-        recover_exit_detail(&joined),
-        "tap[ex-ray]: alloc inner port: address in use"
-    );
-}
-
-#[skuld::test]
-fn recover_exit_detail_falls_back_on_a_clean_exit() {
-    // `run()` returning `Ok(())` here means shutdown raced the readiness
-    // report, not a real failure — nothing more specific to recover.
-    let joined: Result<garter::Result<()>, tokio::task::JoinError> = Ok(Ok(()));
-    assert_eq!(recover_exit_detail(&joined), garter::EXITED_BEFORE_READY_DETAIL);
-}
-
-#[skuld::test]
-async fn recover_exit_detail_falls_back_when_the_task_panicked() {
-    let handle = tokio::spawn(async { panic!("boom") });
-    let joined = handle.await;
-    assert!(joined.is_err(), "expected a real JoinError from the panicked task");
-    assert_eq!(recover_exit_detail(&joined), garter::EXITED_BEFORE_READY_DETAIL);
-}
+// `recover_exit_detail_from_joined`'s own behavior is tested at its source
+// (garter's `sitrep_tests.rs`) — galoshes just calls it directly from
+// `main`, nothing left here to test in isolation.

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -1150,28 +1150,38 @@ async fn echo_keepalive(mut stream: yamux::Stream) -> Result<()> {
 /// Parse the optional client-side `udp_timeout` (whole seconds) from an
 /// `SS_PLUGIN_OPTIONS` string.
 ///
-/// Returns [`DEFAULT_UDP_TIMEOUT`] when the key is absent. The last occurrence
-/// wins (consistent with ex-ray's duplicate-key semantics). A value that
-/// is not a positive integer is a hard error — `0` would evict every
-/// association immediately, breaking all UDP. ex-ray ignores this key,
-/// so it can share the same options string.
+/// Returns [`DEFAULT_UDP_TIMEOUT`] when the key is absent. The FIRST
+/// occurrence wins on a duplicate key — matching every other reader of this
+/// same options string (ex-ray's own `Args.Get`, and the bridge's
+/// `classify_transport`/garter-bin's `config_path_from_plugin_options`),
+/// even though `udp_timeout` is galoshes' own extension ex-ray never reads:
+/// there is no cross-tool parity requirement for this key, but there IS an
+/// intra-string one — an operator reading one options string should not
+/// see different keys resolve duplicates in opposite directions.
+///
+/// EVERY occurrence is validated, not just the winning first one — a value
+/// that is not a positive integer is a hard error on ANY occurrence (`0`
+/// would evict every association immediately, breaking all UDP), so a
+/// self-contradictory duplicate still refuses the start rather than
+/// silently keeping the first value and discarding the rest unchecked.
 pub fn parse_udp_timeout(plugin_options: Option<&str>) -> Result<Duration> {
     let Some(opts) = plugin_options else {
         return Ok(DEFAULT_UDP_TIMEOUT);
     };
-    let mut timeout = DEFAULT_UDP_TIMEOUT;
-    for (key, value) in garter::parse_plugin_options(opts) {
-        if key == "udp_timeout" {
-            let secs: u64 = value
-                .parse()
-                .with_context(|| format!("invalid udp_timeout (expected a positive integer of seconds): {value:?}"))?;
-            if secs == 0 {
-                anyhow::bail!("udp_timeout must be greater than 0 seconds");
-            }
-            timeout = Duration::from_secs(secs);
+    let mut selected: Option<Duration> = None;
+    for (key, value) in garter::parse_plugin_options(opts).map_err(garter::Error::from)? {
+        if key != "udp_timeout" {
+            continue;
         }
+        let secs: u64 = value
+            .parse()
+            .with_context(|| format!("invalid udp_timeout (expected a positive integer of seconds): {value:?}"))?;
+        if secs == 0 {
+            anyhow::bail!("udp_timeout must be greater than 0 seconds");
+        }
+        selected.get_or_insert(Duration::from_secs(secs));
     }
-    Ok(timeout)
+    Ok(selected.unwrap_or(DEFAULT_UDP_TIMEOUT))
 }
 
 pub struct YamuxPlugin {

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -183,10 +183,10 @@ fn udp_timeout_parsed_value() {
 }
 
 #[skuld::test]
-fn udp_timeout_last_occurrence_wins() {
+fn udp_timeout_first_occurrence_wins() {
     assert_eq!(
         parse_udp_timeout(Some("udp_timeout=5;udp_timeout=20")).unwrap(),
-        Duration::from_secs(20)
+        Duration::from_secs(5)
     );
 }
 
@@ -197,6 +197,27 @@ fn udp_timeout_invalid_is_error() {
     // 0 would evict every association immediately — rejected.
     assert!(parse_udp_timeout(Some("udp_timeout=0")).is_err());
     assert!(parse_udp_timeout(Some("udp_timeout=-1")).is_err());
+}
+
+// First-wins selects the value, but every occurrence is still validated —
+// a self-contradictory duplicate must still refuse the start, not silently
+// keep the first (valid) value and ignore an invalid later one.
+#[skuld::test]
+fn udp_timeout_validates_every_occurrence_not_just_the_first() {
+    assert!(parse_udp_timeout(Some("udp_timeout=30;udp_timeout=0")).is_err());
+    assert!(parse_udp_timeout(Some("udp_timeout=30;udp_timeout=abc")).is_err());
+}
+
+#[skuld::test]
+fn udp_timeout_errors_on_malformed_options() {
+    // A dangling trailing backslash is fatal to ex-ray's own parser; failing
+    // loud here beats silently falling back to the default. The reason must
+    // survive in the error's own message, not just the fact that it failed.
+    let err = parse_udp_timeout(Some(r"udp_timeout=10;path=/a\")).unwrap_err();
+    assert!(
+        err.to_string().contains("unpaired backslash"),
+        "expected the specific reason in the message, got: {err}"
+    );
 }
 
 // End-to-end UDP relay (#415) -----------------------------------------------------------------------------------------

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -199,9 +199,8 @@ fn udp_timeout_invalid_is_error() {
     assert!(parse_udp_timeout(Some("udp_timeout=-1")).is_err());
 }
 
-// First-wins selects the value, but every occurrence is still validated —
-// a self-contradictory duplicate must still refuse the start, not silently
-// keep the first (valid) value and ignore an invalid later one.
+// A self-contradictory duplicate (valid first, invalid later) must still
+// refuse the start.
 #[skuld::test]
 fn udp_timeout_validates_every_occurrence_not_just_the_first() {
     assert!(parse_udp_timeout(Some("udp_timeout=30;udp_timeout=0")).is_err());

--- a/crates/garter-bin/src/config.rs
+++ b/crates/garter-bin/src/config.rs
@@ -35,3 +35,259 @@ pub fn load_config(path: &Path) -> anyhow::Result<ChainConfig> {
     let config_dir = path.parent().unwrap_or(Path::new("."));
     Ok(config.resolve_paths(config_dir))
 }
+
+/// The chain config path from `config=`, plus whether decoding it likely
+/// mangled an unescaped Windows-style path — carried alongside the path
+/// rather than logged immediately, so a LOAD failure (not just a parse)
+/// can explain itself; see [`load_config_or_explain_escaping`].
+#[derive(Debug)]
+pub struct ConfigPath {
+    pub path: String,
+    pub mangled_from: Option<MangledPath>,
+}
+
+/// Two corrected spellings for a `config=` value `value_was_mangled_by_unescaping`
+/// flagged: double every literal backslash, or use forward slashes instead
+/// (Windows accepts both). `forward_slashes` is `None` off Windows — there
+/// `\` is an ordinary filename byte, not a path separator, so substituting
+/// `/` names a genuinely different path rather than an equivalent spelling;
+/// offering it as a "fix" there would be actively misleading.
+#[derive(Debug)]
+pub struct MangledPath {
+    pub doubled: String,
+    pub forward_slashes: Option<String>,
+}
+
+/// Extract `config=<path>` from a SIP003 `SS_PLUGIN_OPTIONS` string.
+///
+/// A malformed options string (e.g. a dangling trailing backslash) is
+/// reported distinctly from a simply-absent `config` key, so a caller can
+/// tell "you forgot `config=`" from "your options string doesn't parse." A
+/// bare `config` or an explicit `config=` (empty value) are both treated as
+/// absent — a path can't be the empty string. Does NOT reject a mangled
+/// value itself (`load_config_or_explain_escaping` reports it, only if the
+/// path then fails to load — a mangled decode isn't necessarily wrong: it
+/// could coincidentally still name a real file).
+pub fn config_path_from_plugin_options(plugin_options: Option<&str>) -> anyhow::Result<ConfigPath> {
+    let Some(opts) = plugin_options else {
+        anyhow::bail!("SS_PLUGIN_OPTIONS must contain config=/path/to/chain.yaml");
+    };
+    let segments = garter::split_plugin_options(opts).map_err(garter::Error::from)?;
+    let segment = segments
+        .iter()
+        .find(|s| s.key == "config")
+        .ok_or_else(|| anyhow::anyhow!("SS_PLUGIN_OPTIONS must contain config=/path/to/chain.yaml"))?;
+    if segment.value.is_empty() {
+        anyhow::bail!("SS_PLUGIN_OPTIONS config= must name a non-empty path");
+    }
+    Ok(ConfigPath {
+        path: segment.value.clone(),
+        mangled_from: value_was_mangled_by_unescaping(segment).then(|| mangled_spellings(segment)),
+    })
+}
+
+/// The two corrected spellings for a segment `value_was_mangled_by_unescaping`
+/// already confirmed is mangled. Splits `raw` at its first `=` under the
+/// same caller-restricted assumption as `value_was_mangled_by_unescaping`
+/// — see that function's doc comment — then delegates the actual
+/// reconstruction to [`reconstruct_intended`], the single implementation of
+/// this walk (shared with `value_was_mangled_by_unescaping`).
+fn mangled_spellings(segment: &garter::OptionSegment<'_>) -> MangledPath {
+    let eq = segment
+        .raw
+        .find('=')
+        .expect("value_was_mangled_by_unescaping already confirmed an '=' exists");
+    let (intended, _) = reconstruct_intended(&segment.raw[eq + 1..])
+        .expect("segment already validated by split_plugin_options: no dangling escape");
+    MangledPath {
+        doubled: escape_sip003(&intended),
+        forward_slashes: cfg!(windows).then(|| escape_sip003(&intended.replace('\\', "/"))),
+    }
+}
+
+/// Reconstruct `s`'s "intended literal" reading — a `config=` diagnostic
+/// heuristic (not a SIP003 protocol primitive, so it lives here rather than
+/// in the publishable `garter` crate) for explaining, not just decoding, a
+/// value suspected of being a raw Windows path pasted in without proper
+/// escaping.
+///
+/// A `\` before one of the three [`garter::sip003::is_sip003_metacharacter`]
+/// bytes decodes as usual (consumed) — the operator escaped correctly
+/// there. A `\` before any OTHER byte is instead kept as BOTH characters
+/// rather than consumed: the actual defect, treated as a literal `\` the
+/// operator forgot to double, so it can be re-escaped exactly once by a
+/// caller re-serializing `intended` rather than escaped a second time on
+/// top of an escape that was already correct (a naive "double every
+/// backslash in `s`" would do that on a partially-escaped value). Returns
+/// whether any such defect was found.
+///
+/// A value starting with exactly two backslashes (not four or more) is a
+/// special case: a Windows UNC (`\\server\share\...`) or extended-length
+/// (`\\?\C:\...`) prefix reads identically to one legitimate escape of a
+/// literal `\` — `\\` decodes to one `\` either way — so which the
+/// operator meant is genuinely ambiguous from the bytes alone. Since an
+/// entirely-unescaped literal path is the overwhelmingly common real
+/// input, both leading backslashes are reconstructed as literal rather
+/// than run through the escape detection above (which would drop one).
+/// Four or more leading backslashes are left to the normal detection — a
+/// repeated, correctly-doubled pair is evidence of deliberate escaping,
+/// not the single ambiguous case this exists to catch. This ambiguous
+/// leading pair is NOT by itself evidence of mangling, though (the
+/// returned `bool`): a value consisting solely of a correctly-escaped
+/// leading backslash, with no other defect anywhere, is indistinguishable
+/// from this case and must not be flagged — only a defect ELSEWHERE in the
+/// value marks it mangled.
+///
+/// `Err` only on a dangling trailing `\` — every caller reaches this on an
+/// [`garter::OptionSegment::value`] this was already decoded from, so has
+/// necessarily already ruled this out via [`garter::split_plugin_options`].
+///
+/// Delegates the walk itself to [`garter::sip003::walk_escaped`] (shared
+/// with garter's own `unescape_any`) — only the escaped-byte handling
+/// (metacharacter-vs-not, and the leading-pair special case) is specific to
+/// this diagnostic.
+pub(crate) fn reconstruct_intended(s: &str) -> Result<(String, bool), garter::MalformedOptions> {
+    let (prefix, rest) = if s.starts_with(r"\\") && !s.starts_with(r"\\\\") {
+        (r"\\", &s[2..])
+    } else {
+        ("", s)
+    };
+
+    let mut was_mangled = false;
+    let walked = garter::sip003::walk_escaped(rest, |c, out| {
+        if garter::sip003::is_sip003_metacharacter(c) {
+            out.push(c);
+        } else {
+            out.push('\\');
+            out.push(c);
+            was_mangled = true;
+        }
+    })?;
+    Ok((format!("{prefix}{walked}"), was_mangled))
+}
+
+/// Escape every SIP003 metacharacter in `s` so it round-trips as ONE
+/// segment through [`garter::split_plugin_options`] — used to serialize
+/// [`mangled_spellings`]'s reconstructed literal path back into a valid
+/// `config=` value. Escaping only `\` leaves a decoded `;`/`=` unescaped,
+/// silently splitting the suggestion into more than one segment or moving
+/// the key/value boundary.
+pub(crate) fn escape_sip003(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| {
+            if garter::sip003::is_sip003_metacharacter(c) {
+                vec!['\\', c]
+            } else {
+                vec![c]
+            }
+        })
+        .collect()
+}
+
+/// Load the chain config at `config.path`. If the path came from a
+/// `config=` value `value_was_mangled_by_unescaping` flagged (an unescaped
+/// literal backslash silently dropped) and the load then fails with ANY
+/// IO-layer error — narrowly checking `NotFound` would miss e.g.
+/// `PermissionDenied` (a dropped backslash collapsing the path into a
+/// protected location) on the same known-mangled path — names the
+/// escaping as the cause and offers two corrected spellings, rather than a
+/// bare IO error that gives no hint the real cause was SIP003 escaping. A
+/// legitimately doubled/clean path never has `mangled_from` set, so it
+/// never triggers this text — and neither does a YAML-parse failure on a
+/// path that DID resolve to a real file: `yaml_serde` errors don't
+/// downcast to `std::io::Error`, so that failure has nothing to do with
+/// escaping and is left to speak plainly rather than misattributed.
+pub fn load_config_or_explain_escaping(config: &ConfigPath) -> anyhow::Result<ChainConfig> {
+    load_config(std::path::Path::new(&config.path)).map_err(|e| {
+        let io_failure = e.downcast_ref::<std::io::Error>().is_some();
+        match (&config.mangled_from, io_failure) {
+            (Some(m), true) => {
+                let suggestion = match &m.forward_slashes {
+                    Some(fs) => format!("try config={} or config={}", m.doubled, fs),
+                    None => format!("try config={}", m.doubled),
+                };
+                anyhow::anyhow!(
+                    "failed to load chain config at {:?}: {e}\n\
+                     this path came from a SIP003 config= value containing an unescaped `\\`; SIP003 requires \
+                     doubling a literal `\\` — {suggestion}",
+                    config.path,
+                )
+            }
+            _ => anyhow::anyhow!("failed to load chain config at {:?}: {e}", config.path),
+        }
+    })
+}
+
+/// Whether `segment`'s raw value contains a backslash escaping a byte with
+/// no SIP003 meaning — the signal a Windows-style path was written with an
+/// UNESCAPED literal backslash and got silently mangled. Delegates the walk
+/// to [`reconstruct_intended`] (shared with `mangled_spellings`) and keeps
+/// only its `bool` half. `pub(crate)` for direct unit testing rather than
+/// asserting on captured log output.
+///
+/// Splits `raw` at its first `=` rather than the first UNESCAPED one: safe
+/// here because the only caller reaches this on a segment whose DECODED key
+/// is exactly `"config"`, which has no `=` in it, so no escape sequence in
+/// the key portion can move where the real separator is — enforced below,
+/// not just documented.
+pub(crate) fn value_was_mangled_by_unescaping(segment: &garter::OptionSegment<'_>) -> bool {
+    debug_assert_eq!(
+        segment.key, "config",
+        "value_was_mangled_by_unescaping's raw.find('=') shortcut is only valid for a config= segment"
+    );
+    let Some(eq) = segment.raw.find('=') else {
+        return false; // a bare key has no value to mangle
+    };
+    reconstruct_intended(&segment.raw[eq + 1..])
+        .expect("segment already validated by split_plugin_options: no dangling escape")
+        .1
+}
+
+/// Validate every chain entry's `options` up front, before any plugin
+/// spawns. ex-ray silently discards a malformed `SS_PLUGIN_OPTIONS` string
+/// and reports `ready` on its flag-default port instead of failing — better
+/// to fail the whole chain loudly here than let one plugin silently come up
+/// wired wrong.
+pub fn validate_chain_options(chain: &[PluginEntry]) -> anyhow::Result<()> {
+    for (index, entry) in chain.iter().enumerate() {
+        if let Some(opts) = &entry.options {
+            garter::parse_plugin_options(opts).map_err(|e| {
+                anyhow::anyhow!(
+                    "chain entry {index} ({}): malformed options: {e}",
+                    entry.plugin.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the chain config from `SS_PLUGIN_OPTIONS`: extract `config=`,
+/// load the YAML (naming an unescaped Windows path if that's why loading
+/// failed), require a non-empty chain, and validate every entry's own
+/// options — the exact sequence `main` runs before touching any plugin
+/// process. Broken out of `main` so this composition is unit-testable
+/// end to end without spawning `garter-bin` as a subprocess.
+///
+/// A detected mangling is warned about here, BEFORE attempting the load —
+/// not only in [`load_config_or_explain_escaping`]'s failure path. A
+/// mangled path (typically a relative one, resolved against the process's
+/// current directory) can coincidentally name a real, loadable file that is
+/// NOT the one the operator wrote in `config=`; if that happens, the load
+/// below succeeds silently and the operator would otherwise have no
+/// indication the wrong file was opened.
+pub fn resolve_chain_config(plugin_options: Option<&str>) -> anyhow::Result<ChainConfig> {
+    let config = config_path_from_plugin_options(plugin_options)?;
+    if let Some(m) = &config.mangled_from {
+        tracing::warn!(
+            path = %config.path,
+            doubled_suggestion = %m.doubled,
+            forward_slash_suggestion = ?m.forward_slashes,
+            "config= names a path that came from an unescaped `\\`; opening the DECODED path, which may not be what was intended"
+        );
+    }
+    let cfg = load_config_or_explain_escaping(&config)?;
+    anyhow::ensure!(!cfg.chain.is_empty(), "chain config must have at least one plugin");
+    validate_chain_options(&cfg.chain)?;
+    Ok(cfg)
+}

--- a/crates/garter-bin/src/config_tests.rs
+++ b/crates/garter-bin/src/config_tests.rs
@@ -1,6 +1,11 @@
 use std::path::Path;
 
-use crate::config::ChainConfig;
+use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+use crate::config::{
+    config_path_from_plugin_options, load_config_or_explain_escaping, reconstruct_intended, resolve_chain_config,
+    validate_chain_options, value_was_mangled_by_unescaping, ChainConfig, ConfigPath, MangledPath,
+};
 
 #[skuld::test]
 fn parse_valid_config() {
@@ -46,4 +51,544 @@ chain:
     let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
     let resolved = config.resolve_paths(Path::new("/somewhere/else"));
     assert_eq!(resolved.chain[0].plugin, Path::new("/usr/bin/v2ray-plugin"));
+}
+
+// config_path_from_plugin_options =====================================================================================
+
+#[skuld::test]
+fn config_path_found() {
+    assert_eq!(
+        config_path_from_plugin_options(Some("config=/etc/chain.yaml"))
+            .unwrap()
+            .path,
+        "/etc/chain.yaml"
+    );
+    assert_eq!(
+        config_path_from_plugin_options(Some("mode=quic;config=/etc/chain.yaml;path=/x"))
+            .unwrap()
+            .path,
+        "/etc/chain.yaml"
+    );
+}
+
+#[skuld::test]
+fn config_path_missing_is_an_error() {
+    assert!(config_path_from_plugin_options(None).is_err());
+    assert!(config_path_from_plugin_options(Some("")).is_err());
+    assert!(config_path_from_plugin_options(Some("mode=quic")).is_err());
+    // A bare key or an explicitly empty value are both "no path named",
+    // not "path is the empty string".
+    assert!(config_path_from_plugin_options(Some("config")).is_err());
+    assert!(config_path_from_plugin_options(Some("config=")).is_err());
+}
+
+#[skuld::test]
+fn config_path_malformed_options_is_a_distinct_error() {
+    let err = config_path_from_plugin_options(Some(r"config=/etc/chain.yaml;path=/a\")).unwrap_err();
+    assert!(
+        err.to_string().contains("malformed SS_PLUGIN_OPTIONS"),
+        "expected a malformed-options error, got: {err}"
+    );
+}
+
+#[skuld::test]
+fn config_path_reports_mangling_with_corrected_spellings() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\Users\x\chain.yaml")).unwrap();
+    assert_eq!(config.path, "C:Usersxchain.yaml");
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    assert_eq!(mangled.doubled, r"C:\\Users\\x\\chain.yaml");
+    assert_forward_slashes_platform_correct(&mangled, "C:/Users/x/chain.yaml");
+}
+
+// A forward-slash spelling only round-trips to the SAME path on Windows
+// (which accepts both separators) — on Unix `\` is an ordinary filename
+// byte, so it must not be offered as a "fix" there.
+fn assert_forward_slashes_platform_correct(mangled: &MangledPath, expected_on_windows: &str) {
+    if cfg!(windows) {
+        assert_eq!(mangled.forward_slashes.as_deref(), Some(expected_on_windows));
+    } else {
+        assert!(
+            mangled.forward_slashes.is_none(),
+            "forward-slash spelling must not be offered off Windows, got {:?}",
+            mangled.forward_slashes
+        );
+    }
+}
+
+#[skuld::test]
+fn config_path_reports_no_mangling_for_a_correctly_escaped_path() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\\Users\\x\\chain.yaml")).unwrap();
+    assert_eq!(config.path, r"C:\Users\x\chain.yaml");
+    assert!(config.mangled_from.is_none());
+}
+
+// A Windows UNC path's leading `\\` is genuinely ambiguous SIP003 input
+// (see `reconstruct_intended`'s doc comment) — this pins that it's read as
+// two literal backslashes, not as one legitimate SIP003 escape.
+#[skuld::test]
+fn config_path_unc_prefix_keeps_both_leading_backslashes() {
+    let config = config_path_from_plugin_options(Some(r"config=\\fileserver\share\chain.yaml")).unwrap();
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    assert_eq!(mangled.doubled, r"\\\\fileserver\\share\\chain.yaml");
+    assert_forward_slashes_platform_correct(&mangled, "//fileserver/share/chain.yaml");
+
+    // The suggestion must round-trip back to the exact original UNC path.
+    let doubled_opts = format!("config={}", mangled.doubled);
+    let doubled_segments = garter::split_plugin_options(&doubled_opts).unwrap();
+    assert_eq!(doubled_segments[0].value, r"\\fileserver\share\chain.yaml");
+}
+
+// The extended-length prefix `\\?\` starts the same way and must get the
+// same treatment.
+#[skuld::test]
+fn config_path_extended_length_prefix_keeps_both_leading_backslashes() {
+    let config = config_path_from_plugin_options(Some(r"config=\\?\C:\very\long\chain.yaml")).unwrap();
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    let doubled_opts = format!("config={}", mangled.doubled);
+    let doubled_segments = garter::split_plugin_options(&doubled_opts).unwrap();
+    assert_eq!(doubled_segments[0].value, r"\\?\C:\very\long\chain.yaml");
+}
+
+// A partially-escaped value (one separator correctly doubled, the rest
+// not) must not double-escape the already-correct part in its suggestion.
+#[skuld::test]
+fn config_path_mixed_escaping_suggests_the_fully_corrected_spelling() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\\shared\data\chain.yaml")).unwrap();
+    assert_eq!(config.path, r"C:\shareddatachain.yaml");
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    assert_eq!(mangled.doubled, r"C:\\shared\\data\\chain.yaml");
+    assert_forward_slashes_platform_correct(&mangled, "C:/shared/data/chain.yaml");
+}
+
+// A suggestion must re-escape EVERY SIP003 metacharacter it decoded while
+// reconstructing the intended path, not just `\` — otherwise it names a
+// spelling that no longer round-trips through the shared decoder as ONE
+// segment.
+#[skuld::test]
+fn config_path_mangled_suggestion_reescapes_semicolons_and_equals() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\dir\my\;chain.yaml")).unwrap();
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+
+    let doubled_opts = format!("config={}", mangled.doubled);
+    let doubled_segments = garter::split_plugin_options(&doubled_opts)
+        .unwrap_or_else(|e| panic!("doubled suggestion {:?} does not even parse: {e}", mangled.doubled));
+    assert_eq!(
+        doubled_segments.len(),
+        1,
+        "doubled suggestion {:?} split into more than one segment",
+        mangled.doubled
+    );
+    assert_eq!(doubled_segments[0].value, r"C:\dir\my;chain.yaml");
+
+    if cfg!(windows) {
+        let fs = mangled
+            .forward_slashes
+            .as_deref()
+            .expect("Windows must offer a forward-slash spelling");
+        let forward_opts = format!("config={fs}");
+        let forward_segments = garter::split_plugin_options(&forward_opts)
+            .unwrap_or_else(|e| panic!("forward-slash suggestion {fs:?} does not even parse: {e}"));
+        assert_eq!(
+            forward_segments.len(),
+            1,
+            "forward-slash suggestion {fs:?} split into more than one segment"
+        );
+        assert_eq!(forward_segments[0].value, "C:/dir/my;chain.yaml");
+    } else {
+        assert!(mangled.forward_slashes.is_none());
+    }
+}
+
+#[skuld::test]
+fn config_path_first_wins_on_duplicate_key() {
+    // ex-ray's Args.Get is first-wins; the FIRST config= must be the one
+    // consulted.
+    assert_eq!(
+        config_path_from_plugin_options(Some("config=/first;config=/second"))
+            .unwrap()
+            .path,
+        "/first"
+    );
+}
+
+// load_config_or_explain_escaping =====================================================================================
+
+#[skuld::test]
+fn load_config_names_the_escaping_when_a_mangled_path_fails_to_load() {
+    let config = ConfigPath {
+        path: "C:Usersxchain.yaml".to_string(), // nonexistent, mangled
+        mangled_from: Some(MangledPath {
+            doubled: r"C:\\Users\\x\\chain.yaml".to_string(),
+            forward_slashes: Some("C:/Users/x/chain.yaml".to_string()),
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unescaped"),
+        "expected the error to name escaping as the cause: {msg}"
+    );
+    assert!(
+        msg.contains(r"C:\\Users\\x\\chain.yaml"),
+        "expected the doubled-backslash suggestion: {msg}"
+    );
+    assert!(
+        msg.contains("C:/Users/x/chain.yaml"),
+        "expected the forward-slash suggestion: {msg}"
+    );
+}
+
+// Off Windows (`forward_slashes: None`), only the doubled-backslash
+// suggestion is offered — no misleading second spelling that would name a
+// different path on that platform.
+#[skuld::test]
+fn load_config_offers_only_the_doubled_suggestion_when_forward_slashes_is_none() {
+    let config = ConfigPath {
+        path: "C:Usersxchain.yaml".to_string(), // nonexistent, mangled
+        mangled_from: Some(MangledPath {
+            doubled: r"C:\\Users\\x\\chain.yaml".to_string(),
+            forward_slashes: None,
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains(r"C:\\Users\\x\\chain.yaml"),
+        "expected the doubled-backslash suggestion: {msg}"
+    );
+    assert!(
+        !msg.contains(" or config="),
+        "must not offer a second suggestion when forward_slashes is None: {msg}"
+    );
+}
+
+#[skuld::test]
+fn load_config_names_the_escaping_on_a_non_not_found_io_error() {
+    // A directory, not a file: `read_to_string` fails with an OS-specific IO
+    // error that is NOT `NotFound` (e.g. `IsADirectory`/`PermissionDenied`)
+    // on every platform. The escaping explanation must still fire — it
+    // covers any IO-layer failure on a known-mangled path, not just
+    // "file not found".
+    let dir_path = std::env::temp_dir();
+    let config = ConfigPath {
+        path: dir_path.to_string_lossy().into_owned(),
+        mangled_from: Some(MangledPath {
+            doubled: r"C:\\Users\\x\\chain.yaml".to_string(),
+            forward_slashes: Some("C:/Users/x/chain.yaml".to_string()),
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    assert!(
+        err.to_string().contains("unescaped"),
+        "expected the error to name escaping as the cause for a non-NotFound IO error: {err}"
+    );
+}
+
+#[skuld::test]
+fn load_config_plain_error_when_the_path_was_not_mangled() {
+    let config = ConfigPath {
+        path: "/nonexistent/chain.yaml".to_string(),
+        mangled_from: None,
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    assert!(
+        !err.to_string().contains("unescaped"),
+        "a legitimately doubled/clean path must not trigger the escaping explanation: {err}"
+    );
+}
+
+#[skuld::test]
+fn load_config_does_not_blame_escaping_for_a_yaml_parse_failure() {
+    // A mangled path that coincidentally resolves to a REAL file with bad
+    // YAML must not get the escaping explanation — that's not what went
+    // wrong, and blaming it anyway sends the operator chasing the wrong fix.
+    let path = std::env::temp_dir().join(format!("garter-bin-test-{}-{}.yaml", std::process::id(), line!()));
+    std::fs::write(&path, "not: [valid: yaml").unwrap();
+    let config = ConfigPath {
+        path: path.to_string_lossy().into_owned(),
+        mangled_from: Some(MangledPath {
+            doubled: "unused".to_string(),
+            forward_slashes: Some("unused".to_string()),
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    std::fs::remove_file(&path).ok();
+    assert!(
+        !err.to_string().contains("unescaped"),
+        "a YAML-parse failure must not be blamed on escaping: {err}"
+    );
+}
+
+// value_was_mangled_by_unescaping =====================================================================================
+
+// The pure detector behind the escape warning, tested directly rather than
+// via captured log output — see its doc comment for the false positive it
+// avoids.
+#[skuld::test]
+fn value_was_mangled_by_unescaping_detects_only_the_defect() {
+    let seg = |raw: &'static str| garter::split_plugin_options(raw).unwrap().into_iter().next().unwrap();
+    // Mangled: a backslash escaping a byte with no SIP003 meaning.
+    assert!(value_was_mangled_by_unescaping(&seg(r"config=C:\Users\x\chain.yaml")));
+    // Correctly escaped backslash: legitimate, not mangled.
+    assert!(!value_was_mangled_by_unescaping(&seg(
+        r"config=C:\\Users\\x\\chain.yaml"
+    )));
+    // No backslash at all.
+    assert!(!value_was_mangled_by_unescaping(&seg("config=/etc/chain.yaml")));
+    // An escaped KEY spelling with a clean value is not a value defect.
+    assert!(!value_was_mangled_by_unescaping(&seg(r"\config=/etc/chain.yaml")));
+    // A correctly escaped `;` or `=` inside the value is legitimate too —
+    // NOT the same as an unescaped literal backslash.
+    assert!(!value_was_mangled_by_unescaping(&seg(r"config=/etc/a\;b.yaml")));
+    assert!(!value_was_mangled_by_unescaping(&seg(r"config=/etc/a\=b.yaml")));
+    // A bare key (no `=` at all) has no value to mangle.
+    assert!(!value_was_mangled_by_unescaping(&seg("config")));
+}
+
+// reconstruct_intended ================================================================================================
+
+#[skuld::test]
+fn reconstruct_intended_leaves_a_correctly_escaped_value_unchanged_and_unflagged() {
+    assert_eq!(
+        reconstruct_intended(r"C:\\Users\\x\\chain.yaml").unwrap(),
+        (r"C:\Users\x\chain.yaml".to_string(), false)
+    );
+}
+
+#[skuld::test]
+fn reconstruct_intended_detects_and_repairs_an_unescaped_backslash() {
+    assert_eq!(
+        reconstruct_intended(r"C:\Users\x\chain.yaml").unwrap(),
+        (r"C:\Users\x\chain.yaml".to_string(), true)
+    );
+}
+
+#[skuld::test]
+fn reconstruct_intended_errors_on_a_dangling_trailing_escape() {
+    assert_eq!(
+        reconstruct_intended(r"C:\Users\x\chain.yaml\"),
+        Err(garter::MalformedOptions::DanglingEscape)
+    );
+}
+
+// A leading `\\` is genuinely ambiguous (UNC/extended-length prefix vs. one
+// legitimate escape) and is reconstructed as two literal backslashes — but
+// is NOT by itself evidence of mangling, since a value that's otherwise
+// entirely correctly escaped is indistinguishable from this case.
+#[skuld::test]
+fn reconstruct_intended_leading_pair_is_literal_but_not_alone_mangled() {
+    assert_eq!(
+        reconstruct_intended(r"\\file.yaml").unwrap(),
+        (r"\\file.yaml".to_string(), false)
+    );
+    // A defect ELSEWHERE in the same value still flags it, and the leading
+    // pair is still reconstructed as literal.
+    assert_eq!(
+        reconstruct_intended(r"\\fileserver\share\chain.yaml").unwrap(),
+        (r"\\fileserver\share\chain.yaml".to_string(), true)
+    );
+}
+
+// Four or more leading backslashes are left to the normal per-pair
+// detection — a repeated, correctly-doubled pair is evidence of deliberate
+// escaping, not the single ambiguous case the leading-pair rule targets.
+#[skuld::test]
+fn reconstruct_intended_four_leading_backslashes_use_normal_detection() {
+    assert_eq!(
+        reconstruct_intended(r"\\\\server\\share\\file.yaml").unwrap(),
+        (r"\\server\share\file.yaml".to_string(), false)
+    );
+}
+
+// validate_chain_options ==============================================================================================
+
+#[skuld::test]
+fn validate_chain_options_rejects_a_malformed_entry() {
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "server;path=/a\\"
+"#;
+    let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
+    assert!(validate_chain_options(&config.chain).is_err());
+}
+
+#[skuld::test]
+fn validate_chain_options_accepts_well_formed_entries() {
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "tls;host=example.com"
+  - plugin: /usr/bin/obfs-plugin
+"#;
+    let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
+    assert!(validate_chain_options(&config.chain).is_ok());
+}
+
+// resolve_chain_config (main's own composition, tested end to end) ====================================================
+
+/// Escape a REAL on-disk path (e.g. from `std::env::temp_dir()`, which on
+/// Windows contains literal backslashes) for embedding as a `config=` SIP003
+/// value — otherwise the reference decoder consumes the unescaped `\` and the
+/// test fails on a mangled path instead of exercising the intended behavior.
+/// Reuses production's own `escape_sip003` rather than a second
+/// hand-rolled copy of the same algorithm.
+fn escape_path_for_sip003(path: &std::path::Path) -> String {
+    crate::config::escape_sip003(&path.to_string_lossy())
+}
+
+#[skuld::test]
+fn resolve_chain_config_loads_a_well_formed_chain() {
+    let path = std::env::temp_dir().join(format!("garter-bin-test-{}-{}.yaml", std::process::id(), line!()));
+    std::fs::write(
+        &path,
+        r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "tls;host=example.com"
+"#,
+    )
+    .unwrap();
+    let opts = format!("config={}", escape_path_for_sip003(&path));
+    let result = resolve_chain_config(Some(&opts));
+    std::fs::remove_file(&path).ok();
+
+    let cfg = result.unwrap();
+    assert_eq!(cfg.chain.len(), 1);
+}
+
+/// Capturing `MakeWriter` for asserting on a `tracing::warn!` call.
+#[derive(Clone, Default)]
+struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl CaptureWriter {
+    fn snapshot(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().expect("poisoned")).into_owned()
+    }
+}
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("poisoned").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+// A mangled path can coincidentally still resolve to a real file — see
+// resolve_chain_config's doc comment for why the warning must fire on
+// detection, not only on a subsequent load failure.
+#[skuld::test]
+fn resolve_chain_config_warns_when_a_mangled_path_coincidentally_loads() {
+    let real_path = std::env::temp_dir().join(format!(
+        "garter-bin-mangle-warn-test-{}-{}.yaml",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(&real_path, "chain:\n  - plugin: /usr/bin/v2ray-plugin\n").unwrap();
+
+    // Correctly escape the real path, then insert one EXTRA, deliberately
+    // unescaped backslash right before the last character (a plain letter,
+    // never a SIP003 metacharacter) — it decodes away to nothing (so the
+    // opened path is still the exact real one) while still being flagged as
+    // mangled, simulating "coincidentally still opens a real file."
+    let correctly_escaped = escape_path_for_sip003(&real_path);
+    let (before_last, last) = correctly_escaped.split_at(correctly_escaped.len() - 1);
+    let opts = format!("config={before_last}\\{last}");
+
+    let writer = CaptureWriter::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+    );
+    let result = {
+        let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+        resolve_chain_config(Some(&opts))
+    };
+    std::fs::remove_file(&real_path).ok();
+
+    result.expect("the mangled path coincidentally names a real, loadable file");
+    let output = writer.snapshot();
+    assert!(
+        output.contains("unescaped"),
+        "expected a warning naming the escaping, got:\n{output}"
+    );
+}
+
+#[skuld::test]
+fn resolve_chain_config_names_the_escaping_on_a_mangled_windows_path() {
+    // A raw, un-doubled backslash in `config=` — proves the escaping
+    // explanation reaches the top-level error through the FULL `main`
+    // composition (config extraction → load → escaping check), not just
+    // through `load_config_or_explain_escaping` called directly with a
+    // hand-built `ConfigPath`, as the tests above it do.
+    let err = resolve_chain_config(Some(r"config=C:\Users\nonexistent\chain.yaml")).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unescaped"),
+        "expected the composed error to name escaping as the cause: {msg}"
+    );
+}
+
+#[skuld::test]
+fn resolve_chain_config_rejects_an_empty_chain() {
+    let path = std::env::temp_dir().join(format!("garter-bin-test-{}-{}.yaml", std::process::id(), line!()));
+    std::fs::write(&path, "chain: []").unwrap();
+    let opts = format!("config={}", escape_path_for_sip003(&path));
+    let result = resolve_chain_config(Some(&opts));
+    std::fs::remove_file(&path).ok();
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("at least one plugin"),
+        "expected the empty-chain guard's message, got: {err}"
+    );
+}
+
+#[skuld::test]
+fn resolve_chain_config_rejects_a_malformed_entry_via_validate_chain_options() {
+    let path = std::env::temp_dir().join(format!("garter-bin-test-{}-{}.yaml", std::process::id(), line!()));
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "server;path=/a\\"
+"#;
+    std::fs::write(&path, yaml).unwrap();
+    let opts = format!("config={}", escape_path_for_sip003(&path));
+    let result = resolve_chain_config(Some(&opts));
+    std::fs::remove_file(&path).ok();
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("chain entry 0"),
+        "expected validate_chain_options's own message to survive the composition, got: {err}"
+    );
+}
+
+#[skuld::test]
+fn validate_chain_options_reports_the_malformed_entrys_index() {
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "tls;host=example.com"
+  - plugin: /usr/bin/obfs-plugin
+    options: "server;path=/a\\"
+"#;
+    let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
+    let err = validate_chain_options(&config.chain).unwrap_err();
+    assert!(
+        err.to_string().contains("chain entry 1"),
+        "expected the error to name entry 1, got: {err}"
+    );
 }

--- a/crates/garter-bin/src/config_tests.rs
+++ b/crates/garter-bin/src/config_tests.rs
@@ -128,6 +128,12 @@ fn config_path_reports_no_mangling_for_a_correctly_escaped_path() {
 #[skuld::test]
 fn config_path_unc_prefix_keeps_both_leading_backslashes() {
     let config = config_path_from_plugin_options(Some(r"config=\\fileserver\share\chain.yaml")).unwrap();
+    // `config.path` is the ordinary decode (not `reconstruct_intended`'s
+    // leading-pair special case), so it's the garbled, separator-free
+    // reading — this is the value that's ABOUT to fail to load; pin it so a
+    // regression in the ordinary decode for this exact shape is caught,
+    // not just a regression in the suggestion built from it.
+    assert_eq!(config.path, r"\fileserversharechain.yaml");
     let mangled = config.mangled_from.expect("expected mangling to be detected");
     assert_eq!(mangled.doubled, r"\\\\fileserver\\share\\chain.yaml");
     assert_forward_slashes_platform_correct(&mangled, "//fileserver/share/chain.yaml");
@@ -143,6 +149,9 @@ fn config_path_unc_prefix_keeps_both_leading_backslashes() {
 #[skuld::test]
 fn config_path_extended_length_prefix_keeps_both_leading_backslashes() {
     let config = config_path_from_plugin_options(Some(r"config=\\?\C:\very\long\chain.yaml")).unwrap();
+    // Same reasoning as `config_path_unc_prefix_keeps_both_leading_backslashes`:
+    // pin the ordinary (garbled) decode this exact shape produces.
+    assert_eq!(config.path, r"\?C:verylongchain.yaml");
     let mangled = config.mangled_from.expect("expected mangling to be detected");
     let doubled_opts = format!("config={}", mangled.doubled);
     let doubled_segments = garter::split_plugin_options(&doubled_opts).unwrap();

--- a/crates/garter-bin/src/main.rs
+++ b/crates/garter-bin/src/main.rs
@@ -1,4 +1,3 @@
-use garter::sip003::parse_plugin_options;
 use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv};
 
 #[tokio::main]
@@ -12,21 +11,24 @@ async fn main() -> anyhow::Result<()> {
 
     let env = PluginEnv::from_env().map_err(|e| anyhow::anyhow!("failed to parse SIP003u environment: {e}"))?;
 
-    let config_path = env
-        .plugin_options
-        .as_ref()
-        .and_then(|opts| {
-            parse_plugin_options(opts)
-                .into_iter()
-                .find(|(k, _)| k == "config")
-                .map(|(_, v)| v)
-        })
-        .ok_or_else(|| anyhow::anyhow!("SS_PLUGIN_OPTIONS must contain config=/path/to/chain.yaml"))?;
+    let cfg = garter_bin::config::resolve_chain_config(env.plugin_options.as_deref())?;
 
-    let cfg = garter_bin::config::load_config(std::path::Path::new(&config_path))?;
-    anyhow::ensure!(!cfg.chain.is_empty(), "chain config must have at least one plugin");
-
-    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    // Contract, not input validation: `resolve_chain_config` above already
+    // ran the same string through the identical parser
+    // (`config_path_from_plugin_options` → `split_plugin_options`) and
+    // returned `Ok`, so this is provably unreachable on every real input.
+    // `debug_assert!` makes a violation panic loudly in debug/test builds —
+    // a genuine contract break, not routine input handling — while staying
+    // truly zero-cost in release (compiled out entirely, per CLAUDE.md);
+    // the `?` alongside it is release's own fallback, so a violation there
+    // degrades to a normal, well-formed error instead of an uncontrolled
+    // panic in a binary that ships.
+    let mode_result = Mode::from_plugin_options(env.plugin_options.as_deref());
+    debug_assert!(
+        mode_result.is_ok(),
+        "already validated by resolve_chain_config's config_path_from_plugin_options call above"
+    );
+    let mode = mode_result?;
     let mut runner = ChainRunner::new().mode(mode);
     for entry in cfg.chain {
         runner = runner.add(Box::new(BinaryPlugin::new(entry.plugin, entry.options.as_deref())));

--- a/crates/garter-bin/src/main.rs
+++ b/crates/garter-bin/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     // returned `Ok`, so this is provably unreachable on every real input.
     // `debug_assert!` makes a violation panic loudly in debug/test builds —
     // a genuine contract break, not routine input handling — while staying
-    // truly zero-cost in release (compiled out entirely, per CLAUDE.md);
+    // truly zero-cost in release (compiled out entirely);
     // the `?` alongside it is release's own fallback, so a violation there
     // degrades to a normal, well-formed error instead of an uncontrolled
     // panic in a binary that ships.

--- a/crates/garter-bin/src/main.rs
+++ b/crates/garter-bin/src/main.rs
@@ -17,12 +17,6 @@ async fn main() -> anyhow::Result<()> {
     // ran the same string through the identical parser
     // (`config_path_from_plugin_options` → `split_plugin_options`) and
     // returned `Ok`, so this is provably unreachable on every real input.
-    // `debug_assert!` makes a violation panic loudly in debug/test builds —
-    // a genuine contract break, not routine input handling — while staying
-    // truly zero-cost in release (compiled out entirely);
-    // the `?` alongside it is release's own fallback, so a violation there
-    // degrades to a normal, well-formed error instead of an uncontrolled
-    // panic in a binary that ships.
     let mode_result = Mode::from_plugin_options(env.plugin_options.as_deref());
     debug_assert!(
         mode_result.is_ok(),

--- a/crates/garter/README.md
+++ b/crates/garter/README.md
@@ -23,7 +23,8 @@ byte-level diagnostics.
 - **`CountingStream` / `StreamCounters`** — wire-level instrumentation
   for any `tokio::io::AsyncRead + AsyncWrite` stream.
 - **`parse_plugin_options`** — parses the SIP003 `;`-separated options
-  string into a typed `HashMap`.
+  string into an ordered list of key/value pairs, or an error for a string a
+  SIP003 plugin would reject outright.
 - **`Mode`** — selects chain direction (`Client` / `Server`); see below.
 
 ### Modes
@@ -71,7 +72,7 @@ async fn main() -> garter::Result<()> {
     // Detect SIP003 chain mode from SS_PLUGIN_OPTIONS (`server` keyword
     // = Server; default = Client). Same parse used by v2ray-plugin and
     // other SIP003 plugins.
-    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref())?;
 
     let chain = ChainRunner::new()
         .mode(mode)

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -138,21 +138,21 @@ impl BinaryPlugin {
     /// to `crate` for testability; production callers use [`Self::run`]
     /// which feeds this into `Command::env`. See [`Sip003Env`] for the
     /// client/server semantics.
-    pub(crate) fn sip003_env(&self, local: SocketAddr, remote: SocketAddr) -> Sip003Env {
+    pub(crate) fn sip003_env(&self, local: SocketAddr, remote: SocketAddr) -> crate::Result<Sip003Env> {
         // In server mode the binary itself swaps SS_LOCAL/SS_REMOTE
         // semantics (SS_REMOTE = inbound listener, SS_LOCAL = outbound
         // dial). We swap here first so the binary's swap restores the
         // direction we wanted.
-        let (ss_local, ss_remote) = match Mode::from_plugin_options(self.options.as_deref()) {
+        let (ss_local, ss_remote) = match Mode::from_plugin_options(self.options.as_deref())? {
             Mode::Client => (local, remote),
             Mode::Server => (remote, local),
         };
-        Sip003Env {
+        Ok(Sip003Env {
             ss_local_host: ss_local.ip().to_string(),
             ss_local_port: ss_local.port(),
             ss_remote_host: ss_remote.ip().to_string(),
             ss_remote_port: ss_remote.port(),
-        }
+        })
     }
 }
 
@@ -185,7 +185,7 @@ impl ChainPlugin for BinaryPlugin {
         shutdown: CancellationToken,
         ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
-        let env = self.sip003_env(local, remote);
+        let env = self.sip003_env(local, remote)?;
         let mut cmd = Command::new(&self.path);
         cmd.env("SS_LOCAL_HOST", env.ss_local_host);
         cmd.env("SS_LOCAL_PORT", env.ss_local_port.to_string());

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -32,7 +32,7 @@ fn sip003_env_client_mode_straight_through() {
     let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
     let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("tls;host=example.com"));
-    let env = plugin.sip003_env(listen, dial);
+    let env = plugin.sip003_env(listen, dial).unwrap();
     assert_eq!(env.ss_local_host, "127.0.0.1");
     assert_eq!(env.ss_local_port, 9001);
     assert_eq!(env.ss_remote_host, "203.0.113.1");
@@ -51,7 +51,7 @@ fn sip003_env_server_mode_swaps_addresses() {
     let listen: SocketAddr = "[::]:80".parse().unwrap();
     let dial: SocketAddr = "127.0.0.1:45589".parse().unwrap();
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("server;host=example.com"));
-    let env = plugin.sip003_env(listen, dial);
+    let env = plugin.sip003_env(listen, dial).unwrap();
     // Swap: BinaryPlugin's `local` (where the chain wants the binary to
     // bind, [::]:80) must reach v2ray-plugin as SS_REMOTE so its
     // server-mode swap interprets it as the listen address.
@@ -68,11 +68,22 @@ fn sip003_env_client_mode_when_options_only_have_servername() {
     let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
     let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("servername=cdn.example.com"));
-    let env = plugin.sip003_env(listen, dial);
+    let env = plugin.sip003_env(listen, dial).unwrap();
     assert_eq!(env.ss_local_host, "127.0.0.1");
     assert_eq!(env.ss_local_port, 9001);
     assert_eq!(env.ss_remote_host, "203.0.113.1");
     assert_eq!(env.ss_remote_port, 8388);
+}
+
+// Pinned here because this is the call site that actually wires
+// SS_LOCAL/SS_REMOTE, not just a diagnostic mode read: a malformed
+// per-plugin `options:` string must not silently pick a chain direction.
+#[skuld::test]
+fn sip003_env_errors_on_malformed_options() {
+    let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+    let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
+    let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some(r"server;path=/a\"));
+    assert!(plugin.sip003_env(listen, dial).is_err());
 }
 
 // Readiness-mode tests ================================================================================================

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -372,23 +372,22 @@ impl ChainRunner {
 /// `Empty` (or holds an `Ok(PluginReady)`, which is not a failure and is
 /// ignored here) — the caller then has nothing to recover.
 ///
-/// A point-in-time `try_recv` snapshot, not an await-to-resolution drain,
-/// is deliberate: [`run_readiness_aggregator`] must terminate PROMPTLY when
-/// nothing is recoverable (a remaining plugin can be legitimately,
-/// indefinitely `Empty` — still starting up, not yet failed) rather than
-/// block on it — see `aggregator_shutdown_with_nothing_to_recover_drops_ready_tx_promptly`
-/// in `chain_tests.rs`, which pins exactly that. This narrows the window
-/// where a `BindConflict`/`Fatal` delivered a moment AFTER the snapshot is
-/// missed; it does not close it. Closing it fully would need the scan
-/// bounded by the SAME `drain_timeout` [`ChainRunner`] already uses to
-/// force-kill a lingering plugin — a real change to this fn's signature and
-/// caller, not a local tweak — so it is left as a known, narrowed gap
-/// rather than traded for a hang.
+/// A point-in-time `try_recv` snapshot — used ONLY where the caller must
+/// terminate PROMPTLY even when a remaining receiver is legitimately,
+/// indefinitely `Empty` (a plugin still starting up, not yet failed): the
+/// shutdown-preempted arm of [`run_readiness_aggregator`] (shutdown does not
+/// itself mean any plugin failed) and [`crate::tap::TapPlugin`]'s inner-exit
+/// race (the single receiver scanned there is already resolved by the time
+/// it's reached, so this is exact, not approximate). See
+/// `aggregator_shutdown_with_nothing_to_recover_drops_ready_tx_promptly` in
+/// `chain_tests.rs`, which pins the prompt-termination requirement.
 ///
-/// `pub(crate)`: also used by [`crate::tap::TapPlugin`], which races its
-/// inner plugin's own (otherwise-discarded) readiness channel against that
-/// plugin's exit for the identical reason — an inner `BindConflict`/`Fatal`
-/// must survive the race, not collapse to `ExitedBeforeReady`.
+/// For the OTHER two arms of `run_readiness_aggregator` — `Err(_recv)` and a
+/// delivered `ExitedBeforeReady` — a plugin has already DEFINITIVELY failed,
+/// so [`drain_for_delivered_error`] is used instead: awaiting there cannot
+/// hang, because that same failure fires `shutdown` via `record_exit`,
+/// which bounds every other remaining plugin via `ChainRunner::run`'s own
+/// `drain_timeout`/`abort_all`.
 pub(crate) fn scan_for_delivered_error<'a>(
     rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
 ) -> Option<StartError> {
@@ -399,6 +398,32 @@ pub(crate) fn scan_for_delivered_error<'a>(
             Ok(Err(e)) => return Some(e),
             Err(oneshot::error::TryRecvError::Closed) => saw_generic = true,
             Ok(Ok(_)) | Err(oneshot::error::TryRecvError::Empty) => {}
+        }
+    }
+    saw_generic.then_some(StartError::ExitedBeforeReady)
+}
+
+/// Await `rxs` — each to ITS OWN resolution — for the same preference
+/// [`scan_for_delivered_error`] applies (a SPECIFIC `Err(StartError)` over a
+/// generic `Closed`/delivered-`ExitedBeforeReady` signal, regardless of
+/// order). Used only by [`send_recovered_or_generic`], from the TWO
+/// `run_readiness_aggregator` arms where a plugin has already definitively
+/// failed — see [`scan_for_delivered_error`]'s doc comment for why awaiting
+/// is safe (bounded by `ChainRunner`'s own `drain_timeout`) in exactly those
+/// two arms and NOT the shutdown-preempted one. Closes the window
+/// `scan_for_delivered_error`'s try_recv snapshot leaves open: a
+/// `BindConflict`/`Fatal` delivered a moment AFTER a snapshot would run is
+/// still recovered here, not silently downgraded.
+async fn drain_for_delivered_error<'a>(
+    rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
+) -> Option<StartError> {
+    let mut saw_generic = false;
+    for r in rxs {
+        match r.await {
+            Ok(Err(StartError::ExitedBeforeReady)) => saw_generic = true,
+            Ok(Err(e)) => return Some(e),
+            Err(_recv) => saw_generic = true,
+            Ok(Ok(_)) => {}
         }
     }
     saw_generic.then_some(StartError::ExitedBeforeReady)
@@ -480,7 +505,7 @@ pub(crate) async fn run_readiness_aggregator(
             // `scan_for_delivered_error`'s doc comment.
             Ok(Err(StartError::ExitedBeforeReady)) => {
                 let rest = remaining.iter_mut().map(|(_, r)| r);
-                send_recovered_or_generic(rest, ready_tx);
+                send_recovered_or_generic(rest, ready_tx).await;
                 return;
             }
             Ok(Err(start_err)) => {
@@ -496,7 +521,7 @@ pub(crate) async fn run_readiness_aggregator(
                 // are intentionally separate observers of one event; do NOT
                 // reconcile them into one value.
                 let rest = remaining.iter_mut().map(|(_, r)| r);
-                send_recovered_or_generic(rest, ready_tx);
+                send_recovered_or_generic(rest, ready_tx).await;
                 return;
             }
         }
@@ -505,20 +530,26 @@ pub(crate) async fn run_readiness_aggregator(
     let _ = ready_tx.send(Ok(ChainReady { listen, transports }));
 }
 
-/// Scan `rest` and send the best recoverable error on `ready_tx` — shared by
-/// the `ExitedBeforeReady` and `Err(_recv)` arms above, which reach this in
-/// the identical shape: one plugin has already confirmed "I have no reason
-/// of my own", so scan every other not-yet-processed receiver for something
-/// better, falling back to the generic placeholder rather than dropping
-/// `ready_tx` unsent. Unlike the shutdown-preempted arm (which drops
-/// `ready_tx` when nothing is recoverable, matching "shutdown before
-/// anything ready"), these two arms already KNOW a plugin failed — there is
-/// always something to report here, even if it's only "no reason given".
-fn send_recovered_or_generic<'a>(
+/// Drain `rest` to resolution and send the best recoverable error on
+/// `ready_tx` — shared by the `ExitedBeforeReady` and `Err(_recv)` arms
+/// above, which reach this in the identical shape: one plugin has already
+/// confirmed "I have no reason of my own", so drain every other
+/// not-yet-processed receiver for something better, falling back to the
+/// generic placeholder rather than dropping `ready_tx` unsent. Unlike the
+/// shutdown-preempted arm (which drops `ready_tx` when nothing is
+/// recoverable, matching "shutdown before anything ready"), these two arms
+/// already KNOW a plugin failed — there is always something to report here,
+/// even if it's only "no reason given". Uses [`drain_for_delivered_error`]
+/// (await-to-resolution), not [`scan_for_delivered_error`] (point-in-time
+/// snapshot) — see the latter's doc comment for why that's safe here and
+/// not in the shutdown-preempted arm.
+async fn send_recovered_or_generic<'a>(
     rest: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
     ready_tx: oneshot::Sender<Result<ChainReady, StartError>>,
 ) {
-    let recovered = scan_for_delivered_error(rest).unwrap_or(StartError::ExitedBeforeReady);
+    let recovered = drain_for_delivered_error(rest)
+        .await
+        .unwrap_or(StartError::ExitedBeforeReady);
     let _ = ready_tx.send(Err(recovered));
 }
 

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -51,20 +51,32 @@ pub enum Mode {
 impl Mode {
     /// Derive the SIP003 chain mode from the `SS_PLUGIN_OPTIONS` string.
     /// Returns [`Mode::Server`] if a `server` key is present in the
-    /// options (with or without a value), [`Mode::Client`] otherwise.
-    /// Uses the spec-correct key parser ([`crate::parse_plugin_options`]),
-    /// so options like `servername=cdn.example.com` correctly resolve to
-    /// client mode.
-    pub fn from_plugin_options(opts: Option<&str>) -> Self {
-        let Some(opts) = opts else { return Mode::Client };
-        if crate::sip003::parse_plugin_options(opts)
-            .iter()
-            .any(|(k, _)| k == "server")
-        {
-            Mode::Server
-        } else {
-            Mode::Client
-        }
+    /// options (with or without a value), [`Mode::Client`] otherwise. Uses
+    /// [`crate::parse_plugin_options`] to decide, so options like
+    /// `servername=cdn.example.com` correctly resolve to client mode, and
+    /// an escaped spelling like `\server` still resolves to server mode —
+    /// matching how ex-ray reads the same string.
+    ///
+    /// `Err` on a malformed options string (e.g. a dangling trailing
+    /// backslash or an empty key). Neither `Mode::Client` nor `Mode::Server`
+    /// would be real parity with ex-ray here, and there is no safe default to
+    /// guess, so the failure is surfaced rather than papered over with one.
+    ///
+    /// Returns `crate::Error` (not the narrower `MalformedOptions`) so every
+    /// caller gets the canonical "malformed SS_PLUGIN_OPTIONS: {reason}"
+    /// wording through a plain `?`, with nothing to hand-write at the call site.
+    pub fn from_plugin_options(opts: Option<&str>) -> crate::Result<Self> {
+        let Some(opts) = opts else { return Ok(Mode::Client) };
+        Ok(
+            if crate::sip003::parse_plugin_options(opts)?
+                .iter()
+                .any(|(k, _)| k == "server")
+            {
+                Mode::Server
+            } else {
+                Mode::Client
+            },
+        )
     }
 }
 
@@ -342,6 +354,28 @@ impl ChainRunner {
 
 // Helpers =============================================================================================================
 
+/// Scan `rxs` for an already-delivered start-failure signal, preferring a
+/// SPECIFIC `Err(StartError)` over a generic `Closed` sender (dropped
+/// unsent) regardless of which order they're found in — a `Closed` earlier
+/// in iteration order must never mask a real `BindConflict`/`Fatal`
+/// delivered by a later one. Returns `None` only when every scanned
+/// receiver is genuinely `Empty` (or holds an `Ok(PluginReady)`, which is
+/// not a failure and is ignored here) — the caller then has nothing to
+/// recover.
+fn scan_for_delivered_error<'a>(
+    rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
+) -> Option<StartError> {
+    let mut any_closed = false;
+    for r in rxs {
+        match r.try_recv() {
+            Ok(Err(e)) => return Some(e),
+            Err(oneshot::error::TryRecvError::Closed) => any_closed = true,
+            Ok(Ok(_)) | Err(oneshot::error::TryRecvError::Empty) => {}
+        }
+    }
+    any_closed.then_some(StartError::ExitedBeforeReady)
+}
+
 /// Aggregate the N per-plugin readiness results into a single chain-level
 /// outcome on `ready_tx`.
 ///
@@ -350,7 +384,7 @@ impl ChainRunner {
 /// position-0 plugin's reported `listen` is the chain's public address in
 /// Client mode; in Server mode it is position N-1. The chain's transports
 /// are the intersection across all hops.
-async fn run_readiness_aggregator(
+pub(crate) async fn run_readiness_aggregator(
     ready_rxs: Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)>,
     n: usize,
     mode: Mode,
@@ -366,15 +400,38 @@ async fn run_readiness_aggregator(
         Mode::Client => 0,
         Mode::Server => n - 1,
     };
-    for (i, rrx) in ready_rxs {
-        let outcome = tokio::select! {
+    let mut remaining: std::collections::VecDeque<_> = ready_rxs.into_iter().collect();
+    while let Some((i, mut rrx)) = remaining.pop_front() {
+        // `biased` checks the shutdown arm first regardless of whether
+        // `rrx` ALSO already has a value waiting — a plugin can call
+        // `ready.send(...)` and exit (dropping its task, which is what
+        // fires `shutdown` via `record_exit`) within the same poll, with
+        // no `.await` between the two. Naively discarding on shutdown here
+        // would silently downgrade a real `BindConflict`/`Fatal` to a
+        // generic `ExitedBeforeReady`, so the shutdown arm yields `None`
+        // instead of returning outright, and the scan below checks for an
+        // already-delivered value — on ANY not-yet-processed receiver, not
+        // just this one, since shutdown can win the bias while an EARLIER
+        // poll of a LATER plugin already delivered — before treating this
+        // as shutdown preempting a chain that never got to report anything.
+        let selected = tokio::select! {
             biased;
-            () = shutdown.cancelled() => {
-                // Shutdown before all plugins readied → drop ready_tx; the
-                // receiver gets RecvError.
-                return;
+            () = shutdown.cancelled() => None,
+            r = &mut rrx => Some(r),
+        };
+        let outcome = match selected {
+            Some(r) => r,
+            None => {
+                // See `scan_for_delivered_error`'s doc comment.
+                let rest = std::iter::once(&mut rrx).chain(remaining.iter_mut().map(|(_, r)| r));
+                match scan_for_delivered_error(rest) {
+                    Some(e) => {
+                        let _ = ready_tx.send(Err(e));
+                        return;
+                    }
+                    None => return, // nothing to recover anywhere → drop ready_tx; the receiver gets RecvError.
+                }
             }
-            r = rrx => r,
         };
         match outcome {
             Ok(Ok(pr)) => {
@@ -386,19 +443,21 @@ async fn run_readiness_aggregator(
                 return;
             }
             Err(_recv) => {
-                // Plugin dropped its sender unsent → it exited before
-                // readying. Synthesize a process-exit Fatal. This is the
-                // START-GATE channel; the SAME exit is independently
-                // observed by the Phase-1 record_exit loop, which sets
-                // first_error + cancels — that is the LIFECYCLE channel that
-                // becomes run()'s return. The two are intentionally separate
+                // This receiver's sender was dropped unsent → it exited
+                // before readying. Before synthesizing the generic
+                // `ExitedBeforeReady` cause, check whether a LATER plugin
+                // already delivered a specific one — same preference as the
+                // shutdown scan above, and for the same reason. This is the
+                // START-GATE channel; the SAME exit is independently observed by the
+                // Phase-1 record_exit loop, which sets first_error +
+                // cancels — that is the LIFECYCLE channel that becomes
+                // run()'s return. The two are intentionally separate
                 // observers of one event (typed cause to on_ready AND
                 // lifecycle error to teardown). Do NOT try to reconcile them
                 // into one value.
-                let _ = ready_tx.send(Err(StartError::Fatal {
-                    detail: "plugin exited before becoming ready".into(),
-                    errno: None,
-                }));
+                let rest = remaining.iter_mut().map(|(_, r)| r);
+                let recovered = scan_for_delivered_error(rest).unwrap_or(StartError::ExitedBeforeReady);
+                let _ = ready_tx.send(Err(recovered));
                 return;
             }
         }

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -376,11 +376,18 @@ impl ChainRunner {
 /// terminate PROMPTLY even when a remaining receiver is legitimately,
 /// indefinitely `Empty` (a plugin still starting up, not yet failed): the
 /// shutdown-preempted arm of [`run_readiness_aggregator`] (shutdown does not
-/// itself mean any plugin failed) and [`crate::tap::TapPlugin`]'s inner-exit
-/// race (the single receiver scanned there is already resolved by the time
-/// it's reached, so this is exact, not approximate). See
-/// `aggregator_shutdown_with_nothing_to_recover_drops_ready_tx_promptly` in
-/// `chain_tests.rs`, which pins the prompt-termination requirement.
+/// itself mean any plugin failed), and both of [`crate::tap::TapPlugin`]'s
+/// inner-exit arms. In the aggregator this is exact for `run_client`/
+/// `run_server`-style plugins whose own task owns the sender directly, but
+/// for [`crate::tap::TapPlugin`]'s wrapped `BinaryPlugin` inners it is only
+/// NARROWED, not exact: the sender there is owned by a detached/best-effort-
+/// joined reader or self-probe task neither `TapPlugin` nor `BinaryPlugin`'s
+/// own future guarantees has resolved by the time it's reached — see
+/// `TapPlugin::run`'s own doc comments on both arms for the full reasoning
+/// and a prior, reverted attempt to close this with an await instead (it
+/// deadlocked). See `aggregator_shutdown_with_nothing_to_recover_drops_ready_tx_promptly`
+/// in `chain_tests.rs`, which pins the prompt-termination requirement this
+/// snapshot exists to satisfy.
 ///
 /// For the OTHER two arms of `run_readiness_aggregator` — `Err(_recv)` and a
 /// delivered `ExitedBeforeReady` — a plugin has already DEFINITIVELY failed,
@@ -472,18 +479,13 @@ pub(crate) async fn run_readiness_aggregator(
     };
     let mut remaining: std::collections::VecDeque<_> = ready_rxs.into_iter().collect();
     while let Some((i, mut rrx)) = remaining.pop_front() {
-        // `biased` checks the shutdown arm first regardless of whether
-        // `rrx` ALSO already has a value waiting — a plugin can call
-        // `ready.send(...)` and exit (dropping its task, which is what
-        // fires `shutdown` via `record_exit`) within the same poll, with
-        // no `.await` between the two. Naively discarding on shutdown here
-        // would silently downgrade a real `BindConflict`/`Fatal` to a
-        // generic `ExitedBeforeReady`, so the shutdown arm yields `None`
-        // instead of returning outright, and the scan below checks for an
-        // already-delivered value — on ANY not-yet-processed receiver, not
-        // just this one, since shutdown can win the bias while an EARLIER
-        // poll of a LATER plugin already delivered — before treating this
-        // as shutdown preempting a chain that never got to report anything.
+        // A plugin can `ready.send(...)` and exit (firing `shutdown` via
+        // `record_exit`) within the same poll, with no `.await` between the
+        // two, so the scan below checks for an already-delivered value —
+        // on ANY not-yet-processed receiver, not just this one, since
+        // shutdown can win the bias while an EARLIER poll of a LATER
+        // plugin already delivered — before treating this as shutdown
+        // preempting a chain that never got to report anything.
         let selected = tokio::select! {
             biased;
             () = shutdown.cancelled() => None,

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -208,8 +208,15 @@ impl ChainRunner {
     /// the `ready` channel passed to [`ChainPlugin::run`]; the aggregator
     /// collects the N per-plugin results into one chain-level outcome.
     ///
-    /// If shutdown fires before every plugin has readied, `tx` is dropped
-    /// and the receiver gets `RecvError`.
+    /// If shutdown fires before every plugin has readied, `tx` carries
+    /// whichever outcome is most specific rather than being unconditionally
+    /// dropped: the most specific already-delivered `StartError` if any
+    /// plugin had one buffered, else `Err(StartError::ExitedBeforeReady)`
+    /// if any plugin's readiness sender had already closed unsent, and
+    /// only drops `tx` (leaving the receiver to see `RecvError`) when every
+    /// remaining plugin is genuinely still pending. See
+    /// [`run_readiness_aggregator`]'s doc comment for why shutdown alone is
+    /// never enough to justify dropping `tx` outright.
     pub fn on_ready(mut self, tx: oneshot::Sender<Result<ChainReady, StartError>>) -> Self {
         self.ready_tx = Some(tx);
         self
@@ -380,10 +387,16 @@ fn scan_for_delivered_error<'a>(
 /// outcome on `ready_tx`.
 ///
 /// Awaits each plugin's `ready` receiver in turn, racing the shared
-/// `shutdown` token so a cancel during startup doesn't hang. The
-/// position-0 plugin's reported `listen` is the chain's public address in
-/// Client mode; in Server mode it is position N-1. The chain's transports
-/// are the intersection across all hops.
+/// `shutdown` token so a cancel during startup doesn't hang. `shutdown` is
+/// checked with `biased`, so on any poll where both it and the receiver
+/// being awaited are simultaneously ready, `shutdown` wins and the receiver
+/// is never polled that round — before returning on shutdown, this fn
+/// therefore always falls back to [`scan_for_delivered_error`] to recover
+/// whatever the biased check would otherwise have discarded, rather than
+/// dropping `ready_tx` unconditionally. The position-0 plugin's reported
+/// `listen` is the chain's public address in Client mode; in Server mode it
+/// is position N-1. The chain's transports are the intersection across all
+/// hops.
 pub(crate) async fn run_readiness_aggregator(
     ready_rxs: Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)>,
     n: usize,
@@ -437,6 +450,19 @@ pub(crate) async fn run_readiness_aggregator(
             Ok(Ok(pr)) => {
                 plugin_listens[i] = Some(pr.listen);
                 transports &= pr.transports;
+            }
+            // A delivered `ExitedBeforeReady` is itself a "no reason known"
+            // placeholder (see its doc comment) — before forwarding it,
+            // check whether a LATER plugin already delivered something more
+            // specific, same preference and same reason as the shutdown
+            // scan above and the `Err(_recv)` scan below. Otherwise this
+            // arm would let the FIRST plugin to report "I have no reason"
+            // permanently mask a later plugin's real `BindConflict`/`Fatal`.
+            Ok(Err(StartError::ExitedBeforeReady)) => {
+                let rest = remaining.iter_mut().map(|(_, r)| r);
+                let recovered = scan_for_delivered_error(rest).unwrap_or(StartError::ExitedBeforeReady);
+                let _ = ready_tx.send(Err(recovered));
+                return;
             }
             Ok(Err(start_err)) => {
                 let _ = ready_tx.send(Err(start_err));

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -371,7 +371,25 @@ impl ChainRunner {
 /// arrives. Returns `None` only when every scanned receiver is genuinely
 /// `Empty` (or holds an `Ok(PluginReady)`, which is not a failure and is
 /// ignored here) — the caller then has nothing to recover.
-fn scan_for_delivered_error<'a>(
+///
+/// A point-in-time `try_recv` snapshot, not an await-to-resolution drain,
+/// is deliberate: [`run_readiness_aggregator`] must terminate PROMPTLY when
+/// nothing is recoverable (a remaining plugin can be legitimately,
+/// indefinitely `Empty` — still starting up, not yet failed) rather than
+/// block on it — see `aggregator_shutdown_with_nothing_to_recover_drops_ready_tx_promptly`
+/// in `chain_tests.rs`, which pins exactly that. This narrows the window
+/// where a `BindConflict`/`Fatal` delivered a moment AFTER the snapshot is
+/// missed; it does not close it. Closing it fully would need the scan
+/// bounded by the SAME `drain_timeout` [`ChainRunner`] already uses to
+/// force-kill a lingering plugin — a real change to this fn's signature and
+/// caller, not a local tweak — so it is left as a known, narrowed gap
+/// rather than traded for a hang.
+///
+/// `pub(crate)`: also used by [`crate::tap::TapPlugin`], which races its
+/// inner plugin's own (otherwise-discarded) readiness channel against that
+/// plugin's exit for the identical reason — an inner `BindConflict`/`Fatal`
+/// must survive the race, not collapse to `ExitedBeforeReady`.
+pub(crate) fn scan_for_delivered_error<'a>(
     rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
 ) -> Option<StartError> {
     let mut saw_generic = false;
@@ -438,7 +456,8 @@ pub(crate) async fn run_readiness_aggregator(
         let outcome = match selected {
             Some(r) => r,
             None => {
-                // See `scan_for_delivered_error`'s doc comment.
+                // Same preference as the shutdown-arm scan above: see
+                // `scan_for_delivered_error`'s doc comment.
                 let rest = std::iter::once(&mut rrx).chain(remaining.iter_mut().map(|(_, r)| r));
                 match scan_for_delivered_error(rest) {
                     Some(e) => {
@@ -456,15 +475,12 @@ pub(crate) async fn run_readiness_aggregator(
             }
             // A delivered `ExitedBeforeReady` is itself a "no reason known"
             // placeholder (see its doc comment) — before forwarding it,
-            // check whether a LATER plugin already delivered something more
-            // specific, same preference and same reason as the shutdown
-            // scan above and the `Err(_recv)` scan below. Otherwise this
-            // arm would let the FIRST plugin to report "I have no reason"
-            // permanently mask a later plugin's real `BindConflict`/`Fatal`.
+            // check whether a LATER plugin already delivered (or still
+            // delivers) something more specific: same preference as
+            // `scan_for_delivered_error`'s doc comment.
             Ok(Err(StartError::ExitedBeforeReady)) => {
                 let rest = remaining.iter_mut().map(|(_, r)| r);
-                let recovered = scan_for_delivered_error(rest).unwrap_or(StartError::ExitedBeforeReady);
-                let _ = ready_tx.send(Err(recovered));
+                send_recovered_or_generic(rest, ready_tx);
                 return;
             }
             Ok(Err(start_err)) => {
@@ -472,27 +488,38 @@ pub(crate) async fn run_readiness_aggregator(
                 return;
             }
             Err(_recv) => {
-                // This receiver's sender was dropped unsent → it exited
-                // before readying. Before synthesizing the generic
-                // `ExitedBeforeReady` cause, check whether a LATER plugin
-                // already delivered a specific one — same preference as the
-                // shutdown scan above, and for the same reason. This is the
-                // START-GATE channel; the SAME exit is independently observed by the
-                // Phase-1 record_exit loop, which sets first_error +
-                // cancels — that is the LIFECYCLE channel that becomes
-                // run()'s return. The two are intentionally separate
-                // observers of one event (typed cause to on_ready AND
-                // lifecycle error to teardown). Do NOT try to reconcile them
-                // into one value.
+                // Sender dropped unsent → exited before readying; same recovery
+                // preference as above (see `scan_for_delivered_error`'s doc
+                // comment). This is the START-GATE channel — the SAME exit is
+                // independently observed by the Phase-1 record_exit loop as
+                // the LIFECYCLE channel that becomes run()'s return. The two
+                // are intentionally separate observers of one event; do NOT
+                // reconcile them into one value.
                 let rest = remaining.iter_mut().map(|(_, r)| r);
-                let recovered = scan_for_delivered_error(rest).unwrap_or(StartError::ExitedBeforeReady);
-                let _ = ready_tx.send(Err(recovered));
+                send_recovered_or_generic(rest, ready_tx);
                 return;
             }
         }
     }
     let listen = plugin_listens[public_index].expect("public plugin must have reported a listen address");
     let _ = ready_tx.send(Ok(ChainReady { listen, transports }));
+}
+
+/// Scan `rest` and send the best recoverable error on `ready_tx` — shared by
+/// the `ExitedBeforeReady` and `Err(_recv)` arms above, which reach this in
+/// the identical shape: one plugin has already confirmed "I have no reason
+/// of my own", so scan every other not-yet-processed receiver for something
+/// better, falling back to the generic placeholder rather than dropping
+/// `ready_tx` unsent. Unlike the shutdown-preempted arm (which drops
+/// `ready_tx` when nothing is recoverable, matching "shutdown before
+/// anything ready"), these two arms already KNOW a plugin failed — there is
+/// always something to report here, even if it's only "no reason given".
+fn send_recovered_or_generic<'a>(
+    rest: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
+    ready_tx: oneshot::Sender<Result<ChainReady, StartError>>,
+) {
+    let recovered = scan_for_delivered_error(rest).unwrap_or(StartError::ExitedBeforeReady);
+    let _ = ready_tx.send(Err(recovered));
 }
 
 /// Shared handler for a single plugin-task exit result. Updates

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -362,25 +362,28 @@ impl ChainRunner {
 // Helpers =============================================================================================================
 
 /// Scan `rxs` for an already-delivered start-failure signal, preferring a
-/// SPECIFIC `Err(StartError)` over a generic `Closed` sender (dropped
-/// unsent) regardless of which order they're found in — a `Closed` earlier
-/// in iteration order must never mask a real `BindConflict`/`Fatal`
-/// delivered by a later one. Returns `None` only when every scanned
-/// receiver is genuinely `Empty` (or holds an `Ok(PluginReady)`, which is
-/// not a failure and is ignored here) — the caller then has nothing to
-/// recover.
+/// SPECIFIC `Err(StartError)` — anything other than `ExitedBeforeReady`,
+/// which is itself a "no reason known" placeholder, not a real diagnosis —
+/// over a generic signal (a `Closed` sender, or a *delivered*
+/// `ExitedBeforeReady`) regardless of which order they're found in. A
+/// generic signal earlier in iteration order must never mask a real
+/// `BindConflict`/`Fatal` delivered by a later one, however that later one
+/// arrives. Returns `None` only when every scanned receiver is genuinely
+/// `Empty` (or holds an `Ok(PluginReady)`, which is not a failure and is
+/// ignored here) — the caller then has nothing to recover.
 fn scan_for_delivered_error<'a>(
     rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
 ) -> Option<StartError> {
-    let mut any_closed = false;
+    let mut saw_generic = false;
     for r in rxs {
         match r.try_recv() {
+            Ok(Err(StartError::ExitedBeforeReady)) => saw_generic = true,
             Ok(Err(e)) => return Some(e),
-            Err(oneshot::error::TryRecvError::Closed) => any_closed = true,
+            Err(oneshot::error::TryRecvError::Closed) => saw_generic = true,
             Ok(Ok(_)) | Err(oneshot::error::TryRecvError::Empty) => {}
         }
     }
-    any_closed.then_some(StartError::ExitedBeforeReady)
+    saw_generic.then_some(StartError::ExitedBeforeReady)
 }
 
 /// Aggregate the N per-plugin readiness results into a single chain-level

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -406,7 +406,7 @@ pub(crate) fn scan_for_delivered_error<'a>(
 /// Await `rxs` — each to ITS OWN resolution — for the same preference
 /// [`scan_for_delivered_error`] applies (a SPECIFIC `Err(StartError)` over a
 /// generic `Closed`/delivered-`ExitedBeforeReady` signal, regardless of
-/// order). Used only by [`send_recovered_or_generic`], from the TWO
+/// order). Used by [`send_recovered_or_generic`], from the TWO
 /// `run_readiness_aggregator` arms where a plugin has already definitively
 /// failed — see [`scan_for_delivered_error`]'s doc comment for why awaiting
 /// is safe (bounded by `ChainRunner`'s own `drain_timeout`) in exactly those
@@ -414,7 +414,17 @@ pub(crate) fn scan_for_delivered_error<'a>(
 /// `scan_for_delivered_error`'s try_recv snapshot leaves open: a
 /// `BindConflict`/`Fatal` delivered a moment AFTER a snapshot would run is
 /// still recovered here, not silently downgraded.
-async fn drain_for_delivered_error<'a>(
+///
+/// `pub(crate)`: also used by [`crate::tap::TapPlugin`]'s `join` arm, for
+/// the identical reason — `BinaryPlugin::run` (the only inner the bridge
+/// ever taps) hands its readiness sender to a spawned reader task that is
+/// only best-effort-joined (a 100ms grace window) before `run` returns, so
+/// `inner_handle` completing does NOT guarantee `inner_ready_rx` has
+/// resolved yet. Awaiting here is bounded the same way: the child process
+/// has already exited by this point, so its stdout pipe closes and the
+/// reader task's own `lines.next_line()` loop terminates on EOF shortly
+/// after, dropping the sender if it never sent.
+pub(crate) async fn drain_for_delivered_error<'a>(
     rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
 ) -> Option<StartError> {
     let mut saw_generic = false;

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -415,16 +415,17 @@ pub(crate) fn scan_for_delivered_error<'a>(
 /// `BindConflict`/`Fatal` delivered a moment AFTER a snapshot would run is
 /// still recovered here, not silently downgraded.
 ///
-/// `pub(crate)`: also used by [`crate::tap::TapPlugin`]'s `join` arm, for
-/// the identical reason — `BinaryPlugin::run` (the only inner the bridge
-/// ever taps) hands its readiness sender to a spawned reader task that is
-/// only best-effort-joined (a 100ms grace window) before `run` returns, so
-/// `inner_handle` completing does NOT guarantee `inner_ready_rx` has
-/// resolved yet. Awaiting here is bounded the same way: the child process
-/// has already exited by this point, so its stdout pipe closes and the
-/// reader task's own `lines.next_line()` loop terminates on EOF shortly
-/// after, dropping the sender if it never sent.
-pub(crate) async fn drain_for_delivered_error<'a>(
+/// NOT safe for [`crate::tap::TapPlugin`]'s inner-exit race, despite the
+/// superficially identical shape — confirmed by a reproduced deadlock, not
+/// just reasoned about: for `BinaryPlugin` in `ReadinessMode::Probe`, the
+/// readiness sender lives in a task the tap never joins, whose own exit is
+/// gated on the SAME `shutdown` token the tap itself is currently blocking
+/// on returning — a circular wait with nothing to break it. The "the
+/// process already exited, so its reader task will EOF shortly" reasoning
+/// that justifies awaiting here does NOT hold there: Probe mode's
+/// readiness task is a self-probe racing `shutdown`, not a stdout reader
+/// racing process exit.
+async fn drain_for_delivered_error<'a>(
     rxs: impl Iterator<Item = &'a mut oneshot::Receiver<Result<PluginReady, StartError>>>,
 ) -> Option<StartError> {
     let mut saw_generic = false;

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -563,6 +563,48 @@ async fn aggregator_delivered_exited_before_ready_prefers_a_later_specific_error
     );
 }
 
+// `scan_for_delivered_error` itself must not stop at the FIRST generic
+// placeholder it scans past: two plugins ahead of the specific error both
+// deliver `ExitedBeforeReady`, so a scan that treats the first one as
+// "specific" (returning early) would mask index 2's real `BindConflict`
+// just as surely as a single placeholder would.
+#[skuld::test]
+async fn aggregator_delivered_exited_before_ready_prefers_a_specific_error_past_two_placeholders() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx0.send(Err(StartError::ExitedBeforeReady)).unwrap();
+
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx1.send(Err(StartError::ExitedBeforeReady)).unwrap();
+
+    let (rtx2, rrx2) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx2.send(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    let shutdown = CancellationToken::new(); // never cancelled
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(
+        vec![(0, rrx0), (1, rrx1), (2, rrx2)],
+        3,
+        Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: plugin 2 already delivered a value");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected plugin 2's delivered BindConflict to survive past TWO generic ExitedBeforeReady \
+         placeholders, got {outcome:?}"
+    );
+}
+
 /// The aggregator reports the end-to-end transports as the intersection
 /// across every hop: a transport is carried only if EVERY plugin serves
 /// it. Here a TCP|UDP hop and a TCP-only hop must intersect to TCP. The

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
-use crate::chain::{allocate_ports, ChainRunner};
+use crate::chain::{allocate_ports, run_readiness_aggregator, ChainRunner, Mode};
 use crate::plugin::ChainPlugin;
 use crate::sitrep::{PluginReady, StartError, Transports};
 
@@ -340,22 +340,193 @@ async fn on_ready_dropped_on_plugin_failure() {
 
     let handle = tokio::spawn(runner.run(env));
 
-    // The plugin exits before readying, so the aggregator synthesizes a
-    // process-exit `StartError::Fatal` and sends it through ready_tx.
+    // The plugin exits before readying, so the aggregator synthesizes
+    // `StartError::ExitedBeforeReady` and sends it through ready_tx.
     let outcome = rx.await.expect("aggregator should report a start error, not drop");
-    match outcome {
-        Err(StartError::Fatal { detail, .. }) => {
-            assert!(
-                detail.contains("exited before becoming ready"),
-                "expected exited-before-ready Fatal, got: {detail}"
-            );
-        }
-        other => panic!("expected StartError::Fatal, got {other:?}"),
-    }
+    assert!(
+        matches!(outcome, Err(StartError::ExitedBeforeReady)),
+        "expected StartError::ExitedBeforeReady, got {outcome:?}"
+    );
 
     // The chain should have returned an error.
     let chain_result = handle.await.unwrap();
     assert!(chain_result.is_err());
+}
+
+// Reproduces the race `run_readiness_aggregator`'s `biased` comment
+// describes: send on `rtx` and cancel `shutdown` BEFORE the aggregator is
+// ever polled, so both arms are ready at the very first poll and `biased`
+// picks shutdown every time — only the recovery scan below can recover the
+// already-delivered value.
+#[skuld::test]
+async fn aggregator_shutdown_race_does_not_discard_an_already_delivered_start_error() {
+    let (rtx, rrx) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx.send(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx)], 1, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: a value WAS delivered");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected the delivered BindConflict to survive the shutdown race, got {outcome:?}"
+    );
+}
+
+// The same race, but the delivered `StartError` sits on a LATER receiver
+// than the one the loop is currently polling: index 0 is still pending (its
+// sender is alive but hasn't sent), index 1 already holds a delivered
+// `BindConflict`. The recovery scan must check every remaining receiver,
+// not just the one that lost the `biased` race.
+#[skuld::test]
+async fn aggregator_shutdown_race_recovers_from_a_later_receiver() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx1.send(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+    // rtx0 is kept alive (not sent, not dropped) so index 0's receiver is
+    // genuinely `Empty`, not `Closed` — a live plugin still starting up.
+    let _keep_alive = rtx0;
+
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx0), (1, rrx1)], 2, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: plugin 1 already delivered a value");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected plugin 1's delivered BindConflict to survive, got {outcome:?}"
+    );
+}
+
+// A recovered `Ok(PluginReady)` must NOT let the aggregator report the
+// chain ready — shutdown having already fired makes this a start failure,
+// never a success, exactly like the pre-recovery behavior (an unconditional
+// `return`, dropping `ready_tx`) for this case.
+#[skuld::test]
+async fn aggregator_shutdown_race_never_reports_ready_after_shutdown() {
+    let (rtx, rrx) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx.send(Ok(PluginReady {
+        listen: "127.0.0.1:1080".parse().unwrap(),
+        transports: Transports::TCP,
+    }))
+    .unwrap();
+
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx)], 1, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx.await;
+    assert!(
+        outcome.is_err(),
+        "a recovered PluginReady after shutdown must not produce a chain-level Ok, got {outcome:?}"
+    );
+}
+
+// The ordinary case the recovery scan exists ALONGSIDE, not instead of:
+// shutdown fires while every remaining plugin is still legitimately starting
+// up — neither delivered nor closed, genuinely `Empty`. The scan must find
+// nothing to recover and terminate promptly with `ready_tx` dropped (the
+// pre-recovery behavior for this case), not hang or misclassify an `Empty`
+// receiver as `Closed`.
+#[skuld::test]
+async fn aggregator_shutdown_with_nothing_to_recover_drops_ready_tx_promptly() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    // Kept alive (not sent, not dropped): both plugins are still starting.
+    let _keep_alive = (rtx0, rtx1);
+
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx0), (1, rrx1)], 2, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx.await;
+    assert!(
+        outcome.is_err(),
+        "shutdown with nothing delivered anywhere must drop ready_tx (RecvError), got {outcome:?}"
+    );
+}
+
+// A `Closed` sender earlier in iteration order must never mask a specific
+// `Err(StartError)` delivered by a LATER plugin, regardless of scan order.
+// Index 0's sender is dropped unsent (Closed); index 1 already holds a
+// delivered `BindConflict`. Shutdown is pre-cancelled so this exercises the
+// shutdown-branch scan specifically.
+#[skuld::test]
+async fn aggregator_shutdown_scan_prefers_a_later_specific_error_over_an_earlier_closed_one() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    drop(rtx0);
+
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx1.send(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    let shutdown = CancellationToken::new();
+    shutdown.cancel();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx0), (1, rrx1)], 2, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: plugin 1 already delivered a value");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected plugin 1's delivered BindConflict to survive despite plugin 0 being closed first, got {outcome:?}"
+    );
+}
+
+// The same preference, but reached via the plain (non-shutdown) `Err(_recv)`
+// arm: index 0's sender drops unsent with NO shutdown involved at all (a
+// natural RecvError on the receiver the loop is sitting on), while index 1
+// already holds a delivered `BindConflict`.
+#[skuld::test]
+async fn aggregator_recv_error_prefers_a_later_specific_error_over_an_earlier_closed_one() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    drop(rtx0);
+
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx1.send(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    let shutdown = CancellationToken::new(); // never cancelled
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx0), (1, rrx1)], 2, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: plugin 1 already delivered a value");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected plugin 1's delivered BindConflict to survive despite plugin 0 closing first, got {outcome:?}"
+    );
 }
 
 /// The aggregator reports the end-to-end transports as the intersection
@@ -632,22 +803,28 @@ async fn chain_runner_default_matches_explicit_client_mode() {
 #[skuld::test]
 async fn mode_from_plugin_options_detects_bare_server_keyword() {
     use crate::chain::Mode;
-    assert_eq!(Mode::from_plugin_options(Some("server")), Mode::Server);
-    assert_eq!(Mode::from_plugin_options(Some("server;path=/")), Mode::Server);
-    assert_eq!(Mode::from_plugin_options(Some("path=/;server;host=h")), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("server")).unwrap(), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("server;path=/")).unwrap(), Mode::Server);
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/;server;host=h")).unwrap(),
+        Mode::Server
+    );
 }
 
 #[skuld::test]
 async fn mode_from_plugin_options_false_when_server_only_appears_as_substring() {
     use crate::chain::Mode;
     assert_eq!(
-        Mode::from_plugin_options(Some("servername=cdn.example.com")),
+        Mode::from_plugin_options(Some("servername=cdn.example.com")).unwrap(),
         Mode::Client
     );
-    assert_eq!(Mode::from_plugin_options(Some("path=/serverlist")), Mode::Client);
-    assert_eq!(Mode::from_plugin_options(Some("path=/server")), Mode::Client);
     assert_eq!(
-        Mode::from_plugin_options(Some("path=/serverlist;servername=foo")),
+        Mode::from_plugin_options(Some("path=/serverlist")).unwrap(),
+        Mode::Client
+    );
+    assert_eq!(Mode::from_plugin_options(Some("path=/server")).unwrap(), Mode::Client);
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/serverlist;servername=foo")).unwrap(),
         Mode::Client
     );
 }
@@ -655,8 +832,8 @@ async fn mode_from_plugin_options_false_when_server_only_appears_as_substring() 
 #[skuld::test]
 async fn mode_from_plugin_options_false_when_options_missing() {
     use crate::chain::Mode;
-    assert_eq!(Mode::from_plugin_options(None), Mode::Client);
-    assert_eq!(Mode::from_plugin_options(Some("")), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(None).unwrap(), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("")).unwrap(), Mode::Client);
 }
 
 #[skuld::test]
@@ -665,7 +842,7 @@ async fn mode_from_plugin_options_handles_mixed_options() {
     // Realistic server-side `plugin_opts`:
     // `server;fast-open;path=/t/<token>;host=<fqdn>`.
     let opts = "server;fast-open;path=/t/abc123;host=hole-stgn.binarydreams.me";
-    assert_eq!(Mode::from_plugin_options(Some(opts)), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some(opts)).unwrap(), Mode::Server);
 }
 
 #[skuld::test]
@@ -674,8 +851,8 @@ async fn mode_from_plugin_options_false_for_capitalized_keyword() {
     // SIP003 keys are lowercase per v2ray-plugin convention; pin the
     // case-sensitive behavior so a future "be lenient about case" patch
     // is a conscious decision rather than drift.
-    assert_eq!(Mode::from_plugin_options(Some("Server")), Mode::Client);
-    assert_eq!(Mode::from_plugin_options(Some("SERVER;path=/")), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("Server")).unwrap(), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("SERVER;path=/")).unwrap(), Mode::Client);
 }
 
 #[skuld::test]
@@ -685,17 +862,40 @@ async fn mode_from_plugin_options_true_when_key_has_value() {
     // own parser uses `opts.Get("server")` which matches `server=value`
     // (value ignored). Mirror that semantics: presence of the key triggers
     // server mode regardless of value.
-    assert_eq!(Mode::from_plugin_options(Some("server=1;path=/")), Mode::Server);
-    assert_eq!(Mode::from_plugin_options(Some("server=true")), Mode::Server);
+    assert_eq!(
+        Mode::from_plugin_options(Some("server=1;path=/")).unwrap(),
+        Mode::Server
+    );
+    assert_eq!(Mode::from_plugin_options(Some("server=true")).unwrap(), Mode::Server);
 }
 
 #[skuld::test]
-async fn mode_from_plugin_options_false_for_escaped_server() {
+async fn mode_from_plugin_options_true_for_escaped_server() {
     use crate::chain::Mode;
-    // `\s` is not a SIP003-recognized escape (only \;, \\, \= per
-    // parse_plugin_options). So `\server` parses as the literal
-    // string `\server` -- which is NOT the bare key `server`.
-    assert_eq!(Mode::from_plugin_options(Some(r"\server")), Mode::Client);
+    // A backslash escapes whatever byte follows, so `\server` IS the bare
+    // key `server` — to ex-ray, and here.
+    assert_eq!(Mode::from_plugin_options(Some(r"\server")).unwrap(), Mode::Server);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_errors_on_malformed_options() {
+    use crate::chain::Mode;
+    // See Mode::from_plugin_options's doc comment for why neither Client
+    // nor Server is a safe default here.
+    assert!(Mode::from_plugin_options(Some(r"server;path=/a\")).is_err());
+    assert!(Mode::from_plugin_options(Some("server;;path=/a")).is_err());
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_unaffected_by_a_duplicate_non_deciding_key() {
+    use crate::chain::Mode;
+    // `server` is decided by presence (`.any(...)`), not by ex-ray's
+    // first-wins `Get` — a duplicate, unrelated key elsewhere in the string
+    // must not perturb that.
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/a;path=/b;server")).unwrap(),
+        Mode::Server
+    );
 }
 
 // Drain-timeout semantics tests =======================================================================================

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -529,6 +529,40 @@ async fn aggregator_recv_error_prefers_a_later_specific_error_over_an_earlier_cl
     );
 }
 
+// A THIRD way an early generic placeholder can reach the aggregator: index
+// 0 actively SENDS `ExitedBeforeReady` (e.g. a `TapPlugin` reporting its
+// inner's exit race) rather than dropping its sender unsent, while index 1
+// already holds a delivered `BindConflict`. The `Ok(Err(start_err))` arm
+// must scan for a better answer just like the shutdown and `Err(_recv)`
+// arms do, or the first plugin to report "no reason known" permanently
+// masks a later plugin's real error.
+#[skuld::test]
+async fn aggregator_delivered_exited_before_ready_prefers_a_later_specific_error() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx0.send(Err(StartError::ExitedBeforeReady)).unwrap();
+
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    rtx1.send(Err(StartError::BindConflict {
+        errno: 10048,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    let shutdown = CancellationToken::new(); // never cancelled
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    run_readiness_aggregator(vec![(0, rrx0), (1, rrx1)], 2, Mode::Client, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: plugin 1 already delivered a value");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected plugin 1's delivered BindConflict to survive despite plugin 0 sending a generic \
+         ExitedBeforeReady first, got {outcome:?}"
+    );
+}
+
 /// The aggregator reports the end-to-end transports as the intersection
 /// across every hop: a transport is carried only if EVERY plugin serves
 /// it. Here a TCP|UDP hop and a TCP-only hop must intersect to TCP. The

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -529,6 +529,51 @@ async fn aggregator_recv_error_prefers_a_later_specific_error_over_an_earlier_cl
     );
 }
 
+// The `Err(_recv)` arm's drain must recover a value that arrives strictly
+// AFTER the drain begins awaiting it, not just one already buffered
+// beforehand (which a `try_recv` snapshot could also catch) — the exact race
+// `scan_for_delivered_error`'s point-in-time snapshot leaves open, and
+// `drain_for_delivered_error` (used only by this arm and the delivered-
+// `ExitedBeforeReady` arm, never the shutdown-preempted one) exists to
+// close.
+//
+// No sleep, no spawned task, no scheduler race: `tokio::join!` polls its
+// arguments once per round, in declaration order, all within this ONE task.
+// Plugin 0's sender is already dropped before the aggregator starts, so on
+// round 1 the aggregator (first argument) runs synchronously through the
+// `Err(_recv)` arm and into the drain, which registers its interest on
+// plugin 1's receiver and returns Pending — only THEN does the second
+// argument's synchronous `rtx1.send` run, later in that same round. That
+// ordering is a documented `join!` guarantee, not a race bet.
+#[skuld::test]
+async fn aggregator_recv_error_recovers_a_value_delivered_after_the_drain_begins() {
+    let (rtx0, rrx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    drop(rtx0);
+
+    let (rtx1, rrx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+
+    let shutdown = CancellationToken::new(); // never cancelled
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let ((), ()) = tokio::join!(
+        run_readiness_aggregator(vec![(0, rrx0), (1, rrx1)], 2, Mode::Client, shutdown, ready_tx),
+        async {
+            let _ = rtx1.send(Err(StartError::BindConflict {
+                errno: 10048,
+                addr: "127.0.0.1:1080".parse().unwrap(),
+            }));
+        }
+    );
+
+    let outcome = ready_rx
+        .await
+        .expect("aggregator must not drop ready_tx: plugin 1 delivered a value");
+    assert!(
+        matches!(outcome, Err(StartError::BindConflict { errno: 10048, .. })),
+        "expected plugin 1's BindConflict, delivered after the drain began, to still be recovered, got {outcome:?}"
+    );
+}
+
 // A THIRD way an early generic placeholder can reach the aggregator: index
 // 0 actively SENDS `ExitedBeforeReady` (e.g. a `TapPlugin` reporting its
 // inner's exit race) rather than dropping its sender unsent, while index 1

--- a/crates/garter/src/error.rs
+++ b/crates/garter/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
 
     #[error("environment variable '{var}' missing or invalid: {reason}")]
     Env { var: String, reason: String },
+
+    #[error("malformed SS_PLUGIN_OPTIONS: {0}")]
+    MalformedOptions(#[from] crate::sip003::MalformedOptions),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -20,7 +20,9 @@ pub use error::{Error, Result};
 pub use plugin::ChainPlugin;
 pub use sip003::PluginEnv;
 pub use sip003::{join_plugin_options, parse_plugin_options, split_plugin_options, MalformedOptions, OptionSegment};
-pub use sitrep::{PluginReady, ProtocolSupport, SitrepEvent, StartError, Transports, SITREP_PROTOCOL};
+pub use sitrep::{
+    PluginReady, ProtocolSupport, SitrepEvent, StartError, Transports, EXITED_BEFORE_READY_DETAIL, SITREP_PROTOCOL,
+};
 pub use tap::TapPlugin;
 
 #[cfg(test)]

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -21,7 +21,8 @@ pub use plugin::ChainPlugin;
 pub use sip003::PluginEnv;
 pub use sip003::{join_plugin_options, parse_plugin_options, split_plugin_options, MalformedOptions, OptionSegment};
 pub use sitrep::{
-    PluginReady, ProtocolSupport, SitrepEvent, StartError, Transports, EXITED_BEFORE_READY_DETAIL, SITREP_PROTOCOL,
+    recover_exit_detail_from_joined, PluginReady, ProtocolSupport, SitrepEvent, StartError, Transports,
+    EXITED_BEFORE_READY_DETAIL, SITREP_PROTOCOL,
 };
 pub use tap::TapPlugin;
 

--- a/crates/garter/src/sip003.rs
+++ b/crates/garter/src/sip003.rs
@@ -18,7 +18,7 @@ impl PluginEnv {
             local_port: read_env_parsed("SS_LOCAL_PORT")?,
             remote_host: read_env("SS_REMOTE_HOST")?,
             remote_port: read_env_parsed("SS_REMOTE_PORT")?,
-            plugin_options: std::env::var("SS_PLUGIN_OPTIONS").ok(),
+            plugin_options: read_env_optional("SS_PLUGIN_OPTIONS")?,
         })
     }
 
@@ -52,30 +52,40 @@ where
     })
 }
 
+/// Like [`read_env`], but absence is `Ok(None)` rather than an error — for
+/// a var that's genuinely optional. Non-Unicode is still a loud error: an
+/// unreadable value must not collapse into the same `None` as "not set".
+fn read_env_optional(var: &str) -> crate::Result<Option<String>> {
+    match std::env::var(var) {
+        Ok(val) => Ok(Some(val)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(Error::Env {
+            var: var.into(),
+            reason: "contains invalid Unicode".into(),
+        }),
+    }
+}
+
 /// Parse SIP003 plugin options string into key-value pairs.
 /// Format: `key1=value1;key2=value2`
-/// Bare keys (no `=`) have value `""`.
-/// Escaping: `\;` → `;`, `\\` → `\`, `\=` → `=`.
+/// Bare keys (no `=`) have value `""` — see [`split_plugin_options`] for how
+/// this differs from ex-ray's own `"1"`.
 ///
-/// Two-pass approach:
-/// 1. Split on unescaped `;` (preserving escape sequences)
-/// 2. For each segment, split on first unescaped `=`, then unescape both parts
-pub fn parse_plugin_options(opts: &str) -> Vec<(String, String)> {
-    if opts.is_empty() {
-        return Vec::new();
-    }
-    let segments = split_on_unescaped(opts, ';');
-    let mut result = Vec::new();
-    for segment in segments {
-        if let Some(eq_pos) = find_unescaped(&segment, '=') {
-            let key = unescape(&segment[..eq_pos]);
-            let value = unescape(&segment[eq_pos + 1..]);
-            result.push((key, value));
-        } else {
-            result.push((unescape(&segment), String::new()));
-        }
-    }
-    result
+/// Decodes with the same escaping rule and segmentation
+/// [`split_plugin_options`] uses: a `\` escapes whatever byte follows, and
+/// one malformed segment — a dangling trailing `\` or an empty key —
+/// rejects the whole string rather than returning the pairs parsed so far
+/// (though not always with the same [`MalformedOptions`] variant ex-ray's
+/// single-pass scan would report for a string with more than one defect).
+/// The two primitives differ only in shape: this one decodes straight to
+/// owned pairs, while [`split_plugin_options`] keeps each segment's
+/// original bytes for a caller that must rewrite the string byte-exactly
+/// (see [`OptionSegment`]).
+pub fn parse_plugin_options(opts: &str) -> Result<Vec<(String, String)>, MalformedOptions> {
+    Ok(split_plugin_options(opts)?
+        .into_iter()
+        .map(|seg| (seg.key, seg.value))
+        .collect())
 }
 
 /// An options string a SIP003 plugin rejects outright. Reported rather than
@@ -97,12 +107,9 @@ pub enum MalformedOptions {
 pub struct OptionSegment<'a> {
     /// The segment exactly as written, escapes intact.
     pub raw: &'a str,
-    /// The key as a SIP003 PLUGIN reads it: a `\` escapes whatever byte follows.
-    /// This is deliberately more permissive than [`parse_plugin_options`], which
-    /// honours only `\;`, `\\` and `\=` and otherwise keeps the backslash — so
-    /// `ech\-doh` is `ech-doh` here and `ech\-doh` there. Use this field to
-    /// decide which key a plugin will ACT on; a check that used the narrower
-    /// rule could be evaded by escaping one character of the name.
+    /// The key as a SIP003 PLUGIN reads it: a `\` escapes whatever byte
+    /// follows — the same rule [`parse_plugin_options`] uses. Use this
+    /// field to decide which key a plugin will ACT on.
     pub key: String,
     /// The value, decoded by the same rule. Empty for a bare key — a caller
     /// that must distinguish `tls` from `tls=` reads `raw`.
@@ -151,8 +158,8 @@ pub fn join_plugin_options<'a>(segments: impl IntoIterator<Item = &'a str>) -> S
     segments.into_iter().collect::<Vec<_>>().join(";")
 }
 
-/// [`split_on_unescaped`] without the copy: yields subslices of `s`. Errors on a
-/// trailing `\` that escapes nothing.
+/// Segment `s` on unescaped occurrences of `delimiter`, yielding subslices
+/// rather than copies. Errors on a trailing `\` that escapes nothing.
 fn split_on_unescaped_borrowed(s: &str, delimiter: char) -> Result<Vec<&str>, MalformedOptions> {
     let mut segments = Vec::new();
     let mut start = 0;
@@ -171,14 +178,22 @@ fn split_on_unescaped_borrowed(s: &str, delimiter: char) -> Result<Vec<&str>, Ma
     Ok(segments)
 }
 
-/// Unescape by the SIP003 reference rule: `\` escapes whatever character
-/// follows — see [`OptionSegment::key`] for why this differs from [`unescape`].
-fn unescape_any(s: &str) -> Result<String, MalformedOptions> {
+/// Walk `s`, splitting on `\`-escapes: every non-`\` character is copied
+/// into the output verbatim, and `on_escaped` decides what to push for the
+/// byte immediately following each `\`. [`unescape_any`] and a caller that
+/// must instead tell a legitimate SIP003 escape from a mangled one apart
+/// (e.g. `garter-bin`'s `config=` diagnostic) both build on this one walk
+/// rather than each re-implementing it — they differ only in what
+/// `on_escaped` does with the escaped byte.
+///
+/// `Err` only on a dangling trailing `\` that escapes nothing.
+pub fn walk_escaped(s: &str, mut on_escaped: impl FnMut(char, &mut String)) -> Result<String, MalformedOptions> {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();
     while let Some(ch) = chars.next() {
         if ch == '\\' {
-            out.push(chars.next().ok_or(MalformedOptions::DanglingEscape)?);
+            let escaped = chars.next().ok_or(MalformedOptions::DanglingEscape)?;
+            on_escaped(escaped, &mut out);
         } else {
             out.push(ch);
         }
@@ -186,27 +201,19 @@ fn unescape_any(s: &str) -> Result<String, MalformedOptions> {
     Ok(out)
 }
 
-fn split_on_unescaped(s: &str, delimiter: char) -> Vec<String> {
-    let mut segments = Vec::new();
-    let mut current = String::new();
-    let mut chars = s.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            current.push(ch);
-            if let Some(&next) = chars.peek() {
-                current.push(next);
-                chars.next();
-            }
-        } else if ch == delimiter {
-            segments.push(std::mem::take(&mut current));
-        } else {
-            current.push(ch);
-        }
-    }
-    if !current.is_empty() {
-        segments.push(current);
-    }
-    segments
+/// Unescape by the SIP003 reference rule: `\` escapes whatever character
+/// follows.
+fn unescape_any(s: &str) -> Result<String, MalformedOptions> {
+    walk_escaped(s, |c, out| out.push(c))
+}
+
+/// Whether `c` is one of the three bytes SIP003 gives a `\` special
+/// meaning before: `;` (segment separator), `\` (escape character), `=`
+/// (key/value separator). A `\` before any OTHER byte still decodes (drops
+/// the `\`, keeps the byte — see [`OptionSegment::key`]), but these three
+/// are the only ones a `\` is ever actually NEEDED for.
+pub fn is_sip003_metacharacter(c: char) -> bool {
+    matches!(c, ';' | '\\' | '=')
 }
 
 fn find_unescaped(s: &str, target: char) -> Option<usize> {
@@ -219,27 +226,4 @@ fn find_unescaped(s: &str, target: char) -> Option<usize> {
         }
     }
     None
-}
-
-fn unescape(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            if let Some(&next) = chars.peek() {
-                match next {
-                    ';' | '\\' | '=' => {
-                        result.push(next);
-                        chars.next();
-                    }
-                    _ => result.push(ch),
-                }
-            } else {
-                result.push(ch);
-            }
-        } else {
-            result.push(ch);
-        }
-    }
-    result
 }

--- a/crates/garter/src/sip003_tests.rs
+++ b/crates/garter/src/sip003_tests.rs
@@ -46,7 +46,7 @@ fn parse_env_no_plugin_options(#[fixture] env: &skuld::EnvGuard) {
 
 #[skuld::test]
 fn parse_plugin_options_basic() {
-    let opts = parse_plugin_options("tls;host=example.com;mode=websocket");
+    let opts = parse_plugin_options("tls;host=example.com;mode=websocket").unwrap();
     assert_eq!(
         opts,
         vec![
@@ -59,7 +59,7 @@ fn parse_plugin_options_basic() {
 
 #[skuld::test]
 fn parse_plugin_options_escaped() {
-    let opts = parse_plugin_options(r"path=/a\;b;key=val\\ue");
+    let opts = parse_plugin_options(r"path=/a\;b;key=val\\ue").unwrap();
     assert_eq!(
         opts,
         vec![
@@ -71,8 +71,63 @@ fn parse_plugin_options_escaped() {
 
 #[skuld::test]
 fn parse_plugin_options_empty() {
-    let opts = parse_plugin_options("");
+    let opts = parse_plugin_options("").unwrap();
     assert!(opts.is_empty());
+}
+
+#[skuld::test]
+fn parse_plugin_options_drops_backslash_before_any_byte() {
+    // A backslash escapes whatever byte follows, matching ex-ray's
+    // `indexUnescaped` — not just the SIP003 metacharacters `;`, `\`, `=`.
+    assert_eq!(
+        parse_plugin_options(r"ech\-doh=x").unwrap(),
+        vec![("ech-doh".to_string(), "x".to_string())]
+    );
+    assert_eq!(
+        parse_plugin_options(r"\server").unwrap(),
+        vec![("server".to_string(), "".to_string())]
+    );
+}
+
+#[skuld::test]
+fn parse_plugin_options_rejects_a_dangling_trailing_escape() {
+    assert_eq!(parse_plugin_options(r"path=/a\"), Err(MalformedOptions::DanglingEscape));
+    assert_eq!(parse_plugin_options(r"a=1;b=2\"), Err(MalformedOptions::DanglingEscape));
+}
+
+#[skuld::test]
+fn parse_plugin_options_rejects_an_empty_key() {
+    assert_eq!(
+        parse_plugin_options("a=1;;b=2"),
+        Err(MalformedOptions::EmptyKey { index: 1 })
+    );
+    assert_eq!(
+        parse_plugin_options("a=1;;"),
+        Err(MalformedOptions::EmptyKey { index: 1 })
+    );
+    assert_eq!(parse_plugin_options("=v"), Err(MalformedOptions::EmptyKey { index: 0 }));
+    assert_eq!(
+        parse_plugin_options("host=h;=v;mux=0"),
+        Err(MalformedOptions::EmptyKey { index: 1 })
+    );
+    // A trailing separator alone is not an empty key.
+    assert_eq!(
+        parse_plugin_options("a=1;").unwrap(),
+        vec![("a".to_string(), "1".to_string())]
+    );
+}
+
+// ex-ray's parsePluginOptions is a true single left-to-right scan and
+// returns on the FIRST error in byte order, so a string with BOTH an empty
+// key (position 0) and a later dangling escape reports the empty key —
+// the scan never reaches the backslash. `split_plugin_options` scans in two
+// phases (delimiters/dangling-escape across the whole string, then
+// per-segment key-emptiness), so it reports DanglingEscape here instead.
+// Both sides still reject the string; only the diagnosed REASON differs,
+// and no caller branches on which variant it is.
+#[skuld::test]
+fn parse_plugin_options_error_precedence_differs_from_ex_ray_on_multiple_defects() {
+    assert_eq!(parse_plugin_options(r";a=1\"), Err(MalformedOptions::DanglingEscape));
 }
 
 #[skuld::test]
@@ -91,13 +146,13 @@ fn plugin_env_local_addr(#[fixture] env: &skuld::EnvGuard) {
 
 #[skuld::test]
 fn parse_plugin_options_escaped_equals_in_key() {
-    let opts = parse_plugin_options(r"k\=ey=value");
+    let opts = parse_plugin_options(r"k\=ey=value").unwrap();
     assert_eq!(opts, vec![("k=ey".to_string(), "value".to_string()),]);
 }
 
 #[skuld::test]
 fn parse_plugin_options_equals_in_value() {
-    let opts = parse_plugin_options("key=a=b");
+    let opts = parse_plugin_options("key=a=b").unwrap();
     assert_eq!(opts, vec![("key".to_string(), "a=b".to_string()),]);
 }
 
@@ -128,13 +183,13 @@ fn split_decodes_the_key_but_leaves_the_segment_raw() {
     assert_eq!(s[0].raw, r"k\=ey=a\;b");
 }
 
-// See `OptionSegment::key` for why this decoding rule differs from `parse_plugin_options`.
+// `parse_plugin_options` decodes a key by the same reference rule as
+// `OptionSegment::key`: a backslash escapes whatever byte follows.
 #[skuld::test]
 fn split_decodes_a_key_the_way_a_sip003_plugin_does() {
     assert_eq!(segs(r"ech\-doh=x")[0].key, "ech-doh");
     assert_eq!(segs(r"log\level=warning")[0].key, "loglevel");
-    // The narrower `parse_plugin_options` alphabet deliberately differs.
-    assert_eq!(parse_plugin_options(r"ech\-doh=x")[0].0, r"ech\-doh");
+    assert_eq!(parse_plugin_options(r"ech\-doh=x").unwrap()[0].0, "ech-doh");
 }
 
 // An escaped `;` is part of a value, not a separator.
@@ -225,7 +280,49 @@ fn appending_after_a_join_survives_a_trailing_escaped_semicolon() {
     let appended = join_plugin_options(segs(r"path=/a\;").iter().map(|x| x.raw).chain(["mux=0"]));
     assert_eq!(appended, r"path=/a\;;mux=0");
     assert_eq!(
-        parse_plugin_options(&appended),
+        parse_plugin_options(&appended).unwrap(),
         vec![("path".into(), "/a;".to_string()), ("mux".into(), "0".to_string())],
+    );
+}
+
+#[skuld::test]
+#[cfg(windows)]
+fn parse_env_rejects_non_unicode_plugin_options(#[fixture] env: &skuld::EnvGuard) {
+    env.set("SS_LOCAL_HOST", "127.0.0.1");
+    env.set("SS_LOCAL_PORT", "1080");
+    env.set("SS_REMOTE_HOST", "example.com");
+    env.set("SS_REMOTE_PORT", "443");
+    use std::os::windows::ffi::OsStringExt;
+    let invalid = std::ffi::OsString::from_wide(&[0xD800]); // unpaired UTF-16 surrogate
+                                                            // `env.remove` first so the guard's restore stack captures the prior
+                                                            // value (or absence) before the raw, non-&str set below bypasses it.
+    env.remove("SS_PLUGIN_OPTIONS");
+    // SAFETY: serialized by the `env` fixture's `serial` scheduling.
+    unsafe { std::env::set_var("SS_PLUGIN_OPTIONS", &invalid) };
+    let result = PluginEnv::from_env();
+    assert!(
+        result.is_err(),
+        "a non-Unicode SS_PLUGIN_OPTIONS must be a loud error, not treated as absent"
+    );
+}
+
+#[skuld::test]
+#[cfg(unix)]
+fn parse_env_rejects_non_unicode_plugin_options(#[fixture] env: &skuld::EnvGuard) {
+    env.set("SS_LOCAL_HOST", "127.0.0.1");
+    env.set("SS_LOCAL_PORT", "1080");
+    env.set("SS_REMOTE_HOST", "example.com");
+    env.set("SS_REMOTE_PORT", "443");
+    use std::os::unix::ffi::OsStrExt;
+    let invalid = std::ffi::OsStr::from_bytes(&[0xFF, 0xFE]); // not valid UTF-8
+                                                              // `env.remove` first so the guard's restore stack captures the prior
+                                                              // value (or absence) before the raw, non-&str set below bypasses it.
+    env.remove("SS_PLUGIN_OPTIONS");
+    // SAFETY: serialized by the `env` fixture's `serial` scheduling.
+    unsafe { std::env::set_var("SS_PLUGIN_OPTIONS", invalid) };
+    let result = PluginEnv::from_env();
+    assert!(
+        result.is_err(),
+        "a non-Unicode SS_PLUGIN_OPTIONS must be a loud error, not treated as absent"
     );
 }

--- a/crates/garter/src/sitrep.rs
+++ b/crates/garter/src/sitrep.rs
@@ -37,6 +37,10 @@ pub struct PluginReady {
     pub transports: Transports,
 }
 
+/// Display text for [`StartError::ExitedBeforeReady`] and the fallback a
+/// caller shows if it can't recover anything more specific.
+pub const EXITED_BEFORE_READY_DETAIL: &str = "plugin exited before becoming ready";
+
 /// A typed start failure reported by a plugin (or synthesized from a
 /// bare process exit by the runner). The consumer maps this to a retry
 /// decision — `BindConflict` is the only retryable class.
@@ -45,9 +49,25 @@ pub enum StartError {
     /// The plugin could not bind its listener. `errno` is the raw OS
     /// error (locale-proof) where the plugin could type it; 0 if unknown.
     BindConflict { errno: i32, addr: SocketAddr },
-    /// Any terminal start failure (config error, upstream-dial failure,
-    /// bare process exit). Never retried.
+    /// Any terminal start failure the reporter can already name (config
+    /// error, upstream-dial failure, bare process exit). Never retried.
     Fatal { detail: String, errno: Option<i32> },
+    /// A plugin's readiness sender dropped unsent before ever reporting
+    /// `ready` or a specific `Fatal` — synthesized locally
+    /// (`ChainRunner`'s readiness aggregator, `TapPlugin`'s inner-exit
+    /// race) when the cause is not known at the point this is raised.
+    ///
+    /// Deliberately distinct from `Fatal`, not just a `Fatal` with
+    /// [`EXITED_BEFORE_READY_DETAIL`] text: `SitrepEvent` has no wire
+    /// counterpart for this variant, so a `StartError` reconstructed FROM
+    /// a parsed sitrep event can only ever be `BindConflict`/`Fatal`, never
+    /// this. A caller holding the plugin's own driving task (e.g. bridge's
+    /// `spawn_plugin_runner_at`) can therefore match on the variant — not
+    /// compare `detail` text — to tell "no reason was ever given, go look"
+    /// from a genuine plugin-reported `Fatal` apart, even one forwarded
+    /// verbatim by a nested garter whose own placeholder text happens to
+    /// read the same.
+    ExitedBeforeReady,
 }
 
 impl std::fmt::Display for StartError {
@@ -57,6 +77,7 @@ impl std::fmt::Display for StartError {
                 write!(f, "bind conflict on {addr} (errno {errno})")
             }
             StartError::Fatal { detail, .. } => write!(f, "{detail}"),
+            StartError::ExitedBeforeReady => write!(f, "{EXITED_BEFORE_READY_DETAIL}"),
         }
     }
 }

--- a/crates/garter/src/sitrep.rs
+++ b/crates/garter/src/sitrep.rs
@@ -82,6 +82,34 @@ impl std::fmt::Display for StartError {
     }
 }
 
+/// Recover a specific exit reason from `joined` — the outcome of joining a
+/// plugin-driving task (a `ChainRunner::run` future, or equivalent) — for
+/// the case where the ready-gate signal itself carried no diagnosis (a bare
+/// [`StartError::ExitedBeforeReady`], or the ready channel dropping unsent
+/// before anything was reported).
+///
+/// `Ok(Err(e))` (the task's own `run()` call returned a specific error)
+/// yields that error's `Display` text. `Ok(Ok(()))` (a clean exit — e.g.
+/// shutdown raced the readiness report) and `Err(_)` (the task panicked or
+/// was cancelled while being joined) both fall back to
+/// [`EXITED_BEFORE_READY_DETAIL`]; the panic/cancel case is also logged at
+/// `error!`, since it signals a bug rather than routine diagnostic noise.
+///
+/// Shared by every caller that joins a plugin-driving task for this exact
+/// gap — bridge's `spawn_plugin_runner_at`, galoshes' `main`, and
+/// plugin-e2e's `run_roundtrip` all reach the identical three-way match;
+/// this is the single implementation.
+pub fn recover_exit_detail_from_joined(joined: &Result<crate::Result<()>, tokio::task::JoinError>) -> String {
+    match joined {
+        Ok(Err(e)) => e.to_string(),
+        Ok(Ok(())) => EXITED_BEFORE_READY_DETAIL.into(),
+        Err(join_err) => {
+            tracing::error!(error = %join_err, "plugin-driving task ended abnormally while recovering exit detail");
+            EXITED_BEFORE_READY_DETAIL.into()
+        }
+    }
+}
+
 /// A parsed sitrep control event.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]

--- a/crates/garter/src/sitrep_tests.rs
+++ b/crates/garter/src/sitrep_tests.rs
@@ -168,3 +168,30 @@ fn fatal_includes_errno_key_when_some() {
         r#"{"event":"fatal","detail":"boom","errno":13}"#
     );
 }
+
+#[skuld::test]
+fn recover_exit_detail_from_joined_surfaces_the_tasks_specific_error() {
+    let joined: Result<crate::Result<()>, tokio::task::JoinError> = Ok(Err(crate::Error::Chain(
+        "tap[ex-ray]: alloc inner port: address in use".into(),
+    )));
+    assert_eq!(
+        recover_exit_detail_from_joined(&joined),
+        "tap[ex-ray]: alloc inner port: address in use"
+    );
+}
+
+#[skuld::test]
+fn recover_exit_detail_from_joined_falls_back_on_a_clean_exit() {
+    // `run()` returning `Ok(())` here means shutdown raced the readiness
+    // report, not a real failure — nothing more specific to recover.
+    let joined: Result<crate::Result<()>, tokio::task::JoinError> = Ok(Ok(()));
+    assert_eq!(recover_exit_detail_from_joined(&joined), EXITED_BEFORE_READY_DETAIL);
+}
+
+#[skuld::test]
+async fn recover_exit_detail_from_joined_falls_back_when_the_task_panicked() {
+    let handle = tokio::spawn(async { panic!("boom") });
+    let joined = handle.await;
+    assert!(joined.is_err(), "expected a real JoinError from the panicked task");
+    assert_eq!(recover_exit_detail_from_joined(&joined), EXITED_BEFORE_READY_DETAIL);
+}

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -158,14 +158,24 @@ impl ChainPlugin for TapPlugin {
                 // itself (not `None`) for "closed, nothing specific", so
                 // this fallback must match on THAT too, not just `None`.
                 //
-                // Drains (awaits) `inner_ready_rx` to resolution rather than
-                // sampling it: `inner_handle` completing does NOT mean the
-                // reader task that owns the inner's `ready` sender has
-                // finished too (`BinaryPlugin::run` only best-effort-joins
-                // it under a short grace window before returning) — see
-                // `drain_for_delivered_error`'s doc comment for why awaiting
-                // here is still bounded, not a hang risk.
-                let err = match crate::chain::drain_for_delivered_error(std::iter::once(&mut inner_ready_rx)).await {
+                // Deliberately `scan_for_delivered_error` (point-in-time
+                // `try_recv`), NOT an await-to-resolution drain: for
+                // `BinaryPlugin` in `ReadinessMode::Probe`, the readiness
+                // sender lives in a task this fn never joins, whose own
+                // exit is gated on THIS `shutdown` token — which nothing
+                // cancels until the tap's own task (the one currently
+                // executing this line) returns. Awaiting `inner_ready_rx`
+                // here is a real, reproduced circular-wait deadlock in that
+                // case, not just an unbounded wait — confirmed by a
+                // temporary repro test (a Probe-shaped inner whose
+                // detached readiness task only resolves on `shutdown`,
+                // with nothing external to cancel it): `tap.run` hung past
+                // a 5s bound with the drain, returned in a few ms without
+                // it. This narrows a delivery race (see the doc comment on
+                // `scan_for_delivered_error`) rather than closing it —
+                // closing it needs `BinaryPlugin::run` itself to guarantee
+                // its readiness sender resolves before `run` returns.
+                let err = match crate::chain::scan_for_delivered_error(std::iter::once(&mut inner_ready_rx)) {
                     Some(e) if !matches!(e, StartError::ExitedBeforeReady) => e,
                     _ => StartError::Fatal {
                         detail: match &join {

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -144,30 +144,28 @@ impl ChainPlugin for TapPlugin {
             r = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => r,
             join = &mut inner_handle => {
                 // Inner exited before binding — propagate its result. No
-                // tap listener was ever opened. Preference order, most to
-                // least specific:
-                //  1. A `StartError` the inner already delivered on its own
-                //     readiness channel (e.g. `BindConflict`) — mirroring
-                //     `chain::scan_for_delivered_error`, which the
-                //     aggregator applies for the same reason.
-                //  2. `join`'s own `Err` — `self.inner.run(...)`'s actual
-                //     returned error (e.g. a malformed-options
-                //     `crate::Error`), sitting right here in `join` and
-                //     otherwise destroyed: bridge's `spawn_plugin_runner_at`
-                //     treats a `Fatal` (unlike `ExitedBeforeReady`) as
-                //     already-as-specific-as-it-gets and does NOT join the
-                //     handle for more detail, so if this arm didn't consult
-                //     `join` here, that Err would be lost for good, not
-                //     just deferred to a later recovery.
-                //  3. A generic, name-bearing `Fatal` (not the bare
-                //     `ExitedBeforeReady` placeholder) — reached only on a
-                //     clean, silent inner exit (`join == Ok(Ok(()))`), where
-                //     naming the tap and plugin is strictly more useful
-                //     than a placeholder no later recovery can improve on.
+                // tap listener was ever opened. Preference: (1) a specific
+                // `StartError` the inner already delivered on its own
+                // readiness channel, via `scan_for_delivered_error`'s match
+                // below; (2) `join`'s own `Err` — `self.inner.run(...)`'s
+                // actual returned error, otherwise destroyed here: bridge's
+                // `spawn_plugin_runner_at` treats a `Fatal` (unlike
+                // `ExitedBeforeReady`) as already-as-specific-as-it-gets and
+                // does NOT join the handle again, so skipping `join` here
+                // would lose that error for good, not just defer recovering
+                // it; (3) a generic, name-bearing `Fatal` otherwise —
                 // `scan_for_delivered_error` returns `Some(ExitedBeforeReady)`
-                // itself (not `None`) for "closed, nothing specific" — so
-                // step 3's fallback must match on THAT too, not just `None`.
-                let err = match crate::chain::scan_for_delivered_error(std::iter::once(&mut inner_ready_rx)) {
+                // itself (not `None`) for "closed, nothing specific", so
+                // this fallback must match on THAT too, not just `None`.
+                //
+                // Drains (awaits) `inner_ready_rx` to resolution rather than
+                // sampling it: `inner_handle` completing does NOT mean the
+                // reader task that owns the inner's `ready` sender has
+                // finished too (`BinaryPlugin::run` only best-effort-joins
+                // it under a short grace window before returning) — see
+                // `drain_for_delivered_error`'s doc comment for why awaiting
+                // here is still bounded, not a hang risk.
+                let err = match crate::chain::drain_for_delivered_error(std::iter::once(&mut inner_ready_rx)).await {
                     Some(e) if !matches!(e, StartError::ExitedBeforeReady) => e,
                     _ => StartError::Fatal {
                         detail: match &join {
@@ -187,10 +185,28 @@ impl ChainPlugin for TapPlugin {
         match ready_outcome {
             Ok(Some(_)) => {}
             Ok(None) => {
-                // Shutdown fired before inner was ready. Drop `ready` unsent
-                // (RecvError, matching the "shutdown before ready"
-                // semantics). Wait for inner to unwind and propagate.
-                return drain_inner(plugin_name.as_str(), inner_handle).await;
+                // Shutdown fired before inner was ready — but the inner may
+                // already have delivered (or, mid-unwind, be about to
+                // deliver) a specific `StartError` on its own readiness
+                // channel before `drain_inner` below observes it exit; the
+                // neighboring `join` arm above scans for exactly this same
+                // race. `drain_inner` awaits `inner_handle` to completion
+                // first (bounded by shutdown, same as everywhere else in
+                // this file), so BY THE TIME it returns, the inner's own
+                // sender has necessarily resolved (sent or dropped) — a
+                // plain `scan_for_delivered_error` snapshot taken then is
+                // exact, not approximate. Only a genuinely non-specific
+                // outcome (nothing, or a bare `ExitedBeforeReady`) falls
+                // through to dropping `ready` unsent (RecvError, matching
+                // the "shutdown before ready" semantics for the ordinary
+                // case).
+                let result = drain_inner(plugin_name.as_str(), inner_handle).await;
+                if let Some(e) = crate::chain::scan_for_delivered_error(std::iter::once(&mut inner_ready_rx)) {
+                    if !matches!(e, StartError::ExitedBeforeReady) {
+                        let _ = ready.send(Err(e));
+                    }
+                }
+                return result;
             }
             Err(_) => {
                 inner_handle.abort();

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -144,29 +144,36 @@ impl ChainPlugin for TapPlugin {
             r = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => r,
             join = &mut inner_handle => {
                 // Inner exited before binding — propagate its result. No
-                // tap listener was ever opened. The inner may have already
-                // delivered a specific `StartError` (e.g. `BindConflict`)
-                // on its own readiness channel before exiting; forward that
-                // instead of the generic placeholder, so a retryable class
-                // survives through the tap — mirroring
-                // `chain::scan_for_delivered_error`, which the aggregator
-                // applies for the same reason. If the inner sent nothing at
-                // all (a clean, silent exit — e.g. `join` resolves
-                // `Ok(Ok(()))`), fall back to a name-bearing `Fatal` rather
-                // than the bare `ExitedBeforeReady` placeholder: a caller
-                // that later joins the WHOLE chain's own driving task to
-                // recover more detail (bridge's `recover_exit_detail`) finds
-                // nothing better than the same already-resolved `Ok(Ok(()))`
-                // this arm is looking at right now, so naming which plugin,
-                // wrapped by which tap, right here is strictly more useful
-                // than deferring to a recovery that cannot succeed.
+                // tap listener was ever opened. Preference order, most to
+                // least specific:
+                //  1. A `StartError` the inner already delivered on its own
+                //     readiness channel (e.g. `BindConflict`) — mirroring
+                //     `chain::scan_for_delivered_error`, which the
+                //     aggregator applies for the same reason.
+                //  2. `join`'s own `Err` — `self.inner.run(...)`'s actual
+                //     returned error (e.g. a malformed-options
+                //     `crate::Error`), sitting right here in `join` and
+                //     otherwise destroyed: bridge's `spawn_plugin_runner_at`
+                //     treats a `Fatal` (unlike `ExitedBeforeReady`) as
+                //     already-as-specific-as-it-gets and does NOT join the
+                //     handle for more detail, so if this arm didn't consult
+                //     `join` here, that Err would be lost for good, not
+                //     just deferred to a later recovery.
+                //  3. A generic, name-bearing `Fatal` (not the bare
+                //     `ExitedBeforeReady` placeholder) — reached only on a
+                //     clean, silent inner exit (`join == Ok(Ok(()))`), where
+                //     naming the tap and plugin is strictly more useful
+                //     than a placeholder no later recovery can improve on.
                 // `scan_for_delivered_error` returns `Some(ExitedBeforeReady)`
-                // itself (not `None`) for "closed, nothing specific" — so the
-                // fallback below must match on THAT too, not just `None`.
+                // itself (not `None`) for "closed, nothing specific" — so
+                // step 3's fallback must match on THAT too, not just `None`.
                 let err = match crate::chain::scan_for_delivered_error(std::iter::once(&mut inner_ready_rx)) {
                     Some(e) if !matches!(e, StartError::ExitedBeforeReady) => e,
                     _ => StartError::Fatal {
-                        detail: format!("tap[{plugin_name}]: inner exited before becoming ready"),
+                        detail: match &join {
+                            Ok(Err(e)) => format!("tap[{plugin_name}]: {e}"),
+                            _ => format!("tap[{plugin_name}]: inner exited before becoming ready"),
+                        },
                         errno: None,
                     },
                 };

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -200,13 +200,17 @@ impl ChainPlugin for TapPlugin {
                 // deliver) a specific `StartError` on its own readiness
                 // channel before `drain_inner` below observes it exit; the
                 // neighboring `join` arm above scans for exactly this same
-                // race. `drain_inner` awaits `inner_handle` to completion
-                // first (bounded by shutdown, same as everywhere else in
-                // this file), so BY THE TIME it returns, the inner's own
-                // sender has necessarily resolved (sent or dropped) — a
-                // plain `scan_for_delivered_error` snapshot taken then is
-                // exact, not approximate. Only a genuinely non-specific
-                // outcome (nothing, or a bare `ExitedBeforeReady`) falls
+                // race, and its doc comment applies here too: `drain_inner`
+                // awaits `inner_handle` — `self.inner.run(...)`'s own
+                // future — to completion, NOT the detached/best-effort-
+                // joined task that actually owns `inner_ready_tx` for a
+                // `BinaryPlugin` inner (see `scan_for_delivered_error`'s
+                // doc comment). So this `scan_for_delivered_error` snapshot
+                // is, like the join arm's, a narrowed race, not a closed
+                // one — it recovers what's already landed by the time
+                // `drain_inner` returns, not necessarily everything that
+                // will ever land. Only a genuinely non-specific outcome
+                // (nothing yet, or a bare `ExitedBeforeReady`) falls
                 // through to dropping `ready` unsent (RecvError, matching
                 // the "shutdown before ready" semantics for the ordinary
                 // case).
@@ -221,12 +225,24 @@ impl ChainPlugin for TapPlugin {
             Err(_) => {
                 inner_handle.abort();
                 let _ = inner_handle.await;
-                let _ = ready.send(Err(StartError::Fatal {
-                    detail: format!(
-                        "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
-                    ),
-                    errno: None,
-                }));
+                // Same recovery as the two arms above: the inner may have
+                // already delivered a specific `StartError` (e.g.
+                // `BindConflict`) on its own readiness channel before this
+                // timeout fired — a point-in-time, non-blocking snapshot
+                // (`abort()` only stops `inner_handle`'s own task, not a
+                // detached reader/self-probe task that might still own the
+                // sender, so this can't be turned into an await without the
+                // same deadlock risk documented on the arms above).
+                let err = match crate::chain::scan_for_delivered_error(std::iter::once(&mut inner_ready_rx)) {
+                    Some(e) if !matches!(e, StartError::ExitedBeforeReady) => e,
+                    _ => StartError::Fatal {
+                        detail: format!(
+                            "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
+                        ),
+                        errno: None,
+                    },
+                };
+                let _ = ready.send(Err(err));
                 return Err(crate::Error::Chain(format!(
                     "tap[{plugin_name}]: inner plugin did not bind {inner_local} within {INNER_READY_TIMEOUT:?}"
                 )));

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -142,10 +142,7 @@ impl ChainPlugin for TapPlugin {
                 // tap listener was ever opened. Report the inner's failure
                 // through our own readiness channel so the chain aggregator
                 // sees a typed cause.
-                let _ = ready.send(Err(StartError::Fatal {
-                    detail: format!("tap[{plugin_name}]: inner exited before becoming ready"),
-                    errno: None,
-                }));
+                let _ = ready.send(Err(StartError::ExitedBeforeReady));
                 return match join {
                     Ok(result) => result,
                     Err(je) => Err(crate::Error::Chain(format!("tap[{plugin_name}]: inner task: {je}"))),

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -21,10 +21,12 @@
 //!    that internal port.
 //! 3. Wait for the inner plugin to actually accept TCP via
 //!    [`crate::chain::poll_ready`], racing the inner task's `JoinHandle`
-//!    so an early inner failure unblocks us. (The inner's own readiness
-//!    channel is discarded — the tap detects inner readiness by the probe
-//!    and inner failure by the join.) Bounded at 30s; on timeout the
-//!    inner task is aborted and `Error::Chain` propagates.
+//!    so an early inner failure unblocks us. (Inner readiness itself is
+//!    still detected by the probe, not the inner's own readiness channel —
+//!    but on the early-exit race arm, a specific `StartError` already
+//!    delivered on that channel is recovered rather than lost.) Bounded at
+//!    30s; on timeout the inner task is aborted and `Error::Chain`
+//!    propagates.
 //! 4. Bind the tap's public listener on `local` (only after step 3, so the
 //!    public bind happens only once the data plane is actually wired
 //!    through), then report the tap's OWN readiness on the `ready` channel
@@ -119,13 +121,16 @@ impl ChainPlugin for TapPlugin {
             }
         };
 
-        // 2. Spawn the inner plugin against `inner_local`. The trait
-        //    requires a readiness channel, but the tap discards the inner's
-        //    (it detects inner readiness via the TCP probe in step 3 and
-        //    inner failure via the join); the tap reports its OWN readiness
-        //    (below) once the public listener is bound.
+        // 2. Spawn the inner plugin against `inner_local`. The tap detects
+        //    inner readiness via the TCP probe in step 3 and inner SUCCESS
+        //    via the join, not via the inner's own readiness channel — but
+        //    that channel is still kept (not discarded): on the inner-exit
+        //    race arm below, a specific `StartError` the inner already
+        //    delivered on it is recovered rather than lost, so the tap
+        //    reports its OWN readiness (below) once the public listener is
+        //    bound.
         let inner_shutdown = shutdown.clone();
-        let (inner_ready_tx, _inner_ready_rx) = oneshot::channel();
+        let (inner_ready_tx, mut inner_ready_rx) = oneshot::channel();
         let mut inner_handle = tokio::spawn(self.inner.run(inner_local, remote, inner_shutdown, inner_ready_tx));
 
         // 3. Wait for the inner plugin to bind the inner port. Race
@@ -139,10 +144,33 @@ impl ChainPlugin for TapPlugin {
             r = tokio::time::timeout(INNER_READY_TIMEOUT, crate::chain::poll_ready(inner_local, ready_token)) => r,
             join = &mut inner_handle => {
                 // Inner exited before binding — propagate its result. No
-                // tap listener was ever opened. Report the inner's failure
-                // through our own readiness channel so the chain aggregator
-                // sees a typed cause.
-                let _ = ready.send(Err(StartError::ExitedBeforeReady));
+                // tap listener was ever opened. The inner may have already
+                // delivered a specific `StartError` (e.g. `BindConflict`)
+                // on its own readiness channel before exiting; forward that
+                // instead of the generic placeholder, so a retryable class
+                // survives through the tap — mirroring
+                // `chain::scan_for_delivered_error`, which the aggregator
+                // applies for the same reason. If the inner sent nothing at
+                // all (a clean, silent exit — e.g. `join` resolves
+                // `Ok(Ok(()))`), fall back to a name-bearing `Fatal` rather
+                // than the bare `ExitedBeforeReady` placeholder: a caller
+                // that later joins the WHOLE chain's own driving task to
+                // recover more detail (bridge's `recover_exit_detail`) finds
+                // nothing better than the same already-resolved `Ok(Ok(()))`
+                // this arm is looking at right now, so naming which plugin,
+                // wrapped by which tap, right here is strictly more useful
+                // than deferring to a recovery that cannot succeed.
+                // `scan_for_delivered_error` returns `Some(ExitedBeforeReady)`
+                // itself (not `None`) for "closed, nothing specific" — so the
+                // fallback below must match on THAT too, not just `None`.
+                let err = match crate::chain::scan_for_delivered_error(std::iter::once(&mut inner_ready_rx)) {
+                    Some(e) if !matches!(e, StartError::ExitedBeforeReady) => e,
+                    _ => StartError::Fatal {
+                        detail: format!("tap[{plugin_name}]: inner exited before becoming ready"),
+                        errno: None,
+                    },
+                };
+                let _ = ready.send(Err(err));
                 return match join {
                     Ok(result) => result,
                     Err(je) => Err(crate::Error::Chain(format!("tap[{plugin_name}]: inner task: {je}"))),

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -152,6 +152,33 @@ impl ChainPlugin for ExitsBeforeReadyPlugin {
     }
 }
 
+/// Drops its readiness channel unsent (like `ExitsBeforeReadyPlugin`) but
+/// returns a specific `Err` from `run()` itself — the shape a malformed
+/// SS_PLUGIN_OPTIONS string produces (`BinaryPlugin::run` fails via
+/// `Mode::from_plugin_options`? before ever touching `ready`). Pins that
+/// this reaches the tap's `ready.send`, not just `join`'s own return value.
+struct ExitsWithASpecificErrorPlugin;
+
+#[async_trait::async_trait]
+impl ChainPlugin for ExitsWithASpecificErrorPlugin {
+    fn name(&self) -> &str {
+        "exits-with-a-specific-error"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        _local: SocketAddr,
+        _remote: SocketAddr,
+        _shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
+    ) -> crate::Result<()> {
+        drop(ready);
+        Err(crate::Error::Chain(
+            "malformed SS_PLUGIN_OPTIONS: plugin options end in an unpaired backslash".into(),
+        ))
+    }
+}
+
 /// Sends a specific `StartError::BindConflict` on its own readiness channel
 /// then exits — the shape that used to collapse to a bare
 /// `ExitedBeforeReady` through the tap's inner-exit race arm before it
@@ -474,6 +501,42 @@ async fn tap_reports_a_name_bearing_fatal_when_inner_exits_cleanly_and_silently(
             );
         }
         other => panic!("expected a name-bearing Fatal, got {other:?}"),
+    }
+}
+
+// When the inner returns a SPECIFIC `Err` from `run()` itself (e.g. a
+// malformed-options error `BinaryPlugin::run` returns before ever touching
+// `ready`) without ever sending on its own readiness channel, the tap must
+// forward that text, not the generic "inner exited before becoming ready"
+// placeholder. Losing it here is worse than the clean-silent-exit case:
+// bridge's `spawn_plugin_runner_at` treats a `Fatal` as already-as-specific-
+// as-it-gets and does not join the handle for more detail, so a `Fatal`
+// without this text would discard the real reason permanently, not just
+// defer recovering it.
+#[skuld::test]
+async fn tap_forwards_the_inner_runs_own_specific_error_when_it_exits_silently() {
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new();
+    let inner = Box::new(ExitsWithASpecificErrorPlugin) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let _ = tap.run(local, remote, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("tap must report something on its own ready channel");
+    match outcome {
+        Err(crate::sitrep::StartError::Fatal { detail, errno: None }) => {
+            assert!(
+                detail.contains("exits-with-a-specific-error")
+                    && detail.contains("malformed SS_PLUGIN_OPTIONS")
+                    && detail.contains("unpaired backslash"),
+                "expected the plugin name and the inner's own specific reason in the detail, got {detail:?}"
+            );
+        }
+        other => panic!("expected a Fatal carrying the inner's specific reason, got {other:?}"),
     }
 }
 

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -152,10 +152,49 @@ impl ChainPlugin for ExitsBeforeReadyPlugin {
     }
 }
 
+/// Mimics `BinaryPlugin::run`'s `ReadinessMode::Probe` shape exactly: hands
+/// `ready` to a DETACHED spawned task (never joined by `run` itself) that
+/// only resolves it once `shutdown` fires (or the target ever becomes
+/// reachable, which it never will here) — `run` itself returns `Ok(())`
+/// immediately, well before that. Nothing OTHER than the tap's own eventual
+/// exit would ever cancel `shutdown` in this shape, matching production:
+/// `record_exit` only fires once `TapPlugin::run`'s own task completes.
+/// Regression coverage for a real, reproduced deadlock (see
+/// `tap_join_arm_does_not_deadlock_on_a_probe_mode_inner_with_no_external_shutdown`):
+/// an earlier attempt to `.await` this receiver (instead of `try_recv`) in
+/// the `join` arm hung indefinitely, since resolving it required `shutdown`
+/// to fire, which required this very task to return first.
+struct ProbeModeLikePlugin;
+
+#[async_trait::async_trait]
+impl ChainPlugin for ProbeModeLikePlugin {
+    fn name(&self) -> &str {
+        "probe-mode-like"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        _remote: SocketAddr,
+        shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
+    ) -> crate::Result<()> {
+        tokio::spawn(async move {
+            if let Some(addr) = crate::chain::poll_ready(local, shutdown).await {
+                let _ = ready.send(Ok(crate::sitrep::PluginReady {
+                    listen: addr,
+                    transports: crate::sitrep::Transports::TCP,
+                }));
+            }
+        });
+        Ok(())
+    }
+}
+
 /// Drops its readiness channel unsent (like `ExitsBeforeReadyPlugin`) but
 /// returns a specific `Err` from `run()` itself — the shape a malformed
 /// SS_PLUGIN_OPTIONS string produces (`BinaryPlugin::run` fails via
-/// `Mode::from_plugin_options`? before ever touching `ready`). Pins that
+/// `Mode::from_plugin_options` before ever touching `ready`). Pins that
 /// this reaches the tap's `ready.send`, not just `join`'s own return value.
 struct ExitsWithASpecificErrorPlugin;
 
@@ -180,10 +219,9 @@ impl ChainPlugin for ExitsWithASpecificErrorPlugin {
 }
 
 /// Sends a specific `StartError::BindConflict` on its own readiness channel
-/// then exits — the shape that used to collapse to a bare
-/// `ExitedBeforeReady` through the tap's inner-exit race arm before it
-/// recovered a delivered error the same way the chain aggregator does. See
-/// `TapPlugin::run`'s inner-exit race doc comment.
+/// then exits — pins that the tap's inner-exit race recovers a delivered
+/// error the same way the chain aggregator does. See `TapPlugin::run`'s
+/// inner-exit race doc comment.
 struct BindConflictPlugin;
 
 #[async_trait::async_trait]
@@ -582,4 +620,35 @@ async fn counting_stream_smoke() {
     counted.read_exact(&mut buf).await.unwrap();
     assert_eq!(counters.read(), 3);
     server.await.unwrap();
+}
+
+// Regression test for a real, previously-reproduced deadlock (see
+// `scan_for_delivered_error`'s and `TapPlugin::run`'s doc comments): the
+// join arm must use a point-in-time `try_recv` snapshot, never an
+// await-to-resolution drain, on `inner_ready_rx`. `ProbeModeLikePlugin`
+// reproduces `BinaryPlugin::run`'s `ReadinessMode::Probe` shape exactly —
+// its readiness sender lives in a detached task gated on `shutdown`, which
+// nothing but the tap's own eventual exit would ever cancel. If this arm
+// were changed back to an await-based drain, this test would hang past its
+// bound instead of returning promptly.
+#[skuld::test]
+async fn tap_join_arm_does_not_deadlock_on_a_probe_mode_inner_with_no_external_shutdown() {
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new(); // never cancelled by this test
+    let inner = Box::new(ProbeModeLikePlugin) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
+    // The timeout here is a failure bound surfaced to the test, not a
+    // synchronization primitive: `tap.run` genuinely might never return if
+    // this arm regresses to an await-based drain, and there is no other
+    // event to wait on that would prove that. A generous, hang-detecting
+    // bound, not a race with the correct outcome.
+    let outcome = tokio::time::timeout(Duration::from_secs(10), tap.run(local, remote, shutdown, ready_tx)).await;
+    assert!(
+        outcome.is_ok(),
+        "TapPlugin::run's join arm deadlocked on a Probe-mode inner with no external shutdown trigger \
+         — it must scan (try_recv) inner_ready_rx, never await it"
+    );
 }

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -152,6 +152,34 @@ impl ChainPlugin for ExitsBeforeReadyPlugin {
     }
 }
 
+/// Sends a specific `StartError::BindConflict` on its own readiness channel
+/// then exits — the shape that used to collapse to a bare
+/// `ExitedBeforeReady` through the tap's inner-exit race arm before it
+/// recovered a delivered error the same way the chain aggregator does. See
+/// `TapPlugin::run`'s inner-exit race doc comment.
+struct BindConflictPlugin;
+
+#[async_trait::async_trait]
+impl ChainPlugin for BindConflictPlugin {
+    fn name(&self) -> &str {
+        "bind-conflict"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        _remote: SocketAddr,
+        _shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
+    ) -> crate::Result<()> {
+        let _ = ready.send(Err(crate::sitrep::StartError::BindConflict {
+            errno: 10048,
+            addr: local,
+        }));
+        Ok(())
+    }
+}
+
 fn unused_remote() -> SocketAddr {
     // The stubs ignore `remote`; any valid address works.
     "127.0.0.1:1".parse().unwrap()
@@ -416,12 +444,16 @@ async fn cross_check_inbound_and_upstream_counters_match() {
     );
 }
 
-// `StartError::ExitedBeforeReady` lets a caller `match` on the variant
-// instead of comparing `detail` text (see its doc comment, which names
-// TapPlugin's inner-exit race by name) — this pins that TapPlugin actually
-// emits it.
+// When the inner exits cleanly and silently — never sending anything on its
+// own readiness channel — the tap has NOTHING to recover beyond what it
+// already knows: which plugin, wrapped by which tap, didn't bind. So it
+// reports a name-bearing `Fatal` directly rather than the bare
+// `ExitedBeforeReady` placeholder — a caller that later joins the whole
+// chain's own driving task for more detail (bridge's `recover_exit_detail`)
+// would find only the same already-resolved clean exit and recover nothing
+// better, so deferring to it here would only lose the plugin name for free.
 #[skuld::test]
-async fn tap_reports_exited_before_ready_when_inner_exits_without_binding() {
+async fn tap_reports_a_name_bearing_fatal_when_inner_exits_cleanly_and_silently() {
     let local = pick_local().await;
     let remote = unused_remote();
     let shutdown = CancellationToken::new();
@@ -434,9 +466,39 @@ async fn tap_reports_exited_before_ready_when_inner_exits_without_binding() {
     let outcome = ready_rx
         .await
         .expect("tap must report something on its own ready channel");
+    match outcome {
+        Err(crate::sitrep::StartError::Fatal { detail, errno: None }) => {
+            assert!(
+                detail.contains("exits-before-ready") && detail.contains("inner exited before becoming ready"),
+                "expected the plugin name and reason in the detail, got {detail:?}"
+            );
+        }
+        other => panic!("expected a name-bearing Fatal, got {other:?}"),
+    }
+}
+
+// A specific `StartError` the inner delivered on its own readiness channel
+// before exiting must survive the tap's inner-exit race, not collapse to
+// the generic `ExitedBeforeReady` placeholder — `BindConflict` is the only
+// retryable class, so losing it here turns a transient port collision into
+// a hard failure.
+#[skuld::test]
+async fn tap_forwards_a_specific_bind_conflict_the_inner_delivered_before_exiting() {
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new();
+    let inner = Box::new(BindConflictPlugin) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let _ = tap.run(local, remote, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("tap must report something on its own ready channel");
     assert!(
-        matches!(outcome, Err(crate::sitrep::StartError::ExitedBeforeReady)),
-        "expected ExitedBeforeReady, got {outcome:?}"
+        matches!(outcome, Err(crate::sitrep::StartError::BindConflict { .. })),
+        "expected the inner's BindConflict to survive the tap, got {outcome:?}"
     );
 }
 

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -129,6 +129,29 @@ async fn handle_stub_conn(mut stream: TcpStream, behavior: Behavior) {
     }
 }
 
+/// Never binds anything and returns immediately without ever sending on its
+/// `ready` channel — the shape `TapPlugin::run`'s inner-exit race (see its
+/// doc comment) exists to detect.
+struct ExitsBeforeReadyPlugin;
+
+#[async_trait::async_trait]
+impl ChainPlugin for ExitsBeforeReadyPlugin {
+    fn name(&self) -> &str {
+        "exits-before-ready"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        _local: SocketAddr,
+        _remote: SocketAddr,
+        _shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
+    ) -> crate::Result<()> {
+        drop(ready);
+        Ok(())
+    }
+}
+
 fn unused_remote() -> SocketAddr {
     // The stubs ignore `remote`; any valid address works.
     "127.0.0.1:1".parse().unwrap()
@@ -390,6 +413,30 @@ async fn cross_check_inbound_and_upstream_counters_match() {
     assert!(
         captured.contains("bytes_inbound_written=7"),
         "inbound_written=7:\n{captured}"
+    );
+}
+
+// This PR introduced `StartError::ExitedBeforeReady` specifically so a caller
+// can `match` on the variant instead of comparing `detail` text (see its doc
+// comment, which names TapPlugin's inner-exit race by name) — this pins that
+// TapPlugin actually emits it, not the `Fatal` variant it used before.
+#[skuld::test]
+async fn tap_reports_exited_before_ready_when_inner_exits_without_binding() {
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new();
+    let inner = Box::new(ExitsBeforeReadyPlugin) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let _ = tap.run(local, remote, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("tap must report something on its own ready channel");
+    assert!(
+        matches!(outcome, Err(crate::sitrep::StartError::ExitedBeforeReady)),
+        "expected ExitedBeforeReady, got {outcome:?}"
     );
 }
 

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -207,6 +207,40 @@ impl ChainPlugin for BindConflictPlugin {
     }
 }
 
+/// Mimics `BinaryPlugin::run`'s real shape (not `BindConflictPlugin`'s
+/// simplified one): hands `ready` to a DETACHED spawned task — never
+/// joined by `run` itself before it returns — that sends a specific
+/// `StartError` only after a couple of scheduler yields. `run` returns
+/// `Ok(())` immediately, well before that send happens. This is the exact
+/// race `TapPlugin::run`'s `join` arm uses `drain_for_delivered_error`
+/// (await, not `try_recv`) to close.
+struct DetachedSenderPlugin;
+
+#[async_trait::async_trait]
+impl ChainPlugin for DetachedSenderPlugin {
+    fn name(&self) -> &str {
+        "detached-sender"
+    }
+
+    async fn run(
+        self: Box<Self>,
+        local: SocketAddr,
+        _remote: SocketAddr,
+        _shutdown: CancellationToken,
+        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
+    ) -> crate::Result<()> {
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            tokio::task::yield_now().await;
+            let _ = ready.send(Err(crate::sitrep::StartError::BindConflict {
+                errno: 10048,
+                addr: local,
+            }));
+        });
+        Ok(())
+    }
+}
+
 fn unused_remote() -> SocketAddr {
     // The stubs ignore `remote`; any valid address works.
     "127.0.0.1:1".parse().unwrap()
@@ -562,6 +596,36 @@ async fn tap_forwards_a_specific_bind_conflict_the_inner_delivered_before_exitin
     assert!(
         matches!(outcome, Err(crate::sitrep::StartError::BindConflict { .. })),
         "expected the inner's BindConflict to survive the tap, got {outcome:?}"
+    );
+}
+
+// `BinaryPlugin::run` hands its readiness sender to a spawned reader task
+// it only best-effort-joins (a short grace window) before returning — so
+// `inner_handle` completing does NOT mean the sender has resolved yet. A
+// plain `try_recv` snapshot at that point would see `Empty` and lose a
+// `BindConflict` sent moments later. This pins that the tap's `join` arm
+// recovers it anyway (via `drain_for_delivered_error`, not
+// `scan_for_delivered_error`).
+#[skuld::test]
+async fn tap_forwards_a_bind_conflict_delivered_by_a_detached_task_after_inner_run_returns() {
+    let local = pick_local().await;
+    let remote = unused_remote();
+    let shutdown = CancellationToken::new();
+    let inner = Box::new(DetachedSenderPlugin) as Box<dyn ChainPlugin>;
+    let tap = Box::new(TapPlugin::wrap(inner));
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let _ = tap.run(local, remote, shutdown, ready_tx).await;
+
+    let outcome = ready_rx
+        .await
+        .expect("tap must report something on its own ready channel");
+    assert!(
+        matches!(
+            outcome,
+            Err(crate::sitrep::StartError::BindConflict { errno: 10048, .. })
+        ),
+        "expected the detached task's BindConflict, delivered after inner.run() returned, to survive, got {outcome:?}"
     );
 }
 

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -419,7 +419,7 @@ async fn cross_check_inbound_and_upstream_counters_match() {
 // `StartError::ExitedBeforeReady` lets a caller `match` on the variant
 // instead of comparing `detail` text (see its doc comment, which names
 // TapPlugin's inner-exit race by name) — this pins that TapPlugin actually
-// emits it, not the `Fatal` variant it used before.
+// emits it.
 #[skuld::test]
 async fn tap_reports_exited_before_ready_when_inner_exits_without_binding() {
     let local = pick_local().await;

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -416,10 +416,10 @@ async fn cross_check_inbound_and_upstream_counters_match() {
     );
 }
 
-// This PR introduced `StartError::ExitedBeforeReady` specifically so a caller
-// can `match` on the variant instead of comparing `detail` text (see its doc
-// comment, which names TapPlugin's inner-exit race by name) — this pins that
-// TapPlugin actually emits it, not the `Fatal` variant it used before.
+// `StartError::ExitedBeforeReady` lets a caller `match` on the variant
+// instead of comparing `detail` text (see its doc comment, which names
+// TapPlugin's inner-exit race by name) — this pins that TapPlugin actually
+// emits it, not the `Fatal` variant it used before.
 #[skuld::test]
 async fn tap_reports_exited_before_ready_when_inner_exits_without_binding() {
     let local = pick_local().await;

--- a/crates/garter/src/tap_tests.rs
+++ b/crates/garter/src/tap_tests.rs
@@ -207,40 +207,6 @@ impl ChainPlugin for BindConflictPlugin {
     }
 }
 
-/// Mimics `BinaryPlugin::run`'s real shape (not `BindConflictPlugin`'s
-/// simplified one): hands `ready` to a DETACHED spawned task — never
-/// joined by `run` itself before it returns — that sends a specific
-/// `StartError` only after a couple of scheduler yields. `run` returns
-/// `Ok(())` immediately, well before that send happens. This is the exact
-/// race `TapPlugin::run`'s `join` arm uses `drain_for_delivered_error`
-/// (await, not `try_recv`) to close.
-struct DetachedSenderPlugin;
-
-#[async_trait::async_trait]
-impl ChainPlugin for DetachedSenderPlugin {
-    fn name(&self) -> &str {
-        "detached-sender"
-    }
-
-    async fn run(
-        self: Box<Self>,
-        local: SocketAddr,
-        _remote: SocketAddr,
-        _shutdown: CancellationToken,
-        ready: tokio::sync::oneshot::Sender<Result<crate::sitrep::PluginReady, crate::sitrep::StartError>>,
-    ) -> crate::Result<()> {
-        tokio::spawn(async move {
-            tokio::task::yield_now().await;
-            tokio::task::yield_now().await;
-            let _ = ready.send(Err(crate::sitrep::StartError::BindConflict {
-                errno: 10048,
-                addr: local,
-            }));
-        });
-        Ok(())
-    }
-}
-
 fn unused_remote() -> SocketAddr {
     // The stubs ignore `remote`; any valid address works.
     "127.0.0.1:1".parse().unwrap()
@@ -596,36 +562,6 @@ async fn tap_forwards_a_specific_bind_conflict_the_inner_delivered_before_exitin
     assert!(
         matches!(outcome, Err(crate::sitrep::StartError::BindConflict { .. })),
         "expected the inner's BindConflict to survive the tap, got {outcome:?}"
-    );
-}
-
-// `BinaryPlugin::run` hands its readiness sender to a spawned reader task
-// it only best-effort-joins (a short grace window) before returning — so
-// `inner_handle` completing does NOT mean the sender has resolved yet. A
-// plain `try_recv` snapshot at that point would see `Empty` and lose a
-// `BindConflict` sent moments later. This pins that the tap's `join` arm
-// recovers it anyway (via `drain_for_delivered_error`, not
-// `scan_for_delivered_error`).
-#[skuld::test]
-async fn tap_forwards_a_bind_conflict_delivered_by_a_detached_task_after_inner_run_returns() {
-    let local = pick_local().await;
-    let remote = unused_remote();
-    let shutdown = CancellationToken::new();
-    let inner = Box::new(DetachedSenderPlugin) as Box<dyn ChainPlugin>;
-    let tap = Box::new(TapPlugin::wrap(inner));
-
-    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-    let _ = tap.run(local, remote, shutdown, ready_tx).await;
-
-    let outcome = ready_rx
-        .await
-        .expect("tap must report something on its own ready channel");
-    assert!(
-        matches!(
-            outcome,
-            Err(crate::sitrep::StartError::BindConflict { errno: 10048, .. })
-        ),
-        "expected the detached task's BindConflict, delivered after inner.run() returned, to survive, got {outcome:?}"
     );
 }
 

--- a/crates/plugin-e2e/src/roundtrip.rs
+++ b/crates/plugin-e2e/src/roundtrip.rs
@@ -144,10 +144,10 @@ pub async fn run_roundtrip(
     let listen = match timeout(cfg.ready_timeout, ready_rx).await {
         Ok(Ok(Ok(chain_ready))) => chain_ready.listen,
         // A generic `ExitedBeforeReady` joins `handle` for a specific reason
-        // instead of discarding it — e.g. a malformed `client_opts` string
-        // now fails `BinaryPlugin::run` (via `Mode::from_plugin_options`)
-        // before it ever touches `ready`, so the readiness signal alone
-        // carries no diagnosis — delegates to `garter::recover_exit_detail_from_joined`,
+        // — e.g. a malformed `client_opts` string fails `BinaryPlugin::run`
+        // (via `Mode::from_plugin_options`) before it ever touches `ready`,
+        // so the readiness signal alone carries no diagnosis — delegates to
+        // `garter::recover_exit_detail_from_joined`,
         // the same recovery bridge's and galoshes' own `recover_exit_detail`
         // callers use for the identical gap. Any OTHER `StartError`
         // (`BindConflict`, `Fatal`) is already as specific as it gets and

--- a/crates/plugin-e2e/src/roundtrip.rs
+++ b/crates/plugin-e2e/src/roundtrip.rs
@@ -143,15 +143,28 @@ pub async fn run_roundtrip(
 
     let listen = match timeout(cfg.ready_timeout, ready_rx).await {
         Ok(Ok(Ok(chain_ready))) => chain_ready.listen,
+        // Both arms below join `handle` for a specific reason instead of
+        // discarding it — e.g. a malformed `client_opts` string now fails
+        // `BinaryPlugin::run` (via `Mode::from_plugin_options`) before it
+        // ever touches `ready`, so the readiness signal alone (a bare
+        // `StartError::ExitedBeforeReady`, or `ready_tx` dropped unsent)
+        // carries no diagnosis — mirrors bridge's own `recover_exit_detail`
+        // for the identical gap.
         Ok(Ok(Err(start_err))) => {
             cancel.cancel();
-            let _ = handle.await;
-            return Roundtrip::ChainFailed(format!("{start_err:?}"));
+            let detail = match handle.await {
+                Ok(Err(e)) => e.to_string(),
+                _ => format!("{start_err:?}"),
+            };
+            return Roundtrip::ChainFailed(detail);
         }
         Ok(Err(_recv)) => {
             cancel.cancel();
-            let _ = handle.await;
-            return Roundtrip::ChainFailed("client plugin exited before becoming ready".into());
+            let detail = match handle.await {
+                Ok(Err(e)) => e.to_string(),
+                _ => "client plugin exited before becoming ready".into(),
+            };
+            return Roundtrip::ChainFailed(detail);
         }
         Err(_timeout) => {
             cancel.cancel();

--- a/crates/plugin-e2e/src/roundtrip.rs
+++ b/crates/plugin-e2e/src/roundtrip.rs
@@ -143,27 +143,29 @@ pub async fn run_roundtrip(
 
     let listen = match timeout(cfg.ready_timeout, ready_rx).await {
         Ok(Ok(Ok(chain_ready))) => chain_ready.listen,
-        // Both arms below join `handle` for a specific reason instead of
-        // discarding it — e.g. a malformed `client_opts` string now fails
-        // `BinaryPlugin::run` (via `Mode::from_plugin_options`) before it
-        // ever touches `ready`, so the readiness signal alone (a bare
-        // `StartError::ExitedBeforeReady`, or `ready_tx` dropped unsent)
-        // carries no diagnosis — mirrors bridge's own `recover_exit_detail`
-        // for the identical gap.
+        // A generic `ExitedBeforeReady` joins `handle` for a specific reason
+        // instead of discarding it — e.g. a malformed `client_opts` string
+        // now fails `BinaryPlugin::run` (via `Mode::from_plugin_options`)
+        // before it ever touches `ready`, so the readiness signal alone
+        // carries no diagnosis — delegates to `garter::recover_exit_detail_from_joined`,
+        // the same recovery bridge's and galoshes' own `recover_exit_detail`
+        // callers use for the identical gap. Any OTHER `StartError`
+        // (`BindConflict`, `Fatal`) is already as specific as it gets and
+        // must not be overridden by whatever `ChainRunner::run` happens to
+        // return on teardown (e.g. a generic "drain timeout expired").
+        Ok(Ok(Err(garter::StartError::ExitedBeforeReady))) => {
+            cancel.cancel();
+            let detail = garter::recover_exit_detail_from_joined(&handle.await);
+            return Roundtrip::ChainFailed(detail);
+        }
         Ok(Ok(Err(start_err))) => {
             cancel.cancel();
-            let detail = match handle.await {
-                Ok(Err(e)) => e.to_string(),
-                _ => format!("{start_err:?}"),
-            };
-            return Roundtrip::ChainFailed(detail);
+            let _ = handle.await;
+            return Roundtrip::ChainFailed(format!("{start_err:?}"));
         }
         Ok(Err(_recv)) => {
             cancel.cancel();
-            let detail = match handle.await {
-                Ok(Err(e)) => e.to_string(),
-                _ => "client plugin exited before becoming ready".into(),
-            };
+            let detail = garter::recover_exit_detail_from_joined(&handle.await);
             return Roundtrip::ChainFailed(detail);
         }
         Err(_timeout) => {

--- a/crates/plugin-e2e/src/ssserver.rs
+++ b/crates/plugin-e2e/src/ssserver.rs
@@ -275,7 +275,12 @@ async fn spawn_ss_with_plugin(
                 let _ = chain.await;
                 panic!("server plugin failed to start: {detail} (errno={errno:?})");
             }
-            Ok(Err(_recv)) => {
+            // Two distinct signals with the same diagnosis here: the
+            // aggregator synthesized `ExitedBeforeReady`, or the chain-level
+            // ready oneshot itself dropped unsent — this fixture doesn't
+            // need bridge's `recover_exit_detail` treatment, just to fail
+            // loudly either way.
+            Ok(Ok(Err(StartError::ExitedBeforeReady))) | Ok(Err(_)) => {
                 cancel.cancel();
                 let outcome = chain.await;
                 panic!("server plugin exited before readiness: {outcome:?}");

--- a/crates/plugin-e2e/tests/roundtrip.rs
+++ b/crates/plugin-e2e/tests/roundtrip.rs
@@ -107,7 +107,7 @@ mod malformed_options {
             assert!(!out.status.success(), "galoshes must refuse to start: {:?}", out.status);
             let stderr = String::from_utf8_lossy(&out.stderr);
             assert!(
-                stderr.contains("embedded ex-ray") && stderr.contains("unpaired backslash"),
+                stderr.contains("malformed SS_PLUGIN_OPTIONS") && stderr.contains("unpaired backslash"),
                 "stderr must name the malformed options as the reason, got: {stderr}"
             );
         });


### PR DESCRIPTION
Closes #734, closes #738.

`garter::parse_plugin_options` used a narrower unescape rule than ex-ray's `indexUnescaped` (`crates/ex-ray/args.go`), so a key could be spelled in a form garter didn't recognise but ex-ray did — evading key-based filtering (#734) and making `Mode::from_plugin_options` disagree with ex-ray about client/server direction (#738). Rewrites `parse_plugin_options` to delegate to the already-correct `split_plugin_options` (landed in #736), making it fallible. That signature change ripples through every real caller across `garter`, `garter-bin`, `bridge`, and `galoshes`.

## Breaking changes
- `garter::parse_plugin_options` and `garter::Mode::from_plugin_options` are now fallible (`Result<_, MalformedOptions>`), matching `garter::classify_transport`-adjacent primitives already introduced in #736. `garter` is 0.x; every caller is inside this repo.
- `garter-bin`'s `config=` value now decodes with the same reference rule as everything else, so an unescaped Windows-style path (e.g. `config=C:\Users\x\chain.yaml`) that worked by accident of the old lenient rule now fails to load — with a hard, actionable error naming the escaping as the cause and offering corrected `\`-doubled and `/`-forward-slash spellings. `garter-bin` is `publish = false` (standalone chain runner, not shipped to end users).

## Also fixed while auditing every `parse_plugin_options`/`classify_transport` caller for #738's "decision from a key name" class
- `bridge::proxy::plugin::inject_plugin_directives` now validates the options string for *every* plugin name, not just `v2ray-plugin`/`ex-ray`/`galoshes` — previously a malformed string for an unrecognized plugin name reached `BinaryPlugin` unvalidated.
- `garter-bin` validates every chain entry's `options` up front (`validate_chain_options`), before any plugin spawns.
- `galoshes`'s own `main()` now fails loud on a malformed `SS_PLUGIN_OPTIONS` via `Mode::from_plugin_options`'s own fallibility, rather than relying on `parse_udp_timeout`'s later `?` to catch it as an accident of statement order.
- `bridge::server_test::server_endpoint_is_udp` treats an unclassifiable options string as UDP (skip the TCP preflight) rather than guessing TCP — guessing TCP wrong reproduces the exact false `TcpTimeout`/`TcpRefused` verdict #421 fixed.
- `bridge::reachability::probe_server_reachability` reports `Inconclusive` on an unclassifiable options string rather than guessing a transport to connect with; `classify_transport`'s bare-`path`-vs-`path=`-vs-absent handling was also corrected to match ex-ray's actual `Args.Get`/flag-default semantics (three different values, not one collapsed default).
- `PluginEnv::from_env` no longer collapses a non-Unicode `SS_PLUGIN_OPTIONS` into the same `None` as "absent" (matches the existing `NotUnicode` handling already used for the other four `SS_*` vars).

## Also closes
- #756 — `run_readiness_aggregator`'s biased shutdown arm could discard an already-delivered `BindConflict`/`Fatal` (the only retryable start class), turning a transient local-port collision into a hard start failure instead of a silent retry. Pre-existing, not introduced here; found and fixed because this PR was already touching the same function (the new `StartError::ExitedBeforeReady` variant, needed for `Mode::from_plugin_options`'s own fallibility, required threading through the readiness aggregator). Four deterministic regression tests reproduce all three shapes of the bug without relying on timing.

## Filed, not fixed here
- #757 — galoshes' own sitrep emission still reports a generic placeholder for `StartError::ExitedBeforeReady` instead of recovering the specific cause, unlike this PR's new `recover_exit_detail` on the bridge side. Left as a tracked follow-up: symmetric recovery needs galoshes' emitter-vs-runner concurrency reworked, not a small patch.

## Known, deliberately out-of-scope divergences
- Bare-key value (`""` vs ex-ray's `"1"`) — filed as #744, queued as the immediate follow-up on this same file.
- Multi-defect error-precedence (which `MalformedOptions` variant wins when a string has more than one defect) — filed as #746, back of queue; both sides still reject the same inputs, only the diagnosed reason differs.
