### PR TITLE
fix(garter): decode SIP003 options keys by the reference (ex-ray) unescape rule

### DIFF
--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -52,11 +52,13 @@ pub enum ProxyError {
     #[error("plugin error: {0}")]
     Plugin(String),
     /// Plugin options a SIP003 parser rejects. Refused rather than forwarded:
-    /// ex-ray discards the whole SS_* environment on a parse error and reports
-    /// ready on its default port, so a forwarded string yields a dead tunnel
-    /// that looks healthy. PII-free `Display` by construction — the wrapped
-    /// `MalformedOptions` names the fault class and a segment index, never the
-    /// segment, which can carry a per-connection secret.
+    /// ex-ray fails fatally on the same string rather than silently
+    /// discarding it, so refusing here isn't preventing a silent bad-config
+    /// start — it's failing earlier and attributably, naming the fault
+    /// before spawning a process that would die immediately after. PII-free
+    /// `Display` by construction — the wrapped `MalformedOptions` names the
+    /// fault class and a segment index, never the segment, which can carry a
+    /// per-connection secret.
     #[error("malformed plugin options: {0}")]
     MalformedPluginOptions(String),
     /// A plugin reported a typed bind conflict (`StartError::BindConflict`

--- a/crates/bridge/src/proxy/plugin.rs
+++ b/crates/bridge/src/proxy/plugin.rs
@@ -466,10 +466,10 @@ fn unpinned_reason(ech_doh: Option<&crate::dns::ech::EchDoh>) -> &'static str {
 /// `ech-doh` for. `v2ray-plugin` resolves to the first-party `ex-ray` binary,
 /// but a config may also name `ex-ray` directly, so both spellings are
 /// covered; `galoshes` ignores the keys itself but forwards the whole options
-/// string to its inner ex-ray. Every OTHER plugin name is passed through
-/// `inject_plugin_directives` completely unmodified — no `ech-doh` is ever
-/// injected, so nothing that plugin does can be influenced by Hole's ECH
-/// derivation at all.
+/// string to its inner ex-ray. Every OTHER plugin name gets no `ech-doh`
+/// injected — nothing that plugin does can be influenced by Hole's ECH
+/// derivation at all — but its options string is still validated; see
+/// `inject_plugin_directives`'s doc comment.
 fn takes_ech_directives(plugin_name: &str) -> bool {
     matches!(plugin_name, "v2ray-plugin" | "ex-ray" | "galoshes")
 }
@@ -1149,9 +1149,11 @@ fn classify_ech_doh(
 /// Only the v2ray-family plugins receive these: `v2ray-plugin` resolves to the
 /// first-party `ex-ray` binary, but a config may also name `ex-ray` directly,
 /// so both spellings are covered; `galoshes` ignores the keys itself but
-/// forwards the whole options string to its inner ex-ray. Every other plugin
-/// name is passed through unmodified — the ONE gate (`takes_ech_directives`)
-/// both this function and its callers rely on, checked exactly once, here.
+/// forwards the whole options string to its inner ex-ray. Every OTHER plugin
+/// name still has its options string validated, though nothing is injected —
+/// a malformed string must not reach `BinaryPlugin` unvalidated just because
+/// the plugin isn't one of these three. The ONE gate (`takes_ech_directives`)
+/// both this function and its callers rely on is checked exactly once, here.
 /// Emits the ECH-posture `tracing::warn!` lines — called exactly once per
 /// actual plugin spawn (`start_plugin_chain`); the permit-derivation query
 /// [`effective_ech_doh`] deliberately does NOT call this, to avoid
@@ -1162,7 +1164,13 @@ fn inject_plugin_directives(
     ech_doh: Option<&crate::dns::ech::EchDoh>,
 ) -> Result<Option<String>, ProxyError> {
     if !takes_ech_directives(plugin_name) {
-        return Ok(opts.map(String::from));
+        // Still validated: see the doc comment above.
+        return match opts {
+            Some(o) => garter::split_plugin_options(o)
+                .map(|_| Some(o.to_string()))
+                .map_err(|e| ProxyError::MalformedPluginOptions(format!("{plugin_name}: {e}"))),
+            None => Ok(None),
+        };
     }
     {
         let opts = opts.unwrap_or_default();
@@ -1434,6 +1442,11 @@ mod inject_tests {
     }
 
     #[skuld::test]
+    fn unknown_plugin_with_malformed_options_is_rejected() {
+        assert!(inject_plugin_directives("obfs-local", Some(r"server;path=/a\"), None).is_err());
+    }
+
+    #[skuld::test]
     fn v2ray_plugin_gets_ech_doh_after_loglevel() {
         let out = merged(
             "v2ray-plugin",
@@ -1625,9 +1638,9 @@ mod inject_tests {
         );
     }
 
-    // ex-ray discards the whole SS_* environment on a parse error and reports
-    // `ready` on its default port, so forwarding these would produce a dead
-    // tunnel that looks healthy. Refuse the start instead.
+    // ex-ray fails fatally on a malformed `SS_PLUGIN_OPTIONS` string rather
+    // than silently discarding it — but only after spawning. Refusing here
+    // fails earlier and attributably instead.
     #[skuld::test]
     fn malformed_options_fail_the_start() {
         for opts in [r"path=/a\", "host=h;=v;mux=0", "a=1;;b=2"] {

--- a/crates/bridge/src/reachability.rs
+++ b/crates/bridge/src/reachability.rs
@@ -49,28 +49,66 @@ pub(crate) enum ProbeTransport {
     Raw,
 }
 
-pub(crate) fn classify_transport(plugin: Option<&str>, plugin_opts: Option<&str>, server_host: &str) -> ProbeTransport {
-    if plugin.is_none() {
-        return ProbeTransport::Raw;
+/// Mirrors vendored v2ray-core's `websocket.Config::GetNormalizedPath`
+/// (`crates/ex-ray/third_party/v2ray-core/transport/internet/websocket/config.go`)
+/// byte for byte: this is what actually decides the WebSocket
+/// request-target on the wire, applied unconditionally to whatever the
+/// `path` SIP003 flag decoded to.
+fn normalize_ws_path(path: String) -> String {
+    if path.is_empty() {
+        "/".into()
+    } else if !path.starts_with('/') {
+        format!("/{path}")
+    } else {
+        path
     }
-    let opts = plugin_opts.map(garter::parse_plugin_options).unwrap_or_default();
-    let get = |k: &str| opts.iter().find(|(kk, _)| kk == k).map(|(_, v)| v.clone());
-    let has = |k: &str| opts.iter().any(|(kk, _)| kk == k);
+}
+
+pub(crate) fn classify_transport(
+    plugin: Option<&str>,
+    plugin_opts: Option<&str>,
+    server_host: &str,
+) -> Result<ProbeTransport, garter::MalformedOptions> {
+    if plugin.is_none() {
+        return Ok(ProbeTransport::Raw);
+    }
+    // `split_plugin_options`, not `parse_plugin_options`: the latter maps a
+    // bare key and an explicit `key=` to the same decoded `""`, but ex-ray's
+    // own `Args.Get`/`main.go` do NOT treat them the same for `path` (see
+    // below) — only `OptionSegment::raw` can tell bare from valued apart.
+    let segments = plugin_opts
+        .map(garter::split_plugin_options)
+        .transpose()?
+        .unwrap_or_default();
+    let get = |k: &str| segments.iter().find(|s| s.key == k).map(|s| s.value.clone());
+    let has = |k: &str| segments.iter().any(|s| s.key == k);
     // The probe's first-flight SNI/Host is the connect target (the DoH-resolved
     // IP — IP-SNI): a failure-only diagnostic must not emit the domain in
     // cleartext, and the real tunnel hides it via ECH, so a domain-SNI probe
     // would test a path the client never uses.
     let sni = server_host.to_string();
     if get("mode").as_deref() == Some("quic") {
-        return ProbeTransport::Quic { sni };
+        return Ok(ProbeTransport::Quic { sni });
     }
     if has("tls") {
-        return ProbeTransport::TlsWs { sni };
+        return Ok(ProbeTransport::TlsWs { sni });
     }
-    ProbeTransport::PlainWs {
+    Ok(ProbeTransport::PlainWs {
         host: sni,
-        path: get("path").unwrap_or_else(|| "/".into()),
-    }
+        // Mirrors what ex-ray actually puts on the wire for the two shapes
+        // ex-ray itself accepts: an ABSENT `path` key uses the flag default
+        // "/"; a present key reads `exray_value` (a BARE `path` decodes as
+        // "1", matching `Args.Add`). An explicit `path=` (empty value) is
+        // NOT one of those shapes — ex-ray's own
+        // `parseStringOption(..., emptyOK=false)` (options.go) rejects it as
+        // a config error before ever building a websocket.Config, so there
+        // is no wire behavior to mirror here; "/" is this classifier's own
+        // graceful fallback for an input ex-ray would refuse to start on.
+        path: normalize_ws_path(match segments.iter().find(|s| s.key == "path") {
+            None => "/".into(),
+            Some(s) => s.exray_value().to_string(),
+        }),
+    })
 }
 
 pub async fn probe_server_reachability(
@@ -80,7 +118,19 @@ pub async fn probe_server_reachability(
     plugin_opts: Option<&str>,
     cancel: &CancellationToken,
 ) -> ReachabilityVerdict {
-    let transport = classify_transport(plugin, plugin_opts, host);
+    // A malformed options string means the transport can't be classified,
+    // and guessing wrong in either direction (TCP vs UDP) produces an
+    // actively false confident verdict — unlike `server_endpoint_is_udp`'s
+    // preflight-skip decision, there is no safe default transport to probe
+    // with here, so this best-effort diagnostic stays a graceful Result
+    // (Inconclusive) rather than an assertion.
+    let transport = match classify_transport(plugin, plugin_opts, host) {
+        Ok(t) => t,
+        Err(e) => {
+            debug!(%e, "malformed SS_PLUGIN_OPTIONS in reachability probe");
+            return ReachabilityVerdict::Inconclusive;
+        }
+    };
     let v = tokio::select! {
         _ = cancel.cancelled() => ReachabilityVerdict::Inconclusive,
         v = probe_inner(host, port, &transport) => v,

--- a/crates/bridge/src/reachability_tests.rs
+++ b/crates/bridge/src/reachability_tests.rs
@@ -46,12 +46,15 @@ async fn accept_then_answer() -> SocketAddr {
 // `nextest run … reachability_tests` substring filter only matches with it.
 #[skuld::test(name = "reachability_tests::classify_no_plugin_is_raw")]
 fn classify_no_plugin_is_raw() {
-    assert!(matches!(classify_transport(None, None, "ex.com"), ProbeTransport::Raw));
+    assert!(matches!(
+        classify_transport(None, None, "ex.com").unwrap(),
+        ProbeTransport::Raw
+    ));
 }
 #[skuld::test(name = "reachability_tests::classify_tls_ws_sni_is_connect_host_not_opt")]
 fn classify_tls_ws_sni_is_connect_host_not_opt() {
     // A failure-only diagnostic must not emit the proxy domain in cleartext.
-    match classify_transport(Some("galoshes"), Some("tls;path=/t/x;host=h.ex.com"), "srv") {
+    match classify_transport(Some("galoshes"), Some("tls;path=/t/x;host=h.ex.com"), "srv").unwrap() {
         ProbeTransport::TlsWs { sni } => {
             assert_eq!(sni, "srv", "SNI must be the connect host");
             assert_ne!(sni, "h.ex.com", "SNI must not leak the host= opt (domain)");
@@ -61,7 +64,7 @@ fn classify_tls_ws_sni_is_connect_host_not_opt() {
 }
 #[skuld::test(name = "reachability_tests::classify_plain_ws_defaults_path_and_host")]
 fn classify_plain_ws_defaults_path_and_host() {
-    match classify_transport(Some("galoshes"), Some("path=/t/x"), "srv.ex.com") {
+    match classify_transport(Some("galoshes"), Some("path=/t/x"), "srv.ex.com").unwrap() {
         ProbeTransport::PlainWs { host, path } => {
             assert_eq!(host, "srv.ex.com");
             assert_eq!(path, "/t/x");
@@ -69,16 +72,91 @@ fn classify_plain_ws_defaults_path_and_host() {
         _ => panic!(),
     }
 }
+// Mirrors classify_transport's bare-path handling (see its doc comment) for
+// every shape ex-ray itself accepts. The one shape ex-ray does NOT accept
+// (`path=`, explicit empty) is pinned separately below, by a test named for
+// what it actually verifies.
+#[skuld::test(name = "reachability_tests::classify_path_key_matches_ex_ray_for_shapes_ex_ray_accepts")]
+fn classify_path_key_matches_ex_ray_for_shapes_ex_ray_accepts() {
+    let cases = [
+        ("host=h", "/"),
+        ("path;host=h", "/1"),
+        ("path=x;host=h", "/x"),
+        ("path=/x;host=h", "/x"),
+    ];
+    for (opts, expected) in cases {
+        match classify_transport(Some("galoshes"), Some(opts), "srv.ex.com").unwrap() {
+            ProbeTransport::PlainWs { path, .. } => {
+                assert_eq!(path, expected, "opts={opts:?}");
+            }
+            _ => panic!("expected PlainWs for opts={opts:?}"),
+        }
+    }
+}
+// The one shape ex-ray itself rejects outright — see classify_transport's
+// doc comment for why "/" is still the fallback here.
+#[skuld::test(name = "reachability_tests::classify_explicit_empty_path_falls_back_to_slash")]
+fn classify_explicit_empty_path_falls_back_to_slash() {
+    match classify_transport(Some("galoshes"), Some("path=;host=h"), "srv.ex.com").unwrap() {
+        ProbeTransport::PlainWs { path, .. } => assert_eq!(path, "/"),
+        _ => panic!("expected PlainWs"),
+    }
+}
 #[skuld::test(name = "reachability_tests::classify_quic_forces_quic")]
 fn classify_quic_forces_quic() {
     // Same no-domain-leak rule as the TLS-WS probe.
-    match classify_transport(Some("galoshes"), Some("mode=quic;host=h"), "srv") {
+    match classify_transport(Some("galoshes"), Some("mode=quic;host=h"), "srv").unwrap() {
         ProbeTransport::Quic { sni } => {
             assert_eq!(sni, "srv", "SNI must be the connect host");
             assert_ne!(sni, "h", "SNI must not leak the host= opt");
         }
         _ => panic!("expected Quic"),
     }
+}
+#[skuld::test(name = "reachability_tests::classify_rejects_malformed_options")]
+fn classify_rejects_malformed_options() {
+    assert!(classify_transport(Some("galoshes"), Some(r"path=/a\"), "srv").is_err());
+}
+#[skuld::test(name = "reachability_tests::classify_recognizes_an_escaped_tls_key")]
+fn classify_recognizes_an_escaped_tls_key() {
+    // A backslash escapes whatever byte follows, so `\tls` IS `tls` — to
+    // ex-ray, and here.
+    match classify_transport(Some("galoshes"), Some(r"\tls;host=h"), "srv").unwrap() {
+        ProbeTransport::TlsWs { .. } => {}
+        _ => panic!("expected TlsWs for an escaped tls key"),
+    }
+}
+#[skuld::test(name = "reachability_tests::classify_first_wins_on_duplicate_mode_key")]
+fn classify_first_wins_on_duplicate_mode_key() {
+    // ex-ray's Args.Get is first-wins; the FIRST `mode=` must be the one
+    // consulted.
+    match classify_transport(Some("galoshes"), Some("mode=quic;mode=websocket"), "srv").unwrap() {
+        ProbeTransport::Quic { .. } => {}
+        _ => panic!("expected Quic (first mode= wins)"),
+    }
+}
+#[skuld::test(name = "reachability_tests::malformed_options_probe_is_inconclusive")]
+async fn malformed_options_probe_is_inconclusive() {
+    // `classify_transport` rejects the malformed options before any connect
+    // is attempted, so the port is deliberately left closed (not backed by a
+    // live fixture): were a future regression to let a connection through
+    // anyway, this address would produce TcpRefused/TcpTimeout, not
+    // Inconclusive, and fail the assertion below rather than passing on an
+    // unused live server.
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let a = l.local_addr().unwrap();
+    drop(l);
+    assert_eq!(
+        probe_server_reachability(
+            &a.ip().to_string(),
+            a.port(),
+            Some("galoshes"),
+            Some(r"path=/a\"),
+            &CancellationToken::new()
+        )
+        .await,
+        ReachabilityVerdict::Inconclusive
+    );
 }
 // A `.` flanked by alphanumerics on both sides — the shape of a domain label or
 // IP octet boundary (`ex.com`, `1.2.3.4`). A sentence-final `.` (followed by a

--- a/crates/bridge/src/server_test.rs
+++ b/crates/bridge/src/server_test.rs
@@ -251,14 +251,28 @@ async fn reclassify_blocked(
 /// TCP listener to connect to — so [`run_server_test`] skips it and lets the
 /// full tunnel handshake produce the diagnosis. Covers a direct
 /// v2ray-plugin/ex-ray QUIC server AND a galoshes server (which passes
-/// `mode=quic` through to its embedded ex-ray). Shares the reachability probe's
-/// transport classifier, so the two agree on what a QUIC endpoint is. See
-/// bindreams/hole#421.
+/// `mode=quic` through to its embedded ex-ray). Shares the reachability
+/// probe's transport classifier, so the two agree on what a QUIC endpoint
+/// is.
+///
+/// A malformed options string also skips the preflight, even though the
+/// endpoint might really be TCP: the risk is asymmetric. Guessing UDP when
+/// it's actually TCP costs only diagnosis precision (the full tunnel
+/// handshake still runs and produces a correct, if vaguer, verdict).
+/// Guessing TCP when it's actually UDP-only reproduces the exact false
+/// TcpTimeout/TcpRefused verdict this asymmetry exists to avoid, and a raw
+/// TCP connect can't distinguish "genuinely TCP" from "unclassifiable" to
+/// make that guess safely.
 fn server_endpoint_is_udp(entry: &ServerEntry) -> bool {
-    matches!(
-        crate::reachability::classify_transport(entry.plugin.as_deref(), entry.plugin_opts.as_deref(), &entry.server),
-        crate::reachability::ProbeTransport::Quic { .. }
-    )
+    match crate::reachability::classify_transport(entry.plugin.as_deref(), entry.plugin_opts.as_deref(), &entry.server)
+    {
+        Ok(crate::reachability::ProbeTransport::Quic { .. }) => true,
+        Ok(_) => false,
+        Err(e) => {
+            debug!(%e, "malformed SS_PLUGIN_OPTIONS in server_endpoint_is_udp, assuming UDP");
+            true
+        }
+    }
 }
 
 /// Raw-TCP-connect to the DoH-resolved `addr`. Returns `Err(outcome)` with a

--- a/crates/bridge/src/server_test_preflight_tests.rs
+++ b/crates/bridge/src/server_test_preflight_tests.rs
@@ -57,6 +57,11 @@ fn non_quic_endpoint_is_tcp() {
     )));
 }
 
+#[skuld::test]
+fn malformed_options_endpoint_is_treated_as_udp() {
+    assert!(server_endpoint_is_udp(&entry(Some("galoshes"), Some(r"path=/a\"))));
+}
+
 // preflight ===========================================================================================================
 //
 // `preflight` takes a resolved `SocketAddr` (DoH already resolved the

--- a/crates/galoshes/src/exray_options.rs
+++ b/crates/galoshes/src/exray_options.rs
@@ -13,10 +13,9 @@ pub fn ex_ray_options(plugin_options: Option<&str>) -> Result<String> {
     let Some(opts) = plugin_options.filter(|s| !s.is_empty()) else {
         return Ok(MUX_OFF.to_string());
     };
-    // A rejected string is fatal here because ex-ray does not reject it: it
-    // discards every option and reports `ready` on the flag-default port. The
-    // reason comes from the error's own Display, which names the shape without
-    // echoing options that may carry a secret.
+    // In the real galoshes binary this Err is unreachable — `main` validates
+    // the same string via `Mode::from_plugin_options` first — but it stays
+    // live for direct callers and this module's own unit tests.
     let segments = garter::split_plugin_options(opts).context("cannot build plugin options for the embedded ex-ray")?;
     let out = garter::join_plugin_options(segments.iter().map(|s| s.raw).chain([MUX_OFF]));
     // Contract, not input validation: the split accepts exactly what ex-ray
@@ -25,6 +24,7 @@ pub fn ex_ray_options(plugin_options: Option<&str>) -> Result<String> {
     // would satisfy a mere presence check while the append was being swallowed.
     debug_assert_eq!(
         garter::parse_plugin_options(&out)
+            .expect("well-formed by construction: raw segments already validated by split_plugin_options")
             .last()
             .map(|(k, v)| (k.as_str(), v.as_str())),
         Some(("mux", "0")),

--- a/crates/galoshes/src/exray_options_tests.rs
+++ b/crates/galoshes/src/exray_options_tests.rs
@@ -15,14 +15,17 @@ fn server_mode_and_other_directives_survive() {
     // `Mode::from_plugin_options` keys off `server`; appending must not disturb it.
     let out = ex_ray_options(Some("server;host=cloudfront.com;path=/;tls")).unwrap();
     assert_eq!(out, "server;host=cloudfront.com;path=/;tls;mux=0");
-    assert_eq!(garter::Mode::from_plugin_options(Some(&out)), garter::Mode::Server);
+    assert_eq!(
+        garter::Mode::from_plugin_options(Some(&out)).unwrap(),
+        garter::Mode::Server
+    );
 }
 
 #[skuld::test]
 fn an_operator_mux_wins() {
     // ex-ray is first-wins, so an earlier `mux=` overrides the appended default.
     let out = ex_ray_options(Some("mux=8;path=/")).unwrap();
-    let pairs = garter::parse_plugin_options(&out);
+    let pairs = garter::parse_plugin_options(&out).unwrap();
     let first_mux = pairs.iter().find(|(k, _)| k == "mux").expect("mux key present");
     assert_eq!(first_mux.1, "8");
 }
@@ -44,22 +47,22 @@ fn an_escaped_trailing_semicolon_is_not_swallowed() {
     let out = ex_ray_options(Some(r"path=/a\;")).unwrap();
     assert_eq!(out, r"path=/a\;;mux=0");
     assert_eq!(
-        garter::parse_plugin_options(&out),
+        garter::parse_plugin_options(&out).unwrap(),
         vec![("path".into(), "/a;".into()), ("mux".into(), "0".into())]
     );
 }
 
 #[skuld::test]
 fn a_trailing_separator_does_not_make_an_empty_segment() {
-    // `mode=websocket;;mux=0` makes ex-ray reject the WHOLE string ("empty key")
-    // and fall back to every flag default.
+    // `mode=websocket;;mux=0` makes ex-ray reject the WHOLE string ("empty
+    // key") and exit fatally.
     let out = ex_ray_options(Some("mode=websocket;")).unwrap();
     assert_eq!(out, "mode=websocket;mux=0");
 }
 
 // These two assert galoshes' OWN disposition, not garter's classification: on a
-// string ex-ray would silently discard, `ex_ray_options` must not hand back
-// something that looks usable.
+// string ex-ray would itself reject fatally, `ex_ray_options` must not hand
+// back something that looks usable.
 #[skuld::test]
 fn a_dangling_final_escape_is_rejected() {
     // `path=/a\` + `;mux=0` = `path=/a\;mux=0`: the escape swallows the separator

--- a/crates/galoshes/src/main.rs
+++ b/crates/galoshes/src/main.rs
@@ -75,7 +75,10 @@ async fn main() -> anyhow::Result<()> {
 
     let verified = ex_ray_binary.prepare()?;
 
-    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    // The same defect would also fail `parse_udp_timeout`/`ex_ray_options`
+    // below, but they can never reach that branch through this binary; both
+    // stay fallible for their own callers and unit tests.
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref())?;
     // Parse the galoshes-specific client UDP NAT idle-eviction timeout from the
     // shared options string before any I/O so a misconfiguration fails loudly
     // at startup. ex-ray ignores unrecognized keys (it only reads keys it knows).

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -35,6 +35,24 @@ const UDP_ASSOC_CHANNEL_CAPACITY: usize = 64;
 /// in `SS_PLUGIN_OPTIONS`. Matches shadowsocks-rust's `udp_timeout` default.
 pub const DEFAULT_UDP_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// `Instant::now() + udp_timeout`, saturating instead of panicking on
+/// overflow. `run_udp_association`'s idle-eviction reset re-reads the clock
+/// on every datagram for the process's whole lifetime, so a `udp_timeout`
+/// that fit `Instant::now()` at parse time (`parse_udp_timeout`'s own
+/// `checked_add` probe) is not guaranteed to still fit once the process has
+/// been up for a while — the margin shrinks as uptime grows. Mirrors the
+/// ask-forgiveness shape `tokio::time::sleep` itself uses (`checked_add`
+/// falling back to `Instant::far_future`), re-derived here because
+/// `far_future` is `pub(crate)` upstream.
+pub(crate) fn saturating_deadline(udp_timeout: Duration) -> Instant {
+    Instant::now().checked_add(udp_timeout).unwrap_or_else(|| {
+        // Roughly 30 years out — matches tokio::time::Instant::far_future's
+        // own margin, chosen there because 1000 years overflows on macOS and
+        // 100 years overflows on FreeBSD.
+        Instant::now() + Duration::from_secs(86_400 * 365 * 30)
+    })
+}
+
 // Protocol framing ====================================================================================================
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -554,7 +572,7 @@ async fn run_udp_association(
             // local app -> server
             maybe = outbound_rx.recv() => {
                 let Some(payload) = maybe else { break "channel closed" };
-                idle.as_mut().reset(Instant::now() + udp_timeout);
+                idle.as_mut().reset(saturating_deadline(udp_timeout));
                 let framed = frame_udp_datagram(&payload);
                 if stream.write_all(&framed).await.is_err() {
                     break "stream write error";
@@ -570,7 +588,7 @@ async fn run_udp_association(
                     Ok(n) => n,
                     Err(_) => break "stream read error",
                 };
-                idle.as_mut().reset(Instant::now() + udp_timeout);
+                idle.as_mut().reset(saturating_deadline(udp_timeout));
                 acc.push(&read_buf[..n]);
                 while let Some(payload) = acc.next_frame() {
                     if let Err(e) = udp_socket.send_to(&payload, peer).await {
@@ -1150,28 +1168,53 @@ async fn echo_keepalive(mut stream: yamux::Stream) -> Result<()> {
 /// Parse the optional client-side `udp_timeout` (whole seconds) from an
 /// `SS_PLUGIN_OPTIONS` string.
 ///
-/// Returns [`DEFAULT_UDP_TIMEOUT`] when the key is absent. The last occurrence
-/// wins (consistent with ex-ray's duplicate-key semantics). A value that
-/// is not a positive integer is a hard error — `0` would evict every
-/// association immediately, breaking all UDP. ex-ray ignores this key,
-/// so it can share the same options string.
+/// Returns [`DEFAULT_UDP_TIMEOUT`] when the key is absent. The FIRST
+/// occurrence wins on a duplicate key — matching every other reader of this
+/// same options string (ex-ray's own `Args.Get`, and the bridge's
+/// `classify_transport`/garter-bin's `config_path_from_plugin_options`),
+/// even though `udp_timeout` is galoshes' own extension ex-ray never reads:
+/// there is no cross-tool parity requirement for this key, but there IS an
+/// intra-string one — an operator reading one options string should not
+/// see different keys resolve duplicates in opposite directions.
+///
+/// EVERY occurrence is validated, not just the winning first one — a value
+/// that is not a positive integer is a hard error on ANY occurrence (`0`
+/// would evict every association immediately, breaking all UDP), so a
+/// self-contradictory duplicate still refuses the start rather than
+/// silently keeping the first value and discarding the rest unchecked.
 pub fn parse_udp_timeout(plugin_options: Option<&str>) -> Result<Duration> {
     let Some(opts) = plugin_options else {
         return Ok(DEFAULT_UDP_TIMEOUT);
     };
-    let mut timeout = DEFAULT_UDP_TIMEOUT;
-    for (key, value) in garter::parse_plugin_options(opts) {
-        if key == "udp_timeout" {
-            let secs: u64 = value
-                .parse()
-                .with_context(|| format!("invalid udp_timeout (expected a positive integer of seconds): {value:?}"))?;
-            if secs == 0 {
-                anyhow::bail!("udp_timeout must be greater than 0 seconds");
-            }
-            timeout = Duration::from_secs(secs);
+    let mut selected: Option<Duration> = None;
+    for (key, value) in garter::parse_plugin_options(opts).map_err(garter::Error::from)? {
+        if key != "udp_timeout" {
+            continue;
         }
+        // Never echo the rejected value: SIP003 escaping lets a `\` absorb a
+        // later segment into a value, so an unparseable
+        // `udp_timeout=abc\;token=SECRET` could otherwise leak `token`'s
+        // value through this message (same reason `Mode::from_plugin_options`
+        // and every `parse*Option` in ex-ray's own options.go withhold theirs).
+        let secs: u64 = value
+            .parse()
+            .context("invalid udp_timeout: value is not a positive integer of seconds")?;
+        if secs == 0 {
+            anyhow::bail!("udp_timeout must be greater than 0 seconds");
+        }
+        let timeout = Duration::from_secs(secs);
+        // A diagnostic, not the safety net: `run_udp_association`'s own idle
+        // resets use `saturating_deadline`, which can't panic no matter what
+        // `timeout` is. This check exists so a `udp_timeout` too large to
+        // fit `Instant` even right now — which would defeat NAT idle-eviction
+        // as thoroughly as `0` defeats it in the other direction — is
+        // reported at startup instead of silently accepted.
+        if std::time::Instant::now().checked_add(timeout).is_none() {
+            anyhow::bail!("udp_timeout is too large to represent as a deadline");
+        }
+        selected.get_or_insert(timeout);
     }
-    Ok(timeout)
+    Ok(selected.unwrap_or(DEFAULT_UDP_TIMEOUT))
 }
 
 pub struct YamuxPlugin {

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
 use tokio_util::compat::TokioAsyncReadCompatExt as _;
 use tokio_util::sync::CancellationToken;
 
@@ -21,10 +22,10 @@ use crate::yamux::keepalive::Cadence;
 use crate::yamux::{
     bind_udp, connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram, drive_connection,
     driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client,
-    run_client_session, run_server, run_server_with_connections, serve_driven_connection, session_reconnect_backoff,
-    ClientBoundAddrs, FrameAccumulator, OpenStreamReply, SessionOutcome, SessionTransport, StreamTag,
-    TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE,
-    REMOTE_BACKOFF_MAX,
+    run_client_session, run_server, run_server_with_connections, saturating_deadline, serve_driven_connection,
+    session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, OpenStreamReply, SessionOutcome, SessionTransport,
+    StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN, LOOPBACK_CONNECT_RETRY,
+    REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
 
 #[skuld::test]
@@ -183,10 +184,10 @@ fn udp_timeout_parsed_value() {
 }
 
 #[skuld::test]
-fn udp_timeout_last_occurrence_wins() {
+fn udp_timeout_first_occurrence_wins() {
     assert_eq!(
         parse_udp_timeout(Some("udp_timeout=5;udp_timeout=20")).unwrap(),
-        Duration::from_secs(20)
+        Duration::from_secs(5)
     );
 }
 
@@ -197,6 +198,52 @@ fn udp_timeout_invalid_is_error() {
     // 0 would evict every association immediately — rejected.
     assert!(parse_udp_timeout(Some("udp_timeout=0")).is_err());
     assert!(parse_udp_timeout(Some("udp_timeout=-1")).is_err());
+    // Too large to fit `Instant` even right now — `run_udp_association`'s
+    // resets would saturate rather than panic on this, but it's still
+    // rejected early as a diagnostic (it would defeat idle-eviction as
+    // thoroughly as `0` does in the other direction).
+    assert!(parse_udp_timeout(Some("udp_timeout=18446744073709551615")).is_err());
+}
+
+#[skuld::test]
+fn udp_timeout_validates_every_occurrence_not_just_the_first() {
+    assert!(parse_udp_timeout(Some("udp_timeout=30;udp_timeout=0")).is_err());
+    assert!(parse_udp_timeout(Some("udp_timeout=30;udp_timeout=abc")).is_err());
+}
+
+#[skuld::test]
+fn udp_timeout_errors_on_malformed_options() {
+    // A dangling trailing backslash is fatal to ex-ray's own parser; failing
+    // loud here beats silently falling back to the default. The reason must
+    // survive in the error's own message, not just the fact that it failed.
+    let err = parse_udp_timeout(Some(r"udp_timeout=10;path=/a\")).unwrap_err();
+    assert!(
+        err.to_string().contains("unpaired backslash"),
+        "expected the specific reason in the message, got: {err}"
+    );
+}
+
+#[skuld::test]
+fn udp_timeout_rejected_value_never_reaches_the_error_message() {
+    // An escaped `;` absorbs the following segment into `udp_timeout`'s own
+    // value instead of starting a new one, so a naive `{value:?}` in the
+    // error would leak whatever follows — here, a stand-in secret.
+    let err = parse_udp_timeout(Some(r"udp_timeout=abc\;token=SECRET")).unwrap_err();
+    assert!(
+        !err.to_string().contains("SECRET"),
+        "error message leaks the rejected value: {err}"
+    );
+}
+
+#[skuld::test]
+fn saturating_deadline_never_panics_on_a_duration_too_large_to_add() {
+    // The value `parse_udp_timeout` rejects at parse time as too large to
+    // fit `Instant` right now still must not panic here: uptime narrows the
+    // margin, so a value that DID fit at parse time can still overflow by
+    // the time a reset actually runs. `saturating_deadline` is what
+    // `run_udp_association`'s resets call instead of a bare `+`.
+    let deadline = saturating_deadline(Duration::from_secs(u64::MAX));
+    assert!(deadline > Instant::now(), "must still land in the future");
 }
 
 // End-to-end UDP relay (#415) -----------------------------------------------------------------------------------------

--- a/crates/garter-bin/src/config.rs
+++ b/crates/garter-bin/src/config.rs
@@ -2,6 +2,13 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+pub(crate) mod escaping;
+#[cfg(test)]
+mod escaping_tests;
+
+use escaping::config_path_from_plugin_options;
+pub use escaping::{load_config_or_explain_escaping, ConfigPath, MangledPath};
+
 #[derive(Debug, Deserialize)]
 pub struct ChainConfig {
     pub chain: Vec<PluginEntry>,
@@ -34,4 +41,52 @@ pub fn load_config(path: &Path) -> anyhow::Result<ChainConfig> {
     let config: ChainConfig = yaml_serde::from_str(&contents)?;
     let config_dir = path.parent().unwrap_or(Path::new("."));
     Ok(config.resolve_paths(config_dir))
+}
+
+/// Validate every chain entry's `options` up front, before any plugin
+/// spawns — naming the specific chain entry index before any plugin
+/// process spawns, rather than only once that entry's own plugin starts
+/// and dies mid-chain.
+pub fn validate_chain_options(chain: &[PluginEntry]) -> anyhow::Result<()> {
+    for (index, entry) in chain.iter().enumerate() {
+        if let Some(opts) = &entry.options {
+            garter::parse_plugin_options(opts).map_err(|e| {
+                anyhow::anyhow!(
+                    "chain entry {index} ({}): malformed options: {e}",
+                    entry.plugin.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the chain config from `SS_PLUGIN_OPTIONS`: extract `config=`,
+/// load the YAML (naming an unescaped Windows path if that's why loading
+/// failed), require a non-empty chain, and validate every entry's own
+/// options — the exact sequence `main` runs before touching any plugin
+/// process. Broken out of `main` so this composition is unit-testable
+/// end to end without spawning `garter-bin` as a subprocess.
+///
+/// A detected mangling is warned about here, BEFORE attempting the load —
+/// not only in [`load_config_or_explain_escaping`]'s failure path. A
+/// mangled path (typically a relative one, resolved against the process's
+/// current directory) can coincidentally name a real, loadable file that is
+/// NOT the one the operator wrote in `config=`; if that happens, the load
+/// below succeeds silently and the operator would otherwise have no
+/// indication the wrong file was opened.
+pub fn resolve_chain_config(plugin_options: Option<&str>) -> anyhow::Result<ChainConfig> {
+    let config = config_path_from_plugin_options(plugin_options)?;
+    if let Some(m) = &config.mangled_from {
+        tracing::warn!(
+            path = %config.path,
+            doubled_suggestion = %m.doubled,
+            forward_slash_suggestion = ?m.forward_slashes,
+            "config= names a path that came from an unescaped `\\`; opening the DECODED path, which may not be what was intended"
+        );
+    }
+    let cfg = load_config_or_explain_escaping(&config)?;
+    anyhow::ensure!(!cfg.chain.is_empty(), "chain config must have at least one plugin");
+    validate_chain_options(&cfg.chain)?;
+    Ok(cfg)
 }

--- a/crates/garter-bin/src/config/escaping.rs
+++ b/crates/garter-bin/src/config/escaping.rs
@@ -1,0 +1,223 @@
+//! Extract `config=` from `SS_PLUGIN_OPTIONS` and diagnose the common
+//! mistake of pasting an unescaped Windows path into it (SIP003 requires
+//! doubling a literal `\`). Self-contained: nothing here is a SIP003
+//! protocol primitive (that's [`garter::sip003`]) — this is a `config=`-
+//! specific diagnostic heuristic that reconstructs what an operator likely
+//! meant and suggests a corrected spelling.
+
+/// Whether `c` is one of the three bytes that must be re-escaped to
+/// round-trip as one segment through `garter::split_plugin_options`: `;`
+/// (that crate's `split_on_unescaped_borrowed` delimiter), `=` (its
+/// `find_unescaped` key/value separator), and `\` (the escape character
+/// itself). Defined locally rather than in `garter::sip003` — that crate's
+/// own decoder has no metacharacter notion to reuse (a `\` there escapes
+/// any byte), and this one-line body has no reason to expand garter's
+/// published API for a single external caller.
+fn is_sip003_metacharacter(c: char) -> bool {
+    matches!(c, ';' | '\\' | '=')
+}
+
+/// The chain config path from `config=`, plus whether decoding it likely
+/// mangled an unescaped Windows-style path — carried alongside the path
+/// rather than logged immediately, so a LOAD failure (not just a parse)
+/// can explain itself; see [`load_config_or_explain_escaping`].
+#[derive(Debug)]
+pub struct ConfigPath {
+    pub path: String,
+    pub mangled_from: Option<MangledPath>,
+}
+
+/// Two corrected spellings for a `config=` value `value_was_mangled_by_unescaping`
+/// flagged: double every literal backslash, or use forward slashes instead
+/// (Windows accepts both). `forward_slashes` is `None` off Windows — there
+/// `\` is an ordinary filename byte, not a path separator, so substituting
+/// `/` names a genuinely different path rather than an equivalent spelling;
+/// offering it as a "fix" there would be actively misleading.
+#[derive(Debug)]
+pub struct MangledPath {
+    pub doubled: String,
+    pub forward_slashes: Option<String>,
+}
+
+/// Extract `config=<path>` from a SIP003 `SS_PLUGIN_OPTIONS` string.
+///
+/// A malformed options string (e.g. a dangling trailing backslash) is
+/// reported distinctly from a simply-absent `config` key, so a caller can
+/// tell "you forgot `config=`" from "your options string doesn't parse." A
+/// bare `config` or an explicit `config=` (empty value) are both treated as
+/// absent — a path can't be the empty string. Does NOT reject a mangled
+/// value itself (`load_config_or_explain_escaping` reports it, only if the
+/// path then fails to load — a mangled decode isn't necessarily wrong: it
+/// could coincidentally still name a real file).
+pub fn config_path_from_plugin_options(plugin_options: Option<&str>) -> anyhow::Result<ConfigPath> {
+    let Some(opts) = plugin_options else {
+        anyhow::bail!("SS_PLUGIN_OPTIONS must contain config=/path/to/chain.yaml");
+    };
+    let segments = garter::split_plugin_options(opts).map_err(garter::Error::from)?;
+    let segment = segments
+        .iter()
+        .find(|s| s.key == "config")
+        .ok_or_else(|| anyhow::anyhow!("SS_PLUGIN_OPTIONS must contain config=/path/to/chain.yaml"))?;
+    if segment.value.is_empty() {
+        anyhow::bail!("SS_PLUGIN_OPTIONS config= must name a non-empty path");
+    }
+    Ok(ConfigPath {
+        path: segment.value.clone(),
+        mangled_from: value_was_mangled_by_unescaping(segment).then(|| mangled_spellings(segment)),
+    })
+}
+
+/// The two corrected spellings for a segment `value_was_mangled_by_unescaping`
+/// already confirmed is mangled. Splits `raw` at its first `=` under the
+/// same caller-restricted assumption as `value_was_mangled_by_unescaping`
+/// — see that function's doc comment — then delegates the actual
+/// reconstruction to [`reconstruct_intended`], the single implementation of
+/// this walk (shared with `value_was_mangled_by_unescaping`).
+fn mangled_spellings(segment: &garter::OptionSegment<'_>) -> MangledPath {
+    let eq = segment
+        .raw
+        .find('=')
+        .expect("value_was_mangled_by_unescaping already confirmed an '=' exists");
+    let (intended, _) = reconstruct_intended(&segment.raw[eq + 1..])
+        .expect("segment already validated by split_plugin_options: no dangling escape");
+    MangledPath {
+        doubled: escape_sip003(&intended),
+        forward_slashes: cfg!(windows).then(|| escape_sip003(&intended.replace('\\', "/"))),
+    }
+}
+
+/// Reconstruct `s`'s "intended literal" reading — a `config=` diagnostic
+/// heuristic for explaining, not just decoding, a value suspected of being
+/// a raw Windows path pasted in without proper escaping.
+///
+/// A `\` before one of the three [`is_sip003_metacharacter`]
+/// bytes decodes as usual (consumed) — the operator escaped correctly
+/// there. A `\` before any OTHER byte is instead kept as BOTH characters
+/// rather than consumed: the actual defect, treated as a literal `\` the
+/// operator forgot to double, so it can be re-escaped exactly once by a
+/// caller re-serializing `intended` rather than escaped a second time on
+/// top of an escape that was already correct (a naive "double every
+/// backslash in `s`" would do that on a partially-escaped value). Returns
+/// whether any such defect was found.
+///
+/// A value starting with exactly two backslashes (not four or more) is a
+/// special case: a Windows UNC (`\\server\share\...`) or extended-length
+/// (`\\?\C:\...`) prefix reads identically to one legitimate escape of a
+/// literal `\` — `\\` decodes to one `\` either way — so which the
+/// operator meant is genuinely ambiguous from the bytes alone. Since an
+/// entirely-unescaped literal path is the overwhelmingly common real
+/// input, both leading backslashes are reconstructed as literal rather
+/// than run through the escape detection above (which would drop one).
+/// Four or more leading backslashes are left to the normal detection — a
+/// repeated, correctly-doubled pair is evidence of deliberate escaping,
+/// not the single ambiguous case this exists to catch. This ambiguous
+/// leading pair is NOT by itself evidence of mangling, though (the
+/// returned `bool`): a value consisting solely of a correctly-escaped
+/// leading backslash, with no other defect anywhere, is indistinguishable
+/// from this case and must not be flagged — only a defect ELSEWHERE in the
+/// value marks it mangled.
+///
+/// `Err` only on a dangling trailing `\` — every caller reaches this on an
+/// [`garter::OptionSegment::value`] this was already decoded from, so has
+/// necessarily already ruled this out via [`garter::split_plugin_options`].
+///
+/// Delegates the walk itself to [`garter::sip003::walk_escaped`] (shared
+/// with garter's own `unescape_any`) — only the escaped-byte handling
+/// (metacharacter-vs-not, and the leading-pair special case) is specific to
+/// this diagnostic.
+pub(crate) fn reconstruct_intended(s: &str) -> Result<(String, bool), garter::MalformedOptions> {
+    let (prefix, rest) = if s.starts_with(r"\\") && !s.starts_with(r"\\\\") {
+        (r"\\", &s[2..])
+    } else {
+        ("", s)
+    };
+
+    let mut was_mangled = false;
+    let walked = garter::sip003::walk_escaped(rest, |c, out| {
+        if is_sip003_metacharacter(c) {
+            out.push(c);
+        } else {
+            out.push('\\');
+            out.push(c);
+            was_mangled = true;
+        }
+    })?;
+    Ok((format!("{prefix}{walked}"), was_mangled))
+}
+
+/// Escape every SIP003 metacharacter in `s` so it round-trips as ONE
+/// segment through [`garter::split_plugin_options`] — used to serialize
+/// [`mangled_spellings`]'s reconstructed literal path back into a valid
+/// `config=` value. Escaping only `\` leaves a decoded `;`/`=` unescaped,
+/// silently splitting the suggestion into more than one segment or moving
+/// the key/value boundary.
+pub(crate) fn escape_sip003(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| {
+            if is_sip003_metacharacter(c) {
+                vec!['\\', c]
+            } else {
+                vec![c]
+            }
+        })
+        .collect()
+}
+
+/// Load the chain config at `config.path`. If the path came from a
+/// `config=` value `value_was_mangled_by_unescaping` flagged (an unescaped
+/// literal backslash silently dropped) and the load then fails with ANY
+/// IO-layer error — narrowly checking `NotFound` would miss e.g.
+/// `PermissionDenied` (a dropped backslash collapsing the path into a
+/// protected location) on the same known-mangled path — names the
+/// escaping as the cause and offers two corrected spellings, rather than a
+/// bare IO error that gives no hint the real cause was SIP003 escaping. A
+/// legitimately doubled/clean path never has `mangled_from` set, so it
+/// never triggers this text — and neither does a YAML-parse failure on a
+/// path that DID resolve to a real file: `yaml_serde` errors don't
+/// downcast to `std::io::Error`, so that failure has nothing to do with
+/// escaping and is left to speak plainly rather than misattributed.
+pub fn load_config_or_explain_escaping(config: &ConfigPath) -> anyhow::Result<crate::config::ChainConfig> {
+    crate::config::load_config(std::path::Path::new(&config.path)).map_err(|e| {
+        let io_failure = e.downcast_ref::<std::io::Error>().is_some();
+        match (&config.mangled_from, io_failure) {
+            (Some(m), true) => {
+                let suggestion = match &m.forward_slashes {
+                    Some(fs) => format!("try config={} or config={}", m.doubled, fs),
+                    None => format!("try config={}", m.doubled),
+                };
+                anyhow::anyhow!(
+                    "failed to load chain config at {:?}: {e}\n\
+                     this path came from a SIP003 config= value containing an unescaped `\\`; SIP003 requires \
+                     doubling a literal `\\` — {suggestion}",
+                    config.path,
+                )
+            }
+            _ => anyhow::anyhow!("failed to load chain config at {:?}: {e}", config.path),
+        }
+    })
+}
+
+/// Whether `segment`'s raw value contains a backslash escaping a byte with
+/// no SIP003 meaning — the signal a Windows-style path was written with an
+/// UNESCAPED literal backslash and got silently mangled. Delegates the walk
+/// to [`reconstruct_intended`] (shared with `mangled_spellings`) and keeps
+/// only its `bool` half. `pub(crate)` for direct unit testing rather than
+/// asserting on captured log output.
+///
+/// Splits `raw` at its first `=` rather than the first UNESCAPED one: safe
+/// here because the only caller reaches this on a segment whose DECODED key
+/// is exactly `"config"`, which has no `=` in it, so no escape sequence in
+/// the key portion can move where the real separator is — enforced below,
+/// not just documented.
+pub(crate) fn value_was_mangled_by_unescaping(segment: &garter::OptionSegment<'_>) -> bool {
+    debug_assert_eq!(
+        segment.key, "config",
+        "value_was_mangled_by_unescaping's raw.find('=') shortcut is only valid for a config= segment"
+    );
+    let Some(eq) = segment.raw.find('=') else {
+        return false; // a bare key has no value to mangle
+    };
+    reconstruct_intended(&segment.raw[eq + 1..])
+        .expect("segment already validated by split_plugin_options: no dangling escape")
+        .1
+}

--- a/crates/garter-bin/src/config/escaping_tests.rs
+++ b/crates/garter-bin/src/config/escaping_tests.rs
@@ -1,0 +1,348 @@
+use super::escaping::*;
+
+// config_path_from_plugin_options =====================================================================================
+
+#[skuld::test]
+fn config_path_found() {
+    assert_eq!(
+        config_path_from_plugin_options(Some("config=/etc/chain.yaml"))
+            .unwrap()
+            .path,
+        "/etc/chain.yaml"
+    );
+    assert_eq!(
+        config_path_from_plugin_options(Some("mode=quic;config=/etc/chain.yaml;path=/x"))
+            .unwrap()
+            .path,
+        "/etc/chain.yaml"
+    );
+}
+
+#[skuld::test]
+fn config_path_missing_is_an_error() {
+    assert!(config_path_from_plugin_options(None).is_err());
+    assert!(config_path_from_plugin_options(Some("")).is_err());
+    assert!(config_path_from_plugin_options(Some("mode=quic")).is_err());
+    // A bare key or an explicitly empty value are both "no path named",
+    // not "path is the empty string".
+    assert!(config_path_from_plugin_options(Some("config")).is_err());
+    assert!(config_path_from_plugin_options(Some("config=")).is_err());
+}
+
+#[skuld::test]
+fn config_path_malformed_options_is_a_distinct_error() {
+    let err = config_path_from_plugin_options(Some(r"config=/etc/chain.yaml;path=/a\")).unwrap_err();
+    assert!(
+        err.to_string().contains("malformed SS_PLUGIN_OPTIONS"),
+        "expected a malformed-options error, got: {err}"
+    );
+}
+
+#[skuld::test]
+fn config_path_reports_mangling_with_corrected_spellings() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\Users\x\chain.yaml")).unwrap();
+    assert_eq!(config.path, "C:Usersxchain.yaml");
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    assert_eq!(mangled.doubled, r"C:\\Users\\x\\chain.yaml");
+    assert_forward_slashes_platform_correct(&mangled, "C:/Users/x/chain.yaml");
+}
+
+// A forward-slash spelling only round-trips to the SAME path on Windows
+// (which accepts both separators) — on Unix `\` is an ordinary filename
+// byte, so it must not be offered as a "fix" there.
+fn assert_forward_slashes_platform_correct(mangled: &MangledPath, expected_on_windows: &str) {
+    if cfg!(windows) {
+        assert_eq!(mangled.forward_slashes.as_deref(), Some(expected_on_windows));
+    } else {
+        assert!(
+            mangled.forward_slashes.is_none(),
+            "forward-slash spelling must not be offered off Windows, got {:?}",
+            mangled.forward_slashes
+        );
+    }
+}
+
+#[skuld::test]
+fn config_path_reports_no_mangling_for_a_correctly_escaped_path() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\\Users\\x\\chain.yaml")).unwrap();
+    assert_eq!(config.path, r"C:\Users\x\chain.yaml");
+    assert!(config.mangled_from.is_none());
+}
+
+// A Windows UNC path's leading `\\` is genuinely ambiguous SIP003 input
+// (see `reconstruct_intended`'s doc comment) — this pins that it's read as
+// two literal backslashes, not as one legitimate SIP003 escape.
+#[skuld::test]
+fn config_path_unc_prefix_keeps_both_leading_backslashes() {
+    let config = config_path_from_plugin_options(Some(r"config=\\fileserver\share\chain.yaml")).unwrap();
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    assert_eq!(mangled.doubled, r"\\\\fileserver\\share\\chain.yaml");
+    assert_forward_slashes_platform_correct(&mangled, "//fileserver/share/chain.yaml");
+
+    // The suggestion must round-trip back to the exact original UNC path.
+    let doubled_opts = format!("config={}", mangled.doubled);
+    let doubled_segments = garter::split_plugin_options(&doubled_opts).unwrap();
+    assert_eq!(doubled_segments[0].value, r"\\fileserver\share\chain.yaml");
+}
+
+// The extended-length prefix `\\?\` starts the same way and must get the
+// same treatment.
+#[skuld::test]
+fn config_path_extended_length_prefix_keeps_both_leading_backslashes() {
+    let config = config_path_from_plugin_options(Some(r"config=\\?\C:\very\long\chain.yaml")).unwrap();
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    let doubled_opts = format!("config={}", mangled.doubled);
+    let doubled_segments = garter::split_plugin_options(&doubled_opts).unwrap();
+    assert_eq!(doubled_segments[0].value, r"\\?\C:\very\long\chain.yaml");
+}
+
+// A partially-escaped value (one separator correctly doubled, the rest
+// not) must not double-escape the already-correct part in its suggestion.
+#[skuld::test]
+fn config_path_mixed_escaping_suggests_the_fully_corrected_spelling() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\\shared\data\chain.yaml")).unwrap();
+    assert_eq!(config.path, r"C:\shareddatachain.yaml");
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+    assert_eq!(mangled.doubled, r"C:\\shared\\data\\chain.yaml");
+    assert_forward_slashes_platform_correct(&mangled, "C:/shared/data/chain.yaml");
+}
+
+// A suggestion must re-escape EVERY SIP003 metacharacter it decoded while
+// reconstructing the intended path, not just `\` — otherwise it names a
+// spelling that no longer round-trips through the shared decoder as ONE
+// segment.
+#[skuld::test]
+fn config_path_mangled_suggestion_reescapes_semicolons_and_equals() {
+    let config = config_path_from_plugin_options(Some(r"config=C:\dir\my\;chain.yaml")).unwrap();
+    let mangled = config.mangled_from.expect("expected mangling to be detected");
+
+    let doubled_opts = format!("config={}", mangled.doubled);
+    let doubled_segments = garter::split_plugin_options(&doubled_opts)
+        .unwrap_or_else(|e| panic!("doubled suggestion {:?} does not even parse: {e}", mangled.doubled));
+    assert_eq!(
+        doubled_segments.len(),
+        1,
+        "doubled suggestion {:?} split into more than one segment",
+        mangled.doubled
+    );
+    assert_eq!(doubled_segments[0].value, r"C:\dir\my;chain.yaml");
+
+    if cfg!(windows) {
+        let fs = mangled
+            .forward_slashes
+            .as_deref()
+            .expect("Windows must offer a forward-slash spelling");
+        let forward_opts = format!("config={fs}");
+        let forward_segments = garter::split_plugin_options(&forward_opts)
+            .unwrap_or_else(|e| panic!("forward-slash suggestion {fs:?} does not even parse: {e}"));
+        assert_eq!(
+            forward_segments.len(),
+            1,
+            "forward-slash suggestion {fs:?} split into more than one segment"
+        );
+        assert_eq!(forward_segments[0].value, "C:/dir/my;chain.yaml");
+    } else {
+        assert!(mangled.forward_slashes.is_none());
+    }
+}
+
+#[skuld::test]
+fn config_path_first_wins_on_duplicate_key() {
+    // ex-ray's Args.Get is first-wins; the FIRST config= must be the one
+    // consulted.
+    assert_eq!(
+        config_path_from_plugin_options(Some("config=/first;config=/second"))
+            .unwrap()
+            .path,
+        "/first"
+    );
+}
+
+// load_config_or_explain_escaping =====================================================================================
+
+#[skuld::test]
+fn load_config_names_the_escaping_when_a_mangled_path_fails_to_load() {
+    let config = ConfigPath {
+        path: "C:Usersxchain.yaml".to_string(), // nonexistent, mangled
+        mangled_from: Some(MangledPath {
+            doubled: r"C:\\Users\\x\\chain.yaml".to_string(),
+            forward_slashes: Some("C:/Users/x/chain.yaml".to_string()),
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unescaped"),
+        "expected the error to name escaping as the cause: {msg}"
+    );
+    assert!(
+        msg.contains(r"C:\\Users\\x\\chain.yaml"),
+        "expected the doubled-backslash suggestion: {msg}"
+    );
+    assert!(
+        msg.contains("C:/Users/x/chain.yaml"),
+        "expected the forward-slash suggestion: {msg}"
+    );
+}
+
+// Off Windows (`forward_slashes: None`), only the doubled-backslash
+// suggestion is offered — no misleading second spelling that would name a
+// different path on that platform.
+#[skuld::test]
+fn load_config_offers_only_the_doubled_suggestion_when_forward_slashes_is_none() {
+    let config = ConfigPath {
+        path: "C:Usersxchain.yaml".to_string(), // nonexistent, mangled
+        mangled_from: Some(MangledPath {
+            doubled: r"C:\\Users\\x\\chain.yaml".to_string(),
+            forward_slashes: None,
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains(r"C:\\Users\\x\\chain.yaml"),
+        "expected the doubled-backslash suggestion: {msg}"
+    );
+    assert!(
+        !msg.contains(" or config="),
+        "must not offer a second suggestion when forward_slashes is None: {msg}"
+    );
+}
+
+#[skuld::test]
+fn load_config_names_the_escaping_on_a_non_not_found_io_error() {
+    // A directory, not a file: `read_to_string` fails with an OS-specific IO
+    // error that is NOT `NotFound` (e.g. `IsADirectory`/`PermissionDenied`)
+    // on every platform. The escaping explanation must still fire — it
+    // covers any IO-layer failure on a known-mangled path, not just
+    // "file not found".
+    let dir_path = std::env::temp_dir();
+    let config = ConfigPath {
+        path: dir_path.to_string_lossy().into_owned(),
+        mangled_from: Some(MangledPath {
+            doubled: r"C:\\Users\\x\\chain.yaml".to_string(),
+            forward_slashes: Some("C:/Users/x/chain.yaml".to_string()),
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    assert!(
+        err.to_string().contains("unescaped"),
+        "expected the error to name escaping as the cause for a non-NotFound IO error: {err}"
+    );
+}
+
+#[skuld::test]
+fn load_config_plain_error_when_the_path_was_not_mangled() {
+    let config = ConfigPath {
+        path: "/nonexistent/chain.yaml".to_string(),
+        mangled_from: None,
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    assert!(
+        !err.to_string().contains("unescaped"),
+        "a legitimately doubled/clean path must not trigger the escaping explanation: {err}"
+    );
+}
+
+#[skuld::test]
+fn load_config_does_not_blame_escaping_for_a_yaml_parse_failure() {
+    // A mangled path that coincidentally resolves to a REAL file with bad
+    // YAML must not get the escaping explanation — that's not what went
+    // wrong, and blaming it anyway sends the operator chasing the wrong fix.
+    let path = std::env::temp_dir().join(format!(
+        "garter-bin-escaping-test-{}-{}.yaml",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(&path, "not: [valid: yaml").unwrap();
+    let config = ConfigPath {
+        path: path.to_string_lossy().into_owned(),
+        mangled_from: Some(MangledPath {
+            doubled: "unused".to_string(),
+            forward_slashes: Some("unused".to_string()),
+        }),
+    };
+    let err = load_config_or_explain_escaping(&config).unwrap_err();
+    std::fs::remove_file(&path).ok();
+    assert!(
+        !err.to_string().contains("unescaped"),
+        "a YAML-parse failure must not be blamed on escaping: {err}"
+    );
+}
+
+// value_was_mangled_by_unescaping =====================================================================================
+
+// The pure detector behind the escape warning, tested directly rather than
+// via captured log output — see its doc comment for the false positive it
+// avoids.
+#[skuld::test]
+fn value_was_mangled_by_unescaping_detects_only_the_defect() {
+    let seg = |raw: &'static str| garter::split_plugin_options(raw).unwrap().into_iter().next().unwrap();
+    // Mangled: a backslash escaping a byte with no SIP003 meaning.
+    assert!(value_was_mangled_by_unescaping(&seg(r"config=C:\Users\x\chain.yaml")));
+    // Correctly escaped backslash: legitimate, not mangled.
+    assert!(!value_was_mangled_by_unescaping(&seg(
+        r"config=C:\\Users\\x\\chain.yaml"
+    )));
+    // No backslash at all.
+    assert!(!value_was_mangled_by_unescaping(&seg("config=/etc/chain.yaml")));
+    // An escaped KEY spelling with a clean value is not a value defect.
+    assert!(!value_was_mangled_by_unescaping(&seg(r"\config=/etc/chain.yaml")));
+    // A correctly escaped `;` or `=` inside the value is legitimate too —
+    // NOT the same as an unescaped literal backslash.
+    assert!(!value_was_mangled_by_unescaping(&seg(r"config=/etc/a\;b.yaml")));
+    assert!(!value_was_mangled_by_unescaping(&seg(r"config=/etc/a\=b.yaml")));
+    // A bare key (no `=` at all) has no value to mangle.
+    assert!(!value_was_mangled_by_unescaping(&seg("config")));
+}
+
+// reconstruct_intended ================================================================================================
+
+#[skuld::test]
+fn reconstruct_intended_leaves_a_correctly_escaped_value_unchanged_and_unflagged() {
+    assert_eq!(
+        reconstruct_intended(r"C:\\Users\\x\\chain.yaml").unwrap(),
+        (r"C:\Users\x\chain.yaml".to_string(), false)
+    );
+}
+
+#[skuld::test]
+fn reconstruct_intended_detects_and_repairs_an_unescaped_backslash() {
+    assert_eq!(
+        reconstruct_intended(r"C:\Users\x\chain.yaml").unwrap(),
+        (r"C:\Users\x\chain.yaml".to_string(), true)
+    );
+}
+
+#[skuld::test]
+fn reconstruct_intended_errors_on_a_dangling_trailing_escape() {
+    assert_eq!(
+        reconstruct_intended(r"C:\Users\x\chain.yaml\"),
+        Err(garter::MalformedOptions::DanglingEscape)
+    );
+}
+
+// The leading-pair ambiguity rule — see reconstruct_intended's doc comment.
+#[skuld::test]
+fn reconstruct_intended_leading_pair_is_literal_but_not_alone_mangled() {
+    assert_eq!(
+        reconstruct_intended(r"\\file.yaml").unwrap(),
+        (r"\\file.yaml".to_string(), false)
+    );
+    // A defect ELSEWHERE in the same value still flags it, and the leading
+    // pair is still reconstructed as literal.
+    assert_eq!(
+        reconstruct_intended(r"\\fileserver\share\chain.yaml").unwrap(),
+        (r"\\fileserver\share\chain.yaml".to_string(), true)
+    );
+}
+
+// Four-plus leading backslashes: normal per-pair detection, not the
+// ambiguity rule — see reconstruct_intended's doc comment.
+#[skuld::test]
+fn reconstruct_intended_four_leading_backslashes_use_normal_detection() {
+    assert_eq!(
+        reconstruct_intended(r"\\\\server\\share\\file.yaml").unwrap(),
+        (r"\\server\share\file.yaml".to_string(), false)
+    );
+}

--- a/crates/garter-bin/src/config_tests.rs
+++ b/crates/garter-bin/src/config_tests.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use crate::config::ChainConfig;
+use tracing_subscriber::layer::{Layer, SubscriberExt};
+
+use crate::config::{resolve_chain_config, validate_chain_options, ChainConfig};
 
 #[skuld::test]
 fn parse_valid_config() {
@@ -46,4 +48,209 @@ chain:
     let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
     let resolved = config.resolve_paths(Path::new("/somewhere/else"));
     assert_eq!(resolved.chain[0].plugin, Path::new("/usr/bin/v2ray-plugin"));
+}
+
+// validate_chain_options ==============================================================================================
+
+#[skuld::test]
+fn validate_chain_options_rejects_a_malformed_entry() {
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "server;path=/a\\"
+"#;
+    let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
+    assert!(validate_chain_options(&config.chain).is_err());
+}
+
+#[skuld::test]
+fn validate_chain_options_accepts_well_formed_entries() {
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "tls;host=example.com"
+  - plugin: /usr/bin/obfs-plugin
+"#;
+    let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
+    assert!(validate_chain_options(&config.chain).is_ok());
+}
+
+#[skuld::test]
+fn validate_chain_options_reports_the_malformed_entrys_index() {
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "tls;host=example.com"
+  - plugin: /usr/bin/obfs-plugin
+    options: "server;path=/a\\"
+"#;
+    let config: ChainConfig = yaml_serde::from_str(yaml).unwrap();
+    let err = validate_chain_options(&config.chain).unwrap_err();
+    assert!(
+        err.to_string().contains("chain entry 1"),
+        "expected the error to name entry 1, got: {err}"
+    );
+}
+
+// resolve_chain_config (main's own composition, tested end to end) ====================================================
+
+/// Escape a REAL on-disk path (e.g. from `std::env::temp_dir()`, which on
+/// Windows contains literal backslashes) for embedding as a `config=` SIP003
+/// value — otherwise the reference decoder consumes the unescaped `\` and the
+/// test fails on a mangled path instead of exercising the intended behavior.
+/// Reuses production's own `escape_sip003` rather than a second
+/// hand-rolled copy of the same algorithm.
+fn escape_path_for_sip003(path: &std::path::Path) -> String {
+    crate::config::escaping::escape_sip003(&path.to_string_lossy())
+}
+
+#[skuld::test]
+fn resolve_chain_config_loads_a_well_formed_chain() {
+    let path = std::env::temp_dir().join(format!(
+        "garter-bin-config-test-{}-{}.yaml",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(
+        &path,
+        r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "tls;host=example.com"
+"#,
+    )
+    .unwrap();
+    let opts = format!("config={}", escape_path_for_sip003(&path));
+    let result = resolve_chain_config(Some(&opts));
+    std::fs::remove_file(&path).ok();
+
+    let cfg = result.unwrap();
+    assert_eq!(cfg.chain.len(), 1);
+}
+
+/// Capturing `MakeWriter` for asserting on a `tracing::warn!` call.
+#[derive(Clone, Default)]
+struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl CaptureWriter {
+    fn snapshot(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().expect("poisoned")).into_owned()
+    }
+}
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("poisoned").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+// A mangled path can coincidentally still resolve to a real file — see
+// resolve_chain_config's doc comment for why the warning must fire on
+// detection, not only on a subsequent load failure.
+#[skuld::test]
+fn resolve_chain_config_warns_when_a_mangled_path_coincidentally_loads() {
+    let real_path = std::env::temp_dir().join(format!(
+        "garter-bin-mangle-warn-test-{}-{}.yaml",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(&real_path, "chain:\n  - plugin: /usr/bin/v2ray-plugin\n").unwrap();
+
+    // Correctly escape the real path, then insert one EXTRA, deliberately
+    // unescaped backslash right before the last character (a plain letter,
+    // never a SIP003 metacharacter) — it decodes away to nothing (so the
+    // opened path is still the exact real one) while still being flagged as
+    // mangled, simulating "coincidentally still opens a real file."
+    let correctly_escaped = escape_path_for_sip003(&real_path);
+    let (before_last, last) = correctly_escaped.split_at(correctly_escaped.len() - 1);
+    let opts = format!("config={before_last}\\{last}");
+
+    let writer = CaptureWriter::default();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
+    );
+    let result = {
+        let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
+        resolve_chain_config(Some(&opts))
+    };
+    std::fs::remove_file(&real_path).ok();
+
+    result.expect("the mangled path coincidentally names a real, loadable file");
+    let output = writer.snapshot();
+    assert!(
+        output.contains("unescaped"),
+        "expected a warning naming the escaping, got:\n{output}"
+    );
+}
+
+#[skuld::test]
+fn resolve_chain_config_names_the_escaping_on_a_mangled_windows_path() {
+    // A raw, un-doubled backslash in `config=` — proves the escaping
+    // explanation reaches the top-level error through the FULL `main`
+    // composition (config extraction → load → escaping check), not just
+    // through `load_config_or_explain_escaping` called directly with a
+    // hand-built `ConfigPath`, as `escaping_tests` does.
+    let err = resolve_chain_config(Some(r"config=C:\Users\nonexistent\chain.yaml")).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unescaped"),
+        "expected the composed error to name escaping as the cause: {msg}"
+    );
+}
+
+#[skuld::test]
+fn resolve_chain_config_rejects_an_empty_chain() {
+    let path = std::env::temp_dir().join(format!(
+        "garter-bin-config-test-{}-{}.yaml",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(&path, "chain: []").unwrap();
+    let opts = format!("config={}", escape_path_for_sip003(&path));
+    let result = resolve_chain_config(Some(&opts));
+    std::fs::remove_file(&path).ok();
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("at least one plugin"),
+        "expected the empty-chain guard's message, got: {err}"
+    );
+}
+
+#[skuld::test]
+fn resolve_chain_config_rejects_a_malformed_entry_via_validate_chain_options() {
+    let path = std::env::temp_dir().join(format!(
+        "garter-bin-config-test-{}-{}.yaml",
+        std::process::id(),
+        line!()
+    ));
+    let yaml = r#"
+chain:
+  - plugin: /usr/bin/v2ray-plugin
+    options: "server;path=/a\\"
+"#;
+    std::fs::write(&path, yaml).unwrap();
+    let opts = format!("config={}", escape_path_for_sip003(&path));
+    let result = resolve_chain_config(Some(&opts));
+    std::fs::remove_file(&path).ok();
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("chain entry 0"),
+        "expected validate_chain_options's own message to survive the composition, got: {err}"
+    );
 }

--- a/crates/garter-bin/src/main.rs
+++ b/crates/garter-bin/src/main.rs
@@ -1,4 +1,3 @@
-use garter::sip003::parse_plugin_options;
 use garter::{BinaryPlugin, ChainRunner, Mode, PluginEnv};
 
 #[tokio::main]
@@ -12,21 +11,17 @@ async fn main() -> anyhow::Result<()> {
 
     let env = PluginEnv::from_env().map_err(|e| anyhow::anyhow!("failed to parse SIP003u environment: {e}"))?;
 
-    let config_path = env
-        .plugin_options
-        .as_ref()
-        .and_then(|opts| {
-            parse_plugin_options(opts)
-                .into_iter()
-                .find(|(k, _)| k == "config")
-                .map(|(_, v)| v)
-        })
-        .ok_or_else(|| anyhow::anyhow!("SS_PLUGIN_OPTIONS must contain config=/path/to/chain.yaml"))?;
+    let cfg = garter_bin::config::resolve_chain_config(env.plugin_options.as_deref())?;
 
-    let cfg = garter_bin::config::load_config(std::path::Path::new(&config_path))?;
-    anyhow::ensure!(!cfg.chain.is_empty(), "chain config must have at least one plugin");
-
-    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    // Contract, not input validation: `resolve_chain_config` above already
+    // ran the same string through the identical parser
+    // (`config_path_from_plugin_options` → `split_plugin_options`) and
+    // returned `Ok`, so this is provably unreachable on every real input —
+    // a hard `.expect()`, not a soft `?`, matching `exray_options.rs`'s own
+    // idiom for the identical shape (a value already re-validated by the
+    // same underlying parser).
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref())
+        .expect("well-formed by construction: already validated by resolve_chain_config above");
     let mut runner = ChainRunner::new().mode(mode);
     for entry in cfg.chain {
         runner = runner.add(Box::new(BinaryPlugin::new(entry.plugin, entry.options.as_deref())));

--- a/crates/garter/README.md
+++ b/crates/garter/README.md
@@ -23,7 +23,8 @@ byte-level diagnostics.
 - **`CountingStream` / `StreamCounters`** — wire-level instrumentation
   for any `tokio::io::AsyncRead + AsyncWrite` stream.
 - **`parse_plugin_options`** — parses the SIP003 `;`-separated options
-  string into a typed `HashMap`.
+  string into an ordered list of key/value pairs, or an error for a string a
+  SIP003 plugin would reject outright.
 - **`Mode`** — selects chain direction (`Client` / `Server`); see below.
 
 ### Modes
@@ -71,7 +72,7 @@ async fn main() -> garter::Result<()> {
     // Detect SIP003 chain mode from SS_PLUGIN_OPTIONS (`server` keyword
     // = Server; default = Client). Same parse used by v2ray-plugin and
     // other SIP003 plugins.
-    let mode = Mode::from_plugin_options(env.plugin_options.as_deref());
+    let mode = Mode::from_plugin_options(env.plugin_options.as_deref())?;
 
     let chain = ChainRunner::new()
         .mode(mode)

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -138,21 +138,21 @@ impl BinaryPlugin {
     /// to `crate` for testability; production callers use [`Self::run`]
     /// which feeds this into `Command::env`. See [`Sip003Env`] for the
     /// client/server semantics.
-    pub(crate) fn sip003_env(&self, local: SocketAddr, remote: SocketAddr) -> Sip003Env {
+    pub(crate) fn sip003_env(&self, local: SocketAddr, remote: SocketAddr) -> crate::Result<Sip003Env> {
         // In server mode the binary itself swaps SS_LOCAL/SS_REMOTE
         // semantics (SS_REMOTE = inbound listener, SS_LOCAL = outbound
         // dial). We swap here first so the binary's swap restores the
         // direction we wanted.
-        let (ss_local, ss_remote) = match Mode::from_plugin_options(self.options.as_deref()) {
+        let (ss_local, ss_remote) = match Mode::from_plugin_options(self.options.as_deref())? {
             Mode::Client => (local, remote),
             Mode::Server => (remote, local),
         };
-        Sip003Env {
+        Ok(Sip003Env {
             ss_local_host: ss_local.ip().to_string(),
             ss_local_port: ss_local.port(),
             ss_remote_host: ss_remote.ip().to_string(),
             ss_remote_port: ss_remote.port(),
-        }
+        })
     }
 }
 
@@ -185,7 +185,7 @@ impl ChainPlugin for BinaryPlugin {
         shutdown: CancellationToken,
         ready: oneshot::Sender<Result<PluginReady, StartError>>,
     ) -> crate::Result<()> {
-        let env = self.sip003_env(local, remote);
+        let env = self.sip003_env(local, remote)?;
         let mut cmd = Command::new(&self.path);
         cmd.env("SS_LOCAL_HOST", env.ss_local_host);
         cmd.env("SS_LOCAL_PORT", env.ss_local_port.to_string());

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -32,7 +32,7 @@ fn sip003_env_client_mode_straight_through() {
     let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
     let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("tls;host=example.com"));
-    let env = plugin.sip003_env(listen, dial);
+    let env = plugin.sip003_env(listen, dial).unwrap();
     assert_eq!(env.ss_local_host, "127.0.0.1");
     assert_eq!(env.ss_local_port, 9001);
     assert_eq!(env.ss_remote_host, "203.0.113.1");
@@ -51,7 +51,7 @@ fn sip003_env_server_mode_swaps_addresses() {
     let listen: SocketAddr = "[::]:80".parse().unwrap();
     let dial: SocketAddr = "127.0.0.1:45589".parse().unwrap();
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("server;host=example.com"));
-    let env = plugin.sip003_env(listen, dial);
+    let env = plugin.sip003_env(listen, dial).unwrap();
     // Swap: BinaryPlugin's `local` (where the chain wants the binary to
     // bind, [::]:80) must reach v2ray-plugin as SS_REMOTE so its
     // server-mode swap interprets it as the listen address.
@@ -68,11 +68,22 @@ fn sip003_env_client_mode_when_options_only_have_servername() {
     let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
     let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
     let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some("servername=cdn.example.com"));
-    let env = plugin.sip003_env(listen, dial);
+    let env = plugin.sip003_env(listen, dial).unwrap();
     assert_eq!(env.ss_local_host, "127.0.0.1");
     assert_eq!(env.ss_local_port, 9001);
     assert_eq!(env.ss_remote_host, "203.0.113.1");
     assert_eq!(env.ss_remote_port, 8388);
+}
+
+// Pinned here because this is the call site that actually wires
+// SS_LOCAL/SS_REMOTE, not just a diagnostic mode read: a malformed
+// per-plugin `options:` string must not silently pick a chain direction.
+#[skuld::test]
+fn sip003_env_errors_on_malformed_options() {
+    let listen: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+    let dial: SocketAddr = "203.0.113.1:8388".parse().unwrap();
+    let plugin = BinaryPlugin::new("/usr/bin/v2ray-plugin", Some(r"server;path=/a\"));
+    assert!(plugin.sip003_env(listen, dial).is_err());
 }
 
 // Readiness-mode tests ================================================================================================

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -51,20 +51,43 @@ pub enum Mode {
 impl Mode {
     /// Derive the SIP003 chain mode from the `SS_PLUGIN_OPTIONS` string.
     /// Returns [`Mode::Server`] if a `server` key is present in the
-    /// options (with or without a value), [`Mode::Client`] otherwise.
-    /// Uses the spec-correct key parser ([`crate::parse_plugin_options`]),
-    /// so options like `servername=cdn.example.com` correctly resolve to
-    /// client mode.
-    pub fn from_plugin_options(opts: Option<&str>) -> Self {
-        let Some(opts) = opts else { return Mode::Client };
-        if crate::sip003::parse_plugin_options(opts)
-            .iter()
-            .any(|(k, _)| k == "server")
-        {
-            Mode::Server
-        } else {
-            Mode::Client
-        }
+    /// options (with or without a value), [`Mode::Client`] otherwise. Uses
+    /// [`crate::parse_plugin_options`] to decide, so options like
+    /// `servername=cdn.example.com` correctly resolve to client mode, and
+    /// an escaped spelling like `\server` still resolves to server mode —
+    /// matching how ex-ray reads the same string.
+    ///
+    /// Deliberately does NOT re-validate the `server` key's VALUE against
+    /// ex-ray's own `parseBoolOption` grammar (bare/`1` only): this function
+    /// is `BinaryPlugin::sip003_env`'s plugin-agnostic chain-direction
+    /// detector, reached for every `BinaryPlugin` in a chain, not only
+    /// ex-ray-family ones (garter's own README chains `obfs-local`
+    /// alongside `v2ray-plugin`) — hard-rejecting a value spelling a
+    /// third-party plugin accepts would be a false regression here. Where
+    /// it IS ex-ray, `parseBoolOption` is itself fatal on those same
+    /// spellings, so a real disagreement already fails loud when ex-ray
+    /// starts.
+    ///
+    /// `Err` on a malformed options string (e.g. a dangling trailing
+    /// backslash or an empty key). Neither `Mode::Client` nor `Mode::Server`
+    /// would be real parity with ex-ray here, and there is no safe default to
+    /// guess, so the failure is surfaced rather than papered over with one.
+    ///
+    /// Returns `crate::Error` (not the narrower `MalformedOptions`) so every
+    /// caller gets the canonical "malformed SS_PLUGIN_OPTIONS: {reason}"
+    /// wording through a plain `?`, with nothing to hand-write at the call site.
+    pub fn from_plugin_options(opts: Option<&str>) -> crate::Result<Self> {
+        let Some(opts) = opts else { return Ok(Mode::Client) };
+        Ok(
+            if crate::sip003::parse_plugin_options(opts)?
+                .iter()
+                .any(|(k, _)| k == "server")
+            {
+                Mode::Server
+            } else {
+                Mode::Client
+            },
+        )
     }
 }
 

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -632,22 +632,28 @@ async fn chain_runner_default_matches_explicit_client_mode() {
 #[skuld::test]
 async fn mode_from_plugin_options_detects_bare_server_keyword() {
     use crate::chain::Mode;
-    assert_eq!(Mode::from_plugin_options(Some("server")), Mode::Server);
-    assert_eq!(Mode::from_plugin_options(Some("server;path=/")), Mode::Server);
-    assert_eq!(Mode::from_plugin_options(Some("path=/;server;host=h")), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("server")).unwrap(), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some("server;path=/")).unwrap(), Mode::Server);
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/;server;host=h")).unwrap(),
+        Mode::Server
+    );
 }
 
 #[skuld::test]
 async fn mode_from_plugin_options_false_when_server_only_appears_as_substring() {
     use crate::chain::Mode;
     assert_eq!(
-        Mode::from_plugin_options(Some("servername=cdn.example.com")),
+        Mode::from_plugin_options(Some("servername=cdn.example.com")).unwrap(),
         Mode::Client
     );
-    assert_eq!(Mode::from_plugin_options(Some("path=/serverlist")), Mode::Client);
-    assert_eq!(Mode::from_plugin_options(Some("path=/server")), Mode::Client);
     assert_eq!(
-        Mode::from_plugin_options(Some("path=/serverlist;servername=foo")),
+        Mode::from_plugin_options(Some("path=/serverlist")).unwrap(),
+        Mode::Client
+    );
+    assert_eq!(Mode::from_plugin_options(Some("path=/server")).unwrap(), Mode::Client);
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/serverlist;servername=foo")).unwrap(),
         Mode::Client
     );
 }
@@ -655,8 +661,8 @@ async fn mode_from_plugin_options_false_when_server_only_appears_as_substring() 
 #[skuld::test]
 async fn mode_from_plugin_options_false_when_options_missing() {
     use crate::chain::Mode;
-    assert_eq!(Mode::from_plugin_options(None), Mode::Client);
-    assert_eq!(Mode::from_plugin_options(Some("")), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(None).unwrap(), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("")).unwrap(), Mode::Client);
 }
 
 #[skuld::test]
@@ -665,7 +671,7 @@ async fn mode_from_plugin_options_handles_mixed_options() {
     // Realistic server-side `plugin_opts`:
     // `server;fast-open;path=/t/<token>;host=<fqdn>`.
     let opts = "server;fast-open;path=/t/abc123;host=hole-stgn.binarydreams.me";
-    assert_eq!(Mode::from_plugin_options(Some(opts)), Mode::Server);
+    assert_eq!(Mode::from_plugin_options(Some(opts)).unwrap(), Mode::Server);
 }
 
 #[skuld::test]
@@ -674,8 +680,8 @@ async fn mode_from_plugin_options_false_for_capitalized_keyword() {
     // SIP003 keys are lowercase per v2ray-plugin convention; pin the
     // case-sensitive behavior so a future "be lenient about case" patch
     // is a conscious decision rather than drift.
-    assert_eq!(Mode::from_plugin_options(Some("Server")), Mode::Client);
-    assert_eq!(Mode::from_plugin_options(Some("SERVER;path=/")), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("Server")).unwrap(), Mode::Client);
+    assert_eq!(Mode::from_plugin_options(Some("SERVER;path=/")).unwrap(), Mode::Client);
 }
 
 #[skuld::test]
@@ -685,17 +691,40 @@ async fn mode_from_plugin_options_true_when_key_has_value() {
     // own parser uses `opts.Get("server")` which matches `server=value`
     // (value ignored). Mirror that semantics: presence of the key triggers
     // server mode regardless of value.
-    assert_eq!(Mode::from_plugin_options(Some("server=1;path=/")), Mode::Server);
-    assert_eq!(Mode::from_plugin_options(Some("server=true")), Mode::Server);
+    assert_eq!(
+        Mode::from_plugin_options(Some("server=1;path=/")).unwrap(),
+        Mode::Server
+    );
+    assert_eq!(Mode::from_plugin_options(Some("server=true")).unwrap(), Mode::Server);
 }
 
 #[skuld::test]
-async fn mode_from_plugin_options_false_for_escaped_server() {
+async fn mode_from_plugin_options_true_for_escaped_server() {
     use crate::chain::Mode;
-    // `\s` is not a SIP003-recognized escape (only \;, \\, \= per
-    // parse_plugin_options). So `\server` parses as the literal
-    // string `\server` -- which is NOT the bare key `server`.
-    assert_eq!(Mode::from_plugin_options(Some(r"\server")), Mode::Client);
+    // A backslash escapes whatever byte follows, so `\server` IS the bare
+    // key `server` — to ex-ray, and here.
+    assert_eq!(Mode::from_plugin_options(Some(r"\server")).unwrap(), Mode::Server);
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_errors_on_malformed_options() {
+    use crate::chain::Mode;
+    // See Mode::from_plugin_options's doc comment for why neither Client
+    // nor Server is a safe default here.
+    assert!(Mode::from_plugin_options(Some(r"server;path=/a\")).is_err());
+    assert!(Mode::from_plugin_options(Some("server;;path=/a")).is_err());
+}
+
+#[skuld::test]
+async fn mode_from_plugin_options_unaffected_by_a_duplicate_non_deciding_key() {
+    use crate::chain::Mode;
+    // `server` is decided by presence (`.any(...)`), not by ex-ray's
+    // first-wins `Get` — a duplicate, unrelated key elsewhere in the string
+    // must not perturb that.
+    assert_eq!(
+        Mode::from_plugin_options(Some("path=/a;path=/b;server")).unwrap(),
+        Mode::Server
+    );
 }
 
 // Drain-timeout semantics tests =======================================================================================

--- a/crates/garter/src/error.rs
+++ b/crates/garter/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
 
     #[error("environment variable '{var}' missing or invalid: {reason}")]
     Env { var: String, reason: String },
+
+    #[error("malformed SS_PLUGIN_OPTIONS: {0}")]
+    MalformedOptions(#[from] crate::sip003::MalformedOptions),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/garter/src/sip003.rs
+++ b/crates/garter/src/sip003.rs
@@ -18,7 +18,7 @@ impl PluginEnv {
             local_port: read_env_parsed("SS_LOCAL_PORT")?,
             remote_host: read_env("SS_REMOTE_HOST")?,
             remote_port: read_env_parsed("SS_REMOTE_PORT")?,
-            plugin_options: std::env::var("SS_PLUGIN_OPTIONS").ok(),
+            plugin_options: read_env_optional("SS_PLUGIN_OPTIONS")?,
         })
     }
 
@@ -52,30 +52,40 @@ where
     })
 }
 
+/// Like [`read_env`], but absence is `Ok(None)` rather than an error — for
+/// a var that's genuinely optional. Non-Unicode is still a loud error: an
+/// unreadable value must not collapse into the same `None` as "not set".
+fn read_env_optional(var: &str) -> crate::Result<Option<String>> {
+    match std::env::var(var) {
+        Ok(val) => Ok(Some(val)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(Error::Env {
+            var: var.into(),
+            reason: "contains invalid Unicode".into(),
+        }),
+    }
+}
+
 /// Parse SIP003 plugin options string into key-value pairs.
 /// Format: `key1=value1;key2=value2`
-/// Bare keys (no `=`) have value `""`.
-/// Escaping: `\;` → `;`, `\\` → `\`, `\=` → `=`.
+/// Bare keys (no `=`) have value `""` — see [`split_plugin_options`] for how
+/// this differs from ex-ray's own `"1"`.
 ///
-/// Two-pass approach:
-/// 1. Split on unescaped `;` (preserving escape sequences)
-/// 2. For each segment, split on first unescaped `=`, then unescape both parts
-pub fn parse_plugin_options(opts: &str) -> Vec<(String, String)> {
-    if opts.is_empty() {
-        return Vec::new();
-    }
-    let segments = split_on_unescaped(opts, ';');
-    let mut result = Vec::new();
-    for segment in segments {
-        if let Some(eq_pos) = find_unescaped(&segment, '=') {
-            let key = unescape(&segment[..eq_pos]);
-            let value = unescape(&segment[eq_pos + 1..]);
-            result.push((key, value));
-        } else {
-            result.push((unescape(&segment), String::new()));
-        }
-    }
-    result
+/// Decodes with the same escaping rule and segmentation
+/// [`split_plugin_options`] uses: a `\` escapes whatever byte follows, and
+/// one malformed segment — a dangling trailing `\` or an empty key —
+/// rejects the whole string rather than returning the pairs parsed so far
+/// (though not always with the same [`MalformedOptions`] variant ex-ray's
+/// single-pass scan would report for a string with more than one defect).
+/// The two primitives differ only in shape: this one decodes straight to
+/// owned pairs, while [`split_plugin_options`] keeps each segment's
+/// original bytes for a caller that must rewrite the string byte-exactly
+/// (see [`OptionSegment`]).
+pub fn parse_plugin_options(opts: &str) -> Result<Vec<(String, String)>, MalformedOptions> {
+    Ok(split_plugin_options(opts)?
+        .into_iter()
+        .map(|seg| (seg.key, seg.value))
+        .collect())
 }
 
 /// An options string a SIP003 plugin rejects outright. Reported rather than
@@ -97,12 +107,9 @@ pub enum MalformedOptions {
 pub struct OptionSegment<'a> {
     /// The segment exactly as written, escapes intact.
     pub raw: &'a str,
-    /// The key as a SIP003 PLUGIN reads it: a `\` escapes whatever byte follows.
-    /// This is deliberately more permissive than [`parse_plugin_options`], which
-    /// honours only `\;`, `\\` and `\=` and otherwise keeps the backslash — so
-    /// `ech\-doh` is `ech-doh` here and `ech\-doh` there. Use this field to
-    /// decide which key a plugin will ACT on; a check that used the narrower
-    /// rule could be evaded by escaping one character of the name.
+    /// The key as a SIP003 PLUGIN reads it: a `\` escapes whatever byte
+    /// follows — the same rule [`parse_plugin_options`] uses. Use this
+    /// field to decide which key a plugin will ACT on.
     pub key: String,
     /// The value, decoded by the same rule. Empty for BOTH a bare key
     /// (`tls`) and an explicit empty one (`tls=`) — the two are otherwise
@@ -116,6 +123,28 @@ pub struct OptionSegment<'a> {
     /// `false` for bare `tls`. See [`value`](Self::value)'s doc for why this
     /// exists.
     pub has_value: bool,
+}
+
+impl<'a> OptionSegment<'a> {
+    /// The value ex-ray's own `Args.Get` would read for this segment: a
+    /// BARE key (no unescaped `=` at all) decodes to the literal `"1"`
+    /// (`Args.Add`'s own rule for a no-equals option), not the empty string
+    /// [`OptionSegment::value`] gives it. A caller that must match ex-ray's
+    /// specific "was this key given a truthy/bare spelling" semantics — a
+    /// presence-style bool flag (`server`), or a flag whose bare and
+    /// explicit-empty spellings differ (v2ray-core's `path`) — reads this
+    /// instead of `value`.
+    ///
+    /// Reads [`has_value`](Self::has_value) rather than re-deriving it from
+    /// `raw`, so this struct has exactly one answer to "was there a real
+    /// (unescaped) `=`" instead of two that could disagree.
+    pub fn exray_value(&self) -> &str {
+        if self.has_value {
+            &self.value
+        } else {
+            "1"
+        }
+    }
 }
 
 /// Split an options string into segments on unescaped `;`, decoding each key for
@@ -165,8 +194,8 @@ pub fn join_plugin_options<'a>(segments: impl IntoIterator<Item = &'a str>) -> S
     segments.into_iter().collect::<Vec<_>>().join(";")
 }
 
-/// [`split_on_unescaped`] without the copy: yields subslices of `s`. Errors on a
-/// trailing `\` that escapes nothing.
+/// Segment `s` on unescaped occurrences of `delimiter`, yielding subslices
+/// rather than copies. Errors on a trailing `\` that escapes nothing.
 fn split_on_unescaped_borrowed(s: &str, delimiter: char) -> Result<Vec<&str>, MalformedOptions> {
     let mut segments = Vec::new();
     let mut start = 0;
@@ -185,14 +214,30 @@ fn split_on_unescaped_borrowed(s: &str, delimiter: char) -> Result<Vec<&str>, Ma
     Ok(segments)
 }
 
-/// Unescape by the SIP003 reference rule: `\` escapes whatever character
-/// follows — see [`OptionSegment::key`] for why this differs from [`unescape`].
-fn unescape_any(s: &str) -> Result<String, MalformedOptions> {
+/// Walk `s`, splitting on `\`-escapes: every non-`\` character is copied
+/// into the output verbatim, and `on_escaped` decides what to push for the
+/// byte immediately following each `\`. [`unescape_any`] and a caller that
+/// must instead tell a legitimate SIP003 escape from a mangled one apart
+/// (e.g. `garter-bin`'s `config=` diagnostic) both build on this one walk
+/// rather than each re-implementing it — they differ only in what
+/// `on_escaped` does with the escaped byte.
+///
+/// `pub` (and `#[doc(hidden)]`) rather than `pub(crate)` only because that
+/// one other caller is a sibling crate, not this one — Rust has no
+/// workspace-scoped visibility narrower than `pub`. This is NOT general
+/// public API: it exists for `garter-bin::config::escaping`'s single call
+/// site, not for external consumers of the published `garter` crate, which
+/// is why it's hidden from its rendered docs.
+///
+/// `Err` only on a dangling trailing `\` that escapes nothing.
+#[doc(hidden)]
+pub fn walk_escaped(s: &str, mut on_escaped: impl FnMut(char, &mut String)) -> Result<String, MalformedOptions> {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();
     while let Some(ch) = chars.next() {
         if ch == '\\' {
-            out.push(chars.next().ok_or(MalformedOptions::DanglingEscape)?);
+            let escaped = chars.next().ok_or(MalformedOptions::DanglingEscape)?;
+            on_escaped(escaped, &mut out);
         } else {
             out.push(ch);
         }
@@ -200,27 +245,10 @@ fn unescape_any(s: &str) -> Result<String, MalformedOptions> {
     Ok(out)
 }
 
-fn split_on_unescaped(s: &str, delimiter: char) -> Vec<String> {
-    let mut segments = Vec::new();
-    let mut current = String::new();
-    let mut chars = s.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            current.push(ch);
-            if let Some(&next) = chars.peek() {
-                current.push(next);
-                chars.next();
-            }
-        } else if ch == delimiter {
-            segments.push(std::mem::take(&mut current));
-        } else {
-            current.push(ch);
-        }
-    }
-    if !current.is_empty() {
-        segments.push(current);
-    }
-    segments
+/// Unescape by the SIP003 reference rule: `\` escapes whatever character
+/// follows.
+fn unescape_any(s: &str) -> Result<String, MalformedOptions> {
+    walk_escaped(s, |c, out| out.push(c))
 }
 
 fn find_unescaped(s: &str, target: char) -> Option<usize> {
@@ -233,27 +261,4 @@ fn find_unescaped(s: &str, target: char) -> Option<usize> {
         }
     }
     None
-}
-
-fn unescape(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            if let Some(&next) = chars.peek() {
-                match next {
-                    ';' | '\\' | '=' => {
-                        result.push(next);
-                        chars.next();
-                    }
-                    _ => result.push(ch),
-                }
-            } else {
-                result.push(ch);
-            }
-        } else {
-            result.push(ch);
-        }
-    }
-    result
 }

--- a/crates/garter/src/sip003_tests.rs
+++ b/crates/garter/src/sip003_tests.rs
@@ -46,7 +46,7 @@ fn parse_env_no_plugin_options(#[fixture] env: &skuld::EnvGuard) {
 
 #[skuld::test]
 fn parse_plugin_options_basic() {
-    let opts = parse_plugin_options("tls;host=example.com;mode=websocket");
+    let opts = parse_plugin_options("tls;host=example.com;mode=websocket").unwrap();
     assert_eq!(
         opts,
         vec![
@@ -59,7 +59,7 @@ fn parse_plugin_options_basic() {
 
 #[skuld::test]
 fn parse_plugin_options_escaped() {
-    let opts = parse_plugin_options(r"path=/a\;b;key=val\\ue");
+    let opts = parse_plugin_options(r"path=/a\;b;key=val\\ue").unwrap();
     assert_eq!(
         opts,
         vec![
@@ -71,8 +71,63 @@ fn parse_plugin_options_escaped() {
 
 #[skuld::test]
 fn parse_plugin_options_empty() {
-    let opts = parse_plugin_options("");
+    let opts = parse_plugin_options("").unwrap();
     assert!(opts.is_empty());
+}
+
+#[skuld::test]
+fn parse_plugin_options_drops_backslash_before_any_byte() {
+    // A backslash escapes whatever byte follows, matching ex-ray's
+    // `indexUnescaped` — not just the SIP003 metacharacters `;`, `\`, `=`.
+    assert_eq!(
+        parse_plugin_options(r"ech\-doh=x").unwrap(),
+        vec![("ech-doh".to_string(), "x".to_string())]
+    );
+    assert_eq!(
+        parse_plugin_options(r"\server").unwrap(),
+        vec![("server".to_string(), "".to_string())]
+    );
+}
+
+#[skuld::test]
+fn parse_plugin_options_rejects_a_dangling_trailing_escape() {
+    assert_eq!(parse_plugin_options(r"path=/a\"), Err(MalformedOptions::DanglingEscape));
+    assert_eq!(parse_plugin_options(r"a=1;b=2\"), Err(MalformedOptions::DanglingEscape));
+}
+
+#[skuld::test]
+fn parse_plugin_options_rejects_an_empty_key() {
+    assert_eq!(
+        parse_plugin_options("a=1;;b=2"),
+        Err(MalformedOptions::EmptyKey { index: 1 })
+    );
+    assert_eq!(
+        parse_plugin_options("a=1;;"),
+        Err(MalformedOptions::EmptyKey { index: 1 })
+    );
+    assert_eq!(parse_plugin_options("=v"), Err(MalformedOptions::EmptyKey { index: 0 }));
+    assert_eq!(
+        parse_plugin_options("host=h;=v;mux=0"),
+        Err(MalformedOptions::EmptyKey { index: 1 })
+    );
+    // A trailing separator alone is not an empty key.
+    assert_eq!(
+        parse_plugin_options("a=1;").unwrap(),
+        vec![("a".to_string(), "1".to_string())]
+    );
+}
+
+// ex-ray's parsePluginOptions is a true single left-to-right scan and
+// returns on the FIRST error in byte order, so a string with BOTH an empty
+// key (position 0) and a later dangling escape reports the empty key —
+// the scan never reaches the backslash. `split_plugin_options` scans in two
+// phases (delimiters/dangling-escape across the whole string, then
+// per-segment key-emptiness), so it reports DanglingEscape here instead.
+// Both sides still reject the string; only the diagnosed REASON differs,
+// and no caller branches on which variant it is.
+#[skuld::test]
+fn parse_plugin_options_error_precedence_differs_from_ex_ray_on_multiple_defects() {
+    assert_eq!(parse_plugin_options(r";a=1\"), Err(MalformedOptions::DanglingEscape));
 }
 
 #[skuld::test]
@@ -91,13 +146,13 @@ fn plugin_env_local_addr(#[fixture] env: &skuld::EnvGuard) {
 
 #[skuld::test]
 fn parse_plugin_options_escaped_equals_in_key() {
-    let opts = parse_plugin_options(r"k\=ey=value");
+    let opts = parse_plugin_options(r"k\=ey=value").unwrap();
     assert_eq!(opts, vec![("k=ey".to_string(), "value".to_string()),]);
 }
 
 #[skuld::test]
 fn parse_plugin_options_equals_in_value() {
-    let opts = parse_plugin_options("key=a=b");
+    let opts = parse_plugin_options("key=a=b").unwrap();
     assert_eq!(opts, vec![("key".to_string(), "a=b".to_string()),]);
 }
 
@@ -128,13 +183,43 @@ fn split_decodes_the_key_but_leaves_the_segment_raw() {
     assert_eq!(s[0].raw, r"k\=ey=a\;b");
 }
 
-// See `OptionSegment::key` for why this decoding rule differs from `parse_plugin_options`.
+// `parse_plugin_options` decodes a key by the same reference rule as
+// `OptionSegment::key`: a backslash escapes whatever byte follows.
 #[skuld::test]
 fn split_decodes_a_key_the_way_a_sip003_plugin_does() {
     assert_eq!(segs(r"ech\-doh=x")[0].key, "ech-doh");
     assert_eq!(segs(r"log\level=warning")[0].key, "loglevel");
-    // The narrower `parse_plugin_options` alphabet deliberately differs.
-    assert_eq!(parse_plugin_options(r"ech\-doh=x")[0].0, r"ech\-doh");
+    assert_eq!(parse_plugin_options(r"ech\-doh=x").unwrap()[0].0, "ech-doh");
+}
+
+// exray_value: the value ex-ray's own Args.Get would read — a bare key
+// (no unescaped `=`) is "1" (Args.Add's own rule), not the "" OptionSegment::value gives it.
+#[skuld::test]
+fn exray_value_bare_key_is_one() {
+    assert_eq!(segs("server")[0].exray_value(), "1");
+}
+
+#[skuld::test]
+fn exray_value_explicit_value_is_read_verbatim() {
+    assert_eq!(segs("server=1")[0].exray_value(), "1");
+    assert_eq!(segs("server=true")[0].exray_value(), "true");
+}
+
+// Explicit empty (`server=`) is NOT the same as bare — ex-ray's Args.Get
+// reads "" here, not "1".
+#[skuld::test]
+fn exray_value_explicit_empty_is_not_bare() {
+    assert_eq!(segs("server=")[0].exray_value(), "");
+}
+
+// An escaped `=` inside the key portion must not be mistaken for the real
+// separator — a naive `raw.contains('=')` check would misclassify this
+// genuinely bare key as valued.
+#[skuld::test]
+fn exray_value_escaped_equals_in_key_is_still_bare() {
+    let s = segs(r"a\=b");
+    assert_eq!(s[0].key, "a=b");
+    assert_eq!(s[0].exray_value(), "1");
 }
 
 // An escaped `;` is part of a value, not a separator.
@@ -242,7 +327,49 @@ fn appending_after_a_join_survives_a_trailing_escaped_semicolon() {
     let appended = join_plugin_options(segs(r"path=/a\;").iter().map(|x| x.raw).chain(["mux=0"]));
     assert_eq!(appended, r"path=/a\;;mux=0");
     assert_eq!(
-        parse_plugin_options(&appended),
+        parse_plugin_options(&appended).unwrap(),
         vec![("path".into(), "/a;".to_string()), ("mux".into(), "0".to_string())],
+    );
+}
+
+#[skuld::test]
+#[cfg(windows)]
+fn parse_env_rejects_non_unicode_plugin_options(#[fixture] env: &skuld::EnvGuard) {
+    env.set("SS_LOCAL_HOST", "127.0.0.1");
+    env.set("SS_LOCAL_PORT", "1080");
+    env.set("SS_REMOTE_HOST", "example.com");
+    env.set("SS_REMOTE_PORT", "443");
+    use std::os::windows::ffi::OsStringExt;
+    let invalid = std::ffi::OsString::from_wide(&[0xD800]); // unpaired UTF-16 surrogate
+                                                            // `env.remove` first so the guard's restore stack captures the prior
+                                                            // value (or absence) before the raw, non-&str set below bypasses it.
+    env.remove("SS_PLUGIN_OPTIONS");
+    // SAFETY: serialized by the `env` fixture's `serial` scheduling.
+    unsafe { std::env::set_var("SS_PLUGIN_OPTIONS", &invalid) };
+    let result = PluginEnv::from_env();
+    assert!(
+        result.is_err(),
+        "a non-Unicode SS_PLUGIN_OPTIONS must be a loud error, not treated as absent"
+    );
+}
+
+#[skuld::test]
+#[cfg(unix)]
+fn parse_env_rejects_non_unicode_plugin_options(#[fixture] env: &skuld::EnvGuard) {
+    env.set("SS_LOCAL_HOST", "127.0.0.1");
+    env.set("SS_LOCAL_PORT", "1080");
+    env.set("SS_REMOTE_HOST", "example.com");
+    env.set("SS_REMOTE_PORT", "443");
+    use std::os::unix::ffi::OsStrExt;
+    let invalid = std::ffi::OsStr::from_bytes(&[0xFF, 0xFE]); // not valid UTF-8
+                                                              // `env.remove` first so the guard's restore stack captures the prior
+                                                              // value (or absence) before the raw, non-&str set below bypasses it.
+    env.remove("SS_PLUGIN_OPTIONS");
+    // SAFETY: serialized by the `env` fixture's `serial` scheduling.
+    unsafe { std::env::set_var("SS_PLUGIN_OPTIONS", invalid) };
+    let result = PluginEnv::from_env();
+    assert!(
+        result.is_err(),
+        "a non-Unicode SS_PLUGIN_OPTIONS must be a loud error, not treated as absent"
     );
 }

--- a/crates/plugin-e2e/tests/roundtrip.rs
+++ b/crates/plugin-e2e/tests/roundtrip.rs
@@ -50,9 +50,9 @@ mod launcher_smoke {
 }
 
 /// A malformed options string must stop galoshes at startup with a diagnosable
-/// message. ex-ray would not: it discards every option and reports `ready` on
-/// the flag-default port, so galoshes is the last place the operator can be
-/// told. The bridge relays this stderr into its own log.
+/// message — before ever reaching the embedded ex-ray, which would itself
+/// fail fatally on the same string, but only after spawning and without
+/// galoshes' own framing. The bridge relays this stderr into its own log.
 mod malformed_options {
     use plugin_e2e::locators::locate_built_galoshes;
     use plugin_e2e::util::{require_binary, rt};
@@ -107,7 +107,7 @@ mod malformed_options {
             assert!(!out.status.success(), "galoshes must refuse to start: {:?}", out.status);
             let stderr = String::from_utf8_lossy(&out.stderr);
             assert!(
-                stderr.contains("embedded ex-ray") && stderr.contains("unpaired backslash"),
+                stderr.contains("malformed SS_PLUGIN_OPTIONS") && stderr.contains("unpaired backslash"),
                 "stderr must name the malformed options as the reason, got: {stderr}"
             );
         });


### PR DESCRIPTION
Closes #734, closes #738.

`garter::parse_plugin_options` decoded SIP003 option keys by a narrower rule
than ex-ray: ex-ray drops a backslash before **any** byte, garter only did so
for `;`, `\` and `=`. `ech\-doh` is one key to garter and another to ex-ray,
and since ex-ray resolves duplicate keys first-wins,
`ech\-doh=<attacker>;ech-doh=<ours>` slipped past the filter meant to strip an
operator-supplied value. The same divergence made `Mode::from_plugin_options`
disagree with ex-ray about client-vs-server direction.

Decodes keys with ex-ray's actual rule everywhere `SS_PLUGIN_OPTIONS` is read:
`garter::sip003`, `Mode::from_plugin_options`, the bridge's
`inject_plugin_directives`/`classify_transport`, galoshes'
`parse_udp_timeout`, and garter-bin's config-path escaping.

## Accepted breaking changes

- `garter-bin`'s `config=` no longer takes an unescaped Windows path (a bare
  `\` now escapes the following byte, matching every other SIP003 reader).
- Six of six real plugin decoders agree with the new rule; it is settled on
  external authority (SIP003 inherits decoder behavior from Tor's Pluggable
  Transports spec via `goptlib`).

## Explicitly out of scope

- `Mode::from_plugin_options` stays presence-only (any `server` key means
  server mode, whatever its value) — it's garter's general chain-direction
  detector, used for third-party plugins too; strictness there was tried,
  caused a regression, and was deliberately reverted. A generic-detector +
  ex-ray-specific-validator split is a follow-up.
- A `tls`-presence issue in the reachability probe predates this PR and is
  tracked separately.
- Readiness-race work (`run_readiness_aggregator`, `scan_for_delivered_error`,
  `drain_for_delivered_error`, `send_recovered_or_generic` in `chain.rs`; the
  recovery arms in `tap.rs`; `recover_exit_detail*` in `sitrep.rs`) was split
  out of this branch's predecessor to #756 / #757.

## Conflict resolution note

This branch rebased onto `main` after #760 (ECH reachability gate,
`classify_ech_doh`, single-emit posture-warning fix) landed and touched the
same function, `inject_plugin_directives`. The conflict was resolved by
taking `main`'s file wholesale and reapplying this branch's one behavioral
change — non-v2ray-family plugins get their options string validated
(rejecting a malformed string) instead of passed through unvalidated — at the
early-return site, plus a matching doc comment.
