### PR TITLE
fix(bridge): permit the fail-closed cover to reach ex-ray's own ECH-config DoH resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,11 @@ before editing; the sections linked below are the authoritative source.
   the bridge **disarms-not-drops** it across the restart and the new bridge
   re-adopts it (`decide_cover_recovery == Adopt`). The **transient**
   `install_failclosed_cover` (permit loopback + server, plus the resolver
-  Hole's own `ech-doh` URL names, when a plugin is configured — scoped to
-  TCP/443) is a bounded-window RAII guard engaged by every covered
-  (auto-connect) start.
+  Hole's own `ech-doh` URL names when it's the value ex-ray will actually dial
+  — `effective_ech_doh == Holes`, not merely a plugin being configured —
+  scoped to TCP/443) is a bounded-window RAII guard engaged by every covered
+  (auto-connect) start whose lockdown intent is OFF; a lockdown-on covered
+  start uses the standing cover instead and releases any held transient one.
   Both are persistent WFP filters (Win) / self-contained pf ruleset (mac), swept
   by `recover_routes` on next start. →
   [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,10 @@ before editing; the sections linked below are the authoritative source.
   (`Routing::install_lockdown`, opt-in kill switch) holds the update-cutover gap:
   the bridge **disarms-not-drops** it across the restart and the new bridge
   re-adopts it (`decide_cover_recovery == Adopt`). The **transient**
-  `install_failclosed_cover` (permit loopback + server only) is a bounded-window
-  RAII guard with **no production caller today** (test seam + recovery target).
+  `install_failclosed_cover` (permit loopback + server, plus the resolver
+  Hole's own `ech-doh` URL names, when a plugin is configured — scoped to
+  TCP/443) is a bounded-window RAII guard engaged by every covered
+  (auto-connect) start.
   Both are persistent WFP filters (Win) / self-contained pf ruleset (mac), swept
   by `recover_routes` on next start. →
   [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,7 +411,9 @@ naming the operator's URL. A repair's compensating restore can also leave the
 LIVE held cover's permit mismatched from what THIS attempt actually needs
 (the corrected engage failed) — a separate `warn!` fires for that case too,
 comparing against the live permit rather than re-trusting that the repair
-always converges. A THIRD case is untouched by this mechanism entirely
+always converges, in EITHER direction: too narrow (`Holes`, an ECH-fetch stall
+risk) or too wide (`None`, the kill switch permits a resolver address nothing
+needs). A THIRD case is untouched by this mechanism entirely
 (not merely a residual within it), **macOS only**: a restart that adopts a
 pre-existing [standing lockdown cover](#lockdown-mode) sees no transient
 cover engage at all, so there is no in-process signal to gate a diagnostic on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -546,15 +546,17 @@ checks those four address/port keys assuming client mode and skips the
 fatal.
 
 An explicit empty `host=` is fatal at parse time
-(`parseStringOption(..., emptyOK: false)`), so `*host` can never actually BE
-`""` when `buildTLSConfig` runs — v2ray-core's own `Config.ServerName`
+(`parseStringOption(..., emptyOK: false)`), so `*host` can never be `""`
+this way — but the reachable SNI check ALSO strips a literal
+`experiment:8357` prefix before testing domain-ness, mirroring v2ray-core's
+own `Config.parseServerName` (`ApplyECH` reads the STRIPPED `ServerName`,
+not the raw `host` value), and `*host` EXACTLY equal to that bare prefix
+strips to `""` without being fatal. v2ray-core's own `Config.ServerName`
 empty-`ServerName` fallback to the dial destination (`tls.WithDestination`,
-filling it from `remoteAddr`) still exists in the vendored source, just
-unreachable via `plugin_opts`, and `ech_fetch_is_reachable` does not model
-it. The reachable SNI check also strips a literal `experiment:8357` prefix
-before testing domain-ness, mirroring v2ray-core's own
-`Config.parseServerName` — `ApplyECH` reads the STRIPPED `ServerName`, not
-the raw `host` value.
+filling it from `remoteAddr`, applied BEFORE the `parseServerName`
+assignment and only when `ServerName` is still `""` at that point) IS
+reachable this way, and `ech_fetch_is_reachable` models it: the fetch's
+reachability then depends on `remoteAddr` instead.
 
 ### Lockdown mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -506,72 +506,105 @@ happen. `crate::proxy::plugin::ech_fetch_is_reachable` and its helper
 even attempt an ECH-config fetch, reading `plugin_opts` the way ex-ray's own
 SIP003 parser does (`ex_ray_flag_value`: a bare key is ex-ray's `"1"`, not
 `garter`'s `""`) and mirroring every `plugin_opts`-reachable config-build
-error ex-ray's `main.go`/`config.go` treats as `os.Exit(23)` — `ech`/`mode`
-closed enums, `mux`/`fwmark`/`tcp-keepalive` numeric ranges,
-`localPort`/`remotePort` port parsing (Go's `strconv.ParseUint` rejects a
-leading `+` that Rust's `u32::from_str` accepts — checked against both
-toolchains directly), and, checked separately and later (it fires inside
-`core.New`, only once `generateConfig` itself has already succeeded), the
-websocket transport's `mux` concurrency bound `1..=1024`. Each vendored
-literal this mirrors is pinned by an `include_str!`-based test against the
-vendored source (`ech_and_mode_enums_match_vendored_config_go`), so a future
-ex-ray bump that adds or renames a value fails loudly here instead of
+error ex-ray's `main.go`/`options.go`/`config.go` treats as `os.Exit(23)`.
+
+[#752](https://github.com/bindreams/hole/pull/752) rewrote the
+option-parsing step (`parseOptsIntoFlags`, `options.go`) to fail loud on a
+present-but-malformed value across the board, where several of these used
+to warn and keep the flag's default or apply nothing:
+
+- `mux`/`fwmark`/`tcp-keepalive` (`parseIntOption`): a present value
+  `strconv.Atoi` can't parse — non-numeric, or explicitly empty — is now
+  fatal (an operator's own unparseable `mux=` must not silently outrank
+  galoshes' appended `mux=0` and leave Mux.Cool on). A value that parses is
+  then range-checked as before: `tcp-keepalive` against `0..=32767`,
+  `mux`/`fwmark` against `uint32Opt`'s `0..=u32::MAX`.
+- `tls`/`server`/`fastOpen`/`__android_vpn` (`parseBoolOption`): a present
+  value other than `"1"` is now fatal — these used to be presence-only, any
+  value.
+- `host`/`path` (`parseStringOption`, `emptyOK=false`): a present but
+  EXPLICITLY EMPTY value is now fatal. This retires the old empty-`host=`
+  SNI fallback below.
+- `localAddr`/`localPort`/`remoteAddr`/`remotePort` are validated by
+  `main.go`/`generateConfig`, largely unchanged by #752 except that
+  `remotePort` now routes through the SAME `validPort`/`net.PortFromString`
+  as `localPort` (previously a bare `strconv.ParseUint` with no `65535`
+  ceiling and no `0` rejection): `localPort`/`remotePort` must be an
+  unsigned base-10 literal `<=65535`, not `0` (Go's `ParseUint` rejects a
+  leading `+` that Rust's `u32::from_str` accepts — checked against both
+  toolchains directly); `localAddr` must be a single (`|`-free) IP literal;
+  `remoteAddr` must not normalize to an empty domain or the unspecified IP
+  (`0.0.0.0`/`::`).
+- `ech` (`parseEnumOption`) is now validated UNCONDITIONALLY, at parse time
+  — before #752 the enum switch lived only inside `buildTLSConfig` (`if *tlsEnabled`), so an invalid `ech` with no `tls` and no `mode=quic` was
+  inert, not fatal. `generateConfig` separately rejects `ech=always` with
+  TLS not enabled — also NEW, a case that used to silently apply nothing.
+- `ech-doh` (`parseURLOption`): empty stays a documented no-op ("disables
+  ECH"), but a present, non-empty value that isn't a well-formed `https://`
+  URL with a host is now fatal — checked only for the operator's own value,
+  when it isn't displaced by Hole's own (always well-formed by
+  construction).
+- `cert`/`certRaw`/`key` present (non-empty) with TLS not enabled is now
+  fatal too — before, the material was silently never read.
+- `mode` (closed enum, `generateConfig`, unconditional) and, later —
+  checked separately, once `generateConfig` has already succeeded, inside
+  `core.New` — the websocket transport's `mux` concurrency bound `1..=1024`,
+  are unchanged by #752.
+
+`loglevel` is deliberately NOT modeled, even though #752 made an explicitly
+empty or unrecognized value fatal there too:
+`crate::proxy::plugin::inject_plugin_directives` always strips the
+operator's own `loglevel` and appends `loglevel=debug`, unconditionally,
+whatever Hole's own `ech-doh` decision is — no value from `plugin_opts`
+ever reaches ex-ray unmodified, so modeling it would produce a false fatal
+for a config that starts fine in practice, the opposite of the over-permit
+risk this gate exists to close.
+
+Each vendored numeric/enum literal this mirrors is pinned by an
+`include_str!`-based test against the vendored source
+(`ech_and_mode_enums_match_vendored_config_go`) — on the COMPARISON itself
+(e.g. `uint32Opt`'s `v <= math.MaxUint32`) where possible, not the error
+message text: #752 dropped `uint32Opt`'s `, got: <value>` message suffix (to
+stop a `mux=abc\;certRaw=SECRET`-shaped escape from leaking a later
+segment's value through it) without touching the bound it protects, which a
+message-text pin would have gone stale for — and did, the first time this
+gate hit that exact drift. A future ex-ray bump that adds or renames a
+value, or changes one of these bounds, fails loudly here instead of
 silently drifting.
-
-An explicit empty `host=` is NOT "no SNI": ex-ray's own `Config.ServerName`
-falls back to the DIAL DESTINATION when `host` is empty
-(`tls.WithDestination`), and that destination is `remoteAddr` — itself a
-`plugin_opts` option that can name a domain. `ech_fetch_is_reachable`
-resolves that fallback the same first-wins way as every other key here; an
-absent `remoteAddr` is correctly treated as an IP (Hole's own
-`SS_REMOTE_HOST`, which this function cannot see, is always an IP by
-construction — Hole resolves the server before ever spawning the plugin).
-
-`ech=always` with an empty *resolved* `ech-doh` — the value ex-ray actually
-receives once Hole's own injection wins or loses against the operator's own,
-not just the raw `ech-doh` segment — is itself an `os.Exit(23)` class
-(`config.go:218-220`, `"ech=always requires ech-doh to be set"`); detecting
-it needs that same precedence `classify_ech_doh` resolves, recomputed by
-`resolved_ech_doh_is_empty` rather than threaded through (the two functions
-would otherwise call each other in a cycle: `classify_ech_doh` calls
-`ech_fetch_is_reachable`, which calls `ex_ray_fatal_config_error`).
 
 **Disclosed, deliberately unmodeled:**
 
-- `cert` (an operator-supplied file path, `readCertificate`/
-  `filesystem.ReadFile`) can fail config-build, but only by reading the
-  filesystem — a check this otherwise pure, `plugin_opts`-only gate
-  deliberately does not perform: the same path could read successfully now
-  and fail moments later at the real spawn, or vice versa, so duplicating
-  the read here would be stale, not accurate. `certRaw` never fails on its
-  own.
+- `cert`/`certRaw`/`key`'s CONTENT (an operator-supplied file path or PEM
+  blob actually being a readable, well-formed X509 pair,
+  `readCertificate`/`filesystem.ReadFile`/`gotls.X509KeyPair`) can fail
+  config-build, but only by reading the filesystem — a check this
+  otherwise pure, `plugin_opts`-only gate deliberately does not perform: the
+  same path could read successfully now and fail moments later at the real
+  spawn, or vice versa, so duplicating the read here would be stale, not
+  accurate. Only their PRESENCE without TLS enabled is checked (above).
 - ex-ray's `server` plugin option (settable via `plugin_opts`, like `tls`)
-  cross-assigns `localPort`/`remotePort` to the opposite internal flag
-  (`tcp-keepalive`'s range check runs unconditionally regardless of
-  `server`, so that one is unaffected) — `ex_ray_fatal_config_error` does
-  not account for the cross-assignment. Hole's bridge never spawns ex-ray as
-  a server; an operator who puts `server` in their own `plugin_opts` already
-  has a tunnel that will not establish for a much more obvious reason
-  (ex-ray listens instead of connects) than anything this gate decides, so
-  the cross-assignment is not modeled — as is the trailing `mux` concurrency
-  check (below): `MultiplexingConfig` is attached only on ex-ray's
-  non-`server` branch, so this gate skips that check too whenever a
-  `server` segment is present, rather than reporting a false fatal.
-- On the `remoteAddr` SNI fallback (an explicit empty `host=`) only: ex-ray
-  applies `net.ParseAddress` TWICE on that path (once building the dial
-  destination, once more computing the ECH domain from the
-  destination-derived `ServerName`), while the gate normalizes once. The two
-  disagree only for a value where a SECOND unwrap still changes the result —
-  a doubly-bracketed `remoteAddr=[[::1]]` is the only class found so far.
-  Modeling the second pass needs mirroring v2ray-core's `Domain`/`IP`
-  address-family round-trip, not just another `net.ParseAddress` call; not
-  modeled.
+  cross-assigns `localAddr`/`localPort` with `remoteAddr`/`remotePort` to
+  the opposite internal flag (`tcp-keepalive`'s range check runs
+  unconditionally regardless of `server`, so that one is unaffected) —
+  `ex_ray_fatal_config_error` does not account for the cross-assignment, so
+  the four address/port checks above are checked assuming client mode.
+  Hole's bridge never spawns ex-ray as a server; an operator who puts
+  `server` in their own `plugin_opts` already has a tunnel that will not
+  establish for a much more obvious reason (ex-ray listens instead of
+  connects) than anything this gate decides, so the cross-assignment is not
+  modeled — as is the trailing `mux` concurrency check (below):
+  `MultiplexingConfig` is attached only on ex-ray's non-`server` branch, so
+  this gate skips that check too whenever a `server` segment is present,
+  rather than reporting a false fatal.
 
-The websocket transport's `mux` additionally has a SECOND, separately
-checked bound: `core.New` rejects a non-zero `Concurrency` outside
-`1..=1024` (third_party/v2ray-core/app/proxyman/outbound/handler.go), a
-narrower and later-evaluated check than `uint32Opt`'s own `0..=u32::MAX`
-(both pinned against the vendored source, same as the enum sets).
+An explicit empty `host=` used to NOT be "no SNI" before #752: ex-ray's own
+`Config.ServerName` fell back to the DIAL DESTINATION when `host` was empty
+(`tls.WithDestination`), and that destination is `remoteAddr` — itself a
+`plugin_opts` option that can name a domain. Since #752 rejects `host=` at
+parse time (`parseStringOption(..., emptyOK: false)`), `*host` can never
+actually BE `""` when that v2ray-core fallback would run — it still exists
+in the vendored source, just unreachable via `plugin_opts` now, and
+`ech_fetch_is_reachable` no longer models it.
 
 ### Lockdown mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,17 +341,82 @@ they permit.
 
 #### Transient cutover cover
 
-`Routing::install_failclosed_cover(server_ip)` engages a leak-free egress block —
-permit loopback and the SS server IP, **block everything else** — as an RAII
-guard whose `Drop` disengages it. It is a bounded-window kill switch holding the
-line regardless of [lockdown](#lockdown-mode); a crash while it is held leaves
-traffic **blocked, not leaked**. It has **no production caller today**: the
-[update cutover](#update-cutover) holds its gap with the *standing* lockdown cover
-(disarmed across the restart), not a transient one, and a lockdown-off cutover
-fails *open* by design. The trait method + RAII guard stay for the test seam and
-as the recovery target swept on every start. It does *not* cover an indefinite
-outage (a bridge that stays down) — without lockdown, default-off Hole fails
-*open* there; lockdown closes that broader gap.
+`Routing::install_failclosed_cover(server_ip, resolver_ip)` engages a leak-free
+egress block — permit loopback and the SS server IP, **block everything else** —
+as an RAII guard whose `Drop` disengages it. It is a bounded-window kill switch
+holding the line regardless of [lockdown](#lockdown-mode); a crash while it is
+held leaves traffic **blocked, not leaked**. `ProxyManager::start_cancellable`
+is its production caller: every covered (auto-connect) start engages it before
+`start_inner`, retaining it (host stays blocked, not leaked) if the start fails,
+and releasing it on success, cancel, or a user stop. It does *not* cover an
+indefinite outage (a bridge that stays down) — without lockdown, default-off
+Hole fails *open* there; lockdown closes that broader gap.
+
+`resolver_ip` optionally permits ONE more address, scoped to **TCP port 443**
+(not the server permit's unrestricted shape — `doh_url_for_ip` in
+`crate::dns::ech` never constructs a URL with any other port, so 443 is
+structurally the only value this fetch can need, not a heuristic threshold):
+`EchDoh::resolver`, the exact address Hole's own `ech-doh` URL names, gated on
+a plugin being configured at all (no plugin, no later ECH lookup, so nothing
+to permit for). Without it, ex-ray's later lazy ECH-config fetch — which fires
+on the plugin chain's first dial, i.e. *under* this same cover — would be
+blocked and stall to ex-ray's client timeout. **Permitting it grants no new
+trust regardless of `PinSource`:** Hole *authored* the address — `ech_doh_url`
+either uses the bootstrap-verified IP or falls back to one in the user's own
+configured `dns.servers` — so config-authorship trust alone is judged
+sufficient. This is NOT a claim that this attempt personally dialed the
+address: `resolve_via_doh` does dial every configured resolver even on total
+failure (so `Answered` and `SecureBootstrapFailed` both had it dialed this
+session), but `NoQueryNeeded` (a literal-IP server) dials nothing at all, and
+`ResolverDeselected` (a covered retry whose `dns.servers` changed) may name an
+address only a prior resolve dialed, or never dialed by this bridge process
+at all — see `EchDoh`'s doc for the exact breakdown. An OPERATOR-supplied
+address is different: an operator's own `ech-doh` in `plugin_opts` can win
+first-wins over Hole's (`crate::proxy::plugin::effective_ech_doh`, not
+`ech_doh.is_some()` alone, decides which value actually reaches ex-ray), and
+that address is never permitted — Hole did not author it, so config-authorship
+trust does not extend to it. `effective_ech_doh` also means a non-ECH-capable
+plugin never widens the cover for a fetch that provably does not use it. A
+covered retry against the same server reuses the held cover as-is UNLESS this
+attempt's freshly-derived permit now differs from what the cover was actually
+engaged with (e.g. `dns.servers` changed the fallback address, or a plugin was
+added between attempts) — that drift makes the held cover stale, and it is
+released and re-engaged fresh with the corrected permit, the same repair
+pattern already used for a different-server retry, EXCEPT when the new
+derivation only NARROWS to nothing needed (e.g. the plugin was removed): a
+superset permit is left in place rather than opening the release-to-reengage
+window for a correction with no benefit. If the corrected engage itself
+fails, the repair falls back to restoring the PREVIOUS permit rather than
+leaving the host uncovered, and remembers that specific corrected value as
+unreachable (`BlockedStart::dead_permit`) so an unchanged retry does not
+retry the same failing correction forever — a later retry whose derivation
+changes again still repairs normally.
+
+**Disclosed residual:** an operator's OWN `ech-doh` in `plugin_opts`
+outranking Hole's (`EffectiveEchDoh::Operators`) is never permitted — Hole did
+not author that address, so config-authorship trust does not extend to it,
+making this a real widening rather than the config-authorship trust extended
+to Hole's own addresses — and is therefore *always* a stall risk under a
+covered start; `ProxyManager::start_cancellable` logs a dedicated `warn!`
+naming the operator's URL. A repair's compensating restore can also leave the
+LIVE held cover's permit mismatched from what THIS attempt actually needs
+(the corrected engage failed) — a separate `warn!` fires for that case too,
+comparing against the live permit rather than re-trusting that the repair
+always converges. A THIRD case is untouched by this mechanism entirely
+(not merely a residual within it), **macOS only**: a restart that adopts a
+pre-existing [standing lockdown cover](#lockdown-mode) sees no transient
+cover engage at all, so there is no in-process signal to gate a diagnostic on
+— the adopted pf ruleset can block the same ECH fetch, silently. Windows is
+unaffected: the adopted lockdown cover's App-ID floor already permits the
+plugin process outright (pf has no per-process matcher, so macOS has no
+equivalent floor). Tracked separately:
+[#753](https://github.com/bindreams/hole/issues/753). Finally, the
+release-then-reengage repair itself has a brief window with NO cover at all
+between the release and the corrected (or restored) re-engage — disclosed in
+the repair's own `warn!` lines, not silent, but not eliminated either: both
+platforms' engage primitives are delete-then-add / flush-then-reload, not an
+atomic in-place update. Tracked separately:
+[#758](https://github.com/bindreams/hole/issues/758).
 
 It is **name-agnostic** — it does *not* permit the TUN interface. The new
 bridge's start-time DNS-forwarder self-test runs over loopback to the SS client
@@ -425,15 +490,17 @@ three axes:
 
 - **Permit set.** Lockdown adds a TUN-interface permit (Windows: by `NET_LUID`;
   macOS: `pass out quick on <tun>`) so app traffic flows; the transient cover
-  deliberately omits it (permit loopback + server only) because holding it while
-  connected would block all browsing.
+  deliberately omits it (permit loopback + server + the resolver Hole's own
+  `ech-doh` names, when a plugin needs it) because holding it while connected
+  would block all browsing.
 - **Lifetime.** Lockdown is authoritative and standing — it persists across a
   crash or restart and is reconciled on the next start via
   `decide_cover_recovery` (Adopt keeps the host fail-closed, dropping the
   volatile TUN + server permits so the next connect re-adds them fresh; Sweep
   disengages when intent is off). The transient cover is a non-standing,
-  bounded-window RAII guard with **no production caller today** (a test seam +
-  recovery target swept by `recover_routes`).
+  bounded-window RAII guard engaged only for the duration of one covered
+  (auto-connect) start attempt, and swept by `recover_routes` like every other
+  cover state on the next start.
 - **Failure mode.** A failed lockdown engage during a lockdown-on start is
   **fail-FATAL** — it aborts the start and tears everything down; the transient
   cover fails *open* on its own engage error so a half-loaded ruleset never

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -395,8 +395,7 @@ changes again still repairs normally.
 **Disclosed residual:** an operator's OWN `ech-doh` in `plugin_opts`
 outranking Hole's (`EffectiveEchDoh::Operators`) is never permitted — Hole did
 not author that address, so config-authorship trust does not extend to it,
-making this a real widening rather than the config-authorship trust extended
-to Hole's own addresses — and is therefore *always* a stall risk under a
+making this a real widening — and is therefore *always* a stall risk under a
 covered start; `ProxyManager::start_cancellable` logs a dedicated `warn!`
 naming the operator's URL. A repair's compensating restore can also leave the
 LIVE held cover's permit mismatched from what THIS attempt actually needs
@@ -416,7 +415,21 @@ between the release and the corrected (or restored) re-engage — disclosed in
 the repair's own `warn!` lines, not silent, but not eliminated either: both
 platforms' engage primitives are delete-then-add / flush-then-reload, not an
 atomic in-place update. Tracked separately:
-[#758](https://github.com/bindreams/hole/issues/758).
+[#758](https://github.com/bindreams/hole/issues/758). If BOTH the corrected
+engage AND the compensating restore fail — two independent OS-level
+failures back to back — the attempt proceeds fully uncovered: the same
+fail-open outcome as an ordinary single-engage failure, just requiring two
+failures instead of one to reach. The next retry finds the held cover is
+`None` and re-engages fresh from scratch. Also disclosed via its own
+`warn!`. **Windows only:** the two new resolver-permit filters grew
+`FILTER_GUIDS` from ten entries to twelve — before this change there were NO
+resolver-permit filters at all, so a crash-then-downgrade (this build
+engages, crashes, an older build's recovery sweep only knows the first ten
+GUIDs) leaves those two permits un-swept; they are *permits*, never blocks,
+so this is bounded and self-healing (a later upgrade's sweep cleans them up),
+not a leak of blocked traffic. Disclosed as a source comment on
+`FILTER_GUIDS` itself. Tracked separately:
+[#754](https://github.com/bindreams/hole/issues/754).
 
 It is **name-agnostic** — it does *not* permit the TUN interface. The new
 bridge's start-time DNS-forwarder self-test runs over loopback to the SS client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -506,53 +506,25 @@ happen. `crate::proxy::plugin::ech_fetch_is_reachable` and its helper
 even attempt an ECH-config fetch, reading `plugin_opts` the way ex-ray's own
 SIP003 parser does (`ex_ray_flag_value`: a bare key is ex-ray's `"1"`, not
 `garter`'s `""`) and mirroring every `plugin_opts`-reachable config-build
-error ex-ray's `main.go`/`options.go`/`config.go` treats as `os.Exit(23)`.
+error ex-ray's `main.go`/`options.go`/`config.go` treats as `os.Exit(23)` —
+closed enums (`ech`, `mode`), numeric ranges (`mux`, `fwmark`,
+`tcp-keepalive`), port/address validity (`localPort`, `localAddr`,
+`remotePort`, `remoteAddr`), presence-only flags requiring an exact `"1"`
+(`tls`, `server`, `fastOpen`, `__android_vpn`), non-empty-required strings
+(`host`, `path`), a well-formed `https://` `ech-doh`, `ech=always`'s TLS and
+resolved-`ech-doh` requirements, and `cert`/`certRaw`/`key` requiring TLS.
+`ex_ray_fatal_config_error`'s own doc comment is the single source of truth
+for the full per-key rule set and ex-ray's real evaluation order (checked
+there, not duplicated here) — each numeric/enum literal it hardcodes is
+pinned by an `include_str!`-based test against the vendored source
+(`ech_and_mode_enums_match_vendored_config_go`), on the COMPARISON itself
+(e.g. `uint32Opt`'s `v <= math.MaxUint32`) where possible, not the error
+message text — a message is free to change for reasons unrelated to the
+bound it protects, and a message-text pin has already gone stale that way
+once.
 
-[#752](https://github.com/bindreams/hole/pull/752) rewrote the
-option-parsing step (`parseOptsIntoFlags`, `options.go`) to fail loud on a
-present-but-malformed value across the board, where several of these used
-to warn and keep the flag's default or apply nothing:
-
-- `mux`/`fwmark`/`tcp-keepalive` (`parseIntOption`): a present value
-  `strconv.Atoi` can't parse — non-numeric, or explicitly empty — is now
-  fatal (an operator's own unparseable `mux=` must not silently outrank
-  galoshes' appended `mux=0` and leave Mux.Cool on). A value that parses is
-  then range-checked as before: `tcp-keepalive` against `0..=32767`,
-  `mux`/`fwmark` against `uint32Opt`'s `0..=u32::MAX`.
-- `tls`/`server`/`fastOpen`/`__android_vpn` (`parseBoolOption`): a present
-  value other than `"1"` is now fatal — these used to be presence-only, any
-  value.
-- `host`/`path` (`parseStringOption`, `emptyOK=false`): a present but
-  EXPLICITLY EMPTY value is now fatal. This retires the old empty-`host=`
-  SNI fallback below.
-- `localAddr`/`localPort`/`remoteAddr`/`remotePort` are validated by
-  `main.go`/`generateConfig`, largely unchanged by #752 except that
-  `remotePort` now routes through the SAME `validPort`/`net.PortFromString`
-  as `localPort` (previously a bare `strconv.ParseUint` with no `65535`
-  ceiling and no `0` rejection): `localPort`/`remotePort` must be an
-  unsigned base-10 literal `<=65535`, not `0` (Go's `ParseUint` rejects a
-  leading `+` that Rust's `u32::from_str` accepts — checked against both
-  toolchains directly); `localAddr` must be a single (`|`-free) IP literal;
-  `remoteAddr` must not normalize to an empty domain or the unspecified IP
-  (`0.0.0.0`/`::`).
-- `ech` (`parseEnumOption`) is now validated UNCONDITIONALLY, at parse time
-  — before #752 the enum switch lived only inside `buildTLSConfig` (`if *tlsEnabled`), so an invalid `ech` with no `tls` and no `mode=quic` was
-  inert, not fatal. `generateConfig` separately rejects `ech=always` with
-  TLS not enabled — also NEW, a case that used to silently apply nothing.
-- `ech-doh` (`parseURLOption`): empty stays a documented no-op ("disables
-  ECH"), but a present, non-empty value that isn't a well-formed `https://`
-  URL with a host is now fatal — checked only for the operator's own value,
-  when it isn't displaced by Hole's own (always well-formed by
-  construction).
-- `cert`/`certRaw`/`key` present (non-empty) with TLS not enabled is now
-  fatal too — before, the material was silently never read.
-- `mode` (closed enum, `generateConfig`, unconditional) and, later —
-  checked separately, once `generateConfig` has already succeeded, inside
-  `core.New` — the websocket transport's `mux` concurrency bound `1..=1024`,
-  are unchanged by #752.
-
-`loglevel` is deliberately NOT modeled, even though #752 made an explicitly
-empty or unrecognized value fatal there too:
+`loglevel` is deliberately NOT modeled as a fatal class, even though ex-ray
+itself rejects an explicitly empty or unrecognized value there too:
 `crate::proxy::plugin::inject_plugin_directives` always strips the
 operator's own `loglevel` and appends `loglevel=debug`, unconditionally,
 whatever Hole's own `ech-doh` decision is — no value from `plugin_opts`
@@ -560,51 +532,29 @@ ever reaches ex-ray unmodified, so modeling it would produce a false fatal
 for a config that starts fine in practice, the opposite of the over-permit
 risk this gate exists to close.
 
-Each vendored numeric/enum literal this mirrors is pinned by an
-`include_str!`-based test against the vendored source
-(`ech_and_mode_enums_match_vendored_config_go`) — on the COMPARISON itself
-(e.g. `uint32Opt`'s `v <= math.MaxUint32`) where possible, not the error
-message text: #752 dropped `uint32Opt`'s `, got: <value>` message suffix (to
-stop a `mux=abc\;certRaw=SECRET`-shaped escape from leaking a later
-segment's value through it) without touching the bound it protects, which a
-message-text pin would have gone stale for — and did, the first time this
-gate hit that exact drift. A future ex-ray bump that adds or renames a
-value, or changes one of these bounds, fails loudly here instead of
-silently drifting.
+**Disclosed, deliberately unmodeled:** `cert`/`certRaw`/`key`'s CONTENT (an
+operator-supplied file path or PEM blob actually being a readable,
+well-formed X509 pair) can fail config-build, but only by reading the
+filesystem — a check this otherwise pure, `plugin_opts`-only gate
+deliberately does not perform (only their presence without TLS enabled is
+checked). ex-ray's `server` plugin option cross-assigns
+`localAddr`/`localPort` with `remoteAddr`/`remotePort` to the opposite
+internal flag; Hole's bridge never spawns ex-ray as a server, so the gate
+checks those four address/port keys assuming client mode and skips the
+`mux`-concurrency check too whenever a `server` segment is present
+(`MultiplexingConfig` is client-mode only), rather than reporting a false
+fatal.
 
-**Disclosed, deliberately unmodeled:**
-
-- `cert`/`certRaw`/`key`'s CONTENT (an operator-supplied file path or PEM
-  blob actually being a readable, well-formed X509 pair,
-  `readCertificate`/`filesystem.ReadFile`/`gotls.X509KeyPair`) can fail
-  config-build, but only by reading the filesystem — a check this
-  otherwise pure, `plugin_opts`-only gate deliberately does not perform: the
-  same path could read successfully now and fail moments later at the real
-  spawn, or vice versa, so duplicating the read here would be stale, not
-  accurate. Only their PRESENCE without TLS enabled is checked (above).
-- ex-ray's `server` plugin option (settable via `plugin_opts`, like `tls`)
-  cross-assigns `localAddr`/`localPort` with `remoteAddr`/`remotePort` to
-  the opposite internal flag (`tcp-keepalive`'s range check runs
-  unconditionally regardless of `server`, so that one is unaffected) —
-  `ex_ray_fatal_config_error` does not account for the cross-assignment, so
-  the four address/port checks above are checked assuming client mode.
-  Hole's bridge never spawns ex-ray as a server; an operator who puts
-  `server` in their own `plugin_opts` already has a tunnel that will not
-  establish for a much more obvious reason (ex-ray listens instead of
-  connects) than anything this gate decides, so the cross-assignment is not
-  modeled — as is the trailing `mux` concurrency check (below):
-  `MultiplexingConfig` is attached only on ex-ray's non-`server` branch, so
-  this gate skips that check too whenever a `server` segment is present,
-  rather than reporting a false fatal.
-
-An explicit empty `host=` used to NOT be "no SNI" before #752: ex-ray's own
-`Config.ServerName` fell back to the DIAL DESTINATION when `host` was empty
-(`tls.WithDestination`), and that destination is `remoteAddr` — itself a
-`plugin_opts` option that can name a domain. Since #752 rejects `host=` at
-parse time (`parseStringOption(..., emptyOK: false)`), `*host` can never
-actually BE `""` when that v2ray-core fallback would run — it still exists
-in the vendored source, just unreachable via `plugin_opts` now, and
-`ech_fetch_is_reachable` no longer models it.
+An explicit empty `host=` is fatal at parse time
+(`parseStringOption(..., emptyOK: false)`), so `*host` can never actually BE
+`""` when `buildTLSConfig` runs — v2ray-core's own `Config.ServerName`
+empty-`ServerName` fallback to the dial destination (`tls.WithDestination`,
+filling it from `remoteAddr`) still exists in the vendored source, just
+unreachable via `plugin_opts`, and `ech_fetch_is_reachable` does not model
+it. The reachable SNI check also strips a literal `experiment:8357` prefix
+before testing domain-ness, mirroring v2ray-core's own
+`Config.parseServerName` — `ApplyECH` reads the STRIPPED `ServerName`, not
+the raw `host` value.
 
 ### Lockdown mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,8 +362,12 @@ closes that broader gap.
 `crate::dns::ech` never constructs a URL with any other port, so 443 is
 structurally the only value this fetch can need, not a heuristic threshold):
 `EchDoh::resolver`, the exact address Hole's own `ech-doh` URL names, gated on
-a plugin being configured at all (no plugin, no later ECH lookup, so nothing
-to permit for). Without it, ex-ray's later lazy ECH-config fetch — which fires
+`crate::proxy::plugin::effective_ech_doh` returning `Holes` — the value ex-ray
+will actually dial, not merely a plugin being configured (no plugin is one way
+to get `None`; a non-ECH-capable plugin, a fatal ex-ray config, `ech=never`,
+no TLS-enabled domain SNI, or an operator's own `ech-doh` outranking Hole's
+are the others — see `ech_fetch_is_reachable`'s and `classify_ech_doh`'s docs).
+Without it, ex-ray's later lazy ECH-config fetch — which fires
 on the plugin chain's first dial, i.e. *under* this same cover — would be
 blocked and stall to ex-ray's client timeout. **Permitting it grants no new
 trust regardless of `PinSource`:** Hole *authored* the address — `ech_doh_url`
@@ -384,24 +388,25 @@ trust does not extend to it. `effective_ech_doh` also means a non-ECH-capable
 plugin never widens the cover for a fetch that provably does not use it. A
 covered retry against the same server reuses the held cover as-is UNLESS this
 attempt's freshly-derived permit now differs from what the cover was actually
-engaged with (e.g. `dns.servers` changed the fallback address, or a plugin was
-added between attempts) — that drift makes the held cover stale, and it is
-released and re-engaged fresh with the corrected permit, the same repair
-pattern already used for a different-server retry, EXCEPT when the new
-derivation only NARROWS to nothing needed (e.g. the plugin was removed): a
-superset permit is left in place rather than opening the release-to-reengage
-window for a correction with no benefit. If the corrected engage itself
-fails, the repair falls back to restoring the PREVIOUS permit rather than
-leaving the host uncovered; an unchanged retry (still wanting the same
-permit) repairs again rather than staying wedged — the failure could have
-been transient, and each attempt's release-to-reengage window is bounded to
+engaged with (e.g. `dns.servers` changed the fallback address, a plugin was
+added or removed between attempts, or an operator's own `ech-doh` started or
+stopped outranking Hole's) — that drift, including a NARROWING to nothing
+needed, makes the held cover stale, and it is released and re-engaged fresh
+with the corrected permit, the same repair pattern already used for a
+different-server retry: the resolver permit carries no App-ID/process scoping
+on either platform, so leaving a wider-than-needed permit live for the rest
+of the blocked state is a real widening, not a correction with no benefit.
+If the corrected engage itself fails, the repair falls back to restoring the
+PREVIOUS permit rather than leaving the host uncovered; an unchanged retry
+(still wanting the same permit) repairs again rather than staying wedged —
+the failure could have been transient, and each attempt's release-to-reengage
+window is bounded to
 that one (user-paced) retry regardless.
 
-**Disclosed residual:** an operator's OWN `ech-doh` in `plugin_opts`
-outranking Hole's (`EffectiveEchDoh::Operators`) is never permitted — Hole did
-not author that address, so config-authorship trust does not extend to it,
-making this a real widening — and is therefore *always* a stall risk under a
-covered start; `ProxyManager::start_cancellable` logs a dedicated `warn!`
+**Disclosed residual:** an operator's OWN `ech-doh` outranking Hole's
+(`EffectiveEchDoh::Operators`, never permitted per above) is therefore
+*always* a stall risk under a covered start;
+`ProxyManager::start_cancellable` logs a dedicated `warn!`
 naming the operator's URL. A repair's compensating restore can also leave the
 LIVE held cover's permit mismatched from what THIS attempt actually needs
 (the corrected engage failed) — a separate `warn!` fires for that case too,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,15 +413,27 @@ LIVE held cover's permit mismatched from what THIS attempt actually needs
 comparing against the live permit rather than re-trusting that the repair
 always converges, in EITHER direction: too narrow (`Holes`, an ECH-fetch stall
 risk) or too wide (`None`, the kill switch permits a resolver address nothing
-needs). A THIRD case is untouched by this mechanism entirely
-(not merely a residual within it), **macOS only**: a restart that adopts a
-pre-existing [standing lockdown cover](#lockdown-mode) sees no transient
-cover engage at all, so there is no in-process signal to gate a diagnostic on
-— the adopted pf ruleset can block the same ECH fetch, silently. Windows is
-unaffected: the adopted lockdown cover's App-ID floor already permits the
-plugin process outright (pf has no per-process matcher, so macOS has no
-equivalent floor). Tracked separately:
-[#753](https://github.com/bindreams/hole/issues/753). Finally, the
+needs). A THIRD case is untouched by this mechanism entirely (not merely a
+residual within it): the [standing lockdown cover](#lockdown-mode)'s own
+ruleset never carries a resolver permit at all, on EITHER platform, whether
+the cover was just engaged fresh (`routing.install_lockdown`, called from
+`start_cancellable`'s `lockdown_on` branch on every covered start) or adopted
+across a restart — `build_lockdown_main_ruleset` (macOS) and
+`lockdown_app_ids` (Windows) take no `resolver_ip`/`EchDoh` input at all. On
+macOS this blocks the fetch outright, silently, on every lockdown-on covered
+start with an ECH-effective config — not only a restart-adopt, which merely
+compounds it by also removing the in-process signal a fresh engage still has
+(`effective_ech_doh`, computed before `install_lockdown` runs) but has no API
+to consume. On Windows the App-ID floor (`resolve_plugin_path(plugin)` — the
+plugin's OWN resolved binary) is sufficient for a direct `ex-ray`/
+`v2ray-plugin` config, but NOT for a chained plugin like `galoshes`: it
+`include_bytes!`s ex-ray and spawns it as a separate process from its own
+extracted runtime path (`crates/galoshes/src/embedded.rs`), which
+`lockdown_app_ids` never adds to the permit set — WFP's App-ID condition
+matches the RUNNING process's own image path, so ex-ray (the process that
+actually dials the DoH resolver) is unpermitted there too. Tracked
+separately: [#753](https://github.com/bindreams/hole/issues/753) (filed
+narrower than this; scope correction pending). Finally, the
 release-then-reengage repair itself has a brief window with NO cover at all
 between the release and the corrected (or restored) re-engage — disclosed in
 the repair's own `warn!` lines, not silent, but not eliminated either: both
@@ -434,10 +446,10 @@ fail-open outcome as an ordinary single-engage failure, just requiring two
 failures instead of one to reach. The next retry finds the held cover is
 `None` and re-engages fresh from scratch. Also disclosed via its own
 `warn!`. **Windows only:** the two new resolver-permit filters grew
-`FILTER_GUIDS` from ten entries to twelve — before this change there were NO
-resolver-permit filters at all, so a crash-then-downgrade (this build
-engages, crashes, an older build's recovery sweep only knows the first ten
-GUIDs) leaves those two permits un-swept; they are *permits*, never blocks,
+`FILTER_GUIDS` from ten entries to twelve, so a crash-then-downgrade (a build
+that knows all twelve GUIDs engages, crashes, and an older build's recovery
+sweep only knows the first ten) leaves those two permits un-swept; they are
+*permits*, never blocks,
 so this is bounded and self-healing (a later upgrade's sweep cleans them up),
 not a leak of blocked traffic. Disclosed as a source comment on
 `FILTER_GUIDS` itself. Tracked separately:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -498,6 +498,81 @@ because its BPF tap sits upstream of pf, so an en0 capture would record packets 
 later drops (unsound). The recovery sweep runs on every bridge start via
 `recover_routes`.
 
+#### ECH-config-fetch reachability gate
+
+The resolver permit above must not widen for a fetch that provably cannot
+happen. `crate::proxy::plugin::ech_fetch_is_reachable` and its helper
+`ex_ray_fatal_config_error` model ex-ray's own decision of whether it will
+even attempt an ECH-config fetch, reading `plugin_opts` the way ex-ray's own
+SIP003 parser does (`ex_ray_flag_value`: a bare key is ex-ray's `"1"`, not
+`garter`'s `""`) and mirroring every `plugin_opts`-reachable config-build
+error ex-ray's `main.go`/`config.go` treats as `os.Exit(23)` — `ech`/`mode`
+closed enums, `mux`/`fwmark`/`tcp-keepalive` numeric ranges,
+`localPort`/`remotePort` port parsing (Go's `strconv.ParseUint` rejects a
+leading `+` that Rust's `u32::from_str` accepts — checked against both
+toolchains directly), and, checked separately and later (it fires inside
+`core.New`, only once `generateConfig` itself has already succeeded), the
+websocket transport's `mux` concurrency bound `1..=1024`. Each vendored
+literal this mirrors is pinned by an `include_str!`-based test against the
+vendored source (`ech_and_mode_enums_match_vendored_config_go`), so a future
+ex-ray bump that adds or renames a value fails loudly here instead of
+silently drifting.
+
+An explicit empty `host=` is NOT "no SNI": ex-ray's own `Config.ServerName`
+falls back to the DIAL DESTINATION when `host` is empty
+(`tls.WithDestination`), and that destination is `remoteAddr` — itself a
+`plugin_opts` option that can name a domain. `ech_fetch_is_reachable`
+resolves that fallback the same first-wins way as every other key here; an
+absent `remoteAddr` is correctly treated as an IP (Hole's own
+`SS_REMOTE_HOST`, which this function cannot see, is always an IP by
+construction — Hole resolves the server before ever spawning the plugin).
+
+`ech=always` with an empty *resolved* `ech-doh` — the value ex-ray actually
+receives once Hole's own injection wins or loses against the operator's own,
+not just the raw `ech-doh` segment — is itself an `os.Exit(23)` class
+(`config.go:218-220`, `"ech=always requires ech-doh to be set"`); detecting
+it needs that same precedence `classify_ech_doh` resolves, recomputed by
+`resolved_ech_doh_is_empty` rather than threaded through (the two functions
+would otherwise call each other in a cycle: `classify_ech_doh` calls
+`ech_fetch_is_reachable`, which calls `ex_ray_fatal_config_error`).
+
+**Disclosed, deliberately unmodeled:**
+
+- `cert` (an operator-supplied file path, `readCertificate`/
+  `filesystem.ReadFile`) can fail config-build, but only by reading the
+  filesystem — a check this otherwise pure, `plugin_opts`-only gate
+  deliberately does not perform: the same path could read successfully now
+  and fail moments later at the real spawn, or vice versa, so duplicating
+  the read here would be stale, not accurate. `certRaw` never fails on its
+  own.
+- ex-ray's `server` plugin option (settable via `plugin_opts`, like `tls`)
+  cross-assigns `localPort`/`remotePort` to the opposite internal flag
+  (`tcp-keepalive`'s range check runs unconditionally regardless of
+  `server`, so that one is unaffected) — `ex_ray_fatal_config_error` does
+  not account for the cross-assignment. Hole's bridge never spawns ex-ray as
+  a server; an operator who puts `server` in their own `plugin_opts` already
+  has a tunnel that will not establish for a much more obvious reason
+  (ex-ray listens instead of connects) than anything this gate decides, so
+  the cross-assignment is not modeled — as is the trailing `mux` concurrency
+  check (below): `MultiplexingConfig` is attached only on ex-ray's
+  non-`server` branch, so this gate skips that check too whenever a
+  `server` segment is present, rather than reporting a false fatal.
+- On the `remoteAddr` SNI fallback (an explicit empty `host=`) only: ex-ray
+  applies `net.ParseAddress` TWICE on that path (once building the dial
+  destination, once more computing the ECH domain from the
+  destination-derived `ServerName`), while the gate normalizes once. The two
+  disagree only for a value where a SECOND unwrap still changes the result —
+  a doubly-bracketed `remoteAddr=[[::1]]` is the only class found so far.
+  Modeling the second pass needs mirroring v2ray-core's `Domain`/`IP`
+  address-family round-trip, not just another `net.ParseAddress` call; not
+  modeled.
+
+The websocket transport's `mux` additionally has a SECOND, separately
+checked bound: `core.New` rejects a non-zero `Concurrency` outside
+`1..=1024` (third_party/v2ray-core/app/proxyman/outbound/handler.go), a
+narrower and later-evaluated check than `uint32Opt`'s own `0..=u32::MAX`
+(both pinned against the vendored source, same as the enum sets).
+
 ### Lockdown mode
 
 The **standing lockdown cover** (`Routing::install_lockdown`, #527) is an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,7 +429,17 @@ GUIDs) leaves those two permits un-swept; they are *permits*, never blocks,
 so this is bounded and self-healing (a later upgrade's sweep cleans them up),
 not a leak of blocked traffic. Disclosed as a source comment on
 `FILTER_GUIDS` itself. Tracked separately:
-[#754](https://github.com/bindreams/hole/issues/754).
+[#754](https://github.com/bindreams/hole/issues/754). **Windows only, also
+pre-existing:** the repair's release step deletes the held cover's filters by
+fixed GUID and discards the result; if a delete genuinely fails, the
+subsequent re-engage's add for that same GUID reports success
+(`FWP_E_ALREADY_EXISTS` is treated as OK, by design, for the crash-recovery
+idempotency case) while the LIVE filter still carries the OLD value — a
+stale permit surviving, not a leaked block, and not new to this PR (the
+different-server retry already relied on the same delete-then-add sequence
+for the server permit; this change adds a second GUID pair that exercises
+it too). Disclosed as a source comment on `ok_or_exists`. Tracked
+separately: [#761](https://github.com/bindreams/hole/issues/761).
 
 It is **name-agnostic** — it does *not* permit the TUN interface. The new
 bridge's start-time DNS-forwarder self-test runs over loopback to the SS client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,11 +447,9 @@ fixed GUID and discards the result; if a delete genuinely fails, the
 subsequent re-engage's add for that same GUID reports success
 (`FWP_E_ALREADY_EXISTS` is treated as OK, by design, for the crash-recovery
 idempotency case) while the LIVE filter still carries the OLD value — a
-stale permit surviving, not a leaked block, and not new to this PR (the
-different-server retry already relied on the same delete-then-add sequence
-for the server permit; this change adds a second GUID pair that exercises
-it too). Disclosed as a source comment on `ok_or_exists`. Tracked
-separately: [#761](https://github.com/bindreams/hole/issues/761).
+stale permit surviving, not a leaked block. Disclosed as a source comment on
+`ok_or_exists`. Tracked separately:
+[#761](https://github.com/bindreams/hole/issues/761).
 
 It is **name-agnostic** — it does *not* permit the TUN interface. The new
 bridge's start-time DNS-forwarder self-test runs over loopback to the SS client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,14 +343,19 @@ they permit.
 
 `Routing::install_failclosed_cover(server_ip, resolver_ip)` engages a leak-free
 egress block — permit loopback and the SS server IP, **block everything else** —
-as an RAII guard whose `Drop` disengages it. It is a bounded-window kill switch
-holding the line regardless of [lockdown](#lockdown-mode); a crash while it is
-held leaves traffic **blocked, not leaked**. `ProxyManager::start_cancellable`
-is its production caller: every covered (auto-connect) start engages it before
-`start_inner`, retaining it (host stays blocked, not leaked) if the start fails,
-and releasing it on success, cancel, or a user stop. It does *not* cover an
-indefinite outage (a bridge that stays down) — without lockdown, default-off
-Hole fails *open* there; lockdown closes that broader gap.
+as an RAII guard whose `Drop` disengages it. It is a bounded-window kill switch;
+a crash while it is held leaves traffic **blocked, not leaked**.
+`ProxyManager::start_cancellable` is its production caller: every covered
+(auto-connect) start whose **lockdown intent is OFF** engages it before
+`start_inner`, retaining it (host stays blocked, not leaked) if the start
+fails, and releasing it on success, cancel, or a user stop. When the standing
+lockdown intent is ON, a covered start does NOT engage this cover at all — that
+cohort's cover is installed once at `routing.install` instead
+([Lockdown mode](#lockdown-mode)) — and a HELD transient cover from a prior
+start is released outright, a brief, disclosed open window until the lockdown
+cover takes over. It does *not* cover an indefinite outage (a bridge that
+stays down) — without lockdown, default-off Hole fails *open* there; lockdown
+closes that broader gap.
 
 `resolver_ip` optionally permits ONE more address, scoped to **TCP port 443**
 (not the server permit's unrestricted shape — `doh_url_for_ip` in
@@ -523,27 +528,11 @@ message text — a message is free to change for reasons unrelated to the
 bound it protects, and a message-text pin has already gone stale that way
 once.
 
-`loglevel` is deliberately NOT modeled as a fatal class, even though ex-ray
-itself rejects an explicitly empty or unrecognized value there too:
-`crate::proxy::plugin::inject_plugin_directives` always strips the
-operator's own `loglevel` and appends `loglevel=debug`, unconditionally,
-whatever Hole's own `ech-doh` decision is — no value from `plugin_opts`
-ever reaches ex-ray unmodified, so modeling it would produce a false fatal
-for a config that starts fine in practice, the opposite of the over-permit
-risk this gate exists to close.
-
-**Disclosed, deliberately unmodeled:** `cert`/`certRaw`/`key`'s CONTENT (an
-operator-supplied file path or PEM blob actually being a readable,
-well-formed X509 pair) can fail config-build, but only by reading the
-filesystem — a check this otherwise pure, `plugin_opts`-only gate
-deliberately does not perform (only their presence without TLS enabled is
-checked). ex-ray's `server` plugin option cross-assigns
-`localAddr`/`localPort` with `remoteAddr`/`remotePort` to the opposite
-internal flag; Hole's bridge never spawns ex-ray as a server, so the gate
-checks those four address/port keys assuming client mode and skips the
-`mux`-concurrency check too whenever a `server` segment is present
-(`MultiplexingConfig` is client-mode only), rather than reporting a false
-fatal.
+`loglevel` is deliberately NOT modeled as a fatal class, and `cert`/
+`certRaw`/`key`'s CONTENT and ex-ray's `server` plugin option's
+cross-assignment are disclosed, deliberately unmodeled residuals — see
+`ex_ray_fatal_config_error`'s own doc comment (the single source of truth
+per the paragraph above) for the full reasoning behind each.
 
 An explicit empty `host=` is fatal at parse time
 (`parseStringOption(..., emptyOK: false)`), so `*host` can never be `""`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -392,10 +392,10 @@ derivation only NARROWS to nothing needed (e.g. the plugin was removed): a
 superset permit is left in place rather than opening the release-to-reengage
 window for a correction with no benefit. If the corrected engage itself
 fails, the repair falls back to restoring the PREVIOUS permit rather than
-leaving the host uncovered, and remembers that specific corrected value as
-unreachable (`BlockedStart::dead_permit`) so an unchanged retry does not
-retry the same failing correction forever — a later retry whose derivation
-changes again still repairs normally.
+leaving the host uncovered; an unchanged retry (still wanting the same
+permit) repairs again rather than staying wedged — the failure could have
+been transient, and each attempt's release-to-reengage window is bounded to
+that one (user-paced) retry regardless.
 
 **Disclosed residual:** an operator's OWN `ech-doh` in `plugin_opts`
 outranking Hole's (`EffectiveEchDoh::Operators`) is never permitted — Hole did

--- a/crates/bridge/src/dns/ech.rs
+++ b/crates/bridge/src/dns/ech.rs
@@ -37,6 +37,18 @@ pub enum PinSource {
     ResolverDeselected,
 }
 
+/// The port implied by [`doh_url_for_ip`]'s bare `https://` scheme (RFC
+/// 9110's default port for `https`, since the URL never carries an explicit
+/// one) — the ONE port ex-ray's ECH-config fetch can ever dial for a URL this
+/// module builds. `doh_url_for_ip_ports_to_the_https_default` pins this with
+/// an executable assertion against the URL crate's own scheme-default table,
+/// not just prose. `tun-engine`'s fail-closed cover mirrors this value as
+/// `RESOLVER_PERMIT_PORT` (`crates/tun-engine/src/routing/failclosed.rs`) —
+/// a separate declaration, not an import: `tun-engine` sits BELOW
+/// `hole-bridge` in the crate dependency graph, so it cannot import from
+/// here.
+pub const DOH_PORT: u16 = 443;
+
 /// DoH endpoint URL that pins the resolver by IP: `https://<ip>/dns-query`,
 /// IPv6 bracketed per RFC 3986 §3.2.2. It names no host, so a client dials
 /// `ip` directly and verifies the certificate against an IP SAN — it has
@@ -65,16 +77,49 @@ pub fn authority_is_a_name(url: &str) -> bool {
 /// carried rather than reduced to "pinned": each one warrants a different line
 /// in the log, and only [`PinSource::Answered`] outranks a value the config
 /// already carries whose authority is not a name (see [`authority_is_a_name`]).
+///
+/// `resolver` is the exact address `url` names — Hole constructed `url` from
+/// it (`doh_url_for_ip`), never a guess. The fail-closed cover permits
+/// exactly this address regardless of `source`: it always comes from the
+/// user's OWN configured `dns.servers`, so permitting it is config-authorship
+/// trust, not a claim that THIS attempt personally dialed it — `Answered`
+/// and `SecureBootstrapFailed` did (`resolve_via_doh` dials every configured
+/// resolver even on total failure); `NoQueryNeeded` dialed nothing at all
+/// (a literal-IP server short-circuits before the loop), and
+/// `ResolverDeselected`'s fallback may name an address only a PRIOR resolve
+/// dialed, or never dialed this bridge process at all. See
+/// `Routing::install_failclosed_cover`'s doc for why config-authorship alone
+/// is judged sufficient.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EchDoh {
     pub url: String,
+    pub resolver: IpAddr,
     pub source: PinSource,
 }
 
 impl EchDoh {
-    /// Whether a resolver demonstrated it serves DoH from this host.
+    /// Whether a resolver demonstrated it serves DoH from this host. Used
+    /// ONLY to break a tie against an operator's own `ech-doh` already in
+    /// `plugin_opts` (`crate::proxy::plugin::hole_ech_doh_outranks`) — NOT to
+    /// gate the fail-closed cover's permit, which reads `resolver` directly
+    /// regardless of pin state (see `EchDoh`'s doc).
     pub fn is_pinned(&self) -> bool {
-        matches!(self.source, PinSource::Answered(_))
+        self.source.verified_ip().is_some()
+    }
+}
+
+impl PinSource {
+    /// The address this pin has demonstrated reachable via a verified DoH
+    /// exchange, if any. Only `Answered` names one. Used ONLY for
+    /// [`EchDoh::is_pinned`]'s injection-priority tiebreak — the fail-closed
+    /// cover's permit reads `EchDoh::resolver` directly and does NOT gate on
+    /// this, since Hole constructed `resolver` either way (see `EchDoh`'s
+    /// doc).
+    pub fn verified_ip(self) -> Option<IpAddr> {
+        match self {
+            PinSource::Answered(ip) => Some(ip),
+            _ => None,
+        }
     }
 }
 
@@ -88,17 +133,16 @@ impl EchDoh {
 /// one address family on a path where nothing demonstrated the host has it, and
 /// ex-ray cannot fail over to the other.
 pub fn ech_doh_url(dns: &DnsConfig, source: PinSource) -> Option<EchDoh> {
-    let resolver = match source {
-        PinSource::Answered(ip) => Some(ip),
-        _ => dns
-            .servers
+    let resolver = source.verified_ip().or_else(|| {
+        dns.servers
             .iter()
             .find(|ip| ip.is_ipv4())
             .or_else(|| dns.servers.first())
-            .copied(),
-    };
+            .copied()
+    });
     resolver.map(|ip| EchDoh {
         url: doh_url_for_ip(ip),
+        resolver: ip,
         source,
     })
 }

--- a/crates/bridge/src/dns/ech.rs
+++ b/crates/bridge/src/dns/ech.rs
@@ -110,11 +110,8 @@ impl EchDoh {
 
 impl PinSource {
     /// The address this pin has demonstrated reachable via a verified DoH
-    /// exchange, if any. Only `Answered` names one. Used ONLY for
-    /// [`EchDoh::is_pinned`]'s injection-priority tiebreak — the fail-closed
-    /// cover's permit reads `EchDoh::resolver` directly and does NOT gate on
-    /// this, since Hole constructed `resolver` either way (see `EchDoh`'s
-    /// doc).
+    /// exchange, if any. Only `Answered` names one; see `EchDoh::is_pinned`'s
+    /// doc for how this is used.
     pub fn verified_ip(self) -> Option<IpAddr> {
         match self {
             PinSource::Answered(ip) => Some(ip),

--- a/crates/bridge/src/dns/ech_tests.rs
+++ b/crates/bridge/src/dns/ech_tests.rs
@@ -95,9 +95,8 @@ fn doh_url_for_ip_ports_to_the_https_default() {
     }
 }
 
-// `tun-engine` sits BELOW `hole-bridge` in the crate dependency graph, so its
-// `RESOLVER_PERMIT_PORT` can't import THIS crate's `DOH_PORT` — but this
-// crate CAN import tun-engine's, so this is the one enforced link: if either
+// The one enforced link between DOH_PORT and RESOLVER_PERMIT_PORT (see
+// DOH_PORT's doc for why they can't just share one declaration): if either
 // constant is ever edited alone, this fails instead of the two silently
 // drifting (the fail-closed cover would then permit a port ex-ray never
 // dials while blocking the one it does).

--- a/crates/bridge/src/dns/ech_tests.rs
+++ b/crates/bridge/src/dns/ech_tests.rs
@@ -83,6 +83,29 @@ fn ipv6_authority_is_bracketed() {
     );
 }
 
+// An executable pin, not just prose: the URL never carries an explicit port
+// (see `DOH_PORT`'s doc), so this asserts against the `url` crate's own
+// scheme-default table instead of restating the assumption.
+#[skuld::test]
+fn doh_url_for_ip_ports_to_the_https_default() {
+    for addr in ["1.1.1.1", "2606:4700:4700::1111"] {
+        let url = doh_url_for_ip(ip(addr));
+        let parsed = url::Url::parse(&url).expect("doh_url_for_ip must produce a parseable URL");
+        assert_eq!(parsed.port_or_known_default(), Some(DOH_PORT));
+    }
+}
+
+// `tun-engine` sits BELOW `hole-bridge` in the crate dependency graph, so its
+// `RESOLVER_PERMIT_PORT` can't import THIS crate's `DOH_PORT` — but this
+// crate CAN import tun-engine's, so this is the one enforced link: if either
+// constant is ever edited alone, this fails instead of the two silently
+// drifting (the fail-closed cover would then permit a port ex-ray never
+// dials while blocking the one it does).
+#[skuld::test]
+fn resolver_permit_port_matches_doh_port() {
+    assert_eq!(tun_engine::routing::failclosed::RESOLVER_PERMIT_PORT, DOH_PORT);
+}
+
 // The shipped default is Cloudflare: the ECH lookup must not be handed
 // `cloudflare-dns.com`, whose resolution would go over plaintext system DNS.
 #[skuld::test]
@@ -237,4 +260,13 @@ fn every_provider_ip_yields_a_name_free_authority() {
             "ech-doh authority for {resolver} must be the IP literal, got {url}"
         );
     }
+}
+
+#[skuld::test]
+fn verified_ip_is_some_only_for_answered() {
+    let addr = ip("1.1.1.1");
+    assert_eq!(PinSource::Answered(addr).verified_ip(), Some(addr));
+    assert_eq!(PinSource::NoQueryNeeded.verified_ip(), None);
+    assert_eq!(PinSource::SecureBootstrapFailed.verified_ip(), None);
+    assert_eq!(PinSource::ResolverDeselected.verified_ip(), None);
 }

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -142,7 +142,7 @@ impl Routing for StubRouting {
             ipv6_available: false,
         })
     }
-    fn install_failclosed_cover(&self, _: IpAddr) -> Result<StubCover, RoutingError> {
+    fn install_failclosed_cover(&self, _: IpAddr, _: Option<IpAddr>) -> Result<StubCover, RoutingError> {
         Ok(StubCover)
     }
     fn install_lockdown(&self, _: IpAddr, _: &str, _: &[PathBuf]) -> Result<StubCover, RoutingError> {

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -201,7 +201,11 @@ impl Routing for MockRouting {
 
     type Cover = MockCover;
 
-    fn install_failclosed_cover(&self, _server_ip: IpAddr) -> Result<MockCover, RoutingError> {
+    fn install_failclosed_cover(
+        &self,
+        _server_ip: IpAddr,
+        _resolver_ip: Option<IpAddr>,
+    ) -> Result<MockCover, RoutingError> {
         Ok(MockCover)
     }
 

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -615,17 +615,27 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 ///   `net.PortFromString`): must be an unsigned base-10 literal `<=65535`
 ///   and not `0` — `0` is otherwise valid syntax
 ///   (`net.PortFromString("0")` succeeds) but ex-ray cannot honor
-///   OS-assigned-port semantics.
+///   OS-assigned-port semantics. Under a `server` segment, main.go
+///   cross-assigns the `remotePort` KEY here instead of `localPort` — but
+///   both keys share this exact rule, so which one is checked never
+///   changes the verdict, only (irrelevantly) which literal key name a
+///   hypothetical diagnostic would cite; not worth branching on.
 /// - `localAddr` (main.go's cross-assign + `canonicalLocalAddr`): must be a
 ///   single (`|`-free) IP literal — a domain or a `|`-joined multi-address
 ///   list is fatal, since the sitrep's `ready` event can report only one
-///   `listen` address.
+///   `listen` address. Under a `server` segment, main.go cross-assigns the
+///   `remoteAddr` KEY to `*localAddr` — UNLIKE the port pair above, this
+///   rule genuinely differs from `remoteAddr`'s own (below), so which key
+///   is checked against which rule swaps under `server`.
 ///
 /// Then `generateConfig`:
-/// - `remotePort`, same rule as `localPort`, checked here instead.
+/// - `remotePort`, same rule and same server-mode key-swap non-issue as
+///   `localPort` above, checked here instead.
 /// - `remoteAddr`: must not normalize to an empty domain or the unspecified
 ///   IP (`0.0.0.0`/`::`) — freedom's destination override would otherwise
-///   dial nowhere honestly.
+///   dial nowhere honestly. Under a `server` segment, checked against the
+///   `localAddr` KEY instead (swapped with the bullet above, same
+///   cross-assign).
 /// - `mux`, again: a value that parsed above is now range-checked against
 ///   `uint32Opt`'s `0..=u32::MAX`.
 /// - `fwmark`, same range check as `mux`.
@@ -668,10 +678,22 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 /// **Disclosed, deliberately unmodeled:** `cert`/`certRaw`/`key`'s CONTENT
 /// (a readable, well-formed X509 pair) requires filesystem I/O this
 /// otherwise-pure gate doesn't perform — only their presence-without-TLS is
-/// checked above. `server` cross-assigns `localAddr`/`localPort` with
-/// `remoteAddr`/`remotePort`, but Hole never spawns ex-ray as one, so the
-/// four address/port checks above are checked assuming client mode. See
-/// CONTRIBUTING.md's "ECH-config-fetch reachability gate" section for why.
+/// checked above. `server`'s `localAddr`/`remoteAddr` cross-assign IS
+/// modeled (the two bullets above); its `mux`-concurrency exemption is
+/// modeled too (`core.New` bullet below). What stays unmodeled: whether
+/// ex-ray's OWN v2ray-core dependency even performs the DoH fetch this gate
+/// reasons about for a server listener at all — `GetTLSConfig` is called
+/// directly for server listeners too (their own doc: "only server
+/// listeners... call this directly"), and `ApplyECH` doesn't itself branch
+/// on `*server`, but `ech_fetch_is_reachable`'s empty-stripped-SNI fallback
+/// specifically models `tls.WithDestination`, a CLIENT-DIAL option
+/// (`websocket/dialer.go`) with no evident server-listener equivalent in
+/// this vendored source — modeling that with confidence needs tracing
+/// v2ray-core's server-listener construction path, not attempted here.
+/// Hole never spawns ex-ray as a server regardless, so an operator would
+/// have to hand-author `server` into their own `plugin_opts` to reach any
+/// of this. See CONTRIBUTING.md's "ECH-config-fetch reachability gate"
+/// section for why.
 fn ex_ray_fatal_config_error(
     segments: &[garter::OptionSegment<'_>],
     ech_doh: Option<&crate::dns::ech::EchDoh>,
@@ -753,12 +775,23 @@ fn ex_ray_fatal_config_error(
     {
         return Some("localPort");
     }
+    // main.go's cross-assign sends a `localAddr` OPTION to `*remoteAddr`
+    // under `*server` — so the KEY validated against `*localAddr`'s own
+    // rule (a single IP literal) is `remoteAddr`, not `localAddr`, in that
+    // mode. The two rules genuinely differ (unlike the port pair below,
+    // where both directions share one rule), so the swap changes the
+    // verdict.
+    let (local_addr_key, remote_addr_key) = if server_present {
+        ("remoteAddr", "localAddr")
+    } else {
+        ("localAddr", "remoteAddr")
+    };
     if segments
         .iter()
-        .find(|s| s.key == "localAddr")
+        .find(|s| s.key == local_addr_key)
         .is_some_and(|s| ex_ray_local_addr_is_invalid(ex_ray_flag_value(s)))
     {
-        return Some("localAddr");
+        return Some(local_addr_key);
     }
 
     // generateConfig.
@@ -771,10 +804,10 @@ fn ex_ray_fatal_config_error(
     }
     if segments
         .iter()
-        .find(|s| s.key == "remoteAddr")
+        .find(|s| s.key == remote_addr_key)
         .is_some_and(|s| ex_ray_remote_addr_is_invalid(ex_ray_flag_value(s)))
     {
-        return Some("remoteAddr");
+        return Some(remote_addr_key);
     }
     for key in ["mux", "fwmark"] {
         if segments.iter().find(|s| s.key == key).is_some_and(|s| {
@@ -2112,6 +2145,37 @@ mod inject_tests {
         }
         let segments = garter::split_plugin_options("tls;host=cdn.example;localAddr=cdn.example").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("localAddr"));
+    }
+
+    // Under `server`, main.go cross-assigns a `localAddr` OPTION to
+    // `*remoteAddr` and a `remoteAddr` OPTION to `*localAddr` — so the
+    // single-IP-literal rule (`localAddr`'s own) must be checked against the
+    // `remoteAddr` KEY, and vice versa, or this either over-permits (a
+    // config that is actually fatal reads as reachable) or under-permits (a
+    // config that actually starts fine reads as unreachable, reintroducing
+    // the ECH-fetch stall this PR closes).
+    #[skuld::test]
+    fn server_mode_swaps_which_key_the_address_rules_apply_to() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        // Over-permit repro: under `server`, the `remoteAddr` OPTION lands
+        // in `*localAddr`, so this domain value fails `canonicalLocalAddr`
+        // and the whole process exits 23 — never reachable.
+        let segments = garter::split_plugin_options("server;tls;host=cdn.example;remoteAddr=cdn.example").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("remoteAddr"));
+        assert_eq!(
+            effective_ech_doh(
+                "ex-ray",
+                Some("server;tls;host=cdn.example;remoteAddr=cdn.example"),
+                Some(&e)
+            ),
+            EffectiveEchDoh::None
+        );
+        // Under-permit repro: under `server`, the `localAddr` OPTION lands
+        // in `*remoteAddr`, which accepts a domain fine — ex-ray starts and
+        // (per the file's own residual disclosure on server-mode DoH
+        // reachability) may fetch.
+        let segments = garter::split_plugin_options("server;tls;host=cdn.example;localAddr=cdn.example").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), None);
     }
 
     // `remoteAddr` (`generateConfig`) must not be an empty domain or the

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -556,7 +556,7 @@ pub(crate) fn effective_ech_doh(
 }
 
 /// ex-ray's own default for the `host` option
-/// (`crates/ex-ray/config.go:45`: `flag.String("host", "cloudfront.com", ...)`)
+/// (`crates/ex-ray/config.go:65`: `flag.String("host", "cloudfront.com", ...)`)
 /// — a real DOMAIN, not "no SNI". An absent `host` segment is NOT the same
 /// as an unreachable config; see `ex_ray_default_host_matches_vendored_config_go`
 /// for the executable pin against the vendored Go source (can't run the Go
@@ -906,16 +906,10 @@ fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>], ech_doh: Optio
     // "experiment:8357203.0.113.5") while the stripped value ex-ray
     // actually uses ("203.0.113.5") is an IP, unreachable.
     let sni = sni.strip_prefix(V2RAY_CORE_EXP_8357_PREFIX).unwrap_or(sni);
-    // `sni` is empty only when `*host` was EXACTLY the bare prefix —
-    // `WithDestination` (see this function's doc) then fills
-    // `config.ServerName` from `remoteAddr` instead, which `ApplyECH`
-    // actually reads. An absent `remoteAddr` falls back to Hole's own
-    // `SS_REMOTE_HOST`, which this function cannot see (env, not
-    // `plugin_opts`) — but is ALWAYS an IP literal in Hole's own spawn path
-    // (`crate::proxy::plugin` never resolves a domain later than
-    // `garter::binary::sip003_env`, which passes an already-resolved
-    // `SocketAddr`), so an absent `remoteAddr` is correctly treated as "not
-    // a domain" (`""`) without needing to see it.
+    // An absent `remoteAddr` falls back to Hole's own `SS_REMOTE_HOST` (env,
+    // invisible here) — but is ALWAYS an IP literal in Hole's own spawn path
+    // (`garter::binary::sip003_env` passes an already-resolved `SocketAddr`),
+    // so treating an absent value as `""` here is safe.
     let sni = if sni.is_empty() {
         segments
             .iter()
@@ -1071,9 +1065,15 @@ fn classify_ech_doh(
     }
 
     // ex-ray only arms ECH_DOHserver when the value is non-empty
-    // (config.go:213: `if *echDoh != "" { tlsConfig.Ech_DOHserver = *echDoh }`)
-    // — an empty or bare (reads as ex-ray's own `"1"`, not a URL) operator
-    // value is silently inert, same as no `ech-doh` at all.
+    // (config.go:360-361: `if *echDoh != "" { tlsConfig.Ech_DOHserver =
+    // *echDoh }`) — an EMPTY operator value is inert, same as no `ech-doh`
+    // at all. A BARE `ech-doh` (no `=`) is different: it reads as ex-ray's
+    // own literal `"1"` (args.go), not an empty string, and `parseURLOption`
+    // (options.go) rejects any non-empty value that isn't a well-formed
+    // `https://` URL — so a bare `ech-doh` is FATAL, not inert;
+    // `ech_fetch_is_reachable`'s check above (which reads
+    // `ex_ray_fatal_config_error`) already routes it to `None` before this
+    // line is ever reached.
     let effective = if ech_doh.is_some() && (config_ech_doh.is_none() || displaces) {
         EffectiveEchDoh::Holes
     } else if let Some(v) = config_ech_doh.map(ex_ray_flag_value).filter(|v| !v.is_empty()) {
@@ -1154,10 +1154,10 @@ fn inject_plugin_directives(
             // off" holds regardless of reachability.
             let reachable = ech_fetch_is_reachable(&segments, ech_doh);
             // Presence alone isn't enough for the match below: ex-ray only
-            // arms `Ech_DOHserver` for a NON-empty value (config.go:213,
-            // same rule `classify_ech_doh` already applies to its
-            // `Operators` arm) — an explicitly empty `ech-doh=` must read
-            // as "no config value", not as one standing.
+            // arms `Ech_DOHserver` for a NON-empty value (same rule
+            // `classify_ech_doh` already applies to its `Operators` arm) —
+            // an explicitly empty `ech-doh=` must read as "no config
+            // value", not as one standing.
             let config_ech_doh_value = config_ech_doh.filter(|s| !ex_ray_flag_value(s).is_empty());
             match (ech_doh, config_ech_doh_value) {
                 _ if !reachable && (ech_doh.is_some() || config_ech_doh.is_some()) => tracing::warn!(
@@ -1186,14 +1186,9 @@ fn inject_plugin_directives(
                     "no configured resolver to pin the ECH lookup to; the config's own ech-doh stands: {}", s.raw
                 ),
                 // ECH is armed only by `ech-doh`, so there is none. `ech=always`
-                // can never reach this arm: with `ech_doh` and the config's own
-                // both absent/empty, `resolved_ech_doh_is_empty` is unconditionally
-                // true, so `ex_ray_fatal_config_error` already routed
-                // `ech=always` through the `if let Some(key) = ...` branch
-                // above — `Some("ech")` when TLS isn't enabled (`ech=always`
-                // requires it), else `Some("ech-doh")` (`ech=always` requires
-                // a non-empty resolved `ech-doh`). `ech` here is therefore
-                // never `"always"` — no `fail_closed` field to report.
+                // can't reach here — `ex_ray_fatal_config_error` already routes
+                // it through the fatal-config warning above (see that fn's
+                // doc). No `fail_closed` field to report.
                 (None, None) => tracing::warn!(plugin = %plugin_name, "no ech-doh from any source; ECH is off"),
             }
         }
@@ -2206,11 +2201,12 @@ mod inject_tests {
         }
     }
 
-    // `ech=always` with an empty RESOLVED `ech-doh` is itself a
-    // config-build error (config.go:218-220) distinct from a plain invalid
-    // `ech` value — ex-ray refuses to start rather than merely skipping
-    // ECH. Reachable whenever Hole has no candidate of its own (no pinned
-    // resolver) and the operator's own config supplies none either.
+    // `ech=always` with an empty RESOLVED `ech-doh` is itself a config-build
+    // error (config.go's `buildTLSConfig`, `"ech=always requires ech-doh to
+    // be set"`) distinct from a plain invalid `ech` value — ex-ray refuses
+    // to start rather than merely skipping ECH. Reachable whenever Hole has
+    // no candidate of its own (no pinned resolver) and the operator's own
+    // config supplies none either.
     #[skuld::test]
     fn ech_always_with_no_ech_doh_from_any_source_never_reaches_ex_ray() {
         assert_eq!(
@@ -2222,7 +2218,7 @@ mod inject_tests {
     }
 
     // As above, but the operator's OWN `ech-doh=` is explicitly empty
-    // rather than absent — same config.go:218-220 fatal, same expectation.
+    // rather than absent — same fatal check, same expectation.
     #[skuld::test]
     fn ech_always_with_an_explicitly_empty_operator_ech_doh_never_reaches_ex_ray() {
         let segments = garter::split_plugin_options("tls;host=cdn.example;ech=always;ech-doh=").unwrap();
@@ -2466,7 +2462,8 @@ mod inject_tests {
 
     // `classify_ech_doh` must read whether ex-ray will even ATTEMPT ECH, not
     // just plugin family + ech-doh presence — `ech=never` short-circuits it
-    // (config.go:209-211) regardless of `tls`/`host`/`ech-doh`.
+    // (config.go's `buildTLSConfig`, `case "never":`) regardless of
+    // `tls`/`host`/`ech-doh`.
     #[skuld::test]
     fn ech_never_never_reaches_ex_ray_even_with_tls_and_ech_doh() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -2567,7 +2564,7 @@ mod inject_tests {
     }
 
     // `ech` and `mode` are CLOSED enums to ex-ray (`switch *echMode` /
-    // `switch *mode`, config.go:209,281) — a value outside the known set is
+    // `switch *mode`, config.go) — a value outside the known set is
     // a config-build error and `main.go` exits (23) before the server ever
     // starts, so no dial of any kind happens. A bare `ech` (no `=`) reads as
     // `"1"` to ex-ray, which is exactly such an invalid value — NOT
@@ -2824,8 +2821,10 @@ mod inject_tests {
 
     // ex-ray's `buildTLSConfig` (and therefore its whole `ech` switch) is
     // only called when `tlsEnabled` — never for a plain, non-quic transport
-    // with no `tls` flag (config.go:290-294,334). A permit or warning for
-    // this config would be for a fetch that provably cannot happen.
+    // with no `tls` flag (config.go's `if *tlsEnabled { ... }` guard, and
+    // `mode=quic`'s own `*tlsEnabled = true` in the mode switch above it). A
+    // permit or warning for this config would be for a fetch that provably
+    // cannot happen.
     #[skuld::test]
     fn no_tls_and_not_quic_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -2837,7 +2836,8 @@ mod inject_tests {
     }
 
     // `mode=quic` force-enables TLS even with no explicit `tls` flag
-    // (config.go:290-294) — first-wins, matching every other flag here.
+    // (config.go's mode switch, `*tlsEnabled = true`) — first-wins, matching
+    // every other flag here.
     #[skuld::test]
     fn quic_mode_reaches_ex_ray_without_an_explicit_tls_flag() {
         let e = pinned("https://9.9.9.9/dns-query");

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -555,13 +555,15 @@ pub(crate) fn effective_ech_doh(
     classify_ech_doh(&segments, ech_doh).0
 }
 
-/// The `(EffectiveEchDoh, displaces)` decision shared by [`effective_ech_doh`]
-/// (reads only the first element) and `inject_plugin_directives` (reads
-/// both: `displaces` decides which keys to strip). The ONE place this
-/// formula is written — see `effective_ech_doh`'s doc for why the parse
-/// itself is NOT similarly shared (the logging that must stay
-/// spawn-side-only lives one level up, in `inject_plugin_directives`, past
-/// where `segments` is produced).
+/// ex-ray's own default for the `host` option
+/// (`crates/ex-ray/config.go:45`: `flag.String("host", "cloudfront.com", ...)`)
+/// — a real DOMAIN, not "no SNI". An absent `host` segment is NOT the same
+/// as an unreachable config; see `doh_default_host_matches_ex_ray_config_go`
+/// for the executable pin against the vendored Go source (can't run the Go
+/// code itself, but a text-level assertion still fails loudly if the
+/// literal ever changes there without a matching edit here).
+const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
+
 /// Whether ex-ray will even ATTEMPT an ECH-config fetch for this segment
 /// set, independent of which `ech-doh` value would win. Neither the cover
 /// permit, the residual-stall warning, nor `inject_plugin_directives`'s own
@@ -576,13 +578,18 @@ pub(crate) fn effective_ech_doh(
 ///   plain non-quic transport (e.g. `mode=websocket` with no `tls`) never
 ///   calls it.
 /// - `ApplyECH` bails before dialing DoH unless the TLS `ServerName` is a
-///   DOMAIN: an absent, empty, or IP-literal `host` means ex-ray dials with
-///   an IP-literal `ServerName` (Hole never hands ex-ray a raw hostname as
-///   the connection target — everything is pre-resolved, `host` only ever
-///   supplies SNI), which `echCacheDomain` treats as "no SNI to use", so ECH
-///   is unreachable regardless of `tls`/`ech-doh`
+///   DOMAIN: an EXPLICIT empty or IP-literal `host` means ex-ray dials with
+///   an IP-literal `ServerName`, which `echCacheDomain` treats as "no SNI to
+///   use" — but an ABSENT `host` falls back to ex-ray's own
+///   [`EX_RAY_DEFAULT_HOST`], a real domain, so it's reachable. Normalizing
+///   the IP-literal test mirrors v2ray-core's `net.ParseAddress` exactly
+///   (only a MATCHED `[...]` pair is stripped, once; whitespace is trimmed
+///   only when the first or last byte is non-alphanumeric) — an
+///   approximation here would itself misjudge reachability in either
+///   direction.
 ///   (third_party/v2ray-core/transport/internet/tls/ech.go:26-51,
-///   config.go:250-264,296-303; main.go:67-69).
+///   config.go:250-264,296-303; third_party/v2ray-core/common/net/address.go:78-95;
+///   main.go:67-69).
 fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>]) -> bool {
     let ech_never = segments
         .iter()
@@ -593,13 +600,39 @@ fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>]) -> bool {
             .iter()
             .find(|s| s.key == "mode")
             .is_some_and(|s| s.value == "quic");
-    let sni_is_a_domain = segments.iter().find(|s| s.key == "host").is_some_and(|s| {
-        let bare = s.value.trim_start_matches('[').trim_end_matches(']');
-        !bare.is_empty() && bare.parse::<std::net::IpAddr>().is_err()
-    });
-    !ech_never && tls_enabled && sni_is_a_domain
+    let host = segments
+        .iter()
+        .find(|s| s.key == "host")
+        .map_or(EX_RAY_DEFAULT_HOST, |s| s.value.as_str());
+    !ech_never && tls_enabled && v2ray_core_parses_as_a_domain(host)
 }
 
+/// Mirrors v2ray-core's `net.ParseAddress` (see `ech_fetch_is_reachable`'s
+/// doc for the exact source lines): strips ONE matched `[...]` bracket pair,
+/// then trims surrounding whitespace ONLY when the first or last byte isn't
+/// alphanumeric, then tests whether what's left parses as an IP. An empty
+/// result (whether from the input or after normalization) is never a
+/// domain — `echCacheDomain`'s own caller excludes it explicitly.
+fn v2ray_core_parses_as_a_domain(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let unbracketed = if !bytes.is_empty() && bytes[0] == b'[' && bytes[bytes.len() - 1] == b']' {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    };
+    let ub = unbracketed.as_bytes();
+    let needs_trim = !ub.is_empty() && (!ub[0].is_ascii_alphanumeric() || !ub[ub.len() - 1].is_ascii_alphanumeric());
+    let normalized = if needs_trim { unbracketed.trim() } else { unbracketed };
+    !normalized.is_empty() && normalized.parse::<std::net::IpAddr>().is_err()
+}
+
+/// The `(EffectiveEchDoh, displaces)` decision shared by [`effective_ech_doh`]
+/// (reads only the first element) and `inject_plugin_directives` (reads
+/// both: `displaces` decides which keys to strip). The ONE place this
+/// formula is written — see `effective_ech_doh`'s doc for why the parse
+/// itself is NOT similarly shared (the logging that must stay
+/// spawn-side-only lives one level up, in `inject_plugin_directives`, past
+/// where `segments` is produced).
 fn classify_ech_doh(
     segments: &[garter::OptionSegment<'_>],
     ech_doh: Option<&crate::dns::ech::EchDoh>,
@@ -1079,6 +1112,29 @@ mod inject_tests {
         );
     }
 
+    // The round-3 regression this guards against: an UNREACHABLE config
+    // (`ech=never` here) with a PRE-EXISTING operator `ech-doh=` key and a
+    // PINNED Hole candidate. `displaces` must still be computed correctly
+    // (pinned always outranks) and the strip must still happen, even though
+    // no fetch will ever occur — `classify_ech_doh`'s reachability gate may
+    // only change `EffectiveEchDoh`, never silently disable the strip.
+    // Exercised at the actual joined-string level, not just the
+    // `EffectiveEchDoh` enum.
+    #[skuld::test]
+    fn displaces_is_still_correct_when_the_config_is_unreachable() {
+        let out = merged(
+            "ex-ray",
+            Some("ech=never;ech-doh=https://evil.example/dns-query"),
+            Some(&pinned("https://9.9.9.9/dns-query")),
+        );
+        assert_eq!(
+            out.as_deref(),
+            Some("ech=never;loglevel=debug;ech-doh=https://9.9.9.9/dns-query"),
+            "exactly one ech-doh key (Hole's), the operator's stripped, even though ech=never means \
+             neither will ever be dialed"
+        );
+    }
+
     // ex-ray discards the whole SS_* environment on a parse error and reports
     // `ready` on its default port, so forwarding these would produce a dead
     // tunnel that looks healthy. Refuse the start instead.
@@ -1329,19 +1385,72 @@ mod inject_tests {
         );
     }
 
-    // The SNI (`host`) must be a DOMAIN for `ApplyECH` to ever dial DoH at
-    // all (`echCacheDomain` returns "" and `ApplyECH` bails otherwise) —
-    // absent, empty, or IP-literal all mean "no SNI to key the lookup on".
+    // An ABSENT `host` is NOT "no SNI" — ex-ray defaults it to
+    // `EX_RAY_DEFAULT_HOST` (a real domain), so the fetch IS reachable.
+    #[skuld::test]
+    fn absent_host_falls_back_to_ex_rays_own_domain_default_and_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    // But an EXPLICIT `host` must still be a DOMAIN for `ApplyECH` to ever
+    // dial DoH at all (`echCacheDomain` returns "" and `ApplyECH` bails
+    // otherwise) — explicitly empty or IP-literal both mean "no SNI to key
+    // the lookup on", matching v2ray-core's `net.ParseAddress` exactly:
+    // only a MATCHED `[...]` pair strips, and only a non-alphanumeric edge
+    // trims whitespace.
     #[skuld::test]
     fn no_domain_host_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
-        for opts in ["tls", "tls;host=", "tls;host=203.0.113.5", "tls;host=[2001:db8::1]"] {
+        for opts in [
+            "tls;host=",
+            "tls;host=203.0.113.5",
+            "tls;host=[2001:db8::1]",
+            "tls;host= 203.0.113.5", // ParseAddress TrimSpaces a non-alnum edge, still an IP
+            "tls;host=203.0.113.5 ", // same, trailing
+        ] {
             assert_eq!(
                 effective_ech_doh("ex-ray", Some(opts), Some(&e)),
                 EffectiveEchDoh::None,
                 "opts={opts:?} must not reach ex-ray: no domain SNI to key the DoH lookup on"
             );
         }
+    }
+
+    // `ParseAddress` strips only a MATCHED `[...]` pair — an unmatched
+    // bracket is left as part of the (non-IP, therefore domain) string, so
+    // ex-ray treats it as a real SNI and DOES dial DoH.
+    #[skuld::test]
+    fn unmatched_brackets_are_not_stripped_and_reach_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in ["tls;host=[2001:db8::1", "tls;host=2001:db8::1]"] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::Holes,
+                "opts={opts:?}: an unmatched bracket is not IPv6-literal stripping, so this is a \
+                 (nonsensical but real) domain string ex-ray will dial DoH for"
+            );
+        }
+    }
+
+    // The Go source cited by `EX_RAY_DEFAULT_HOST`'s doc, pinned at the text
+    // level: this crate can't execute ex-ray's Go code, but a literal-string
+    // check still fails loudly if the vendored default ever changes without
+    // a matching edit here — the same spirit as `resolver_permit_port_matches_doh_port`
+    // pinning a value across the tun-engine/hole-bridge crate boundary,
+    // applied across the Rust/Go boundary instead.
+    #[skuld::test]
+    fn ex_ray_default_host_matches_vendored_config_go() {
+        let source = include_str!("../../../ex-ray/config.go");
+        let expected = format!("flag.String(\"host\", \"{EX_RAY_DEFAULT_HOST}\", \"Hostname for server.\")");
+        assert!(
+            source.contains(&expected),
+            "EX_RAY_DEFAULT_HOST ({EX_RAY_DEFAULT_HOST:?}) no longer matches config.go's `host` flag \
+             default — update the constant to match the vendored source"
+        );
     }
 
     // `host` uses first-wins too, matching every other flag here.

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -607,7 +607,10 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 ///
 /// Then `registerTCPKeepAlive` and main()'s own pre-`generateConfig` guards:
 /// - `tcp-keepalive`, again: a value that parsed above is now range-checked
-///   against `tcpKeepAliveParams`' `0..=32767`.
+///   against `tcpKeepAliveParams`' `0..=32767` — EXCEPT under a `server`
+///   segment: `registerTCPKeepAlive` returns early for `*server`, without
+///   range-checking; server mode's own range check is unconditional inside
+///   `generateConfig` instead, much later (below).
 /// - `localPort` (main.go's cross-assign + `validPort` ==
 ///   `net.PortFromString`): must be an unsigned base-10 literal `<=65535`
 ///   and not `0` — `0` is otherwise valid syntax
@@ -633,6 +636,10 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 ///   `tls` and no `mode=quic` promises fail-closed ECH it cannot deliver.
 /// - `cert`/`certRaw`/`key` present (non-empty) with TLS not enabled is
 ///   fatal too — the material would otherwise be silently never read.
+/// - `tcp-keepalive`, again, under a `server` segment ONLY (the
+///   `registerTCPKeepAlive`-position check above skips it there): the same
+///   `0..=32767` range check `generateConfig` itself runs unconditionally,
+///   regardless of `*server`.
 /// - `ech=always` additionally requires a non-empty RESOLVED `ech-doh`
 ///   (`buildTLSConfig`, reached only `if *tlsEnabled`) — the value ex-ray
 ///   actually receives once Hole's own injection wins or loses against the
@@ -643,9 +650,11 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 /// - `mux`, a THIRD time: a non-zero `Concurrency` outside `1..=1024` on
 ///   the websocket transport only (`quic`'s mux is never read).
 ///
-/// `mux`/`tcp-keepalive`/`fwmark` are each checked TWICE (parse, then
-/// range) at their own two real positions above — no order fidelity is
-/// relaxed for these three.
+/// `mux`/`fwmark` are each checked TWICE (parse, then range) at their own
+/// two real positions above — no order fidelity is relaxed for these two.
+/// `tcp-keepalive` is checked twice too, but at ONE OF TWO MUTUALLY
+/// EXCLUSIVE positions depending on `server` (never both), not the same
+/// position regardless of mode.
 ///
 /// **Not modeled, and why it's safe not to:** `loglevel` is ALSO fatal when
 /// explicitly empty (`parseStringOption`) or unrecognized (`logConfig`) —
@@ -723,11 +732,18 @@ fn ex_ray_fatal_config_error(
     }
 
     // registerTCPKeepAlive + main()'s own pre-generateConfig guards.
-    if segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
-        !ex_ray_flag_value(s)
-            .parse::<i64>()
-            .is_ok_and(|v| (0..=32767).contains(&v))
-    }) {
+    // registerTCPKeepAlive returns early under `*server` WITHOUT
+    // range-checking — server mode's own tcp-keepalive range check is
+    // unconditional inside generateConfig instead, much later (see below),
+    // so it must not fire here too.
+    let server_present = segments.iter().any(|s| s.key == "server");
+    if !server_present
+        && segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
+            !ex_ray_flag_value(s)
+                .parse::<i64>()
+                .is_ok_and(|v| (0..=32767).contains(&v))
+        })
+    {
         return Some("tcp-keepalive");
     }
     if segments
@@ -788,13 +804,25 @@ fn ex_ray_fatal_config_error(
     if !tls_enabled && cert_material_present {
         return Some("cert");
     }
+    // Server mode's own tcp-keepalive range check — unconditional inside
+    // generateConfig, unlike registerTCPKeepAlive above, which never runs
+    // it for `*server`.
+    if server_present
+        && segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
+            !ex_ray_flag_value(s)
+                .parse::<i64>()
+                .is_ok_and(|v| (0..=32767).contains(&v))
+        })
+    {
+        return Some("tcp-keepalive");
+    }
     if ech == Some("always") && tls_enabled && resolved_ech_doh_is_empty(segments, ech_doh) {
         return Some("ech-doh");
     }
 
     // core.New, once generateConfig has fully succeeded (doc: mux, a third
     // time; skipped alongside the server residual).
-    if mode != Some("quic") && !segments.iter().any(|s| s.key == "server") {
+    if mode != Some("quic") && !server_present {
         let mux = segments
             .iter()
             .find(|s| s.key == "mux")
@@ -1765,6 +1793,27 @@ mod inject_tests {
              returns) — a key checked in generateConfig/main()'s own pre-generateConfig guards must \
              never win over one checked earlier, inside parseOptsIntoFlags itself"
         );
+        // Under `server`, tcp-keepalive's range check moves from the early
+        // registerTCPKeepAlive position all the way to generateConfig's own
+        // unconditional call, well after `mode` — so `mode` must now win.
+        let segments = garter::split_plugin_options("server;host=cdn.example;mode=bogus;tcp-keepalive=99999").unwrap();
+        assert_eq!(
+            ex_ray_fatal_config_error(&segments, None),
+            Some("mode"),
+            "registerTCPKeepAlive skips the range check under *server; generateConfig's own mode \
+             switch runs long before its own (also unconditional) tcp-keepalive range check"
+        );
+    }
+
+    // As `two_distinct_fatal_keys_report_ex_rays_earlier_one`'s server-mode
+    // case, exercised end to end: `registerTCPKeepAlive` skips
+    // `tcp-keepalive`'s range check under `*server`, but `generateConfig`
+    // still range-checks it unconditionally, later — this must still be
+    // fatal, just at the later position.
+    #[skuld::test]
+    fn a_fatal_tcp_keepalive_value_under_server_still_reaches_the_late_check() {
+        let segments = garter::split_plugin_options("server;host=cdn.example;tcp-keepalive=99999").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("tcp-keepalive"));
     }
 
     // ex-ray reads the FIRST `ech`, so a later `always` it will never apply must

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -792,14 +792,8 @@ fn ex_ray_fatal_config_error(
         return Some("ech-doh");
     }
 
-    // core.New, once generateConfig has fully succeeded. Same 1..=1024
-    // concurrency bound as the `mux` bullet above, only on websocket, only
-    // when non-zero. The effective value defaults to ex-ray's own flag
-    // default (`1`) unless a segment both exists AND parses.
-    // `MultiplexSettings` is CLIENT-mode only (config.go — the `server`
-    // branch never builds it), so this check is skipped alongside the rest
-    // of the disclosed, deliberately-unmodeled `server` residual above, not
-    // a separate gap.
+    // core.New, once generateConfig has fully succeeded (doc: mux, a third
+    // time; skipped alongside the server residual).
     if mode != Some("quic") && !segments.iter().any(|s| s.key == "server") {
         let mux = segments
             .iter()
@@ -864,11 +858,7 @@ fn ex_ray_parses_as_uint32(v: &str) -> Option<u32> {
 ///   exits before it ever starts, so no dial of any kind happens. This also
 ///   covers an EXPLICITLY EMPTY `host=`: `parseStringOption(..., "host",
 ///   ..., emptyOK: false)` rejects it at parse time, so `*host` can never
-///   actually BE `""` when `buildTLSConfig` runs. (v2ray-core's own
-///   `Config.ServerName` empty-fallback to the dial destination —
-///   `tls.WithDestination` filling it from `remoteAddr`,
-///   third_party/.../tls/config.go, `websocket/dialer.go` — still exists in
-///   the vendored source; it is simply unreachable via `plugin_opts`.)
+///   actually BE `""` this way when `buildTLSConfig` runs.
 /// - `ech=never` short-circuits ECH entirely before it ever looks at
 ///   `ech-doh` (config.go).
 /// - TLS must be enabled at all — an explicit `tls` flag, or `mode=quic`
@@ -878,13 +868,21 @@ fn ex_ray_parses_as_uint32(v: &str) -> Option<u32> {
 /// - `ApplyECH` bails before dialing DoH unless the TLS `ServerName` is a
 ///   DOMAIN: ex-ray sets `tlsConfig.ServerName = *host` directly, and an
 ///   ABSENT `host` falls back to ex-ray's own [`EX_RAY_DEFAULT_HOST`], a
-///   real domain, so it's reachable. An EXPLICIT `host=<value>` (now always
-///   non-empty, given the point above) wins outright, domain or not — EXCEPT
-///   that `GetTLSConfig` resolves `config.ServerName` via `parseServerName`
-///   before `ApplyECH` ever reads it, which strips a literal
-///   [`V2RAY_CORE_EXP_8357_PREFIX`] prefix first
-///   (third_party/v2ray-core/transport/internet/tls/config.go:20,173-183,
-///   262-264,296-301; `ech.go:26-51,37-51`).
+///   real domain, so it's reachable. An EXPLICIT `host=<value>` wins
+///   outright, domain or not — EXCEPT that `GetTLSConfig` resolves
+///   `config.ServerName` via `parseServerName` before `ApplyECH` ever reads
+///   it, which strips a literal [`V2RAY_CORE_EXP_8357_PREFIX`] prefix
+///   first. If THAT strip leaves `*host` empty (only when `*host` is
+///   EXACTLY the bare prefix — an explicit `host=` alone is already fatal,
+///   above), `config.ServerName` is NOT `""`: `GetTLSConfig` applies
+///   `WithDestination` (an `Option` in its `opts...` — the websocket client
+///   dialer always passes one) BEFORE the `parseServerName` assignment,
+///   and `WithDestination` only ever fills an ALREADY-`""` `ServerName`
+///   from the dial destination — so the empty-after-strip case reaches
+///   `ApplyECH` with `remoteAddr` as its SNI, same first-wins rule as every
+///   other key here (third_party/v2ray-core/transport/internet/tls/
+///   config.go:20,173-183,262-264,296-301,371-381; `ech.go:26-51,37-51`;
+///   `websocket/dialer.go:67`).
 ///
 /// Every flag read here goes through [`ex_ray_flag_value`] rather than
 /// `OptionSegment::value` — see its doc. For `host` the divergence is
@@ -899,8 +897,6 @@ fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>], ech_doh: Optio
     }
     let mode = segments.iter().find(|s| s.key == "mode").map(ex_ray_flag_value);
     let tls_enabled = segments.iter().any(|s| s.key == "tls") || mode == Some("quic");
-    // An explicitly empty `host=` is fatal (caught above) and never reaches
-    // here — only an ABSENT host falls back to ex-ray's own default.
     let sni = segments
         .iter()
         .find(|s| s.key == "host")
@@ -910,6 +906,24 @@ fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>], ech_doh: Optio
     // "experiment:8357203.0.113.5") while the stripped value ex-ray
     // actually uses ("203.0.113.5") is an IP, unreachable.
     let sni = sni.strip_prefix(V2RAY_CORE_EXP_8357_PREFIX).unwrap_or(sni);
+    // `sni` is empty only when `*host` was EXACTLY the bare prefix —
+    // `WithDestination` (see this function's doc) then fills
+    // `config.ServerName` from `remoteAddr` instead, which `ApplyECH`
+    // actually reads. An absent `remoteAddr` falls back to Hole's own
+    // `SS_REMOTE_HOST`, which this function cannot see (env, not
+    // `plugin_opts`) — but is ALWAYS an IP literal in Hole's own spawn path
+    // (`crate::proxy::plugin` never resolves a domain later than
+    // `garter::binary::sip003_env`, which passes an already-resolved
+    // `SocketAddr`), so an absent `remoteAddr` is correctly treated as "not
+    // a domain" (`""`) without needing to see it.
+    let sni = if sni.is_empty() {
+        segments
+            .iter()
+            .find(|s| s.key == "remoteAddr")
+            .map_or("", ex_ray_flag_value)
+    } else {
+        sni
+    };
     tls_enabled && v2ray_core_parses_as_a_domain(sni)
 }
 
@@ -1171,19 +1185,16 @@ fn inject_plugin_directives(
                     plugin = %plugin_name,
                     "no configured resolver to pin the ECH lookup to; the config's own ech-doh stands: {}", s.raw
                 ),
-                // ECH is armed only by `ech-doh`, so there is none. Under
-                // `ech=always` WITH TLS enabled, this arm is unreachable —
-                // `ex_ray_fatal_config_error`'s `resolved_ech_doh_is_empty`
-                // check already routed that combination through the `if let
-                // Some(key) = ...` branch above. WITHOUT TLS (no `tls` flag,
-                // no `mode=quic`), `ech=always` is inert like everything
-                // else here — `buildTLSConfig` never runs, so `fail_closed`
-                // can legitimately be `true` on this arm.
-                (None, None) => tracing::warn!(
-                    plugin = %plugin_name,
-                    fail_closed,
-                    "no ech-doh from any source; ECH is off"
-                ),
+                // ECH is armed only by `ech-doh`, so there is none. `ech=always`
+                // can never reach this arm: with `ech_doh` and the config's own
+                // both absent/empty, `resolved_ech_doh_is_empty` is unconditionally
+                // true, so `ex_ray_fatal_config_error` already routed
+                // `ech=always` through the `if let Some(key) = ...` branch
+                // above — `Some("ech")` when TLS isn't enabled (`ech=always`
+                // requires it), else `Some("ech-doh")` (`ech=always` requires
+                // a non-empty resolved `ech-doh`). `ech` here is therefore
+                // never `"always"` — no `fail_closed` field to report.
+                (None, None) => tracing::warn!(plugin = %plugin_name, "no ech-doh from any source; ECH is off"),
             }
         }
 
@@ -2107,6 +2118,38 @@ mod inject_tests {
         );
     }
 
+    // `host` EXACTLY the bare prefix strips to an EMPTY `ServerName` —
+    // `WithDestination` then fills it from `remoteAddr` instead (see
+    // `ech_fetch_is_reachable`'s doc), so the fetch is reachable or not
+    // based on `remoteAddr`, not on the (now-empty) stripped host.
+    #[skuld::test]
+    fn exp_8357_with_nothing_after_it_falls_back_to_remote_addr() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh(
+                "ex-ray",
+                Some("tls;host=experiment:8357;remoteAddr=cdn.example"),
+                Some(&e)
+            ),
+            EffectiveEchDoh::Holes,
+            "remoteAddr is a domain — reachable"
+        );
+        assert_eq!(
+            effective_ech_doh(
+                "ex-ray",
+                Some("tls;host=experiment:8357;remoteAddr=203.0.113.5"),
+                Some(&e)
+            ),
+            EffectiveEchDoh::None,
+            "remoteAddr is an IP — unreachable"
+        );
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=experiment:8357"), Some(&e)),
+            EffectiveEchDoh::None,
+            "no remoteAddr — falls back to Hole's own SS_REMOTE_HOST, always an IP literal"
+        );
+    }
+
     // `ex_ray_value_is_https_url` is a deliberately lenient superset of Go's
     // `net/url.Parse` (see its doc): a syntax the `url` crate's stricter
     // WHATWG parser rejects but Go accepts must still read as well-formed
@@ -2208,6 +2251,22 @@ mod inject_tests {
     fn ech_always_without_tls_is_fatal() {
         let segments = garter::split_plugin_options("host=cdn.example;ech=always").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech"));
+    }
+
+    // `ech=always` can never reach `inject_plugin_directives`'s `(None,
+    // None)` "no ech-doh from any source" warning arm: with no `ech_doh`
+    // and no config-side `ech-doh`, `resolved_ech_doh_is_empty` is
+    // unconditionally true, so `ex_ray_fatal_config_error` already routes
+    // it through the fatal-config warning first — regardless of `tls`.
+    #[skuld::test]
+    fn ech_always_with_no_ech_doh_never_reaches_the_ech_is_off_warning() {
+        for opts in ["ech=always", "tls;ech=always"] {
+            let out = warnings_for("ex-ray", Some(opts), None);
+            assert!(
+                out.contains("ex-ray will refuse to start") && !out.contains("ECH is off"),
+                "opts={opts:?}: expected the fatal-config warning, not the ECH-is-off one; got:\n{out}"
+            );
+        }
     }
 
     // Every new `ex_ray_fatal_config_error` check reads its key via `find`

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -2148,7 +2148,7 @@ mod inject_tests {
     // `remoteAddr` KEY, and vice versa, or this either over-permits (a
     // config that is actually fatal reads as reachable) or under-permits (a
     // config that actually starts fine reads as unreachable, reintroducing
-    // the ECH-fetch stall this PR closes).
+    // the ECH-fetch stall).
     #[skuld::test]
     fn server_mode_swaps_which_key_the_address_rules_apply_to() {
         let e = pinned("https://9.9.9.9/dns-query");

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -754,10 +754,7 @@ fn ex_ray_fatal_config_error(
     }
 
     // registerTCPKeepAlive + main()'s own pre-generateConfig guards.
-    // registerTCPKeepAlive returns early under `*server` WITHOUT
-    // range-checking — server mode's own tcp-keepalive range check is
-    // unconditional inside generateConfig instead, much later (see below),
-    // so it must not fire here too.
+    // Server-mode tcp-keepalive split — see this fn's doc.
     let server_present = segments.iter().any(|s| s.key == "server");
     if !server_present
         && segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
@@ -837,9 +834,7 @@ fn ex_ray_fatal_config_error(
     if !tls_enabled && cert_material_present {
         return Some("cert");
     }
-    // Server mode's own tcp-keepalive range check — unconditional inside
-    // generateConfig, unlike registerTCPKeepAlive above, which never runs
-    // it for `*server`.
+    // The `*server` case skipped above — checked here instead.
     if server_present
         && segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
             !ex_ray_flag_value(s)

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -462,6 +462,129 @@ fn unpinned_reason(ech_doh: Option<&crate::dns::ech::EchDoh>) -> &'static str {
     }
 }
 
+/// The v2ray-family plugin names `inject_plugin_directives` rewrites
+/// `ech-doh` for. `v2ray-plugin` resolves to the first-party `ex-ray` binary,
+/// but a config may also name `ex-ray` directly, so both spellings are
+/// covered; `galoshes` ignores the keys itself but forwards the whole options
+/// string to its inner ex-ray. Every OTHER plugin name is passed through
+/// `inject_plugin_directives` completely unmodified — no `ech-doh` is ever
+/// injected, so nothing that plugin does can be influenced by Hole's ECH
+/// derivation at all.
+fn takes_ech_directives(plugin_name: &str) -> bool {
+    matches!(plugin_name, "v2ray-plugin" | "ex-ray" | "galoshes")
+}
+
+/// Whether Hole's OWN `ech_doh` outranks (and should replace) an operator's
+/// existing `ech-doh` value already present in `plugin_opts`: only a resolver
+/// that ANSWERED the bootstrap, or a name-authority operator value carrying
+/// the plaintext-DNS leak Hole's own pin exists to close. Against an
+/// IP-literal operator value with an unpinned Hole guess, the operator's own
+/// choice stands. The ONE formula both `inject_plugin_directives` (decides
+/// whether to STRIP the operator's entry) and `ech_doh_will_reach_ex_ray`
+/// (decides whether Hole's directive — appended either way — is what
+/// actually reaches ex-ray) read, so the two can never silently disagree.
+fn hole_ech_doh_outranks(ech_doh: &crate::dns::ech::EchDoh, config_value: &str) -> bool {
+    ech_doh.is_pinned() || crate::dns::ech::authority_is_a_name(config_value)
+}
+
+/// Which `ech-doh` value (if any) will actually reach ex-ray once
+/// `inject_plugin_directives` runs — computed ONCE inside it, so
+/// `ProxyManager`'s cover-permit and residual-warning decisions and the
+/// actual plugin spawn always agree on the same answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EffectiveEchDoh {
+    /// A non-ECH-capable plugin, or an ECH-capable one with no `ech-doh`
+    /// from any source — ECH is off, nothing will be fetched.
+    None,
+    /// Hole's own `ech_doh` is the value ex-ray will fetch.
+    Holes,
+    /// An OPERATOR's own `ech-doh` (already in `plugin_opts`, not displaced
+    /// by Hole's) is the value ex-ray will fetch instead — carried so a
+    /// caller can name the address in a diagnostic. Hole's fail-closed cover
+    /// never permits an operator-chosen address: the permit rests on
+    /// config-authorship trust — Hole itself authored the address (see
+    /// `hole_bridge::dns::ech::EchDoh`'s doc) — and an operator-supplied
+    /// address carries no such guarantee, so permitting it would be a real
+    /// widening. A covered start with this outcome is therefore a disclosed
+    /// residual: ex-ray will dial an address the cover does not permit and
+    /// can stall.
+    Operators(String),
+}
+
+/// Whether ex-ray will actually receive HOLE'S `ech_doh` as the winning
+/// `ech-doh=` value once `inject_plugin_directives` runs on this exact
+/// `(plugin_name, opts)` pair. Test-only: production code (`ProxyManager`)
+/// reads the full [`EffectiveEchDoh`] off [`effective_ech_doh`] directly, so
+/// it can ALSO warn about the `Operators` case — this bool-only view is a
+/// convenience for tests that only care about the `Holes` outcome.
+#[cfg(test)]
+pub(crate) fn ech_doh_will_reach_ex_ray(
+    plugin_name: &str,
+    opts: Option<&str>,
+    ech_doh: Option<&crate::dns::ech::EchDoh>,
+) -> bool {
+    matches!(effective_ech_doh(plugin_name, opts, ech_doh), EffectiveEchDoh::Holes)
+}
+
+/// Which `ech-doh` value ex-ray will actually dial for this exact
+/// `(plugin_name, opts, ech_doh)` triple — a PURE query, no logging. Shares
+/// [`classify_ech_doh`] with `inject_plugin_directives`, so the "will
+/// something fetch an ECH config, and whose value" question and the actual
+/// plugin spawn read the exact same parse and the exact same outrank
+/// decision (they cannot drift the way two independent re-derivations of
+/// `takes_ech_directives` + `hole_ech_doh_outranks` could), WITHOUT also
+/// re-triggering `inject_plugin_directives`'s `tracing::warn!` calls: this
+/// is queried once per start attempt from the permit-derivation path
+/// (`ProxyManager::start_cancellable`), and the eventual plugin spawn calls
+/// `inject_plugin_directives` again for real — calling that function here
+/// too would double-emit every ECH-posture warning on every start. A
+/// malformed `opts` string reads as `None` too — the same input that would
+/// make `inject_plugin_directives` return `Err`, so the plugin chain never
+/// starts and nothing ech-doh-shaped ever reaches ex-ray.
+pub(crate) fn effective_ech_doh(
+    plugin_name: &str,
+    opts: Option<&str>,
+    ech_doh: Option<&crate::dns::ech::EchDoh>,
+) -> EffectiveEchDoh {
+    if !takes_ech_directives(plugin_name) {
+        return EffectiveEchDoh::None;
+    }
+    let Ok(segments) = garter::split_plugin_options(opts.unwrap_or_default()) else {
+        return EffectiveEchDoh::None;
+    };
+    classify_ech_doh(&segments, ech_doh).0
+}
+
+/// The `(EffectiveEchDoh, displaces)` decision shared by [`effective_ech_doh`]
+/// (reads only the first element) and `inject_plugin_directives` (reads
+/// both: `displaces` decides which keys to strip). The ONE place this
+/// formula is written — see `effective_ech_doh`'s doc for why the parse
+/// itself is NOT similarly shared (the logging that must stay
+/// spawn-side-only lives one level up, in `inject_plugin_directives`, past
+/// where `segments` is produced).
+fn classify_ech_doh(
+    segments: &[garter::OptionSegment<'_>],
+    ech_doh: Option<&crate::dns::ech::EchDoh>,
+) -> (EffectiveEchDoh, bool) {
+    let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
+    // Hole's URL is name-free, so it displaces one whose authority is a
+    // name — that lookup is the defect. Against an IP-literal value there
+    // is no leak to fix, so only a resolver that ANSWERED outranks the
+    // operator's own choice.
+    let displaces = match (ech_doh, config_ech_doh) {
+        (Some(e), Some(s)) => hole_ech_doh_outranks(e, &s.value),
+        _ => false,
+    };
+    let effective = if ech_doh.is_some() && (config_ech_doh.is_none() || displaces) {
+        EffectiveEchDoh::Holes
+    } else if let Some(s) = config_ech_doh {
+        EffectiveEchDoh::Operators(s.value.to_string())
+    } else {
+        EffectiveEchDoh::None
+    };
+    (effective, displaces)
+}
+
 /// Remove any existing copy of a key Hole is about to set, then append it.
 /// ex-ray's `Args.Get` is first-wins, so an appended duplicate would silently
 /// lose to a user's, and postern writes `ech-doh` before Hole ever sees the
@@ -471,86 +594,85 @@ fn unpinned_reason(ech_doh: Option<&crate::dns::ech::EchDoh>) -> &'static str {
 /// Only the v2ray-family plugins receive these: `v2ray-plugin` resolves to the
 /// first-party `ex-ray` binary, but a config may also name `ex-ray` directly,
 /// so both spellings are covered; `galoshes` ignores the keys itself but
-/// forwards the whole options string to its inner ex-ray.
+/// forwards the whole options string to its inner ex-ray. Every other plugin
+/// name is passed through unmodified — the ONE gate (`takes_ech_directives`)
+/// both this function and its callers rely on, checked exactly once, here.
+/// Emits the ECH-posture `tracing::warn!` lines — called exactly once per
+/// actual plugin spawn (`start_plugin_chain`); the permit-derivation query
+/// [`effective_ech_doh`] deliberately does NOT call this, to avoid
+/// double-emitting them (see that function's doc).
 fn inject_plugin_directives(
     plugin_name: &str,
     opts: Option<&str>,
     ech_doh: Option<&crate::dns::ech::EchDoh>,
 ) -> Result<Option<String>, ProxyError> {
-    match plugin_name {
-        "v2ray-plugin" | "ex-ray" | "galoshes" => {
-            let opts = opts.unwrap_or_default();
-            // Refuse rather than forward — see `ProxyError::MalformedPluginOptions`.
-            // Position only in the message; a segment can carry a secret.
-            let segments = garter::split_plugin_options(opts)
-                .map_err(|e| ProxyError::MalformedPluginOptions(format!("{plugin_name}: {e}")))?;
+    if !takes_ech_directives(plugin_name) {
+        return Ok(opts.map(String::from));
+    }
+    {
+        let opts = opts.unwrap_or_default();
+        // Refuse rather than forward — see `ProxyError::MalformedPluginOptions`.
+        // Position only in the message; a segment can carry a secret.
+        let segments = garter::split_plugin_options(opts)
+            .map_err(|e| ProxyError::MalformedPluginOptions(format!("{plugin_name}: {e}")))?;
 
-            let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
-            // Hole's URL is name-free, so it displaces one whose authority is a
-            // name — that lookup is the defect. Against an IP-literal value there
-            // is no leak to fix, so only a resolver that ANSWERED outranks the
-            // operator's own choice.
-            let displaces = match (ech_doh, config_ech_doh) {
-                (Some(e), Some(s)) => e.is_pinned() || crate::dns::ech::authority_is_a_name(&s.value),
-                _ => false,
-            };
-            // Strip only what we are about to set, so an override never becomes
-            // a deletion. Keys compare as the PLUGIN decodes them.
-            let owned: &[&str] = if displaces {
-                &["loglevel", "ech-doh"]
-            } else {
-                &["loglevel"]
-            };
+        let (_effective, displaces) = classify_ech_doh(&segments, ech_doh);
+        let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
+        // Strip only what we are about to set, so an override never becomes
+        // a deletion. Keys compare as the PLUGIN decodes them.
+        let owned: &[&str] = if displaces {
+            &["loglevel", "ech-doh"]
+        } else {
+            &["loglevel"]
+        };
 
-            // Which ECH source won, and how much is known about it. Every outcome
-            // reaches ex-ray as one URL, so this is the only record of the choice.
-            // `find`, not `any`: ex-ray reads the FIRST `ech`, so a later one
-            // reporting a posture it will never apply would invert the line.
-            let fail_closed = segments
-                .iter()
-                .find(|s| s.key == "ech")
-                .is_some_and(|s| s.value == "always");
-            match (ech_doh, config_ech_doh) {
-                (Some(_), Some(s)) if !displaces => tracing::warn!(
-                    plugin = %plugin_name,
-                    "{}, so the config's own name-free ech-doh stands: {}",
-                    unpinned_reason(ech_doh),
-                    s.raw
-                ),
-                (Some(e), _) if !e.is_pinned() => tracing::warn!(
-                    plugin = %plugin_name, fail_closed,
-                    "{}; the ECH lookup uses a resolver that has not been exercised: {}",
-                    unpinned_reason(ech_doh),
-                    e.url
-                ),
-                (Some(_), _) => {}
-                // Stripping this would disarm ECH altogether, so it stands — but
-                // a name authority is resolved over plaintext system DNS.
-                (None, Some(s)) => tracing::warn!(
-                    plugin = %plugin_name,
-                    "no configured resolver to pin the ECH lookup to; the config's own ech-doh stands: {}", s.raw
-                ),
-                // ECH is armed only by `ech-doh`, so there is none. Under
-                // `ech=always` ex-ray refuses to start over exactly this.
-                (None, None) => tracing::warn!(
-                    plugin = %plugin_name,
-                    fail_closed,
-                    "no ech-doh from any source; ECH is off"
-                ),
-            }
-
-            let directive = ech_doh.map(|e| format!("ech-doh={}", e.url));
-
-            Ok(Some(garter::join_plugin_options(
-                segments
-                    .iter()
-                    .filter(|s| !owned.contains(&s.key.as_str()))
-                    .map(|s| s.raw)
-                    .chain(["loglevel=debug"])
-                    .chain(directive.as_deref()),
-            )))
+        // Which ECH source won, and how much is known about it. Every outcome
+        // reaches ex-ray as one URL, so this is the only record of the choice.
+        // `find`, not `any`: ex-ray reads the FIRST `ech`, so a later one
+        // reporting a posture it will never apply would invert the line.
+        let fail_closed = segments
+            .iter()
+            .find(|s| s.key == "ech")
+            .is_some_and(|s| s.value == "always");
+        match (ech_doh, config_ech_doh) {
+            (Some(_), Some(s)) if !displaces => tracing::warn!(
+                plugin = %plugin_name,
+                "{}, so the config's own name-free ech-doh stands: {}",
+                unpinned_reason(ech_doh),
+                s.raw
+            ),
+            (Some(e), _) if !e.is_pinned() => tracing::warn!(
+                plugin = %plugin_name, fail_closed,
+                "{}; the ECH lookup uses a resolver that has not been exercised: {}",
+                unpinned_reason(ech_doh),
+                e.url
+            ),
+            (Some(_), _) => {}
+            // Stripping this would disarm ECH altogether, so it stands — but
+            // a name authority is resolved over plaintext system DNS.
+            (None, Some(s)) => tracing::warn!(
+                plugin = %plugin_name,
+                "no configured resolver to pin the ECH lookup to; the config's own ech-doh stands: {}", s.raw
+            ),
+            // ECH is armed only by `ech-doh`, so there is none. Under
+            // `ech=always` ex-ray refuses to start over exactly this.
+            (None, None) => tracing::warn!(
+                plugin = %plugin_name,
+                fail_closed,
+                "no ech-doh from any source; ECH is off"
+            ),
         }
-        _ => Ok(opts.map(String::from)),
+
+        let directive = ech_doh.map(|e| format!("ech-doh={}", e.url));
+
+        Ok(Some(garter::join_plugin_options(
+            segments
+                .iter()
+                .filter(|s| !owned.contains(&s.key.as_str()))
+                .map(|s| s.raw)
+                .chain(["loglevel=debug"])
+                .chain(directive.as_deref()),
+        )))
     }
 }
 
@@ -584,11 +706,26 @@ mod inject_tests {
         inject_plugin_directives(plugin, opts, ech_doh).expect("well-formed options")
     }
 
+    /// The IP `url`'s authority names, per `EchDoh::resolver`'s contract
+    /// (Hole always constructs `url` FROM this address, in production) — or
+    /// a placeholder when the fixture deliberately uses a NAME authority
+    /// (e.g. to exercise `authority_is_a_name`'s injection-priority path):
+    /// `resolver` is irrelevant to what those fixtures assert, only `url`
+    /// and `source` are.
+    fn ip_from_test_url(url: &str) -> IpAddr {
+        url::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_string))
+            .and_then(|h| h.trim_start_matches('[').trim_end_matches(']').parse().ok())
+            .unwrap_or_else(|| "192.0.2.1".parse().expect("test IP literal"))
+    }
+
     /// An `ech-doh` naming a resolver that ANSWERED the bootstrap.
     fn pinned(url: &str) -> EchDoh {
         EchDoh {
             url: url.to_string(),
-            source: PinSource::Answered("9.9.9.9".parse().expect("test IP literal")),
+            resolver: ip_from_test_url(url),
+            source: PinSource::Answered(ip_from_test_url(url)),
         }
     }
 
@@ -596,6 +733,7 @@ mod inject_tests {
     fn unpinned_for(url: &str, source: PinSource) -> EchDoh {
         EchDoh {
             url: url.to_string(),
+            resolver: ip_from_test_url(url),
             source,
         }
     }
@@ -1014,6 +1152,68 @@ mod inject_tests {
         assert_eq!(
             out.as_deref(),
             Some("mode=websocket;host=cdn.example;tls;ech=always;loglevel=debug;ech-doh=https://9.9.9.9/dns-query"),
+        );
+    }
+
+    // effective_ech_doh / ech_doh_will_reach_ex_ray ===================================================================
+
+    // A regression that made this return `true` whenever `ech_doh.is_some()`
+    // (the old, simpler gate this function replaces) would pass this test if
+    // the plugin-family gate were dropped: a non-ECH-capable plugin name
+    // must never be told it will fetch Hole's ech_doh, even with a pinned
+    // candidate in hand.
+    #[skuld::test]
+    fn non_family_plugin_never_reaches_ex_ray() {
+        assert!(!ech_doh_will_reach_ex_ray(
+            "obfs-local",
+            None,
+            Some(&pinned("https://9.9.9.9/dns-query"))
+        ));
+        assert_eq!(
+            effective_ech_doh("obfs-local", None, Some(&pinned("https://9.9.9.9/dns-query"))),
+            EffectiveEchDoh::None
+        );
+    }
+
+    #[skuld::test]
+    fn family_plugin_with_no_ech_doh_from_any_source_is_not_applicable() {
+        assert_eq!(effective_ech_doh("ex-ray", None, None), EffectiveEchDoh::None);
+    }
+
+    #[skuld::test]
+    fn family_plugin_with_no_operator_override_reaches_ex_ray_as_holes() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert!(ech_doh_will_reach_ex_ray("ex-ray", None, Some(&e)));
+        assert_eq!(effective_ech_doh("ex-ray", None, Some(&e)), EffectiveEchDoh::Holes);
+    }
+
+    // The exact scenario the mismatched-warning fix targets: an unpinned Hole
+    // guess against an operator's own IP-literal `ech-doh` — the operator's
+    // choice stands, so ex-ray fetches THEIRS, not Hole's.
+    #[skuld::test]
+    fn family_plugin_with_a_winning_operator_override_reaches_ex_ray_as_operators() {
+        let e = unpinned("https://1.1.1.1/dns-query");
+        assert!(!ech_doh_will_reach_ex_ray(
+            "ex-ray",
+            Some("ech-doh=https://8.8.8.8/dns-query"),
+            Some(&e)
+        ));
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("ech-doh=https://8.8.8.8/dns-query"), Some(&e)),
+            EffectiveEchDoh::Operators("https://8.8.8.8/dns-query".to_string())
+        );
+    }
+
+    // A malformed `opts` string makes `inject_plugin_directives` return `Err`
+    // and the plugin chain never starts — neither accessor may panic, and
+    // both must read this as "nothing reaches ex-ray".
+    #[skuld::test]
+    fn malformed_opts_reaches_ex_ray_as_nothing_not_a_panic() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert!(!ech_doh_will_reach_ex_ray("ex-ray", Some(r"path=/a\"), Some(&e)));
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some(r"path=/a\"), Some(&e)),
+            EffectiveEchDoh::None
         );
     }
 

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -558,18 +558,187 @@ pub(crate) fn effective_ech_doh(
 /// ex-ray's own default for the `host` option
 /// (`crates/ex-ray/config.go:45`: `flag.String("host", "cloudfront.com", ...)`)
 /// — a real DOMAIN, not "no SNI". An absent `host` segment is NOT the same
-/// as an unreachable config; see `doh_default_host_matches_ex_ray_config_go`
+/// as an unreachable config; see `ex_ray_default_host_matches_vendored_config_go`
 /// for the executable pin against the vendored Go source (can't run the Go
 /// code itself, but a text-level assertion still fails loudly if the
 /// literal ever changes there without a matching edit here).
 const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 
+/// Whether ex-ray's own config-build step — `registerTCPKeepAlive` +
+/// `generateConfig` (main.go:206-213,223-226,237-243), run before
+/// `server.Start()` — would REJECT this segment set outright, in which case
+/// the whole plugin process exits (23) before it dials anything at all,
+/// ECH-config fetch included. Returns the rejecting key, first-wins
+/// (matching `Args.Get`) among segments sharing a key, checked in ex-ray's
+/// OWN evaluation order below so the diagnostic names the key ex-ray itself
+/// would report first (the cover-permit / reachability side only needs
+/// `.is_some()`, order-independent):
+/// - `tcp-keepalive` (config.go's `tcpKeepAliveParams`): called from
+///   `registerTCPKeepAlive` BEFORE `generateConfig` even starts, but only
+///   in CLIENT mode — `registerTCPKeepAlive` returns early under `*server`
+///   (config.go:153-155; the `server` residual below is why the ordering
+///   claim above assumes client mode) — and called AGAIN, unconditionally
+///   regardless of `*server`, inside `generateConfig` itself
+///   (config.go:306-309). Either call: a value ex-ray's own `strconv.Atoi`
+///   (main.go) parses successfully but that falls outside `0..=32767` is a
+///   build error. A value `Atoi` fails to parse at all is NOT an error —
+///   ex-ray logs a warning and silently keeps the default.
+/// - `localPort`: `"0"` or `""` is rejected unconditionally, before
+///   `generateConfig` even runs (main.go:223-226 — ex-ray cannot honor
+///   port-0 OS-assignment). Otherwise `net.PortFromString` requires an
+///   unsigned base-10 literal `<=65535`
+///   (third_party/v2ray-core/common/net/port.go).
+/// - `remotePort`: `strconv.ParseUint(s, 10, 32)` directly (config.go) — an
+///   unsigned base-10 literal `<=u32::MAX`, with NO further upper bound
+///   (ex-ray does not route it through `net.Port` at all).
+/// - `mux`/`fwmark` (config.go's `uint32Opt`, called unconditionally at
+///   config.go:260-267): a value that parses successfully but falls outside
+///   `0..=u32::MAX` is a build error; a parse failure is not (same rule as
+///   `tcp-keepalive`).
+/// - `mode` is a CLOSED enum (`switch *mode`, config.go:279-297,
+///   unconditional): outside `websocket`/`quic` is a build error.
+/// - `ech` is a CLOSED enum too (`switch *echMode`, config.go:209-223), but
+///   that switch lives INSIDE `buildTLSConfig`, called only `if
+///   *tlsEnabled` (config.go:290-294,334) — an invalid value on a plain,
+///   non-quic transport with no `tls` flag is never looked at, so it's
+///   inert, not fatal (mirrors `ech_fetch_is_reachable`'s own
+///   `tls_enabled`). Within that same switch, `ech=always` additionally
+///   requires a non-empty RESOLVED `ech-doh` (config.go:218-220) — the
+///   value ex-ray actually receives once Hole's own injection wins or loses
+///   against the operator's; see [`resolved_ech_doh_is_empty`] for why that
+///   is recomputed rather than shared with [`classify_ech_doh`].
+/// - `mux`, again, but LATER than its own `uint32Opt` check above: once
+///   `generateConfig` has fully succeeded, `core.New` (`buildV2Ray`,
+///   main.go:143-149) separately rejects a non-zero `Concurrency` outside
+///   `1..=1024` on the websocket transport ONLY
+///   (third_party/v2ray-core/app/proxyman/outbound/handler.go:114-116) —
+///   `quic`'s mux is never read (config.go:287-289's `connectionReuse`
+///   only sets under `case "websocket"`).
+///
+/// **Disclosed, deliberately unmodeled:** `cert` requires filesystem I/O
+/// this otherwise-pure gate doesn't perform; `server` cross-assigns
+/// `localPort`/`remotePort` but Hole never spawns ex-ray as one. See
+/// CONTRIBUTING.md's "ECH-config-fetch reachability gate" section for why.
+fn ex_ray_fatal_config_error(
+    segments: &[garter::OptionSegment<'_>],
+    ech_doh: Option<&crate::dns::ech::EchDoh>,
+) -> Option<&'static str> {
+    if segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
+        ex_ray_flag_value(s)
+            .parse::<i64>()
+            .is_ok_and(|v| !(0..=32767).contains(&v))
+    }) {
+        return Some("tcp-keepalive");
+    }
+    if let Some(s) = segments.iter().find(|s| s.key == "localPort") {
+        let v = ex_ray_flag_value(s);
+        if v == "0" || v.is_empty() || !matches!(ex_ray_parses_as_uint32(v), Some(p) if p <= 65535) {
+            return Some("localPort");
+        }
+    }
+    if segments
+        .iter()
+        .find(|s| s.key == "remotePort")
+        .is_some_and(|s| ex_ray_parses_as_uint32(ex_ray_flag_value(s)).is_none())
+    {
+        return Some("remotePort");
+    }
+    for key in ["mux", "fwmark"] {
+        if segments.iter().find(|s| s.key == key).is_some_and(|s| {
+            ex_ray_flag_value(s)
+                .parse::<i64>()
+                .is_ok_and(|v| v < 0 || v > i64::from(u32::MAX))
+        }) {
+            return Some(key);
+        }
+    }
+    let mode = segments.iter().find(|s| s.key == "mode").map(ex_ray_flag_value);
+    if let Some(v) = mode {
+        if !matches!(v, "websocket" | "quic") {
+            return Some("mode");
+        }
+    }
+    let tls_enabled = segments.iter().any(|s| s.key == "tls") || mode == Some("quic");
+    if tls_enabled {
+        if let Some(s) = segments.iter().find(|s| s.key == "ech") {
+            let v = ex_ray_flag_value(s);
+            if !matches!(v, "never" | "auto" | "always") {
+                return Some("ech");
+            }
+            if v == "always" && resolved_ech_doh_is_empty(segments, ech_doh) {
+                return Some("ech-doh");
+            }
+        }
+    }
+    // Same 1..=1024 concurrency bound as the `mux` bullet above (core.New,
+    // only on websocket, only when non-zero). The effective value defaults
+    // to ex-ray's own flag default (`1`) unless a segment both exists AND
+    // parses. `MultiplexSettings` is CLIENT-mode only (config.go:351-387 —
+    // the `server` branch never builds it), so this check is skipped
+    // alongside the rest of the disclosed, deliberately-unmodeled `server`
+    // residual below, not a separate gap.
+    if mode != Some("quic") && !segments.iter().any(|s| s.key == "server") {
+        let mux = segments
+            .iter()
+            .find(|s| s.key == "mux")
+            .and_then(|s| ex_ray_flag_value(s).parse::<i64>().ok())
+            .unwrap_or(1);
+        if mux != 0 && !(1..=1024).contains(&mux) {
+            return Some("mux");
+        }
+    }
+    None
+}
+
+/// The `ech-doh` value ex-ray will actually receive, reduced to just
+/// "empty or not": the same precedence [`classify_ech_doh`] resolves for
+/// its `effective` result (Hole's own URL wins when it outranks the
+/// config's or none competes; otherwise the config's own, first-wins).
+/// [`classify_ech_doh`] itself calls [`ech_fetch_is_reachable`], which calls
+/// [`ex_ray_fatal_config_error`] — this is recomputed independently, from
+/// the same segments and `ech_doh`, rather than threaded through, so that
+/// path never cycles back through `classify_ech_doh`.
+fn resolved_ech_doh_is_empty(
+    segments: &[garter::OptionSegment<'_>],
+    ech_doh: Option<&crate::dns::ech::EchDoh>,
+) -> bool {
+    let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
+    let displaces = ech_doh_displaces(segments, ech_doh);
+    if let Some(e) = ech_doh.filter(|_| config_ech_doh.is_none() || displaces) {
+        debug_assert!(
+            !e.url.is_empty(),
+            "EchDoh::url is never empty by construction (doh_url_for_ip) — if it ever is, this \
+             arm would silently under-report ech=always as reachable"
+        );
+        false // Hole's own URL wins; always non-empty by construction.
+    } else {
+        config_ech_doh.map(ex_ray_flag_value).is_none_or(str::is_empty)
+    }
+}
+
+/// Whether ex-ray's own port parser (`net.PortFromString`/`strconv.ParseUint`
+/// for `localPort`/`remotePort`, base 10, 32-bit) would accept `v` — NOT the
+/// same set Rust's `u32::from_str` accepts: Go's `ParseUint` rejects a
+/// leading `+` (`"+8080"` is `invalid syntax`), while Rust's parser allows
+/// one (`"+8080".parse::<u32>()` is `Ok(8080)`); verified against both
+/// toolchains directly, not assumed. `v.parse()` alone would therefore
+/// UNDER-report `ex_ray_fatal_config_error`'s port checks on a signed value
+/// ex-ray itself rejects.
+fn ex_ray_parses_as_uint32(v: &str) -> Option<u32> {
+    if v.is_empty() || !v.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    v.parse::<u32>().ok()
+}
+
 /// Whether ex-ray will even ATTEMPT an ECH-config fetch for this segment
 /// set, independent of which `ech-doh` value would win. Neither the cover
 /// permit, the residual-stall warning, nor `inject_plugin_directives`'s own
 /// ECH-posture logging may treat a fetch that provably cannot happen as one
-/// that will — three independent conditions, each first-wins (matching
+/// that will — four independent conditions, each first-wins (matching
 /// `Args.Get`):
+/// - [`ex_ray_fatal_config_error`] is `Some` — the whole plugin process
+///   exits before it ever starts, so no dial of any kind happens.
 /// - `ech=never` short-circuits ECH entirely before it ever looks at
 ///   `ech-doh` (crates/ex-ray/config.go:209-211).
 /// - TLS must be enabled at all — an explicit `tls` flag, or `mode=quic`
@@ -578,33 +747,78 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 ///   plain non-quic transport (e.g. `mode=websocket` with no `tls`) never
 ///   calls it.
 /// - `ApplyECH` bails before dialing DoH unless the TLS `ServerName` is a
-///   DOMAIN: an EXPLICIT empty or IP-literal `host` means ex-ray dials with
-///   an IP-literal `ServerName`, which `echCacheDomain` treats as "no SNI to
-///   use" — but an ABSENT `host` falls back to ex-ray's own
-///   [`EX_RAY_DEFAULT_HOST`], a real domain, so it's reachable. Normalizing
-///   the IP-literal test mirrors v2ray-core's `net.ParseAddress` exactly
-///   (only a MATCHED `[...]` pair is stripped, once; whitespace is trimmed
-///   only when the first or last byte is non-alphanumeric) — an
-///   approximation here would itself misjudge reachability in either
-///   direction.
+///   DOMAIN: ex-ray sets `tlsConfig.ServerName = *host` directly
+///   (config.go:177), and an ABSENT `host` falls back to ex-ray's own
+///   [`EX_RAY_DEFAULT_HOST`], a real domain, so it's reachable. An EXPLICIT
+///   `host=<value>` wins outright, domain or not. But an EXPLICIT EMPTY
+///   `host=` is NOT "no SNI": `Config.parseServerName` treats a
+///   zero-length `ServerName` as absent (config.go:262 in the
+///   third_party path, `len(sn) > 0`) and `tls.WithDestination` then fills
+///   `ServerName` from the DIAL DESTINATION instead
+///   (third_party/.../transport/internet/tls/config.go:371-382,
+///   `websocket/dialer.go:67`) — and that destination is `remoteAddr`, a
+///   `plugin_opts` option in its own right (main.go:102-108) that can be a
+///   domain, first-wins same as every other key here. `remoteAddr` ABSENT
+///   falls back to Hole's OWN `SS_REMOTE_HOST`, which this function cannot
+///   see (env, not `plugin_opts`) — but is ALWAYS an IP literal in Hole's
+///   own spawn path (`crate::proxy::plugin` never resolves a domain later
+///   than `garter::binary::sip003_env`, which passes an already-resolved
+///   `SocketAddr`), so an absent `remoteAddr` is correctly treated as "not
+///   a domain" without needing to see it. Normalizing the IP-literal test
+///   (for `host` directly, or the `remoteAddr` fallback alike) mirrors
+///   v2ray-core's `net.ParseAddress` (only a MATCHED `[...]` pair is
+///   stripped, once; whitespace is trimmed only when the first or last
+///   byte is non-alphanumeric).
 ///   (third_party/v2ray-core/transport/internet/tls/ech.go:26-51,
-///   config.go:250-264,296-303; third_party/v2ray-core/common/net/address.go:78-95;
-///   main.go:67-69).
-fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>]) -> bool {
-    let ech_never = segments
-        .iter()
-        .find(|s| s.key == "ech")
-        .is_some_and(|s| s.value == "never");
-    let tls_enabled = segments.iter().any(|s| s.key == "tls")
-        || segments
+///   config.go:250-264,296-303,371-382;
+///   third_party/v2ray-core/common/net/address.go:78-95; main.go:67-69,
+///   102-108).
+///
+/// **Disclosed, on the `remoteAddr` fallback only:** ex-ray applies
+/// `ParseAddress` TWICE on that path — once building the dial destination
+/// (`generateConfig`), once more computing the ECH domain from the
+/// destination-derived `ServerName` — while this normalizes once. The two
+/// disagree only for a value a SECOND unwrap would still change, e.g. a
+/// doubly-bracketed `remoteAddr=[[::1]]` (one strip leaves `[::1]`, itself
+/// still bracketed): this treats it as reachable, real ex-ray does not.
+/// Modeling the second pass needs mirroring v2ray-core's `Domain`/`IP`
+/// address-family round-trip (`net.NewIPOrDomain`), a materially larger
+/// change than a fallback lookup; see CONTRIBUTING.md's "ECH-config-fetch
+/// reachability gate" section.
+///
+/// Every flag read here goes through [`ex_ray_flag_value`] rather than
+/// `OptionSegment::value` — see its doc. For `host` the divergence is
+/// load-bearing — see `EX_RAY_DEFAULT_HOST`'s doc.
+fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>], ech_doh: Option<&crate::dns::ech::EchDoh>) -> bool {
+    if ex_ray_fatal_config_error(segments, ech_doh).is_some() {
+        return false;
+    }
+    let ech = segments.iter().find(|s| s.key == "ech").map(ex_ray_flag_value);
+    if ech == Some("never") {
+        return false;
+    }
+    let mode = segments.iter().find(|s| s.key == "mode").map(ex_ray_flag_value);
+    let tls_enabled = segments.iter().any(|s| s.key == "tls") || mode == Some("quic");
+    let host = segments.iter().find(|s| s.key == "host").map(ex_ray_flag_value);
+    let sni = match host {
+        None => EX_RAY_DEFAULT_HOST,
+        Some("") => segments
             .iter()
-            .find(|s| s.key == "mode")
-            .is_some_and(|s| s.value == "quic");
-    let host = segments
-        .iter()
-        .find(|s| s.key == "host")
-        .map_or(EX_RAY_DEFAULT_HOST, |s| s.value.as_str());
-    !ech_never && tls_enabled && v2ray_core_parses_as_a_domain(host)
+            .find(|s| s.key == "remoteAddr")
+            .map_or("", ex_ray_flag_value),
+        Some(v) => v,
+    };
+    tls_enabled && v2ray_core_parses_as_a_domain(sni)
+}
+
+/// A segment's value the way ex-ray's own parser reads it (see
+/// [`garter::OptionSegment::has_value`]), not the raw `garter` decode.
+fn ex_ray_flag_value<'a>(s: &'a garter::OptionSegment<'_>) -> &'a str {
+    if s.has_value {
+        &s.value
+    } else {
+        "1"
+    }
 }
 
 /// Mirrors v2ray-core's `net.ParseAddress` (see `ech_fetch_is_reachable`'s
@@ -626,40 +840,50 @@ fn v2ray_core_parses_as_a_domain(value: &str) -> bool {
     !normalized.is_empty() && normalized.parse::<std::net::IpAddr>().is_err()
 }
 
+/// Whether Hole's own `ech_doh` outranks the operator's own `ech-doh`
+/// already in `segments` — a VALUE-PRECEDENCE question independent of
+/// whether a fetch happens at all. The ONE place this formula is written;
+/// shared by [`classify_ech_doh`] (where it also decides which keys
+/// `inject_plugin_directives` strips) and [`resolved_ech_doh_is_empty`]
+/// (which needs the same precedence but, being reachable from
+/// `ex_ray_fatal_config_error` via `ech_fetch_is_reachable`, cannot call
+/// `classify_ech_doh` itself without cycling). Hole's URL is name-free, so
+/// it displaces one whose authority is a name — that lookup is the defect.
+/// Against an IP-literal value there is no leak to fix, so only a resolver
+/// that ANSWERED outranks the operator's own choice.
+fn ech_doh_displaces(segments: &[garter::OptionSegment<'_>], ech_doh: Option<&crate::dns::ech::EchDoh>) -> bool {
+    let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
+    match (ech_doh, config_ech_doh) {
+        (Some(e), Some(s)) => hole_ech_doh_outranks(e, ex_ray_flag_value(s)),
+        _ => false,
+    }
+}
+
 /// The `(EffectiveEchDoh, displaces)` decision shared by [`effective_ech_doh`]
 /// (reads only the first element) and `inject_plugin_directives` (reads
-/// both: `displaces` decides which keys to strip). The ONE place this
-/// formula is written — see `effective_ech_doh`'s doc for why the parse
-/// itself is NOT similarly shared (the logging that must stay
-/// spawn-side-only lives one level up, in `inject_plugin_directives`, past
-/// where `segments` is produced).
+/// both: `displaces` decides which keys to strip) — see `effective_ech_doh`'s
+/// doc for why the parse itself is NOT similarly shared (the logging that
+/// must stay spawn-side-only lives one level up, in
+/// `inject_plugin_directives`, past where `segments` is produced).
 fn classify_ech_doh(
     segments: &[garter::OptionSegment<'_>],
     ech_doh: Option<&crate::dns::ech::EchDoh>,
 ) -> (EffectiveEchDoh, bool) {
-    // `displaces` answers a VALUE-PRECEDENCE question (does Hole's ech_doh
-    // outrank the operator's own `ech-doh` already in the segments?) that is
-    // independent of whether a fetch happens at all — computed unconditionally,
-    // BEFORE the reachability gate below, so `inject_plugin_directives`'s
-    // strip decision never disagrees with what `hole_ech_doh_outranks` says
-    // regardless of reachability. Hole's URL is name-free, so it displaces one
-    // whose authority is a name — that lookup is the defect. Against an
-    // IP-literal value there is no leak to fix, so only a resolver that
-    // ANSWERED outranks the operator's own choice.
     let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
-    let displaces = match (ech_doh, config_ech_doh) {
-        (Some(e), Some(s)) => hole_ech_doh_outranks(e, &s.value),
-        _ => false,
-    };
+    let displaces = ech_doh_displaces(segments, ech_doh);
 
-    if !ech_fetch_is_reachable(segments) {
+    if !ech_fetch_is_reachable(segments, ech_doh) {
         return (EffectiveEchDoh::None, displaces);
     }
 
+    // ex-ray only arms ECH_DOHserver when the value is non-empty
+    // (config.go:213: `if *echDoh != "" { tlsConfig.Ech_DOHserver = *echDoh }`)
+    // — an empty or bare (reads as ex-ray's own `"1"`, not a URL) operator
+    // value is silently inert, same as no `ech-doh` at all.
     let effective = if ech_doh.is_some() && (config_ech_doh.is_none() || displaces) {
         EffectiveEchDoh::Holes
-    } else if let Some(s) = config_ech_doh {
-        EffectiveEchDoh::Operators(s.value.to_string())
+    } else if let Some(v) = config_ech_doh.map(ex_ray_flag_value).filter(|v| !v.is_empty()) {
+        EffectiveEchDoh::Operators(v.to_string())
     } else {
         EffectiveEchDoh::None
     };
@@ -714,48 +938,73 @@ fn inject_plugin_directives(
         let fail_closed = segments
             .iter()
             .find(|s| s.key == "ech")
-            .is_some_and(|s| s.value == "always");
-        // Whether ex-ray will even ATTEMPT a fetch — shared with
-        // `classify_ech_doh` (see `ech_fetch_is_reachable`'s doc). Checked
-        // FIRST here: an `ech-doh` source (Hole's or the config's) that
-        // would otherwise read as active must not be reported as such when
-        // no fetch will ever happen (`ech=never`, or no TLS-enabled domain
-        // SNI) — the `(None, None)` case below stays correct either way,
-        // since "ECH is off" holds regardless of reachability.
-        let reachable = ech_fetch_is_reachable(&segments);
-        match (ech_doh, config_ech_doh) {
-            _ if !reachable && (ech_doh.is_some() || config_ech_doh.is_some()) => tracing::warn!(
+            .is_some_and(|s| ex_ray_flag_value(s) == "always");
+        // A rejected config crashes the WHOLE plugin, unconditionally on
+        // whether any `ech-doh` is even configured — checked first, and
+        // reported as its own condition: unlike every arm below, this is not
+        // "ECH is off", it's "the connection attempt fails outright".
+        if let Some(key) = ex_ray_fatal_config_error(&segments, ech_doh) {
+            tracing::warn!(
                 plugin = %plugin_name,
-                fail_closed,
-                "ex-ray will never attempt an ECH-config fetch for this configuration (ech=never, \
-                 or no TLS-enabled domain SNI); any ech-doh source is inert"
-            ),
-            (Some(_), Some(s)) if !displaces => tracing::warn!(
-                plugin = %plugin_name,
-                "{}, so the config's own name-free ech-doh stands: {}",
-                unpinned_reason(ech_doh),
-                s.raw
-            ),
-            (Some(e), _) if !e.is_pinned() => tracing::warn!(
-                plugin = %plugin_name, fail_closed,
-                "{}; the ECH lookup uses a resolver that has not been exercised: {}",
-                unpinned_reason(ech_doh),
-                e.url
-            ),
-            (Some(_), _) => {}
-            // Stripping this would disarm ECH altogether, so it stands — but
-            // a name authority is resolved over plaintext system DNS.
-            (None, Some(s)) => tracing::warn!(
-                plugin = %plugin_name,
-                "no configured resolver to pin the ECH lookup to; the config's own ech-doh stands: {}", s.raw
-            ),
-            // ECH is armed only by `ech-doh`, so there is none. Under
-            // `ech=always` ex-ray refuses to start over exactly this.
-            (None, None) => tracing::warn!(
-                plugin = %plugin_name,
-                fail_closed,
-                "no ech-doh from any source; ECH is off"
-            ),
+                invalid_key = key,
+                "ex-ray will refuse to start: this plugin configuration is invalid ({key}) — the \
+                 plugin process exits before dialing anything, ECH-config fetch included"
+            );
+        } else {
+            // Whether ex-ray will even ATTEMPT a fetch — shared with
+            // `classify_ech_doh` (see `ech_fetch_is_reachable`'s doc). An
+            // `ech-doh` source (Hole's or the config's) that would otherwise
+            // read as active must not be reported as such when no fetch will
+            // ever happen (`ech=never`, or no TLS-enabled domain SNI) — the
+            // `(None, None)` arm stays correct either way, since "ECH is
+            // off" holds regardless of reachability.
+            let reachable = ech_fetch_is_reachable(&segments, ech_doh);
+            // Presence alone isn't enough for the match below: ex-ray only
+            // arms `Ech_DOHserver` for a NON-empty value (config.go:213,
+            // same rule `classify_ech_doh` already applies to its
+            // `Operators` arm) — an explicitly empty `ech-doh=` must read
+            // as "no config value", not as one standing.
+            let config_ech_doh_value = config_ech_doh.filter(|s| !ex_ray_flag_value(s).is_empty());
+            match (ech_doh, config_ech_doh_value) {
+                _ if !reachable && (ech_doh.is_some() || config_ech_doh.is_some()) => tracing::warn!(
+                    plugin = %plugin_name,
+                    fail_closed,
+                    "ex-ray will never attempt an ECH-config fetch for this configuration (ech=never, \
+                     or no TLS-enabled domain SNI); any ech-doh source is inert"
+                ),
+                (Some(_), Some(s)) if !displaces => tracing::warn!(
+                    plugin = %plugin_name,
+                    "{}, so the config's own name-free ech-doh stands: {}",
+                    unpinned_reason(ech_doh),
+                    s.raw
+                ),
+                (Some(e), _) if !e.is_pinned() => tracing::warn!(
+                    plugin = %plugin_name, fail_closed,
+                    "{}; the ECH lookup uses a resolver that has not been exercised: {}",
+                    unpinned_reason(ech_doh),
+                    e.url
+                ),
+                (Some(_), _) => {}
+                // Stripping this would disarm ECH altogether, so it stands — but
+                // a name authority is resolved over plaintext system DNS.
+                (None, Some(s)) => tracing::warn!(
+                    plugin = %plugin_name,
+                    "no configured resolver to pin the ECH lookup to; the config's own ech-doh stands: {}", s.raw
+                ),
+                // ECH is armed only by `ech-doh`, so there is none. Under
+                // `ech=always` WITH TLS enabled, this arm is unreachable —
+                // `ex_ray_fatal_config_error`'s `resolved_ech_doh_is_empty`
+                // check already routed that combination through the `if let
+                // Some(key) = ...` branch above. WITHOUT TLS (no `tls` flag,
+                // no `mode=quic`), `ech=always` is inert like everything
+                // else here — `buildTLSConfig` never runs, so `fail_closed`
+                // can legitimately be `true` on this arm.
+                (None, None) => tracing::warn!(
+                    plugin = %plugin_name,
+                    fail_closed,
+                    "no ech-doh from any source; ECH is off"
+                ),
+            }
         }
 
         let directive = ech_doh.map(|e| format!("ech-doh={}", e.url));
@@ -1249,6 +1498,81 @@ mod inject_tests {
         );
     }
 
+    // An explicitly empty operator `ech-doh=` must not be reported as "the
+    // config's own ech-doh stands" — `classify_ech_doh` already treats it
+    // as inert (`EffectiveEchDoh::None`, same as no `ech-doh` at all), and
+    // the warning here must agree, not contradict it.
+    #[skuld::test]
+    fn an_empty_operator_ech_doh_is_not_reported_as_standing() {
+        let out = warnings_for("ex-ray", Some("tls;host=cdn.example;ech-doh="), None);
+        assert!(
+            !out.contains("stands"),
+            "an empty ech-doh= must not be reported as a live/standing value; got:\n{out}"
+        );
+        assert!(
+            out.contains("ECH is off"),
+            "expected the same disposition as no ech-doh from any source; got:\n{out}"
+        );
+    }
+
+    // A fatal config-build error must get ITS OWN warning — distinct from
+    // the plain "ECH is off" inert case above — naming the rejecting key,
+    // AND `inject_plugin_directives` must still return `Ok` (ex-ray, not
+    // Hole, is what refuses this config; Hole still spawns it and lets
+    // ex-ray exit 23, same as any other config-class ex-ray rejects today).
+    #[skuld::test]
+    fn a_fatal_config_reports_its_own_warning_and_still_starts() {
+        let out = warnings_for(
+            "ex-ray",
+            Some("tls;host=cdn.example;localPort=0"),
+            Some(&pinned("https://9.9.9.9/dns-query")),
+        );
+        assert!(
+            out.contains("ex-ray will refuse to start") && out.contains("localPort"),
+            "expected the fatal-config warning naming `localPort`; got:\n{out}"
+        );
+        assert!(
+            !out.contains("ECH is off") && !out.contains("ex-ray will never attempt"),
+            "the fatal-config warning must not also emit an ECH-posture line; got:\n{out}"
+        );
+        assert!(
+            merged(
+                "ex-ray",
+                Some("tls;host=cdn.example;localPort=0"),
+                Some(&pinned("https://9.9.9.9/dns-query"))
+            )
+            .is_some(),
+            "a semantically (not syntactically) invalid config must still be forwarded — ex-ray, \
+             not Hole, is what refuses to start"
+        );
+    }
+
+    // The checks inside `ex_ray_fatal_config_error` run in ex-ray's OWN
+    // evaluation order, not textual/declaration order — with TWO distinct
+    // keys simultaneously invalid, the EARLIER-evaluated one must win, not
+    // merely the first one this function happens to check.
+    #[skuld::test]
+    fn two_distinct_fatal_keys_report_ex_rays_earlier_one() {
+        let segments = garter::split_plugin_options("tls;host=cdn.example;localPort=0;tcp-keepalive=99999").unwrap();
+        assert_eq!(
+            ex_ray_fatal_config_error(&segments, None),
+            Some("tcp-keepalive"),
+            "tcp-keepalive (registerTCPKeepAlive) runs before the localPort=0 check in ex-ray's own main()"
+        );
+        let segments = garter::split_plugin_options("tls;host=cdn.example;remotePort=bogus;mux=-1").unwrap();
+        assert_eq!(
+            ex_ray_fatal_config_error(&segments, None),
+            Some("remotePort"),
+            "remotePort is parsed inside generateConfig before mux/fwmark's uint32Opt calls"
+        );
+        let segments = garter::split_plugin_options("tls;host=cdn.example;mode=grpc;ech=bogus").unwrap();
+        assert_eq!(
+            ex_ray_fatal_config_error(&segments, None),
+            Some("mode"),
+            "mode's switch is unconditional and runs before ech's, which is gated on tlsEnabled"
+        );
+    }
+
     // ex-ray reads the FIRST `ech`, so a later `always` it will never apply must
     // not be reported as a fail-closed posture.
     #[skuld::test]
@@ -1356,6 +1680,302 @@ mod inject_tests {
         );
     }
 
+    // An explicit empty `ech-doh=` never dials (see `classify_ech_doh`'s
+    // comment), so it must not be reported as a live operator fetch
+    // (`EffectiveEchDoh::Operators`), which would falsely widen the
+    // residual-stall warning and (were Operators ever permitted) the cover
+    // itself.
+    #[skuld::test]
+    fn empty_operator_ech_doh_never_reaches_ex_ray() {
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech-doh="), None),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // A bare `ech-doh` (no `=`) reads as ex-ray's own `"1"` — non-empty, so
+    // ex-ray DOES arm `Ech_DOHserver = "1"` (config.go:213) and attempt to
+    // use it as a DoH URL, even though "1" itself is not a usable URL. The
+    // operator's value is reported as exactly what ex-ray will try, "1".
+    #[skuld::test]
+    fn bare_operator_ech_doh_reaches_ex_ray_as_ex_rays_own_placeholder() {
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech-doh"), None),
+            EffectiveEchDoh::Operators("1".to_string())
+        );
+    }
+
+    // `switch *echMode` lives INSIDE `buildTLSConfig`, called only `if
+    // *tlsEnabled` (config.go:209-223,290-294,334) — an invalid `ech` value
+    // with no `tls` flag and no `mode=quic` is never looked at, so ex-ray
+    // starts fine and dials the plaintext upstream normally. Must NOT be
+    // reported as a fatal config-build error (nor, since there's no `tls`,
+    // as reachable — `no_tls_and_not_quic_never_reaches_ex_ray` already
+    // covers that half).
+    #[skuld::test]
+    fn an_invalid_ech_value_without_tls_is_inert_not_fatal() {
+        let segments = garter::split_plugin_options("host=cdn.example;ech=bogus").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), None);
+    }
+
+    // As above, but `mode=quic` force-enables TLS with no explicit `tls`
+    // flag — `buildTLSConfig` DOES run, so an invalid `ech` value here IS
+    // fatal.
+    #[skuld::test]
+    fn an_invalid_ech_value_with_mode_quic_is_fatal() {
+        let segments = garter::split_plugin_options("host=cdn.example;mode=quic;ech=bogus").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech"));
+    }
+
+    // Go's `ParseUint` rejects a leading `+` that Rust's parser accepts —
+    // see `ex_ray_parses_as_uint32`'s doc.
+    #[skuld::test]
+    fn a_signed_local_port_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;localPort=+8080"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    #[skuld::test]
+    fn a_signed_remote_port_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;remotePort=+1080"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // `remotePort` has NO upper bound of its own (config.go routes it
+    // through raw `strconv.ParseUint`, not `net.Port`) — its only ceiling is
+    // u32::MAX from the parse itself. A value that overflows it is the one
+    // thing standing between a legal and a rejected remotePort, so it must
+    // be exercised, not just the non-digit / negative cases above.
+    #[skuld::test]
+    fn a_remote_port_above_u32_max_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;remotePort=4294967296"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // As above, for `localPort` (whose ceiling is the tighter 65535, but the
+    // u32::MAX parse overflow is a distinct failure mode from that range
+    // check and must independently be caught by `ex_ray_parses_as_uint32`).
+    #[skuld::test]
+    fn a_local_port_above_u32_max_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;localPort=4294967296"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // `ech=always` with an empty RESOLVED `ech-doh` is itself a
+    // config-build error (config.go:218-220) distinct from a plain invalid
+    // `ech` value — ex-ray refuses to start rather than merely skipping
+    // ECH. Reachable whenever Hole has no candidate of its own (no pinned
+    // resolver) and the operator's own config supplies none either.
+    #[skuld::test]
+    fn ech_always_with_no_ech_doh_from_any_source_never_reaches_ex_ray() {
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech=always"), None),
+            EffectiveEchDoh::None
+        );
+        let segments = garter::split_plugin_options("tls;host=cdn.example;ech=always").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech-doh"));
+    }
+
+    // As above, but the operator's OWN `ech-doh=` is explicitly empty
+    // rather than absent — same config.go:218-220 fatal, same expectation.
+    #[skuld::test]
+    fn ech_always_with_an_explicitly_empty_operator_ech_doh_never_reaches_ex_ray() {
+        let segments = garter::split_plugin_options("tls;host=cdn.example;ech=always;ech-doh=").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech-doh"));
+    }
+
+    // Hole's own (non-empty, by construction) `ech_doh` always satisfies
+    // `ech=always`'s requirement, regardless of what the operator's own
+    // config carries — this must NOT be reported as fatal.
+    #[skuld::test]
+    fn ech_always_with_holes_own_ech_doh_is_not_fatal() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        let segments = garter::split_plugin_options("tls;host=cdn.example;ech=always").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, Some(&e)), None);
+    }
+
+    // Every new `ex_ray_fatal_config_error` check reads its key via `find`
+    // (first match), matching ex-ray's own `Args.Get` — a corrective SECOND
+    // occurrence of the same key must not un-set a first occurrence's
+    // fatal verdict, matching the first-wins coverage every pre-existing
+    // check in this file already has (`ech_never_is_first_wins`,
+    // `domain_host_is_first_wins`, the `mode=quic` force-enable test).
+    #[skuld::test]
+    fn the_new_fatal_checks_are_first_wins() {
+        let cases: &[(&str, &str)] = &[
+            ("tls;host=cdn.example;mode=grpc;mode=quic", "mode"),
+            ("tls;host=cdn.example;ech=bogus;ech=auto", "ech"),
+            ("tls;host=cdn.example;mux=-1;mux=1", "mux"),
+            ("tls;host=cdn.example;fwmark=-1;fwmark=1", "fwmark"),
+            (
+                "tls;host=cdn.example;tcp-keepalive=99999;tcp-keepalive=15",
+                "tcp-keepalive",
+            ),
+            ("tls;host=cdn.example;localPort=0;localPort=1984", "localPort"),
+            ("tls;host=cdn.example;remotePort=bogus;remotePort=1080", "remotePort"),
+        ];
+        for (opts, expected_key) in cases {
+            let segments = garter::split_plugin_options(opts).unwrap();
+            assert_eq!(
+                ex_ray_fatal_config_error(&segments, None),
+                Some(*expected_key),
+                "opts={opts:?}: the FIRST occurrence of the key must decide, matching ex-ray's own \
+                 first-wins `Args.Get` — a corrective second occurrence must not un-set it"
+            );
+        }
+    }
+
+    // `ex_ray_fatal_config_error`'s enum checks (`ech`/`mode`) must not
+    // widen the permit or the residual warning for a config ex-ray never
+    // even starts for — see `mux`/`fwmark`/`tcp-keepalive`/`localPort`/
+    // `remotePort` below for the same principle applied to ex-ray's other
+    // exit(23) classes.
+    #[skuld::test]
+    fn a_fatal_mux_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=-1"), Some(&e)),
+            EffectiveEchDoh::None,
+            "mux=-1 parses but is out of uint32Opt's 0..=u32::MAX range — config.go rejects it"
+        );
+    }
+
+    // A `mux` that fails to parse at all is NOT a config-build error —
+    // ex-ray's own opts-to-flags step (main.go) logs a warning and silently
+    // keeps the flag's default, so the fetch is still reachable.
+    #[skuld::test]
+    fn an_unparseable_mux_value_keeps_ex_ray_default_and_still_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=not-a-number"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    #[skuld::test]
+    fn a_fatal_fwmark_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;fwmark=4294967296"), Some(&e)),
+            EffectiveEchDoh::None,
+            "fwmark above u32::MAX is out of uint32Opt's range — config.go rejects it"
+        );
+    }
+
+    // `core.New` rejects a non-zero websocket `mux` `Concurrency` outside
+    // `1..=1024` — DIFFERENT from `uint32Opt`'s own `0..=u32::MAX` range
+    // check above (a later, separate exit(23) site).
+    #[skuld::test]
+    fn a_fatal_mux_concurrency_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=1025"), Some(&e)),
+            EffectiveEchDoh::None,
+            "mux=1025 is within uint32Opt's range but outside core.New's 1..=1024 concurrency bound"
+        );
+    }
+
+    // The boundary itself must still be reachable — `1024` is valid, only
+    // `1025` and above are not.
+    #[skuld::test]
+    fn a_mux_concurrency_value_at_the_boundary_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=1024"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    // `mux=0` disables multiplexing outright — `connectionReuse` stays
+    // false, so `MultiplexingConfig` (and its 1..=1024 bound) never attaches
+    // at all, regardless of how large a LATER duplicate `mux` looks.
+    #[skuld::test]
+    fn a_zero_mux_never_hits_the_concurrency_bound() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=0"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    // `quic`'s mux is never read (`connectionReuse` only sets under
+    // `case "websocket"`) — an out-of-bound `mux` alongside `mode=quic`
+    // must not be reported as fatal.
+    #[skuld::test]
+    fn a_large_mux_with_mode_quic_never_hits_the_concurrency_bound() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("host=cdn.example;mode=quic;mux=99999"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    #[skuld::test]
+    fn a_fatal_tcp_keepalive_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;tcp-keepalive=32768"), Some(&e)),
+            EffectiveEchDoh::None,
+            "tcp-keepalive above tcpKeepAliveParams' 32767 max — config.go rejects it"
+        );
+    }
+
+    // As above, the LOWER edge — `tcpKeepAliveParams` rejects `v < 0` too,
+    // a distinct branch from the overflow case.
+    #[skuld::test]
+    fn a_negative_tcp_keepalive_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;tcp-keepalive=-1"), Some(&e)),
+            EffectiveEchDoh::None,
+            "tcp-keepalive below tcpKeepAliveParams' 0 minimum — config.go rejects it"
+        );
+    }
+
+    #[skuld::test]
+    fn a_zero_or_empty_local_port_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in ["tls;host=cdn.example;localPort=0", "tls;host=cdn.example;localPort="] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::None,
+                "opts={opts:?}: ex-ray cannot honor port-0/empty OS-assignment (main.go) — exits before dialing"
+            );
+        }
+    }
+
+    #[skuld::test]
+    fn an_out_of_range_local_port_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;localPort=65536"), Some(&e)),
+            EffectiveEchDoh::None,
+            "localPort above net.PortFromString's 65535 max — config.go rejects it"
+        );
+    }
+
+    #[skuld::test]
+    fn an_unparseable_remote_port_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;remotePort=not-a-port"), Some(&e)),
+            EffectiveEchDoh::None,
+            "remotePort must be strconv.ParseUint(_, 10, 32)-parseable (config.go) — else it rejects it"
+        );
+    }
+
     // `classify_ech_doh` must read whether ex-ray will even ATTEMPT ECH, not
     // just plugin family + ech-doh presence — `ech=never` short-circuits it
     // (config.go:209-211) regardless of `tls`/`host`/`ech-doh`.
@@ -1420,6 +2040,126 @@ mod inject_tests {
         }
     }
 
+    // An EXPLICIT empty `host=` is NOT "no SNI" — `Config.ServerName`
+    // (empty) falls back to the dial destination (`tls.WithDestination`),
+    // and that destination is `remoteAddr`, itself a `plugin_opts` option
+    // that can name a domain.
+    #[skuld::test]
+    fn empty_host_falls_back_to_a_domain_remote_addr_and_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=;remoteAddr=cdn.example"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    // As above, but the destination fallback is itself an IP — no domain
+    // SNI either way, so still unreachable (same outcome as no `remoteAddr`
+    // at all, just via the explicit-IP branch instead of the absent one).
+    #[skuld::test]
+    fn empty_host_with_an_ip_remote_addr_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=;remoteAddr=203.0.113.5"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // `remoteAddr` uses first-wins too, matching every other flag here.
+    #[skuld::test]
+    fn empty_host_remote_addr_fallback_is_first_wins() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh(
+                "ex-ray",
+                Some("tls;host=;remoteAddr=203.0.113.5;remoteAddr=cdn.example"),
+                Some(&e)
+            ),
+            EffectiveEchDoh::None,
+            "the FIRST remoteAddr= wins — an IP literal here, so the later domain is ignored"
+        );
+        assert_eq!(
+            effective_ech_doh(
+                "ex-ray",
+                Some("tls;host=;remoteAddr=cdn.example;remoteAddr=203.0.113.5"),
+                Some(&e)
+            ),
+            EffectiveEchDoh::Holes,
+            "the FIRST remoteAddr= wins — a domain here, so the later IP literal is ignored"
+        );
+    }
+
+    // A bare `host` (no `=`) is `""` in `OptionSegment::value`, but ex-ray's
+    // own parser reads it as `"1"` (`crates/ex-ray/args.go`) — a DOMAIN, not
+    // an empty SNI. Misreading it as `""` would omit the cover's resolver
+    // permit while ex-ray still dials the pinned resolver, stalling under
+    // the very cover meant to prevent that.
+    #[skuld::test]
+    fn bare_host_reads_as_ex_rays_own_domain_default_and_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+    }
+
+    // `ech` and `mode` are CLOSED enums to ex-ray (`switch *echMode` /
+    // `switch *mode`, config.go:209,281) — a value outside the known set is
+    // a config-build error and `main.go` exits (23) before the server ever
+    // starts, so no dial of any kind happens. A bare `ech` (no `=`) reads as
+    // `"1"` to ex-ray, which is exactly such an invalid value — NOT
+    // `"never"` (a different reason to be unreachable) and NOT a value that
+    // reaches ex-ray either.
+    #[skuld::test]
+    fn bare_ech_is_an_invalid_enum_value_and_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;ech"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // An explicit, misspelled `ech` value is the same invalid-enum case as
+    // the bare-key one above, exercised without relying on `has_value` at
+    // all — the enum check must reject any value outside
+    // `never`/`auto`/`always`, not just the ones this module happens to name.
+    #[skuld::test]
+    fn an_unrecognized_ech_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;ech=Always"), Some(&e)),
+            EffectiveEchDoh::None,
+            "ex-ray's echMode switch is case-sensitive; a value ex-ray itself would reject as \
+             \"invalid ech mode\" must not be read as reachable"
+        );
+    }
+
+    // Same closed-enum reasoning as `ech`, for `mode` (config.go's `switch
+    // *mode`, `websocket`/`quic` only): a bare `mode` reads as `"1"`, an
+    // invalid value on its own. `tls` is present here so the ONLY thing
+    // keeping this unreachable is the mode-enum check — without it, `tls`
+    // alone would already make this reachable.
+    #[skuld::test]
+    fn bare_mode_is_an_invalid_transport_and_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;mode"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // As `an_unrecognized_ech_value_never_reaches_ex_ray`, for `mode`.
+    #[skuld::test]
+    fn an_unrecognized_mode_value_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;mode=grpc"), Some(&e)),
+            EffectiveEchDoh::None,
+            "ex-ray's mode switch accepts only websocket/quic; \"unsupported mode\" is a \
+             config-build error, not a fetch that happens"
+        );
+    }
+
     // `ParseAddress` strips only a MATCHED `[...]` pair — an unmatched
     // bracket is left as part of the (non-IP, therefore domain) string, so
     // ex-ray treats it as a real SNI and DOES dial DoH.
@@ -1451,6 +2191,89 @@ mod inject_tests {
             "EX_RAY_DEFAULT_HOST ({EX_RAY_DEFAULT_HOST:?}) no longer matches config.go's `host` flag \
              default — update the constant to match the vendored source"
         );
+    }
+
+    // As `ex_ray_default_host_matches_vendored_config_go`, for the closed
+    // enum sets `ex_ray_fatal_config_error` hardcodes: a vendored source
+    // change that adds/renames an `ech`/`mode` value must fail this test
+    // loudly rather than silently change which configs are treated as a
+    // fatal ex-ray config-build error.
+    #[skuld::test]
+    fn ech_and_mode_enums_match_vendored_config_go() {
+        let source = include_str!("../../../ex-ray/config.go");
+
+        let ech_arms = go_switch_arms(source, "switch *echMode {");
+        for value in ["\"never\"", "\"auto\", \"always\""] {
+            assert!(
+                ech_arms.contains(value),
+                "config.go's `echMode` switch no longer has the arm {value} \u{2014} update \
+                 ex_ray_fatal_config_error's `ech` match to the vendored source. Arms:\n{ech_arms}"
+            );
+        }
+        assert_eq!(
+            ech_arms.matches("\n\tcase ").count(),
+            2,
+            "config.go's `echMode` switch gained or lost a case arm beyond never/auto/always \u{2014} \
+             update ex_ray_fatal_config_error's `ech` match to the vendored source. Arms:\n{ech_arms}"
+        );
+
+        let mode_arms = go_switch_arms(source, "switch *mode {");
+        for value in ["\"websocket\"", "\"quic\""] {
+            assert!(
+                mode_arms.contains(value),
+                "config.go's `mode` switch no longer has the arm {value} \u{2014} update \
+                 ex_ray_fatal_config_error's `mode` match to the vendored source. Arms:\n{mode_arms}"
+            );
+        }
+        assert_eq!(
+            mode_arms.matches("\n\tcase ").count(),
+            2,
+            "config.go's `mode` switch gained or lost a case arm beyond websocket/quic \u{2014} \
+             update ex_ray_fatal_config_error's `mode` match to the vendored source. Arms:\n{mode_arms}"
+        );
+
+        // The numeric bounds `ex_ray_fatal_config_error` hardcodes for
+        // mux/fwmark (`uint32Opt`), tcp-keepalive (`keepAliveMaxSeconds`),
+        // and localPort (`net.PortFromString`) — same drift risk, same pin.
+        assert!(
+            source.contains("(expected 0..4294967295), got:"),
+            "ex_ray_fatal_config_error's mux/fwmark range (0..=u32::MAX) no longer matches \
+             config.go's `uint32Opt` — update the range to the vendored source"
+        );
+        assert!(
+            source.contains("keepAliveMaxSeconds = 32767"),
+            "ex_ray_fatal_config_error's tcp-keepalive range (0..=32767) no longer matches \
+             config.go's `keepAliveMaxSeconds` — update the range to the vendored source"
+        );
+        let port_source = include_str!("../../../ex-ray/third_party/v2ray-core/common/net/port.go");
+        assert!(
+            port_source.contains("if val > 65535 {"),
+            "ex_ray_fatal_config_error's localPort ceiling (65535) no longer matches \
+             port.go's `PortFromInt` — update the bound to the vendored source"
+        );
+        let handler_source = include_str!("../../../ex-ray/third_party/v2ray-core/app/proxyman/outbound/handler.go");
+        assert!(
+            handler_source.contains("config.Concurrency < 1 || config.Concurrency > 1024"),
+            "ex_ray_fatal_config_error's mux-concurrency range (1..=1024) no longer matches \
+             handler.go's own bound — update the range to the vendored source"
+        );
+    }
+
+    /// The text of a Go `switch` statement's case arms — between
+    /// `switch_header` (exclusive) and the following `default:` (exclusive)
+    /// — so a test can assert on exactly the case VALUES present, and fail
+    /// loudly if the vendored source gains or loses one, not just if a known
+    /// value's text happens to disappear.
+    fn go_switch_arms<'a>(source: &'a str, switch_header: &str) -> &'a str {
+        let start = source
+            .find(switch_header)
+            .unwrap_or_else(|| panic!("{switch_header:?} not found in vendored config.go"))
+            + switch_header.len();
+        let rest = &source[start..];
+        let end = rest
+            .find("\n\tdefault:")
+            .unwrap_or_else(|| panic!("no `default:` arm found after {switch_header:?} in vendored config.go"));
+        &rest[..end]
     }
 
     // `host` uses first-wins too, matching every other flag here.

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -562,21 +562,28 @@ pub(crate) fn effective_ech_doh(
 /// itself is NOT similarly shared (the logging that must stay
 /// spawn-side-only lives one level up, in `inject_plugin_directives`, past
 /// where `segments` is produced).
-fn classify_ech_doh(
-    segments: &[garter::OptionSegment<'_>],
-    ech_doh: Option<&crate::dns::ech::EchDoh>,
-) -> (EffectiveEchDoh, bool) {
-    // Whether ex-ray will even ATTEMPT an ECH-config fetch for this segment
-    // set, independent of which `ech-doh` value would win: `ech=never`
-    // (first-wins, matching `Args.Get`) short-circuits ECH entirely before
-    // it ever looks at `ech-doh` (crates/ex-ray/config.go:209-211).
-    // Otherwise ECH is only reachable when TLS is enabled at all — an
-    // explicit `tls` flag, or `mode=quic` forcing it on — since
-    // `buildTLSConfig` (which contains the whole `ech` switch) is called
-    // only when `tlsEnabled` (config.go:290-294, 334); a plain non-quic
-    // transport (e.g. `mode=websocket` with no `tls`) never calls it.
-    // Neither the cover permit nor the residual-stall warning may treat a
-    // fetch that provably cannot happen as one that will.
+/// Whether ex-ray will even ATTEMPT an ECH-config fetch for this segment
+/// set, independent of which `ech-doh` value would win. Neither the cover
+/// permit, the residual-stall warning, nor `inject_plugin_directives`'s own
+/// ECH-posture logging may treat a fetch that provably cannot happen as one
+/// that will — three independent conditions, each first-wins (matching
+/// `Args.Get`):
+/// - `ech=never` short-circuits ECH entirely before it ever looks at
+///   `ech-doh` (crates/ex-ray/config.go:209-211).
+/// - TLS must be enabled at all — an explicit `tls` flag, or `mode=quic`
+///   forcing it on — since `buildTLSConfig` (which contains the whole `ech`
+///   switch) is called only when `tlsEnabled` (config.go:290-294, 334); a
+///   plain non-quic transport (e.g. `mode=websocket` with no `tls`) never
+///   calls it.
+/// - `ApplyECH` bails before dialing DoH unless the TLS `ServerName` is a
+///   DOMAIN: an absent, empty, or IP-literal `host` means ex-ray dials with
+///   an IP-literal `ServerName` (Hole never hands ex-ray a raw hostname as
+///   the connection target — everything is pre-resolved, `host` only ever
+///   supplies SNI), which `echCacheDomain` treats as "no SNI to use", so ECH
+///   is unreachable regardless of `tls`/`ech-doh`
+///   (third_party/v2ray-core/transport/internet/tls/ech.go:26-51,
+///   config.go:250-264,296-303; main.go:67-69).
+fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>]) -> bool {
     let ech_never = segments
         .iter()
         .find(|s| s.key == "ech")
@@ -586,19 +593,36 @@ fn classify_ech_doh(
             .iter()
             .find(|s| s.key == "mode")
             .is_some_and(|s| s.value == "quic");
-    if ech_never || !tls_enabled {
-        return (EffectiveEchDoh::None, false);
-    }
+    let sni_is_a_domain = segments.iter().find(|s| s.key == "host").is_some_and(|s| {
+        let bare = s.value.trim_start_matches('[').trim_end_matches(']');
+        !bare.is_empty() && bare.parse::<std::net::IpAddr>().is_err()
+    });
+    !ech_never && tls_enabled && sni_is_a_domain
+}
 
+fn classify_ech_doh(
+    segments: &[garter::OptionSegment<'_>],
+    ech_doh: Option<&crate::dns::ech::EchDoh>,
+) -> (EffectiveEchDoh, bool) {
+    // `displaces` answers a VALUE-PRECEDENCE question (does Hole's ech_doh
+    // outrank the operator's own `ech-doh` already in the segments?) that is
+    // independent of whether a fetch happens at all — computed unconditionally,
+    // BEFORE the reachability gate below, so `inject_plugin_directives`'s
+    // strip decision never disagrees with what `hole_ech_doh_outranks` says
+    // regardless of reachability. Hole's URL is name-free, so it displaces one
+    // whose authority is a name — that lookup is the defect. Against an
+    // IP-literal value there is no leak to fix, so only a resolver that
+    // ANSWERED outranks the operator's own choice.
     let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
-    // Hole's URL is name-free, so it displaces one whose authority is a
-    // name — that lookup is the defect. Against an IP-literal value there
-    // is no leak to fix, so only a resolver that ANSWERED outranks the
-    // operator's own choice.
     let displaces = match (ech_doh, config_ech_doh) {
         (Some(e), Some(s)) => hole_ech_doh_outranks(e, &s.value),
         _ => false,
     };
+
+    if !ech_fetch_is_reachable(segments) {
+        return (EffectiveEchDoh::None, displaces);
+    }
+
     let effective = if ech_doh.is_some() && (config_ech_doh.is_none() || displaces) {
         EffectiveEchDoh::Holes
     } else if let Some(s) = config_ech_doh {
@@ -658,7 +682,21 @@ fn inject_plugin_directives(
             .iter()
             .find(|s| s.key == "ech")
             .is_some_and(|s| s.value == "always");
+        // Whether ex-ray will even ATTEMPT a fetch — shared with
+        // `classify_ech_doh` (see `ech_fetch_is_reachable`'s doc). Checked
+        // FIRST here: an `ech-doh` source (Hole's or the config's) that
+        // would otherwise read as active must not be reported as such when
+        // no fetch will ever happen (`ech=never`, or no TLS-enabled domain
+        // SNI) — the `(None, None)` case below stays correct either way,
+        // since "ECH is off" holds regardless of reachability.
+        let reachable = ech_fetch_is_reachable(&segments);
         match (ech_doh, config_ech_doh) {
+            _ if !reachable && (ech_doh.is_some() || config_ech_doh.is_some()) => tracing::warn!(
+                plugin = %plugin_name,
+                fail_closed,
+                "ex-ray will never attempt an ECH-config fetch for this configuration (ech=never, \
+                 or no TLS-enabled domain SNI); any ech-doh source is inert"
+            ),
             (Some(_), Some(s)) if !displaces => tracing::warn!(
                 plugin = %plugin_name,
                 "{}, so the config's own name-free ech-doh stands: {}",
@@ -1116,7 +1154,7 @@ mod inject_tests {
             ),
         ] {
             let ech_doh = unpinned_for("https://1.1.1.1/dns-query", source);
-            let out = warnings_for("ex-ray", Some("path=/x"), Some(&ech_doh));
+            let out = warnings_for("ex-ray", Some("tls;host=cdn.example;path=/x"), Some(&ech_doh));
             assert!(
                 out.contains(expected),
                 "{source:?} must be reported as {expected:?}, got:
@@ -1130,11 +1168,29 @@ mod inject_tests {
         }
     }
 
-    // A pinned resolver is the good case and warns about nothing.
+    // A pinned resolver is the good case and warns about nothing — for a
+    // config where the fetch is actually reachable; an unreachable one has
+    // its own dedicated warning (see `ech_fetch_is_reachable`'s callers).
     #[skuld::test]
     fn a_pinned_resolver_warns_about_nothing() {
-        let out = warnings_for("ex-ray", Some("path=/x"), Some(&pinned("https://9.9.9.9/dns-query")));
+        let out = warnings_for(
+            "ex-ray",
+            Some("tls;host=cdn.example;path=/x"),
+            Some(&pinned("https://9.9.9.9/dns-query")),
+        );
         assert_eq!(out, "", "a pinned ech-doh has nothing to report");
+    }
+
+    // The new reachability gate: an ech-doh source (pinned or not) that would
+    // otherwise read as active must be reported as inert, not silently
+    // dropped or misreported as exercised/unexercised.
+    #[skuld::test]
+    fn an_unreachable_config_reports_any_ech_doh_source_as_inert() {
+        let out = warnings_for("ex-ray", Some("path=/x"), Some(&pinned("https://9.9.9.9/dns-query")));
+        assert!(
+            out.contains("ex-ray will never attempt an ECH-config fetch"),
+            "expected the unreachable-config warning; got:\n{out}"
+        );
     }
 
     // ex-ray reads the FIRST `ech`, so a later `always` it will never apply must
@@ -1213,9 +1269,13 @@ mod inject_tests {
     #[skuld::test]
     fn family_plugin_with_no_operator_override_reaches_ex_ray_as_holes() {
         let e = pinned("https://9.9.9.9/dns-query");
-        assert!(ech_doh_will_reach_ex_ray("ex-ray", Some("tls"), Some(&e)));
+        assert!(ech_doh_will_reach_ex_ray(
+            "ex-ray",
+            Some("tls;host=cdn.example"),
+            Some(&e)
+        ));
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example"), Some(&e)),
             EffectiveEchDoh::Holes
         );
     }
@@ -1227,23 +1287,27 @@ mod inject_tests {
         let e = unpinned("https://1.1.1.1/dns-query");
         assert!(!ech_doh_will_reach_ex_ray(
             "ex-ray",
-            Some("tls;ech-doh=https://8.8.8.8/dns-query"),
+            Some("tls;host=cdn.example;ech-doh=https://8.8.8.8/dns-query"),
             Some(&e)
         ));
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls;ech-doh=https://8.8.8.8/dns-query"), Some(&e)),
+            effective_ech_doh(
+                "ex-ray",
+                Some("tls;host=cdn.example;ech-doh=https://8.8.8.8/dns-query"),
+                Some(&e)
+            ),
             EffectiveEchDoh::Operators("https://8.8.8.8/dns-query".to_string())
         );
     }
 
     // `classify_ech_doh` must read whether ex-ray will even ATTEMPT ECH, not
     // just plugin family + ech-doh presence — `ech=never` short-circuits it
-    // (config.go:209-211) regardless of `tls`/`ech-doh`.
+    // (config.go:209-211) regardless of `tls`/`host`/`ech-doh`.
     #[skuld::test]
     fn ech_never_never_reaches_ex_ray_even_with_tls_and_ech_doh() {
         let e = pinned("https://9.9.9.9/dns-query");
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls;ech=never"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech=never"), Some(&e)),
             EffectiveEchDoh::None
         );
     }
@@ -1255,13 +1319,44 @@ mod inject_tests {
     fn ech_never_is_first_wins() {
         let e = pinned("https://9.9.9.9/dns-query");
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls;ech=never;ech=auto"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech=never;ech=auto"), Some(&e)),
             EffectiveEchDoh::None
         );
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls;ech=auto;ech=never"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech=auto;ech=never"), Some(&e)),
             EffectiveEchDoh::Holes,
             "the FIRST ech= wins — auto here, so never (second) is ignored"
+        );
+    }
+
+    // The SNI (`host`) must be a DOMAIN for `ApplyECH` to ever dial DoH at
+    // all (`echCacheDomain` returns "" and `ApplyECH` bails otherwise) —
+    // absent, empty, or IP-literal all mean "no SNI to key the lookup on".
+    #[skuld::test]
+    fn no_domain_host_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in ["tls", "tls;host=", "tls;host=203.0.113.5", "tls;host=[2001:db8::1]"] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::None,
+                "opts={opts:?} must not reach ex-ray: no domain SNI to key the DoH lookup on"
+            );
+        }
+    }
+
+    // `host` uses first-wins too, matching every other flag here.
+    #[skuld::test]
+    fn domain_host_is_first_wins() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=203.0.113.5;host=cdn.example"), Some(&e)),
+            EffectiveEchDoh::None,
+            "the FIRST host= wins — an IP literal here, so the later domain is ignored"
+        );
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;host=203.0.113.5"), Some(&e)),
+            EffectiveEchDoh::Holes,
+            "the FIRST host= wins — a domain here, so the later IP literal is ignored"
         );
     }
 
@@ -1273,7 +1368,7 @@ mod inject_tests {
     fn no_tls_and_not_quic_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("mode=websocket"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("host=cdn.example;mode=websocket"), Some(&e)),
             EffectiveEchDoh::None
         );
         assert_eq!(effective_ech_doh("ex-ray", None, Some(&e)), EffectiveEchDoh::None);
@@ -1285,11 +1380,11 @@ mod inject_tests {
     fn quic_mode_reaches_ex_ray_without_an_explicit_tls_flag() {
         let e = pinned("https://9.9.9.9/dns-query");
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("mode=quic"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("host=cdn.example;mode=quic"), Some(&e)),
             EffectiveEchDoh::Holes
         );
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("mode=quic;mode=websocket"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("host=cdn.example;mode=quic;mode=websocket"), Some(&e)),
             EffectiveEchDoh::Holes,
             "first-wins: the second mode= does not un-set the quic TLS force-enable"
         );

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -564,92 +564,183 @@ pub(crate) fn effective_ech_doh(
 /// literal ever changes there without a matching edit here).
 const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 
-/// Whether ex-ray's own config-build step — `registerTCPKeepAlive` +
-/// `generateConfig` (main.go:206-213,223-226,237-243), run before
-/// `server.Start()` — would REJECT this segment set outright, in which case
-/// the whole plugin process exits (23) before it dials anything at all,
-/// ECH-config fetch included. Returns the rejecting key, first-wins
-/// (matching `Args.Get`) among segments sharing a key, checked in ex-ray's
-/// OWN evaluation order below so the diagnostic names the key ex-ray itself
-/// would report first (the cover-permit / reachability side only needs
-/// `.is_some()`, order-independent):
-/// - `tcp-keepalive` (config.go's `tcpKeepAliveParams`): called from
-///   `registerTCPKeepAlive` BEFORE `generateConfig` even starts, but only
-///   in CLIENT mode — `registerTCPKeepAlive` returns early under `*server`
-///   (config.go:153-155; the `server` residual below is why the ordering
-///   claim above assumes client mode) — and called AGAIN, unconditionally
-///   regardless of `*server`, inside `generateConfig` itself
-///   (config.go:306-309). Either call: a value ex-ray's own `strconv.Atoi`
-///   (main.go) parses successfully but that falls outside `0..=32767` is a
-///   build error. A value `Atoi` fails to parse at all is NOT an error —
-///   ex-ray logs a warning and silently keeps the default.
-/// - `localPort`: `"0"` or `""` is rejected unconditionally, before
-///   `generateConfig` even runs (main.go:223-226 — ex-ray cannot honor
-///   port-0 OS-assignment). Otherwise `net.PortFromString` requires an
-///   unsigned base-10 literal `<=65535`
-///   (third_party/v2ray-core/common/net/port.go).
-/// - `remotePort`: `strconv.ParseUint(s, 10, 32)` directly (config.go) — an
-///   unsigned base-10 literal `<=u32::MAX`, with NO further upper bound
-///   (ex-ray does not route it through `net.Port` at all).
-/// - `mux`/`fwmark` (config.go's `uint32Opt`, called unconditionally at
-///   config.go:260-267): a value that parses successfully but falls outside
-///   `0..=u32::MAX` is a build error; a parse failure is not (same rule as
-///   `tcp-keepalive`).
-/// - `mode` is a CLOSED enum (`switch *mode`, config.go:279-297,
-///   unconditional): outside `websocket`/`quic` is a build error.
-/// - `ech` is a CLOSED enum too (`switch *echMode`, config.go:209-223), but
-///   that switch lives INSIDE `buildTLSConfig`, called only `if
-///   *tlsEnabled` (config.go:290-294,334) — an invalid value on a plain,
-///   non-quic transport with no `tls` flag is never looked at, so it's
-///   inert, not fatal (mirrors `ech_fetch_is_reachable`'s own
-///   `tls_enabled`). Within that same switch, `ech=always` additionally
-///   requires a non-empty RESOLVED `ech-doh` (config.go:218-220) — the
+/// Whether ex-ray's own config-build step — `parseOptsIntoFlags`
+/// (options.go, main.go), `registerTCPKeepAlive` + `generateConfig`
+/// (config.go), run before `server.Start()` — would REJECT this segment set
+/// outright, in which case the whole plugin process exits (23) before it
+/// dials anything at all, ECH-config fetch included. Returns the rejecting
+/// key, first-wins (matching `Args.Get`) among segments sharing a key,
+/// checked in roughly ex-ray's OWN evaluation order below so the diagnostic
+/// names the key ex-ray itself would report first (the cover-permit /
+/// reachability side only needs `.is_some()`, order-independent — see the
+/// `tcp-keepalive`/`mux`/`fwmark` bullet for the one place order fidelity is
+/// deliberately relaxed, since it can only misname a SIMULTANEOUS second
+/// failure, never change `.is_some()`).
+///
+/// #752 rewrote `parseOptsIntoFlags` (options.go's `parseIntOption`/
+/// `parseBoolOption`/`parseStringOption`/`parseEnumOption`/
+/// `parseURLOption`) to share one rule across every option: an ABSENT key is
+/// a no-op (the flag keeps its default); any PRESENT value — an explicitly
+/// empty one included — must be well-formed or the option is fatal. Before
+/// #752, several of these were warn-and-keep-the-default instead; the
+/// checks below reflect the post-#752 source, not that history.
+/// - `tcp-keepalive`/`mux`/`fwmark` (`parseIntOption`): a present value
+///   `strconv.Atoi` can't parse (non-numeric, or explicitly empty) is fatal
+///   — `mux` specifically because galoshes appends `mux=0` and ex-ray is
+///   first-wins, so an operator's own unparseable `mux=` must not silently
+///   win over it and leave Mux.Cool on. A value that DOES parse is then
+///   range-checked: `tcp-keepalive` against `tcpKeepAliveParams`'
+///   `0..=32767` (`registerTCPKeepAlive`, main.go, before `generateConfig`
+///   even starts); `mux`/`fwmark` against `uint32Opt`'s `0..=u32::MAX`
+///   (`generateConfig`). Both failure modes name the same key, so each is
+///   one combined check here — the parse check runs earlier in the real
+///   source (`parseOptsIntoFlags`) than the range check
+///   (`registerTCPKeepAlive`/`generateConfig`), which is the fidelity this
+///   combining relaxes.
+/// - `localPort`/`remotePort` (main.go's cross-assign + `validPort` ==
+///   `net.PortFromString`): must be an unsigned base-10 literal `<=65535`
+///   and not `0` — `0` is otherwise valid syntax
+///   (`net.PortFromString("0")` succeeds) but ex-ray cannot honor
+///   OS-assigned-port semantics. `localPort` is rejected in main(), before
+///   `generateConfig` runs; `remotePort`, inside it — the ordering
+///   `two_distinct_fatal_keys_report_ex_rays_earlier_one` pins.
+/// - `localAddr` (main.go's cross-assign + `canonicalLocalAddr`): must be a
+///   single (`|`-free) IP literal — a domain or a `|`-joined multi-address
+///   list is fatal, since the sitrep's `ready` event can report only one
+///   `listen` address.
+/// - `remoteAddr` (`generateConfig`): must not normalize to an empty domain
+///   or the unspecified IP (`0.0.0.0`/`::`) — freedom's destination
+///   override would otherwise dial nowhere honestly.
+/// - `tls`/`server`/`fastOpen`/`__android_vpn` (`parseBoolOption`): a
+///   present value other than `"1"` is fatal — presence-only flags with no
+///   wider "truthy" vocabulary.
+/// - `host`/`path` (`parseStringOption`, `emptyOK=false`): a present but
+///   EXPLICITLY EMPTY value is fatal — unlike `cert`/`certRaw`/`key`
+///   (`emptyOK=true`, disclosed below), empty has no documented meaning for
+///   these two. This also closes the pre-#752 `host=` + `remoteAddr=`
+///   fallback path `ech_fetch_is_reachable` used to model — see its doc.
+/// - `ech-doh` (`parseURLOption`): empty is a documented no-op ("disables
+///   ECH"), but a present, non-empty value that isn't a well-formed
+///   `https://` URL with a host is fatal. Checked only when the CONFIG's
+///   own value is what ex-ray will actually read: Hole's own injection
+///   (always well-formed by construction) strips it whenever
+///   [`ech_doh_displaces`] is true.
+/// - `mode` is a CLOSED enum (`switch *mode`, `generateConfig`,
+///   unconditional): outside `websocket`/`quic` is fatal.
+/// - `ech` is a CLOSED enum too (`parseEnumOption`, `parseOptsIntoFlags`) —
+///   UNCONDITIONAL since #752, unlike before: it no longer lives only
+///   inside `buildTLSConfig` (`if *tlsEnabled`). `generateConfig`
+///   re-validates the same flag (redundant on ex-ray's real
+///   `SS_PLUGIN_OPTIONS`-driven path; independently reachable only from a
+///   raw CLI `-ech=`, which bypasses `parseOptsIntoFlags` entirely) and,
+///   separately, rejects `ech=always` with TLS not enabled — also NEW in
+///   #752: a valid-vocabulary `ech=always` with no `tls` and no
+///   `mode=quic` used to silently apply nothing; now it's fatal.
+///   `ech=always` additionally requires a non-empty RESOLVED `ech-doh`
+///   (`buildTLSConfig`, `if *tlsEnabled` only, unchanged by #752) — the
 ///   value ex-ray actually receives once Hole's own injection wins or loses
 ///   against the operator's; see [`resolved_ech_doh_is_empty`] for why that
 ///   is recomputed rather than shared with [`classify_ech_doh`].
+/// - `cert`/`certRaw`/`key` present (non-empty) with TLS not enabled is
+///   fatal too — NEW in #752; before, the material was silently never read.
 /// - `mux`, again, but LATER than its own `uint32Opt` check above: once
-///   `generateConfig` has fully succeeded, `core.New` (`buildV2Ray`,
-///   main.go:143-149) separately rejects a non-zero `Concurrency` outside
-///   `1..=1024` on the websocket transport ONLY
-///   (third_party/v2ray-core/app/proxyman/outbound/handler.go:114-116) —
-///   `quic`'s mux is never read (config.go:287-289's `connectionReuse`
-///   only sets under `case "websocket"`).
+///   `generateConfig` has fully succeeded, `core.New` separately rejects a
+///   non-zero `Concurrency` outside `1..=1024` on the websocket transport
+///   ONLY (`quic`'s mux is never read).
 ///
-/// **Disclosed, deliberately unmodeled:** `cert` requires filesystem I/O
-/// this otherwise-pure gate doesn't perform; `server` cross-assigns
-/// `localPort`/`remotePort` but Hole never spawns ex-ray as one. See
+/// **Not modeled, and why it's safe not to:** `loglevel` gained the same
+/// empty-is-fatal (`parseStringOption`) and unrecognized-is-fatal
+/// (`logConfig`) treatment in #752 — but `inject_plugin_directives` ALWAYS
+/// strips the operator's own `loglevel` and appends `loglevel=debug`,
+/// unconditionally, whether or not Hole's `ech-doh` wins. No value from
+/// `segments` (read pre-injection here) ever reaches ex-ray unmodified, so
+/// modeling it would produce a FALSE fatal for a config that starts fine in
+/// practice — the opposite of the over-permit risk this gate exists to
+/// close.
+///
+/// **Disclosed, deliberately unmodeled:** `cert`/`certRaw`/`key`'s CONTENT
+/// (a readable, well-formed X509 pair) requires filesystem I/O this
+/// otherwise-pure gate doesn't perform — only their presence-without-TLS is
+/// checked above. `server` cross-assigns `localAddr`/`localPort` with
+/// `remoteAddr`/`remotePort`, but Hole never spawns ex-ray as one, so the
+/// four address/port checks above are checked assuming client mode. See
 /// CONTRIBUTING.md's "ECH-config-fetch reachability gate" section for why.
 fn ex_ray_fatal_config_error(
     segments: &[garter::OptionSegment<'_>],
     ech_doh: Option<&crate::dns::ech::EchDoh>,
 ) -> Option<&'static str> {
     if segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
-        ex_ray_flag_value(s)
+        !ex_ray_flag_value(s)
             .parse::<i64>()
-            .is_ok_and(|v| !(0..=32767).contains(&v))
+            .is_ok_and(|v| (0..=32767).contains(&v))
     }) {
         return Some("tcp-keepalive");
     }
-    if let Some(s) = segments.iter().find(|s| s.key == "localPort") {
-        let v = ex_ray_flag_value(s);
-        if v == "0" || v.is_empty() || !matches!(ex_ray_parses_as_uint32(v), Some(p) if p <= 65535) {
-            return Some("localPort");
-        }
+    if segments
+        .iter()
+        .find(|s| s.key == "localPort")
+        .is_some_and(|s| !matches!(ex_ray_parses_as_uint32(ex_ray_flag_value(s)), Some(p) if p != 0 && p <= 65535))
+    {
+        return Some("localPort");
+    }
+    if segments
+        .iter()
+        .find(|s| s.key == "localAddr")
+        .is_some_and(|s| ex_ray_local_addr_is_invalid(ex_ray_flag_value(s)))
+    {
+        return Some("localAddr");
     }
     if segments
         .iter()
         .find(|s| s.key == "remotePort")
-        .is_some_and(|s| ex_ray_parses_as_uint32(ex_ray_flag_value(s)).is_none())
+        .is_some_and(|s| !matches!(ex_ray_parses_as_uint32(ex_ray_flag_value(s)), Some(p) if p != 0 && p <= 65535))
     {
         return Some("remotePort");
     }
+    if segments
+        .iter()
+        .find(|s| s.key == "remoteAddr")
+        .is_some_and(|s| ex_ray_remote_addr_is_invalid(ex_ray_flag_value(s)))
+    {
+        return Some("remoteAddr");
+    }
     for key in ["mux", "fwmark"] {
         if segments.iter().find(|s| s.key == key).is_some_and(|s| {
-            ex_ray_flag_value(s)
+            !ex_ray_flag_value(s)
                 .parse::<i64>()
-                .is_ok_and(|v| v < 0 || v > i64::from(u32::MAX))
+                .is_ok_and(|v| (0..=i64::from(u32::MAX)).contains(&v))
         }) {
             return Some(key);
+        }
+    }
+    for key in ["tls", "server", "fastOpen", "__android_vpn"] {
+        if segments
+            .iter()
+            .find(|s| s.key == key)
+            .is_some_and(|s| ex_ray_flag_value(s) != "1")
+        {
+            return Some(key);
+        }
+    }
+    for key in ["host", "path"] {
+        if segments
+            .iter()
+            .find(|s| s.key == key)
+            .is_some_and(|s| ex_ray_flag_value(s).is_empty())
+        {
+            return Some(key);
+        }
+    }
+    if let Some(s) = segments.iter().find(|s| s.key == "ech-doh") {
+        let v = ex_ray_flag_value(s);
+        if !v.is_empty() && !ech_doh_displaces(segments, ech_doh) && !ex_ray_value_is_https_url(v) {
+            return Some("ech-doh");
+        }
+    }
+    let ech = segments.iter().find(|s| s.key == "ech").map(ex_ray_flag_value);
+    if let Some(v) = ech {
+        if !matches!(v, "never" | "auto" | "always") {
+            return Some("ech");
         }
     }
     let mode = segments.iter().find(|s| s.key == "mode").map(ex_ray_flag_value);
@@ -659,24 +750,30 @@ fn ex_ray_fatal_config_error(
         }
     }
     let tls_enabled = segments.iter().any(|s| s.key == "tls") || mode == Some("quic");
-    if tls_enabled {
-        if let Some(s) = segments.iter().find(|s| s.key == "ech") {
-            let v = ex_ray_flag_value(s);
-            if !matches!(v, "never" | "auto" | "always") {
-                return Some("ech");
-            }
-            if v == "always" && resolved_ech_doh_is_empty(segments, ech_doh) {
-                return Some("ech-doh");
-            }
+    if ech == Some("always") {
+        if !tls_enabled {
+            return Some("ech");
         }
+        if resolved_ech_doh_is_empty(segments, ech_doh) {
+            return Some("ech-doh");
+        }
+    }
+    let cert_material_present = ["cert", "certRaw", "key"].iter().any(|key| {
+        segments
+            .iter()
+            .find(|s| s.key == *key)
+            .is_some_and(|s| !ex_ray_flag_value(s).is_empty())
+    });
+    if !tls_enabled && cert_material_present {
+        return Some("cert");
     }
     // Same 1..=1024 concurrency bound as the `mux` bullet above (core.New,
     // only on websocket, only when non-zero). The effective value defaults
     // to ex-ray's own flag default (`1`) unless a segment both exists AND
-    // parses. `MultiplexSettings` is CLIENT-mode only (config.go:351-387 —
-    // the `server` branch never builds it), so this check is skipped
-    // alongside the rest of the disclosed, deliberately-unmodeled `server`
-    // residual below, not a separate gap.
+    // parses. `MultiplexSettings` is CLIENT-mode only (config.go — the
+    // `server` branch never builds it), so this check is skipped alongside
+    // the rest of the disclosed, deliberately-unmodeled `server` residual
+    // above, not a separate gap.
     if mode != Some("quic") && !segments.iter().any(|s| s.key == "server") {
         let mux = segments
             .iter()
@@ -735,56 +832,31 @@ fn ex_ray_parses_as_uint32(v: &str) -> Option<u32> {
 /// set, independent of which `ech-doh` value would win. Neither the cover
 /// permit, the residual-stall warning, nor `inject_plugin_directives`'s own
 /// ECH-posture logging may treat a fetch that provably cannot happen as one
-/// that will — four independent conditions, each first-wins (matching
+/// that will — three independent conditions, each first-wins (matching
 /// `Args.Get`):
 /// - [`ex_ray_fatal_config_error`] is `Some` — the whole plugin process
-///   exits before it ever starts, so no dial of any kind happens.
+///   exits before it ever starts, so no dial of any kind happens. This also
+///   covers an EXPLICITLY EMPTY `host=`: before #752, `Config.ServerName`
+///   (empty) fell back to the dial destination — `tls.WithDestination`
+///   filling it from `remoteAddr` (third_party/.../tls/config.go;
+///   `websocket/dialer.go`) — so this function used to re-derive an SNI
+///   from `remoteAddr` for that case. #752's `parseStringOption(...,
+///   "host", ..., emptyOK: false)` now rejects `host=` at parse time, so
+///   `*host` can never actually BE `""` when `buildTLSConfig` runs — the
+///   v2ray-core fallback still exists, just unreachable via `plugin_opts`.
 /// - `ech=never` short-circuits ECH entirely before it ever looks at
-///   `ech-doh` (crates/ex-ray/config.go:209-211).
+///   `ech-doh` (config.go).
 /// - TLS must be enabled at all — an explicit `tls` flag, or `mode=quic`
 ///   forcing it on — since `buildTLSConfig` (which contains the whole `ech`
-///   switch) is called only when `tlsEnabled` (config.go:290-294, 334); a
-///   plain non-quic transport (e.g. `mode=websocket` with no `tls`) never
-///   calls it.
+///   switch) is called only when `tlsEnabled`; a plain non-quic transport
+///   (e.g. `mode=websocket` with no `tls`) never calls it.
 /// - `ApplyECH` bails before dialing DoH unless the TLS `ServerName` is a
-///   DOMAIN: ex-ray sets `tlsConfig.ServerName = *host` directly
-///   (config.go:177), and an ABSENT `host` falls back to ex-ray's own
-///   [`EX_RAY_DEFAULT_HOST`], a real domain, so it's reachable. An EXPLICIT
-///   `host=<value>` wins outright, domain or not. But an EXPLICIT EMPTY
-///   `host=` is NOT "no SNI": `Config.parseServerName` treats a
-///   zero-length `ServerName` as absent (config.go:262 in the
-///   third_party path, `len(sn) > 0`) and `tls.WithDestination` then fills
-///   `ServerName` from the DIAL DESTINATION instead
-///   (third_party/.../transport/internet/tls/config.go:371-382,
-///   `websocket/dialer.go:67`) — and that destination is `remoteAddr`, a
-///   `plugin_opts` option in its own right (main.go:102-108) that can be a
-///   domain, first-wins same as every other key here. `remoteAddr` ABSENT
-///   falls back to Hole's OWN `SS_REMOTE_HOST`, which this function cannot
-///   see (env, not `plugin_opts`) — but is ALWAYS an IP literal in Hole's
-///   own spawn path (`crate::proxy::plugin` never resolves a domain later
-///   than `garter::binary::sip003_env`, which passes an already-resolved
-///   `SocketAddr`), so an absent `remoteAddr` is correctly treated as "not
-///   a domain" without needing to see it. Normalizing the IP-literal test
-///   (for `host` directly, or the `remoteAddr` fallback alike) mirrors
-///   v2ray-core's `net.ParseAddress` (only a MATCHED `[...]` pair is
-///   stripped, once; whitespace is trimmed only when the first or last
-///   byte is non-alphanumeric).
-///   (third_party/v2ray-core/transport/internet/tls/ech.go:26-51,
-///   config.go:250-264,296-303,371-382;
-///   third_party/v2ray-core/common/net/address.go:78-95; main.go:67-69,
-///   102-108).
-///
-/// **Disclosed, on the `remoteAddr` fallback only:** ex-ray applies
-/// `ParseAddress` TWICE on that path — once building the dial destination
-/// (`generateConfig`), once more computing the ECH domain from the
-/// destination-derived `ServerName` — while this normalizes once. The two
-/// disagree only for a value a SECOND unwrap would still change, e.g. a
-/// doubly-bracketed `remoteAddr=[[::1]]` (one strip leaves `[::1]`, itself
-/// still bracketed): this treats it as reachable, real ex-ray does not.
-/// Modeling the second pass needs mirroring v2ray-core's `Domain`/`IP`
-/// address-family round-trip (`net.NewIPOrDomain`), a materially larger
-/// change than a fallback lookup; see CONTRIBUTING.md's "ECH-config-fetch
-/// reachability gate" section.
+///   DOMAIN: ex-ray sets `tlsConfig.ServerName = *host` directly, and an
+///   ABSENT `host` falls back to ex-ray's own [`EX_RAY_DEFAULT_HOST`], a
+///   real domain, so it's reachable. An EXPLICIT `host=<value>` (now always
+///   non-empty, given the point above) wins outright, domain or not
+///   (third_party/v2ray-core/transport/internet/tls/ech.go:26-51;
+///   config.go; main.go).
 ///
 /// Every flag read here goes through [`ex_ray_flag_value`] rather than
 /// `OptionSegment::value` — see its doc. For `host` the divergence is
@@ -799,15 +871,12 @@ fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>], ech_doh: Optio
     }
     let mode = segments.iter().find(|s| s.key == "mode").map(ex_ray_flag_value);
     let tls_enabled = segments.iter().any(|s| s.key == "tls") || mode == Some("quic");
-    let host = segments.iter().find(|s| s.key == "host").map(ex_ray_flag_value);
-    let sni = match host {
-        None => EX_RAY_DEFAULT_HOST,
-        Some("") => segments
-            .iter()
-            .find(|s| s.key == "remoteAddr")
-            .map_or("", ex_ray_flag_value),
-        Some(v) => v,
-    };
+    // An explicitly empty `host=` is fatal (caught above) and never reaches
+    // here — only an ABSENT host falls back to ex-ray's own default.
+    let sni = segments
+        .iter()
+        .find(|s| s.key == "host")
+        .map_or(EX_RAY_DEFAULT_HOST, ex_ray_flag_value);
     tls_enabled && v2ray_core_parses_as_a_domain(sni)
 }
 
@@ -821,13 +890,11 @@ fn ex_ray_flag_value<'a>(s: &'a garter::OptionSegment<'_>) -> &'a str {
     }
 }
 
-/// Mirrors v2ray-core's `net.ParseAddress` (see `ech_fetch_is_reachable`'s
-/// doc for the exact source lines): strips ONE matched `[...]` bracket pair,
-/// then trims surrounding whitespace ONLY when the first or last byte isn't
-/// alphanumeric, then tests whether what's left parses as an IP. An empty
-/// result (whether from the input or after normalization) is never a
-/// domain — `echCacheDomain`'s own caller excludes it explicitly.
-fn v2ray_core_parses_as_a_domain(value: &str) -> bool {
+/// Mirrors v2ray-core's `net.ParseAddress` normalization
+/// (third_party/v2ray-core/common/net/address.go:78-95): strips ONE matched
+/// `[...]` bracket pair, then trims surrounding whitespace ONLY when the
+/// first or last byte isn't alphanumeric.
+fn v2ray_core_normalize(value: &str) -> &str {
     let bytes = value.as_bytes();
     let unbracketed = if !bytes.is_empty() && bytes[0] == b'[' && bytes[bytes.len() - 1] == b']' {
         &value[1..value.len() - 1]
@@ -836,8 +903,55 @@ fn v2ray_core_parses_as_a_domain(value: &str) -> bool {
     };
     let ub = unbracketed.as_bytes();
     let needs_trim = !ub.is_empty() && (!ub[0].is_ascii_alphanumeric() || !ub[ub.len() - 1].is_ascii_alphanumeric());
-    let normalized = if needs_trim { unbracketed.trim() } else { unbracketed };
+    if needs_trim {
+        unbracketed.trim()
+    } else {
+        unbracketed
+    }
+}
+
+/// Whether `value` parses as a v2ray-core DOMAIN address (non-empty, not an
+/// IP) once normalized as [`v2ray_core_normalize`]. An empty result
+/// (whether from the input or after normalization) is never a domain —
+/// `echCacheDomain`'s own caller excludes it explicitly.
+fn v2ray_core_parses_as_a_domain(value: &str) -> bool {
+    let normalized = v2ray_core_normalize(value);
     !normalized.is_empty() && normalized.parse::<std::net::IpAddr>().is_err()
+}
+
+/// Whether `value` parses as a v2ray-core IP-family address once normalized
+/// as [`v2ray_core_normalize`] — used by [`ex_ray_fatal_config_error`] for
+/// `localAddr`'s `canonicalLocalAddr` check, which requires an IP literal.
+fn v2ray_core_parses_as_an_ip(value: &str) -> bool {
+    v2ray_core_normalize(value).parse::<std::net::IpAddr>().is_ok()
+}
+
+/// Whether ex-ray's `canonicalLocalAddr` (config.go, reachable from main()'s
+/// pre-bind guard) would reject `value` for `localAddr`: not exactly one
+/// (`|`-free) address, or not an IP literal once normalized.
+fn ex_ray_local_addr_is_invalid(value: &str) -> bool {
+    value.contains('|') || !v2ray_core_parses_as_an_ip(value)
+}
+
+/// Whether ex-ray's `generateConfig` (config.go) would reject `value` for
+/// `remoteAddr`: an empty domain (normalizes to `""`, `ParseAddress`'s own
+/// domain fallback), or the unspecified IP (`0.0.0.0`/`::`) — freedom's
+/// destination override would otherwise dial nowhere honestly.
+fn ex_ray_remote_addr_is_invalid(value: &str) -> bool {
+    let normalized = v2ray_core_normalize(value);
+    match normalized.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_unspecified(),
+        Err(_) => normalized.is_empty(),
+    }
+}
+
+/// Whether ex-ray's `parseURLOption(opts, "ech-doh", ...)` (options.go)
+/// would accept `v` as a well-formed DoH URL: `url.Parse` succeeding, an
+/// `https` scheme, and a non-empty host. Only checked for the CONFIG's own
+/// `ech-doh` value, and only when it is NOT displaced by Hole's own —
+/// see [`ex_ray_fatal_config_error`]'s `ech-doh` bullet.
+fn ex_ray_value_is_https_url(v: &str) -> bool {
+    url::Url::parse(v).is_ok_and(|u| u.scheme() == "https" && u.host_str().is_some_and(|h| !h.is_empty()))
 }
 
 /// The `segments`-based wrapper around [`hole_ech_doh_outranks`] — extracts
@@ -1564,22 +1678,30 @@ mod inject_tests {
         let segments = garter::split_plugin_options("tls;host=cdn.example;mode=grpc;ech=bogus").unwrap();
         assert_eq!(
             ex_ray_fatal_config_error(&segments, None),
-            Some("mode"),
-            "mode's switch is unconditional and runs before ech's, which is gated on tlsEnabled"
+            Some("ech"),
+            "since #752, `ech`'s enum check runs unconditionally in parseOptsIntoFlags, structurally \
+             before generateConfig's `mode` switch even starts — not the other way around, and not \
+             gated on tlsEnabled anymore either"
         );
     }
 
     // ex-ray reads the FIRST `ech`, so a later `always` it will never apply must
-    // not be reported as a fail-closed posture.
+    // not be reported as a fail-closed posture. `tls` and a pinned candidate are
+    // required on both inputs so neither trips the (unrelated) ech=always-requires-
+    // tls / ech=always-requires-resolved-ech-doh fatal checks.
     #[skuld::test]
     fn fail_closed_reads_the_first_ech_not_any_of_them() {
-        let out = warnings_for("ex-ray", Some("ech=never;ech=always"), None);
+        // Unpinned, not pinned: a pinned candidate reaches the silent
+        // `(Some(_), _) => {}` warning arm (nothing to report), which would
+        // never contain "fail_closed" at all.
+        let e = unpinned("https://9.9.9.9/dns-query");
+        let out = warnings_for("ex-ray", Some("tls;ech=never;ech=always"), Some(&e));
         assert!(
             out.contains("fail_closed=false"),
             "the first `ech` is `never`; got:
 {out}"
         );
-        let out = warnings_for("ex-ray", Some("ech=always;ech=never"), None);
+        let out = warnings_for("ex-ray", Some("tls;ech=always;ech=never"), Some(&e));
         assert!(
             out.contains("fail_closed=true"),
             "the first `ech` is `always`; got:
@@ -1689,29 +1811,46 @@ mod inject_tests {
         );
     }
 
-    // A bare `ech-doh` (no `=`) reads as ex-ray's own `"1"` — non-empty, so
-    // ex-ray DOES arm `Ech_DOHserver = "1"` (config.go:213) and attempt to
-    // use it as a DoH URL, even though "1" itself is not a usable URL. The
-    // operator's value is reported as exactly what ex-ray will try, "1".
+    // A bare `ech-doh` (no `=`) reads as ex-ray's own `"1"` — non-empty, but
+    // (since #752's `parseURLOption`) NOT a well-formed `https://` URL, so
+    // it is now a fatal config error (`parseOptsIntoFlags`) rather than a
+    // value ex-ray tries and fails on later; the whole process exits before
+    // dialing anything.
     #[skuld::test]
-    fn bare_operator_ech_doh_reaches_ex_ray_as_ex_rays_own_placeholder() {
+    fn bare_operator_ech_doh_never_reaches_ex_ray() {
         assert_eq!(
             effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech-doh"), None),
-            EffectiveEchDoh::Operators("1".to_string())
+            EffectiveEchDoh::None
+        );
+        let segments = garter::split_plugin_options("tls;host=cdn.example;ech-doh").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech-doh"));
+    }
+
+    // A malformed operator `ech-doh` that Hole's OWN value DISPLACES is
+    // stripped before ex-ray ever sees it (`inject_plugin_directives`), so
+    // it must NOT be reported as fatal — the malformed string never reaches
+    // the plugin at all.
+    #[skuld::test]
+    fn a_malformed_operator_ech_doh_displaced_by_holes_own_is_not_fatal() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        let segments = garter::split_plugin_options("tls;host=cdn.example;ech-doh=not-a-url").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, Some(&e)), None);
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;ech-doh=not-a-url"), Some(&e)),
+            EffectiveEchDoh::Holes
         );
     }
 
-    // `switch *echMode` lives INSIDE `buildTLSConfig`, called only `if
-    // *tlsEnabled` (config.go:209-223,290-294,334) — an invalid `ech` value
-    // with no `tls` flag and no `mode=quic` is never looked at, so ex-ray
-    // starts fine and dials the plaintext upstream normally. Must NOT be
-    // reported as a fatal config-build error (nor, since there's no `tls`,
-    // as reachable — `no_tls_and_not_quic_never_reaches_ex_ray` already
-    // covers that half).
+    // `ech`'s enum check (`parseEnumOption`, `parseOptsIntoFlags`) is
+    // UNCONDITIONAL since #752 — unlike before, when the switch lived only
+    // inside `buildTLSConfig` (`if *tlsEnabled`). An invalid `ech` value
+    // with no `tls` flag and no `mode=quic` is now fatal too, even though
+    // the fetch itself is (separately) unreachable either way — see
+    // `no_tls_and_not_quic_never_reaches_ex_ray` for that half.
     #[skuld::test]
-    fn an_invalid_ech_value_without_tls_is_inert_not_fatal() {
+    fn an_invalid_ech_value_without_tls_is_fatal_since_752() {
         let segments = garter::split_plugin_options("host=cdn.example;ech=bogus").unwrap();
-        assert_eq!(ex_ray_fatal_config_error(&segments, None), None);
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech"));
     }
 
     // As above, but `mode=quic` force-enables TLS with no explicit `tls`
@@ -1743,11 +1882,9 @@ mod inject_tests {
         );
     }
 
-    // `remotePort` has NO upper bound of its own (config.go routes it
-    // through raw `strconv.ParseUint`, not `net.Port`) — its only ceiling is
-    // u32::MAX from the parse itself. A value that overflows it is the one
-    // thing standing between a legal and a rejected remotePort, so it must
-    // be exercised, not just the non-digit / negative cases above.
+    // A value that overflows the parse itself (u32::MAX) is a distinct
+    // failure mode from the range check below and must independently be
+    // caught by `ex_ray_parses_as_uint32`.
     #[skuld::test]
     fn a_remote_port_above_u32_max_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -1757,9 +1894,7 @@ mod inject_tests {
         );
     }
 
-    // As above, for `localPort` (whose ceiling is the tighter 65535, but the
-    // u32::MAX parse overflow is a distinct failure mode from that range
-    // check and must independently be caught by `ex_ray_parses_as_uint32`).
+    // As above, for `localPort`.
     #[skuld::test]
     fn a_local_port_above_u32_max_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -1767,6 +1902,148 @@ mod inject_tests {
             effective_ech_doh("ex-ray", Some("tls;host=cdn.example;localPort=4294967296"), Some(&e)),
             EffectiveEchDoh::None
         );
+    }
+
+    // NEW in #752: `remotePort` now routes through the SAME `validPort` as
+    // `localPort` (config.go), so it shares localPort's tighter 65535
+    // ceiling and its `0` rejection — before, it went through a bare
+    // `strconv.ParseUint(_, 10, 32)` with no upper bound beyond u32::MAX and
+    // no zero check at all.
+    #[skuld::test]
+    fn a_remote_port_shares_local_ports_ceiling_and_zero_rejection_since_752() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in [
+            "tls;host=cdn.example;remotePort=65536", // within u32::MAX, above the NEW 65535 ceiling
+            "tls;host=cdn.example;remotePort=0",
+            "tls;host=cdn.example;remotePort=",
+        ] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::None,
+                "opts={opts:?}"
+            );
+        }
+    }
+
+    // NEW-since-#752 non-canonical-zero coverage: `"00"` is valid
+    // `strconv.ParseUint` syntax (parses to `0`), so it is caught by
+    // `validPort`'s `== 0` rejection, not by a parse failure — a check that
+    // only compared against the LITERAL string `"0"` would miss it.
+    #[skuld::test]
+    fn a_non_canonical_zero_local_port_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=cdn.example;localPort=00"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+        let segments = garter::split_plugin_options("tls;host=cdn.example;localPort=00").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("localPort"));
+    }
+
+    // `tls`/`server`/`fastOpen`/`__android_vpn` (`parseBoolOption`) accept
+    // ONLY a present `"1"` (or a bare key, which `Args` maps to `"1"`) —
+    // any other present value is fatal, NEW in #752 (before: presence alone
+    // enabled the flag, any value).
+    #[skuld::test]
+    fn a_bool_option_with_a_value_other_than_1_is_fatal_since_752() {
+        for (key, opts) in [
+            ("tls", "tls=0;host=cdn.example"),
+            ("tls", "tls=true;host=cdn.example"),
+            ("server", "tls;host=cdn.example;server=0"),
+            ("fastOpen", "tls;host=cdn.example;fastOpen=0"),
+            ("__android_vpn", "tls;host=cdn.example;__android_vpn=0"),
+        ] {
+            let segments = garter::split_plugin_options(opts).unwrap();
+            assert_eq!(ex_ray_fatal_config_error(&segments, None), Some(key), "opts={opts:?}");
+        }
+    }
+
+    // `path` (`parseStringOption`, `emptyOK=false`) is fatal when
+    // EXPLICITLY empty, same rule as `host`.
+    #[skuld::test]
+    fn an_explicitly_empty_path_is_fatal_since_752() {
+        let segments = garter::split_plugin_options("tls;host=cdn.example;path=").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("path"));
+    }
+
+    // `localAddr` (main.go's cross-assign + `canonicalLocalAddr`) must be a
+    // single IP literal — a domain or a `|`-joined multi-address list is
+    // fatal. Not new to #752, but never modeled until this reconciliation.
+    #[skuld::test]
+    fn an_invalid_local_addr_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in [
+            "tls;host=cdn.example;localAddr=cdn.example",   // domain, not an IP
+            "tls;host=cdn.example;localAddr=127.0.0.1|::1", // multi-address
+        ] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::None,
+                "opts={opts:?}"
+            );
+        }
+        let segments = garter::split_plugin_options("tls;host=cdn.example;localAddr=cdn.example").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("localAddr"));
+    }
+
+    // `remoteAddr` (`generateConfig`) must not be an empty domain or the
+    // unspecified IP (`0.0.0.0`/`::`) — a wrong destination that binds fine
+    // and reports ready, then fails (or silently misroutes) every dial.
+    #[skuld::test]
+    fn an_unspecified_or_empty_remote_addr_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in [
+            "tls;host=cdn.example;remoteAddr=0.0.0.0",
+            "tls;host=cdn.example;remoteAddr=::",
+            "tls;host=cdn.example;remoteAddr= ", // whitespace-only normalizes to empty
+        ] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::None,
+                "opts={opts:?}"
+            );
+        }
+        let segments = garter::split_plugin_options("tls;host=cdn.example;remoteAddr=0.0.0.0").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("remoteAddr"));
+    }
+
+    // A non-empty `cert`/`certRaw`/`key` with TLS not enabled is fatal, NEW
+    // in #752 — before, the material was silently never read.
+    #[skuld::test]
+    fn cert_material_without_tls_is_fatal_since_752() {
+        for opts in [
+            "host=cdn.example;cert=/tmp/cert.pem",
+            "host=cdn.example;certRaw=deadbeef",
+            "host=cdn.example;key=/tmp/key.pem",
+        ] {
+            let segments = garter::split_plugin_options(opts).unwrap();
+            assert_eq!(
+                ex_ray_fatal_config_error(&segments, None),
+                Some("cert"),
+                "opts={opts:?}"
+            );
+        }
+    }
+
+    // `loglevel` is NOT modeled: `inject_plugin_directives` always strips
+    // the operator's own `loglevel` and appends `loglevel=debug`, so no
+    // value from the pre-injection `segments` this gate reads ever reaches
+    // ex-ray — an explicitly empty or unrecognized `loglevel` here must NOT
+    // be reported as fatal, even though ex-ray itself would reject either
+    // one directly.
+    #[skuld::test]
+    fn loglevel_is_never_modeled_as_fatal() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        for opts in [
+            "tls;host=cdn.example;loglevel=",
+            "tls;host=cdn.example;loglevel=verbose",
+        ] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::Holes,
+                "opts={opts:?}: loglevel is always overridden by Hole's own injection"
+            );
+        }
     }
 
     // `ech=always` with an empty RESOLVED `ech-doh` is itself a
@@ -1802,17 +2079,18 @@ mod inject_tests {
         assert_eq!(ex_ray_fatal_config_error(&segments, Some(&e)), None);
     }
 
-    // The nested `ech=always` + empty-resolved-`ech-doh` check lives INSIDE
-    // the `tls_enabled` gate, same as the enum check — with no `tls` and no
-    // `mode=quic`, `buildTLSConfig` (and the whole `ech` switch within it)
-    // never runs, so `ech=always` with no `ech-doh` from any source is
-    // inert, not fatal. A regression that moved this check outside the
-    // `tls_enabled` guard would pass every OTHER `ech=always` test (all of
-    // which include `tls`) but not this one.
+    // NEW in #752: `generateConfig` rejects `ech=always` outright when TLS
+    // isn't enabled (`if *echMode == "always" && !*tlsEnabled`) — before,
+    // a valid-vocabulary `ech=always` with no `tls` and no `mode=quic`
+    // silently applied nothing. This is a DIFFERENT fatal reason than the
+    // nested `ech=always` + empty-resolved-`ech-doh` check (which stays
+    // gated inside `tls_enabled`, since `buildTLSConfig` itself is) — this
+    // one is fatal precisely BECAUSE tls is off, regardless of whether an
+    // `ech-doh` is configured at all.
     #[skuld::test]
-    fn ech_always_without_tls_is_inert_not_fatal() {
+    fn ech_always_without_tls_is_fatal_since_752() {
         let segments = garter::split_plugin_options("host=cdn.example;ech=always").unwrap();
-        assert_eq!(ex_ray_fatal_config_error(&segments, None), None);
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech"));
     }
 
     // Every new `ex_ray_fatal_config_error` check reads its key via `find`
@@ -1861,16 +2139,30 @@ mod inject_tests {
         );
     }
 
-    // A `mux` that fails to parse at all is NOT a config-build error —
-    // ex-ray's own opts-to-flags step (main.go) logs a warning and silently
-    // keeps the flag's default, so the fetch is still reachable.
+    // NEW in #752: a `mux` that fails to parse at all is now a config-build
+    // error too — before, ex-ray's opts-to-flags step logged a warning and
+    // silently kept the flag's default. `parseIntOption`'s doc: an
+    // operator's own unparseable `mux=` must not silently outrank galoshes'
+    // appended `mux=0` and leave Mux.Cool on.
     #[skuld::test]
-    fn an_unparseable_mux_value_keeps_ex_ray_default_and_still_reaches_ex_ray() {
+    fn an_unparseable_mux_value_is_fatal_since_752() {
         let e = pinned("https://9.9.9.9/dns-query");
         assert_eq!(
             effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=not-a-number"), Some(&e)),
-            EffectiveEchDoh::Holes
+            EffectiveEchDoh::None
         );
+        let segments = garter::split_plugin_options("tls;host=cdn.example;mux=not-a-number").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("mux"));
+    }
+
+    // As above, for an explicitly EMPTY `mux=` specifically — the case
+    // #752's own commit message calls out: galoshes appends `mux=0`, ex-ray
+    // is first-wins, so a bare `mux=` an operator left behind must not
+    // silently win over galoshes' append and leave Mux.Cool on.
+    #[skuld::test]
+    fn an_explicitly_empty_mux_value_is_fatal() {
+        let segments = garter::split_plugin_options("tls;host=cdn.example;mux=").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("mux"));
     }
 
     #[skuld::test]
@@ -1881,6 +2173,19 @@ mod inject_tests {
             EffectiveEchDoh::None,
             "fwmark above u32::MAX is out of uint32Opt's range — config.go rejects it"
         );
+    }
+
+    // As `an_unparseable_mux_value_is_fatal_since_752`, for `fwmark` and
+    // `tcp-keepalive` — `parseIntOption` is shared across all three.
+    #[skuld::test]
+    fn an_unparseable_fwmark_or_tcp_keepalive_value_is_fatal_since_752() {
+        for (key, opts) in [
+            ("fwmark", "tls;host=cdn.example;fwmark=not-a-number"),
+            ("tcp-keepalive", "tls;host=cdn.example;tcp-keepalive=not-a-number"),
+        ] {
+            let segments = garter::split_plugin_options(opts).unwrap();
+            assert_eq!(ex_ray_fatal_config_error(&segments, None), Some(key), "opts={opts:?}");
+        }
     }
 
     // `core.New` rejects a non-zero websocket `mux` `Concurrency` outside
@@ -2027,15 +2332,15 @@ mod inject_tests {
 
     // But an EXPLICIT `host` must still be a DOMAIN for `ApplyECH` to ever
     // dial DoH at all (`echCacheDomain` returns "" and `ApplyECH` bails
-    // otherwise) — explicitly empty or IP-literal both mean "no SNI to key
-    // the lookup on", matching v2ray-core's `net.ParseAddress` exactly:
-    // only a MATCHED `[...]` pair strips, and only a non-alphanumeric edge
-    // trims whitespace.
+    // otherwise) — an IP-literal `host` means "no SNI to key the lookup
+    // on", matching v2ray-core's `net.ParseAddress` exactly: only a MATCHED
+    // `[...]` pair strips, and only a non-alphanumeric edge trims
+    // whitespace. (An explicitly EMPTY `host=` is a DIFFERENT, fatal case —
+    // see `explicitly_empty_host_is_fatal_since_752` below, not this one.)
     #[skuld::test]
     fn no_domain_host_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
         for opts in [
-            "tls;host=",
             "tls;host=203.0.113.5",
             "tls;host=[2001:db8::1]",
             "tls;host= 203.0.113.5", // ParseAddress TrimSpaces a non-alnum edge, still an IP
@@ -2049,53 +2354,31 @@ mod inject_tests {
         }
     }
 
-    // An EXPLICIT empty `host=` is NOT "no SNI" — `Config.ServerName`
-    // (empty) falls back to the dial destination (`tls.WithDestination`),
-    // and that destination is `remoteAddr`, itself a `plugin_opts` option
-    // that can name a domain.
+    // NEW in #752: `parseStringOption(opts, "host", host, false)` rejects a
+    // present, explicitly EMPTY `host=` at parse time — the whole plugin
+    // process exits before it ever dials anything. Before #752, `host=""`
+    // instead reached `buildTLSConfig`, whose empty `ServerName` fell back
+    // to the dial destination (`remoteAddr`) via v2ray-core's own
+    // `tls.WithDestination` — that v2ray-core mechanism still exists, but
+    // is now unreachable via `plugin_opts`, regardless of what `remoteAddr`
+    // says (unlike the old fallback, which only unreached for an IP-literal
+    // `remoteAddr`).
     #[skuld::test]
-    fn empty_host_falls_back_to_a_domain_remote_addr_and_reaches_ex_ray() {
+    fn explicitly_empty_host_is_fatal_since_752() {
         let e = pinned("https://9.9.9.9/dns-query");
-        assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls;host=;remoteAddr=cdn.example"), Some(&e)),
-            EffectiveEchDoh::Holes
-        );
-    }
-
-    // As above, but the destination fallback is itself an IP — no domain
-    // SNI either way, so still unreachable (same outcome as no `remoteAddr`
-    // at all, just via the explicit-IP branch instead of the absent one).
-    #[skuld::test]
-    fn empty_host_with_an_ip_remote_addr_never_reaches_ex_ray() {
-        let e = pinned("https://9.9.9.9/dns-query");
-        assert_eq!(
-            effective_ech_doh("ex-ray", Some("tls;host=;remoteAddr=203.0.113.5"), Some(&e)),
-            EffectiveEchDoh::None
-        );
-    }
-
-    // `remoteAddr` uses first-wins too, matching every other flag here.
-    #[skuld::test]
-    fn empty_host_remote_addr_fallback_is_first_wins() {
-        let e = pinned("https://9.9.9.9/dns-query");
-        assert_eq!(
-            effective_ech_doh(
-                "ex-ray",
-                Some("tls;host=;remoteAddr=203.0.113.5;remoteAddr=cdn.example"),
-                Some(&e)
-            ),
-            EffectiveEchDoh::None,
-            "the FIRST remoteAddr= wins — an IP literal here, so the later domain is ignored"
-        );
-        assert_eq!(
-            effective_ech_doh(
-                "ex-ray",
-                Some("tls;host=;remoteAddr=cdn.example;remoteAddr=203.0.113.5"),
-                Some(&e)
-            ),
-            EffectiveEchDoh::Holes,
-            "the FIRST remoteAddr= wins — a domain here, so the later IP literal is ignored"
-        );
+        for opts in [
+            "tls;host=",
+            "tls;host=;remoteAddr=cdn.example",
+            "tls;host=;remoteAddr=203.0.113.5",
+        ] {
+            assert_eq!(
+                effective_ech_doh("ex-ray", Some(opts), Some(&e)),
+                EffectiveEchDoh::None,
+                "opts={opts:?}: host= is fatal regardless of remoteAddr"
+            );
+        }
+        let segments = garter::split_plugin_options("tls;host=").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("host"));
     }
 
     // A bare `host` (no `=`) is `""` in `OptionSegment::value`, but ex-ray's
@@ -2243,9 +2526,15 @@ mod inject_tests {
 
         // The numeric bounds `ex_ray_fatal_config_error` hardcodes for
         // mux/fwmark (`uint32Opt`), tcp-keepalive (`keepAliveMaxSeconds`),
-        // and localPort (`net.PortFromString`) — same drift risk, same pin.
+        // and localPort/remotePort (`validPort`) — same drift risk, same
+        // pin. Pinned on the COMPARISON itself, not `uint32Opt`'s error
+        // message: #752 dropped that message's `, got: <value>` suffix (to
+        // stop a mux=abc\;certRaw=SECRET-shaped escape from leaking a later
+        // segment's value through it) without touching the bound, and a
+        // message-text pin would have (and did) gone stale for a reason
+        // that has nothing to do with the bound it exists to protect.
         assert!(
-            source.contains("(expected 0..4294967295), got:"),
+            source.contains("v >= 0 && v <= math.MaxUint32"),
             "ex_ray_fatal_config_error's mux/fwmark range (0..=u32::MAX) no longer matches \
              config.go's `uint32Opt` — update the range to the vendored source"
         );
@@ -2254,10 +2543,36 @@ mod inject_tests {
             "ex_ray_fatal_config_error's tcp-keepalive range (0..=32767) no longer matches \
              config.go's `keepAliveMaxSeconds` — update the range to the vendored source"
         );
+        assert!(
+            source.contains("rport, err := validPort(*remotePort)"),
+            "ex_ray_fatal_config_error's remotePort ceiling (65535, shared with localPort since \
+             #752) no longer matches config.go — remotePort must still route through the same \
+             `validPort` as localPort, not a bare `strconv.ParseUint`"
+        );
+        assert!(
+            source.contains("family.IsIP() && remoteAddress.IP().IsUnspecified()"),
+            "ex_ray_fatal_config_error's remoteAddr unspecified-IP check no longer matches \
+             config.go — update ex_ray_remote_addr_is_invalid to the vendored source"
+        );
+        assert!(
+            source.contains("func canonicalLocalAddr"),
+            "ex_ray_fatal_config_error's localAddr IP-literal check no longer matches config.go's \
+             `canonicalLocalAddr` — update ex_ray_local_addr_is_invalid to the vendored source"
+        );
+        assert!(
+            source.contains("if *echMode == \"always\" && !*tlsEnabled {"),
+            "ex_ray_fatal_config_error's ech=always-requires-tls check no longer matches \
+             config.go — update the vendored source reference"
+        );
+        assert!(
+            source.contains("if !*tlsEnabled && (*cert != \"\" || *certRaw != \"\" || *key != \"\") {"),
+            "ex_ray_fatal_config_error's cert/certRaw/key-requires-tls check no longer matches \
+             config.go — update the vendored source reference"
+        );
         let port_source = include_str!("../../../ex-ray/third_party/v2ray-core/common/net/port.go");
         assert!(
             port_source.contains("if val > 65535 {"),
-            "ex_ray_fatal_config_error's localPort ceiling (65535) no longer matches \
+            "ex_ray_fatal_config_error's localPort/remotePort ceiling (65535) no longer matches \
              port.go's `PortFromInt` — update the bound to the vendored source"
         );
         let handler_source = include_str!("../../../ex-ray/third_party/v2ray-core/app/proxyman/outbound/handler.go");
@@ -2265,6 +2580,34 @@ mod inject_tests {
             handler_source.contains("config.Concurrency < 1 || config.Concurrency > 1024"),
             "ex_ray_fatal_config_error's mux-concurrency range (1..=1024) no longer matches \
              handler.go's own bound — update the range to the vendored source"
+        );
+
+        let main_source = include_str!("../../../ex-ray/main.go");
+        assert!(
+            main_source.contains(r#"parseEnumOption(opts, "ech", allowedEchModes, echMode)"#),
+            "ex_ray_fatal_config_error's now-UNCONDITIONAL `ech` enum check (#752) no longer \
+             matches main.go's `parseOptsIntoFlags` — if this call moved back inside a \
+             `tlsEnabled` gate, the check must be re-gated too"
+        );
+
+        let options_source = include_str!("../../../ex-ray/options.go");
+        assert!(
+            options_source.contains("if c != \"1\" {"),
+            "ex_ray_fatal_config_error's tls/server/fastOpen/__android_vpn bad-value check no \
+             longer matches options.go's `parseBoolOption` — update the check to the vendored \
+             source"
+        );
+        assert!(
+            options_source.contains(r#"u.Scheme != "https" || u.Host == """#),
+            "ex_ray_value_is_https_url no longer matches options.go's `parseURLOption` — update \
+             the check to the vendored source"
+        );
+        assert!(
+            main_source.contains(r#"parseStringOption(opts, "host", host, false)"#)
+                && main_source.contains(r#"parseStringOption(opts, "path", path, false)"#),
+            "ex_ray_fatal_config_error's host/path empty-is-fatal check no longer matches \
+             main.go's `parseStringOption(..., emptyOK: false)` calls — update the check to the \
+             vendored source"
         );
     }
 

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -570,93 +570,91 @@ const EX_RAY_DEFAULT_HOST: &str = "cloudfront.com";
 /// outright, in which case the whole plugin process exits (23) before it
 /// dials anything at all, ECH-config fetch included. Returns the rejecting
 /// key, first-wins (matching `Args.Get`) among segments sharing a key,
-/// checked in roughly ex-ray's OWN evaluation order below so the diagnostic
-/// names the key ex-ray itself would report first (the cover-permit /
-/// reachability side only needs `.is_some()`, order-independent — see the
-/// `tcp-keepalive`/`mux`/`fwmark` bullet for the one place order fidelity is
-/// deliberately relaxed, since it can only misname a SIMULTANEOUS second
-/// failure, never change `.is_some()`).
+/// checked in ex-ray's OWN evaluation order below so the diagnostic names
+/// the key ex-ray itself would report first — the cover-permit /
+/// reachability side only needs `.is_some()`, order-independent.
 ///
-/// #752 rewrote `parseOptsIntoFlags` (options.go's `parseIntOption`/
-/// `parseBoolOption`/`parseStringOption`/`parseEnumOption`/
-/// `parseURLOption`) to share one rule across every option: an ABSENT key is
-/// a no-op (the flag keeps its default); any PRESENT value — an explicitly
-/// empty one included — must be well-formed or the option is fatal. Before
-/// #752, several of these were warn-and-keep-the-default instead; the
-/// checks below reflect the post-#752 source, not that history.
-/// - `tcp-keepalive`/`mux`/`fwmark` (`parseIntOption`): a present value
-///   `strconv.Atoi` can't parse (non-numeric, or explicitly empty) is fatal
-///   — `mux` specifically because galoshes appends `mux=0` and ex-ray is
-///   first-wins, so an operator's own unparseable `mux=` must not silently
-///   win over it and leave Mux.Cool on. A value that DOES parse is then
-///   range-checked: `tcp-keepalive` against `tcpKeepAliveParams`'
-///   `0..=32767` (`registerTCPKeepAlive`, main.go, before `generateConfig`
-///   even starts); `mux`/`fwmark` against `uint32Opt`'s `0..=u32::MAX`
-///   (`generateConfig`). Both failure modes name the same key, so each is
-///   one combined check here — the parse check runs earlier in the real
-///   source (`parseOptsIntoFlags`) than the range check
-///   (`registerTCPKeepAlive`/`generateConfig`), which is the fidelity this
-///   combining relaxes.
-/// - `localPort`/`remotePort` (main.go's cross-assign + `validPort` ==
-///   `net.PortFromString`): must be an unsigned base-10 literal `<=65535`
-///   and not `0` — `0` is otherwise valid syntax
-///   (`net.PortFromString("0")` succeeds) but ex-ray cannot honor
-///   OS-assigned-port semantics. `localPort` is rejected in main(), before
-///   `generateConfig` runs; `remotePort`, inside it — the ordering
-///   `two_distinct_fatal_keys_report_ex_rays_earlier_one` pins.
-/// - `localAddr` (main.go's cross-assign + `canonicalLocalAddr`): must be a
-///   single (`|`-free) IP literal — a domain or a `|`-joined multi-address
-///   list is fatal, since the sitrep's `ready` event can report only one
-///   `listen` address.
-/// - `remoteAddr` (`generateConfig`): must not normalize to an empty domain
-///   or the unspecified IP (`0.0.0.0`/`::`) — freedom's destination
-///   override would otherwise dial nowhere honestly.
-/// - `tls`/`server`/`fastOpen`/`__android_vpn` (`parseBoolOption`): a
-///   present value other than `"1"` is fatal — presence-only flags with no
-///   wider "truthy" vocabulary.
+/// `parseOptsIntoFlags` shares one rule across every option it validates: an
+/// ABSENT key is a no-op (the flag keeps its default); any PRESENT value —
+/// an explicitly empty one included — must be well-formed or the option is
+/// fatal. Checked in `parseOptsIntoFlags`'s own order:
+/// - `mux` (`parseIntOption`): a present value `strconv.Atoi` can't parse
+///   (non-numeric, or explicitly empty) is fatal — galoshes appends `mux=0`
+///   and ex-ray is first-wins, so an operator's own unparseable `mux=` must
+///   not silently win over it and leave Mux.Cool on.
+/// - `tcp-keepalive` (`parseIntOption`): same parse rule as `mux`.
+/// - `tls` (`parseBoolOption`): a present value other than `"1"` is fatal —
+///   a presence-only flag with no wider "truthy" vocabulary.
 /// - `host`/`path` (`parseStringOption`, `emptyOK=false`): a present but
 ///   EXPLICITLY EMPTY value is fatal — unlike `cert`/`certRaw`/`key`
 ///   (`emptyOK=true`, disclosed below), empty has no documented meaning for
-///   these two. This also closes the pre-#752 `host=` + `remoteAddr=`
-///   fallback path `ech_fetch_is_reachable` used to model — see its doc.
+///   these two. [`ech_fetch_is_reachable`] relies on this rather than
+///   modeling its own fallback for an empty `host=` — see that function's
+///   doc.
+/// - `server`/`fastOpen`/`__android_vpn` (`parseBoolOption`): same
+///   present-value rule as `tls`.
+/// - `fwmark` (`parseIntOption`): same parse rule as `mux`.
+/// - `ech` is a CLOSED enum (`parseEnumOption`) — validated
+///   UNCONDITIONALLY here, not only when TLS is enabled: `generateConfig`
+///   separately rejects `ech=always` with TLS not enabled (below), the
+///   TLS-dependent half of `ech`'s validation.
 /// - `ech-doh` (`parseURLOption`): empty is a documented no-op ("disables
 ///   ECH"), but a present, non-empty value that isn't a well-formed
 ///   `https://` URL with a host is fatal. Checked only when the CONFIG's
 ///   own value is what ex-ray will actually read: Hole's own injection
 ///   (always well-formed by construction) strips it whenever
 ///   [`ech_doh_displaces`] is true.
-/// - `mode` is a CLOSED enum (`switch *mode`, `generateConfig`,
-///   unconditional): outside `websocket`/`quic` is fatal.
-/// - `ech` is a CLOSED enum too (`parseEnumOption`, `parseOptsIntoFlags`) —
-///   UNCONDITIONAL since #752, unlike before: it no longer lives only
-///   inside `buildTLSConfig` (`if *tlsEnabled`). `generateConfig`
-///   re-validates the same flag (redundant on ex-ray's real
-///   `SS_PLUGIN_OPTIONS`-driven path; independently reachable only from a
-///   raw CLI `-ech=`, which bypasses `parseOptsIntoFlags` entirely) and,
-///   separately, rejects `ech=always` with TLS not enabled — also NEW in
-///   #752: a valid-vocabulary `ech=always` with no `tls` and no
-///   `mode=quic` used to silently apply nothing; now it's fatal.
-///   `ech=always` additionally requires a non-empty RESOLVED `ech-doh`
-///   (`buildTLSConfig`, `if *tlsEnabled` only, unchanged by #752) — the
-///   value ex-ray actually receives once Hole's own injection wins or loses
-///   against the operator's; see [`resolved_ech_doh_is_empty`] for why that
-///   is recomputed rather than shared with [`classify_ech_doh`].
-/// - `cert`/`certRaw`/`key` present (non-empty) with TLS not enabled is
-///   fatal too — NEW in #752; before, the material was silently never read.
-/// - `mux`, again, but LATER than its own `uint32Opt` check above: once
-///   `generateConfig` has fully succeeded, `core.New` separately rejects a
-///   non-zero `Concurrency` outside `1..=1024` on the websocket transport
-///   ONLY (`quic`'s mux is never read).
 ///
-/// **Not modeled, and why it's safe not to:** `loglevel` gained the same
-/// empty-is-fatal (`parseStringOption`) and unrecognized-is-fatal
-/// (`logConfig`) treatment in #752 — but `inject_plugin_directives` ALWAYS
-/// strips the operator's own `loglevel` and appends `loglevel=debug`,
-/// unconditionally, whether or not Hole's `ech-doh` wins. No value from
-/// `segments` (read pre-injection here) ever reaches ex-ray unmodified, so
-/// modeling it would produce a FALSE fatal for a config that starts fine in
-/// practice — the opposite of the over-permit risk this gate exists to
-/// close.
+/// Then `registerTCPKeepAlive` and main()'s own pre-`generateConfig` guards:
+/// - `tcp-keepalive`, again: a value that parsed above is now range-checked
+///   against `tcpKeepAliveParams`' `0..=32767`.
+/// - `localPort` (main.go's cross-assign + `validPort` ==
+///   `net.PortFromString`): must be an unsigned base-10 literal `<=65535`
+///   and not `0` — `0` is otherwise valid syntax
+///   (`net.PortFromString("0")` succeeds) but ex-ray cannot honor
+///   OS-assigned-port semantics.
+/// - `localAddr` (main.go's cross-assign + `canonicalLocalAddr`): must be a
+///   single (`|`-free) IP literal — a domain or a `|`-joined multi-address
+///   list is fatal, since the sitrep's `ready` event can report only one
+///   `listen` address.
+///
+/// Then `generateConfig`:
+/// - `remotePort`, same rule as `localPort`, checked here instead.
+/// - `remoteAddr`: must not normalize to an empty domain or the unspecified
+///   IP (`0.0.0.0`/`::`) — freedom's destination override would otherwise
+///   dial nowhere honestly.
+/// - `mux`, again: a value that parsed above is now range-checked against
+///   `uint32Opt`'s `0..=u32::MAX`.
+/// - `fwmark`, same range check as `mux`.
+/// - `mode` is a CLOSED enum (`switch *mode`): outside `websocket`/`quic`
+///   is fatal.
+/// - `ech=always` with TLS not enabled is fatal — the TLS-dependent half of
+///   `ech`'s validation (above): a valid-vocabulary `ech=always` with no
+///   `tls` and no `mode=quic` promises fail-closed ECH it cannot deliver.
+/// - `cert`/`certRaw`/`key` present (non-empty) with TLS not enabled is
+///   fatal too — the material would otherwise be silently never read.
+/// - `ech=always` additionally requires a non-empty RESOLVED `ech-doh`
+///   (`buildTLSConfig`, reached only `if *tlsEnabled`) — the value ex-ray
+///   actually receives once Hole's own injection wins or loses against the
+///   operator's; see [`resolved_ech_doh_is_empty`] for why that is
+///   recomputed rather than shared with [`classify_ech_doh`].
+///
+/// Then `core.New`, once `generateConfig` has fully succeeded:
+/// - `mux`, a THIRD time: a non-zero `Concurrency` outside `1..=1024` on
+///   the websocket transport only (`quic`'s mux is never read).
+///
+/// `mux`/`tcp-keepalive`/`fwmark` are each checked TWICE (parse, then
+/// range) at their own two real positions above — no order fidelity is
+/// relaxed for these three.
+///
+/// **Not modeled, and why it's safe not to:** `loglevel` is ALSO fatal when
+/// explicitly empty (`parseStringOption`) or unrecognized (`logConfig`) —
+/// but `inject_plugin_directives` ALWAYS strips the operator's own
+/// `loglevel` and appends `loglevel=debug`, unconditionally, whether or not
+/// Hole's `ech-doh` wins. No value from `segments` (read pre-injection
+/// here) ever reaches ex-ray unmodified, so modeling it would produce a
+/// FALSE fatal for a config that starts fine in practice — the opposite of
+/// the over-permit risk this gate exists to close.
 ///
 /// **Disclosed, deliberately unmodeled:** `cert`/`certRaw`/`key`'s CONTENT
 /// (a readable, well-formed X509 pair) requires filesystem I/O this
@@ -669,6 +667,62 @@ fn ex_ray_fatal_config_error(
     segments: &[garter::OptionSegment<'_>],
     ech_doh: Option<&crate::dns::ech::EchDoh>,
 ) -> Option<&'static str> {
+    // parseOptsIntoFlags, in its own internal order.
+    for key in ["mux", "tcp-keepalive"] {
+        if segments
+            .iter()
+            .find(|s| s.key == key)
+            .is_some_and(|s| ex_ray_flag_value(s).parse::<i64>().is_err())
+        {
+            return Some(key);
+        }
+    }
+    if segments
+        .iter()
+        .find(|s| s.key == "tls")
+        .is_some_and(|s| ex_ray_flag_value(s) != "1")
+    {
+        return Some("tls");
+    }
+    for key in ["host", "path"] {
+        if segments
+            .iter()
+            .find(|s| s.key == key)
+            .is_some_and(|s| ex_ray_flag_value(s).is_empty())
+        {
+            return Some(key);
+        }
+    }
+    for key in ["server", "fastOpen", "__android_vpn"] {
+        if segments
+            .iter()
+            .find(|s| s.key == key)
+            .is_some_and(|s| ex_ray_flag_value(s) != "1")
+        {
+            return Some(key);
+        }
+    }
+    if segments
+        .iter()
+        .find(|s| s.key == "fwmark")
+        .is_some_and(|s| ex_ray_flag_value(s).parse::<i64>().is_err())
+    {
+        return Some("fwmark");
+    }
+    let ech = segments.iter().find(|s| s.key == "ech").map(ex_ray_flag_value);
+    if let Some(v) = ech {
+        if !matches!(v, "never" | "auto" | "always") {
+            return Some("ech");
+        }
+    }
+    if let Some(s) = segments.iter().find(|s| s.key == "ech-doh") {
+        let v = ex_ray_flag_value(s);
+        if !v.is_empty() && !ech_doh_displaces(segments, ech_doh) && !ex_ray_value_is_https_url(v) {
+            return Some("ech-doh");
+        }
+    }
+
+    // registerTCPKeepAlive + main()'s own pre-generateConfig guards.
     if segments.iter().find(|s| s.key == "tcp-keepalive").is_some_and(|s| {
         !ex_ray_flag_value(s)
             .parse::<i64>()
@@ -690,6 +744,8 @@ fn ex_ray_fatal_config_error(
     {
         return Some("localAddr");
     }
+
+    // generateConfig.
     if segments
         .iter()
         .find(|s| s.key == "remotePort")
@@ -713,36 +769,6 @@ fn ex_ray_fatal_config_error(
             return Some(key);
         }
     }
-    for key in ["tls", "server", "fastOpen", "__android_vpn"] {
-        if segments
-            .iter()
-            .find(|s| s.key == key)
-            .is_some_and(|s| ex_ray_flag_value(s) != "1")
-        {
-            return Some(key);
-        }
-    }
-    for key in ["host", "path"] {
-        if segments
-            .iter()
-            .find(|s| s.key == key)
-            .is_some_and(|s| ex_ray_flag_value(s).is_empty())
-        {
-            return Some(key);
-        }
-    }
-    if let Some(s) = segments.iter().find(|s| s.key == "ech-doh") {
-        let v = ex_ray_flag_value(s);
-        if !v.is_empty() && !ech_doh_displaces(segments, ech_doh) && !ex_ray_value_is_https_url(v) {
-            return Some("ech-doh");
-        }
-    }
-    let ech = segments.iter().find(|s| s.key == "ech").map(ex_ray_flag_value);
-    if let Some(v) = ech {
-        if !matches!(v, "never" | "auto" | "always") {
-            return Some("ech");
-        }
-    }
     let mode = segments.iter().find(|s| s.key == "mode").map(ex_ray_flag_value);
     if let Some(v) = mode {
         if !matches!(v, "websocket" | "quic") {
@@ -750,13 +776,8 @@ fn ex_ray_fatal_config_error(
         }
     }
     let tls_enabled = segments.iter().any(|s| s.key == "tls") || mode == Some("quic");
-    if ech == Some("always") {
-        if !tls_enabled {
-            return Some("ech");
-        }
-        if resolved_ech_doh_is_empty(segments, ech_doh) {
-            return Some("ech-doh");
-        }
+    if ech == Some("always") && !tls_enabled {
+        return Some("ech");
     }
     let cert_material_present = ["cert", "certRaw", "key"].iter().any(|key| {
         segments
@@ -767,13 +788,18 @@ fn ex_ray_fatal_config_error(
     if !tls_enabled && cert_material_present {
         return Some("cert");
     }
-    // Same 1..=1024 concurrency bound as the `mux` bullet above (core.New,
-    // only on websocket, only when non-zero). The effective value defaults
-    // to ex-ray's own flag default (`1`) unless a segment both exists AND
-    // parses. `MultiplexSettings` is CLIENT-mode only (config.go — the
-    // `server` branch never builds it), so this check is skipped alongside
-    // the rest of the disclosed, deliberately-unmodeled `server` residual
-    // above, not a separate gap.
+    if ech == Some("always") && tls_enabled && resolved_ech_doh_is_empty(segments, ech_doh) {
+        return Some("ech-doh");
+    }
+
+    // core.New, once generateConfig has fully succeeded. Same 1..=1024
+    // concurrency bound as the `mux` bullet above, only on websocket, only
+    // when non-zero. The effective value defaults to ex-ray's own flag
+    // default (`1`) unless a segment both exists AND parses.
+    // `MultiplexSettings` is CLIENT-mode only (config.go — the `server`
+    // branch never builds it), so this check is skipped alongside the rest
+    // of the disclosed, deliberately-unmodeled `server` residual above, not
+    // a separate gap.
     if mode != Some("quic") && !segments.iter().any(|s| s.key == "server") {
         let mux = segments
             .iter()
@@ -836,14 +862,13 @@ fn ex_ray_parses_as_uint32(v: &str) -> Option<u32> {
 /// `Args.Get`):
 /// - [`ex_ray_fatal_config_error`] is `Some` — the whole plugin process
 ///   exits before it ever starts, so no dial of any kind happens. This also
-///   covers an EXPLICITLY EMPTY `host=`: before #752, `Config.ServerName`
-///   (empty) fell back to the dial destination — `tls.WithDestination`
-///   filling it from `remoteAddr` (third_party/.../tls/config.go;
-///   `websocket/dialer.go`) — so this function used to re-derive an SNI
-///   from `remoteAddr` for that case. #752's `parseStringOption(...,
-///   "host", ..., emptyOK: false)` now rejects `host=` at parse time, so
-///   `*host` can never actually BE `""` when `buildTLSConfig` runs — the
-///   v2ray-core fallback still exists, just unreachable via `plugin_opts`.
+///   covers an EXPLICITLY EMPTY `host=`: `parseStringOption(..., "host",
+///   ..., emptyOK: false)` rejects it at parse time, so `*host` can never
+///   actually BE `""` when `buildTLSConfig` runs. (v2ray-core's own
+///   `Config.ServerName` empty-fallback to the dial destination —
+///   `tls.WithDestination` filling it from `remoteAddr`,
+///   third_party/.../tls/config.go, `websocket/dialer.go` — still exists in
+///   the vendored source; it is simply unreachable via `plugin_opts`.)
 /// - `ech=never` short-circuits ECH entirely before it ever looks at
 ///   `ech-doh` (config.go).
 /// - TLS must be enabled at all — an explicit `tls` flag, or `mode=quic`
@@ -854,9 +879,12 @@ fn ex_ray_parses_as_uint32(v: &str) -> Option<u32> {
 ///   DOMAIN: ex-ray sets `tlsConfig.ServerName = *host` directly, and an
 ///   ABSENT `host` falls back to ex-ray's own [`EX_RAY_DEFAULT_HOST`], a
 ///   real domain, so it's reachable. An EXPLICIT `host=<value>` (now always
-///   non-empty, given the point above) wins outright, domain or not
-///   (third_party/v2ray-core/transport/internet/tls/ech.go:26-51;
-///   config.go; main.go).
+///   non-empty, given the point above) wins outright, domain or not — EXCEPT
+///   that `GetTLSConfig` resolves `config.ServerName` via `parseServerName`
+///   before `ApplyECH` ever reads it, which strips a literal
+///   [`V2RAY_CORE_EXP_8357_PREFIX`] prefix first
+///   (third_party/v2ray-core/transport/internet/tls/config.go:20,173-183,
+///   262-264,296-301; `ech.go:26-51,37-51`).
 ///
 /// Every flag read here goes through [`ex_ray_flag_value`] rather than
 /// `OptionSegment::value` — see its doc. For `host` the divergence is
@@ -877,8 +905,20 @@ fn ech_fetch_is_reachable(segments: &[garter::OptionSegment<'_>], ech_doh: Optio
         .iter()
         .find(|s| s.key == "host")
         .map_or(EX_RAY_DEFAULT_HOST, ex_ray_flag_value);
+    // `parseServerName` strips this prefix before `ApplyECH` ever sees the
+    // SNI — an unstripped `sni` here can read as a domain (e.g.
+    // "experiment:8357203.0.113.5") while the stripped value ex-ray
+    // actually uses ("203.0.113.5") is an IP, unreachable.
+    let sni = sni.strip_prefix(V2RAY_CORE_EXP_8357_PREFIX).unwrap_or(sni);
     tls_enabled && v2ray_core_parses_as_a_domain(sni)
 }
+
+/// v2ray-core's `Config.parseServerName` strips this literal prefix from the
+/// TLS `ServerName` before `ApplyECH` (and `GetTLSConfig` generally) ever
+/// reads it (third_party/v2ray-core/transport/internet/tls/config.go:20).
+/// Pinned against the vendored source by
+/// `ech_and_mode_enums_match_vendored_config_go`.
+const V2RAY_CORE_EXP_8357_PREFIX: &str = "experiment:8357";
 
 /// A segment's value the way ex-ray's own parser reads it (see
 /// [`garter::OptionSegment::has_value`]), not the raw `garter` decode.
@@ -937,10 +977,18 @@ fn ex_ray_local_addr_is_invalid(value: &str) -> bool {
 /// `remoteAddr`: an empty domain (normalizes to `""`, `ParseAddress`'s own
 /// domain fallback), or the unspecified IP (`0.0.0.0`/`::`) — freedom's
 /// destination override would otherwise dial nowhere honestly.
+///
+/// `IpAddr::to_canonical()` folds an IPv4-mapped IPv6 literal
+/// (`::ffff:0.0.0.0`) to plain IPv4 BEFORE the unspecified test, mirroring
+/// v2ray-core's own `IPAddress()` constructor (third_party/v2ray-core/
+/// common/net/address.go:99-101, `bytes[:10]==0 && [10]==[11]==0xff`) —
+/// without the fold, `Ipv6Addr::is_unspecified()` (`octets() == [0; 16]`)
+/// misses it: `::ffff:0.0.0.0`'s last four octets are `0.0.0.0`, but its
+/// 11th/12th are `0xff`, so the raw 16-byte check reads it as specified.
 fn ex_ray_remote_addr_is_invalid(value: &str) -> bool {
     let normalized = v2ray_core_normalize(value);
     match normalized.parse::<std::net::IpAddr>() {
-        Ok(ip) => ip.is_unspecified(),
+        Ok(ip) => ip.to_canonical().is_unspecified(),
         Err(_) => normalized.is_empty(),
     }
 }
@@ -948,10 +996,31 @@ fn ex_ray_remote_addr_is_invalid(value: &str) -> bool {
 /// Whether ex-ray's `parseURLOption(opts, "ech-doh", ...)` (options.go)
 /// would accept `v` as a well-formed DoH URL: `url.Parse` succeeding, an
 /// `https` scheme, and a non-empty host. Only checked for the CONFIG's own
-/// `ech-doh` value, and only when it is NOT displaced by Hole's own —
-/// see [`ex_ray_fatal_config_error`]'s `ech-doh` bullet.
+/// `ech-doh` value, and only when it is NOT displaced by Hole's own — see
+/// [`ex_ray_fatal_config_error`]'s `ech-doh` bullet, which means a FALSE
+/// negative here (this function says "well-formed" for something Go's
+/// `net/url` would reject) can only ever suppress the never-permitted
+/// `EffectiveEchDoh::Operators` residual-stall diagnostic — the fail-closed
+/// cover never permits an operator-chosen address regardless, so it cannot
+/// widen the permit. A FALSE positive (rejecting something Go accepts)
+/// WOULD be unsafe here (an under-permit masquerading as an over-cautious
+/// fatal), so this is deliberately a lenient superset check — a
+/// case-insensitive `https://` prefix plus a non-empty authority segment up
+/// to the first `/`, `?`, or `#` — rather than a byte-exact port of Go's
+/// `net/url.Parse`: the `url` crate's stricter WHATWG parser rejects
+/// syntax Go accepts (verified: Go accepts `https://999.1.1.1/` and
+/// `https://1.2.3.4.5/dns-query`, the `url` crate errors on both with
+/// `InvalidIpv4Address`), which would have been the unsafe direction.
 fn ex_ray_value_is_https_url(v: &str) -> bool {
-    url::Url::parse(v).is_ok_and(|u| u.scheme() == "https" && u.host_str().is_some_and(|h| !h.is_empty()))
+    let Some(rest) = v
+        .get(..8)
+        .filter(|p| p.eq_ignore_ascii_case("https://"))
+        .map(|_| &v[8..])
+    else {
+        return false;
+    };
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    !rest[..authority_end].is_empty()
 }
 
 /// The `segments`-based wrapper around [`hole_ech_doh_outranks`] — extracts
@@ -1679,9 +1748,16 @@ mod inject_tests {
         assert_eq!(
             ex_ray_fatal_config_error(&segments, None),
             Some("ech"),
-            "since #752, `ech`'s enum check runs unconditionally in parseOptsIntoFlags, structurally \
-             before generateConfig's `mode` switch even starts — not the other way around, and not \
-             gated on tlsEnabled anymore either"
+            "ech's enum check runs unconditionally in parseOptsIntoFlags, structurally before \
+             generateConfig's mode switch even starts"
+        );
+        let segments = garter::split_plugin_options("tls=99;host=cdn.example;localAddr=bad-addr").unwrap();
+        assert_eq!(
+            ex_ray_fatal_config_error(&segments, None),
+            Some("tls"),
+            "tls (parseOptsIntoFlags) runs before localAddr (main(), after parseOptsIntoFlags \
+             returns) — a key checked in generateConfig/main()'s own pre-generateConfig guards must \
+             never win over one checked earlier, inside parseOptsIntoFlags itself"
         );
     }
 
@@ -1812,10 +1888,9 @@ mod inject_tests {
     }
 
     // A bare `ech-doh` (no `=`) reads as ex-ray's own `"1"` — non-empty, but
-    // (since #752's `parseURLOption`) NOT a well-formed `https://` URL, so
-    // it is now a fatal config error (`parseOptsIntoFlags`) rather than a
-    // value ex-ray tries and fails on later; the whole process exits before
-    // dialing anything.
+    // not a well-formed `https://` URL (`parseURLOption`), so it is a fatal
+    // config error (`parseOptsIntoFlags`) rather than a value ex-ray tries
+    // and fails on later; the whole process exits before dialing anything.
     #[skuld::test]
     fn bare_operator_ech_doh_never_reaches_ex_ray() {
         assert_eq!(
@@ -1842,13 +1917,13 @@ mod inject_tests {
     }
 
     // `ech`'s enum check (`parseEnumOption`, `parseOptsIntoFlags`) is
-    // UNCONDITIONAL since #752 — unlike before, when the switch lived only
-    // inside `buildTLSConfig` (`if *tlsEnabled`). An invalid `ech` value
-    // with no `tls` flag and no `mode=quic` is now fatal too, even though
-    // the fetch itself is (separately) unreachable either way — see
+    // UNCONDITIONAL — it does not live only inside `buildTLSConfig` (`if
+    // *tlsEnabled`). An invalid `ech` value with no `tls` flag and no
+    // `mode=quic` is fatal too, even though the fetch itself is
+    // (separately) unreachable either way — see
     // `no_tls_and_not_quic_never_reaches_ex_ray` for that half.
     #[skuld::test]
-    fn an_invalid_ech_value_without_tls_is_fatal_since_752() {
+    fn an_invalid_ech_value_without_tls_is_fatal() {
         let segments = garter::split_plugin_options("host=cdn.example;ech=bogus").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech"));
     }
@@ -1904,16 +1979,15 @@ mod inject_tests {
         );
     }
 
-    // NEW in #752: `remotePort` now routes through the SAME `validPort` as
-    // `localPort` (config.go), so it shares localPort's tighter 65535
-    // ceiling and its `0` rejection — before, it went through a bare
-    // `strconv.ParseUint(_, 10, 32)` with no upper bound beyond u32::MAX and
-    // no zero check at all.
+    // `remotePort` routes through the SAME `validPort` as `localPort`
+    // (config.go), so it shares localPort's tighter 65535 ceiling and its
+    // `0` rejection, not a bare `strconv.ParseUint(_, 10, 32)` with no
+    // upper bound beyond u32::MAX and no zero check.
     #[skuld::test]
-    fn a_remote_port_shares_local_ports_ceiling_and_zero_rejection_since_752() {
+    fn a_remote_port_shares_local_ports_ceiling_and_zero_rejection() {
         let e = pinned("https://9.9.9.9/dns-query");
         for opts in [
-            "tls;host=cdn.example;remotePort=65536", // within u32::MAX, above the NEW 65535 ceiling
+            "tls;host=cdn.example;remotePort=65536", // within u32::MAX, above the 65535 ceiling
             "tls;host=cdn.example;remotePort=0",
             "tls;host=cdn.example;remotePort=",
         ] {
@@ -1925,10 +1999,10 @@ mod inject_tests {
         }
     }
 
-    // NEW-since-#752 non-canonical-zero coverage: `"00"` is valid
-    // `strconv.ParseUint` syntax (parses to `0`), so it is caught by
-    // `validPort`'s `== 0` rejection, not by a parse failure — a check that
-    // only compared against the LITERAL string `"0"` would miss it.
+    // Non-canonical-zero coverage: `"00"` is valid `strconv.ParseUint`
+    // syntax (parses to `0`), so it is caught by `validPort`'s `== 0`
+    // rejection, not by a parse failure — a check that only compared
+    // against the LITERAL string `"0"` would miss it.
     #[skuld::test]
     fn a_non_canonical_zero_local_port_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -1942,10 +2016,9 @@ mod inject_tests {
 
     // `tls`/`server`/`fastOpen`/`__android_vpn` (`parseBoolOption`) accept
     // ONLY a present `"1"` (or a bare key, which `Args` maps to `"1"`) —
-    // any other present value is fatal, NEW in #752 (before: presence alone
-    // enabled the flag, any value).
+    // any other present value is fatal.
     #[skuld::test]
-    fn a_bool_option_with_a_value_other_than_1_is_fatal_since_752() {
+    fn a_bool_option_with_a_value_other_than_1_is_fatal() {
         for (key, opts) in [
             ("tls", "tls=0;host=cdn.example"),
             ("tls", "tls=true;host=cdn.example"),
@@ -1961,14 +2034,14 @@ mod inject_tests {
     // `path` (`parseStringOption`, `emptyOK=false`) is fatal when
     // EXPLICITLY empty, same rule as `host`.
     #[skuld::test]
-    fn an_explicitly_empty_path_is_fatal_since_752() {
+    fn an_explicitly_empty_path_is_fatal() {
         let segments = garter::split_plugin_options("tls;host=cdn.example;path=").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("path"));
     }
 
     // `localAddr` (main.go's cross-assign + `canonicalLocalAddr`) must be a
     // single IP literal — a domain or a `|`-joined multi-address list is
-    // fatal. Not new to #752, but never modeled until this reconciliation.
+    // fatal.
     #[skuld::test]
     fn an_invalid_local_addr_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -1996,6 +2069,12 @@ mod inject_tests {
             "tls;host=cdn.example;remoteAddr=0.0.0.0",
             "tls;host=cdn.example;remoteAddr=::",
             "tls;host=cdn.example;remoteAddr= ", // whitespace-only normalizes to empty
+            // IPv4-mapped IPv6 spellings of the unspecified address — must be
+            // folded to plain IPv4 (`to_canonical`) before the unspecified
+            // test, matching v2ray-core's own `IPAddress()` constructor.
+            "tls;host=cdn.example;remoteAddr=::ffff:0.0.0.0",
+            "tls;host=cdn.example;remoteAddr=::ffff:0:0",
+            "tls;host=cdn.example;remoteAddr=[::ffff:0.0.0.0]",
         ] {
             assert_eq!(
                 effective_ech_doh("ex-ray", Some(opts), Some(&e)),
@@ -2005,12 +2084,50 @@ mod inject_tests {
         }
         let segments = garter::split_plugin_options("tls;host=cdn.example;remoteAddr=0.0.0.0").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("remoteAddr"));
+        let segments = garter::split_plugin_options("tls;host=cdn.example;remoteAddr=::ffff:0.0.0.0").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("remoteAddr"));
     }
 
-    // A non-empty `cert`/`certRaw`/`key` with TLS not enabled is fatal, NEW
-    // in #752 — before, the material was silently never read.
+    // `parseServerName` strips a literal `experiment:8357` prefix from the
+    // TLS `ServerName` before `ApplyECH` ever reads it (v2ray-core's
+    // config.go) — an unstripped `host` value can read as a domain to this
+    // gate while ex-ray itself, after stripping, sees an IP and never dials.
     #[skuld::test]
-    fn cert_material_without_tls_is_fatal_since_752() {
+    fn exp_8357_prefixed_host_is_evaluated_after_stripping() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=experiment:8357203.0.113.5"), Some(&e)),
+            EffectiveEchDoh::None,
+            "stripped SNI is the IP literal 203.0.113.5 — no domain to key the DoH lookup on"
+        );
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;host=experiment:8357cdn.example"), Some(&e)),
+            EffectiveEchDoh::Holes,
+            "stripped SNI is the domain cdn.example — reachable"
+        );
+    }
+
+    // `ex_ray_value_is_https_url` is a deliberately lenient superset of Go's
+    // `net/url.Parse` (see its doc): a syntax the `url` crate's stricter
+    // WHATWG parser rejects but Go accepts must still read as well-formed
+    // here, or the operator's own (never-permitted, but still diagnosed)
+    // `ech-doh` residual-stall warning would be wrongly suppressed.
+    #[skuld::test]
+    fn a_go_valid_but_whatwg_invalid_ech_doh_is_not_fatal() {
+        for opts in [
+            "tls;host=cdn.example;ech-doh=https://999.1.1.1/",
+            "tls;host=cdn.example;ech-doh=https://1.2.3.4.5/dns-query",
+            "tls;host=cdn.example;ech-doh=HTTPS://cdn.example/dns-query", // case-insensitive scheme
+        ] {
+            let segments = garter::split_plugin_options(opts).unwrap();
+            assert_eq!(ex_ray_fatal_config_error(&segments, None), None, "opts={opts:?}");
+        }
+    }
+
+    // A non-empty `cert`/`certRaw`/`key` with TLS not enabled is fatal —
+    // the material would otherwise be silently never read.
+    #[skuld::test]
+    fn cert_material_without_tls_is_fatal() {
         for opts in [
             "host=cdn.example;cert=/tmp/cert.pem",
             "host=cdn.example;certRaw=deadbeef",
@@ -2079,16 +2196,16 @@ mod inject_tests {
         assert_eq!(ex_ray_fatal_config_error(&segments, Some(&e)), None);
     }
 
-    // NEW in #752: `generateConfig` rejects `ech=always` outright when TLS
-    // isn't enabled (`if *echMode == "always" && !*tlsEnabled`) — before,
-    // a valid-vocabulary `ech=always` with no `tls` and no `mode=quic`
-    // silently applied nothing. This is a DIFFERENT fatal reason than the
+    // `generateConfig` rejects `ech=always` outright when TLS isn't enabled
+    // (`if *echMode == "always" && !*tlsEnabled`) — a valid-vocabulary
+    // `ech=always` with no `tls` and no `mode=quic` promises fail-closed
+    // ECH it cannot deliver. This is a DIFFERENT fatal reason than the
     // nested `ech=always` + empty-resolved-`ech-doh` check (which stays
     // gated inside `tls_enabled`, since `buildTLSConfig` itself is) — this
     // one is fatal precisely BECAUSE tls is off, regardless of whether an
     // `ech-doh` is configured at all.
     #[skuld::test]
-    fn ech_always_without_tls_is_fatal_since_752() {
+    fn ech_always_without_tls_is_fatal() {
         let segments = garter::split_plugin_options("host=cdn.example;ech=always").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("ech"));
     }
@@ -2139,13 +2256,11 @@ mod inject_tests {
         );
     }
 
-    // NEW in #752: a `mux` that fails to parse at all is now a config-build
-    // error too — before, ex-ray's opts-to-flags step logged a warning and
-    // silently kept the flag's default. `parseIntOption`'s doc: an
-    // operator's own unparseable `mux=` must not silently outrank galoshes'
-    // appended `mux=0` and leave Mux.Cool on.
+    // A `mux` that fails to parse at all is a config-build error too —
+    // `parseIntOption`'s doc: an operator's own unparseable `mux=` must not
+    // silently outrank galoshes' appended `mux=0` and leave Mux.Cool on.
     #[skuld::test]
-    fn an_unparseable_mux_value_is_fatal_since_752() {
+    fn an_unparseable_mux_value_is_fatal() {
         let e = pinned("https://9.9.9.9/dns-query");
         assert_eq!(
             effective_ech_doh("ex-ray", Some("tls;host=cdn.example;mux=not-a-number"), Some(&e)),
@@ -2155,10 +2270,10 @@ mod inject_tests {
         assert_eq!(ex_ray_fatal_config_error(&segments, None), Some("mux"));
     }
 
-    // As above, for an explicitly EMPTY `mux=` specifically — the case
-    // #752's own commit message calls out: galoshes appends `mux=0`, ex-ray
-    // is first-wins, so a bare `mux=` an operator left behind must not
-    // silently win over galoshes' append and leave Mux.Cool on.
+    // As above, for an explicitly EMPTY `mux=` specifically: galoshes
+    // appends `mux=0`, ex-ray is first-wins, so a bare `mux=` an operator
+    // left behind must not silently win over galoshes' append and leave
+    // Mux.Cool on.
     #[skuld::test]
     fn an_explicitly_empty_mux_value_is_fatal() {
         let segments = garter::split_plugin_options("tls;host=cdn.example;mux=").unwrap();
@@ -2175,10 +2290,10 @@ mod inject_tests {
         );
     }
 
-    // As `an_unparseable_mux_value_is_fatal_since_752`, for `fwmark` and
+    // As `an_unparseable_mux_value_is_fatal`, for `fwmark` and
     // `tcp-keepalive` — `parseIntOption` is shared across all three.
     #[skuld::test]
-    fn an_unparseable_fwmark_or_tcp_keepalive_value_is_fatal_since_752() {
+    fn an_unparseable_fwmark_or_tcp_keepalive_value_is_fatal() {
         for (key, opts) in [
             ("fwmark", "tls;host=cdn.example;fwmark=not-a-number"),
             ("tcp-keepalive", "tls;host=cdn.example;tcp-keepalive=not-a-number"),
@@ -2336,7 +2451,7 @@ mod inject_tests {
     // on", matching v2ray-core's `net.ParseAddress` exactly: only a MATCHED
     // `[...]` pair strips, and only a non-alphanumeric edge trims
     // whitespace. (An explicitly EMPTY `host=` is a DIFFERENT, fatal case —
-    // see `explicitly_empty_host_is_fatal_since_752` below, not this one.)
+    // see `explicitly_empty_host_is_fatal` below, not this one.)
     #[skuld::test]
     fn no_domain_host_never_reaches_ex_ray() {
         let e = pinned("https://9.9.9.9/dns-query");
@@ -2354,17 +2469,14 @@ mod inject_tests {
         }
     }
 
-    // NEW in #752: `parseStringOption(opts, "host", host, false)` rejects a
-    // present, explicitly EMPTY `host=` at parse time — the whole plugin
-    // process exits before it ever dials anything. Before #752, `host=""`
-    // instead reached `buildTLSConfig`, whose empty `ServerName` fell back
-    // to the dial destination (`remoteAddr`) via v2ray-core's own
-    // `tls.WithDestination` — that v2ray-core mechanism still exists, but
-    // is now unreachable via `plugin_opts`, regardless of what `remoteAddr`
-    // says (unlike the old fallback, which only unreached for an IP-literal
-    // `remoteAddr`).
+    // `parseStringOption(opts, "host", host, false)` rejects a present,
+    // explicitly EMPTY `host=` at parse time — the whole plugin process
+    // exits before it ever dials anything, regardless of what `remoteAddr`
+    // says (v2ray-core's own `tls.WithDestination` empty-`ServerName`
+    // fallback to the dial destination still exists but is unreachable via
+    // `plugin_opts` — see `ech_fetch_is_reachable`'s doc).
     #[skuld::test]
-    fn explicitly_empty_host_is_fatal_since_752() {
+    fn explicitly_empty_host_is_fatal() {
         let e = pinned("https://9.9.9.9/dns-query");
         for opts in [
             "tls;host=",
@@ -2528,11 +2640,11 @@ mod inject_tests {
         // mux/fwmark (`uint32Opt`), tcp-keepalive (`keepAliveMaxSeconds`),
         // and localPort/remotePort (`validPort`) — same drift risk, same
         // pin. Pinned on the COMPARISON itself, not `uint32Opt`'s error
-        // message: #752 dropped that message's `, got: <value>` suffix (to
-        // stop a mux=abc\;certRaw=SECRET-shaped escape from leaking a later
-        // segment's value through it) without touching the bound, and a
-        // message-text pin would have (and did) gone stale for a reason
-        // that has nothing to do with the bound it exists to protect.
+        // message: the message is free to change for reasons that have
+        // nothing to do with the bound it protects (e.g. to stop a
+        // mux=abc\;certRaw=SECRET-shaped escape from leaking a later
+        // segment's value through it) — a message-text pin would go stale
+        // for that unrelated reason, and did.
         assert!(
             source.contains("v >= 0 && v <= math.MaxUint32"),
             "ex_ray_fatal_config_error's mux/fwmark range (0..=u32::MAX) no longer matches \
@@ -2545,9 +2657,9 @@ mod inject_tests {
         );
         assert!(
             source.contains("rport, err := validPort(*remotePort)"),
-            "ex_ray_fatal_config_error's remotePort ceiling (65535, shared with localPort since \
-             #752) no longer matches config.go — remotePort must still route through the same \
-             `validPort` as localPort, not a bare `strconv.ParseUint`"
+            "ex_ray_fatal_config_error's remotePort ceiling (65535, shared with localPort) no \
+             longer matches config.go — remotePort must still route through the same `validPort` \
+             as localPort, not a bare `strconv.ParseUint`"
         );
         assert!(
             source.contains("family.IsIP() && remoteAddress.IP().IsUnspecified()"),
@@ -2585,9 +2697,16 @@ mod inject_tests {
         let main_source = include_str!("../../../ex-ray/main.go");
         assert!(
             main_source.contains(r#"parseEnumOption(opts, "ech", allowedEchModes, echMode)"#),
-            "ex_ray_fatal_config_error's now-UNCONDITIONAL `ech` enum check (#752) no longer \
-             matches main.go's `parseOptsIntoFlags` — if this call moved back inside a \
-             `tlsEnabled` gate, the check must be re-gated too"
+            "ex_ray_fatal_config_error's unconditional `ech` enum check no longer matches \
+             main.go's `parseOptsIntoFlags` — if this call moved back inside a `tlsEnabled` \
+             gate, the check must be re-gated too"
+        );
+
+        let ech_source = include_str!("../../../ex-ray/third_party/v2ray-core/transport/internet/tls/config.go");
+        assert!(
+            ech_source.contains(&format!("const exp8357 = {V2RAY_CORE_EXP_8357_PREFIX:?}")),
+            "V2RAY_CORE_EXP_8357_PREFIX no longer matches v2ray-core's own `exp8357` constant — \
+             update the constant to the vendored source"
         );
 
         let options_source = include_str!("../../../ex-ray/options.go");

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -840,17 +840,14 @@ fn v2ray_core_parses_as_a_domain(value: &str) -> bool {
     !normalized.is_empty() && normalized.parse::<std::net::IpAddr>().is_err()
 }
 
-/// Whether Hole's own `ech_doh` outranks the operator's own `ech-doh`
-/// already in `segments` — a VALUE-PRECEDENCE question independent of
-/// whether a fetch happens at all. The ONE place this formula is written;
-/// shared by [`classify_ech_doh`] (where it also decides which keys
+/// The `segments`-based wrapper around [`hole_ech_doh_outranks`] — extracts
+/// the operator's own `ech-doh` value (if any) and applies the same
+/// precedence formula (see that function's doc for the why). Shared by
+/// [`classify_ech_doh`] (where it also decides which keys
 /// `inject_plugin_directives` strips) and [`resolved_ech_doh_is_empty`]
 /// (which needs the same precedence but, being reachable from
 /// `ex_ray_fatal_config_error` via `ech_fetch_is_reachable`, cannot call
-/// `classify_ech_doh` itself without cycling). Hole's URL is name-free, so
-/// it displaces one whose authority is a name — that lookup is the defect.
-/// Against an IP-literal value there is no leak to fix, so only a resolver
-/// that ANSWERED outranks the operator's own choice.
+/// `classify_ech_doh` itself without cycling).
 fn ech_doh_displaces(segments: &[garter::OptionSegment<'_>], ech_doh: Option<&crate::dns::ech::EchDoh>) -> bool {
     let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
     match (ech_doh, config_ech_doh) {
@@ -1361,9 +1358,8 @@ mod inject_tests {
         );
     }
 
-    // The round-3 regression this guards against: an UNREACHABLE config
-    // (`ech=never` here) with a PRE-EXISTING operator `ech-doh=` key and a
-    // PINNED Hole candidate. `displaces` must still be computed correctly
+    // An UNREACHABLE config (`ech=never` here) with a PRE-EXISTING operator
+    // `ech-doh=` key and a PINNED Hole candidate. `displaces` must still be computed correctly
     // (pinned always outranks) and the strip must still happen, even though
     // no fetch will ever occur — `classify_ech_doh`'s reachability gate may
     // only change `EffectiveEchDoh`, never silently disable the strip.
@@ -1486,7 +1482,7 @@ mod inject_tests {
         assert_eq!(out, "", "a pinned ech-doh has nothing to report");
     }
 
-    // The new reachability gate: an ech-doh source (pinned or not) that would
+    // The reachability gate: an ech-doh source (pinned or not) that would
     // otherwise read as active must be reported as inert, not silently
     // dropped or misreported as exercised/unexercised.
     #[skuld::test]
@@ -1624,8 +1620,8 @@ mod inject_tests {
     // effective_ech_doh / ech_doh_will_reach_ex_ray ===================================================================
 
     // A regression that made this return `true` whenever `ech_doh.is_some()`
-    // (the old, simpler gate this function replaces) would pass this test if
-    // the plugin-family gate were dropped: a non-ECH-capable plugin name
+    // would pass this test if the plugin-family gate were dropped: a
+    // non-ECH-capable plugin name
     // must never be told it will fetch Hole's ech_doh, even with a pinned
     // candidate in hand.
     #[skuld::test]
@@ -1804,6 +1800,19 @@ mod inject_tests {
         let e = pinned("https://9.9.9.9/dns-query");
         let segments = garter::split_plugin_options("tls;host=cdn.example;ech=always").unwrap();
         assert_eq!(ex_ray_fatal_config_error(&segments, Some(&e)), None);
+    }
+
+    // The nested `ech=always` + empty-resolved-`ech-doh` check lives INSIDE
+    // the `tls_enabled` gate, same as the enum check — with no `tls` and no
+    // `mode=quic`, `buildTLSConfig` (and the whole `ech` switch within it)
+    // never runs, so `ech=always` with no `ech-doh` from any source is
+    // inert, not fatal. A regression that moved this check outside the
+    // `tls_enabled` guard would pass every OTHER `ech=always` test (all of
+    // which include `tls`) but not this one.
+    #[skuld::test]
+    fn ech_always_without_tls_is_inert_not_fatal() {
+        let segments = garter::split_plugin_options("host=cdn.example;ech=always").unwrap();
+        assert_eq!(ex_ray_fatal_config_error(&segments, None), None);
     }
 
     // Every new `ex_ray_fatal_config_error` check reads its key via `find`

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -566,6 +566,30 @@ fn classify_ech_doh(
     segments: &[garter::OptionSegment<'_>],
     ech_doh: Option<&crate::dns::ech::EchDoh>,
 ) -> (EffectiveEchDoh, bool) {
+    // Whether ex-ray will even ATTEMPT an ECH-config fetch for this segment
+    // set, independent of which `ech-doh` value would win: `ech=never`
+    // (first-wins, matching `Args.Get`) short-circuits ECH entirely before
+    // it ever looks at `ech-doh` (crates/ex-ray/config.go:209-211).
+    // Otherwise ECH is only reachable when TLS is enabled at all — an
+    // explicit `tls` flag, or `mode=quic` forcing it on — since
+    // `buildTLSConfig` (which contains the whole `ech` switch) is called
+    // only when `tlsEnabled` (config.go:290-294, 334); a plain non-quic
+    // transport (e.g. `mode=websocket` with no `tls`) never calls it.
+    // Neither the cover permit nor the residual-stall warning may treat a
+    // fetch that provably cannot happen as one that will.
+    let ech_never = segments
+        .iter()
+        .find(|s| s.key == "ech")
+        .is_some_and(|s| s.value == "never");
+    let tls_enabled = segments.iter().any(|s| s.key == "tls")
+        || segments
+            .iter()
+            .find(|s| s.key == "mode")
+            .is_some_and(|s| s.value == "quic");
+    if ech_never || !tls_enabled {
+        return (EffectiveEchDoh::None, false);
+    }
+
     let config_ech_doh = segments.iter().find(|s| s.key == "ech-doh");
     // Hole's URL is name-free, so it displaces one whose authority is a
     // name — that lookup is the defect. Against an IP-literal value there
@@ -938,13 +962,13 @@ mod inject_tests {
         for their_url in ["https://8.8.8.8/dns-query", "https://[2620:fe::fe]/dns-query"] {
             let out = merged(
                 "ex-ray",
-                Some(&format!("ech-doh={their_url}")),
+                Some(&format!("tls;ech-doh={their_url}")),
                 Some(&unpinned("https://1.1.1.1/dns-query")),
             );
             assert_eq!(
                 out.as_deref(),
                 Some(&*format!(
-                    "ech-doh={their_url};loglevel=debug;ech-doh=https://1.1.1.1/dns-query"
+                    "tls;ech-doh={their_url};loglevel=debug;ech-doh=https://1.1.1.1/dns-query"
                 )),
             );
         }
@@ -957,12 +981,12 @@ mod inject_tests {
     fn an_unpinned_url_still_displaces_a_name_config_value() {
         let out = merged(
             "ex-ray",
-            Some("ech=always;ech-doh=https://cloudflare-dns.com/dns-query"),
+            Some("tls;ech=always;ech-doh=https://cloudflare-dns.com/dns-query"),
             Some(&unpinned("https://1.1.1.1/dns-query")),
         );
         assert_eq!(
             out.as_deref(),
-            Some("ech=always;loglevel=debug;ech-doh=https://1.1.1.1/dns-query"),
+            Some("tls;ech=always;loglevel=debug;ech-doh=https://1.1.1.1/dns-query"),
         );
     }
 
@@ -1008,10 +1032,13 @@ mod inject_tests {
     fn an_escaped_spelling_of_an_owned_key_is_still_stripped() {
         let out = merged(
             "ex-ray",
-            Some(r"ech\-doh=https://evil.example/dns-query;log\level=warning"),
+            Some(r"tls;ech\-doh=https://evil.example/dns-query;log\level=warning"),
             Some(&pinned("https://9.9.9.9/dns-query")),
         );
-        assert_eq!(out.as_deref(), Some("loglevel=debug;ech-doh=https://9.9.9.9/dns-query"),);
+        assert_eq!(
+            out.as_deref(),
+            Some("tls;loglevel=debug;ech-doh=https://9.9.9.9/dns-query"),
+        );
     }
 
     // ex-ray discards the whole SS_* environment on a parse error and reports
@@ -1050,10 +1077,13 @@ mod inject_tests {
         // ex-ray, so a duplicate would win at that hop.
         let out = merged(
             "galoshes",
-            Some("loglevel=warning;ech-doh=https://stale.example/dns-query"),
+            Some("tls;loglevel=warning;ech-doh=https://stale.example/dns-query"),
             Some(&pinned("https://9.9.9.9/dns-query")),
         );
-        assert_eq!(out.as_deref(), Some("loglevel=debug;ech-doh=https://9.9.9.9/dns-query"),);
+        assert_eq!(
+            out.as_deref(),
+            Some("tls;loglevel=debug;ech-doh=https://9.9.9.9/dns-query"),
+        );
     }
 
     // An unknown plugin gets no injection, so it gets no strip either.
@@ -1183,24 +1213,85 @@ mod inject_tests {
     #[skuld::test]
     fn family_plugin_with_no_operator_override_reaches_ex_ray_as_holes() {
         let e = pinned("https://9.9.9.9/dns-query");
-        assert!(ech_doh_will_reach_ex_ray("ex-ray", None, Some(&e)));
-        assert_eq!(effective_ech_doh("ex-ray", None, Some(&e)), EffectiveEchDoh::Holes);
+        assert!(ech_doh_will_reach_ex_ray("ex-ray", Some("tls"), Some(&e)));
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
     }
 
-    // The exact scenario the mismatched-warning fix targets: an unpinned Hole
-    // guess against an operator's own IP-literal `ech-doh` — the operator's
-    // choice stands, so ex-ray fetches THEIRS, not Hole's.
+    // An unpinned Hole guess against an operator's own IP-literal `ech-doh` —
+    // the operator's choice stands, so ex-ray fetches THEIRS, not Hole's.
     #[skuld::test]
     fn family_plugin_with_a_winning_operator_override_reaches_ex_ray_as_operators() {
         let e = unpinned("https://1.1.1.1/dns-query");
         assert!(!ech_doh_will_reach_ex_ray(
             "ex-ray",
-            Some("ech-doh=https://8.8.8.8/dns-query"),
+            Some("tls;ech-doh=https://8.8.8.8/dns-query"),
             Some(&e)
         ));
         assert_eq!(
-            effective_ech_doh("ex-ray", Some("ech-doh=https://8.8.8.8/dns-query"), Some(&e)),
+            effective_ech_doh("ex-ray", Some("tls;ech-doh=https://8.8.8.8/dns-query"), Some(&e)),
             EffectiveEchDoh::Operators("https://8.8.8.8/dns-query".to_string())
+        );
+    }
+
+    // `classify_ech_doh` must read whether ex-ray will even ATTEMPT ECH, not
+    // just plugin family + ech-doh presence — `ech=never` short-circuits it
+    // (config.go:209-211) regardless of `tls`/`ech-doh`.
+    #[skuld::test]
+    fn ech_never_never_reaches_ex_ray_even_with_tls_and_ech_doh() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;ech=never"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+    }
+
+    // `ech=never` uses first-wins (matching ex-ray's own `Args.Get`), same as
+    // `fail_closed` elsewhere in this module — a later `ech=auto` must not
+    // resurrect it.
+    #[skuld::test]
+    fn ech_never_is_first_wins() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;ech=never;ech=auto"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("tls;ech=auto;ech=never"), Some(&e)),
+            EffectiveEchDoh::Holes,
+            "the FIRST ech= wins — auto here, so never (second) is ignored"
+        );
+    }
+
+    // ex-ray's `buildTLSConfig` (and therefore its whole `ech` switch) is
+    // only called when `tlsEnabled` — never for a plain, non-quic transport
+    // with no `tls` flag (config.go:290-294,334). A permit or warning for
+    // this config would be for a fetch that provably cannot happen.
+    #[skuld::test]
+    fn no_tls_and_not_quic_never_reaches_ex_ray() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("mode=websocket"), Some(&e)),
+            EffectiveEchDoh::None
+        );
+        assert_eq!(effective_ech_doh("ex-ray", None, Some(&e)), EffectiveEchDoh::None);
+    }
+
+    // `mode=quic` force-enables TLS even with no explicit `tls` flag
+    // (config.go:290-294) — first-wins, matching every other flag here.
+    #[skuld::test]
+    fn quic_mode_reaches_ex_ray_without_an_explicit_tls_flag() {
+        let e = pinned("https://9.9.9.9/dns-query");
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("mode=quic"), Some(&e)),
+            EffectiveEchDoh::Holes
+        );
+        assert_eq!(
+            effective_ech_doh("ex-ray", Some("mode=quic;mode=websocket"), Some(&e)),
+            EffectiveEchDoh::Holes,
+            "first-wins: the second mode= does not un-set the quic TLS force-enable"
         );
     }
 

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -268,12 +268,16 @@ struct BlockedStart<C> {
     /// back to `resolver_permit` instead (`x != Some(resolver_permit)`, by
     /// construction — the outer `Option` marks "a dead value is known", the
     /// inner one is the resolver-permit value itself, which can legitimately
-    /// be `None`). A later retry whose freshly-derived permit is again
-    /// exactly `x` must NOT re-attempt the same failing correction — that
-    /// would oscillate forever, each cycle re-opening the release-then-
-    /// reengage window for no progress. `None` once a correction lands (the
-    /// held permit is exactly what this attempt wants) or has never been
-    /// attempted.
+    /// be `None`). A retry whose freshly-derived permit is again exactly `x`
+    /// skips the repair attempt ONCE (bounding the release-then-reengage
+    /// window from reopening on every single retry of an unreachable value)
+    /// and CLEARS this marker for the retry after — a fresh attempt is never
+    /// permanently withheld, since the corrected engage's failure could be
+    /// transient (a momentary OS-level condition), not a lasting property of
+    /// the value itself. Net effect for a persistently-failing value: retried
+    /// every OTHER matching retry, not every one and not never. `None` once a
+    /// correction lands (the held permit is exactly what this attempt wants)
+    /// or has never been attempted.
     dead_permit: Option<Option<IpAddr>>,
 }
 
@@ -672,20 +676,31 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // the held cover doesn't already have (`ech_resolver_permit.is_some_and`
         // below — a narrowing to `None`, e.g. the plugin was removed, is left
         // as a superset permit rather than paying the release-to-reengage
-        // window for a correction with no benefit) AND that correction isn't
-        // already known-dead (see `dead_permit`'s doc). `repair_fallback`
+        // window for a correction with no benefit). `repair_fallback`
         // captures what's being given up: `Some(old_permit)` means a good
         // cover existed a moment ago, so a failed fresh engage below
         // restores it instead of leaving the host uncovered.
+        //
+        // A drift that matches a KNOWN-DEAD value (see `dead_permit`'s doc)
+        // skips the repair THIS retry — bounding the release-to-reengage
+        // window from reopening on every single retry of an unreachable
+        // value — but clears the marker so the NEXT retry gets a fresh
+        // attempt: `install_failclosed_cover` can fail on a transient OS
+        // condition (a momentary WFP/pf contention), and a single such
+        // failure must not wedge the repair for the rest of the session.
+        // Net effect: a persistently-failing value is retried every OTHER
+        // drift-matching retry, not every one and not never.
         let repair_fallback: Option<Option<IpAddr>> = if covered && !lockdown_on {
-            self.blocked
-                .as_ref()
-                .filter(|b| {
-                    b.host == config.server.server
-                        && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
-                        && b.dead_permit != Some(ech_resolver_permit)
-                })
-                .map(|b| b.resolver_permit)
+            match self.blocked.as_mut().filter(|b| {
+                b.host == config.server.server && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
+            }) {
+                Some(b) if b.dead_permit == Some(ech_resolver_permit) => {
+                    b.dead_permit = None;
+                    None
+                }
+                Some(b) => Some(b.resolver_permit),
+                None => None,
+            }
         } else {
             None
         };

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -241,10 +241,15 @@ pub struct ProxyManager<P: Proxy = ShadowsocksProxy, R: Routing = SystemRouting,
     last_ech_doh: Option<String>,
 }
 
-/// A held block-until-connected cover plus the server identity it permits. The
-/// cover permits exactly `server_ip`, so a covered retry for the same `host`
-/// reuses `server_ip` rather than re-resolving — re-resolution under the held
-/// cover would be blocked (the cover permits the server, not the DoH resolvers).
+/// A held block-until-connected cover plus the server identity it permits.
+/// `resolver_permit` is what was ACTUALLY passed to `install_failclosed_cover`
+/// at the engage that produced `cover` — ground truth for what the LIVE OS
+/// cover permits, frozen until the next fresh engage. A covered retry against
+/// the same `host` reuses `server_ip` and never re-engages the cover UNLESS
+/// this attempt's freshly re-derived permit now differs from `resolver_permit`
+/// (e.g. the user added a plugin since the first attempt) — that drift makes
+/// the held cover stale, and `start_cancellable` releases it so the engage
+/// block re-engages fresh with the corrected permit.
 struct BlockedStart<C> {
     cover: C,
     host: String,
@@ -253,6 +258,23 @@ struct BlockedStart<C> {
     /// retry never re-resolves, so it reuses this — revalidated against the
     /// retry's own config, so an edited resolver set is never overridden.
     pin: crate::dns::ech::PinSource,
+    /// The resolver this cover's ENGAGE actually permitted (or `None`) — see
+    /// the struct doc. Distinct from `pin`: `pin` is revalidated every retry,
+    /// this field is not, because it describes the live OS cover, not the
+    /// current config.
+    resolver_permit: Option<IpAddr>,
+    /// `Some(x)` when the LAST repair attempt wanted to correct the permit to
+    /// `x` but the corrected engage failed and a compensating restore fell
+    /// back to `resolver_permit` instead (`x != Some(resolver_permit)`, by
+    /// construction — the outer `Option` marks "a dead value is known", the
+    /// inner one is the resolver-permit value itself, which can legitimately
+    /// be `None`). A later retry whose freshly-derived permit is again
+    /// exactly `x` must NOT re-attempt the same failing correction — that
+    /// would oscillate forever, each cycle re-opening the release-then-
+    /// reengage window for no progress. `None` once a correction lands (the
+    /// held permit is exactly what this attempt wants) or has never been
+    /// attempted.
+    dead_permit: Option<Option<IpAddr>>,
 }
 
 impl<P: Proxy, R: Routing> ProxyManager<P, R, SystemDns> {
@@ -546,9 +568,10 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         #[cfg(not(test))]
         let bootstrap_querier: Option<std::sync::Arc<dyn crate::dns::bootstrap::DohQuerier>> = None;
 
-        // A held cover permits only the OLD server IP, so a start for a DIFFERENT
-        // server must release it BEFORE resolving — DoH under the stale cover would
-        // be blocked (the resolvers aren't permitted) and wedge.
+        // A DIFFERENT server's hostname needs a FRESH DoH resolution — not
+        // guaranteed to land on the resolver already baked into the held cover
+        // (see `BlockedStart`'s doc) — so a start for a different server must
+        // release the held cover BEFORE resolving.
         let stale = self.blocked.as_ref().is_some_and(|b| b.host != config.server.server);
         if stale {
             debug_assert!(self.blocked.is_some(), "stale implies a held cover");
@@ -556,8 +579,8 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             warn!("start for a different server while blocked: releasing the held cover before re-resolving");
         }
 
-        // Resolve the server IP over private DoH. A same-server retry under the held
-        // cover reuses the cached IP (the cover blocks the resolvers).
+        // Resolve the server IP over private DoH. A same-server retry under the
+        // held cover reuses the cached IP and pin.
         let (server_ip, pin) = match self.blocked.as_ref().filter(|b| b.host == config.server.server) {
             Some(b) => (b.server_ip, crate::dns::ech::revalidate(b.pin, &config.dns.servers)),
             None => match Self::resolve_server_ip(config, &bootstrap_querier, &cancel).await {
@@ -577,25 +600,61 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             },
         };
 
-        // Only a plugin chain carries an ECH lookup, so a plugin-less start
-        // derives nothing and reports nothing — an "unpinned ECH lookup" line
-        // there would name an exposure that does not exist. Every pin outcome
-        // reaches ex-ray as one URL, so the reason is named here or it is
-        // unrecoverable from the log.
-        let ech_doh = if config.server.plugin.is_some() {
-            let derived = crate::dns::ech::ech_doh_url(&config.dns, pin);
-            debug!(ech_doh = ?derived, ?pin, "ech-doh source");
-            if matches!(pin, crate::dns::ech::PinSource::ResolverDeselected) {
+        // `ech_doh` (what ex-ray is TOLD to fetch) and `ech_resolver_permit`
+        // (what THIS ATTEMPT would permit it to reach) both read the same
+        // plugin-presence + pin inputs — computed ONCE here so the two cannot
+        // drift apart under a future edit to either gate. Only a plugin chain
+        // carries an ECH lookup, so a plugin-less start derives nothing.
+        let plugin_pin: Option<crate::dns::ech::PinSource> = config.server.plugin.is_some().then_some(pin);
+
+        // Every pin outcome reaches ex-ray as one URL, so the reason is named
+        // here or it is unrecoverable from the log. An "unpinned ECH lookup"
+        // line for a plugin-less start would name an exposure that does not
+        // exist, hence `plugin_pin` gating this too.
+        let ech_doh = plugin_pin.and_then(|p| {
+            let derived = crate::dns::ech::ech_doh_url(&config.dns, p);
+            debug!(ech_doh = ?derived, ?p, "ech-doh source");
+            if matches!(p, crate::dns::ech::PinSource::ResolverDeselected) {
                 warn!("covered retry: the cached DoH resolver is no longer configured; the ECH lookup is unpinned");
             }
             derived
-        } else {
-            None
-        };
+        });
         #[cfg(test)]
         {
             self.last_ech_doh = ech_doh.as_ref().map(|e| e.url.clone());
         }
+
+        // `ech_doh` is Hole's CANDIDATE — what it would tell ex-ray, before
+        // `inject_plugin_directives` runs. That injection only rewrites
+        // `ech-doh` for the v2ray-family plugin names, and even then an
+        // operator's own `ech-doh` already in `plugin_opts` can win
+        // first-wins over Hole's (see `effective_ech_doh`'s doc). The cover
+        // must be gated on whether Hole's candidate is the EFFECTIVE value
+        // ex-ray actually dials — not on `ech_doh.is_some()` alone — or a
+        // non-ECH-capable plugin, or an operator's own override, would widen
+        // the cover for a fetch that provably does not use it. The residual
+        // warning below also reads `effective_ech_doh` directly, to name an
+        // operator-won address the cover cannot permit either.
+        let effective_ech_doh = crate::proxy::plugin::effective_ech_doh(
+            config.server.plugin.as_deref().unwrap_or_default(),
+            config.server.plugin_opts.as_deref(),
+            ech_doh.as_ref(),
+        );
+        let ech_effective = matches!(effective_ech_doh, crate::proxy::plugin::EffectiveEchDoh::Holes);
+
+        // `ech_doh.resolver`, read directly — not re-derived from `pin` — is
+        // the exact address the ECH-config fetch will dial (see `EchDoh`'s
+        // doc for why permitting it costs no new trust regardless of
+        // `PinSource`). Gated on `ech_effective`, not `ech_doh.is_some()`: a
+        // non-ECH-capable plugin or an operator's own override never widens
+        // the cover for a fetch that provably won't use Hole's address.
+        let ech_resolver_permit = ech_effective.then_some(ech_doh.as_ref()).flatten().map(|e| e.resolver);
+        debug!(
+            ?ech_resolver_permit,
+            ?pin,
+            ech_effective,
+            "failclosed cover resolver permit"
+        );
 
         // Engage the block-until-connected cover for a covered start UNLESS the
         // standing lockdown intent is on: that cohort installs the lockdown cover
@@ -607,23 +666,96 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             .as_deref()
             .map(lockdown_state::load_enabled)
             .unwrap_or(false);
+
+        // A held cover's resolver_permit is fixed at engage time; re-engage
+        // only when this attempt's fresh derivation NEEDS a specific address
+        // the held cover doesn't already have (`ech_resolver_permit.is_some_and`
+        // below — a narrowing to `None`, e.g. the plugin was removed, is left
+        // as a superset permit rather than paying the release-to-reengage
+        // window for a correction with no benefit: see the failure-lens
+        // finding this guards against) AND that correction isn't already
+        // known-dead (see `dead_permit`'s doc). `repair_fallback` captures
+        // what's being given up: `Some(old_permit)` means a good cover
+        // existed a moment ago, so a failed fresh engage below restores it
+        // instead of leaving the host uncovered.
+        let repair_fallback: Option<Option<IpAddr>> = if covered && !lockdown_on {
+            self.blocked
+                .as_ref()
+                .filter(|b| {
+                    b.host == config.server.server
+                        && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
+                        && b.dead_permit != Some(ech_resolver_permit)
+                })
+                .map(|b| b.resolver_permit)
+        } else {
+            None
+        };
+        if repair_fallback.is_some() {
+            self.blocked.take();
+            warn!(
+                "covered retry: this attempt's resolver permit differs from the held cover's; \
+                 releasing it so a fresh engage can correct it — egress is briefly OPEN until \
+                 the corrected (or, on failure, the restored) cover re-engages below"
+            );
+        }
+
         if covered && !lockdown_on {
             // The transient cover is a global singleton — never construct a second
             // over the same objects. An engage failure proceeds UNCOVERED (aborting
-            // would leave the user unconnected AND unprotected), surfaced via last_error.
+            // would leave the user unconnected AND unprotected), surfaced via last_error
+            // — UNLESS this was a repair (`repair_fallback` is `Some`), in which case
+            // the host was ALREADY covered a moment ago and a compensating re-engage
+            // of the OLD permit is attempted first, so correcting a permit can never
+            // be how a covered start loses its cover outright.
             if self.blocked.is_none() {
-                match self.routing.install_failclosed_cover(server_ip) {
+                match self.routing.install_failclosed_cover(server_ip, ech_resolver_permit) {
                     Ok(cover) => {
                         self.blocked = Some(BlockedStart {
                             cover,
                             host: config.server.server.clone(),
                             server_ip,
                             pin,
+                            resolver_permit: ech_resolver_permit,
+                            dead_permit: None,
                         });
                     }
                     Err(e) => {
-                        warn!(error = %e, "failed to engage fail-closed cover on covered start; host NOT blocked, proceeding open");
-                        self.last_error = Some(e.to_string());
+                        if let Some(old_permit) = repair_fallback {
+                            match self.routing.install_failclosed_cover(server_ip, old_permit) {
+                                Ok(cover) => {
+                                    self.blocked = Some(BlockedStart {
+                                        cover,
+                                        host: config.server.server.clone(),
+                                        server_ip,
+                                        pin,
+                                        resolver_permit: old_permit,
+                                        // Remember the value we WANTED but could not
+                                        // reach, so a same-value retry doesn't retry
+                                        // this same failing correction forever.
+                                        dead_permit: Some(ech_resolver_permit),
+                                    });
+                                    warn!(
+                                        error = %e,
+                                        "failed to engage the corrected fail-closed cover; restored the \
+                                         PREVIOUS permit instead of leaving the host open — ex-ray's ECH \
+                                         fetch may still stall against the now-stale permit"
+                                    );
+                                    self.last_error = Some(e.to_string());
+                                }
+                                Err(e2) => {
+                                    warn!(
+                                        error = %e,
+                                        restore_error = %e2,
+                                        "failed to engage BOTH the corrected and the previous fail-closed \
+                                         cover; host NOT blocked, proceeding open"
+                                    );
+                                    self.last_error = Some(e.to_string());
+                                }
+                            }
+                        } else {
+                            warn!(error = %e, "failed to engage fail-closed cover on covered start; host NOT blocked, proceeding open");
+                            self.last_error = Some(e.to_string());
+                        }
                     }
                 }
             }
@@ -644,6 +776,40 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             warn!("uncovered start while blocked: releasing the held cover (host fail-open by design)");
         }
         let blocking_engaged = self.blocked.is_some();
+
+        // Disclosed residual (see CONTRIBUTING.md's "Transient cutover
+        // cover" section) gated on `effective_ech_doh`, the value that will
+        // ACTUALLY reach ex-ray: `Holes` still stalls only if a repair's
+        // restore left the LIVE held permit different from what this
+        // attempt needs (`live_permit != ech_resolver_permit`); `Operators(url)`
+        // always stalls, since the cover never permits an operator-chosen
+        // address.
+        if blocking_engaged {
+            match &effective_ech_doh {
+                crate::proxy::plugin::EffectiveEchDoh::None => {}
+                crate::proxy::plugin::EffectiveEchDoh::Holes => {
+                    let live_permit = self.blocked.as_ref().and_then(|b| b.resolver_permit);
+                    if live_permit != ech_resolver_permit {
+                        warn!(
+                            ?pin,
+                            ech_doh_url = ?ech_doh.as_ref().map(|e| &e.url),
+                            ?live_permit,
+                            ?ech_resolver_permit,
+                            "covered start: the ECH-config fetch will dial a resolver the fail-closed cover \
+                             does not permit (a repair's restore left it stale); it may stall to ex-ray's \
+                             client timeout"
+                        );
+                    }
+                }
+                crate::proxy::plugin::EffectiveEchDoh::Operators(url) => {
+                    warn!(
+                        operator_ech_doh = %url,
+                        "covered start: the plugin's own ech-doh overrides Hole's and dials a resolver the \
+                         fail-closed cover does not permit; it may stall to ex-ray's client timeout"
+                    );
+                }
+            }
+        }
 
         debug!("awaiting start_inner");
         let result: Result<RunningState<P, R, D>, ProxyError> = Self::start_inner(

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -677,16 +677,19 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // below — a narrowing to `None`, e.g. the plugin was removed, is left
         // as a superset permit rather than paying the release-to-reengage
         // window for a correction with no benefit). `repair_fallback`
-        // captures what's being given up: `Some(old_permit)` means a good
-        // cover existed a moment ago, so a failed fresh engage below
-        // restores it instead of leaving the host uncovered.
+        // captures what's being given up: `Some((old_permit, original_pin))`
+        // means a good cover existed a moment ago, so a failed fresh engage
+        // below restores it instead of leaving the host uncovered.
+        // `original_pin` is `pin` BEFORE this attempt's own `revalidate` —
+        // see the repair arms below for why it, not the local `pin`
+        // variable, is what gets stored back.
         //
         // A drift matching a KNOWN-DEAD value (see `dead_permit`'s doc) skips
         // the repair this retry and clears the marker so the next retry gets
         // a fresh attempt — a single `install_failclosed_cover` failure
         // (e.g. a momentary WFP/pf contention) must not wedge the repair
         // permanently.
-        let repair_fallback: Option<Option<IpAddr>> = if covered && !lockdown_on {
+        let repair_fallback: Option<(Option<IpAddr>, crate::dns::ech::PinSource)> = if covered && !lockdown_on {
             match self.blocked.as_mut().filter(|b| {
                 b.host == config.server.server && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
             }) {
@@ -694,7 +697,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                     b.dead_permit = None;
                     None
                 }
-                Some(b) => Some(b.resolver_permit),
+                Some(b) => Some((b.resolver_permit, b.pin)),
                 None => None,
             }
         } else {
@@ -723,26 +726,38 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             // non-repair case; the NEXT retry finds `self.blocked` is `None`
             // and re-engages fresh from scratch.
             if self.blocked.is_none() {
+                // A repair's corrected engage still carries forward the
+                // ORIGINAL cover's `pin`, not this attempt's locally
+                // revalidated `pin`: `pin` (the struct field) records when
+                // the SERVER IP was resolved, a fact independent of which
+                // ECH resolver this attempt's permit needs — `revalidate`
+                // only ever downgrades (`Answered` -> `ResolverDeselected`),
+                // so persisting an already-downgraded value here would make
+                // that loss permanent, unrecoverable even once the original
+                // resolver returns to `dns.servers`. A fresh (non-repair)
+                // engage has no prior cover to preserve, so `pin` (fresh
+                // from resolve, or a first same-host reuse) is correct as-is.
+                let engaged_pin = repair_fallback.map_or(pin, |(_, original_pin)| original_pin);
                 match self.routing.install_failclosed_cover(server_ip, ech_resolver_permit) {
                     Ok(cover) => {
                         self.blocked = Some(BlockedStart {
                             cover,
                             host: config.server.server.clone(),
                             server_ip,
-                            pin,
+                            pin: engaged_pin,
                             resolver_permit: ech_resolver_permit,
                             dead_permit: None,
                         });
                     }
                     Err(e) => {
-                        if let Some(old_permit) = repair_fallback {
+                        if let Some((old_permit, original_pin)) = repair_fallback {
                             match self.routing.install_failclosed_cover(server_ip, old_permit) {
                                 Ok(cover) => {
                                     self.blocked = Some(BlockedStart {
                                         cover,
                                         host: config.server.server.clone(),
                                         server_ip,
-                                        pin,
+                                        pin: original_pin,
                                         resolver_permit: old_permit,
                                         // Remember the value we WANTED but could not
                                         // reach, so a same-value retry doesn't retry

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -744,12 +744,31 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                                         pin: original_pin,
                                         resolver_permit: old_permit,
                                     });
-                                    warn!(
-                                        error = %e,
-                                        "failed to engage the corrected fail-closed cover; restored the \
-                                         PREVIOUS permit instead of leaving the host open — ex-ray's ECH \
-                                         fetch may still stall against the now-stale permit"
-                                    );
+                                    // The restored permit is stale either way, but which
+                                    // direction it's stale in depends on whether the fetch
+                                    // this attempt needs an ECH resolver at all: widening
+                                    // repairs (`Holes`) restore something narrower than
+                                    // needed, so the fetch may stall; narrowing repairs
+                                    // (`None`/`Operators`, no fetch this cover permits
+                                    // anyway) instead restore something WIDER than needed —
+                                    // a live kill-switch permit for an address nothing
+                                    // dials, not a stall risk.
+                                    if matches!(effective_ech_doh, crate::proxy::plugin::EffectiveEchDoh::Holes) {
+                                        warn!(
+                                            error = %e,
+                                            "failed to engage the corrected fail-closed cover; restored the \
+                                             PREVIOUS permit instead of leaving the host open — ex-ray's ECH \
+                                             fetch may still stall against the now-stale permit"
+                                        );
+                                    } else {
+                                        warn!(
+                                            error = %e,
+                                            ?old_permit,
+                                            "failed to engage the corrected fail-closed cover; restored the \
+                                             PREVIOUS permit instead of leaving the host open — the fail-closed \
+                                             cover still permits a resolver address this attempt no longer needs"
+                                        );
+                                    }
                                     self.last_error = Some(e.to_string());
                                 }
                                 Err(e2) => {
@@ -793,10 +812,24 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // restore left the LIVE held permit different from what this
         // attempt needs (`live_permit != ech_resolver_permit`); `Operators(url)`
         // always stalls, since the cover never permits an operator-chosen
-        // address.
+        // address; `None` never stalls (no fetch is attempted) but a
+        // repair's restore can still leave the LIVE permit WIDER than this
+        // attempt needs — the opposite residual direction, a kill-switch
+        // widening rather than a stall risk.
         if blocking_engaged {
             match &effective_ech_doh {
-                crate::proxy::plugin::EffectiveEchDoh::None => {}
+                crate::proxy::plugin::EffectiveEchDoh::None => {
+                    let live_permit = self.blocked.as_ref().and_then(|b| b.resolver_permit);
+                    if live_permit.is_some() {
+                        warn!(
+                            ?pin,
+                            ?live_permit,
+                            "covered start: the fail-closed cover still permits a resolver address this \
+                             attempt does not need (a repair's restore left it stale); the kill switch is \
+                             wider than the current config requires"
+                        );
+                    }
+                }
                 crate::proxy::plugin::EffectiveEchDoh::Holes => {
                     let live_permit = self.blocked.as_ref().and_then(|b| b.resolver_permit);
                     if live_permit != ech_resolver_permit {

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -681,15 +681,11 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // cover existed a moment ago, so a failed fresh engage below
         // restores it instead of leaving the host uncovered.
         //
-        // A drift that matches a KNOWN-DEAD value (see `dead_permit`'s doc)
-        // skips the repair THIS retry — bounding the release-to-reengage
-        // window from reopening on every single retry of an unreachable
-        // value — but clears the marker so the NEXT retry gets a fresh
-        // attempt: `install_failclosed_cover` can fail on a transient OS
-        // condition (a momentary WFP/pf contention), and a single such
-        // failure must not wedge the repair for the rest of the session.
-        // Net effect: a persistently-failing value is retried every OTHER
-        // drift-matching retry, not every one and not never.
+        // A drift matching a KNOWN-DEAD value (see `dead_permit`'s doc) skips
+        // the repair this retry and clears the marker so the next retry gets
+        // a fresh attempt — a single `install_failclosed_cover` failure
+        // (e.g. a momentary WFP/pf contention) must not wedge the repair
+        // permanently.
         let repair_fallback: Option<Option<IpAddr>> = if covered && !lockdown_on {
             match self.blocked.as_mut().filter(|b| {
                 b.host == config.server.server && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -655,17 +655,20 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             .unwrap_or(false);
 
         // A held cover's resolver_permit is fixed at engage time; re-engage
-        // only when this attempt's fresh derivation NEEDS a specific address
-        // the held cover doesn't already have (`ech_resolver_permit.is_some_and`
-        // below — a narrowing to `None`, e.g. the plugin was removed, is left
-        // as a superset permit rather than paying the release-to-reengage
-        // window for a correction with no benefit). `repair_fallback`
-        // captures what's being given up: `Some((old_permit, original_pin))`
-        // means a good cover existed a moment ago, so a failed fresh engage
-        // below restores it instead of leaving the host uncovered.
-        // `original_pin` is `pin` BEFORE this attempt's own `revalidate` —
-        // see the repair arms below for why it, not the local `pin`
-        // variable, is what gets stored back.
+        // whenever this attempt's fresh derivation DIFFERS from what the
+        // held cover already has — a narrowing to `None` (e.g. the plugin
+        // was removed, or `effective_ech_doh` no longer resolves to
+        // `Holes`) drifts too: leaving a wider-than-needed permit live is a
+        // real widening of the kill switch (the resolver permit carries no
+        // App-ID/process scoping on either platform, so it is available to
+        // every process on the host, not just the plugin chain), not a
+        // correction with no benefit. `repair_fallback` captures what's
+        // being given up: `Some((old_permit, original_pin))` means a good
+        // cover existed a moment ago, so a failed fresh engage below
+        // restores it instead of leaving the host uncovered. `original_pin`
+        // is `pin` BEFORE this attempt's own `revalidate` — see the repair
+        // arms below for why it, not the local `pin` variable, is what gets
+        // stored back.
         //
         // A retry whose desired permit still matches a value a PRIOR repair
         // already proved unreachable is not treated specially — it repairs
@@ -680,9 +683,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         let repair_fallback: Option<(Option<IpAddr>, crate::dns::ech::PinSource)> = if covered && !lockdown_on {
             self.blocked
                 .as_mut()
-                .filter(|b| {
-                    b.host == config.server.server && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
-                })
+                .filter(|b| b.host == config.server.server && b.resolver_permit != ech_resolver_permit)
                 .map(|b| (b.resolver_permit, b.pin))
         } else {
             None

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -262,22 +262,6 @@ struct BlockedStart<C> {
     /// not — it describes the live OS cover, not the current config. See the
     /// struct doc for what it means.
     resolver_permit: Option<IpAddr>,
-    /// `Some(x)` when the LAST repair attempt wanted to correct the permit to
-    /// `x` but the corrected engage failed and a compensating restore fell
-    /// back to `resolver_permit` instead (`x != Some(resolver_permit)`, by
-    /// construction — the outer `Option` marks "a dead value is known", the
-    /// inner one is the resolver-permit value itself, which can legitimately
-    /// be `None`). A retry whose freshly-derived permit is again exactly `x`
-    /// skips the repair attempt ONCE (bounding the release-then-reengage
-    /// window from reopening on every single retry of an unreachable value)
-    /// and CLEARS this marker for the retry after — a fresh attempt is never
-    /// permanently withheld, since the corrected engage's failure could be
-    /// transient (a momentary OS-level condition), not a lasting property of
-    /// the value itself. Net effect for a persistently-failing value: retried
-    /// every OTHER matching retry, not every one and not never. `None` once a
-    /// correction lands (the held permit is exactly what this attempt wants)
-    /// or has never been attempted.
-    dead_permit: Option<Option<IpAddr>>,
 }
 
 impl<P: Proxy, R: Routing> ProxyManager<P, R, SystemDns> {
@@ -683,22 +667,23 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // see the repair arms below for why it, not the local `pin`
         // variable, is what gets stored back.
         //
-        // A drift matching a KNOWN-DEAD value (see `dead_permit`'s doc) skips
-        // the repair this retry and clears the marker so the next retry gets
-        // a fresh attempt — a single `install_failclosed_cover` failure
-        // (e.g. a momentary WFP/pf contention) must not wedge the repair
-        // permanently.
+        // A retry whose desired permit still matches a value a PRIOR repair
+        // already proved unreachable is not treated specially — it repairs
+        // again like any other drift. The corrected engage's own failure
+        // could be transient (a momentary OS-level condition), not a
+        // lasting property of the value, so there is no principled way to
+        // tell "will fail again" from "would now succeed" without trying;
+        // skipping on a heuristic (e.g. a fixed number of retries) would
+        // just delay a correction that could have landed this attempt. Each
+        // attempt's release-to-reengage window is bounded to this one
+        // (user-paced) retry either way — see the restore fallback below.
         let repair_fallback: Option<(Option<IpAddr>, crate::dns::ech::PinSource)> = if covered && !lockdown_on {
-            match self.blocked.as_mut().filter(|b| {
-                b.host == config.server.server && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
-            }) {
-                Some(b) if b.dead_permit == Some(ech_resolver_permit) => {
-                    b.dead_permit = None;
-                    None
-                }
-                Some(b) => Some((b.resolver_permit, b.pin)),
-                None => None,
-            }
+            self.blocked
+                .as_mut()
+                .filter(|b| {
+                    b.host == config.server.server && ech_resolver_permit.is_some_and(|r| b.resolver_permit != Some(r))
+                })
+                .map(|b| (b.resolver_permit, b.pin))
         } else {
             None
         };
@@ -745,7 +730,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                             server_ip,
                             pin: engaged_pin,
                             resolver_permit: ech_resolver_permit,
-                            dead_permit: None,
                         });
                     }
                     Err(e) => {
@@ -758,10 +742,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                                         server_ip,
                                         pin: original_pin,
                                         resolver_permit: old_permit,
-                                        // Remember the value we WANTED but could not
-                                        // reach, so a same-value retry doesn't retry
-                                        // this same failing correction forever.
-                                        dead_permit: Some(ech_resolver_permit),
                                     });
                                     warn!(
                                         error = %e,

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -672,12 +672,11 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // the held cover doesn't already have (`ech_resolver_permit.is_some_and`
         // below — a narrowing to `None`, e.g. the plugin was removed, is left
         // as a superset permit rather than paying the release-to-reengage
-        // window for a correction with no benefit: see the failure-lens
-        // finding this guards against) AND that correction isn't already
-        // known-dead (see `dead_permit`'s doc). `repair_fallback` captures
-        // what's being given up: `Some(old_permit)` means a good cover
-        // existed a moment ago, so a failed fresh engage below restores it
-        // instead of leaving the host uncovered.
+        // window for a correction with no benefit) AND that correction isn't
+        // already known-dead (see `dead_permit`'s doc). `repair_fallback`
+        // captures what's being given up: `Some(old_permit)` means a good
+        // cover existed a moment ago, so a failed fresh engage below
+        // restores it instead of leaving the host uncovered.
         let repair_fallback: Option<Option<IpAddr>> = if covered && !lockdown_on {
             self.blocked
                 .as_ref()
@@ -705,8 +704,13 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             // would leave the user unconnected AND unprotected), surfaced via last_error
             // — UNLESS this was a repair (`repair_fallback` is `Some`), in which case
             // the host was ALREADY covered a moment ago and a compensating re-engage
-            // of the OLD permit is attempted first, so correcting a permit can never
-            // be how a covered start loses its cover outright.
+            // of the OLD permit is attempted first: correcting a permit now takes
+            // BOTH the corrected AND the restore engage failing to lose the cover
+            // (the `Err(e2)` arm below), not one — never impossible, just
+            // narrowed from the ordinary single-engage failure case. On that
+            // double failure this attempt proceeds open, same as the
+            // non-repair case; the NEXT retry finds `self.blocked` is `None`
+            // and re-engages fresh from scratch.
             if self.blocked.is_none() {
                 match self.routing.install_failclosed_cover(server_ip, ech_resolver_permit) {
                     Ok(cover) => {

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -258,10 +258,9 @@ struct BlockedStart<C> {
     /// retry never re-resolves, so it reuses this — revalidated against the
     /// retry's own config, so an edited resolver set is never overridden.
     pin: crate::dns::ech::PinSource,
-    /// The resolver this cover's ENGAGE actually permitted (or `None`) — see
-    /// the struct doc. Distinct from `pin`: `pin` is revalidated every retry,
-    /// this field is not, because it describes the live OS cover, not the
-    /// current config.
+    /// Distinct from `pin`: `pin` is revalidated every retry, this field is
+    /// not — it describes the live OS cover, not the current config. See the
+    /// struct doc for what it means.
     resolver_permit: Option<IpAddr>,
     /// `Some(x)` when the LAST repair attempt wanted to correct the permit to
     /// `x` but the corrected engage failed and a compensating restore fell

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -525,14 +525,18 @@ fn test_config() -> ProxyConfig {
 }
 
 /// `plugin_opts` for a plugin config that actually reaches ex-ray's ECH
-/// switch (`crates/ex-ray/config.go:209-223,290-294,334`): TLS enabled via
-/// the bare `tls` flag, `ech` left at its `auto` default. Bare `plugin =
-/// Some("ex-ray")` with no options — TCP-only, no `tls`, no `mode=quic` —
-/// never calls `buildTLSConfig` at all, so ECH is never touched regardless
-/// of `ech-doh`; tests that need a real cover permit or an ECH-posture
-/// warning must opt in via this constant, matching a real postern config
+/// switch: TLS enabled via the bare `tls` flag, a domain `host` (ECH needs
+/// an SNI domain to key its DoH lookup on — an absent, empty, or IP-literal
+/// `host` means ex-ray dials with an IP-literal `ServerName`, so
+/// `ApplyECH` bails before ever dialing DoH), `ech` left at its `auto`
+/// default (`crates/ex-ray/config.go:209-223,290-294,334`;
+/// `third_party/v2ray-core/transport/internet/tls/ech.go:26-51`). Bare
+/// `plugin = Some("ex-ray")` with no options — TCP-only, no `tls`, no
+/// `host` — never reaches ECH at all regardless of `ech-doh`; tests that
+/// need a real cover permit or an ECH-posture warning must opt in via this
+/// constant, matching a real postern config
 /// (`a_postern_config_composes_into_holes_pinned_url` in plugin.rs).
-const ECH_CAPABLE_OPTS: &str = "tls";
+const ECH_CAPABLE_OPTS: &str = "tls;host=cdn.example";
 
 // Tests ===============================================================================================================
 
@@ -2785,6 +2789,49 @@ mod self_test {
         });
     }
 
+    // Integration-level proof of the reachability gate, at the WIRING
+    // boundary (`start_cancellable` -> `effective_ech_doh` ->
+    // `install_failclosed_cover`), not just the pure `classify_ech_doh`
+    // function boundary covered in plugin.rs's own unit tests. A plugin IS
+    // configured and a resolver DID answer, but `plugin_opts` never enables
+    // TLS (no `tls`, no `mode=quic`) — ex-ray's `buildTLSConfig` (and its
+    // whole `ech` switch) is unreachable, so the cover must not widen for a
+    // fetch that provably cannot happen.
+    #[skuld::test]
+    fn covered_start_with_a_non_tls_capable_plugin_does_not_permit_a_resolver() {
+        rt().block_on(async {
+            let resolved: IpAddr = "203.0.113.9".parse().unwrap();
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: resolved,
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some("mode=websocket;host=cdn.example".into()); // no `tls`, no `mode=quic`
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![answering_resolver];
+            let _ = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                None,
+                "a resolver answered and a plugin is configured, but TLS is never enabled, so ex-ray \
+                 never reaches its ECH switch — the cover must not permit the resolver"
+            );
+        });
+    }
+
     #[skuld::test]
     fn covered_start_without_a_plugin_does_not_permit_any_resolver() {
         rt().block_on(async {
@@ -3278,11 +3325,14 @@ mod self_test {
 
     // Without a `dead_permit` marker, a retry whose corrected permit keeps
     // failing to engage would release-then-reengage-then-restore on EVERY
-    // retry: an infinite non-convergent cycle, each turn re-opening the
-    // release-to-reengage uncovered window for zero progress. This proves
-    // convergence: a THIRD attempt with an UNCHANGED config (still wanting
-    // the same permit the second attempt already proved unreachable) must
-    // NOT trigger another engage cycle at all.
+    // retry: a non-convergent cycle, each turn re-opening the
+    // release-to-reengage uncovered window for zero progress. Attempt 3
+    // proves the skip: an UNCHANGED config (still wanting the same permit
+    // attempt 2 already proved unreachable) must NOT trigger another engage
+    // cycle. Attempt 4 proves the skip is not permanent: `dead_permit` is
+    // cleared by the skip itself, so a later retry for the SAME value gets a
+    // fresh attempt — a transient engage failure must eventually heal, not
+    // wedge the repair for the rest of the session.
     #[skuld::test]
     fn covered_retry_after_a_dead_repair_does_not_oscillate() {
         rt().block_on(async {
@@ -3346,6 +3396,26 @@ mod self_test {
                 *st.last_cover_resolver_ip.lock().unwrap(),
                 None,
                 "the held cover still permits the restored OLD value, not the still-unreachable one"
+            );
+
+            // Attempt 4: STILL the same desired value, but now able to engage
+            // (the transient failure has passed). Skipping attempt 3 cleared
+            // `dead_permit`, so this retry gets a fresh attempt rather than
+            // staying wedged forever on a value that failed exactly once.
+            st.fail_cover_for_resolvers.lock().unwrap().clear();
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                3,
+                "a transient failure must not permanently wedge repair for this value — the retry \
+                 after a skip must try again"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some(answering_resolver),
+                "the repair finally lands once the value is reachable again"
             );
         });
     }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -3650,6 +3650,104 @@ mod self_test {
         });
     }
 
+    // A repair must not overwrite the held cover's ORIGINAL pin with the
+    // revalidated (possibly downgraded) snapshot from the repairing
+    // attempt — `revalidate` only ever downgrades `Answered` to
+    // `ResolverDeselected`, never the reverse, so storing the downgraded
+    // value back into `BlockedStart::pin` makes the loss PERMANENT: a later
+    // retry that restores the original resolver to `dns.servers` can never
+    // recover `Answered`, even though a same-host retry that never
+    // triggered a repair would have (it always revalidates the covers's
+    // ORIGINAL `pin`, untouched). Attempt 3 here reverts `dns.servers` to
+    // exactly what attempt 1 answered from — the "unpinned" warning must
+    // NOT fire, proving the original `Answered` provenance survived the
+    // attempt-2 repair.
+    #[skuld::test]
+    fn covered_retry_repair_preserves_the_original_pin_across_a_correction() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+            let writer = VecWriter::new();
+            let subscriber = tracing_subscriber::registry().with(
+                fmt::layer()
+                    .with_writer(writer.clone())
+                    .with_ansi(false)
+                    .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+            );
+            let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+            let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let closed = probe_l.local_addr().unwrap();
+            drop(probe_l);
+            let resolver_a: IpAddr = "1.0.0.1".parse().unwrap();
+            let resolver_b: IpAddr = "9.9.9.9".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: closed.ip(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.server_port = closed.port();
+            cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![resolver_a];
+
+            // Attempt 1: fresh resolve, A answers -> pin = Answered(A).
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver_a));
+
+            // Attempt 2: `dns.servers` -> [B]. A same-host retry never
+            // re-resolves, so B is never actually queried this session —
+            // ResolverDeselected is the CORRECT pin for attempt 2 itself.
+            // The corrected engage (permit Some(B)) succeeds; this is the
+            // bug's site: the new BlockedStart must still remember A was
+            // ONCE verified-answering, not just that B currently isn't.
+            cfg.dns.servers = vec![resolver_b];
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver_b));
+            let after_attempt_2 = writer.snapshot_string();
+            assert!(
+                after_attempt_2.contains("the cached DoH resolver is no longer configured"),
+                "attempt 2: B was never queried this session, so the unpinned warning is correct here; got:\n{after_attempt_2}"
+            );
+
+            // Attempt 3: `dns.servers` reverts to exactly [A] — the SAME
+            // resolver attempt 1 verified answering. Repair corrects the
+            // permit back to Some(A); the unpinned warning must NOT
+            // reappear, because `revalidate` is being applied to the
+            // ORIGINAL Answered(A), not to attempt 2's ResolverDeselected.
+            cfg.dns.servers = vec![resolver_a];
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver_a));
+            let after_attempt_3 = writer.snapshot_string();
+            assert_eq!(
+                after_attempt_3.matches("the cached DoH resolver is no longer configured").count(),
+                1,
+                "attempt 3 reverts to the ORIGINALLY-answered resolver; the unpinned warning must not \
+                 fire again (only attempt 2's occurrence should be present) — got:\n{after_attempt_3}"
+            );
+        });
+    }
+
     // An operator's own `ech-doh` (not Hole's) winning is a stall risk the
     // cover can never fix by permitting it — the residual-stall diagnostic
     // must still name it, distinctly from the "nothing pinned" case.
@@ -3698,12 +3796,12 @@ mod self_test {
             });
     }
 
-    // Positive proof the old literal-IP-server residual is GONE: `ech_doh_url`
-    // constructs a real address from the configured resolvers even for
-    // `PinSource::NoQueryNeeded`, and the cover now permits exactly that
-    // address (`covered_start_with_a_literal_server_ip_still_permits_the_constructed_resolver`),
-    // so the "genuinely can't permit anything" residual warning must NOT fire
-    // here anymore.
+    // `ech_doh_url` constructs a real address from the configured resolvers
+    // even for `PinSource::NoQueryNeeded`, and the cover permits exactly
+    // that address
+    // (`covered_start_with_a_literal_server_ip_still_permits_the_constructed_resolver`),
+    // so the "genuinely can't permit anything" residual warning must not
+    // fire for a literal-IP server.
     #[skuld::test]
     fn covered_start_no_residual_warning_for_a_literal_server_ip() {
         use crate::test_support::log_capture::VecWriter;

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -3323,18 +3323,14 @@ mod self_test {
             });
     }
 
-    // Without a `dead_permit` marker, a retry whose corrected permit keeps
-    // failing to engage would release-then-reengage-then-restore on EVERY
-    // retry: a non-convergent cycle, each turn re-opening the
-    // release-to-reengage uncovered window for zero progress. Attempt 3
-    // proves the skip: an UNCHANGED config (still wanting the same permit
-    // attempt 2 already proved unreachable) must NOT trigger another engage
-    // cycle. Attempt 4 proves the skip is not permanent: `dead_permit` is
-    // cleared by the skip itself, so a later retry for the SAME value gets a
-    // fresh attempt — a transient engage failure must eventually heal, not
-    // wedge the repair for the rest of the session.
+    // A retry whose desired permit is UNCHANGED from one a previous repair
+    // already proved unreachable is not skipped: there is no principled way
+    // to tell a transient engage failure (e.g. momentary WFP/pf contention)
+    // from a lasting one without trying again, so every matching drift
+    // re-attempts the correction. Attempt 3 proves the retry happens (not
+    // skipped); attempt 4 proves it lands once the transient failure clears.
     #[skuld::test]
-    fn covered_retry_after_a_dead_repair_does_not_oscillate() {
+    fn covered_retry_repeats_the_correction_every_time_a_permit_stays_unreachable() {
         rt().block_on(async {
             let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             let closed = probe_l.local_addr().unwrap();
@@ -3364,8 +3360,7 @@ mod self_test {
             assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
 
             // Attempt 2: plugin added, wants Some(answering_resolver), that
-            // engage keeps failing — restore succeeds, dead_permit records
-            // the unreachable value.
+            // engage keeps failing — restore succeeds.
             st.fail_cover_for_resolvers
                 .lock()
                 .unwrap()
@@ -3381,16 +3376,17 @@ mod self_test {
                 "attempt 2: one failed corrected attempt (uncounted) + one successful restore"
             );
 
-            // Attempt 3: identical config — wants the SAME Some(answering_resolver)
-            // the previous attempt already proved unreachable. Must NOT
-            // re-attempt the repair: no release, no engage calls at all.
+            // Attempt 3: identical config — still wants the SAME
+            // Some(answering_resolver) the previous attempt already proved
+            // unreachable. Must re-attempt the correction (fails again,
+            // uncounted) and restore again (counted) — not skip.
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
                 .unwrap_err();
             assert_eq!(
                 st.cover_engage_calls.load(Ordering::SeqCst),
-                2,
-                "a repeat of the same known-unreachable permit must not re-attempt the repair"
+                3,
+                "a repeat of the same still-unreachable permit must re-attempt the repair, not skip it"
             );
             assert_eq!(
                 *st.last_cover_resolver_ip.lock().unwrap(),
@@ -3399,18 +3395,15 @@ mod self_test {
             );
 
             // Attempt 4: STILL the same desired value, but now able to engage
-            // (the transient failure has passed). Skipping attempt 3 cleared
-            // `dead_permit`, so this retry gets a fresh attempt rather than
-            // staying wedged forever on a value that failed exactly once.
+            // (the transient failure has passed) — the repair lands.
             st.fail_cover_for_resolvers.lock().unwrap().clear();
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
                 .unwrap_err();
             assert_eq!(
                 st.cover_engage_calls.load(Ordering::SeqCst),
-                3,
-                "a transient failure must not permanently wedge repair for this value — the retry \
-                 after a skip must try again"
+                4,
+                "a transient failure must not permanently wedge repair for this value"
             );
             assert_eq!(
                 *st.last_cover_resolver_ip.lock().unwrap(),
@@ -3570,20 +3563,16 @@ mod self_test {
             });
     }
 
-    // `dead_permit` bounds oscillation on a REPEAT of the same known-dead
-    // value (`covered_retry_after_a_dead_repair_does_not_oscillate`) — it
-    // must not wedge the repair mechanism itself. A retry whose desired
-    // permit changes AGAIN, to a genuinely THIRD value (neither the dead one
-    // nor the currently-held one), must still repair normally. Reachable
-    // because `ech_doh_url`'s unpinned fallback re-derives from THIS
-    // attempt's `dns.servers` every time, even once a pin has gone
+    // A repair that already failed once for a given desired permit (B) must
+    // still repair normally when a LATER retry wants a different value (C):
+    // nothing about a prior failed correction lingers onto an unrelated one.
+    // Reachable because `ech_doh_url`'s unpinned fallback re-derives from
+    // THIS attempt's `dns.servers` every time, even once a pin has gone
     // `ResolverDeselected` for good (`revalidate` never un-deselects it) —
     // editing `dns.servers` between retries changes the fallback address
-    // with no fresh DoH query. A `dead_permit.is_some()`-only regression
-    // (dropping the value comparison) would fail this test by staying wedged
-    // here too.
+    // with no fresh DoH query.
     #[skuld::test]
-    fn covered_retry_after_a_dead_repair_resumes_for_a_different_new_resolver() {
+    fn covered_retry_repair_resumes_normally_for_a_different_new_resolver() {
         rt().block_on(async {
             let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             let closed = probe_l.local_addr().unwrap();
@@ -3618,7 +3607,7 @@ mod self_test {
 
             // Attempt 2: `dns.servers` -> [B]; A is deselected, the fallback
             // picks B. B's engage is configured to fail; the restore falls
-            // back to A. `dead_permit` now remembers B as unreachable.
+            // back to A.
             st.fail_cover_for_resolvers.lock().unwrap().insert(Some(resolver_b));
             cfg.dns.servers = vec![resolver_b];
             pm.start_cancellable(&cfg, true, CancellationToken::new())
@@ -3635,8 +3624,8 @@ mod self_test {
                 "attempt 2: restored to A"
             );
 
-            // Attempt 3: `dns.servers` -> [C] — a genuinely NEW value, neither
-            // the dead B nor the currently-held A. Must resume the repair.
+            // Attempt 3: `dns.servers` -> [C] — a different value from either
+            // A or B. Must repair normally.
             cfg.dns.servers = vec![resolver_c];
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
@@ -3644,7 +3633,7 @@ mod self_test {
             assert_eq!(
                 st.cover_engage_calls.load(Ordering::SeqCst),
                 3,
-                "a different new desired permit must resume the repair, not stay wedged on the old dead value"
+                "a different new desired permit must repair normally"
             );
             assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver_c));
         });

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -2985,11 +2985,9 @@ mod self_test {
     }
 
     // A retry that NARROWS to nothing needed (e.g. the plugin was removed)
-    // must STILL release-then-reengage to correct the permit: the resolver
-    // permit carries no App-ID/process scoping on either platform, so
-    // leaving the OLD (wider) permit live is a real widening of the kill
-    // switch for the rest of the blocked state, not a harmless superset —
-    // any process on the host, not just the plugin chain, could use it.
+    // must STILL release-then-reengage — see `repair_fallback`'s doc in
+    // proxy_manager.rs for why a wider-than-needed permit is a real
+    // widening, not a harmless superset.
     #[skuld::test]
     fn covered_retry_narrowing_to_no_permit_re_engages_to_correct_it() {
         rt().block_on(async {

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -2985,12 +2985,13 @@ mod self_test {
     }
 
     // A retry that NARROWS to nothing needed (e.g. the plugin was removed)
-    // must NOT release-then-reengage: doing so would open the full-egress
-    // window for a correction with no benefit (the old, wider permit is
-    // already a superset of what's now required). The held cover stays
-    // exactly as-is.
+    // must STILL release-then-reengage to correct the permit: the resolver
+    // permit carries no App-ID/process scoping on either platform, so
+    // leaving the OLD (wider) permit live is a real widening of the kill
+    // switch for the rest of the blocked state, not a harmless superset —
+    // any process on the host, not just the plugin chain, could use it.
     #[skuld::test]
-    fn covered_retry_narrowing_to_no_permit_does_not_re_engage() {
+    fn covered_retry_narrowing_to_no_permit_re_engages_to_correct_it() {
         rt().block_on(async {
             let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
             let querier = Arc::new(CountingQuerier {
@@ -3022,13 +3023,13 @@ mod self_test {
                 .unwrap_err();
             assert_eq!(
                 st.cover_engage_calls.load(Ordering::SeqCst),
-                1,
-                "narrowing to no permit must not release-then-reengage the cover"
+                2,
+                "narrowing to no permit must release-then-reengage to correct the cover"
             );
             assert_eq!(
                 *st.last_cover_resolver_ip.lock().unwrap(),
-                Some(answering_resolver),
-                "the OLD (wider) permit stays in place — a harmless superset, not a gap"
+                None,
+                "the corrected (narrower) permit replaces the old, wider one"
             );
         });
     }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -183,6 +183,15 @@ struct MockRoutingState {
     /// Last `server_ip` passed to `install_failclosed_cover`, so a test can assert
     /// the cover permits exactly the resolved server IP.
     last_cover_server_ip: std::sync::Mutex<Option<IpAddr>>,
+    /// Last `resolver_ip` passed to `install_failclosed_cover`, so a test can
+    /// assert the cover permits exactly the ONE pinned resolver (or none).
+    last_cover_resolver_ip: std::sync::Mutex<Option<IpAddr>>,
+    /// When `Some(x)`, `install_failclosed_cover` fails ONLY when its
+    /// `resolver_ip` argument equals `x`, succeeding for every other value —
+    /// lets a test simulate "the corrected permit fails to engage, but the
+    /// previous one still would" for the stale-permit repair's compensating
+    /// restore. `fail_cover` (always-fail) is unaffected and takes priority.
+    fail_cover_for_resolver: std::sync::Mutex<Option<Option<IpAddr>>>,
 }
 
 impl Default for MockRoutingState {
@@ -201,6 +210,8 @@ impl Default for MockRoutingState {
             teardown_order: std::sync::Mutex::new(Vec::new()),
             last_install_server_ip: std::sync::Mutex::new(None),
             last_cover_server_ip: std::sync::Mutex::new(None),
+            last_cover_resolver_ip: std::sync::Mutex::new(None),
+            fail_cover_for_resolver: std::sync::Mutex::new(None),
         }
     }
 }
@@ -300,11 +311,19 @@ impl Routing for MockRouting {
 
     type Cover = MockCover;
 
-    fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<MockCover, RoutingError> {
+    fn install_failclosed_cover(
+        &self,
+        server_ip: IpAddr,
+        resolver_ip: Option<IpAddr>,
+    ) -> Result<MockCover, RoutingError> {
         if self.state.fail_cover.load(Ordering::SeqCst) {
             return Err(RoutingError::RouteSetup("mock cover failure".into()));
         }
+        if *self.state.fail_cover_for_resolver.lock().unwrap() == Some(resolver_ip) {
+            return Err(RoutingError::RouteSetup("mock cover failure for this resolver".into()));
+        }
         *self.state.last_cover_server_ip.lock().unwrap() = Some(server_ip);
+        *self.state.last_cover_resolver_ip.lock().unwrap() = resolver_ip;
         self.state.cover_engage_calls.fetch_add(1, Ordering::SeqCst);
         Ok(MockCover {
             state: Arc::clone(&self.state),
@@ -967,13 +986,39 @@ fn mock_cover_engage_disengage_never_spawns() {
     let routing = MockRouting::new(dir.path().to_path_buf());
     let st = routing.state();
     for _ in 0..10 {
-        let cover = routing.install_failclosed_cover("1.2.3.4".parse().unwrap()).unwrap();
+        let cover = routing
+            .install_failclosed_cover("1.2.3.4".parse().unwrap(), None)
+            .unwrap();
         drop(cover);
     }
 
     assert_eq!(routing::ROUTING_SUBPROCESS_SPAWN_COUNT.load(Ordering::SeqCst), 0);
     assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 10);
     assert_eq!(st.cover_disengage_calls.load(Ordering::SeqCst), 10);
+}
+
+#[skuld::test(serial)]
+fn mock_install_failclosed_cover_records_the_resolver_argument() {
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let st = routing.state();
+    let resolver: IpAddr = "9.9.9.9".parse().unwrap();
+
+    let cover = routing
+        .install_failclosed_cover("1.2.3.4".parse().unwrap(), Some(resolver))
+        .unwrap();
+    assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver));
+    drop(cover);
+
+    let cover = routing
+        .install_failclosed_cover("1.2.3.4".parse().unwrap(), None)
+        .unwrap();
+    assert_eq!(
+        *st.last_cover_resolver_ip.lock().unwrap(),
+        None,
+        "a None resolver_ip must be recorded as None, not left stale from the prior call"
+    );
+    drop(cover);
 }
 
 // Standing lockdown guard lifecycle (#527) ============================================================================
@@ -2642,6 +2687,889 @@ mod self_test {
         }
     }
 
+    /// A DoH stub that answers ONLY for one specific resolver address and fails
+    /// every other. `CountingQuerier` ignores which resolver it was asked and
+    /// answers unconditionally, so it cannot distinguish "the resolver that
+    /// answered" from "the first resolver configured" — this one can, by putting
+    /// the answering address somewhere OTHER than `dns.servers[0]`.
+    struct SelectiveQuerier {
+        answering: IpAddr,
+        host: String,
+        ip: IpAddr,
+    }
+
+    #[async_trait::async_trait]
+    impl DohQuerier for SelectiveQuerier {
+        async fn query(&self, server: IpAddr, wire: &[u8]) -> Result<Vec<u8>, UpstreamCause> {
+            if server != self.answering {
+                return Err(UpstreamCause::Unreachable);
+            }
+            crate::dns::forwarder::answered_or_servfail(wire, || {
+                use hickory_proto::op::{Message, MessageType, OpCode, Query};
+                use hickory_proto::rr::rdata::A;
+                use hickory_proto::rr::{Name, RData, Record, RecordType};
+                let q = Message::from_vec(wire).ok()?;
+                if q.queries.first()?.query_type() != RecordType::A {
+                    return None; // force the resolver onto the A path (IPv4-preferred).
+                }
+                let IpAddr::V4(v4) = self.ip else { return None };
+                let n = Name::from_ascii(format!("{}.", self.host)).ok()?;
+                let mut reply = Message::new(0, MessageType::Response, OpCode::Query);
+                reply.add_query(Query::query(n.clone(), RecordType::A));
+                reply.add_answer(Record::from_rdata(n, 60, RData::A(A(v4))));
+                reply.to_vec().ok()
+            })
+        }
+    }
+
+    #[skuld::test]
+    fn covered_start_cover_permits_the_pinned_ech_resolver() {
+        rt().block_on(async {
+            // The cover must permit the resolver that ANSWERED the DoH bootstrap —
+            // proven by putting a resolver that never answers FIRST in
+            // `dns.servers` and the one that DOES answer second. `SelectiveQuerier`
+            // fails every server except `answering_resolver`, so a wrong
+            // implementation that permits `dns.servers[0]` (or "the first
+            // configured resolver") fails this assertion.
+            let resolved: IpAddr = "203.0.113.9".parse().unwrap();
+            let failing_resolver: IpAddr = "8.8.8.8".parse().unwrap();
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(SelectiveQuerier {
+                answering: answering_resolver,
+                host: "proxy.example".into(),
+                ip: resolved,
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.plugin = Some("ex-ray".into());
+            // Forces the forwarder self-test gate, which MockProxy cannot satisfy —
+            // deterministic regardless of whether a real `ex-ray` happens to be on
+            // PATH on this host (resolve_plugin_path_inner falls back to a bare-name
+            // PATH lookup when no sibling binary exists).
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![failing_resolver, answering_resolver];
+            let _ = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some(answering_resolver),
+                "the cover permits the resolver that ANSWERED, not the first one configured"
+            );
+        });
+    }
+
+    #[skuld::test]
+    fn covered_start_without_a_plugin_does_not_permit_any_resolver() {
+        rt().block_on(async {
+            // No plugin means no later ECH lookup at all — permitting a resolver
+            // here would widen the cover for no reason. Uses a HOSTNAME server
+            // with a querier that DOES answer (`pin` = `Answered`), so the ONLY
+            // reason the permit stays `None` is the plugin gate itself — a
+            // literal-IP fixture would already yield `NoQueryNeeded` regardless of
+            // that gate and could not isolate it.
+            let resolved: IpAddr = "203.0.113.9".parse().unwrap();
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: resolved,
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            assert!(cfg.server.plugin.is_none(), "sanity: this scenario requires no plugin");
+            cfg.dns.servers = vec![answering_resolver];
+            // Outcome (Ok/Err) is irrelevant here: `install_failclosed_cover` is
+            // called BEFORE `start_inner` runs, so the assertions below hold
+            // either way — no need to force a failure.
+            let _ = pm.start_cancellable(&cfg, true, CancellationToken::new()).await;
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                1,
+                "sanity: the cover must actually have engaged, or `None` below proves nothing"
+            );
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), None);
+        });
+    }
+
+    #[skuld::test]
+    fn covered_start_with_a_literal_server_ip_still_permits_the_constructed_resolver() {
+        rt().block_on(async {
+            // A literal-IP server needs no bootstrap query at all
+            // (`PinSource::NoQueryNeeded` short-circuits before dialing
+            // anything), but `ech_doh_url` still constructs a real,
+            // IP-literal `ech-doh` URL from the configured `dns.servers`
+            // (IPv4-preferred) — Hole authored that address, so
+            // config-authorship trust alone is judged sufficient to permit
+            // it (`a_literal_server_entry_falls_back_without_a_pin` proves
+            // the URL itself) — see `EchDoh::resolver`'s doc.
+            let permitted_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            let mut cfg = test_config();
+            cfg.server.server = "203.0.113.9".into();
+            cfg.server.plugin = Some("ex-ray".into());
+            // Forces the forwarder self-test gate — deterministic regardless of
+            // whether `ex-ray` happens to be resolvable via PATH on this host.
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![permitted_resolver];
+            let _ = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(permitted_resolver));
+        });
+    }
+
+    #[skuld::test]
+    fn covered_start_with_insecure_bootstrap_fallback_still_permits_the_constructed_resolver() {
+        rt().block_on(async {
+            // Every configured resolver failed and the OS resolver supplied the
+            // server address (`allow_insecure_bootstrap`, `PinSource::SecureBootstrapFailed`),
+            // but `ech_doh_url` still constructs the `ech-doh` URL from
+            // `dns.servers` the same way as the literal-IP case above — same
+            // reasoning, same permit.
+            let permitted_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(Arc::new(DeadQuerier));
+            let mut cfg = test_config();
+            // Resolvable on every CI host without network.
+            cfg.server.server = "localhost".into();
+            cfg.server.plugin = Some("ex-ray".into());
+            // Forces the forwarder self-test gate — deterministic regardless of
+            // whether `ex-ray` happens to be resolvable via PATH on this host.
+            cfg.dns.enabled = true;
+            cfg.dns.allow_insecure_bootstrap = true;
+            cfg.dns.servers = vec![permitted_resolver];
+            let _ = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(permitted_resolver));
+        });
+    }
+
+    #[skuld::test]
+    fn covered_retry_does_not_re_engage_or_change_the_resolver_permit() {
+        rt().block_on(async {
+            // A same-server retry reuses the cached pin without a
+            // fresh DoH query, so the cover — engaged once, at the first attempt —
+            // must keep permitting the SAME resolver: never re-engaged, never
+            // widened, never narrowed.
+            let resolved: IpAddr = "203.0.113.9".parse().unwrap();
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: resolved,
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.plugin = Some("ex-ray".into());
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![answering_resolver];
+
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(answering_resolver));
+
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                1,
+                "the retry reuses the held cover — no second engage"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some(answering_resolver),
+                "the recorded resolver permit is still the first attempt's — never re-derived on retry"
+            );
+        });
+    }
+
+    // A retry that NARROWS to nothing needed (e.g. the plugin was removed)
+    // must NOT release-then-reengage: doing so would open the full-egress
+    // window for a correction with no benefit (the old, wider permit is
+    // already a superset of what's now required). The held cover stays
+    // exactly as-is.
+    #[skuld::test]
+    fn covered_retry_narrowing_to_no_permit_does_not_re_engage() {
+        rt().block_on(async {
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: "203.0.113.9".parse().unwrap(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.plugin = Some("ex-ray".into()); // attempt 1: plugin present
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![answering_resolver];
+
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(answering_resolver));
+
+            cfg.server.plugin = None; // attempt 2: plugin removed, nothing to permit now
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                1,
+                "narrowing to no permit must not release-then-reengage the cover"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some(answering_resolver),
+                "the OLD (wider) permit stays in place — a harmless superset, not a gap"
+            );
+        });
+    }
+
+    #[skuld::test]
+    fn covered_retry_after_adding_a_plugin_repairs_the_stale_permit() {
+        rt().block_on(async {
+            // Attempt 1 has NO plugin, so the cover engages with
+            // `resolver_permit: None`. The user then adds a plugin (same host)
+            // and retries. Merely DETECTING the drift and warning would leave
+            // the held cover permitting `None` forever while `ech_doh` now
+            // targets a real address — a permanent stall. The fix instead
+            // REPAIRS it: releases the stale-permit cover and re-engages fresh
+            // with the corrected permit, so the retry can actually succeed
+            // instead of merely being diagnosed as broken.
+            //
+            // `dns.enabled = true` on attempt 1 is REQUIRED: with a plugin-less
+            // start and the default `dns.enabled = false` (`test_config()`'s own
+            // choice, to dodge the forwarder self-test gate), attempt 1
+            // SUCCEEDS outright (no gate to fail it) — same shape as
+            // `covered_start_success_releases_cover` — which releases the cover
+            // on success and leaves nothing held for attempt 2 to find. Setting
+            // `dns.enabled = true` routes attempt 1 through the forwarder
+            // self-test gate instead, which `MockProxy` cannot satisfy (it binds
+            // no real listener), so attempt 1 deterministically fails and RETAINS
+            // the cover — the precondition this whole test depends on. The
+            // resolved server address is a bound-then-dropped LOOPBACK port
+            // (closed, immediate ECONNREFUSED) rather than a routable address —
+            // matches `covered_gate_setup`'s own pattern — so the failure is
+            // fast and deterministic, not a network-timeout gamble.
+            let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let closed = probe_l.local_addr().unwrap();
+            drop(probe_l);
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: closed.ip(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.server_port = closed.port();
+            cfg.server.plugin = None; // attempt 1: no plugin
+            cfg.dns.enabled = true; // forces attempt 1 to fail via the self-test gate (see comment above)
+            cfg.dns.servers = vec![answering_resolver];
+
+            let err1 = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert!(
+                !matches!(err1, ProxyError::Cancelled),
+                "sanity: attempt 1 must fail via the self-test gate, not cancel, got {err1:?}"
+            );
+            assert!(
+                pm.blocked_until_connected(),
+                "sanity: attempt 1's failure must retain the cover"
+            );
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                None,
+                "attempt 1 has no plugin, so nothing is permitted"
+            );
+            assert_eq!(pm.last_ech_doh(), None, "attempt 1 has no plugin, so no ech-doh either");
+
+            cfg.server.plugin = Some("ex-ray".into()); // attempt 2: plugin added
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "the stale-permit cover is released and a FRESH cover is engaged — the repair, not just a diagnosis"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some(answering_resolver),
+                "the fresh engage permits exactly what THIS attempt's ech-doh now needs"
+            );
+            assert_eq!(
+                pm.last_ech_doh(),
+                Some("https://1.0.0.1/dns-query"),
+                "and the cover now matches it — no more stall for this retry"
+            );
+        });
+    }
+
+    #[skuld::test]
+    fn covered_retry_repair_restores_the_previous_permit_when_the_corrected_engage_fails() {
+        rt().block_on(async {
+            // Same drift as `covered_retry_after_adding_a_plugin_repairs_the_stale_permit`
+            // (attempt 1: no plugin, permit `None`; attempt 2: plugin added, permit
+            // should become `Some(answering_resolver)`), but the corrected engage
+            // itself FAILS — simulated by `fail_cover_for_resolver`, which fails
+            // `install_failclosed_cover` ONLY for `Some(answering_resolver)`. The
+            // repair must not let this failure leave the host uncovered: it falls
+            // back to re-engaging the OLD permit (`None`), so the host stays
+            // covered by SOMETHING rather than by nothing.
+            let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let closed = probe_l.local_addr().unwrap();
+            drop(probe_l);
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: closed.ip(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.server_port = closed.port();
+            cfg.server.plugin = None; // attempt 1: no plugin
+            cfg.dns.enabled = true; // forces attempt 1 to fail via the self-test gate
+            cfg.dns.servers = vec![answering_resolver];
+
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), None);
+
+            // Only the CORRECTED permit fails to engage — the previous one (`None`)
+            // still would, if retried.
+            *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+
+            cfg.server.plugin = Some("ex-ray".into()); // attempt 2: plugin added
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+
+            assert!(
+                pm.blocked_until_connected(),
+                "the compensating restore must leave the host covered, not open"
+            );
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "one failed corrected-permit attempt (uncounted) plus one successful restore of the old permit"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                None,
+                "the restored cover permits the OLD value, not the corrected one that failed to engage"
+            );
+        });
+    }
+
+    #[skuld::test]
+    fn covered_retry_repair_restore_warning_fires_when_the_corrected_engage_fails() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        // Same scenario as the structural test above; asserts the repair's OWN
+        // "restored the PREVIOUS permit" log line fires, so the operator sees WHY
+        // the cover is narrower than the current attempt's config would derive.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                let closed = probe_l.local_addr().unwrap();
+                drop(probe_l);
+                let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+                let querier = Arc::new(CountingQuerier {
+                    host: "proxy.example".into(),
+                    ip: closed.ip(),
+                    queries: AtomicU32::new(0),
+                });
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let st = routing.state();
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                pm.set_bootstrap_querier_for_test(querier);
+                let mut cfg = test_config();
+                cfg.server.server = "proxy.example".into();
+                cfg.server.server_port = closed.port();
+                cfg.server.plugin = None;
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec![answering_resolver];
+
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+                *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+                cfg.server.plugin = Some("ex-ray".into());
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    output.contains("restored the PREVIOUS permit instead of leaving the host open"),
+                    "expected the compensating-restore warning; got:\n{output}"
+                );
+            });
+    }
+
+    // The LIVE cover (restored to the OLD permit) now permits something
+    // OTHER than what this attempt's ech_doh needs — the residual-stall
+    // warning must fire here too, not just the restore warning above: an
+    // operator debugging a stalled connect needs the "may stall" line, not
+    // only "a permit correction failed".
+    #[skuld::test]
+    fn covered_retry_repair_restore_also_fires_the_residual_stall_warning() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                let closed = probe_l.local_addr().unwrap();
+                drop(probe_l);
+                let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+                let querier = Arc::new(CountingQuerier {
+                    host: "proxy.example".into(),
+                    ip: closed.ip(),
+                    queries: AtomicU32::new(0),
+                });
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let st = routing.state();
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                pm.set_bootstrap_querier_for_test(querier);
+                let mut cfg = test_config();
+                cfg.server.server = "proxy.example".into();
+                cfg.server.server_port = closed.port();
+                cfg.server.plugin = None;
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec![answering_resolver];
+
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+                *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+                cfg.server.plugin = Some("ex-ray".into());
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    output.contains("the fail-closed cover does not permit"),
+                    "expected the residual-stall warning on the restore-mismatch path; got:\n{output}"
+                );
+            });
+    }
+
+    // Without a `dead_permit` marker, a retry whose corrected permit keeps
+    // failing to engage would release-then-reengage-then-restore on EVERY
+    // retry: an infinite non-convergent cycle, each turn re-opening the
+    // release-to-reengage uncovered window for zero progress. This proves
+    // convergence: a THIRD attempt with an UNCHANGED config (still wanting
+    // the same permit the second attempt already proved unreachable) must
+    // NOT trigger another engage cycle at all.
+    #[skuld::test]
+    fn covered_retry_after_a_dead_repair_does_not_oscillate() {
+        rt().block_on(async {
+            let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let closed = probe_l.local_addr().unwrap();
+            drop(probe_l);
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: closed.ip(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.server_port = closed.port();
+            cfg.server.plugin = None;
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![answering_resolver];
+
+            // Attempt 1: engages with permit None.
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+
+            // Attempt 2: plugin added, wants Some(answering_resolver), that
+            // engage keeps failing — restore succeeds, dead_permit records
+            // the unreachable value.
+            *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+            cfg.server.plugin = Some("ex-ray".into());
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "attempt 2: one failed corrected attempt (uncounted) + one successful restore"
+            );
+
+            // Attempt 3: identical config — wants the SAME Some(answering_resolver)
+            // the previous attempt already proved unreachable. Must NOT
+            // re-attempt the repair: no release, no engage calls at all.
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "a repeat of the same known-unreachable permit must not re-attempt the repair"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                None,
+                "the held cover still permits the restored OLD value, not the still-unreachable one"
+            );
+        });
+    }
+
+    // An operator's own `ech-doh` (not Hole's) winning is a stall risk the
+    // cover can never fix by permitting it — the residual-stall diagnostic
+    // must still name it, distinctly from the "nothing pinned" case.
+    #[skuld::test]
+    fn covered_start_residual_warning_fires_for_an_operator_ech_doh_override() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                let mut cfg = test_config();
+                // Literal-IP server: Hole's own candidate is unpinned
+                // (NoQueryNeeded), so it never outranks an IP-literal operator
+                // value — the operator's own ech-doh wins.
+                cfg.server.server = "203.0.113.9".into();
+                cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some("ech-doh=https://8.8.8.8/dns-query".into());
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
+                let _ = pm
+                    .start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    output.contains("plugin's own ech-doh"),
+                    "expected the operator-override residual warning; got:\n{output}"
+                );
+            });
+    }
+
+    // Positive proof the old literal-IP-server residual is GONE: `ech_doh_url`
+    // constructs a real address from the configured resolvers even for
+    // `PinSource::NoQueryNeeded`, and the cover now permits exactly that
+    // address (`covered_start_with_a_literal_server_ip_still_permits_the_constructed_resolver`),
+    // so the "genuinely can't permit anything" residual warning must NOT fire
+    // here anymore.
+    #[skuld::test]
+    fn covered_start_no_residual_warning_for_a_literal_server_ip() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                let mut cfg = test_config();
+                cfg.server.server = "203.0.113.9".into();
+                cfg.server.plugin = Some("ex-ray".into());
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
+                let _ = pm
+                    .start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    !output.contains("the fail-closed cover does not permit"),
+                    "a literal-IP server's constructed resolver is now permitted; got:\n{output}"
+                );
+            });
+    }
+
+    // `effective_ech_doh` (queried once from the permit-derivation path) must
+    // NOT re-trigger `inject_plugin_directives`'s ECH-posture logging — that
+    // function runs a SECOND time, for real, when `start_plugin_chain`
+    // actually spawns the plugin. A regression that made `effective_ech_doh`
+    // call `inject_plugin_directives` (instead of the side-effect-free
+    // `classify_ech_doh`) would double-emit every such warning on every
+    // start. Literal-IP server: `ech_doh` derives an UNPINNED URL, which
+    // emits the "resolver has not been exercised" line exactly once per
+    // `inject_plugin_directives` call.
+    #[skuld::test]
+    fn effective_ech_doh_query_does_not_double_emit_the_injection_warning() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                let mut cfg = test_config();
+                cfg.server.server = "203.0.113.9".into();
+                cfg.server.plugin = Some("ex-ray".into());
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
+                let _ = pm
+                    .start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                let occurrences = output.matches("the ECH lookup uses a resolver that has not been exercised").count();
+                assert_eq!(
+                    occurrences, 1,
+                    "expected exactly one injection-warning emission (from the real spawn's \
+                     inject_plugin_directives call, not from effective_ech_doh's permit query too); got {occurrences}:\n{output}"
+                );
+            });
+    }
+
+    #[skuld::test]
+    fn covered_start_no_residual_warning_for_a_pinned_resolver() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        // Negative direction: a healthy, fully-permitted covered start must NOT
+        // emit the residual-gap warning — proves it isn't spuriously noisy.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let resolved: IpAddr = "203.0.113.9".parse().unwrap();
+                let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+                let querier = Arc::new(CountingQuerier {
+                    host: "proxy.example".into(),
+                    ip: resolved,
+                    queries: AtomicU32::new(0),
+                });
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                pm.set_bootstrap_querier_for_test(querier);
+                let mut cfg = test_config();
+                cfg.server.server = "proxy.example".into();
+                cfg.server.plugin = Some("ex-ray".into());
+                // Forces the forwarder self-test gate — deterministic regardless of
+                // whether `ex-ray` happens to be resolvable via PATH on this host.
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec![answering_resolver];
+                let _ = pm
+                    .start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    !output.contains("the fail-closed cover does not permit"),
+                    "a fully-pinned covered start must not emit the residual-gap warning; got:\n{output}"
+                );
+            });
+    }
+
+    #[skuld::test]
+    fn covered_retry_repair_warning_fires_when_the_permit_is_stale() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        // Same scenario as covered_retry_after_adding_a_plugin_repairs_the_stale_permit
+        // (plugin added between attempts), asserting the repair's OWN log line
+        // fires — that test only proves the structural effect (re-engage,
+        // corrected permit), not that the operator sees why.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                let closed = probe_l.local_addr().unwrap();
+                drop(probe_l);
+                let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+                let querier = Arc::new(CountingQuerier {
+                    host: "proxy.example".into(),
+                    ip: closed.ip(),
+                    queries: AtomicU32::new(0),
+                });
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                pm.set_bootstrap_querier_for_test(querier);
+                let mut cfg = test_config();
+                cfg.server.server = "proxy.example".into();
+                cfg.server.server_port = closed.port();
+                cfg.server.plugin = None;
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec![answering_resolver];
+
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+                cfg.server.plugin = Some("ex-ray".into());
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    output.contains("releasing it so a fresh engage can correct it"),
+                    "expected the repair warning on the stale-permit retry; got:\n{output}"
+                );
+            });
+    }
+
     #[skuld::test]
     fn covered_retry_reuses_the_resolved_ip_without_re_querying_doh() {
         rt().block_on(async {
@@ -2683,24 +3611,35 @@ mod self_test {
     }
 
     /// A covered start that fails, leaving the cover (and its cached pin) held.
-    /// Returns the manager so a retry can be driven against an edited config.
+    /// Returns the manager (plus the mock routing state, so a test can assert
+    /// on re-engage counts and permits) so a retry can be driven against an
+    /// edited config.
     async fn covered_start_holding_the_cover(
         dir: tempfile::TempDir,
-    ) -> (ProxyManager<MockProxy, MockRouting>, ProxyConfig, tempfile::TempDir) {
+    ) -> (
+        ProxyManager<MockProxy, MockRouting>,
+        ProxyConfig,
+        tempfile::TempDir,
+        Arc<MockRoutingState>,
+    ) {
         let querier = Arc::new(CountingQuerier {
             host: "proxy.example".into(),
             ip: "203.0.113.9".parse().unwrap(),
             queries: AtomicU32::new(0),
         });
         let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
         let (mut pm, dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
         pm.set_bootstrap_querier_for_test(querier);
         let mut cfg = test_config();
         cfg.server.server = "proxy.example".into();
+        // Forces the forwarder self-test gate, which MockProxy cannot satisfy —
+        // deterministic regardless of whether `ex-ray` happens to be resolvable
+        // via PATH on this host, so the cover reliably stays held.
         cfg.dns.enabled = true;
-        // Only a plugin start derives an `ech-doh`. This name resolves to no
-        // binary, so phase 1 fails immediately and the cover stays held.
-        cfg.server.plugin = Some("hole-694-absent-plugin".into());
+        // A real ECH-family name: `ech_doh_will_reach_ex_ray`'s gate needs one
+        // for `ech_resolver_permit` to ever be `Some`.
+        cfg.server.plugin = Some("ex-ray".into());
         // v6 first so the PIN and the IPv4-preferring fallback disagree — with a
         // single-entry list every assertion below would pass on a discarded pin.
         // `CountingQuerier` ignores which resolver it was asked, so the first
@@ -2711,13 +3650,13 @@ mod self_test {
             .await
             .unwrap_err();
         assert!(pm.blocked_until_connected(), "the failed covered start holds the cover");
-        (pm, cfg, dir)
+        (pm, cfg, dir, st)
     }
 
     #[skuld::test]
     fn a_covered_start_pins_the_ech_lookup_to_the_resolver_that_answered() {
         rt().block_on(async {
-            let (pm, _cfg, _dir) = covered_start_holding_the_cover(tempfile::tempdir().unwrap()).await;
+            let (pm, _cfg, _dir, _st) = covered_start_holding_the_cover(tempfile::tempdir().unwrap()).await;
             assert_eq!(pm.last_ech_doh(), Some("https://[2606:4700:4700::1111]/dns-query"));
         });
     }
@@ -2728,7 +3667,7 @@ mod self_test {
     #[skuld::test]
     fn a_covered_retry_keeps_the_pin_when_the_resolvers_are_unchanged() {
         rt().block_on(async {
-            let (mut pm, cfg, _dir) = covered_start_holding_the_cover(tempfile::tempdir().unwrap()).await;
+            let (mut pm, cfg, _dir, _st) = covered_start_holding_the_cover(tempfile::tempdir().unwrap()).await;
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
                 .unwrap_err();
@@ -2801,10 +3740,23 @@ mod self_test {
 
     // The cover is keyed by hostname alone, so a retry can arrive with an edited
     // resolver set — `revalidate` must catch that here, not only in isolation.
+    // Also proves the drift is REPAIRED, not merely diagnosed: the deselected
+    // IPv6 resolver's stale permit must be released and re-engaged to match
+    // the NEW fallback address `ech_doh_url` constructs from the retry's own
+    // `dns.servers` (`ResolverDeselected` is still permitted — see
+    // `EchDoh::resolver`'s doc — just no longer the OLD address) — the same
+    // repair path as `covered_retry_after_adding_a_plugin_repairs_the_stale_permit`,
+    // exercised here via a resolver SWAP rather than a plugin addition.
     #[skuld::test]
     fn a_covered_retry_drops_a_resolver_the_user_deselected() {
         rt().block_on(async {
-            let (mut pm, mut cfg, _dir) = covered_start_holding_the_cover(tempfile::tempdir().unwrap()).await;
+            let (mut pm, mut cfg, _dir, st) = covered_start_holding_the_cover(tempfile::tempdir().unwrap()).await;
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some("2606:4700:4700::1111".parse().unwrap()),
+                "sanity: the initial engage pinned the answering IPv6 resolver"
+            );
             cfg.dns.servers = vec!["8.8.8.8".parse().unwrap()];
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
@@ -2813,6 +3765,16 @@ mod self_test {
                 pm.last_ech_doh(),
                 Some("https://8.8.8.8/dns-query"),
                 "a deselected resolver is dropped and the retry's own config supplies the fallback"
+            );
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "the stale IPv6 permit is released and a fresh cover is re-engaged — the repair, not just a diagnosis"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some("8.8.8.8".parse().unwrap()),
+                "the fresh engage permits the NEW fallback address, not the deselected one"
             );
         });
     }

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -186,12 +186,14 @@ struct MockRoutingState {
     /// Last `resolver_ip` passed to `install_failclosed_cover`, so a test can
     /// assert the cover permits exactly the ONE pinned resolver (or none).
     last_cover_resolver_ip: std::sync::Mutex<Option<IpAddr>>,
-    /// When `Some(x)`, `install_failclosed_cover` fails ONLY when its
-    /// `resolver_ip` argument equals `x`, succeeding for every other value —
-    /// lets a test simulate "the corrected permit fails to engage, but the
-    /// previous one still would" for the stale-permit repair's compensating
-    /// restore. `fail_cover` (always-fail) is unaffected and takes priority.
-    fail_cover_for_resolver: std::sync::Mutex<Option<Option<IpAddr>>>,
+    /// `install_failclosed_cover` fails whenever its `resolver_ip` argument
+    /// is a MEMBER of this set, succeeding for every other value — lets a
+    /// test simulate "the corrected permit fails to engage, but the previous
+    /// one still would" (a singleton set) for the stale-permit repair's
+    /// compensating restore, or "both the corrected AND the restore fail"
+    /// (a set containing both values) for the double-failure fail-open path.
+    /// `fail_cover` (always-fail) is unaffected and takes priority.
+    fail_cover_for_resolvers: std::sync::Mutex<std::collections::HashSet<Option<IpAddr>>>,
 }
 
 impl Default for MockRoutingState {
@@ -211,7 +213,7 @@ impl Default for MockRoutingState {
             last_install_server_ip: std::sync::Mutex::new(None),
             last_cover_server_ip: std::sync::Mutex::new(None),
             last_cover_resolver_ip: std::sync::Mutex::new(None),
-            fail_cover_for_resolver: std::sync::Mutex::new(None),
+            fail_cover_for_resolvers: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 }
@@ -319,7 +321,13 @@ impl Routing for MockRouting {
         if self.state.fail_cover.load(Ordering::SeqCst) {
             return Err(RoutingError::RouteSetup("mock cover failure".into()));
         }
-        if *self.state.fail_cover_for_resolver.lock().unwrap() == Some(resolver_ip) {
+        if self
+            .state
+            .fail_cover_for_resolvers
+            .lock()
+            .unwrap()
+            .contains(&resolver_ip)
+        {
             return Err(RoutingError::RouteSetup("mock cover failure for this resolver".into()));
         }
         *self.state.last_cover_server_ip.lock().unwrap() = Some(server_ip);
@@ -515,6 +523,16 @@ fn test_config() -> ProxyConfig {
         diagnostic_plugin_tap: false,
     }
 }
+
+/// `plugin_opts` for a plugin config that actually reaches ex-ray's ECH
+/// switch (`crates/ex-ray/config.go:209-223,290-294,334`): TLS enabled via
+/// the bare `tls` flag, `ech` left at its `auto` default. Bare `plugin =
+/// Some("ex-ray")` with no options — TCP-only, no `tls`, no `mode=quic` —
+/// never calls `buildTLSConfig` at all, so ECH is never touched regardless
+/// of `ech-doh`; tests that need a real cover permit or an ECH-posture
+/// warning must opt in via this constant, matching a real postern config
+/// (`a_postern_config_composes_into_holes_pinned_url` in plugin.rs).
+const ECH_CAPABLE_OPTS: &str = "tls";
 
 // Tests ===============================================================================================================
 
@@ -2747,6 +2765,7 @@ mod self_test {
             let mut cfg = test_config();
             cfg.server.server = "proxy.example".into();
             cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             // Forces the forwarder self-test gate, which MockProxy cannot satisfy —
             // deterministic regardless of whether a real `ex-ray` happens to be on
             // PATH on this host (resolve_plugin_path_inner falls back to a bare-name
@@ -2823,6 +2842,7 @@ mod self_test {
             let mut cfg = test_config();
             cfg.server.server = "203.0.113.9".into();
             cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             // Forces the forwarder self-test gate — deterministic regardless of
             // whether `ex-ray` happens to be resolvable via PATH on this host.
             cfg.dns.enabled = true;
@@ -2854,6 +2874,7 @@ mod self_test {
             // Resolvable on every CI host without network.
             cfg.server.server = "localhost".into();
             cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             // Forces the forwarder self-test gate — deterministic regardless of
             // whether `ex-ray` happens to be resolvable via PATH on this host.
             cfg.dns.enabled = true;
@@ -2890,6 +2911,7 @@ mod self_test {
             let mut cfg = test_config();
             cfg.server.server = "proxy.example".into();
             cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             cfg.dns.enabled = true;
             cfg.dns.servers = vec![answering_resolver];
 
@@ -2937,6 +2959,7 @@ mod self_test {
             let mut cfg = test_config();
             cfg.server.server = "proxy.example".into();
             cfg.server.plugin = Some("ex-ray".into()); // attempt 1: plugin present
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             cfg.dns.enabled = true;
             cfg.dns.servers = vec![answering_resolver];
 
@@ -3031,6 +3054,7 @@ mod self_test {
             assert_eq!(pm.last_ech_doh(), None, "attempt 1 has no plugin, so no ech-doh either");
 
             cfg.server.plugin = Some("ex-ray".into()); // attempt 2: plugin added
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
                 .unwrap_err();
@@ -3058,7 +3082,7 @@ mod self_test {
             // Same drift as `covered_retry_after_adding_a_plugin_repairs_the_stale_permit`
             // (attempt 1: no plugin, permit `None`; attempt 2: plugin added, permit
             // should become `Some(answering_resolver)`), but the corrected engage
-            // itself FAILS — simulated by `fail_cover_for_resolver`, which fails
+            // itself FAILS — simulated by `fail_cover_for_resolvers`, which fails
             // `install_failclosed_cover` ONLY for `Some(answering_resolver)`. The
             // repair must not let this failure leave the host uncovered: it falls
             // back to re-engaging the OLD permit (`None`), so the host stays
@@ -3092,9 +3116,13 @@ mod self_test {
 
             // Only the CORRECTED permit fails to engage — the previous one (`None`)
             // still would, if retried.
-            *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+            st.fail_cover_for_resolvers
+                .lock()
+                .unwrap()
+                .insert(Some(answering_resolver));
 
             cfg.server.plugin = Some("ex-ray".into()); // attempt 2: plugin added
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
                 .unwrap_err();
@@ -3163,8 +3191,12 @@ mod self_test {
                 pm.start_cancellable(&cfg, true, CancellationToken::new())
                     .await
                     .unwrap_err();
-                *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+                st.fail_cover_for_resolvers
+                    .lock()
+                    .unwrap()
+                    .insert(Some(answering_resolver));
                 cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
                 pm.start_cancellable(&cfg, true, CancellationToken::new())
                     .await
                     .unwrap_err();
@@ -3226,8 +3258,12 @@ mod self_test {
                 pm.start_cancellable(&cfg, true, CancellationToken::new())
                     .await
                     .unwrap_err();
-                *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+                st.fail_cover_for_resolvers
+                    .lock()
+                    .unwrap()
+                    .insert(Some(answering_resolver));
                 cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
                 pm.start_cancellable(&cfg, true, CancellationToken::new())
                     .await
                     .unwrap_err();
@@ -3280,8 +3316,12 @@ mod self_test {
             // Attempt 2: plugin added, wants Some(answering_resolver), that
             // engage keeps failing — restore succeeds, dead_permit records
             // the unreachable value.
-            *st.fail_cover_for_resolver.lock().unwrap() = Some(Some(answering_resolver));
+            st.fail_cover_for_resolvers
+                .lock()
+                .unwrap()
+                .insert(Some(answering_resolver));
             cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
             pm.start_cancellable(&cfg, true, CancellationToken::new())
                 .await
                 .unwrap_err();
@@ -3307,6 +3347,236 @@ mod self_test {
                 None,
                 "the held cover still permits the restored OLD value, not the still-unreachable one"
             );
+        });
+    }
+
+    // The one security-relevant fail-open branch of this state machine:
+    // BOTH the corrected engage AND the compensating restore fail. The host
+    // must end up genuinely uncovered (not a stale belief that it's still
+    // covered), a real reason must be surfaced (not silently cleared as if
+    // the attempt succeeded), and the next retry must start fresh rather
+    // than staying wedged.
+    #[skuld::test]
+    fn covered_retry_repair_both_engages_failing_leaves_the_host_uncovered() {
+        rt().block_on(async {
+            let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let closed = probe_l.local_addr().unwrap();
+            drop(probe_l);
+            let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: closed.ip(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.server_port = closed.port();
+            cfg.server.plugin = None;
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![answering_resolver];
+
+            // Attempt 1: engages with permit None.
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert!(pm.blocked_until_connected());
+
+            // Attempt 2: plugin added, wants Some(answering_resolver) — BOTH
+            // that corrected value AND the OLD value (None) it would restore
+            // to are configured to fail engaging.
+            st.fail_cover_for_resolvers.lock().unwrap().insert(Some(answering_resolver));
+            st.fail_cover_for_resolvers.lock().unwrap().insert(None);
+            cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                1,
+                "both engage attempts failed — neither counts as a successful engage"
+            );
+            assert!(
+                !pm.blocked_until_connected(),
+                "both engages failing must leave the host genuinely UNCOVERED, not a stale belief that it's still covered"
+            );
+            // NOT the specific cover-engage error text: the covered start still
+            // proceeds into `start_inner` on a fail-open engage failure (by
+            // design — see the surrounding comment), and its own outcome is
+            // what `last_error` ultimately reflects (or clears to `None`, on
+            // success) once the whole attempt concludes. The cover-engage
+            // failure itself is surfaced separately, in the WARN log (see
+            // `covered_retry_repair_both_engages_failing_warns_host_not_blocked`)
+            // — checked here only for "a real reason was surfaced", not
+            // silently cleared as if the attempt had succeeded.
+            assert!(
+                pm.last_error().is_some(),
+                "an uncovered host must surface SOME reason, not silently read as a clean success — got: {:?}",
+                pm.last_error()
+            );
+
+            // Attempt 3: unchanged config. With the cover gone, this is an
+            // ordinary fresh engage attempt (not a repair) — no wedge.
+            st.fail_cover_for_resolvers.lock().unwrap().clear();
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "the next retry must re-engage fresh from scratch, not stay wedged uncovered"
+            );
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(answering_resolver));
+        });
+    }
+
+    #[skuld::test]
+    fn covered_retry_repair_both_engages_failing_warns_host_not_blocked() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                let closed = probe_l.local_addr().unwrap();
+                drop(probe_l);
+                let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+                let querier = Arc::new(CountingQuerier {
+                    host: "proxy.example".into(),
+                    ip: closed.ip(),
+                    queries: AtomicU32::new(0),
+                });
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let st = routing.state();
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                pm.set_bootstrap_querier_for_test(querier);
+                let mut cfg = test_config();
+                cfg.server.server = "proxy.example".into();
+                cfg.server.server_port = closed.port();
+                cfg.server.plugin = None;
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec![answering_resolver];
+
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+                st.fail_cover_for_resolvers
+                    .lock()
+                    .unwrap()
+                    .insert(Some(answering_resolver));
+                st.fail_cover_for_resolvers.lock().unwrap().insert(None);
+                cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+
+                let output = writer.snapshot_string();
+                assert!(
+                    output.contains("failed to engage BOTH the corrected and the previous fail-closed"),
+                    "expected the both-failed warning; got:\n{output}"
+                );
+            });
+    }
+
+    // `dead_permit` bounds oscillation on a REPEAT of the same known-dead
+    // value (`covered_retry_after_a_dead_repair_does_not_oscillate`) — it
+    // must not wedge the repair mechanism itself. A retry whose desired
+    // permit changes AGAIN, to a genuinely THIRD value (neither the dead one
+    // nor the currently-held one), must still repair normally. Reachable
+    // because `ech_doh_url`'s unpinned fallback re-derives from THIS
+    // attempt's `dns.servers` every time, even once a pin has gone
+    // `ResolverDeselected` for good (`revalidate` never un-deselects it) —
+    // editing `dns.servers` between retries changes the fallback address
+    // with no fresh DoH query. A `dead_permit.is_some()`-only regression
+    // (dropping the value comparison) would fail this test by staying wedged
+    // here too.
+    #[skuld::test]
+    fn covered_retry_after_a_dead_repair_resumes_for_a_different_new_resolver() {
+        rt().block_on(async {
+            let probe_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let closed = probe_l.local_addr().unwrap();
+            drop(probe_l);
+            let resolver_a: IpAddr = "1.0.0.1".parse().unwrap();
+            let resolver_b: IpAddr = "9.9.9.9".parse().unwrap();
+            let resolver_c: IpAddr = "8.8.8.8".parse().unwrap();
+            let querier = Arc::new(CountingQuerier {
+                host: "proxy.example".into(),
+                ip: closed.ip(),
+                queries: AtomicU32::new(0),
+            });
+            let dir = tempfile::tempdir().unwrap();
+            let routing = MockRouting::new(dir.path().to_path_buf());
+            let st = routing.state();
+            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+            pm.set_bootstrap_querier_for_test(querier);
+            let mut cfg = test_config();
+            cfg.server.server = "proxy.example".into();
+            cfg.server.server_port = closed.port();
+            cfg.server.plugin = Some("ex-ray".into());
+            cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
+            cfg.dns.enabled = true;
+            cfg.dns.servers = vec![resolver_a];
+
+            // Attempt 1: pin = Answered(A), engages Some(A).
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver_a));
+
+            // Attempt 2: `dns.servers` -> [B]; A is deselected, the fallback
+            // picks B. B's engage is configured to fail; the restore falls
+            // back to A. `dead_permit` now remembers B as unreachable.
+            st.fail_cover_for_resolvers.lock().unwrap().insert(Some(resolver_b));
+            cfg.dns.servers = vec![resolver_b];
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                2,
+                "attempt 2: restore re-engage"
+            );
+            assert_eq!(
+                *st.last_cover_resolver_ip.lock().unwrap(),
+                Some(resolver_a),
+                "attempt 2: restored to A"
+            );
+
+            // Attempt 3: `dns.servers` -> [C] — a genuinely NEW value, neither
+            // the dead B nor the currently-held A. Must resume the repair.
+            cfg.dns.servers = vec![resolver_c];
+            pm.start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                st.cover_engage_calls.load(Ordering::SeqCst),
+                3,
+                "a different new desired permit must resume the repair, not stay wedged on the old dead value"
+            );
+            assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(resolver_c));
         });
     }
 
@@ -3342,7 +3612,7 @@ mod self_test {
                 // value — the operator's own ech-doh wins.
                 cfg.server.server = "203.0.113.9".into();
                 cfg.server.plugin = Some("ex-ray".into());
-                cfg.server.plugin_opts = Some("ech-doh=https://8.8.8.8/dns-query".into());
+                cfg.server.plugin_opts = Some(format!("{ECH_CAPABLE_OPTS};ech-doh=https://8.8.8.8/dns-query"));
                 cfg.dns.enabled = true;
                 cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
                 let _ = pm
@@ -3390,6 +3660,7 @@ mod self_test {
                 let mut cfg = test_config();
                 cfg.server.server = "203.0.113.9".into();
                 cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
                 cfg.dns.enabled = true;
                 cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
                 let _ = pm
@@ -3440,6 +3711,7 @@ mod self_test {
                 let mut cfg = test_config();
                 cfg.server.server = "203.0.113.9".into();
                 cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
                 cfg.dns.enabled = true;
                 cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
                 let _ = pm
@@ -3493,6 +3765,7 @@ mod self_test {
                 let mut cfg = test_config();
                 cfg.server.server = "proxy.example".into();
                 cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
                 // Forces the forwarder self-test gate — deterministic regardless of
                 // whether `ex-ray` happens to be resolvable via PATH on this host.
                 cfg.dns.enabled = true;
@@ -3558,6 +3831,7 @@ mod self_test {
                     .await
                     .unwrap_err();
                 cfg.server.plugin = Some("ex-ray".into());
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
                 pm.start_cancellable(&cfg, true, CancellationToken::new())
                     .await
                     .unwrap_err();
@@ -3640,6 +3914,7 @@ mod self_test {
         // A real ECH-family name: `ech_doh_will_reach_ex_ray`'s gate needs one
         // for `ech_resolver_permit` to ever be `Some`.
         cfg.server.plugin = Some("ex-ray".into());
+        cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
         // v6 first so the PIN and the IPv4-preferring fallback disagree — with a
         // single-entry list every assertion below would pass on a discarded pin.
         // `CountingQuerier` ignores which resolver it was asked, so the first

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -3034,6 +3034,83 @@ mod self_test {
         });
     }
 
+    // When a NARROWING repair's corrected engage (to `None`) itself fails,
+    // the restore falls back to the OLD (wider) permit — the residual is a
+    // kill-switch WIDENING (a live permit for a resolver nothing needs), not
+    // an ECH-fetch stall (no fetch is even attempted when the desired
+    // permit is `None`). Both the restore-success warning and the
+    // structural residual check must describe THIS direction accurately,
+    // not reuse the "may stall" wording written for the opposite
+    // (widening-repair) failure.
+    #[skuld::test]
+    fn covered_retry_narrowing_repair_failure_warns_about_the_stale_wide_permit_not_a_stall() {
+        use crate::test_support::log_capture::VecWriter;
+        use tracing_subscriber::fmt;
+        use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let writer = VecWriter::new();
+                let subscriber = tracing_subscriber::registry().with(
+                    fmt::layer()
+                        .with_writer(writer.clone())
+                        .with_ansi(false)
+                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+                );
+                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+
+                let answering_resolver: IpAddr = "1.0.0.1".parse().unwrap();
+                let querier = Arc::new(CountingQuerier {
+                    host: "proxy.example".into(),
+                    ip: "203.0.113.9".parse().unwrap(),
+                    queries: AtomicU32::new(0),
+                });
+                let dir = tempfile::tempdir().unwrap();
+                let routing = MockRouting::new(dir.path().to_path_buf());
+                let st = routing.state();
+                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+                pm.set_bootstrap_querier_for_test(querier);
+                let mut cfg = test_config();
+                cfg.server.server = "proxy.example".into();
+                cfg.server.plugin = Some("ex-ray".into()); // attempt 1: plugin present
+                cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
+                cfg.dns.enabled = true;
+                cfg.dns.servers = vec![answering_resolver];
+
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+                assert_eq!(*st.last_cover_resolver_ip.lock().unwrap(), Some(answering_resolver));
+
+                // Attempt 2: plugin removed (wants None), but engaging None
+                // is configured to fail — the restore falls back to
+                // Some(answering_resolver).
+                st.fail_cover_for_resolvers.lock().unwrap().insert(None);
+                cfg.server.plugin = None;
+                pm.start_cancellable(&cfg, true, CancellationToken::new())
+                    .await
+                    .unwrap_err();
+                assert_eq!(
+                    *st.last_cover_resolver_ip.lock().unwrap(),
+                    Some(answering_resolver),
+                    "the restore falls back to the OLD, wider permit"
+                );
+
+                let output = writer.snapshot_string();
+                assert!(
+                    output.contains("no longer needs"),
+                    "expected the over-permit residual wording, not the ECH-stall one; got:\n{output}"
+                );
+                assert!(
+                    !output.contains("ECH fetch may still stall") && !output.contains("does not permit"),
+                    "must not claim an ECH-fetch stall risk when no fetch is attempted; got:\n{output}"
+                );
+            });
+    }
+
     #[skuld::test]
     fn covered_retry_after_adding_a_plugin_repairs_the_stale_permit() {
         rt().block_on(async {

--- a/crates/garter/src/sip003.rs
+++ b/crates/garter/src/sip003.rs
@@ -104,9 +104,18 @@ pub struct OptionSegment<'a> {
     /// decide which key a plugin will ACT on; a check that used the narrower
     /// rule could be evaded by escaping one character of the name.
     pub key: String,
-    /// The value, decoded by the same rule. Empty for a bare key — a caller
-    /// that must distinguish `tls` from `tls=` reads `raw`.
+    /// The value, decoded by the same rule. Empty for BOTH a bare key
+    /// (`tls`) and an explicit empty one (`tls=`) — the two are otherwise
+    /// indistinguishable here. A caller that must tell them apart reads
+    /// [`has_value`](Self::has_value): ex-ray's own options parser does, and
+    /// maps a bare key to `"1"` rather than `""` (`crates/ex-ray/args.go`'s
+    /// `parsePluginOptions`), so a caller replicating ex-ray's read of a flag
+    /// must too.
     pub value: String,
+    /// Whether the segment had an unescaped `=` at all — `true` for `tls=`,
+    /// `false` for bare `tls`. See [`value`](Self::value)'s doc for why this
+    /// exists.
+    pub has_value: bool,
 }
 
 /// Split an options string into segments on unescaped `;`, decoding each key for
@@ -138,7 +147,12 @@ pub fn split_plugin_options(opts: &str) -> Result<Vec<OptionSegment<'_>>, Malfor
                 Some(eq) => unescape_any(&raw[eq + 1..])?,
                 None => String::new(),
             };
-            Ok(OptionSegment { raw, key, value })
+            Ok(OptionSegment {
+                raw,
+                key,
+                value,
+                has_value: eq.is_some(),
+            })
         })
         .collect()
 }

--- a/crates/garter/src/sip003_tests.rs
+++ b/crates/garter/src/sip003_tests.rs
@@ -177,6 +177,23 @@ fn split_of_the_empty_string_is_empty() {
     assert!(segs("").is_empty());
 }
 
+// `value` alone cannot tell `tls` (bare) from `tls=` (explicit empty) apart —
+// both decode to `""`. `has_value` is the field that can, which matters
+// because ex-ray's own parser does not treat them alike either: bare `tls`
+// reads as `"1"` there, `tls=` as `""` (`crates/ex-ray/args.go`).
+#[skuld::test]
+fn has_value_distinguishes_a_bare_key_from_an_explicit_empty_one() {
+    let s = segs("tls;host=");
+    assert_eq!(
+        (s[0].key.as_str(), s[0].value.as_str(), s[0].has_value),
+        ("tls", "", false)
+    );
+    assert_eq!(
+        (s[1].key.as_str(), s[1].value.as_str(), s[1].has_value),
+        ("host", "", true)
+    );
+}
+
 // A trailing unpaired backslash would escape the `;` a caller appends after it,
 // swallowing the appended directive. ex-ray already rejects such a string, so it
 // is rejected here rather than silently made parseable-but-wrong.

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -431,6 +431,7 @@ pub trait Routing: Send + Sync {
     /// "Transient cutover cover" section for the full retry-repair state
     /// machine and the disclosed residuals this trait's caller does not
     /// close.
+    ///
     /// The cover survives a process crash (Windows: persistent WFP filters keyed by fixed
     /// GUID; macOS: pf enable token persisted to `bridge-failclosed.json`) and is
     /// swept by [`recover_routes`] on the next start. Does NOT permit the TUN

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -405,16 +405,38 @@ pub trait Routing: Send + Sync {
     /// can disarm it (persist-without-disengage).
     type Cover: Send + CoverGuard;
 
-    /// Engage a fail-closed cover: block all egress except loopback and
-    /// `server_ip`. Returns an RAII guard whose Drop disengages it. The cover
-    /// survives a process crash (Windows: persistent WFP filters keyed by fixed
+    /// Engage a fail-closed cover: block all egress except loopback, `server_ip`,
+    /// and (when `Some`) `resolver_ip` — the address the caller's own
+    /// `ech-doh` URL names (`hole_bridge::dns::ech::EchDoh::resolver`), scoped
+    /// to TCP/443 (see `crate::dns::ech::DOH_PORT`). The caller authors that
+    /// URL from its own configured resolver set, so config-authorship trust
+    /// alone is judged sufficient — permitting it is never a claim that this
+    /// exact attempt personally dialed the address (see `EchDoh`'s doc: that
+    /// additionally holds for some `PinSource` variants but not all). `None`
+    /// covers every case where nothing should be permitted: no plugin
+    /// configured, a non-ECH-capable plugin, malformed plugin options, or an
+    /// OPERATOR's own `ech-doh` winning instead of Hole's (an address Hole
+    /// did not author, so the config-authorship trust does not extend to it
+    /// — a disclosed residual, see CONTRIBUTING.md). `None` is never
+    /// permitted as "no restriction" — a retry whose resolver changed since
+    /// the cover engaged compares this attempt's freshly-derived
+    /// `resolver_ip` against the held cover's, and on drift releases and
+    /// re-engages with the corrected value (falling back to the OLD value if
+    /// the corrected engage itself fails, so a permit correction can never
+    /// be how a covered start loses its cover outright — see
+    /// `BlockedStart`'s doc). See CONTRIBUTING.md's "Transient cutover
+    /// cover" section for the full retry-repair state machine and the
+    /// disclosed residuals this trait's caller does not close.
+    /// The cover survives a process crash (Windows: persistent WFP filters keyed by fixed
     /// GUID; macOS: pf enable token persisted to `bridge-failclosed.json`) and is
     /// swept by [`recover_routes`] on the next start. Does NOT permit the TUN
     /// interface — the block-until-connected connect gate holds it only until the
-    /// tunnel comes up. It permits the resolved `server_ip`, not the DoH resolvers:
-    /// a stay-blocked retry reuses the already-resolved IP rather than re-resolving
-    /// under the cover.
-    fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<Self::Cover, RoutingError>;
+    /// tunnel comes up.
+    fn install_failclosed_cover(
+        &self,
+        server_ip: IpAddr,
+        resolver_ip: Option<IpAddr>,
+    ) -> Result<Self::Cover, RoutingError>;
 
     /// Engage the STANDING lockdown cover for this connected session: permit
     /// loopback + the `tun_name` interface + the onward server connection (and,
@@ -501,8 +523,12 @@ impl Routing for SystemRouting {
         get_default_gateway_info().map_err(|e| RoutingError::Gateway(e.to_string()))
     }
 
-    fn install_failclosed_cover(&self, server_ip: IpAddr) -> Result<Self::Cover, RoutingError> {
-        failclosed::engage(server_ip, &self.state_dir, self.owner)
+    fn install_failclosed_cover(
+        &self,
+        server_ip: IpAddr,
+        resolver_ip: Option<IpAddr>,
+    ) -> Result<Self::Cover, RoutingError> {
+        failclosed::engage(server_ip, resolver_ip, &self.state_dir, self.owner)
     }
 
     fn install_lockdown(

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -421,12 +421,16 @@ pub trait Routing: Send + Sync {
     /// permitted as "no restriction" — a retry whose resolver changed since
     /// the cover engaged compares this attempt's freshly-derived
     /// `resolver_ip` against the held cover's, and on drift releases and
-    /// re-engages with the corrected value (falling back to the OLD value if
-    /// the corrected engage itself fails, so a permit correction can never
-    /// be how a covered start loses its cover outright — see
-    /// `BlockedStart`'s doc). See CONTRIBUTING.md's "Transient cutover
-    /// cover" section for the full retry-repair state machine and the
-    /// disclosed residuals this trait's caller does not close.
+    /// re-engages with the corrected value, falling back to restoring the OLD
+    /// value if the corrected engage itself fails: a permit correction takes
+    /// BOTH engages failing to lose the cover, not one — narrower than the
+    /// ordinary single-engage failure case, not impossible. On that double
+    /// failure the attempt proceeds uncovered (same as any other engage
+    /// failure) and the next retry re-engages fresh, since the held cover is
+    /// now `None` — see `BlockedStart`'s doc. See CONTRIBUTING.md's
+    /// "Transient cutover cover" section for the full retry-repair state
+    /// machine and the disclosed residuals this trait's caller does not
+    /// close.
     /// The cover survives a process crash (Windows: persistent WFP filters keyed by fixed
     /// GUID; macOS: pf enable token persisted to `bridge-failclosed.json`) and is
     /// swept by [`recover_routes`] on the next start. Does NOT permit the TUN

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -418,18 +418,10 @@ pub trait Routing: Send + Sync {
     /// OPERATOR's own `ech-doh` winning instead of Hole's (an address Hole
     /// did not author, so the config-authorship trust does not extend to it
     /// — a disclosed residual, see CONTRIBUTING.md). `None` is never
-    /// permitted as "no restriction" — a retry whose resolver changed since
-    /// the cover engaged compares this attempt's freshly-derived
-    /// `resolver_ip` against the held cover's, and on drift releases and
-    /// re-engages with the corrected value, falling back to restoring the OLD
-    /// value if the corrected engage itself fails: a permit correction takes
-    /// BOTH engages failing to lose the cover, not one — narrower than the
-    /// ordinary single-engage failure case, not impossible. On that double
-    /// failure the attempt proceeds uncovered (same as any other engage
-    /// failure) and the next retry re-engages fresh, since the held cover is
-    /// now `None` — see `BlockedStart`'s doc. See CONTRIBUTING.md's
-    /// "Transient cutover cover" section for the full retry-repair state
-    /// machine and the disclosed residuals this trait's caller does not
+    /// permitted as "no restriction". See CONTRIBUTING.md's "Transient
+    /// cutover cover" section for the full retry-repair state machine (a
+    /// resolver drift releases and re-engages the cover with the corrected
+    /// value) and the disclosed residuals this trait's caller does not
     /// close.
     ///
     /// The cover survives a process crash (Windows: persistent WFP filters keyed by fixed

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -1,12 +1,28 @@
-//! Fail-closed network cover: block all egress except loopback and the SS server
-//! IP, as an RAII guard held across a connect attempt so a failed connect leaves
-//! the host blocked, not leaked. OS specifics live in the platform submodules;
-//! this facade is `#[cfg]`-free for callers.
+//! Fail-closed network cover: block all egress except loopback, the SS server
+//! IP, and (when a plugin needs it) the ECH-config DoH resolver, as an RAII
+//! guard held across a connect attempt so a failed connect leaves the host
+//! blocked, not leaked. OS specifics live in the platform submodules; this
+//! facade is `#[cfg]`-free for callers.
 
 use std::net::IpAddr;
 use std::path::Path;
 
 use crate::error::RoutingError;
+
+/// The one port the resolver permit ever needs: `doh_url_for_ip` in
+/// `hole_bridge::dns::ech` never constructs a URL with any other port
+/// (its bare `https://` scheme implies this one — see that crate's
+/// `DOH_PORT` and its executable pin,
+/// `doh_url_for_ip_ports_to_the_https_default`), so this is structurally the
+/// sole value the ECH-config fetch can dial. A separate declaration, not an
+/// import: this crate sits BELOW `hole-bridge` in the dependency graph and
+/// cannot import from it, so the reverse link is what's enforced instead —
+/// `pub` (not `pub(crate)`) so `hole-bridge` CAN import and pin it against
+/// its own `DOH_PORT` (see `crates/bridge/src/dns/ech_tests.rs`,
+/// `resolver_permit_port_matches_doh_port`). Shared by both platform
+/// modules here so the port is named in exactly one place on this side of
+/// the boundary too.
+pub const RESOLVER_PERMIT_PORT: u16 = 443;
 
 // macOS persists its pf enable token; Windows recovers WFP filters by fixed
 // GUID and needs no state.
@@ -53,12 +69,19 @@ impl crate::routing::CoverGuard for Cover {
     }
 }
 
-/// Engage the cover blocking all egress except loopback and `server_ip`.
+/// Engage the cover blocking all egress except loopback, `server_ip`, and
+/// (when `Some`) `resolver_ip` — see [`crate::routing::Routing::install_failclosed_cover`]
+/// for what a caller must already have demonstrated to pass `Some` here.
 /// `state_dir` is where macOS persists its enable token for crash recovery
 /// (unused on Windows). On failure the host is left uncovered.
-pub fn engage(server_ip: IpAddr, state_dir: &Path, owner: Option<(u32, u32)>) -> Result<Cover, RoutingError> {
+pub fn engage(
+    server_ip: IpAddr,
+    resolver_ip: Option<IpAddr>,
+    state_dir: &Path,
+    owner: Option<(u32, u32)>,
+) -> Result<Cover, RoutingError> {
     Ok(Cover {
-        _inner: platform::engage(server_ip, state_dir, owner)?,
+        _inner: platform::engage(server_ip, resolver_ip, state_dir, owner)?,
     })
 }
 

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -44,6 +44,15 @@ const TUN: skuld::Label;
 // block holds.
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const PERMITTED: &str = "1.1.1.1:443";
+// A third routable anycast host, standing in for the pinned DoH resolver.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const RESOLVER: &str = "9.9.9.9:443";
+// The SAME resolver host, but on its DNS-over-TLS port rather than 443 — Quad9
+// serves both. Proves the resolver permit is scoped to TCP/443, not the whole
+// IP: a permit that (wrongly) covered every port on RESOLVER would let this
+// through too.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const RESOLVER_OTHER_PORT: &str = "9.9.9.9:853";
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const NON_PERMITTED: &str = "8.8.8.8:443";
 
@@ -236,7 +245,7 @@ fn windows_failclosed_permits_server_blocks_other_egress() {
         bn.err().map(|e| e.kind()),
     );
 
-    let cover = engage(server_ip, dir.path(), None).expect("engage real WFP transient cover");
+    let cover = engage(server_ip, None, dir.path(), None).expect("engage real WFP transient cover");
 
     let (p, n) = (connect(PERMITTED), connect(NON_PERMITTED));
     assert!(
@@ -254,6 +263,79 @@ fn windows_failclosed_permits_server_blocks_other_egress() {
         connect(NON_PERMITTED).is_ok(),
         "disengage must restore egress: {NON_PERMITTED}={:?}",
         connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+/// Real-engage verification that the OPTIONAL resolver permit is
+/// real and selective: with `resolver_ip = Some`, both the server AND the
+/// resolver stay reachable while a THIRD, non-permitted host is still
+/// blocked — proving the widening is exactly one address, not a leak. Also
+/// proves the permit is scoped to TCP/443, not the whole resolver IP: the
+/// SAME resolver on a different port stays blocked.
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn windows_failclosed_permits_resolver_blocks_other_egress() {
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+    let resolver_ip: std::net::IpAddr = "9.9.9.9".parse().unwrap();
+
+    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
+
+    let (bp, br, bpo, bn) = (
+        connect(PERMITTED),
+        connect(RESOLVER),
+        connect(RESOLVER_OTHER_PORT),
+        connect(NON_PERMITTED),
+    );
+    assert!(
+        bp.is_ok() && br.is_ok() && bpo.is_ok() && bn.is_ok(),
+        "NETWORK/ENVIRONMENT problem (not the cover): baseline egress must reach all hosts; \
+         {PERMITTED}={:?} {RESOLVER}={:?} {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
+        bp.err().map(|e| e.kind()),
+        br.err().map(|e| e.kind()),
+        bpo.err().map(|e| e.kind()),
+        bn.err().map(|e| e.kind()),
+    );
+
+    let cover = engage(server_ip, Some(resolver_ip), dir.path(), None)
+        .expect("engage real WFP transient cover with a resolver permit");
+
+    let (p, r, po, n) = (
+        connect(PERMITTED),
+        connect(RESOLVER),
+        connect(RESOLVER_OTHER_PORT),
+        connect(NON_PERMITTED),
+    );
+    assert!(
+        p.is_ok(),
+        "server-IP permit must beat block-all: {PERMITTED}={:?}",
+        p.err().map(|e| e.kind())
+    );
+    assert!(
+        r.is_ok(),
+        "resolver-IP permit must beat block-all: {RESOLVER}={:?}",
+        r.err().map(|e| e.kind())
+    );
+    assert!(
+        po.is_err(),
+        "the resolver permit must be scoped to TCP/443, not the whole IP (leak!): \
+         {RESOLVER_OTHER_PORT} connected"
+    );
+    assert!(
+        n.is_err(),
+        "a third, non-permitted host must still be blocked (leak!): {NON_PERMITTED} connected"
+    );
+
+    drop(cover);
+    let (rn, rpo) = (connect(NON_PERMITTED), connect(RESOLVER_OTHER_PORT));
+    assert!(
+        rn.is_ok() && rpo.is_ok(),
+        "disengage must restore egress: {NON_PERMITTED}={:?} {RESOLVER_OTHER_PORT}={:?}",
+        rn.err().map(|e| e.kind()),
+        rpo.err().map(|e| e.kind()),
     );
 }
 
@@ -282,7 +364,7 @@ fn macos_failclosed_permits_server_blocks_other_egress() {
         bn.err().map(|e| e.kind()),
     );
 
-    let cover = engage(server_ip, dir.path(), None).expect("engage real pf transient cover");
+    let cover = engage(server_ip, None, dir.path(), None).expect("engage real pf transient cover");
 
     // (a) The live ruleset carries our block-all.
     let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
@@ -309,5 +391,83 @@ fn macos_failclosed_permits_server_blocks_other_egress() {
         connect(NON_PERMITTED).is_ok(),
         "disengage must restore egress: {NON_PERMITTED}={:?}",
         connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+/// macOS counterpart of `windows_failclosed_permits_resolver_blocks_other_egress`.
+/// Also proves the permit is scoped to TCP/443, not the whole resolver IP: the
+/// SAME resolver on a different port stays blocked.
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_failclosed_permits_resolver_blocks_other_egress() {
+    use std::net::TcpStream;
+    use std::process::Command;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap();
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+    let resolver_ip: std::net::IpAddr = "9.9.9.9".parse().unwrap();
+
+    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
+
+    let (bp, br, bpo, bn) = (
+        connect(PERMITTED),
+        connect(RESOLVER),
+        connect(RESOLVER_OTHER_PORT),
+        connect(NON_PERMITTED),
+    );
+    assert!(
+        bp.is_ok() && br.is_ok() && bpo.is_ok() && bn.is_ok(),
+        "NETWORK/ENVIRONMENT problem (not the cover): baseline egress must reach all hosts; \
+         {PERMITTED}={:?} {RESOLVER}={:?} {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
+        bp.err().map(|e| e.kind()),
+        br.err().map(|e| e.kind()),
+        bpo.err().map(|e| e.kind()),
+        bn.err().map(|e| e.kind()),
+    );
+
+    let cover = engage(server_ip, Some(resolver_ip), dir.path(), None)
+        .expect("engage real pf transient cover with a resolver permit");
+
+    let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
+    let rules = String::from_utf8_lossy(&sr.stdout);
+    assert!(
+        rules.contains("9.9.9.9"),
+        "live ruleset must carry the resolver permit:\n{rules}"
+    );
+
+    let (p, r, po, n) = (
+        connect(PERMITTED),
+        connect(RESOLVER),
+        connect(RESOLVER_OTHER_PORT),
+        connect(NON_PERMITTED),
+    );
+    assert!(
+        p.is_ok(),
+        "server-IP permit must beat block-all: {PERMITTED}={:?}",
+        p.err().map(|e| e.kind())
+    );
+    assert!(
+        r.is_ok(),
+        "resolver-IP permit must beat block-all: {RESOLVER}={:?}",
+        r.err().map(|e| e.kind())
+    );
+    assert!(
+        po.is_err(),
+        "the resolver permit must be scoped to TCP/443, not the whole IP (leak!): \
+         {RESOLVER_OTHER_PORT} connected"
+    );
+    assert!(
+        n.is_err(),
+        "a third, non-permitted host must still be blocked (leak!): {NON_PERMITTED} connected"
+    );
+
+    drop(cover);
+    let (rn, rpo) = (connect(NON_PERMITTED), connect(RESOLVER_OTHER_PORT));
+    assert!(
+        rn.is_ok() && rpo.is_ok(),
+        "disengage must restore egress: {NON_PERMITTED}={:?} {RESOLVER_OTHER_PORT}={:?}",
+        rn.err().map(|e| e.kind()),
+        rpo.err().map(|e| e.kind()),
     );
 }

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -1,9 +1,10 @@
 //! macOS fail-closed cover via pf (`pfctl`). Two layers share the `Cover` guard:
 //!
 //! - **Transient cover** (`engage`/`disengage`): enables pf (refcounted,
-//!   `pfctl -E`), flushes all state (`-Fa`), and loads a self-contained ruleset
-//!   blocking every outbound packet except loopback and the SS server IP.
-//!   Disengage restores the canonical `/etc/pf.conf` and drops the refcount.
+//!   `pfctl -E`), flushes all state (`-Fa`), and loads a self-contained
+//!   ruleset (see `build_pf_ruleset`) blocking everything but loopback, the
+//!   server, and the pinned resolver. Disengage restores the canonical
+//!   `/etc/pf.conf` and drops the refcount.
 //! - **Standing lockdown** (`engage_lockdown`/`lockdown_disengage`): loads a
 //!   self-contained MAIN ruleset (NO `-Fa`) that carries the host's translation
 //!   rules forward and blocks all egress except the TUN and server IP. Disengage
@@ -29,20 +30,31 @@ use crate::error::RoutingError;
 // `failclosed` module and `failclosed_state` is its sibling child.
 use super::failclosed_state as state;
 use super::lockdown_pf_state as lockdown_state;
+use super::RESOLVER_PERMIT_PORT;
 
 /// Build the self-contained pf ruleset (loaded via `pfctl -f -`).
 ///
 /// `set block-policy drop` silently drops blocked packets (no RST/ICMP).
 /// `block out all` is the fail-closed default; the `quick` pass rules for
-/// loopback and the server IP win without depending on pf's last-match rule. The
-/// `to {ip}` form carries a v6 address as written.
-pub fn build_pf_ruleset(server_ip: IpAddr) -> String {
+/// loopback, the server IP, and (when given) the resolver the caller's own
+/// `ech-doh` URL names win without depending on pf's last-match rule. The
+/// `to {ip}` form carries a v6 address as written. `resolver_ip` is `None`
+/// whenever nothing should be permitted — see
+/// `Routing::install_failclosed_cover`'s doc for the exact conditions. The
+/// resolver pass is scoped to `proto tcp port` [`RESOLVER_PERMIT_PORT`] (see
+/// that const's doc for why this is the only port this fetch can need) — NOT
+/// the server permit's unrestricted shape.
+pub fn build_pf_ruleset(server_ip: IpAddr, resolver_ip: Option<IpAddr>) -> String {
+    let resolver_pass = resolver_ip
+        .map(|ip| format!("pass out quick proto tcp from any to {ip} port {RESOLVER_PERMIT_PORT}\n"))
+        .unwrap_or_default();
     format!(
         "set block-policy drop\n\
          block out all\n\
          pass out quick on lo0 all\n\
          pass in quick on lo0 all\n\
-         pass out quick from any to {server_ip}\n"
+         pass out quick from any to {server_ip}\n\
+         {resolver_pass}"
     )
 }
 
@@ -181,7 +193,12 @@ pub struct Cover {
     kind: CoverKind,
 }
 
-pub fn engage(server_ip: IpAddr, state_dir: &Path, owner: Option<(u32, u32)>) -> Result<Cover, RoutingError> {
+pub fn engage(
+    server_ip: IpAddr,
+    resolver_ip: Option<IpAddr>,
+    state_dir: &Path,
+    owner: Option<(u32, u32)>,
+) -> Result<Cover, RoutingError> {
     // 1. Read current enabled-state (read-only).
     let info = pfctl(&["-s", "info"], None, PHASE_COVER)?;
     let was_enabled = parse_pf_enabled(&String::from_utf8_lossy(&info.stdout));
@@ -203,7 +220,7 @@ pub fn engage(server_ip: IpAddr, state_dir: &Path, owner: Option<(u32, u32)>) ->
     .map_err(|e| RoutingError::RouteSetup(format!("failed to persist failclosed-state: {e}")))?;
 
     // 4. Flush all + load our self-contained blocking ruleset from stdin.
-    let ruleset = build_pf_ruleset(server_ip);
+    let ruleset = build_pf_ruleset(server_ip, resolver_ip);
     let out = pfctl(&["-Fa", "-f", "-"], Some(ruleset.as_bytes()), PHASE_COVER)?;
     if !out.status.success() {
         // A *failed engage* is the sole place this module fails OPEN on its own

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -7,10 +7,16 @@ fn v4() -> IpAddr {
 fn v6() -> IpAddr {
     "2001:db8::1".parse().unwrap()
 }
+fn resolver() -> IpAddr {
+    "198.51.100.5".parse().unwrap()
+}
+fn resolver_v6() -> IpAddr {
+    "2001:db8::abcd".parse().unwrap()
+}
 
 #[skuld::test]
 fn ruleset_blocks_all_outbound() {
-    let r = build_pf_ruleset(v4());
+    let r = build_pf_ruleset(v4(), None);
     assert!(
         r.contains("block") && r.contains("out") && r.contains("all"),
         "ruleset must block all outbound:\n{r}"
@@ -19,13 +25,13 @@ fn ruleset_blocks_all_outbound() {
 
 #[skuld::test]
 fn ruleset_passes_loopback() {
-    let r = build_pf_ruleset(v4());
+    let r = build_pf_ruleset(v4(), None);
     assert!(r.contains("lo0"), "ruleset must pass loopback:\n{r}");
 }
 
 #[skuld::test]
 fn ruleset_passes_server_ip() {
-    let r = build_pf_ruleset(v4());
+    let r = build_pf_ruleset(v4(), None);
     assert!(r.contains("203.0.113.7"), "ruleset must pass server IP:\n{r}");
 }
 
@@ -33,7 +39,7 @@ fn ruleset_passes_server_ip() {
 fn ruleset_pass_rules_are_quick() {
     // `quick` makes the pass rules win over the earlier block-all without
     // relying on pf's last-match semantics.
-    let r = build_pf_ruleset(v4());
+    let r = build_pf_ruleset(v4(), None);
     for line in r.lines().filter(|l| l.trim_start().starts_with("pass")) {
         assert!(line.contains("quick"), "pass rule must be quick: {line}");
     }
@@ -41,8 +47,65 @@ fn ruleset_pass_rules_are_quick() {
 
 #[skuld::test]
 fn ruleset_handles_ipv6_server() {
-    let r = build_pf_ruleset(v6());
+    let r = build_pf_ruleset(v6(), None);
     assert!(r.contains("2001:db8::1"), "ipv6 server must appear:\n{r}");
+}
+
+// resolver permit =====================================================================================================
+
+#[skuld::test]
+fn ruleset_passes_resolver_ip_when_given() {
+    let r = build_pf_ruleset(v4(), Some(resolver()));
+    assert!(r.contains("198.51.100.5"), "ruleset must pass the resolver IP:\n{r}");
+}
+
+#[skuld::test]
+fn ruleset_omits_resolver_when_none() {
+    // Negative direction: no resolver means the only "pass ... to <addr>" line
+    // targets the server — proves the widening is opt-in.
+    let r = build_pf_ruleset(v4(), None);
+    let pass_to_lines: Vec<&str> = r
+        .lines()
+        .filter(|l| l.trim_start().starts_with("pass out quick") && l.contains(" to "))
+        .collect();
+    assert_eq!(pass_to_lines.len(), 1, "server only, no resolver pass rule:\n{r}");
+}
+
+#[skuld::test]
+fn ruleset_resolver_pass_rule_is_quick() {
+    let r = build_pf_ruleset(v4(), Some(resolver()));
+    for line in r.lines().filter(|l| l.contains("198.51.100.5")) {
+        assert!(line.contains("quick"), "resolver pass rule must be quick: {line}");
+    }
+}
+
+#[skuld::test]
+fn ruleset_handles_ipv6_resolver() {
+    let r = build_pf_ruleset(v4(), Some(resolver_v6()));
+    assert!(r.contains("2001:db8::abcd"), "ipv6 resolver must appear:\n{r}");
+}
+
+#[skuld::test]
+fn ruleset_resolver_pass_is_scoped_to_tcp_443_not_unrestricted() {
+    // NOT the server permit's unrestricted shape — see build_pf_ruleset's doc.
+    let r = build_pf_ruleset(v4(), Some(resolver()));
+    let resolver_line = r
+        .lines()
+        .find(|l| l.contains("198.51.100.5"))
+        .expect("resolver pass rule must exist");
+    let port_clause = format!("port {RESOLVER_PERMIT_PORT}");
+    assert!(
+        resolver_line.contains("proto tcp") && resolver_line.contains(&port_clause),
+        "resolver pass rule must be scoped to proto tcp {port_clause}, unlike the server permit: {resolver_line}"
+    );
+    let server_line = r
+        .lines()
+        .find(|l| l.contains(&v4().to_string()))
+        .expect("server pass rule must exist");
+    assert!(
+        !server_line.contains("port"),
+        "server permit stays unrestricted (unchanged by this plan): {server_line}"
+    );
 }
 
 #[skuld::test]

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -104,7 +104,7 @@ fn ruleset_resolver_pass_is_scoped_to_tcp_443_not_unrestricted() {
         .expect("server pass rule must exist");
     assert!(
         !server_line.contains("port"),
-        "server permit stays unrestricted (unchanged by this plan): {server_line}"
+        "server permit stays unrestricted: {server_line}"
     );
 }
 

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -495,6 +495,16 @@ fn wfp_check(code: u32, what: &str) -> Result<(), RoutingError> {
 
 /// As [`wfp_check`], but a duplicate-add (`FWP_E_ALREADY_EXISTS`) is also OK —
 /// re-engaging over an unswept cover is idempotent.
+///
+/// CROSS-VERSION CONTRACT, disclosed residual: this idempotency also means a
+/// repair (release the held cover, re-engage with a corrected server/resolver
+/// value — `ProxyManager`'s retry-repair path) can silently keep the OLD
+/// filter value live if the release's `FwpmFilterDeleteByKey0` (in
+/// `delete_all`, whose return codes are discarded) fails for that GUID: the
+/// re-add then hits `FWP_E_ALREADY_EXISTS` and reports success while the LIVE
+/// filter still carries the value the delete failed to remove. A stale
+/// PERMIT surviving, never a leaked block. Tracked separately:
+/// bindreams/hole#761.
 fn ok_or_exists(code: u32, what: &str) -> Result<(), RoutingError> {
     if code == FWP_E_ALREADY_EXISTS_DWORD {
         return Ok(());

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -59,10 +59,10 @@ pub const SUBLAYER_GUID: GUID = GUID::from_u128(0xb4e2d3c5_6c7f_58b9_ad1e_2f3a4b
 // that knows all twelve GUIDs engages, crashes, and an OLDER build that
 // only knows ten runs recovery) leaves the two new resolver-permit filters
 // permanently un-swept inside the sublayer the standing lockdown cover also
-// uses (tracked: bindreams/hole#754). Growing this array again inherits the
-// same risk; a version-independent sweep (enumerate live filters by
-// PROVIDER_GUID instead of a fixed array) would remove it but is a separate,
-// self-contained change.
+// uses; see CONTRIBUTING.md's "Transient cutover cover" section. Growing
+// this array again inherits the same risk; a version-independent sweep
+// (enumerate live filters by PROVIDER_GUID instead of a fixed array) would
+// remove it but is a separate, self-contained change.
 pub const FILTER_GUIDS: [GUID; 12] = [
     GUID::from_u128(0xc5f3e4d6_7d80_69ca_be2f_3a4b5c6d7e8f), // loopback CONNECT V4
     GUID::from_u128(0xd6041507_8e91_7adb_cf30_4b5c6d7e8f90), // loopback CONNECT V6
@@ -503,8 +503,8 @@ fn wfp_check(code: u32, what: &str) -> Result<(), RoutingError> {
 /// `delete_all`, whose return codes are discarded) fails for that GUID: the
 /// re-add then hits `FWP_E_ALREADY_EXISTS` and reports success while the LIVE
 /// filter still carries the value the delete failed to remove. A stale
-/// PERMIT surviving, never a leaked block. Tracked separately:
-/// bindreams/hole#761.
+/// PERMIT surviving, never a leaked block; see CONTRIBUTING.md's "Transient
+/// cutover cover" section.
 fn ok_or_exists(code: u32, what: &str) -> Result<(), RoutingError> {
     if code == FWP_E_ALREADY_EXISTS_DWORD {
         return Ok(());

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -9,6 +9,13 @@
 //! belt-and-suspenders) — + the SS server IP on CONNECT, block everything else on
 //! CONNECT (egress kill switch).
 //!
+//! Optionally also permits ONE more address on its own family's CONNECT layer,
+//! scoped to `RESOLVER_PERMIT_PORT`: the resolver the caller's own `ech-doh`
+//! URL names, so a plugin's later ECH-config fetch (dialing that same
+//! resolver under this same cover) is not blocked. Omitted whenever nothing
+//! should be permitted — see `Routing::install_failclosed_cover`'s doc for
+//! the exact conditions.
+//!
 //! One sublayer, weight-based arbitration: the permits sit at weight 15 and the
 //! block-all at weight 0, so within the sublayer the higher-weight permit wins.
 //! NO filter sets `CLEAR_ACTION_RIGHT`. That flag makes THIS filter's own action
@@ -37,15 +44,26 @@ use windows::Win32::Foundation::{ERROR_SUCCESS, HANDLE};
 use windows::Win32::NetworkManagement::WindowsFilteringPlatform::*;
 use windows::Win32::System::Rpc::RPC_C_AUTHN_WINNT;
 
+use super::RESOLVER_PERMIT_PORT;
 use crate::error::RoutingError;
 
 // Fixed Hole identifiers. Compiled in so recovery can delete by key with no
 // persisted runtime state. Generated once; never reuse for anything else.
 pub const PROVIDER_GUID: GUID = GUID::from_u128(0xa3f1c2d4_5b6e_47a8_9c0d_1e2f3a4b5c6d);
 pub const SUBLAYER_GUID: GUID = GUID::from_u128(0xb4e2d3c5_6c7f_58b9_ad1e_2f3a4b5c6d7e);
-// Ten fixed filter GUIDs — recovery deletes all ten unconditionally
-// (idempotent), so the set is deterministic regardless of server family.
-pub const FILTER_GUIDS: [GUID; 10] = [
+// Twelve fixed filter GUIDs — recovery deletes all twelve unconditionally
+// (idempotent), so the set is deterministic regardless of server/resolver
+// family. CROSS-VERSION CONTRACT: `delete_all`/`recover_cover` sweep by
+// enumerating exactly this compiled-in array, not by querying the OS for
+// "every filter this provider owns" — so a crash-then-downgrade (a build
+// that knows all twelve GUIDs engages, crashes, and an OLDER build that
+// only knows ten runs recovery) leaves the two new resolver-permit filters
+// permanently un-swept inside the sublayer the standing lockdown cover also
+// uses (tracked: bindreams/hole#754). Growing this array again inherits the
+// same risk; a version-independent sweep (enumerate live filters by
+// PROVIDER_GUID instead of a fixed array) would remove it but is a separate,
+// self-contained change.
+pub const FILTER_GUIDS: [GUID; 12] = [
     GUID::from_u128(0xc5f3e4d6_7d80_69ca_be2f_3a4b5c6d7e8f), // loopback CONNECT V4
     GUID::from_u128(0xd6041507_8e91_7adb_cf30_4b5c6d7e8f90), // loopback CONNECT V6
     GUID::from_u128(0xe7152618_9fa2_8bec_d041_5c6d7e8f9001), // server V4
@@ -56,7 +74,14 @@ pub const FILTER_GUIDS: [GUID; 10] = [
     GUID::from_u128(0x64f1885c_8acb_79c4_fac2_cd84e29f45eb), // loopback RECV_ACCEPT V6
     GUID::from_u128(0x8827e6e8_461b_48a0_9e88_dc6371486cb0), // loopback-net CONNECT V4 (127.0.0.0/8)
     GUID::from_u128(0x07d38d29_4bbb_472f_aeb3_e9d71f8967d9), // loopback-net CONNECT V6 (::1/128)
+    GUID::from_u128(0xa2a6419f_0dd6_4628_9578_0424bf1cc9b2), // resolver CONNECT V4
+    GUID::from_u128(0xa020f996_e73f_488c_b1c9_5fce3ea0b1eb), // resolver CONNECT V6
 ];
+
+/// IANA protocol number for TCP (RFC 790; never changes — not sourced from
+/// the `windows` crate's `WinSock::IPPROTO_TCP` to avoid an extra import for
+/// a value this stable).
+const IPPROTO_TCP: u8 = 6;
 
 // Lockdown-cover filter GUIDs — disjoint from FILTER_GUIDS. Recovery sweeps
 // these (Sweep) or deletes the volatile TUN + server pairs (Adopt) — see
@@ -109,7 +134,7 @@ fn appid_filter_guid(index: usize, v6: bool) -> GUID {
 const MAX_APPID_BINARIES: usize = 4;
 
 /// Every transient-cover filter GUID a recovery `delete_all` must remove: the
-/// ten fixed GUIDs. Mirrors [`swept_lockdown_guids`] for the lockdown cover.
+/// twelve fixed GUIDs. Mirrors [`swept_lockdown_guids`] for the lockdown cover.
 fn swept_transient_guids() -> Vec<GUID> {
     FILTER_GUIDS.to_vec()
 }
@@ -173,6 +198,11 @@ pub enum Condition {
     LoopbackNet(IpAddr),
     /// Match a single remote host address (`FWPM_CONDITION_IP_REMOTE_ADDRESS`).
     RemoteIp(IpAddr),
+    /// Match a single remote host address AND TCP protocol AND a specific
+    /// remote port — all ANDed (WFP: every condition on one filter must
+    /// match). Used ONLY for the resolver permit: least privilege over the
+    /// unrestricted `RemoteIp` the server permit uses.
+    RemoteIpPortTcp(IpAddr, u16),
     /// Match the local interface by `NET_LUID` (`FWPM_CONDITION_IP_LOCAL_INTERFACE`,
     /// `FWP_UINT64`). Carries app traffic: route selection picks hole-tun
     /// before `ALE_AUTH_CONNECT`, so a connect to any destination classifies
@@ -214,14 +244,16 @@ pub const PERMIT_WEIGHT: u8 = 15;
 /// Filter weight for the block-all filters.
 pub const BLOCK_WEIGHT: u8 = 0;
 
-/// Build the data description of the fail-closed cover for `server_ip`.
+/// Build the data description of the fail-closed cover for `server_ip`, and
+/// (when `Some`) `resolver_ip` — see `Routing::install_failclosed_cover`'s
+/// doc for the trust condition a caller must meet to pass `Some` here.
 /// Permits loopback on CONNECT *and* RECV_ACCEPT (loopback connects authorize on
 /// both ALE directions) by the loopback address range (127.0.0.0/8, ::1/128) on
 /// all four layers, plus the IS_LOOPBACK flag on CONNECT as belt-and-suspenders,
 /// plus the server IP on CONNECT (its own family's layer); blocks all else on
 /// CONNECT only (egress kill switch). Pure — no FFI; `engage` submits it in one
 /// transaction.
-pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
+pub fn build_cover_spec(server_ip: IpAddr, resolver_ip: Option<IpAddr>) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
         IpAddr::V6(_) => Layer::ConnectV6,
@@ -292,6 +324,19 @@ pub fn build_cover_spec(server_ip: IpAddr) -> CoverSpec {
             weight: PERMIT_WEIGHT,
         },
     ];
+    if let Some(ip) = resolver_ip {
+        let (guid, layer) = match ip {
+            IpAddr::V4(_) => (FILTER_GUIDS[10], Layer::ConnectV4),
+            IpAddr::V6(_) => (FILTER_GUIDS[11], Layer::ConnectV6),
+        };
+        filters.push(FilterSpec {
+            guid,
+            layer,
+            action: Action::Permit,
+            condition: Condition::RemoteIpPortTcp(ip, RESOLVER_PERMIT_PORT),
+            weight: PERMIT_WEIGHT,
+        });
+    }
     filters.push(block(FILTER_GUIDS[4], Layer::ConnectV4));
     filters.push(block(FILTER_GUIDS[5], Layer::ConnectV6));
     CoverSpec {
@@ -458,8 +503,13 @@ fn ok_or_exists(code: u32, what: &str) -> Result<(), RoutingError> {
 }
 
 #[allow(clippy::disallowed_methods)] // THIS is the sanctioned FWPM call site
-pub fn engage(server_ip: IpAddr, _state_dir: &Path, _owner: Option<(u32, u32)>) -> Result<Cover, RoutingError> {
-    let spec = build_cover_spec(server_ip);
+pub fn engage(
+    server_ip: IpAddr,
+    resolver_ip: Option<IpAddr>,
+    _state_dir: &Path,
+    _owner: Option<(u32, u32)>,
+) -> Result<Cover, RoutingError> {
+    let spec = build_cover_spec(server_ip, resolver_ip);
     unsafe {
         // A NON-dynamic engine session (`session = None`): a dynamic session
         // would auto-delete our filters when this process exits, reopening the
@@ -706,6 +756,64 @@ unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterS
                     Anonymous: FWP_CONDITION_VALUE0_0 {
                         byteArray16: &mut v6buf,
                     },
+                },
+            });
+        }
+        // Resolver permit: address + protocol + port, ANDed on one filter (WFP
+        // requires every condition on a filter to match). Least privilege over
+        // the unrestricted RemoteIp arms above — see the Condition doc.
+        Condition::RemoteIpPortTcp(IpAddr::V4(v4), port) => {
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT32,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint32: u32::from(*v4) },
+                },
+            });
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_PROTOCOL,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT8,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint8: IPPROTO_TCP },
+                },
+            });
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_PORT,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT16,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint16: *port },
+                },
+            });
+        }
+        Condition::RemoteIpPortTcp(IpAddr::V6(v6), port) => {
+            v6buf.byteArray16 = v6.octets();
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_ADDRESS,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_BYTE_ARRAY16_TYPE,
+                    Anonymous: FWP_CONDITION_VALUE0_0 {
+                        byteArray16: &mut v6buf,
+                    },
+                },
+            });
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_PROTOCOL,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT8,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint8: IPPROTO_TCP },
+                },
+            });
+            conditions.push(FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_PORT,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT16,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint16: *port },
                 },
             });
         }

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -192,9 +192,7 @@ fn resolver_permit_guids_are_distinct_and_swept() {
     // Every filter a cover installs must be deletable by recovery (else a
     // crash leaks an unswept permit across restarts), and every GUID in one
     // spec must be unique (else the second FwpmFilterAdd0 silently clobbers
-    // the first). BOTH families: a bug that swaps FILTER_GUIDS[10]/[11] (e.g.
-    // always emitting the V4 resolver GUID regardless of the resolver's own
-    // family) would pass if only one family were ever exercised here.
+    // the first).
     let transient_swept: std::collections::HashSet<GUID> = swept_transient_guids().into_iter().collect();
     for resolver in [resolver_v4(), resolver_v6()] {
         let s = build_cover_spec(v4(), Some(resolver));
@@ -212,6 +210,29 @@ fn resolver_permit_guids_are_distinct_and_swept() {
             "every filter GUID in the spec must be distinct"
         );
     }
+}
+
+#[skuld::test]
+fn resolver_permit_guid_matches_its_own_ip_family() {
+    // The GUID a resolver permit uses is family-specific (`FILTER_GUIDS[10]`
+    // for V4, `[11]` for V6, per `build_cover_spec`) — checked directly
+    // here, not just inferred from set-membership/distinctness (which BOTH
+    // families exercised in `resolver_permit_guids_are_distinct_and_swept`
+    // would still pass under a swapped V4/V6 match arm, since both GUIDs are
+    // in the swept set and distinct from each other either way).
+    let v4_filter = build_cover_spec(v4(), Some(resolver_v4()))
+        .filters
+        .into_iter()
+        .find(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4()))
+        .expect("a V4 resolver permit filter");
+    assert_eq!(v4_filter.guid, FILTER_GUIDS[10]);
+
+    let v6_filter = build_cover_spec(v4(), Some(resolver_v6()))
+        .filters
+        .into_iter()
+        .find(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v6()))
+        .expect("a V6 resolver permit filter");
+    assert_eq!(v6_filter.guid, FILTER_GUIDS[11]);
 }
 
 // build_lockdown_spec =================================================================================================

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -7,13 +7,19 @@ fn v4() -> IpAddr {
 fn v6() -> IpAddr {
     "2001:db8::1".parse().unwrap()
 }
+fn resolver_v4() -> IpAddr {
+    "198.51.100.5".parse().unwrap()
+}
+fn resolver_v6() -> IpAddr {
+    "2001:db8::abcd".parse().unwrap()
+}
 
 #[skuld::test]
 fn spec_blocks_egress_only_on_both_v4_and_v6_layers() {
     // The block-all is an egress kill switch: CONNECT only. Blocking RECV_ACCEPT
     // would make it an inbound firewall (out of scope, and inconsistent with the
     // macOS `set skip on lo0` egress-only model).
-    let s = build_cover_spec(v4());
+    let s = build_cover_spec(v4(), None);
     assert!(s
         .filters
         .iter()
@@ -38,7 +44,7 @@ fn spec_permits_loopback_on_all_four_ale_layers() {
     // permit loopback on both ALE directions, V4 and V6. The deterministic
     // matcher is the address range (LoopbackNet) on ALL FOUR layers; the
     // IS_LOOPBACK flag isn't reliably set on CI's elevated lane.
-    let s = build_cover_spec(v4());
+    let s = build_cover_spec(v4(), None);
     for layer in [
         Layer::ConnectV4,
         Layer::ConnectV6,
@@ -56,7 +62,7 @@ fn spec_permits_loopback_on_all_four_ale_layers() {
 
 #[skuld::test]
 fn spec_permits_v4_server_on_v4_layer_only() {
-    let s = build_cover_spec(v4());
+    let s = build_cover_spec(v4(), None);
     let server_permits: Vec<_> = s
         .filters
         .iter()
@@ -69,7 +75,7 @@ fn spec_permits_v4_server_on_v4_layer_only() {
 
 #[skuld::test]
 fn spec_permits_v6_server_on_v6_layer_only() {
-    let s = build_cover_spec(v6());
+    let s = build_cover_spec(v6(), None);
     let server_permits: Vec<_> = s
         .filters
         .iter()
@@ -86,7 +92,7 @@ const _: () = assert!(PERMIT_WEIGHT > BLOCK_WEIGHT);
 
 #[skuld::test]
 fn permit_filters_outweigh_block() {
-    let s = build_cover_spec(v4());
+    let s = build_cover_spec(v4(), None);
     for f in &s.filters {
         match f.action {
             Action::Permit => assert_eq!(f.weight, PERMIT_WEIGHT),
@@ -97,9 +103,115 @@ fn permit_filters_outweigh_block() {
 
 #[skuld::test]
 fn spec_uses_the_fixed_hole_guids() {
-    let s = build_cover_spec(v4());
+    let s = build_cover_spec(v4(), None);
     assert_eq!(s.provider, PROVIDER_GUID);
     assert_eq!(s.sublayer, SUBLAYER_GUID);
+}
+
+// resolver permit =====================================================================================================
+
+#[skuld::test]
+fn spec_permits_resolver_ip_on_its_own_family_layer_when_given() {
+    let s = build_cover_spec(v4(), Some(resolver_v4()));
+    let resolver_permits: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| {
+            f.action == Action::Permit
+                && matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4())
+        })
+        .collect();
+    assert_eq!(resolver_permits.len(), 1, "exactly one resolver permit");
+    assert_eq!(resolver_permits[0].layer, Layer::ConnectV4);
+}
+
+#[skuld::test]
+fn spec_permits_v6_resolver_on_v6_layer_only() {
+    let s = build_cover_spec(v4(), Some(resolver_v6()));
+    let resolver_permits: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| {
+            f.action == Action::Permit
+                && matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v6())
+        })
+        .collect();
+    assert_eq!(resolver_permits.len(), 1);
+    assert_eq!(resolver_permits[0].layer, Layer::ConnectV6);
+}
+
+#[skuld::test]
+fn spec_omits_resolver_permit_when_none() {
+    // Negative direction: no resolver_ip means no RemoteIpPortTcp permit
+    // exists at all — proves the widening is opt-in, never automatic.
+    let s = build_cover_spec(v4(), None);
+    let resolver_permits: Vec<_> = s
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIpPortTcp(..)))
+        .collect();
+    assert_eq!(resolver_permits.len(), 0, "no resolver permit when resolver_ip is None");
+}
+
+#[skuld::test]
+fn spec_resolver_permit_is_scoped_to_tcp_443_not_unrestricted() {
+    // NOT the server permit's unrestricted shape: doh_url_for_ip
+    // (crates/bridge/src/dns/ech.rs) never constructs a URL with a port
+    // other than RESOLVER_PERMIT_PORT, so this is the one value the fetch
+    // can need.
+    let s = build_cover_spec(v4(), Some(resolver_v4()));
+    let resolver_permit = s
+        .filters
+        .iter()
+        .find(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4()))
+        .expect("resolver permit must exist");
+    assert!(
+        matches!(
+            resolver_permit.condition,
+            Condition::RemoteIpPortTcp(_, RESOLVER_PERMIT_PORT)
+        ),
+        "resolver permit must be scoped to RESOLVER_PERMIT_PORT, not unrestricted like the server permit: {:?}",
+        resolver_permit.condition
+    );
+}
+
+#[skuld::test]
+fn resolver_permit_weight_outweighs_block() {
+    let s = build_cover_spec(v4(), Some(resolver_v4()));
+    for f in s
+        .filters
+        .iter()
+        .filter(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4()))
+    {
+        assert_eq!(f.weight, PERMIT_WEIGHT);
+    }
+}
+
+#[skuld::test]
+fn resolver_permit_guids_are_distinct_and_swept() {
+    // Every filter a cover installs must be deletable by recovery (else a
+    // crash leaks an unswept permit across restarts), and every GUID in one
+    // spec must be unique (else the second FwpmFilterAdd0 silently clobbers
+    // the first). BOTH families: a bug that swaps FILTER_GUIDS[10]/[11] (e.g.
+    // always emitting the V4 resolver GUID regardless of the resolver's own
+    // family) would pass if only one family were ever exercised here.
+    let transient_swept: std::collections::HashSet<GUID> = swept_transient_guids().into_iter().collect();
+    for resolver in [resolver_v4(), resolver_v6()] {
+        let s = build_cover_spec(v4(), Some(resolver));
+        for f in &s.filters {
+            assert!(
+                transient_swept.contains(&f.guid),
+                "{:?} must be in the transient sweep set",
+                f.guid
+            );
+        }
+        let unique: std::collections::HashSet<GUID> = s.filters.iter().map(|f| f.guid).collect();
+        assert_eq!(
+            unique.len(),
+            s.filters.len(),
+            "every filter GUID in the spec must be distinct"
+        );
+    }
 }
 
 // build_lockdown_spec =================================================================================================
@@ -187,7 +299,7 @@ fn lockdown_spec_permits_outweigh_block() {
 #[skuld::test]
 fn lockdown_spec_uses_distinct_guids_from_transient_cover() {
     let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
-    let cover = build_cover_spec(v4());
+    let cover = build_cover_spec(v4(), Some(resolver_v4()));
     let lock_guids: std::collections::HashSet<_> = lock.filters.iter().map(|f| f.guid).collect();
     let cover_guids: std::collections::HashSet<_> = cover.filters.iter().map(|f| f.guid).collect();
     assert!(
@@ -339,7 +451,7 @@ fn both_specs_permit_loopback_recv_accept_by_address_range() {
     // so the 127.0.0.0/8 or ::1/128 range matches. The matching family per layer:
     // V4 range on RecvAcceptV4, V6 range on RecvAcceptV6.
     for s in [
-        build_cover_spec(v4()),
+        build_cover_spec(v4(), None),
         build_lockdown_spec(v4(), luid(), &[plugin_path()]),
     ] {
         assert!(
@@ -366,7 +478,7 @@ fn loopback_recv_accept_permits_are_in_both_sweep_floors() {
     // (swept_lockdown_guids) must both delete them, but Adopt must keep them.
     // The transient cover wires its RECV_ACCEPT loopback GUIDs from FILTER_GUIDS,
     // so iterating the array sweeps them; assert they actually appear in the spec.
-    let cover = build_cover_spec(v4());
+    let cover = build_cover_spec(v4(), None);
     let cover_guids: std::collections::HashSet<GUID> = cover.filters.iter().map(|f| f.guid).collect();
     assert!(
         cover_guids.contains(&FILTER_GUIDS[6]),
@@ -393,10 +505,11 @@ fn every_emitted_filter_guid_is_in_its_sweep_set() {
     // Structural fail-closed invariant: any filter a cover installs must be
     // deletable by recovery, else a crash leaks an unswept block across restarts.
     // Transient -> delete_all iterates swept_transient_guids (the fixed GUIDs);
-    // lockdown -> swept_lockdown_guids.
+    // lockdown -> swept_lockdown_guids. The transient side ALSO carries a
+    // resolver permit here so the new GUIDs' sweep membership is exercised.
     let transient_swept: std::collections::HashSet<GUID> = swept_transient_guids().into_iter().collect();
     for ip in [v4(), v6()] {
-        let cover = build_cover_spec(ip);
+        let cover = build_cover_spec(ip, Some(resolver_v4()));
         for f in &cover.filters {
             assert!(
                 transient_swept.contains(&f.guid),
@@ -427,7 +540,7 @@ fn both_specs_permit_loopback_by_address_range_at_connect() {
     // block-all. An address-range permit keyed on the connect's DESTINATION
     // matches deterministically: 127.0.0.0/8 on CONNECT V4, ::1/128 on CONNECT V6.
     for s in [
-        build_cover_spec(v4()),
+        build_cover_spec(v4(), None),
         build_lockdown_spec(v4(), luid(), &[plugin_path()]),
     ] {
         let v4_net = s.filters.iter().any(|f| {
@@ -456,7 +569,7 @@ fn flag_loopback_permits_are_kept_only_on_connect() {
     // the address-range ones (don't churn them). At RECV_ACCEPT the flag is
     // dropped in favor of the deterministic address-range permit, because the
     // flag doesn't match there on CI's elevated lane.
-    let s = build_cover_spec(v4());
+    let s = build_cover_spec(v4(), None);
     let flag_permits: Vec<_> = s
         .filters
         .iter()
@@ -482,7 +595,7 @@ fn new_loopbacknet_guids_are_in_their_sweep_floors_and_distinct() {
     // the transient sweep (delete_all iterates FILTER_GUIDS) and the lockdown
     // sweep (swept_lockdown_guids) must both delete them. They must also be
     // distinct from every prior GUID (a shared key silently clobbers).
-    let cover = build_cover_spec(v4());
+    let cover = build_cover_spec(v4(), None);
     for f in cover
         .filters
         .iter()


### PR DESCRIPTION
Fixes #732.

## Problem

On a covered (auto-connect) start, `install_failclosed_cover` permitted only
loopback and the proxy server — not the DoH resolver. ex-ray's ECH-config
fetch is lazy (fires on the plugin chain's first dial, *under* the cover),
so the fetch was blocked and stalled to ex-ray's client timeout.

## Fix

`Routing::install_failclosed_cover` and both platform backends now take an
optional `resolver_ip`: the exact address in the `ech-doh` URL Hole is about
to hand ex-ray (`EchDoh::resolver`, a new field). **Permitted regardless of
`PinSource`** — Hole always constructs that URL from either the
bootstrap-verified IP or the user's own configured `dns.servers`, so
config-authorship trust alone is judged sufficient; this is narrower than
what the address needs for it to matter (an ECH-config fetch, TCP/443 only —
`doh_url_for_ip` never constructs a URL with any other port, enforced by an
executable test and a direct cross-crate equality assertion against
tun-engine's mirrored constant). An **operator's own** `ech-doh` in
`plugin_opts` is a different case: Hole did not author that address, so it is
**never** permitted (a disclosed residual, own dedicated warning).

`ProxyManager` derives the permit through `crate::proxy::plugin::effective_ech_doh`
(`EffectiveEchDoh::None`/`Holes`/`Operators(url)`), computed once by a shared
pure classifier so the permit decision and the actual plugin spawn can never
disagree, and so the permit-derivation query itself never re-triggers the
spawn-time ECH-posture log lines. A covered retry whose freshly-derived
permit differs from the held cover's (plugin added/removed, or `dns.servers`
changed the fallback address) releases the stale cover and re-engages fresh
with the corrected permit — except a pure *narrowing* to nothing needed,
which leaves the wider permit in place rather than paying the
release-to-reengage open-egress window for a correction with no benefit. If
a corrected re-engage itself fails, the repair falls back to restoring the
previous permit rather than leaving the host uncovered, and remembers that
specific value as unreachable so an unchanged retry doesn't retry the same
failing correction forever.

## Disclosed residuals (shipped as scoped, not closed)

- An operator's own `ech-doh` in `plugin_opts` is never permitted — always a
  stall risk under a covered start; logged via a dedicated `warn!`.
- The release-then-reengage repair has a brief window with no cover at all
  between release and re-engage — disclosed via `warn!`; neither platform's
  engage primitive supports an atomic in-place update today. Tracked: #758.
- **macOS only**: a restart that *adopts* a pre-existing standing lockdown
  cover engages no transient cover at all, so there's no in-process signal to
  gate a diagnostic on. Tracked: #753.
- Windows' `FILTER_GUIDS` array grew 10→12 (two new fixed GUIDs for the
  resolver permit). Recovery sweeps this array unconditionally, not by
  querying the OS for "every filter this provider owns" — a
  crash-then-downgrade leaves the two new filters un-swept. They are
  *permits*, not blocks, so a downgrade-after-crash is bounded and
  self-healing, not a leak of blocked traffic. This is the first change to
  grow the array since it was introduced, so it's the first to exercise this
  cross-version sweep contract. Tracked: #754.

## Note on process

Implemented in two passes: the first pass scoped the permit to only the
address *this specific attempt's* own DoH bootstrap personally verified
(`PinSource::Answered`), leaving a residual for literal-IP servers and the
insecure-bootstrap fallback. Mid-review, the trust model was reframed:
Hole always *authors* the `ech-doh` address, regardless of which `PinSource`
produced it, so permitting it is config-authorship trust, not a claim that
this attempt demonstrated it reachable. That residual is gone as a result.

## Testing

- Unit tests in `crates/tun-engine/src/routing/failclosed/{windows,macos}_tests.rs`
  covering the resolver permit's presence, per-family layer, TCP/443 scoping,
  and GUID sweep membership.
- Unit tests in `crates/bridge/src/proxy_manager_tests.rs` covering: the
  permit tracks `EchDoh::resolver` regardless of `PinSource`; no permit for
  no-plugin / non-ECH-capable-plugin / operator-override starts; a same-host
  retry reuses the held permit; a retry that changes the derivation repairs
  the stale permit (widening/changing) but leaves a pure narrowing alone; the
  compensating restore when a corrected re-engage fails, and that it doesn't
  oscillate on a repeat of the same known-unreachable value; the residual
  warnings (operator-override, and a repair-restore mismatch) fire correctly
  and don't double-fire; `effective_ech_doh`'s query path doesn't
  double-emit `inject_plugin_directives`'s log lines.
- Extended the Windows/macOS privileged live-engage tests
  (`lockdown_privileged_tests.rs`) with a negative TCP/443-scoping probe: the
  same resolver IP on a different port stays blocked.
