### PR TITLE
revert: PR #764 was rejected before merge

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,8 +20,7 @@ nextest-version = "0.9.130"
 # are load-bearing and must change in lockstep with the filter:
 #   - `_full_tunnel_roundtrip` suffix:
 #     crates/bridge/src/proxy_manager_e2e_tests.rs::e2e_none_full_tunnel_roundtrip
-#   - `windows_lockdown_permits_` / `macos_lockdown_permits_` (every real-engage
-#     standing-lockdown-cover test — server-IP AND resolver-IP):
+#   - `windows_lockdown_permits_server_ip_` / `macos_lockdown_permits_server_ip_`:
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #   - `failclosed_permits_` (transient block-until-connected cover real engage):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -37,5 +36,5 @@ nextest-version = "0.9.130"
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_/) + test(/macos_lockdown_permits_/) + test(/failclosed_permits_/) + test(/cutover_global_net_state_/)'
+filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/cutover_global_net_state_/)'
 test-group = 'global-net-state'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,16 +66,15 @@ before editing; the sections linked below are the authoritative source.
   destination, so a `mux=0` client cannot reach a `mux=1` server. →
   [CONTRIBUTING.md#galoshes-mux-default](CONTRIBUTING.md#galoshes-mux-default)
 - **Fail-closed covers.** The **standing lockdown** cover
-  (`Routing::install_lockdown_permits`, opt-in kill switch) holds the update-cutover gap:
+  (`Routing::install_lockdown`, opt-in kill switch) holds the update-cutover gap:
   the bridge **disarms-not-drops** it across the restart and the new bridge
-  re-adopts it (`decide_cover_recovery == Adopt`). Both it and the
-  **transient** `install_failclosed_cover` permit loopback + server, plus the
-  resolver Hole's own `ech-doh` URL names when it's the value ex-ray will
-  actually dial — `effective_ech_doh == Holes`, not merely a plugin being
-  configured — scoped to TCP/443, by IP address on both platforms. The
-  transient cover is a bounded-window RAII guard engaged by every covered (auto-connect) start
-  whose lockdown intent is OFF; a lockdown-on covered start uses the standing
-  cover instead and releases any held transient one.
+  re-adopts it (`decide_cover_recovery == Adopt`). The **transient**
+  `install_failclosed_cover` (permit loopback + server, plus the resolver
+  Hole's own `ech-doh` URL names when it's the value ex-ray will actually dial
+  — `effective_ech_doh == Holes`, not merely a plugin being configured —
+  scoped to TCP/443) is a bounded-window RAII guard engaged by every covered
+  (auto-connect) start whose lockdown intent is OFF; a lockdown-on covered
+  start uses the standing cover instead and releases any held transient one.
   Both are persistent WFP filters (Win) / self-contained pf ruleset (mac), swept
   by `recover_routes` on next start. →
   [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,9 +413,28 @@ LIVE held cover's permit mismatched from what THIS attempt actually needs
 comparing against the live permit rather than re-trusting that the repair
 always converges, in EITHER direction: too narrow (`Holes`, an ECH-fetch stall
 risk) or too wide (`None`, the kill switch permits a resolver address nothing
-needs). The [standing lockdown cover](#lockdown-mode) carries the identical
-permit — see that section. Finally, the release-then-reengage repair itself
-has a brief window with NO cover at all
+needs). A THIRD case is untouched by this mechanism entirely (not merely a
+residual within it): the [standing lockdown cover](#lockdown-mode)'s own
+ruleset never carries a resolver permit at all, on EITHER platform, whether
+the cover was just engaged fresh (`routing.install_lockdown`, called from
+`start_cancellable`'s `lockdown_on` branch on every covered start) or adopted
+across a restart — `build_lockdown_main_ruleset` (macOS) and
+`lockdown_app_ids` (Windows) take no `resolver_ip`/`EchDoh` input at all. On
+macOS this blocks the fetch outright, silently, on every lockdown-on covered
+start with an ECH-effective config — not only a restart-adopt, which merely
+compounds it by also removing the in-process signal a fresh engage still has
+(`effective_ech_doh`, computed before `install_lockdown` runs) but has no API
+to consume. On Windows the App-ID floor (`resolve_plugin_path(plugin)` — the
+plugin's OWN resolved binary) is sufficient for a direct `ex-ray`/
+`v2ray-plugin` config, but NOT for a chained plugin like `galoshes`: it
+`include_bytes!`s ex-ray and spawns it as a separate process from its own
+extracted runtime path (`crates/galoshes/src/embedded.rs`), which
+`lockdown_app_ids` never adds to the permit set — WFP's App-ID condition
+matches the RUNNING process's own image path, so ex-ray (the process that
+actually dials the DoH resolver) is unpermitted there too. Tracked
+separately: [#753](https://github.com/bindreams/hole/issues/753) (filed
+narrower than this; scope correction pending). Finally, the
+release-then-reengage repair itself has a brief window with NO cover at all
 between the release and the corrected (or restored) re-engage — disclosed in
 the repair's own `warn!` lines, not silent, but not eliminated either: both
 platforms' engage primitives are delete-then-add / flush-then-reload, not an
@@ -433,9 +452,7 @@ sweep only knows the first ten) leaves those two permits un-swept; they are
 *permits*, never blocks,
 so this is bounded and self-healing (a later upgrade's sweep cleans them up),
 not a leak of blocked traffic. Disclosed as a source comment on
-`FILTER_GUIDS` itself. The standing lockdown cover's `LOCKDOWN_FILTER_GUIDS`
-grew the same way for the same reason, disclosed as a source comment there
-too; both arrays share the one tracking issue:
+`FILTER_GUIDS` itself. Tracked separately:
 [#754](https://github.com/bindreams/hole/issues/754). **Windows only, also
 pre-existing:** the repair's release step deletes the held cover's filters by
 fixed GUID and discards the result; if a delete genuinely fails, the
@@ -549,15 +566,10 @@ reachability then depends on `remoteAddr` instead.
 
 ### Lockdown mode
 
-The **standing lockdown cover** (`Routing::install_lockdown_permits`, #527) is an
+The **standing lockdown cover** (`Routing::install_lockdown`, #527) is an
 opt-in, **default-off**, bridge-owned kill switch. When enabled it engages a
 persistent OS-level egress block permitting **only** loopback, the `hole-tun`
-interface, the onward server connection, the resolver Hole's own `ech-doh`
-names when a plugin needs it (same gate, same TCP/443 scope, same
-config-authorship trust as the [transient cover's resolver
-permit](#transient-cutover-cover); an address permit, not an App-ID one,
-because a chained plugin like `galoshes` spawns its inner ex-ray as a
-separate process no App-ID set names), and (Windows) the plugin + bridge
+interface, the onward server connection, and (Windows) the plugin + bridge
 binaries by App-ID — so normal traffic flows while connected and the block holds
 across a bridge restart for free. When disabled, behavior is byte-identical to a
 Hole without it.
@@ -567,20 +579,17 @@ three axes:
 
 - **Permit set.** Lockdown adds a TUN-interface permit (Windows: by `NET_LUID`;
   macOS: `pass out quick on <tun>`) so app traffic flows; the transient cover
-  deliberately omits it because holding it while connected would block all
-  browsing. Both covers otherwise permit the identical resolver address under
-  the identical gate — see the paragraph above.
+  deliberately omits it (permit loopback + server + the resolver Hole's own
+  `ech-doh` names, when a plugin needs it) because holding it while connected
+  would block all browsing.
 - **Lifetime.** Lockdown is authoritative and standing — it persists across a
   crash or restart and is reconciled on the next start via
-  `decide_cover_recovery` (Adopt keeps the host fail-closed; on Windows it
-  drops the volatile TUN + server + resolver GUIDs so the next connect
-  re-adds them fresh, on macOS it removes nothing at all — the whole pf
-  ruleset, resolver permit included, stays live from before the
-  crash/restart until the next connect's `engage_lockdown` reloads it; Sweep
+  `decide_cover_recovery` (Adopt keeps the host fail-closed, dropping the
+  volatile TUN + server permits so the next connect re-adds them fresh; Sweep
   disengages when intent is off). The transient cover is a non-standing,
   bounded-window RAII guard engaged only for the duration of one covered
-  (auto-connect) start attempt, and swept by `recover_routes` like
-  every other cover state on the next start.
+  (auto-connect) start attempt, and swept by `recover_routes` like every other
+  cover state on the next start.
 - **Failure mode.** A failed lockdown engage during a lockdown-on start is
   **fail-FATAL** — it aborts the start and tears everything down; the transient
   cover fails *open* on its own engage error so a half-loaded ruleset never
@@ -591,146 +600,6 @@ Intent persists to `bridge-lockdown.json`; macOS additionally records the
 pre-lockdown pf snapshot in `bridge-lockdown-pf.json` so Sweep restores the host
 without `-Fa`. The LUID is **never persisted** (a teardown mints a new one) —
 re-resolved every engage via `LuidResolver`.
-
-**Engage is two-phase.** `Routing::install_lockdown_permits` engages every
-permit except the TUN one — loopback, server, (when `Some`) resolver, App-IDs
-— and RETURNS the RAII `Cover` the running session eventually holds.
-`ProxyManager::start_cancellable` calls it BEFORE `start_inner` even runs,
-mirroring exactly when the transient cover engages, holding the guard in a
-plain LOCAL variable scoped to `start_cancellable` itself — NOT inside
-`start_inner`, so a later phase's failure can't accidentally tear it down via
-`start_inner`'s own RAII unwind (that would also delete a pre-existing
-adopted cover's floor, since both share the same fixed identity).
-`Routing::engage_lockdown_tun` then adds ONLY the TUN permit to that SAME
-guard at Phase 6, once `routing.install` has resolved the adapter — it returns
-no guard of its own: on Windows it opens its own FWPM engine, adds the two TUN
-filters (a tolerant add — `FWP_E_ALREADY_EXISTS` treated as success — is
-correct here because the guard never persists across attempts; there is no
-cross-attempt retry needing a strict add to distinguish from a genuine
-first-engage/Adopt-continuation, which can legitimately see already-present
-floor filters), and closes the engine immediately. On macOS it reloads the
-full pf ruleset (`pfctl -f -` has no incremental update), reusing the
-token/snapshot Phase 0 persisted — and, unlike Phase 0's own load-failure
-handling, a failed reload here does NOT restore the pre-lockdown snapshot:
-`pfctl -f -` is atomic, so a rejected ruleset leaves the PREVIOUSLY loaded
-one (Phase 0's, still fully enforced, just missing the TUN line) unchanged —
-destroying it anyway would take down a cover that is still live and correct.
-Either way the ONE guard Phase 0 returned still owns the whole cover's
-disengage, TUN permit included once Phase 6 adds it.
-
-Without the Phase-0 step, a plugin's Phase-4 forwarder self-test — where
-ex-ray's lazy ECH-config fetch actually fires, on the chain's first real dial
-— runs *before* Phase 6 ever installs the resolver permit; on an
-already-armed machine (a prior run's cover, live or adopted) that dial is
-blocked by the standing block-all with nothing yet permitting it, so the
-start fails identically on every retry. Both engage calls are fail-FATAL.
-
-**The guard's lifetime is bounded to one attempt.** `start_cancellable` holds
-the `Option<R::Cover>` Phase 0 returns as a plain local and passes it into
-`start_inner` for Phase 6 to add the TUN permit to. On success it is marked
-fully owned (`CoverGuard::mark_owned`, next paragraph) and moved into
-`RunningState.lockdown`, where it disengages on an ordinary `stop()` and
-disarms (persist-without-disengage) on a cutover, exactly like every other
-cover this manager holds. On EVERY early return — an ordinary `Err` from any
-later phase, or a `Cancelled` from mid-flight cancellation — the local simply
-goes out of scope and drops via Rust's own RAII, the same way `start_inner`'s
-own `routes` guard unwinds on a Phase 1-5 failure: no special-cased
-retention, no separate "pending" bucket for `stop_with` to reconcile, and no
-distinction between an ordinary failure and a cancel (the transient cover
-already treats those identically — "same trust as a user disconnect" — and
-the standing cover now does too) — **except one: ownership.**
-
-**Ownership: a guard must not destroy a cover it did not create.** Phase 0's
-engage can find a standing cover already live — adopted from a prior bridge
-process that crashed or cutover-restarted (`CoverRecovery::Adopt`), not
-created by this attempt at all. If a *later* phase then fails, the local's
-ordinary-RAII drop described above would, unqualified, tear that adopted
-cover down: on Windows every lockdown GUID deleted, on macOS the
-pre-lockdown snapshot restored and the state file cleared — regressing the
-crash-recovery guarantee for exactly the failure (a blocked self-test) the
-kill switch exists to survive. Each platform's `engage_lockdown` records
-which case it was in an `Ownership` enum on the returned `Cover` (Windows:
-was the floor filter already present before this call touched anything;
-macOS: was there already a persisted state file) and `Drop for Cover`
-branches on it: `Fresh` (this call created the cover from nothing)
-disengages as before; `Adopted` (this call found one already live) does
-nothing, leaving pf/WFP exactly as this attempt's own re-engage left them —
-either the adopted values unchanged (this attempt's engage never reached its
-own mutate) or this attempt's own rewritten ruleset (the engage succeeded,
-loading THIS attempt's server/resolver/App-IDs, and a later phase then
-failed). Either state is still a complete, self-consistent, fully
-fail-closed floor for this attempt's config — never less restrictive than
-before this attempt started, just possibly missing whatever this attempt
-itself never reached (e.g. the TUN permit, if Phase 6 never ran). There is
-no separate "restore to before this attempt" snapshot to fall back to — that
-would be exactly the identity-tracking machinery the simplification above
-dropped, applied one layer further out.
-
-On Windows specifically, `Ownership::Adopted` leaving the volatile TUN/
-server/resolver GUIDs untouched on Drop means a SECOND `Adopted` attempt in
-the SAME process (the first failed after Phase 0 without disengaging, so the
-cover is still `Adopted` for the retry too) can find those fixed-key filters
-already present when it re-engages. `add_filter`'s tolerant `ok_or_exists`
-would otherwise silently keep the FIRST attempt's stale values instead of
-the retry's own — so both `engage_lockdown` and `engage_lockdown_tun`
-delete the volatile GUIDs before re-adding them, every engage, not only in
-`recover_lockdown`'s one-time startup Adopt sweep. Idempotent (a "not
-found" delete is ignored) for `Fresh`, where they don't exist yet.
-
-Ownership is consulted ONLY by `Drop`, and is otherwise inert: no identity
-comparison (host/server/resolver/App-IDs), no staleness check, no repair
-path, no cross-attempt state. It answers exactly one question, asked once,
-at Phase 0: did this attempt create the cover, or find one already there?
-Once a connect attempt actually SUCCEEDS, the running session is what the
-user sees as "connected" and explicitly disconnects from — an explicit stop
-from that point on must always be able to open the host, independent of the
-cover's provenance before this attempt started. `CoverGuard::mark_owned`
-flips an `Adopted` guard to `Fresh` for exactly this reason, called once, in
-`start_cancellable`, immediately before the guard moves into
-`RunningState.lockdown` — without it, `stop_with`'s ordinary `drop(lk)` on
-UserStop would silently no-op for a session that started from an adopted
-cover, which is never correct: a user-initiated disconnect must open the
-host regardless of how the standing cover came to exist.
-
-This accepts a retry-window gap, now narrower than it first appears: a
-`Fresh`-owned attempt's guard disengages immediately on failure or
-cancellation, opening the host briefly until the NEXT retry's own Phase 0
-re-engages fresh — the identical gap an ordinary `main` connect already has
-on every failed or cancelled attempt, so retaining state only for the
-two-phase split would have spent real complexity protecting a window that
-predates this fix and was never in its scope. An `Adopted` attempt's guard
-has no such gap at all: it never disengages on failure, by design. Tracked
-as [#768](https://github.com/bindreams/hole/issues/768).
-
-On macOS, `reconcile_pf_enabled` runs before `engage_lockdown_tun`'s (Phase
-6\) reload, which assumes an already-persisted token: `pfctl -f -` into a
-DISABLED pf exits 0 while enforcing nothing, so skipping this check reports a
-connected, armed session as covered while pf enforces nothing at all. Phase
-0 and Phase 6 can
-still be separated by several seconds within a SINGLE attempt (the plugin
-chain start, self-test, and route install all run in between), so this check
-stays load-bearing even though the guard no longer persists across attempts.
-
-Full mode completes both phases: Phase 0 here, Phase 6 (the TUN permit) in
-`start_inner`. SocksOnly's `start_inner` returns before Phase 6 ever runs —
-no TUN, no LUID — but Phase 0 needs neither, and guard ownership doesn't
-depend on Phase 6 either (`RunningState.lockdown` is filled from the
-caller's local guard on the `Ok` path regardless of mode), so a COVERED
-SocksOnly start under lockdown intent also applies Phase 0:
-`lockdown_applies = intent && (tunnel_mode == Full || covered)`. The
-transient cover is not a viable substitute here — its engage/disengage
-replace pf's entire main ruleset, and it has no way to tell a clean host
-apart from one where a standing cover (this process's own prior attempt, or
-one adopted from before a crash) is already live, so using it for SocksOnly
-would risk destroying that live cover instead of complementing it. A MANUAL
-(uncovered) SocksOnly start still never applies lockdown, matching every
-other manual connect's fail-open-by-design convention — there is no
-fully-uncovered gap to close on a connect the user drove directly.
-`lockdown_applies` is computed once in `start_cancellable` and passed into
-`start_inner` as a parameter, the same pattern `ech_resolver_permit` already
-uses — `start_inner` does not independently re-read the persisted intent
-file, which has out-of-process writers (`hole bridge unlock`) that could
-otherwise flip it mid-attempt and desync the two phases.
 
 `hole bridge unlock` is the elevated escape hatch to disengage a standing cover
 when no bridge is alive (`cutover::unlock`). Unlike the best-effort startup

--- a/crates/bridge/src/dns/ech.rs
+++ b/crates/bridge/src/dns/ech.rs
@@ -79,18 +79,17 @@ pub fn authority_is_a_name(url: &str) -> bool {
 /// already carries whose authority is not a name (see [`authority_is_a_name`]).
 ///
 /// `resolver` is the exact address `url` names — Hole constructed `url` from
-/// it (`doh_url_for_ip`), never a guess. Both fail-closed covers — the
-/// transient `install_failclosed_cover` and the standing
-/// `install_lockdown_permits` — permit exactly this address regardless of `source`:
-/// it always comes from the user's OWN configured `dns.servers`, so
-/// permitting it is config-authorship trust, not a claim that THIS attempt
-/// personally dialed it — `Answered` and `SecureBootstrapFailed` did
-/// (`resolve_via_doh` dials every configured resolver even on total
-/// failure); `NoQueryNeeded` dialed nothing at all (a literal-IP server
-/// short-circuits before the loop), and `ResolverDeselected`'s fallback may
-/// name an address only a PRIOR resolve dialed, or never dialed this bridge
-/// process at all. See `Routing::install_failclosed_cover`'s doc for why
-/// config-authorship alone is judged sufficient.
+/// it (`doh_url_for_ip`), never a guess. The fail-closed cover permits
+/// exactly this address regardless of `source`: it always comes from the
+/// user's OWN configured `dns.servers`, so permitting it is config-authorship
+/// trust, not a claim that THIS attempt personally dialed it — `Answered`
+/// and `SecureBootstrapFailed` did (`resolve_via_doh` dials every configured
+/// resolver even on total failure); `NoQueryNeeded` dialed nothing at all
+/// (a literal-IP server short-circuits before the loop), and
+/// `ResolverDeselected`'s fallback may name an address only a PRIOR resolve
+/// dialed, or never dialed this bridge process at all. See
+/// `Routing::install_failclosed_cover`'s doc for why config-authorship alone
+/// is judged sufficient.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EchDoh {
     pub url: String,

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -145,11 +145,8 @@ impl Routing for StubRouting {
     fn install_failclosed_cover(&self, _: IpAddr, _: Option<IpAddr>) -> Result<StubCover, RoutingError> {
         Ok(StubCover)
     }
-    fn install_lockdown_permits(&self, _: IpAddr, _: Option<IpAddr>, _: &[PathBuf]) -> Result<StubCover, RoutingError> {
+    fn install_lockdown(&self, _: IpAddr, _: &str, _: &[PathBuf]) -> Result<StubCover, RoutingError> {
         Ok(StubCover)
-    }
-    fn engage_lockdown_tun(&self, _: &str, _: IpAddr, _: Option<IpAddr>) -> Result<(), RoutingError> {
-        Ok(())
     }
 }
 
@@ -166,7 +163,6 @@ impl Drop for StubCover {
 
 impl tun_engine::routing::CoverGuard for StubCover {
     fn disarm(self) {}
-    fn mark_owned(&mut self) {}
 }
 
 fn test_socket_path(suffix: &str) -> PathBuf {

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -209,22 +209,13 @@ impl Routing for MockRouting {
         Ok(MockCover)
     }
 
-    fn install_lockdown_permits(
+    fn install_lockdown(
         &self,
         _server_ip: IpAddr,
-        _resolver_ip: Option<IpAddr>,
+        _tun_name: &str,
         _app_ids: &[PathBuf],
     ) -> Result<MockCover, RoutingError> {
         Ok(MockCover)
-    }
-
-    fn engage_lockdown_tun(
-        &self,
-        _tun_name: &str,
-        _server_ip: IpAddr,
-        _resolver_ip: Option<IpAddr>,
-    ) -> Result<(), RoutingError> {
-        Ok(())
     }
 }
 
@@ -236,7 +227,6 @@ impl Drop for MockCover {
 
 impl tun_engine::routing::CoverGuard for MockCover {
     fn disarm(self) {}
-    fn mark_owned(&mut self) {}
 }
 
 struct MockRoutes {

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -239,10 +239,6 @@ pub struct ProxyManager<P: Proxy = ShadowsocksProxy, R: Routing = SystemRouting,
     /// derivation is otherwise observable only through the plugin it spawns.
     #[cfg(test)]
     last_ech_doh: Option<String>,
-    /// Test-only plugin-binary path override — see
-    /// `set_plugin_path_override_for_test`.
-    #[cfg(test)]
-    plugin_path_override: Option<String>,
 }
 
 /// A held block-until-connected cover plus the server identity it permits.
@@ -267,19 +263,6 @@ struct BlockedStart<C> {
     /// struct doc for what it means.
     resolver_permit: Option<IpAddr>,
 }
-
-/// Whether the transient block-until-connected cover is live for this
-/// `start_inner` call. Wrapped (not a bare `bool`) solely so it cannot be
-/// positionally swapped with the adjacent, equally-`bool`-typed
-/// [`LockdownApplies`] parameter at the call site — the two select between
-/// mutually exclusive covers, so a silent swap would misroute which one a
-/// start attempt is actually protected by.
-struct BlockingEngaged(bool);
-
-/// Whether the standing lockdown cover's Phase 0 applies to this attempt —
-/// see [`BlockingEngaged`] for why this is a newtype rather than a bare
-/// `bool`.
-struct LockdownApplies(bool);
 
 impl<P: Proxy, R: Routing> ProxyManager<P, R, SystemDns> {
     pub fn new(proxy: P, routing: R) -> Self {
@@ -311,8 +294,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             bootstrap_querier: None,
             #[cfg(test)]
             last_ech_doh: None,
-            #[cfg(test)]
-            plugin_path_override: None,
         }
     }
 
@@ -322,16 +303,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     #[cfg(test)]
     pub fn set_bootstrap_querier_for_test(&mut self, q: std::sync::Arc<dyn crate::dns::bootstrap::DohQuerier>) {
         self.bootstrap_querier = Some(q);
-    }
-
-    /// Test seam: spawn this exact path instead of resolving the plugin
-    /// binary via `resolve_plugin_path`. Lets a test drive a REAL plugin
-    /// chain (the plugin subprocess isn't behind a `Proxy`/`Routing`/`Dns`
-    /// trait seam) against a binary the test stages itself, with no shared
-    /// destination path and no process-global mutation.
-    #[cfg(test)]
-    pub fn set_plugin_path_override_for_test(&mut self, path: String) {
-        self.plugin_path_override = Some(path);
     }
 
     /// Set the state directory for plugin PID crash recovery.
@@ -479,15 +450,9 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     }
 
     /// Whether a standing lockdown cover is currently engaged (the `active`
-    /// signal). Distinct from the persisted intent (`enabled`). True only
-    /// while running (the cover lives in `RunningState.lockdown`) — the
-    /// Phase-0 guard is a LOCAL variable for the duration of one connect
-    /// attempt (see `start_cancellable`'s "Standing lockdown cover" section),
-    /// so there is no separate "engaged but not running" state to report
-    /// here the way `blocked_until_connected` reports for the transient
-    /// cover.
+    /// signal). Distinct from the persisted intent (`enabled`).
     pub fn lockdown_active(&self) -> bool {
-        self.running.as_ref().is_some_and(|r| r.lockdown.is_some())
+        self.running.as_ref().map(|r| r.lockdown.is_some()).unwrap_or(false)
     }
 
     /// Whether a covered start failed and left the host fail-closed (blocked, not
@@ -590,11 +555,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         #[cfg(not(test))]
         let bootstrap_querier: Option<std::sync::Arc<dyn crate::dns::bootstrap::DohQuerier>> = None;
 
-        #[cfg(test)]
-        let plugin_path_override = self.plugin_path_override.clone();
-        #[cfg(not(test))]
-        let plugin_path_override: Option<String> = None;
-
         // A DIFFERENT server's hostname needs a FRESH DoH resolution — not
         // guaranteed to land on the resolver already baked into the held cover
         // (see `BlockedStart`'s doc) — so a start for a different server must
@@ -606,12 +566,10 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             warn!("start for a different server while blocked: releasing the held cover before re-resolving");
         }
 
-        // Resolve the server IP over private DoH. A same-server retry under
-        // the held transient cover reuses the cached IP and pin — critically,
-        // this means the resolution itself does NOT need to dial out under a
-        // cover that may not yet permit any resolver.
-        let (server_ip, pin) = match self.blocked.as_ref().map(|b| (b.server_ip, b.pin)) {
-            Some((server_ip, pin)) => (server_ip, crate::dns::ech::revalidate(pin, &config.dns.servers)),
+        // Resolve the server IP over private DoH. A same-server retry under the
+        // held cover reuses the cached IP and pin.
+        let (server_ip, pin) = match self.blocked.as_ref().filter(|b| b.host == config.server.server) {
+            Some(b) => (b.server_ip, crate::dns::ech::revalidate(b.pin, &config.dns.servers)),
             None => match Self::resolve_server_ip(config, &bootstrap_querier, &cancel).await {
                 Ok(b) => (b.server_ip, b.via),
                 Err(e) => {
@@ -686,22 +644,15 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         );
 
         // Engage the block-until-connected cover for a covered start UNLESS the
-        // standing lockdown cover applies instead: that cohort installs (and,
-        // via Phase 0 below, already holds) the lockdown cover, and engaging the
-        // transient cover too would (on macOS) clobber the singular pf ruleset.
-        // A corrupt/absent lockdown-state file resolves to off — the fail-SAFE
-        // direction (we engage, blocking not leaking).
+        // standing lockdown intent is on: that cohort installs the lockdown cover
+        // at routing.install, and engaging the transient cover too would (on macOS)
+        // clobber the singular pf ruleset. A corrupt/absent lockdown-state file
+        // resolves to off — the fail-SAFE direction (we engage, blocking not leaking).
         let lockdown_on = self
             .state_dir
             .as_deref()
             .map(lockdown_state::load_enabled)
             .unwrap_or(false);
-
-        // A COVERED SocksOnly start under lockdown intent still applies Phase 0
-        // (it needs no TUN); a MANUAL SocksOnly start does not, matching every
-        // other manual connect's fail-open design. See CONTRIBUTING.md's
-        // "Lockdown mode" for the full rationale.
-        let lockdown_applies = lockdown_on && (matches!(config.tunnel_mode, TunnelMode::Full) || covered);
 
         // A held cover's resolver_permit is fixed at engage time; re-engage
         // whenever this attempt's fresh derivation DIFFERS from what the
@@ -729,7 +680,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // just delay a correction that could have landed this attempt. Each
         // attempt's release-to-reengage window is bounded to this one
         // (user-paced) retry either way — see the restore fallback below.
-        let repair_fallback: Option<(Option<IpAddr>, crate::dns::ech::PinSource)> = if covered && !lockdown_applies {
+        let repair_fallback: Option<(Option<IpAddr>, crate::dns::ech::PinSource)> = if covered && !lockdown_on {
             self.blocked
                 .as_mut()
                 .filter(|b| b.host == config.server.server && b.resolver_permit != ech_resolver_permit)
@@ -746,15 +697,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             );
         }
 
-        // Set when the branch below releases a still-good transient cover
-        // specifically because lockdown just turned on — so a Phase-0 engage
-        // failure a few lines below can disclose the COMPOUND failure (a
-        // cover that used to be live is now gone AND its replacement never
-        // engaged either), not just an ordinary Phase-0 failure with nothing
-        // lost.
-        let mut released_blocked_for_lockdown = false;
-
-        if covered && !lockdown_applies {
+        if covered && !lockdown_on {
             // The transient cover is a global singleton — never construct a second
             // over the same objects. An engage failure proceeds UNCOVERED (aborting
             // would leave the user unconnected AND unprotected), surfaced via last_error
@@ -848,13 +791,12 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         } else if covered {
             // Covered retry after the user enabled lockdown mid-blocked-state:
             // release the held cover. This opens egress until the standing lockdown
-            // cover's Phase-0 engage a few lines below — a brief, disclosed open window.
+            // cover engages at routing.install — a brief, disclosed open window.
             if self.blocked.take().is_some() {
                 warn!(
                     "covered retry with lockdown newly enabled: releasing the held cover; the host is briefly \
-                     uncovered until the standing lockdown cover's Phase-0 engage below"
+                     uncovered until the standing lockdown cover engages at connect"
                 );
-                released_blocked_for_lockdown = true;
             }
         } else if self.blocked.take().is_some() {
             // Manual (uncovered) connect or reload-while-blocked: fail-open by
@@ -863,35 +805,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             warn!("uncovered start while blocked: releasing the held cover (host fail-open by design)");
         }
         let blocking_engaged = self.blocked.is_some();
-
-        // Standing lockdown cover, Phase 0: engage fresh for THIS attempt only,
-        // held as a LOCAL variable -- no cross-attempt cache, no staleness
-        // comparison, no repair. Moved into `RunningState.lockdown` on success
-        // (after `mark_owned`, below); otherwise drops via ordinary
-        // ownership-aware RAII on any early return. See CONTRIBUTING.md's
-        // "Lockdown mode" > "Ownership" for the Fresh/Adopted rationale and #768.
-        let mut lockdown_cover: Option<R::Cover> = if lockdown_applies {
-            let app_ids = lockdown_app_ids(config, plugin_path_override.as_deref());
-            match self
-                .routing
-                .install_lockdown_permits(server_ip, ech_resolver_permit, &app_ids)
-            {
-                Ok(cover) => Some(cover),
-                Err(e) => {
-                    if released_blocked_for_lockdown {
-                        warn!(
-                            error = %e,
-                            "failed to engage the standing lockdown cover after releasing the held \
-                             transient cover for it; host NOT covered by either, proceeding open"
-                        );
-                    }
-                    self.last_error = Some(e.to_string());
-                    return Err(e.into());
-                }
-            }
-        } else {
-            None
-        };
 
         // Disclosed residual (see CONTRIBUTING.md's "Transient cutover
         // cover" section) gated on `effective_ech_doh`, the value that will
@@ -939,20 +852,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                     );
                 }
             }
-        } else if lockdown_applies {
-            // The standing cover always engages fresh with THIS attempt's
-            // OWN `ech_resolver_permit` (no cross-attempt cache to drift
-            // from), so its live permit matches by construction -- only an
-            // operator's own override (never permitted, regardless of
-            // freshness) is worth a warning here.
-            if let crate::proxy::plugin::EffectiveEchDoh::Operators(url) = &effective_ech_doh {
-                warn!(
-                    operator_ech_doh = %url,
-                    "covered start under lockdown: the plugin's own ech-doh overrides Hole's and dials a \
-                     resolver the standing lockdown cover does not permit; it may stall to ex-ray's client \
-                     timeout"
-                );
-            }
         }
 
         debug!("awaiting start_inner");
@@ -963,12 +862,9 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             config,
             server_ip,
             ech_doh,
-            ech_resolver_permit,
-            BlockingEngaged(blocking_engaged),
-            LockdownApplies(lockdown_applies),
+            blocking_engaged,
             self.state_dir.as_deref(),
             self.state_owner,
-            plugin_path_override,
             cancel,
         )
         .await;
@@ -977,22 +873,11 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // only path that mutates `self.running = Some(..)` is strictly
         // after start_inner has completed successfully.
         match result {
-            Ok(mut state) => {
+            Ok(state) => {
                 // Tunnel is up: release the block-until-connected cover (drop →
                 // disengage; already None when lockdown subsumed it — the standing
                 // lockdown cover holds instead).
                 self.blocked = None;
-                // Mark fully owned BEFORE moving into `RunningState.lockdown` --
-                // see `CoverGuard::mark_owned`'s doc. No-op if already Fresh
-                // (the common case).
-                if let Some(ref mut cover) = lockdown_cover {
-                    cover.mark_owned();
-                }
-                // Move the Phase-0 guard into the running session -- start_inner's
-                // Phase 6 already added the TUN permit to this SAME local guard
-                // in place (see start_inner's Phase-6 doc for why no second
-                // guard is ever created).
-                state.lockdown = lockdown_cover;
                 let server_ip = state.server_ip;
                 self.udp_proxy_available = state.udp_proxy_available;
                 self.ipv6_bypass_available = state.ipv6_bypass_available;
@@ -1014,28 +899,17 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
                 Ok(())
             }
             Err(ProxyError::Cancelled) => {
-                // User asked to cancel THIS connection attempt: release the transient
-                // cover (same trust as a user disconnect).
-                //
-                // `lockdown_cover` (if `Some`) is NOT moved here -- it drops via ordinary
-                // RAII, same accepted retry-window gap as the "Standing lockdown
-                // cover" comment above (#768).
+                // User asked to cancel: release the cover (same trust as a user
+                // disconnect). Do NOT set last_error on cancel.
                 self.blocked = None;
                 info!("proxy start cancelled");
                 Err(ProxyError::Cancelled)
             }
             Err(e) => {
-                // Covered start failed: RETAIN the transient cover
-                // (`self.blocked` keeps it, so its Drop does NOT run) — the
-                // host stays blocked, not leaked, until a later successful
-                // start, a user stop/cancel, or a bridge restart. A retry
-                // reuses this held guard and the resolved IP.
-                //
-                // `lockdown_cover` (if `Some`) is a LOCAL variable, not
-                // retained anywhere on `self` — it drops via ordinary RAII
-                // at the end of this function, same as the `Cancelled` arm
-                // above. See that arm's comment for why this is an accepted
-                // gap (#768), not a bug.
+                // Covered start failed: RETAIN the held cover (`self.blocked` keeps
+                // it, so its Drop does NOT run) — the host stays blocked, not leaked,
+                // until a later successful start, a user stop/cancel, or a bridge
+                // restart. A retry reuses this single held guard and its resolved IP.
                 self.last_error = Some(e.to_string());
                 Err(e)
             }
@@ -1064,10 +938,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
 
     /// Produce a [`RunningState`] without touching `self`.
     ///
-    /// `start_inner` takes two adjacent, same-typed `bool` flags
-    /// (`blocking_engaged`, `lockdown_applies`) — see [`BlockingEngaged`] /
-    /// [`LockdownApplies`] for why they arrive wrapped.
-    ///
     /// **Cooperative cancellation.** Each long-running phase
     /// observes the supplied `cancel` token and returns
     /// `Err(ProxyError::Cancelled)` cooperatively. Earlier RAII guards
@@ -1080,21 +950,12 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// 2. `P::Running` — on drop, aborts the spawned proxy task.
     /// 3. `R::Installed` — on drop, tears down routes and clears the
     ///    crash-recovery state file.
-    ///
-    /// The standing lockdown cover's guard is NOT in this list: it is
-    /// engaged and owned by the CALLER (`start_cancellable`'s local
-    /// `lockdown_cover`), never constructed inside this fn, so it is never
-    /// part of this fn's own unwind — an Err return here leaves it exactly as
-    /// the caller already has it (dropped via ordinary RAII once the caller
-    /// returns, unless this call succeeds).
+    /// 4. `Option<R::Cover>` (lockdown) — declared last, so it drops first,
+    ///    before `R::Installed`; disengages the standing cover (only `Some`
+    ///    when intent is on and engage already succeeded). On the fail-FATAL
+    ///    engage `?` it is never constructed, so only `R::Installed` tears down.
     ///
     /// Per-phase cancellation strategy:
-    /// - **Phase 0 (standing-lockdown Phase-0 engage)**: happens in the
-    ///   CALLER before this fn is even invoked — see
-    ///   `Routing::install_lockdown_permits`'s doc for why. `lockdown_applies`
-    ///   is the caller's own already-computed value, passed in as a
-    ///   parameter so Phase 4's probe-suppression check and Phase 6's
-    ///   TUN-permit addition below agree with what the caller actually did.
     /// - **Phase 1 (plugin chain)**: the bridge cancel is threaded into
     ///   `start_plugin_chain`, which derives child tokens for each
     ///   attempt and races readiness against cancel.
@@ -1136,18 +997,11 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         config: &ProxyConfig,
         server_ip: IpAddr,
         ech_doh: Option<crate::dns::ech::EchDoh>,
-        ech_resolver_permit: Option<IpAddr>,
-        blocking_engaged: BlockingEngaged,
-        lockdown_applies: LockdownApplies,
+        blocking_engaged: bool,
         state_dir: Option<&std::path::Path>,
         owner: Option<(u32, u32)>,
-        plugin_path_override: Option<String>,
         cancel: CancellationToken,
     ) -> Result<RunningState<P, R, D>, ProxyError> {
-        // Unwrapped immediately into plain `bool` locals of the SAME names -- the
-        // 200+ lines below read them exactly as before.
-        let blocking_engaged = blocking_engaged.0;
-        let lockdown_applies = lockdown_applies.0;
         debug!("start_inner entered");
         // Pre-flight: short-circuit a pre-cancelled token before any work.
         if cancel.is_cancelled() {
@@ -1155,25 +1009,17 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         }
 
         // `server_ip` is resolved by the caller (`start_cancellable`) via private
-        // DoH BEFORE this fn, so BOTH covers (transient and standing-lockdown)
-        // can be owned in the outer scope — un-leakable by construction:
-        // `start_inner`'s many `?` exits cannot drop a cover they never hold.
-        // `blocking_engaged` is whether the transient cover is live for this
-        // start. `ech_resolver_permit` is the SAME gated value
-        // `start_cancellable` already derived for it (`effective_ech_doh ==
-        // Holes`, read from `ech_doh.resolver`) — passed through, not
-        // re-derived, so the standing lockdown cover (engaged by the caller
-        // BEFORE this fn runs, and completed at Phase 6 below) permits the
-        // identical address without a second derivation site drifting from
-        // the first (see CONTRIBUTING.md's "Lockdown mode").
+        // DoH BEFORE this fn, so the fail-closed cover can be owned in the outer
+        // scope — un-leakable by construction: `start_inner`'s many `?` exits
+        // cannot drop a cover they never hold. `blocking_engaged` is whether that
+        // outer cover is live for this start.
         let server_host = crate::dns::bootstrap::handoff_host(server_ip);
 
         // Phase 1: start plugin chain via Garter if a plugin is configured.
         // `start_plugin_chain` threads `cancel` through to its readiness
         // wait + bind_ephemeral retries.
         let plugin_chain = if let Some(ref plugin_name) = config.server.plugin {
-            let plugin_path =
-                plugin_path_override.unwrap_or_else(|| crate::proxy::config::resolve_plugin_path(plugin_name));
+            let plugin_path = crate::proxy::config::resolve_plugin_path(plugin_name);
             let chain = crate::proxy::plugin::start_plugin_chain(
                 plugin_name,
                 &plugin_path,
@@ -1386,25 +1232,14 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             // adds NO latency. Skip it under an active fail-closed cover: a
             // standing kill-switch (intent on) blocks non-permitted egress, so a
             // probe would mis-report Hole's OWN lockdown as censorship — keep the
-            // original self-test reason. This bridge already engaged its own
-            // lockdown permits at Phase 0 (above), so by this gate `lockdown_applies`
-            // reflects a genuinely live in-process cover, not just a pre-existing
-            // / adopted one. A THIRD term checking raw persisted intent (to also
-            // catch a still-live ADOPTED cover on a manual SocksOnly start, where
-            // `lockdown_applies` is false by design) is deliberately NOT added
-            // here: this whole Phase-4 gate is unreachable for `TunnelMode::SocksOnly`
-            // (that branch returns from `start_inner` earlier, before Phase 3/4 ever
-            // run — see the `if matches!(config.tunnel_mode, TunnelMode::SocksOnly)`
-            // branch above), and for `TunnelMode::Full` (the only mode that reaches
-            // here) `lockdown_applies` already reduces to exactly `lockdown_on`
-            // (`Full` alone satisfies the `(Full || covered)` term), so a third
-            // "raw intent" term would be a no-op duplicate of the second at every
-            // point this code can actually run.
+            // original self-test reason. This bridge installs its own cover later
+            // (after routing.install); at this gate the cover is a pre-existing /
+            // adopted one, and the intent is its honest signal.
             // The live in-process signal (this start's engaged block-until-
-            // connected cover) OR the standing lockdown cover — either means
-            // Hole's OWN cover would classify the probe's egress as blocked, so
-            // suppress it to avoid misreporting our cover as censorship.
-            let cover_active = blocking_engaged || lockdown_applies;
+            // connected cover) OR a pre-existing/adopted standing lockdown — either
+            // means Hole's OWN cover would classify the probe's egress as blocked,
+            // so suppress it to avoid misreporting our cover as censorship.
+            let cover_active = blocking_engaged || state_dir.map(lockdown_state::load_enabled).unwrap_or(false);
             let probe = (!cover_active).then(|| {
                 // The DoH-resolved IP, never the proxy domain: the reachability
                 // probe must not OS-resolve the hostname (that would reopen the
@@ -1523,30 +1358,20 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // Install the routes — NOW traffic starts flowing to the TUN.
         let routes = routing.install(TUN_DEVICE_NAME, server_ip, gw_info.gateway_ip, &gw_info.interface_name)?;
 
-        // Standing lockdown cover (#527). Engaged only when
-        // `lockdown_applies`; when false this whole block is a no-op and the
-        // start is byte-identical to today. Adds the TUN permit to the SAME
-        // guard Phase 0 already engaged (`Routing::engage_lockdown_tun`) — no
-        // second guard is ever created; the caller (`start_cancellable`)
-        // moves that ONE local guard into `RunningState.lockdown` after this
-        // fn returns `Ok`, which is why this fn only sets a placeholder
-        // `None` below. Done AFTER routing.install (TUN exists => LUID
-        // resolvable) and BEFORE Dns::apply, so the line is held the moment
-        // routes go live. FAIL-FATAL: an engage error aborts the start; the
+        // Standing lockdown cover (#527). Engaged only when intent is on; when
+        // off this whole block is a no-op and the start is byte-identical to
+        // today. Engaged AFTER routing.install (TUN exists => LUID resolvable)
+        // and BEFORE Dns::apply, so the line is held the moment routes go live.
+        // FAIL-FATAL: an engage error under intent-on aborts the start; the
         // locally-owned `routes` guard (declared above) Drops on the Err
         // unwind, tearing down — the opposite of the transient cover's
-        // fail-open. The Phase-0 guard itself stays held in the caller's
-        // local variable either way (this fn never owns it), so an error
-        // here does not disengage it directly — it drops via ordinary RAII
-        // once the caller's own function returns (see `start_cancellable`'s
-        // "Standing lockdown cover" comment). `ech_resolver_permit` is
-        // passed through unconditionally, not gated on `covered`: the
-        // standing cover is armed for manual AND covered starts alike, and
-        // the value is already gated on `effective_ech_doh == Holes` by the
-        // caller — see `start_inner`'s entry comment.
-        if lockdown_applies {
-            routing.engage_lockdown_tun(TUN_DEVICE_NAME, server_ip, ech_resolver_permit)?;
-        }
+        // fail-open. Committed only on the Ok path (the field below).
+        let lockdown = if state_dir.map(lockdown_state::load_enabled).unwrap_or(false) {
+            let app_ids = lockdown_app_ids(config);
+            Some(routing.install_lockdown(server_ip, TUN_DEVICE_NAME, &app_ids)?)
+        } else {
+            None
+        };
 
         // Phase 7: apply system DNS AFTER routes install so the OS
         // "best-route to DNS server" lookup resolves through the TUN.
@@ -1594,10 +1419,7 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             dispatcher,
             plugin_chain,
             routes: Some(routes),
-            // Placeholder: the caller (`start_cancellable`) fills this in
-            // from its own local guard on the Ok path -- see this fn's
-            // Phase-6 doc for why the guard is never owned here.
-            lockdown: None,
+            lockdown,
             proxy: running_proxy,
             server_ip: Some(server_ip),
             started_at: Instant::now(),
@@ -1635,13 +1457,6 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
             self.last_error = None;
             self.death_reason = None;
         }
-        // The standing lockdown cover has no separate "pending" bucket to
-        // handle here: its Phase-0 guard is a LOCAL variable scoped to one
-        // `start_cancellable` call, never stored on `self` — a covered start
-        // that engages it and then fails drops it via ordinary RAII before
-        // this function could ever observe it. Only a guard that made it
-        // into `RunningState.lockdown` (a genuinely running session) is
-        // handled here, in the `running.take()` teardown below.
         let Some(state) = self.running.take() else {
             return Ok(());
         };
@@ -1830,28 +1645,19 @@ fn tunnel_mode_label(mode: &TunnelMode) -> &'static str {
 /// resolved plugin binary (if a plugin is configured) and the bridge's own exe.
 /// Empty on macOS (pf has no per-process matching). Path-keyed so the permit
 /// survives a cutover rename.
-///
-/// `plugin_path_override` must be the SAME value `start_inner`'s Phase 1
-/// threads into `start_plugin_chain` (`self.plugin_path_override`, test-only
-/// -- always `None` in production, see `start_cancellable`'s `#[cfg(test)]`
-/// split) — both describe the path of the SAME process this attempt
-/// actually spawns; reading `resolve_plugin_path` unconditionally here would
-/// give a test driving a real plugin chain under a staged binary path an
-/// App-ID permit for a location nothing was ever copied to.
-fn lockdown_app_ids(config: &ProxyConfig, plugin_path_override: Option<&str>) -> Vec<std::path::PathBuf> {
+fn lockdown_app_ids(config: &ProxyConfig) -> Vec<std::path::PathBuf> {
     #[cfg(not(target_os = "windows"))]
     {
-        let _ = (config, plugin_path_override);
+        let _ = config;
         Vec::new()
     }
     #[cfg(target_os = "windows")]
     {
         let mut ids: Vec<std::path::PathBuf> = Vec::new();
         if let Some(ref plugin) = config.server.plugin {
-            let path = plugin_path_override
-                .map(str::to_owned)
-                .unwrap_or_else(|| crate::proxy::config::resolve_plugin_path(plugin));
-            ids.push(std::path::PathBuf::from(path));
+            ids.push(std::path::PathBuf::from(crate::proxy::config::resolve_plugin_path(
+                plugin,
+            )));
         }
         match std::env::current_exe() {
             Ok(exe) => ids.push(exe),

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -5,10 +5,8 @@
 
 use super::*;
 use crate::proxy::{Proxy, ProxyError, RunningProxy, TrafficTotals};
-use crate::test_support::skuld_fixtures::PORT_ALLOC;
 use hole_common::config::ServerEntry;
 use hole_common::protocol::ProxyConfig;
-use plugin_e2e::locators::locate_ex_ray;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
@@ -171,17 +169,13 @@ struct MockRoutingState {
     fail_gateway: AtomicBool,
     cover_engage_calls: AtomicU32,
     cover_disengage_calls: AtomicU32,
-    /// Count of `engage_lockdown_tun` calls (Phase 6, adds the TUN permit).
     lockdown_engage_calls: AtomicU32,
     lockdown_disengage_calls: AtomicU32,
-    /// Makes `engage_lockdown_tun` (Phase 6) fail.
     fail_lockdown: AtomicBool,
     fail_cover: AtomicBool,
-    /// Ordered record of teardown events ("routes" from `MockRoutes::drop`,
-    /// "lockdown" from a standing-cover `MockCover::drop`) so a test can
-    /// observe cross-call teardown ordering — e.g. that routes tear down
-    /// before the standing cover disengages. Shared via the
-    /// `Arc<MockRoutingState>` both `MockRoutes` and `MockCover` clone.
+    /// Ordered record of teardown events ("routes" / "lockdown") so a test can
+    /// observe the unwind teardown sequence. Shared via the `Arc<MockRoutingState>`
+    /// both `MockRoutes` and `MockCover` clone.
     teardown_order: std::sync::Mutex<Vec<&'static str>>,
     /// Last `server_ip` passed to `install`, so a test can assert the bypass
     /// route received the DoH-resolved IP (not a system-resolved one).
@@ -200,23 +194,6 @@ struct MockRoutingState {
     /// (a set containing both values) for the double-failure fail-open path.
     /// `fail_cover` (always-fail) is unaffected and takes priority.
     fail_cover_for_resolvers: std::sync::Mutex<std::collections::HashSet<Option<IpAddr>>>,
-    /// Last `resolver_ip` passed to `engage_lockdown_tun` (Phase 6, adds the
-    /// TUN permit to the cover `install_lockdown_permits` already returned).
-    last_lockdown_resolver_ip: std::sync::Mutex<Option<IpAddr>>,
-    /// Count of `install_lockdown_permits` calls — the Phase-0, pre-Phase-1
-    /// early engage, which returns the cover the running session
-    /// holds. Distinct from `lockdown_engage_calls` (Phase 6, stateless
-    /// TUN-add on the SAME cover) so a test can prove the EARLY call fires
-    /// even when Phase 6 never runs (e.g. the self-test fails first).
-    lockdown_permits_calls: AtomicU32,
-    /// Last `resolver_ip` passed to `install_lockdown_permits`.
-    last_lockdown_permits_resolver_ip: std::sync::Mutex<Option<IpAddr>>,
-    fail_lockdown_permits: AtomicBool,
-    /// When set, `install_lockdown_permits` returns a `MockCover` with
-    /// `owned: false` -- simulating Phase 0 finding a cover already live
-    /// (adopted from a prior bridge process), mirroring the platform
-    /// `Ownership::Adopted` case. See `MockCover::owned`'s doc.
-    lockdown_adopted: AtomicBool,
 }
 
 impl Default for MockRoutingState {
@@ -237,11 +214,6 @@ impl Default for MockRoutingState {
             last_cover_server_ip: std::sync::Mutex::new(None),
             last_cover_resolver_ip: std::sync::Mutex::new(None),
             fail_cover_for_resolvers: std::sync::Mutex::new(std::collections::HashSet::new()),
-            last_lockdown_resolver_ip: std::sync::Mutex::new(None),
-            lockdown_permits_calls: AtomicU32::new(0),
-            last_lockdown_permits_resolver_ip: std::sync::Mutex::new(None),
-            fail_lockdown_permits: AtomicBool::new(false),
-            lockdown_adopted: AtomicBool::new(false),
         }
     }
 }
@@ -277,28 +249,9 @@ impl MockRouting {
         m
     }
 
-    /// Makes the Phase-6 TUN-add (`engage_lockdown_tun`) fail, distinct from
-    /// `failing_lockdown_permits` (which fails the Phase-0 call).
     fn failing_lockdown(state_dir: PathBuf) -> Self {
         let m = Self::new(state_dir);
         m.state.fail_lockdown.store(true, Ordering::SeqCst);
-        m
-    }
-
-    /// Makes the Phase-0 early engage (`install_lockdown_permits`) fail,
-    /// distinct from `failing_lockdown` (which fails the Phase-6 call).
-    fn failing_lockdown_permits(state_dir: PathBuf) -> Self {
-        let m = Self::new(state_dir);
-        m.state.fail_lockdown_permits.store(true, Ordering::SeqCst);
-        m
-    }
-
-    /// Makes `install_lockdown_permits` return an ADOPTED (`owned: false`)
-    /// cover -- simulating Phase 0 finding a standing cover already live
-    /// from a prior bridge process, instead of creating one fresh.
-    fn adopted_lockdown(state_dir: PathBuf) -> Self {
-        let m = Self::new(state_dir);
-        m.state.lockdown_adopted.store(true, Ordering::SeqCst);
         m
     }
 
@@ -383,40 +336,23 @@ impl Routing for MockRouting {
         Ok(MockCover {
             state: Arc::clone(&self.state),
             lockdown: false,
-            owned: true,
         })
     }
 
-    fn install_lockdown_permits(
+    fn install_lockdown(
         &self,
         _server_ip: IpAddr,
-        resolver_ip: Option<IpAddr>,
+        _tun_name: &str,
         _app_ids: &[std::path::PathBuf],
     ) -> Result<MockCover, RoutingError> {
-        if self.state.fail_lockdown_permits.load(Ordering::SeqCst) {
-            return Err(RoutingError::RouteSetup("mock lockdown-permits failure".into()));
-        }
-        *self.state.last_lockdown_permits_resolver_ip.lock().unwrap() = resolver_ip;
-        self.state.lockdown_permits_calls.fetch_add(1, Ordering::SeqCst);
-        Ok(MockCover {
-            state: Arc::clone(&self.state),
-            lockdown: true,
-            owned: !self.state.lockdown_adopted.load(Ordering::SeqCst),
-        })
-    }
-
-    fn engage_lockdown_tun(
-        &self,
-        _tun_name: &str,
-        _server_ip: IpAddr,
-        resolver_ip: Option<IpAddr>,
-    ) -> Result<(), RoutingError> {
         if self.state.fail_lockdown.load(Ordering::SeqCst) {
             return Err(RoutingError::RouteSetup("mock lockdown failure".into()));
         }
-        *self.state.last_lockdown_resolver_ip.lock().unwrap() = resolver_ip;
         self.state.lockdown_engage_calls.fetch_add(1, Ordering::SeqCst);
-        Ok(())
+        Ok(MockCover {
+            state: Arc::clone(&self.state),
+            lockdown: true,
+        })
     }
 }
 
@@ -439,27 +375,13 @@ struct MockCover {
     /// fail-closed cover) — selects which disengage counter Drop bumps, mirroring
     /// the kind-aware `failclosed::Cover`.
     lockdown: bool,
-    /// Mirrors the platform `Ownership` enum (`true` == `Fresh`, `false` ==
-    /// `Adopted`) collapsed to a bool since the mock only needs the two
-    /// states, not the platforms' own reasons for being in either. Only
-    /// meaningful when `lockdown` is true — the transient cover has no
-    /// adoption concept and is always constructed `owned: true`. An
-    /// `Adopted` (`owned: false`) lockdown cover's Drop does NOT disengage,
-    /// mirroring `Drop for (platform) Cover`; `mark_owned` flips it to
-    /// `true`, mirroring `CoverGuard::mark_owned`.
-    owned: bool,
 }
 
 impl Drop for MockCover {
     fn drop(&mut self) {
         if self.lockdown {
-            if self.owned {
-                self.state.lockdown_disengage_calls.fetch_add(1, Ordering::SeqCst);
-                self.state.teardown_order.lock().unwrap().push("lockdown");
-            }
-            // Adopted (`owned: false`): ordinary RAII ownership -- Drop must
-            // not destroy a cover this guard did not create. No-op, exactly
-            // like the platform `Drop for Cover`'s `Adopted` arm.
+            self.state.lockdown_disengage_calls.fetch_add(1, Ordering::SeqCst);
+            self.state.teardown_order.lock().unwrap().push("lockdown");
         } else {
             self.state.cover_disengage_calls.fetch_add(1, Ordering::SeqCst);
         }
@@ -473,10 +395,6 @@ impl tun_engine::routing::CoverGuard for MockCover {
     fn disarm(self) {
         std::mem::forget(self);
     }
-
-    fn mark_owned(&mut self) {
-        self.owned = true;
-    }
 }
 
 // MockRouting lockdown instrumentation ================================================================================
@@ -486,19 +404,15 @@ impl tun_engine::routing::CoverGuard for MockCover {
 // the counters, fail flag, and kind-aware Drop dispatch being correct.
 
 #[skuld::test]
-fn mock_install_lockdown_permits_records_engage_and_drop_records_disengage() {
-    // Phase 0 (`install_lockdown_permits`) is the call that returns the
-    // guard the whole standing-cover session holds -- Phase 6
-    // (`engage_lockdown_tun`) only adds to it, statelessly, and returns
-    // nothing to own.
+fn mock_install_lockdown_records_engage_and_drop_records_disengage() {
     let dir = tempfile::tempdir().unwrap();
     let routing = MockRouting::new(dir.path().to_path_buf());
     let state = routing.state();
 
     let cover = routing
-        .install_lockdown_permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None, &[])
+        .install_lockdown(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), "hole-tun", &[])
         .expect("lockdown engages");
-    assert_eq!(state.lockdown_permits_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(state.lockdown_engage_calls.load(Ordering::SeqCst), 1);
     // The transient-cover counter must NOT move — the two covers are distinct.
     assert_eq!(state.cover_engage_calls.load(Ordering::SeqCst), 0);
     assert_eq!(state.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
@@ -509,115 +423,14 @@ fn mock_install_lockdown_permits_records_engage_and_drop_records_disengage() {
 }
 
 #[skuld::test]
-fn mock_install_lockdown_permits_records_the_resolver_permit() {
-    // The standing lockdown cover must receive the same gated resolver
-    // permit the transient cover would — recorded so ProxyManager-level tests
-    // can assert on it.
-    let dir = tempfile::tempdir().unwrap();
-    let routing = MockRouting::new(dir.path().to_path_buf());
-    let state = routing.state();
-    let resolver_ip = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
-
-    let _cover = routing
-        .install_lockdown_permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), Some(resolver_ip), &[])
-        .expect("lockdown engages");
-    assert_eq!(
-        *state.last_lockdown_permits_resolver_ip.lock().unwrap(),
-        Some(resolver_ip)
-    );
-}
-
-#[skuld::test]
-fn mock_failing_lockdown_permits_returns_err_without_recording() {
-    let dir = tempfile::tempdir().unwrap();
-    let routing = MockRouting::failing_lockdown_permits(dir.path().to_path_buf());
-    let state = routing.state();
-
-    let result = routing.install_lockdown_permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None, &[]);
-    assert!(result.is_err(), "failing_lockdown_permits must return Err");
-    assert_eq!(state.lockdown_permits_calls.load(Ordering::SeqCst), 0);
-}
-
-#[skuld::test]
-fn mock_engage_lockdown_tun_records_the_call_and_resolver_without_a_second_guard() {
-    // Phase 6 adds the TUN permit to the SAME cover Phase 0 already
-    // returned -- it returns `()`, not a second guard, so the ONE cover
-    // from Phase 0 (still) owns the whole disengage.
-    let dir = tempfile::tempdir().unwrap();
-    let routing = MockRouting::new(dir.path().to_path_buf());
-    let state = routing.state();
-    let resolver_ip = IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9));
-
-    let cover = routing
-        .install_lockdown_permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), Some(resolver_ip), &[])
-        .expect("lockdown engages");
-    routing
-        .engage_lockdown_tun("hole-tun", IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), Some(resolver_ip))
-        .expect("tun permit added");
-    assert_eq!(state.lockdown_engage_calls.load(Ordering::SeqCst), 1);
-    assert_eq!(*state.last_lockdown_resolver_ip.lock().unwrap(), Some(resolver_ip));
-    // Adding the TUN permit must not disengage or double-engage anything.
-    assert_eq!(state.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
-    assert_eq!(state.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-
-    drop(cover);
-    assert_eq!(
-        state.lockdown_disengage_calls.load(Ordering::SeqCst),
-        1,
-        "the ONE cover from Phase 0 still owns the disengage"
-    );
-}
-
-#[skuld::test]
-fn mock_failing_engage_lockdown_tun_returns_err_without_recording() {
+fn mock_failing_lockdown_returns_err_without_recording() {
     let dir = tempfile::tempdir().unwrap();
     let routing = MockRouting::failing_lockdown(dir.path().to_path_buf());
     let state = routing.state();
 
-    let result = routing.engage_lockdown_tun("hole-tun", IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None);
+    let result = routing.install_lockdown(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), "hole-tun", &[]);
     assert!(result.is_err(), "failing_lockdown must return Err");
     assert_eq!(state.lockdown_engage_calls.load(Ordering::SeqCst), 0);
-}
-
-// `lockdown_app_ids` (Windows App-ID permits) =========================================================================
-
-#[cfg(target_os = "windows")]
-#[skuld::test]
-fn lockdown_app_ids_uses_the_override_not_resolve_plugin_path() {
-    // The Windows App-ID permit must name the SAME plugin binary path
-    // `start_inner`'s Phase 1 actually spawns -- a test driving a real
-    // plugin chain under `set_plugin_path_override_for_test` (a staged
-    // binary, not wherever `resolve_plugin_path` would normally look) must
-    // get an App-ID permit for the staged path, not the unrelated default
-    // resolution.
-    let mut cfg = test_config();
-    cfg.server.plugin = Some("ex-ray".into());
-
-    let overridden = lockdown_app_ids(&cfg, Some(r"C:\staged\ex-ray.exe"));
-    assert!(
-        overridden.contains(&std::path::PathBuf::from(r"C:\staged\ex-ray.exe")),
-        "expected the override path in the App-ID set, got {overridden:?}"
-    );
-    assert!(
-        !overridden
-            .iter()
-            .any(|p| p != &std::path::PathBuf::from(r"C:\staged\ex-ray.exe") && p.ends_with("ex-ray.exe")),
-        "must not ALSO carry a resolve_plugin_path-derived ex-ray path alongside the override: {overridden:?}"
-    );
-}
-
-#[cfg(target_os = "windows")]
-#[skuld::test]
-fn lockdown_app_ids_falls_back_to_resolve_plugin_path_without_an_override() {
-    let mut cfg = test_config();
-    cfg.server.plugin = Some("ex-ray".into());
-
-    let without_override = lockdown_app_ids(&cfg, None);
-    let expected = std::path::PathBuf::from(crate::proxy::config::resolve_plugin_path("ex-ray"));
-    assert!(
-        without_override.contains(&expected),
-        "expected the resolve_plugin_path fallback in the App-ID set, got {without_override:?}"
-    );
 }
 
 // Helpers =============================================================================================================
@@ -1293,618 +1106,6 @@ fn lockdown_on_engages_after_install_and_disengages_on_stop() {
     });
 }
 
-// Standing lockdown resolver permit ===================================================================================
-//
-// `ech_resolver_permit` is computed ONCE in `start_cancellable` (the same
-// value the transient cover's tests below already exercise extensively) and
-// threaded into BOTH `install_lockdown_permits` (Phase 0, before Phase 1 —
-// see that fn's doc for why) and `engage_lockdown_tun` (Phase 6, which adds
-// the TUN permit to the SAME guard) — see `start_inner`'s entry comment.
-// These tests prove the THREADING, not
-// the derivation: the derivation itself (`effective_ech_doh` / `ech_doh_url`)
-// is already covered by the `covered_start_*_permits_the_constructed_resolver`
-// family for the transient cover.
-
-#[skuld::test]
-fn lockdown_on_engages_with_no_resolver_permit_when_no_plugin_configured() {
-    // No plugin means no later ECH lookup, so BOTH `install_lockdown_permits`
-    // (Phase 0) and `engage_lockdown_tun` (Phase 6) must still be called
-    // (lockdown always engages when intent is on) but with `None` — negative
-    // direction, exercised through the REAL `start_inner` call chain (no
-    // plugin needed to reach it, unlike the positive-permit case below).
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-
-        pm.start(&test_config()).await.unwrap();
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            *st.last_lockdown_permits_resolver_ip.lock().unwrap(),
-            None,
-            "no plugin configured means no resolver permit at the Phase-0 early engage either"
-        );
-        assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            *st.last_lockdown_resolver_ip.lock().unwrap(),
-            None,
-            "no plugin configured means no resolver permit, even under lockdown"
-        );
-    });
-}
-
-/// Stage a copy of the real `ex-ray` binary (built by `cargo xtask ex-ray`)
-/// into a fresh, test-private tempdir and return the exact spawn path.
-/// Panics loud, never skips, matching
-/// `server_test_tests.rs::run_test_with_v2ray_plugin_happy_path`'s contract
-/// for a missing build. Callers pass the result to
-/// `ProxyManager::set_plugin_path_override_for_test` -- no shared destination
-/// path, no process-global mutation (`resolve_plugin_path`'s next-to-exe/PATH
-/// lookup is never consulted).
-fn stage_real_ex_ray() -> (tempfile::TempDir, String) {
-    let ex_ray = locate_ex_ray();
-    assert!(
-        ex_ray.is_file(),
-        "ex-ray not built at {ex_ray:?} -- run `cargo xtask ex-ray` before running this test"
-    );
-    let dir = tempfile::tempdir().unwrap();
-    let dest = dir.path().join(if cfg!(windows) { "ex-ray.exe" } else { "ex-ray" });
-    std::fs::copy(&ex_ray, &dest).expect("copy ex-ray into the test's own private directory");
-    let path = dest.to_string_lossy().into_owned();
-    (dir, path)
-}
-
-// Real ex-ray subprocess via `start_plugin_chain` -- same async plugin-bind
-// TOCTOU as the `ssserver_*` fixtures (hole#304); both the label and the
-// serial gate are required (the label list does not propagate transitively
-// to an inline `start_plugin_chain` call -- see `PORT_ALLOC`'s docstring).
-#[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
-fn lockdown_on_permits_the_gated_ech_resolver_for_a_real_plugin_chain() {
-    // The resolver permit reaches the standing cover's
-    // Phase-0 early engage (`install_lockdown_permits`) -- BEFORE Phase 1, so
-    // BEFORE the plugin chain's Phase-4 dial that actually fetches the
-    // ECH config. `dns.enabled = true` (the default) is left ON, unlike the
-    // old version of this test: it arms the Phase-4 forwarder self-test,
-    // which `MockProxy` cannot satisfy (no real SOCKS5 server behind it), so
-    // the start still fails overall -- but the assertion is on the EARLY
-    // call, which runs regardless of that later, unrelated failure. Exercises
-    // the REAL plugin chain end to end (`start_plugin_chain` isn't behind a
-    // trait seam), so this proves the value genuinely reaches the routing
-    // provider, not just the isolated `MockRouting` contract
-    // (`mock_install_lockdown_permits_records_the_call_and_resolver` proves
-    // that half).
-    rt().block_on(async {
-        let (_plugin_dir, plugin_path) = stage_real_ex_ray();
-
-        let resolver: IpAddr = "198.51.100.5".parse().unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-        pm.set_plugin_path_override_for_test(plugin_path);
-        let mut cfg = test_config();
-        // Literal IP: no bootstrap query needed (`PinSource::NoQueryNeeded`),
-        // so this test doesn't need a mock DoH querier -- `ech_doh_url` still
-        // constructs a real IP-literal URL from `dns.servers`.
-        cfg.server.server = "203.0.113.9".into();
-        cfg.server.plugin = Some("ex-ray".into());
-        cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
-        cfg.dns.enabled = true;
-        cfg.dns.servers = vec![resolver];
-
-        // The overall start still fails (MockProxy can't satisfy Phase 4), but
-        // the early engage already ran by then.
-        let _ = pm.start(&cfg).await.unwrap_err();
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(*st.last_lockdown_permits_resolver_ip.lock().unwrap(), Some(resolver));
-    });
-}
-
-// Real ex-ray subprocess -- see the PORT_ALLOC comment on the previous test.
-#[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
-fn lockdown_on_permits_the_gated_ech_resolver_on_a_covered_start_too() {
-    // `start_inner`'s own doc claims `ech_resolver_permit` is threaded through
-    // unconditionally, not gated on `covered` -- the standing cover is armed
-    // for manual AND covered starts alike. The sibling test above only
-    // exercises the manual path (`pm.start`, `covered = false`); this proves
-    // the claim on the covered (auto-connect) path too, via
-    // `start_cancellable(&cfg, true, ...)`. See that sibling's doc for why
-    // `dns.enabled = true` and an `unwrap_err()` are correct here.
-    rt().block_on(async {
-        let (_plugin_dir, plugin_path) = stage_real_ex_ray();
-
-        let resolver: IpAddr = "198.51.100.5".parse().unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-        pm.set_plugin_path_override_for_test(plugin_path);
-        let mut cfg = test_config();
-        cfg.server.server = "203.0.113.9".into();
-        cfg.server.plugin = Some("ex-ray".into());
-        cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
-        cfg.dns.enabled = true;
-        cfg.dns.servers = vec![resolver];
-
-        let _ = pm
-            .start_cancellable(&cfg, true, CancellationToken::new())
-            .await
-            .unwrap_err();
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(*st.last_lockdown_permits_resolver_ip.lock().unwrap(), Some(resolver));
-    });
-}
-
-// Real ex-ray subprocess -- see the PORT_ALLOC comment above.
-#[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
-fn lockdown_on_omits_the_resolver_permit_for_a_non_ech_capable_plugin() {
-    // Negative direction with a REAL plugin chain (not just the pure gate
-    // unit tests in plugin.rs): a plugin configured with no `tls`/`host` never
-    // reaches ECH, so the reachability gate must keep the lockdown permit at
-    // `None` even though a plugin is genuinely running under the cover.
-    rt().block_on(async {
-        let (_plugin_dir, plugin_path) = stage_real_ex_ray();
-
-        let resolver: IpAddr = "198.51.100.5".parse().unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-        pm.set_plugin_path_override_for_test(plugin_path);
-        let mut cfg = test_config();
-        cfg.server.server = "203.0.113.9".into();
-        cfg.server.plugin = Some("ex-ray".into());
-        cfg.server.plugin_opts = None; // no tls, no host -- never reaches ECH
-        cfg.dns.enabled = false;
-        cfg.dns.servers = vec![resolver];
-
-        pm.start(&cfg).await.expect("a real ex-ray chain must start cleanly");
-        // Phase 0 (the early engage) and Phase 6 (the TUN-add) share the
-        // SAME `ech_resolver_permit` value, computed once in
-        // `start_cancellable` -- assert both, not just Phase 6, so a future
-        // change that derives the two independently can't silently widen
-        // just the Phase-0 permit for this negative case.
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            *st.last_lockdown_permits_resolver_ip.lock().unwrap(),
-            None,
-            "a non-ECH-capable plugin config must not widen the Phase-0 early engage either"
-        );
-        assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            *st.last_lockdown_resolver_ip.lock().unwrap(),
-            None,
-            "a non-ECH-capable plugin config must not widen the lockdown cover"
-        );
-    });
-}
-
-// Real ex-ray subprocess -- see the PORT_ALLOC comment above.
-#[skuld::test(labels = [PORT_ALLOC], serial = PORT_ALLOC)]
-fn lockdown_on_never_reaches_phase_6_when_the_self_test_fails() {
-    // The standing lockdown cover's TUN
-    // permit is still only installed at Phase 6 (`routing.install` /
-    // `engage_lockdown_tun`) -- that half of the claim stays true, asserted
-    // below via `lockdown_engage_calls`. But ex-ray's lazy ECH-config fetch
-    // fires on the plugin chain's FIRST REAL DIAL -- which, whenever
-    // `dns.enabled` (the default), is the Phase 4 forwarder self-test, run
-    // strictly BEFORE Phase 6 -- and the resolver permit that dial needs is
-    // now installed at Phase 0 (`install_lockdown_permits`), BEFORE Phase 1,
-    // so it is already live by the time Phase 4 runs, regardless of whether
-    // Phase 6 is ever reached. This test proves the ordering half of that
-    // claim (the Phase-0 call already carries the correct resolver even
-    // though the self-test then fails for its own, unrelated reason); it
-    // cannot prove the OS-level "fetch actually gets through" half without a
-    // real, privileged WFP/pf cover (see `lockdown_privileged_tests.rs`).
-    rt().block_on(async {
-        let (_plugin_dir, plugin_path) = stage_real_ex_ray();
-
-        let resolver: IpAddr = "198.51.100.5".parse().unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-        pm.set_plugin_path_override_for_test(plugin_path);
-        let mut cfg = test_config();
-        cfg.server.server = "203.0.113.9".into();
-        cfg.server.plugin = Some("ex-ray".into());
-        cfg.server.plugin_opts = Some(ECH_CAPABLE_OPTS.into());
-        // dns.enabled = true (the default) arms the Phase 4 forwarder
-        // self-test, which MockProxy cannot satisfy (no real SOCKS5 server
-        // behind it) -- so it fails deterministically, same as a genuinely
-        // blocked/unreachable ECH-config fetch would under `ech=always`
-        // (crates/ex-ray/third_party/v2ray-core/transport/internet/tls/config.go's
-        // `RequireEchSatisfied`: an unobtainable ECH config makes the dial
-        // itself fail, not just disable ECH).
-        cfg.dns.enabled = true;
-        cfg.dns.servers = vec![resolver];
-
-        let err = pm.start(&cfg).await.unwrap_err();
-        assert!(
-            matches!(
-                err,
-                ProxyError::ForwarderSelfTestFailed { .. }
-                    | ProxyError::TunnelSilent { .. }
-                    | ProxyError::NoTunnelConnection { .. }
-            ),
-            "expected some Phase 4 self-test failure classification, got {err:?}"
-        );
-        // The Phase-0 early engage already carries the correct resolver,
-        // before Phase 4 ever runs.
-        assert_eq!(
-            st.lockdown_permits_calls.load(Ordering::SeqCst),
-            1,
-            "the Phase-0 early engage must run before Phase 1, independent of whether Phase 4 later fails"
-        );
-        assert_eq!(*st.last_lockdown_permits_resolver_ip.lock().unwrap(), Some(resolver));
-        assert_eq!(
-            st.lockdown_engage_calls.load(Ordering::SeqCst),
-            0,
-            "Phase 6 (engage_lockdown_tun, where the TUN permit is added) must never run \
-             when Phase 4 fails first -- irrelevant to the ECH-fetch gap, since the resolver \
-             permit was already live from Phase 0 above"
-        );
-    });
-}
-
-#[skuld::test]
-fn lockdown_permits_engage_failure_is_fatal_before_phase_1() {
-    // Fail-FATAL, mirroring `engage_lockdown_tun`'s own contract: a failed
-    // Phase-0 early engage aborts the start immediately, before Phase 1 ever
-    // spawns a plugin chain or Phase 2 touches the proxy -- nothing has been
-    // constructed yet, so there is nothing to tear down.
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::failing_lockdown_permits(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-
-        let err = pm.start(&test_config()).await.unwrap_err();
-        assert!(
-            err.to_string().contains("mock lockdown-permits failure"),
-            "expected the early-engage error, got {err}"
-        );
-        assert_eq!(pm.state(), ProxyState::Stopped);
-        assert_eq!(
-            st.install_calls.load(Ordering::SeqCst),
-            0,
-            "routes must never be installed -- the early engage fails before Phase 1"
-        );
-        assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 0);
-        assert!(pm.last_error().is_some());
-    });
-}
-
-#[skuld::test]
-fn lockdown_on_never_engages_for_socks_only_mode() {
-    // A MANUAL (uncovered) SocksOnly start never applies lockdown, matching
-    // every other manual connect's fail-open-by-design convention -- unlike
-    // the covered path (next test), there is no fully-uncovered gap to close
-    // here: a manual connect that the user drove directly is not silently
-    // "supposed to be" protected.
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-        let mut cfg = test_config();
-        cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-
-        pm.start(&cfg).await.expect("SocksOnly start must still succeed");
-        assert_eq!(
-            st.lockdown_permits_calls.load(Ordering::SeqCst),
-            0,
-            "the standing cover must never engage for a SocksOnly start"
-        );
-        assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 0);
-        assert!(!pm.lockdown_active());
-
-        pm.stop().await.unwrap();
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            0,
-            "nothing was engaged, so there is nothing to disengage"
-        );
-    });
-}
-
-#[skuld::test]
-fn covered_socks_only_start_with_lockdown_on_uses_the_standing_cover_not_the_transient_one() {
-    // A manual SocksOnly start never applies lockdown (previous test), but a
-    // COVERED SocksOnly start under lockdown intent must not be left with
-    // NEITHER cover -- and must not use the TRANSIENT cover either: its
-    // engage/disengage replace pf's entire main ruleset, which would clobber
-    // a standing cover some other run (this process's prior attempt, or an
-    // adopted one from before a crash) holds live, and the transient cover's
-    // own gate has no way to tell that apart from a clean host. Phase 0 needs
-    // no TUN, so it applies here even though Phase 6 (TUN-only) never runs
-    // for SocksOnly.
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-        let mut cfg = test_config();
-        cfg.tunnel_mode = hole_common::protocol::TunnelMode::SocksOnly;
-
-        pm.start_cancellable(&cfg, true, CancellationToken::new())
-            .await
-            .expect("SocksOnly covered start must still succeed");
-        assert_eq!(
-            st.lockdown_permits_calls.load(Ordering::SeqCst),
-            1,
-            "Phase 0 must engage instead -- a covered start must never be left fully uncovered"
-        );
-        assert_eq!(
-            st.cover_engage_calls.load(Ordering::SeqCst),
-            0,
-            "the transient cover must never engage while lockdown intent is on -- it could clobber a live standing cover"
-        );
-        assert!(pm.lockdown_active());
-
-        pm.stop().await.unwrap();
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            1,
-            "stop must release the Phase-0-only guard SocksOnly never completes to Phase 6"
-        );
-    });
-}
-
-#[skuld::test]
-fn lockdown_cover_disengages_immediately_when_a_later_phase_fails() {
-    // A covered lockdown-on start that engages the Phase-0 guard and THEN
-    // fails at a LATER phase (here, `routing.install`, before Phase 6 ever
-    // calls `engage_lockdown_tun`) does NOT retain that guard across the
-    // failure: it is a local in `start_cancellable`, never moved into
-    // `RunningState.lockdown` on a non-Ok path, so it drops via ordinary
-    // RAII when the function returns -- disengaging within the SAME failed
-    // attempt, not on some later explicit stop. This is the accepted
-    // retry-window gap of #768 (the NEXT retry's Phase 0 re-engages fresh,
-    // rather than reusing a still-armed guard).
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::failing_install(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-
-        let err = pm.start(&test_config()).await.unwrap_err();
-        assert!(
-            err.to_string().contains("mock install failure"),
-            "expected the routes-install error, got {err}"
-        );
-        assert_eq!(pm.state(), ProxyState::Stopped);
-        assert_eq!(
-            st.lockdown_permits_calls.load(Ordering::SeqCst),
-            1,
-            "Phase 0 must have engaged before routes failed"
-        );
-        assert_eq!(
-            st.lockdown_engage_calls.load(Ordering::SeqCst),
-            0,
-            "Phase 6 (TUN permit) never runs -- routes failed first"
-        );
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            1,
-            "the Phase-0 guard disengages via RAII as part of THIS failed attempt (#768)"
-        );
-        assert!(
-            !pm.lockdown_active(),
-            "nothing is held once the failed attempt has already returned"
-        );
-    });
-}
-
-#[skuld::test]
-fn adopted_lockdown_cover_survives_a_later_phase_failure() {
-    // Mirrors `lockdown_cover_disengages_immediately_when_a_later_phase_fails`
-    // for an ADOPTED cover specifically: Phase 0 finds a standing cover
-    // already live (from a prior bridge process that crashed or
-    // cutover-restarted), not one this attempt created. Ordinary RAII
-    // ownership means the guard's Drop must not destroy what this attempt
-    // did not create -- unlike the Fresh case, a later-phase failure here
-    // must NOT disengage.
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::adopted_lockdown(dir.path().to_path_buf());
-        let st = routing.state();
-        st.fail_install.store(true, Ordering::SeqCst);
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-
-        let err = pm.start(&test_config()).await.unwrap_err();
-        assert!(
-            err.to_string().contains("mock install failure"),
-            "expected the routes-install error, got {err}"
-        );
-        assert_eq!(pm.state(), ProxyState::Stopped);
-        assert_eq!(
-            st.lockdown_permits_calls.load(Ordering::SeqCst),
-            1,
-            "Phase 0 must have engaged (re-engaged over the adopted cover) before routes failed"
-        );
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            0,
-            "an ADOPTED cover must NOT be torn down by a failure THIS attempt did not create the cover for"
-        );
-        assert!(
-            !pm.lockdown_active(),
-            "the manager itself holds nothing once the failed attempt has returned -- \
-             the adopted cover lives on at the OS level, outside this manager's tracking, exactly \
-             as an adopted cover already does today when nothing ever calls start_cancellable again"
-        );
-    });
-}
-
-#[skuld::test]
-fn adopted_lockdown_cover_disengages_on_an_explicit_stop_after_success() {
-    // The other half of ownership: once a connect attempt SUCCEEDS, the
-    // running session is what the user sees as "connected" and explicitly
-    // disconnects from -- an explicit stop must always open the host from
-    // there on, regardless of whether the cover was originally adopted.
-    // Proves `mark_owned` actually flips the guard before it reaches
-    // `RunningState.lockdown`: without it, `stop_with`'s `drop(lk)` would
-    // silently no-op on an adopted-then-successful session, same as the
-    // failure-path case above -- but a user-initiated stop must never do
-    // that.
-    rt().block_on(async {
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::adopted_lockdown(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-
-        pm.start(&test_config())
-            .await
-            .expect("adopted-cover start must still succeed");
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-        assert!(pm.lockdown_active());
-
-        pm.stop().await.unwrap();
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            1,
-            "an explicit stop after success must disengage even an originally-adopted cover"
-        );
-        assert!(!pm.lockdown_active());
-    });
-}
-
-#[skuld::test]
-fn compound_failure_warns_when_phase_0_fails_right_after_releasing_the_transient_cover() {
-    // Covered retry with lockdown newly enabled mid-blocked-state: the
-    // `else if covered` branch releases the held transient cover (opening a
-    // brief window until Phase 0's engage a few lines below). If THAT
-    // engage then also fails, the host loses BOTH covers in one attempt --
-    // a strictly worse outcome than an ordinary Phase-0 failure with
-    // nothing lost, and must get its own compound-failure disclosure,
-    // mirroring the analogous double-failure warning the transient cover's
-    // own repair path already has.
-    use crate::test_support::log_capture::VecWriter;
-    use tracing_subscriber::fmt;
-    use tracing_subscriber::layer::{Layer, SubscriberExt};
-
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async {
-            let writer = VecWriter::new();
-            let subscriber = tracing_subscriber::registry().with(
-                fmt::layer()
-                    .with_writer(writer.clone())
-                    .with_ansi(false)
-                    .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
-            );
-            let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
-
-            let dir = tempfile::tempdir().unwrap();
-            let routing = MockRouting::new(dir.path().to_path_buf());
-            let st = routing.state();
-            // Lockdown OFF at construction -- attempt 1 engages the TRANSIENT
-            // cover, matching every other covered-with-lockdown-off start.
-            let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::failing_start(), routing, dir, false);
-
-            // Attempt 1: covered, lockdown off -> transient cover engages, then
-            // `proxy.start` fails -> the transient cover is RETAINED (the
-            // established `self.blocked` failure-retention pattern), not
-            // released, since this attempt never reached the lockdown-newly-on
-            // release branch.
-            pm.start_cancellable(&test_config(), true, CancellationToken::new())
-                .await
-                .expect_err("MockProxy::failing_start always fails");
-            assert_eq!(st.cover_engage_calls.load(Ordering::SeqCst), 1);
-            assert!(
-                pm.blocked_until_connected(),
-                "sanity: attempt 1 retains the transient cover"
-            );
-
-            // Lockdown turns on; the Phase-0 engage is set to fail.
-            pm.set_lockdown_intent(true).unwrap();
-            st.fail_lockdown_permits.store(true, Ordering::SeqCst);
-
-            let err = pm
-                .start_cancellable(&test_config(), true, CancellationToken::new())
-                .await
-                .expect_err("install_lockdown_permits fails on this mock");
-            assert!(
-                err.to_string().contains("mock lockdown-permits failure"),
-                "expected the Phase-0 error, got {err}"
-            );
-            assert!(
-                !pm.blocked_until_connected(),
-                "the transient cover was released for the lockdown attempt, not left double-held"
-            );
-            assert!(
-                !pm.lockdown_active(),
-                "the failed Phase-0 engage never produced a cover to hold"
-            );
-
-            let output = writer.snapshot_string();
-            assert!(
-                output.contains("host NOT covered by either"),
-                "expected the compound-failure warning naming BOTH covers lost; got:\n{output}"
-            );
-        });
-}
-
-#[skuld::test]
-fn lockdown_cover_disengages_immediately_on_cancel() {
-    // Unlike the OLD retained-across-attempts design (where the standing
-    // cover survived a cancel until an explicit stop), the simplified
-    // per-attempt guard treats Cancelled exactly like any other early
-    // return: it is a local in `start_cancellable`, never moved into
-    // `RunningState.lockdown`, so it drops via ordinary RAII as soon as
-    // `start_cancellable` returns -- opening the host briefly until the
-    // next retry's Phase 0 re-engages. This is the accepted #768
-    // retry-window gap, exercised here for the cancel path specifically.
-    //
-    // Phase 0 (in `start_cancellable`) engages BEFORE `start_inner`'s Phase 2
-    // (`proxy.start`), so parking on `MockProxy`'s start gate and firing the
-    // cancel only once `proxy.start` is *known* entered deterministically
-    // exercises "Phase 0 already engaged, then cancelled mid-flight" (a
-    // pre-cancelled token instead would short-circuit at the DoH bootstrap
-    // resolve, strictly BEFORE Phase 0 ever runs, and prove nothing).
-    rt().block_on(async {
-        let gate = Arc::new(tokio::sync::Notify::new());
-        let (entered_tx, entered_rx) = oneshot::channel();
-        let proxy = MockProxy::with_start_gate(gate.clone()).with_entered_signal(entered_tx);
-        let dir = tempfile::tempdir().unwrap();
-        let routing = MockRouting::new(dir.path().to_path_buf());
-        let st = routing.state();
-        let (mut pm, _dir) = new_manager_with_lockdown(proxy, routing, dir, true);
-
-        let cancel = CancellationToken::new();
-        let cancel_clone = cancel.clone();
-        tokio::spawn(async move {
-            entered_rx.await.expect("MockProxy::start never entered");
-            cancel_clone.cancel();
-        });
-
-        let err = pm.start_cancellable(&test_config(), true, cancel).await.unwrap_err();
-        assert!(matches!(err, ProxyError::Cancelled), "expected Cancelled, got {err:?}");
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            1,
-            "cancel drops the Phase-0 guard via ordinary RAII, same as any other early return (#768)"
-        );
-        assert!(
-            !pm.lockdown_active(),
-            "nothing is held once the cancelled attempt has already returned"
-        );
-
-        // A subsequent stop on a manager that never reached `running` is a
-        // no-op -- there is nothing left to disengage a second time.
-        pm.stop().await.unwrap();
-        assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 1);
-        // The gate is still held -- release it so the spawned mock task can
-        // drop cleanly (mirrors `start_cancellable_cancelled_during_ss_start_rolls_back`).
-        gate.notify_one();
-    });
-}
-
 #[skuld::test]
 fn lockdown_engage_failure_is_fatal_and_tears_down() {
     // Fail-FATAL mirror of start_blocks_on_forwarder_self_test_failure: a
@@ -1930,32 +1131,21 @@ fn lockdown_engage_failure_is_fatal_and_tears_down() {
             1,
             "routes must be torn down when lockdown engage fails (fail-FATAL)"
         );
-        // The Phase-0 guard DID engage (before Phase 1 even ran) and drops
-        // via ordinary RAII once the Err unwinds out of `start_cancellable`
-        // -- the Phase-6 TUN-add never succeeded, and #768 accepts the
-        // resulting retry-window gap rather than retaining it.
-        assert_eq!(st.lockdown_permits_calls.load(Ordering::SeqCst), 1);
+        // The engage never succeeded, so no cover was committed and none disengaged.
         assert_eq!(st.lockdown_engage_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            1,
-            "the Phase-0 guard disengages via RAII, same as any other early return (#768)"
-        );
+        assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
         assert!(pm.last_error().is_some());
     });
 }
 
 #[skuld::test]
 fn lockdown_engage_failure_tears_down_routes_only() {
-    // Fail-FATAL Phase-6 engage: routes were installed (Phase 6 runs after
-    // install), then the `?` on `engage_lockdown_tun` unwinds `start_inner`'s
-    // locally-owned `routes` guard FIRST (still inside `start_inner`); only
-    // once the resulting Err propagates back out to `start_cancellable`
-    // does the Phase-0 guard -- a local there, never moved into
-    // `RunningState.lockdown` -- drop via ordinary RAII. The ordered
-    // recorder shows routes tearing down before the standing cover
-    // disengages, exactly like a clean stop (see ProxyManager::stop) --
-    // there is no longer a separate "retained pending guard" branch.
+    // Fail-FATAL engage: routes were installed (engage runs after install) then the
+    // `?` on install_lockdown unwinds the locally-owned `routes` guard. The lockdown
+    // cover is never constructed (the `?` fires before the `lockdown` binding
+    // completes), so the ordered recorder must show exactly one teardown — "routes" —
+    // and the cover disengage counter must stay at zero. (On a clean stop the order
+    // is the reverse — routes then lockdown — by design; see ProxyManager::stop.)
     rt().block_on(async {
         let dir = tempfile::tempdir().unwrap();
         let routing = MockRouting::failing_lockdown(dir.path().to_path_buf());
@@ -1969,20 +1159,10 @@ fn lockdown_engage_failure_tears_down_routes_only() {
         let order = st.teardown_order.lock().unwrap().clone();
         assert_eq!(
             order,
-            vec!["routes", "lockdown"],
-            "routes tear down inside start_inner's unwind, then the Phase-0 guard drops via RAII \
-             once the Err reaches start_cancellable"
+            vec!["routes"],
+            "engage failure tears down routes only; no cover was created"
         );
-        assert_eq!(
-            st.lockdown_permits_calls.load(Ordering::SeqCst),
-            1,
-            "the Phase-0 guard WAS engaged"
-        );
-        assert_eq!(
-            st.lockdown_disengage_calls.load(Ordering::SeqCst),
-            1,
-            "...and disengages via RAII as part of THIS failed attempt (#768)"
-        );
+        assert_eq!(st.lockdown_disengage_calls.load(Ordering::SeqCst), 0);
     });
 }
 
@@ -4677,59 +3857,6 @@ mod self_test {
                 assert!(
                     output.contains("plugin's own ech-doh"),
                     "expected the operator-override residual warning; got:\n{output}"
-                );
-            });
-    }
-
-    // Sibling of the test above for the STANDING lockdown cover's own
-    // residual-stall diagnostic (`else if lockdown_applies` in
-    // `start_cancellable`) -- an operator's own `ech-doh` is never permitted
-    // by either cover, so the lockdown branch needs the identical
-    // disclosure, under lockdown-specific wording naming "the standing
-    // lockdown cover" rather than "the fail-closed cover".
-    #[skuld::test]
-    fn covered_start_under_lockdown_residual_warning_fires_for_an_operator_ech_doh_override() {
-        use crate::test_support::log_capture::VecWriter;
-        use tracing_subscriber::fmt;
-        use tracing_subscriber::layer::{Layer, SubscriberExt};
-
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(async {
-                let writer = VecWriter::new();
-                let subscriber = tracing_subscriber::registry().with(
-                    fmt::layer()
-                        .with_writer(writer.clone())
-                        .with_ansi(false)
-                        .with_filter(tracing_subscriber::filter::LevelFilter::WARN),
-                );
-                let _guard = garter::tracing_test::set_default_in_current_thread(subscriber);
-
-                let dir = tempfile::tempdir().unwrap();
-                let routing = MockRouting::new(dir.path().to_path_buf());
-                // Lockdown ON (the `true` below), unlike the transient-cover
-                // sibling test.
-                let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
-                let mut cfg = test_config();
-                // Literal-IP server: Hole's own candidate is unpinned
-                // (NoQueryNeeded), so it never outranks an IP-literal operator
-                // value — the operator's own ech-doh wins.
-                cfg.server.server = "203.0.113.9".into();
-                cfg.server.plugin = Some("ex-ray".into());
-                cfg.server.plugin_opts = Some(format!("{ECH_CAPABLE_OPTS};ech-doh=https://8.8.8.8/dns-query"));
-                cfg.dns.enabled = true;
-                cfg.dns.servers = vec!["1.0.0.1".parse().unwrap()];
-                let _ = pm
-                    .start_cancellable(&cfg, true, CancellationToken::new())
-                    .await
-                    .unwrap_err();
-
-                let output = writer.snapshot_string();
-                assert!(
-                    output.contains("covered start under lockdown") && output.contains("plugin's own ech-doh"),
-                    "expected the lockdown-cover operator-override residual warning; got:\n{output}"
                 );
             });
     }

--- a/crates/bridge/tests/cutover_leak_privileged.rs
+++ b/crates/bridge/tests/cutover_leak_privileged.rs
@@ -106,7 +106,7 @@ fn cutover_global_net_state_disarm_preserves_the_standing_egress_block() {
     );
 
     lockdown_state::set_enabled(dir.path(), true, None).unwrap();
-    let cover = engage_lockdown(server_ip, None, Some(tun_name), &resolver, &[], dir.path(), None)
+    let cover = engage_lockdown(server_ip, tun_name, &resolver, &[], dir.path(), None)
         .expect("engage the real standing lockdown cover");
 
     // Engaged: server permitted (permit beats block-all), others blocked (no leak).

--- a/crates/bridge/tests/cutover_nic_capture_privileged.rs
+++ b/crates/bridge/tests/cutover_nic_capture_privileged.rs
@@ -250,8 +250,7 @@ fn cutover_global_net_state_nic_capture_no_udp_leak() {
     lockdown_state::set_enabled(dir.path(), true, None).expect("persist lockdown intent");
     let cover = engage_lockdown(
         server_ip,
-        None,
-        Some("Loopback Pseudo-Interface 1"), // always-present LUID source; the block governs the probed egress
+        "Loopback Pseudo-Interface 1", // always-present LUID source; the block governs the probed egress
         &SystemLuidResolver,
         &[],
         dir.path(),

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -214,17 +214,12 @@ pub enum CoverRecovery {
     /// Intent ON + cover present: KEEP the host fail-closed across the restart.
     /// The fail-closed floor (block-all + loopback + App-ID) stays in force; the
     /// volatile permits — the stale TUN-interface permit (dead LUID/utun after
-    /// teardown), the server-IP permit (the server may change before the next
-    /// connect), and the resolver-IP permit (the ECH resolver may change, or be
-    /// dropped entirely, before the next connect) — are refreshed by the next
-    /// connect's `install_lockdown_permits` (server/resolver) and
-    /// `engage_lockdown_tun` (TUN). Windows drops the volatile GUIDs at THIS
-    /// recovery step so the re-add isn't a fixed-key no-op; macOS's Adopt step
-    /// removes nothing at all (the whole pf ruleset, resolver permit included,
-    /// stays live from before the crash/restart until the next connect's
-    /// `engage_lockdown` reloads it fresh). This is the crash-leak fix: a
-    /// crash never runs `stop()`, so the persistent cover survives and Adopt
-    /// holds it.
+    /// teardown) and the server-IP permit (the server may change before the next
+    /// connect) — are refreshed by the next connect's `install_lockdown`. Windows
+    /// drops the volatile GUIDs at recovery so the re-add isn't a fixed-key
+    /// no-op; macOS reloads the whole pf ruleset, refreshing them implicitly.
+    /// This is the crash-leak fix: a crash never runs `stop()`, so the persistent
+    /// cover survives and Adopt holds it.
     Adopt,
     /// Intent OFF + cover present: fully disengage the leftover cover (Windows:
     /// delete all lockdown GUIDs; macOS: restore the pre-lockdown snapshot +
@@ -354,28 +349,6 @@ pub trait CoverGuard {
     /// engine handle), which the kernel reclaims on exit but which a long-lived
     /// caller would leak per call.
     fn disarm(self);
-
-    /// Mark this guard as fully owned by the caller from this point on, so
-    /// its ordinary `Drop` always disengages regardless of how the
-    /// underlying cover came to exist.
-    ///
-    /// The standing lockdown cover's Phase-0 engage may find one already
-    /// live — adopted from a prior bridge process that crashed or
-    /// cutover-restarted (`CoverRecovery::Adopt`) — and in that case its
-    /// `Drop` deliberately does NOT tear the ruleset down on an early
-    /// failure: ordinary RAII ownership means a guard must not destroy what
-    /// it did not create (see the platform `Drop for Cover` impls). But
-    /// once a connect attempt actually SUCCEEDS, the running session is now
-    /// the thing the user sees as "connected" and explicitly disconnects
-    /// from — an explicit stop from that point on must always be able to
-    /// open the host, independent of the cover's provenance before this
-    /// attempt started. `ProxyManager::start_cancellable` calls this
-    /// exactly once, right before moving a successful guard into
-    /// `RunningState.lockdown`.
-    ///
-    /// A no-op for a guard that was already fully owned (a fresh engage, or
-    /// the transient cover, which has no adoption concept at all).
-    fn mark_owned(&mut self);
 }
 
 /// OS routing: install split-tunnel routes and query routing state.
@@ -462,65 +435,21 @@ pub trait Routing: Send + Sync {
         resolver_ip: Option<IpAddr>,
     ) -> Result<Self::Cover, RoutingError>;
 
-    /// Engage the STANDING lockdown cover's permits WITHOUT the TUN-interface
-    /// permit: loopback, the onward server connection, (when `Some`)
-    /// `resolver_ip`, and (Windows) the `app_ids` binaries, block all else.
-    /// Returns the SAME [`Cover`](Self::Cover) RAII guard
+    /// Engage the STANDING lockdown cover for this connected session: permit
+    /// loopback + the `tun_name` interface + the onward server connection (and,
+    /// on Windows, the `app_ids` binaries by App-ID), block all else. Returns
+    /// the SAME [`Cover`](Self::Cover) RAII guard
     /// [`install_failclosed_cover`](Self::install_failclosed_cover) returns —
-    /// the platform guard is kind-aware, so its Drop disengages whichever
-    /// cover it holds. The caller owns this guard for the lifetime of the
-    /// standing cover: [`engage_lockdown_tun`](Self::engage_lockdown_tun)
-    /// later adds the TUN permit to the SAME already-engaged cover in place
-    /// (no second guard), and dropping THIS guard is what tears the whole
-    /// thing down, TUN permit included, whenever it was added.
-    ///
-    /// Call this BEFORE Phase 1 (plugin-chain start) — mirroring exactly when
-    /// [`install_failclosed_cover`](Self::install_failclosed_cover) engages —
-    /// so a plugin's Phase-4 forwarder self-test (where ex-ray's lazy
-    /// ECH-config fetch actually fires, on the chain's first real dial) is
-    /// already covered. Without this, on an armed machine the standing cover
-    /// is already live during Phase 4 (installed by a previous run or adopted
-    /// at startup, blocking everything not yet permitted), and a TUN-gated
-    /// engage alone — gated on Phase 6, which needs `install` to have
-    /// resolved the TUN adapter first — arrives too late to protect that
-    /// dial. Fail-FATAL: the bridge aborts the start on Err.
-    ///
-    /// `resolver_ip` carries the exact same trust condition as
-    /// `install_failclosed_cover`'s (see that method's doc): the caller's own
-    /// `ech-doh` URL names it, gated on `effective_ech_doh == Holes`, so
-    /// config-authorship trust alone is judged sufficient. An App-ID permit
-    /// alone is NOT equivalent here — a chained plugin (e.g. `galoshes`)
-    /// extracts and spawns its inner ex-ray as a SEPARATE process the App-ID
-    /// set never names, so only an address-based permit reaches the process
-    /// that actually dials the resolver (see CONTRIBUTING.md's "Lockdown
-    /// mode" section).
-    fn install_lockdown_permits(
+    /// the platform guard is kind-aware, so its Drop disengages whichever cover
+    /// it holds. Distinct from `install_failclosed_cover`, which does NOT permit
+    /// the TUN. The LUID is re-resolved on every call (never persisted).
+    /// Fail-FATAL: the bridge aborts the start on Err.
+    fn install_lockdown(
         &self,
         server_ip: IpAddr,
-        resolver_ip: Option<IpAddr>,
+        tun_name: &str,
         app_ids: &[PathBuf],
     ) -> Result<Self::Cover, RoutingError>;
-
-    /// Add the TUN-interface permit (Windows: by `NET_LUID`, re-resolved on
-    /// every call, never persisted; macOS: `pass out quick on <tun_name>`) to
-    /// the standing lockdown cover [`install_lockdown_permits`](Self::install_lockdown_permits)
-    /// already engaged, once `install` has resolved the adapter. Idempotent;
-    /// returns no guard — the [`Cover`](Self::Cover)
-    /// `install_lockdown_permits` already returned still owns the whole
-    /// standing cover's disengage-on-drop, TUN permit included once this adds
-    /// it, so calling this does not create anything new to own. `server_ip`
-    /// and `resolver_ip` are the SAME values already passed to
-    /// `install_lockdown_permits` — Windows ignores them (the TUN filter pair
-    /// carries no address condition), macOS needs them again because pf has
-    /// no incremental update: every load replaces the whole ruleset, so this
-    /// rebuilds it with the identical server/resolver permits plus the new
-    /// TUN one. Fail-FATAL, matching `install_lockdown_permits`.
-    fn engage_lockdown_tun(
-        &self,
-        tun_name: &str,
-        server_ip: IpAddr,
-        resolver_ip: Option<IpAddr>,
-    ) -> Result<(), RoutingError>;
 }
 
 // System (production) routing =========================================================================================
@@ -599,37 +528,14 @@ impl Routing for SystemRouting {
         failclosed::engage(server_ip, resolver_ip, &self.state_dir, self.owner)
     }
 
-    fn install_lockdown_permits(
+    fn install_lockdown(
         &self,
         server_ip: IpAddr,
-        resolver_ip: Option<IpAddr>,
+        tun_name: &str,
         app_ids: &[PathBuf],
     ) -> Result<Self::Cover, RoutingError> {
-        failclosed::engage_lockdown(
-            server_ip,
-            resolver_ip,
-            None,
-            &failclosed::SystemLuidResolver,
-            app_ids,
-            &self.state_dir,
-            self.owner,
-        )
-    }
-
-    fn engage_lockdown_tun(
-        &self,
-        tun_name: &str,
-        server_ip: IpAddr,
-        resolver_ip: Option<IpAddr>,
-    ) -> Result<(), RoutingError> {
-        failclosed::engage_lockdown_tun(
-            tun_name,
-            server_ip,
-            resolver_ip,
-            &failclosed::SystemLuidResolver,
-            &self.state_dir,
-            self.owner,
-        )
+        let resolver = failclosed::SystemLuidResolver;
+        failclosed::engage_lockdown(server_ip, tun_name, &resolver, app_ids, &self.state_dir, self.owner)
     }
 }
 

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -67,10 +67,6 @@ impl crate::routing::CoverGuard for Cover {
     fn disarm(self) {
         std::mem::forget(self._inner);
     }
-
-    fn mark_owned(&mut self) {
-        self._inner.mark_owned();
-    }
 }
 
 /// Engage the cover blocking all egress except loopback, `server_ip`, and
@@ -98,23 +94,16 @@ pub fn recover_cover(state_dir: &Path, adopting: bool) {
     platform::recover_cover(state_dir, adopting);
 }
 
-/// Engage the standing lockdown cover, WITHOUT the TUN permit when
-/// `tun_name` is `None` (the Phase-0 early engage, see
-/// [`crate::routing::Routing::install_lockdown_permits`]'s doc) or WITH it
-/// when `Some` (loopback + TUN + onward-server + (when `Some`)
-/// `resolver_ip`, scoped to TCP/443 + —on Windows— plugin/bridge App-IDs
-/// permitted, all else blocked). Returns the SAME [`Cover`] wrapper the
-/// transient `engage` returns — the platform guard is kind-aware, so
-/// dropping it disengages the lockdown cover specifically. On Windows the
-/// LUID is re-resolved here every engage with `Some` (never persisted). On
+/// Engage the standing lockdown cover (loopback + TUN + onward-server + —on
+/// Windows— plugin/bridge App-IDs permitted, all else blocked). Returns the
+/// SAME [`Cover`] wrapper the transient `engage` returns — the platform guard
+/// is kind-aware, so dropping it disengages the lockdown cover specifically.
+/// On Windows the LUID is re-resolved here every engage (never persisted). On
 /// failure the host is left uncovered; the bridge's fail-FATAL caller aborts
-/// the start. `app_ids` is empty on macOS (pf has no per-process matching);
-/// `resolver_ip` carries the same trust condition as [`engage`]'s — see
-/// [`crate::routing::Routing::install_lockdown_permits`]'s doc.
+/// the start. `app_ids` is empty on macOS (pf has no per-process matching).
 pub fn engage_lockdown(
     server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    tun_name: Option<&str>,
+    tun_name: &str,
     resolver: &dyn LuidResolver,
     app_ids: &[std::path::PathBuf],
     state_dir: &Path,
@@ -123,53 +112,24 @@ pub fn engage_lockdown(
     #[cfg(target_os = "windows")]
     {
         let _ = owner;
-        let luid = match tun_name {
-            Some(name) => Some(resolver.resolve(name)?),
-            None => None,
-        };
+        let luid = resolver.resolve(tun_name)?;
         Ok(Cover {
-            _inner: platform::engage_lockdown(server_ip, resolver_ip, luid, app_ids, state_dir)?,
+            _inner: platform::engage_lockdown(server_ip, luid, app_ids, state_dir)?,
         })
     }
     #[cfg(target_os = "macos")]
     {
         let _ = (resolver, app_ids);
         Ok(Cover {
-            _inner: platform::engage_lockdown(server_ip, resolver_ip, tun_name, state_dir, owner)?,
+            _inner: platform::engage_lockdown(server_ip, tun_name, state_dir, owner)?,
         })
-    }
-}
-
-/// Add the TUN permit to an already-engaged standing lockdown cover — see
-/// [`crate::routing::Routing::engage_lockdown_tun`]'s doc for the full
-/// rationale (no guard needed; the earlier [`engage_lockdown`] call's
-/// returned [`Cover`] already owns the whole thing). Idempotent.
-pub fn engage_lockdown_tun(
-    tun_name: &str,
-    server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    resolver: &dyn LuidResolver,
-    state_dir: &Path,
-    owner: Option<(u32, u32)>,
-) -> Result<(), RoutingError> {
-    #[cfg(target_os = "windows")]
-    {
-        let _ = (server_ip, resolver_ip, state_dir, owner);
-        let luid = resolver.resolve(tun_name)?;
-        platform::engage_lockdown_tun(luid)
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let _ = resolver;
-        platform::engage_lockdown_tun(tun_name, server_ip, resolver_ip, state_dir, owner)
     }
 }
 
 /// Act on a [`CoverRecovery`] decision for the standing lockdown cover at
 /// startup. Dispatches to the platform reconciler: `Adopt` keeps the host
-/// fail-closed, refreshing the volatile TUN + server + resolver permits;
-/// `Sweep` fully disengages; `Noop` does nothing. cfg-free for
-/// `routing::recover_routes`.
+/// fail-closed, refreshing the volatile TUN + server permits; `Sweep` fully
+/// disengages; `Noop` does nothing. cfg-free for `routing::recover_routes`.
 /// Best-effort: a `Sweep` that cannot disengage is logged, not propagated —
 /// startup recovery has no caller to act on it.
 pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Path) {
@@ -219,11 +179,10 @@ pub(crate) fn build_lockdown_spec_for_test(
     resolver: &dyn LuidResolver,
     tun_name: &str,
     server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
     app_ids: &[std::path::PathBuf],
 ) -> platform::CoverSpec {
     let luid = resolver.resolve(tun_name).expect("mock resolver");
-    platform::build_lockdown_spec(server_ip, resolver_ip, Some(luid), app_ids)
+    platform::build_lockdown_spec(server_ip, luid, app_ids)
 }
 
 // Windows-only: pins the resolve-then-build LUID ordering. macOS keys pf on the

--- a/crates/tun-engine/src/routing/failclosed/facade_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/facade_tests.rs
@@ -24,7 +24,7 @@ fn engage_lockdown_reresolves_luid_every_call() {
         calls: std::sync::atomic::AtomicU32::new(0),
         luid: 0x99,
     };
-    let spec = build_lockdown_spec_for_test(&r, "hole-tun", "203.0.113.7".parse().unwrap(), None, &[]);
+    let spec = build_lockdown_spec_for_test(&r, "hole-tun", "203.0.113.7".parse().unwrap(), &[]);
     assert_eq!(r.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
     assert!(spec.filters.iter().any(|f| matches!(
         f.condition,

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -27,23 +27,11 @@
 //! `serial = TUN` only serializes within one binary.
 //!
 //! COUPLED NAMES: that group's filter matches these tests by the name substrings
-//! `windows_lockdown_permits_`, `macos_lockdown_permits_` (every real-engage
-//! standing-lockdown test, server-IP and resolver-IP alike), and
-//! `failclosed_permits_` (the transient-cover tests). Renaming one, or adding a
-//! new real-engage test that doesn't share one of these substrings, WITHOUT
-//! updating `.config/nextest.toml` drops the test from the group → a silent
-//! cross-binary race with the bridge's live-egress `e2e_none_full_tunnel_roundtrip`.
-//! Change both together.
-//!
-//! The permitted/resolver/non-permitted targets MUST be addresses this host
-//! does NOT itself own (see `RESOLVER`'s doc for why a self-served target is
-//! unsound here: on macOS/BSD it would be silently exempted by `set skip on
-//! lo0` regardless of whether the resolver rule works at all). That leaves a
-//! residual live-network dependency; `RESOLVER` is picked to share PERMITTED's
-//! proven-reliable anycast network rather than eliminate it, and the
-//! resolver-permit assertions cross-check against PERMITTED at the same
-//! instant so a failure here is not blindly reported as "the permit failed"
-//! when it could be a general outage instead.
+//! `windows_lockdown_permits_server_ip_`, `macos_lockdown_permits_server_ip_`,
+//! and `failclosed_permits_` (the transient-cover tests). Renaming one
+//! WITHOUT updating `.config/nextest.toml` drops the test from the group → a
+//! silent cross-binary race with the bridge's live-egress
+//! `e2e_none_full_tunnel_roundtrip`. Change both together.
 
 use super::*;
 
@@ -57,32 +45,16 @@ const TUN: skuld::Label;
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const PERMITTED: &str = "1.1.1.1:443";
 // A third routable anycast host, standing in for the pinned DoH resolver.
-// Cloudflare's SECONDARY address (1.0.0.1, distinct from PERMITTED's 1.1.1.1)
-// rather than Quad9 (9.9.9.9): `macos_failclosed_permits_resolver_blocks_other_egress`
-// flaked TimedOut against 9.9.9.9 on the darwin/amd64 CI runner (darwin/arm64
-// and every other lane were unaffected), and PERMITTED=1.1.1.1 has never once
-// flaked across the SAME runner in the SAME file — same anycast network,
-// same edge presence, empirically the reliable choice on this infrastructure.
-// A residual live-network dependency remains (see this module's doc above
-// for why a fully self-served target isn't used instead).
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-const RESOLVER: &str = "1.0.0.1:443";
-// The SAME resolver host, but on its DNS-over-TLS port rather than 443 —
-// Cloudflare serves both. Proves the resolver permit is scoped to TCP/443,
-// not the whole IP: a permit that (wrongly) covered every port on RESOLVER
-// would let this through too.
+const RESOLVER: &str = "9.9.9.9:443";
+// The SAME resolver host, but on its DNS-over-TLS port rather than 443 — Quad9
+// serves both. Proves the resolver permit is scoped to TCP/443, not the whole
+// IP: a permit that (wrongly) covered every port on RESOLVER would let this
+// through too.
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-const RESOLVER_OTHER_PORT: &str = "1.0.0.1:853";
+const RESOLVER_OTHER_PORT: &str = "9.9.9.9:853";
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const NON_PERMITTED: &str = "8.8.8.8:443";
-
-/// The bare IP a test engages the resolver permit with — parsed from
-/// `RESOLVER` itself so the address the cover PERMITS can never drift from
-/// the address these tests PROBE (both read the one const).
-#[cfg(any(target_os = "windows", target_os = "macos"))]
-fn resolver_permit_ip() -> std::net::IpAddr {
-    RESOLVER.parse::<std::net::SocketAddr>().unwrap().ip()
-}
 
 /// Windows real-engage verification. Engages the REAL WFP lockdown cover with
 /// `server_ip = 1.1.1.1` and proves it is SELECTIVE: egress to the permitted
@@ -128,8 +100,7 @@ fn windows_lockdown_permits_server_ip_and_blocks_other_egress() {
     // source to exercise the real resolve + `LocalInterface` filter path.
     let cover = engage_lockdown(
         server_ip,
-        None,
-        Some("Loopback Pseudo-Interface 1"),
+        "Loopback Pseudo-Interface 1",
         &resolver,
         &[],
         dir.path(),
@@ -160,208 +131,6 @@ fn windows_lockdown_permits_server_ip_and_blocks_other_egress() {
         connect(NON_PERMITTED).is_ok(),
         "disengage must restore egress to the previously-blocked host: {NON_PERMITTED}={:?}",
         connect(NON_PERMITTED).err().map(|e| e.kind()),
-    );
-}
-
-/// Windows real-engage verification that the STANDING lockdown cover's
-/// OPTIONAL resolver permit is real and selective — the Windows counterpart of
-/// `windows_failclosed_permits_resolver_blocks_other_egress` for the transient
-/// cover. With `resolver_ip = Some`, both the server AND the resolver stay
-/// reachable while a third, non-permitted host is still blocked, and the
-/// resolver permit is scoped to TCP/443 (the same resolver on a different port
-/// stays blocked).
-#[cfg(target_os = "windows")]
-#[skuld::test(labels = [TUN], serial = TUN)]
-fn windows_lockdown_permits_resolver_blocks_other_egress() {
-    use std::net::TcpStream;
-    use std::time::Duration;
-
-    let dir = tempfile::tempdir().unwrap();
-    let resolver = SystemLuidResolver;
-    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = resolver_permit_ip();
-
-    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
-
-    let (bp, br, bpo, bn) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        bp.is_ok() && br.is_ok() && bpo.is_ok() && bn.is_ok(),
-        "NETWORK/ENVIRONMENT problem (not the cover): baseline egress must reach all hosts; \
-         {PERMITTED}={:?} {RESOLVER}={:?} {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
-        bp.err().map(|e| e.kind()),
-        br.err().map(|e| e.kind()),
-        bpo.err().map(|e| e.kind()),
-        bn.err().map(|e| e.kind()),
-    );
-
-    let cover = engage_lockdown(
-        server_ip,
-        Some(resolver_ip),
-        Some("Loopback Pseudo-Interface 1"),
-        &resolver,
-        &[],
-        dir.path(),
-        None,
-    )
-    .expect("engage real WFP lockdown cover with a resolver permit");
-
-    let (p, r, po, n) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        p.is_ok(),
-        "server-IP permit must beat block-all: {PERMITTED}={:?}",
-        p.err().map(|e| e.kind())
-    );
-    assert!(
-        r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the same instant, so if it was reachable this is very unlikely to be a general network outage rather than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
-        r.err().map(|e| e.kind()),
-        if p.is_ok() { "reachable" } else { "ALSO unreachable" }
-    );
-    assert!(
-        po.is_err(),
-        "the resolver permit must be scoped to TCP/443, not the whole IP (leak!): \
-         {RESOLVER_OTHER_PORT} connected"
-    );
-    assert!(
-        n.is_err(),
-        "a third, non-permitted host must still be blocked (leak!): {NON_PERMITTED} connected"
-    );
-
-    drop(cover);
-    let (rn, rpo) = (connect(NON_PERMITTED), connect(RESOLVER_OTHER_PORT));
-    assert!(
-        rn.is_ok() && rpo.is_ok(),
-        "disengage must restore egress: {NON_PERMITTED}={:?} {RESOLVER_OTHER_PORT}={:?}",
-        rn.err().map(|e| e.kind()),
-        rpo.err().map(|e| e.kind()),
-    );
-}
-
-/// Windows real-engage verification of the two-phase handoff:
-/// `engage_lockdown` with `tun_name: None` (Phase 0) followed by
-/// `engage_lockdown_tun` (Phase 6) adding the TUN permit to the SAME
-/// already-returned `Cover` -- proving (a) the Phase-0-only cover is already
-/// selective (server + resolver permitted, a third host blocked) before any
-/// TUN permit exists, (b) adding the TUN permit via the second call does not
-/// disturb the already-engaged permits, and (c) the ONE `Cover` from Phase 0
-/// still owns the whole thing afterward: dropping it restores egress fully,
-/// with no second guard ever created.
-#[cfg(target_os = "windows")]
-#[skuld::test(labels = [TUN], serial = TUN)]
-fn windows_lockdown_permits_phase_0_then_phase_6_share_one_cover() {
-    use std::net::TcpStream;
-    use std::time::Duration;
-
-    let dir = tempfile::tempdir().unwrap();
-    let resolver = SystemLuidResolver;
-    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = resolver_permit_ip();
-
-    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
-
-    let (bp, br, bpo, bn) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        bp.is_ok() && br.is_ok() && bpo.is_ok() && bn.is_ok(),
-        "NETWORK/ENVIRONMENT problem (not the cover): baseline egress must reach all hosts; \
-         {PERMITTED}={:?} {RESOLVER}={:?} {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
-        bp.err().map(|e| e.kind()),
-        br.err().map(|e| e.kind()),
-        bpo.err().map(|e| e.kind()),
-        bn.err().map(|e| e.kind()),
-    );
-
-    // Phase 0: engage without a TUN permit yet -- returns the ONE Cover this
-    // whole session will use.
-    let cover = engage_lockdown(server_ip, Some(resolver_ip), None, &resolver, &[], dir.path(), None)
-        .expect("engage the real WFP lockdown cover's Phase-0 permits");
-
-    let (p, r, po, n) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        p.is_ok(),
-        "server-IP permit must beat block-all even with no TUN permit installed: {PERMITTED}={:?}",
-        p.err().map(|e| e.kind())
-    );
-    assert!(
-        r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the same instant, so if it was reachable this is very unlikely to be a general network outage rather than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
-        r.err().map(|e| e.kind()),
-        if p.is_ok() { "reachable" } else { "ALSO unreachable" }
-    );
-    assert!(
-        po.is_err(),
-        "the resolver permit must be scoped to TCP/443, not the whole IP (leak!): \
-         {RESOLVER_OTHER_PORT} connected"
-    );
-    assert!(
-        n.is_err(),
-        "a third, non-permitted host must still be blocked (leak!): {NON_PERMITTED} connected"
-    );
-
-    // Phase 6: add the TUN permit to the SAME cover (a fresh Cover is never
-    // created). "Loopback Pseudo-Interface 1" is an always-present alias
-    // used only as a LUID source to exercise the real resolve +
-    // `LocalInterface` filter path.
-    engage_lockdown_tun(
-        "Loopback Pseudo-Interface 1",
-        server_ip,
-        Some(resolver_ip),
-        &resolver,
-        dir.path(),
-        None,
-    )
-    .expect("add the TUN permit to the already-engaged cover");
-
-    let (p2, r2, po2, n2) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        p2.is_ok() && r2.is_ok(),
-        "server/resolver permits must still hold after adding the TUN permit: \
-         {PERMITTED}={:?} {RESOLVER}={:?}",
-        p2.err().map(|e| e.kind()),
-        r2.err().map(|e| e.kind()),
-    );
-    assert!(
-        po2.is_err() && n2.is_err(),
-        "adding the TUN permit must not widen anything else: \
-         {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
-        po2.err().map(|e| e.kind()),
-        n2.err().map(|e| e.kind()),
-    );
-
-    // The ONE Cover from Phase 0 still owns the whole thing: dropping it
-    // restores egress fully, TUN permit included, with no second guard ever
-    // created.
-    drop(cover);
-    let (rn, rpo) = (connect(NON_PERMITTED), connect(RESOLVER_OTHER_PORT));
-    assert!(
-        rn.is_ok() && rpo.is_ok(),
-        "disengage must restore egress: {NON_PERMITTED}={:?} {RESOLVER_OTHER_PORT}={:?}",
-        rn.err().map(|e| e.kind()),
-        rpo.err().map(|e| e.kind()),
     );
 }
 
@@ -406,7 +175,7 @@ fn macos_lockdown_permits_server_ip_blocks_other_egress_and_restores() {
         base_non.err().map(|e| e.kind()),
     );
 
-    let cover = engage_lockdown(server_ip, None, Some("utun-absent"), &resolver, &[], dir.path(), None)
+    let cover = engage_lockdown(server_ip, "utun-absent", &resolver, &[], dir.path(), None)
         .expect("engage real pf lockdown cover");
 
     // (a) The live main ruleset carries our authoritative block rule.
@@ -444,216 +213,6 @@ fn macos_lockdown_permits_server_ip_blocks_other_egress_and_restores() {
         connect(NON_PERMITTED).is_ok(),
         "disengage must restore egress to the previously-blocked host: {NON_PERMITTED}={:?}",
         connect(NON_PERMITTED).err().map(|e| e.kind()),
-    );
-}
-
-/// macOS real-engage verification that the STANDING lockdown cover's
-/// OPTIONAL resolver permit is real and selective — the macOS counterpart of
-/// `windows_lockdown_permits_resolver_blocks_other_egress`. Also proves the
-/// permit is scoped to TCP/443, not the whole resolver IP.
-#[cfg(target_os = "macos")]
-#[skuld::test(labels = [TUN], serial = TUN)]
-fn macos_lockdown_permits_resolver_blocks_other_egress() {
-    use std::net::TcpStream;
-    use std::process::Command;
-    use std::time::Duration;
-
-    let dir = tempfile::tempdir().unwrap();
-    let resolver = SystemLuidResolver;
-    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = resolver_permit_ip();
-
-    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
-
-    let (bp, br, bpo, bn) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        bp.is_ok() && br.is_ok() && bpo.is_ok() && bn.is_ok(),
-        "NETWORK/ENVIRONMENT problem (not the cover): baseline egress must reach all hosts; \
-         {PERMITTED}={:?} {RESOLVER}={:?} {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
-        bp.err().map(|e| e.kind()),
-        br.err().map(|e| e.kind()),
-        bpo.err().map(|e| e.kind()),
-        bn.err().map(|e| e.kind()),
-    );
-
-    let cover = engage_lockdown(
-        server_ip,
-        Some(resolver_ip),
-        Some("utun-absent"),
-        &resolver,
-        &[],
-        dir.path(),
-        None,
-    )
-    .expect("engage real pf lockdown cover with a resolver permit");
-
-    let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
-    let rules = String::from_utf8_lossy(&sr.stdout);
-    assert!(
-        rules.contains(&resolver_ip.to_string()),
-        "live lockdown ruleset must carry the resolver permit:\n{rules}"
-    );
-
-    let (p, r, po, n) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        p.is_ok(),
-        "server-IP permit must beat block-all: {PERMITTED}={:?}",
-        p.err().map(|e| e.kind())
-    );
-    assert!(
-        r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the same instant, so if it was reachable this is very unlikely to be a general network outage rather than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
-        r.err().map(|e| e.kind()),
-        if p.is_ok() { "reachable" } else { "ALSO unreachable" }
-    );
-    assert!(
-        po.is_err(),
-        "the resolver permit must be scoped to TCP/443, not the whole IP (leak!): \
-         {RESOLVER_OTHER_PORT} connected"
-    );
-    assert!(
-        n.is_err(),
-        "a third, non-permitted host must still be blocked (leak!): {NON_PERMITTED} connected"
-    );
-
-    drop(cover);
-    let (rn, rpo) = (connect(NON_PERMITTED), connect(RESOLVER_OTHER_PORT));
-    assert!(
-        rn.is_ok() && rpo.is_ok(),
-        "disengage must restore egress: {NON_PERMITTED}={:?} {RESOLVER_OTHER_PORT}={:?}",
-        rn.err().map(|e| e.kind()),
-        rpo.err().map(|e| e.kind()),
-    );
-}
-
-/// macOS real-engage verification of the two-phase handoff:
-/// `engage_lockdown` with `tun_name: None` (Phase 0) followed by
-/// `engage_lockdown_tun` (Phase 6, a full pf ruleset reload adding the TUN
-/// pass line) -- proving (a) the Phase-0-only cover is already selective
-/// with NO TUN pass line live, (b) adding the TUN permit via the second call
-/// reuses the SAME pf enable token (no double `-E`) and does not disturb the
-/// already-engaged permits, and (c) the ONE `Cover` from Phase 0 still owns
-/// the whole thing afterward.
-#[cfg(target_os = "macos")]
-#[skuld::test(labels = [TUN], serial = TUN)]
-fn macos_lockdown_permits_phase_0_then_phase_6_share_one_cover() {
-    use std::net::TcpStream;
-    use std::process::Command;
-    use std::time::Duration;
-
-    let dir = tempfile::tempdir().unwrap();
-    let resolver = SystemLuidResolver;
-    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = resolver_permit_ip();
-
-    let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
-
-    let (bp, br, bpo, bn) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        bp.is_ok() && br.is_ok() && bpo.is_ok() && bn.is_ok(),
-        "NETWORK/ENVIRONMENT problem (not the cover): baseline egress must reach all hosts; \
-         {PERMITTED}={:?} {RESOLVER}={:?} {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
-        bp.err().map(|e| e.kind()),
-        br.err().map(|e| e.kind()),
-        bpo.err().map(|e| e.kind()),
-        bn.err().map(|e| e.kind()),
-    );
-
-    // Phase 0: engage without a TUN pass line yet -- returns the ONE Cover
-    // this whole session will use.
-    let cover = engage_lockdown(server_ip, Some(resolver_ip), None, &resolver, &[], dir.path(), None)
-        .expect("engage the real pf lockdown cover's Phase-0 permits");
-
-    let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
-    let rules = String::from_utf8_lossy(&sr.stdout);
-    assert!(
-        !rules.contains("pass out quick on"),
-        "no TUN pass line must be live before routing.install has resolved the adapter:\n{rules}"
-    );
-
-    let (p, r, po, n) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        p.is_ok(),
-        "server-IP permit must beat block-all even with no TUN permit installed: {PERMITTED}={:?}",
-        p.err().map(|e| e.kind())
-    );
-    assert!(
-        r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the same instant, so if it was reachable this is very unlikely to be a general network outage rather than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
-        r.err().map(|e| e.kind()),
-        if p.is_ok() { "reachable" } else { "ALSO unreachable" }
-    );
-    assert!(
-        po.is_err(),
-        "the resolver permit must be scoped to TCP/443, not the whole IP (leak!): \
-         {RESOLVER_OTHER_PORT} connected"
-    );
-    assert!(
-        n.is_err(),
-        "a third, non-permitted host must still be blocked (leak!): {NON_PERMITTED} connected"
-    );
-
-    // Phase 6: add the TUN permit -- a full pf reload reusing the SAME
-    // persisted token (no double `-E`, no re-snapshot).
-    engage_lockdown_tun("utun-absent", server_ip, Some(resolver_ip), &resolver, dir.path(), None)
-        .expect("add the TUN permit to the already-engaged cover");
-
-    let sr2 = Command::new("pfctl").args(["-sr"]).output().unwrap();
-    let rules2 = String::from_utf8_lossy(&sr2.stdout);
-    assert!(
-        rules2.contains("pass out quick on utun-absent all"),
-        "the TUN pass line must be live after Phase 6:\n{rules2}"
-    );
-
-    let (p2, r2, po2, n2) = (
-        connect(PERMITTED),
-        connect(RESOLVER),
-        connect(RESOLVER_OTHER_PORT),
-        connect(NON_PERMITTED),
-    );
-    assert!(
-        p2.is_ok() && r2.is_ok(),
-        "server/resolver permits must still hold after adding the TUN permit: \
-         {PERMITTED}={:?} {RESOLVER}={:?}",
-        p2.err().map(|e| e.kind()),
-        r2.err().map(|e| e.kind()),
-    );
-    assert!(
-        po2.is_err() && n2.is_err(),
-        "adding the TUN permit must not widen anything else: \
-         {RESOLVER_OTHER_PORT}={:?} {NON_PERMITTED}={:?}",
-        po2.err().map(|e| e.kind()),
-        n2.err().map(|e| e.kind()),
-    );
-
-    // The ONE Cover from Phase 0 still owns the whole thing.
-    drop(cover);
-    let (rn, rpo) = (connect(NON_PERMITTED), connect(RESOLVER_OTHER_PORT));
-    assert!(
-        rn.is_ok() && rpo.is_ok(),
-        "disengage must restore egress: {NON_PERMITTED}={:?} {RESOLVER_OTHER_PORT}={:?}",
-        rn.err().map(|e| e.kind()),
-        rpo.err().map(|e| e.kind()),
     );
 }
 
@@ -721,7 +280,7 @@ fn windows_failclosed_permits_resolver_blocks_other_egress() {
 
     let dir = tempfile::tempdir().unwrap();
     let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = resolver_permit_ip();
+    let resolver_ip: std::net::IpAddr = "9.9.9.9".parse().unwrap();
 
     let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
 
@@ -757,9 +316,8 @@ fn windows_failclosed_permits_resolver_blocks_other_egress() {
     );
     assert!(
         r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the same instant, so if it was reachable this is very unlikely to be a general network outage rather than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
-        r.err().map(|e| e.kind()),
-        if p.is_ok() { "reachable" } else { "ALSO unreachable" }
+        "resolver-IP permit must beat block-all: {RESOLVER}={:?}",
+        r.err().map(|e| e.kind())
     );
     assert!(
         po.is_err(),
@@ -848,7 +406,7 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
 
     let dir = tempfile::tempdir().unwrap();
     let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = resolver_permit_ip();
+    let resolver_ip: std::net::IpAddr = "9.9.9.9".parse().unwrap();
 
     let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
 
@@ -874,7 +432,7 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
     let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
     let rules = String::from_utf8_lossy(&sr.stdout);
     assert!(
-        rules.contains(&resolver_ip.to_string()),
+        rules.contains("9.9.9.9"),
         "live ruleset must carry the resolver permit:\n{rules}"
     );
 
@@ -891,9 +449,8 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
     );
     assert!(
         r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the same instant, so if it was reachable this is very unlikely to be a general network outage rather than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
-        r.err().map(|e| e.kind()),
-        if p.is_ok() { "reachable" } else { "ALSO unreachable" }
+        "resolver-IP permit must beat block-all: {RESOLVER}={:?}",
+        r.err().map(|e| e.kind())
     );
     assert!(
         po.is_err(),

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -7,8 +7,7 @@
 //!   `/etc/pf.conf` and drops the refcount.
 //! - **Standing lockdown** (`engage_lockdown`/`lockdown_disengage`): loads a
 //!   self-contained MAIN ruleset (NO `-Fa`) that carries the host's translation
-//!   rules forward and blocks all egress except the TUN, the server IP, and
-//!   (when a plugin needs it) the pinned resolver. Disengage
+//!   rules forward and blocks all egress except the TUN and server IP. Disengage
 //!   restores the host's pre-lockdown filter+nat from the persisted snapshot —
 //!   not a blind `/etc/pf.conf` reload — and drops the refcount. Engage
 //!   idempotently ENSURES pf is enabled (pf is disabled — and its refcount reset
@@ -46,28 +45,17 @@ use super::RESOLVER_PERMIT_PORT;
 /// that const's doc for why this is the only port this fetch can need) — NOT
 /// the server permit's unrestricted shape.
 pub fn build_pf_ruleset(server_ip: IpAddr, resolver_ip: Option<IpAddr>) -> String {
+    let resolver_pass = resolver_ip
+        .map(|ip| format!("pass out quick proto tcp from any to {ip} port {RESOLVER_PERMIT_PORT}\n"))
+        .unwrap_or_default();
     format!(
         "set block-policy drop\n\
          block out all\n\
          pass out quick on lo0 all\n\
          pass in quick on lo0 all\n\
          pass out quick from any to {server_ip}\n\
-         {resolver_pass}",
-        resolver_pass = resolver_pass_line(resolver_ip),
+         {resolver_pass}"
     )
-}
-
-/// The optional resolver-permit pf line for `resolver_ip`, scoped to
-/// `proto tcp port` [`RESOLVER_PERMIT_PORT`] — shared by `build_pf_ruleset`
-/// (transient) and `build_lockdown_main_ruleset` (standing): both covers
-/// permit the identical resolver address under the identical scope (see
-/// [`crate::routing::Routing::install_failclosed_cover`]'s doc for the trust
-/// condition). Empty string when `resolver_ip` is `None` — omitted whenever
-/// nothing should be permitted.
-fn resolver_pass_line(resolver_ip: Option<IpAddr>) -> String {
-    resolver_ip
-        .map(|ip| format!("pass out quick proto tcp from any to {ip} port {RESOLVER_PERMIT_PORT}\n"))
-        .unwrap_or_default()
 }
 
 /// Normalize a snapshot fragment to end in exactly one `\n`. Empty stays empty
@@ -84,58 +72,29 @@ pub fn ensure_trailing_nl(s: &str) -> String {
 /// Build the self-contained MAIN ruleset for the standing lockdown, loaded via
 /// `pfctl -f -` (NO `-Fa`). It IS the host's egress policy while engaged:
 /// `block drop out quick all` is the fail-closed base, with earlier `quick`
-/// permits for the TUN (when `tun_name` is `Some` — see [`tun_pass_line`]'s
-/// doc for why the pre-Phase-1 engage omits it), the server IP, and (when
-/// `Some`) the resolver Hole's own `ech-doh` URL names, scoped to
-/// `proto tcp port` [`RESOLVER_PERMIT_PORT`] — the same trust condition and
-/// port scope as the transient cover's `build_pf_ruleset` (see
-/// [`crate::routing::Routing::install_lockdown_permits`]'s doc). pf has no
-/// per-process matching, so an App-ID-style permit isn't an option here even
-/// in principle — the address permit is the only way this fetch (which may
-/// run in a plugin's separately-spawned child process, e.g. galoshes'
-/// embedded ex-ray) is ever reachable under the cover.
+/// permits for the TUN and the server IP.
 ///
 /// `set` lives here (main-ruleset-only — it is a parse error inside an anchor),
 /// and the host's translation rules (`nat_snapshot`, from `pfctl -sn`) are
 /// carried forward so the session does not flush NAT. Ordering is
 /// `require-order`-enforced: Options -> Translation (nat) -> Filter. The server
-/// (and resolver) permits precede `block drop out quick inet6 all` so a v6
-/// server/resolver is not killed. pf has no per-process matching, so the
-/// server permit is IP-based.
-pub fn build_lockdown_main_ruleset(
-    tun_name: Option<&str>,
-    server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    nat_snapshot: &str,
-) -> String {
+/// permit precedes `block drop out quick inet6 all` so a v6 server is not
+/// killed. pf has no per-process matching, so the server permit is IP-based.
+pub fn build_lockdown_main_ruleset(tun_name: &str, server_ip: IpAddr, nat_snapshot: &str) -> String {
     let proto = "tcp"; // +udp once a UDP-transport plugin lands; egress is TCP-only today.
     format!(
         "set block-policy drop\n\
          set skip on lo0\n\
          {nat}\
          pass out quick proto {proto} from any to {ip}\n\
-         {resolver}\
-         {tun}\
+         pass out quick on {tun} all\n\
          block drop out quick inet6 all\n\
          block drop out quick all\n",
         nat = ensure_trailing_nl(nat_snapshot),
         proto = proto,
         ip = server_ip,
-        resolver = resolver_pass_line(resolver_ip),
-        tun = tun_pass_line(tun_name),
+        tun = tun_name,
     )
-}
-
-/// The optional TUN-interface pf line for `tun_name` — `None` for the
-/// pre-Phase-1 permits-only engage (see
-/// [`crate::routing::Routing::install_lockdown_permits`]'s doc): app traffic
-/// has nowhere to flow before `routing.install` creates the adapter, so the
-/// permit is omitted entirely rather than naming an interface that cannot yet
-/// exist.
-fn tun_pass_line(tun_name: Option<&str>) -> String {
-    tun_name
-        .map(|t| format!("pass out quick on {t} all\n"))
-        .unwrap_or_default()
 }
 
 /// Build the ruleset that restores the host's pre-lockdown policy on Sweep,
@@ -226,34 +185,12 @@ enum CoverKind {
     Lockdown,
 }
 
-/// Whether THIS `engage_lockdown` call created the standing cover from
-/// nothing, or found one already live (adopted from a prior bridge process
-/// that crashed or cutover, `CoverRecovery::Adopt`). Consulted ONLY by
-/// `Drop` — see there for why. Meaningless for `CoverKind::Transient` (the
-/// transient cover has no adoption concept; every engage is fresh), always
-/// `Fresh` in that case.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Ownership {
-    Fresh,
-    Adopted,
-}
-
 /// pf-backed cover guard. Drop disengages per [`CoverKind`]: the transient
-/// cover restores `/etc/pf.conf`; the lockdown cover restores the snapshot —
-/// UNLESS `ownership` is `Adopted`, in which case Drop leaves pf exactly as
-/// this attempt's own engage left it; see `Drop for Cover`.
+/// cover restores `/etc/pf.conf`; the lockdown cover restores the snapshot.
 pub struct Cover {
     token: String,
     state_dir: std::path::PathBuf,
     kind: CoverKind,
-    ownership: Ownership,
-}
-
-impl Cover {
-    /// See [`crate::routing::CoverGuard::mark_owned`].
-    pub fn mark_owned(&mut self) {
-        self.ownership = Ownership::Fresh;
-    }
 }
 
 pub fn engage(
@@ -307,26 +244,15 @@ pub fn engage(
         token,
         state_dir: state_dir.to_owned(),
         kind: CoverKind::Transient,
-        ownership: Ownership::Fresh,
     })
 }
 
 impl Drop for Cover {
     fn drop(&mut self) {
-        match (self.kind, self.ownership) {
+        match self.kind {
             // A user-stop drop never has a standing cover being adopted.
-            (CoverKind::Transient, _) => disengage(&self.token, &self.state_dir, false),
-            // Lockdown, Fresh: THIS call created the cover from nothing --
-            // restore the pre-lockdown snapshot and drop the refcount, same
-            // as always.
-            (CoverKind::Lockdown, Ownership::Fresh) => lockdown_disengage(&self.state_dir),
-            // Lockdown, Adopted: ordinary RAII ownership -- Drop must not
-            // destroy a cover this attempt did not create. Leaves pf
-            // exactly as this attempt's own engage left it (untouched, or
-            // its own rewritten ruleset if the engage succeeded before a
-            // later phase failed). See CONTRIBUTING.md's "Lockdown mode"
-            // for why no restore-to-before-this-attempt snapshot exists.
-            (CoverKind::Lockdown, Ownership::Adopted) => {}
+            CoverKind::Transient => disengage(&self.token, &self.state_dir, false),
+            CoverKind::Lockdown => lockdown_disengage(&self.state_dir),
         }
     }
 }
@@ -389,76 +315,6 @@ fn capture_and_persist(token: &str, state_dir: &Path, owner: Option<(u32, u32)>)
     Ok(nat_snapshot)
 }
 
-/// Reconcile pf's enabled state against an ALREADY-PERSISTED lockdown token,
-/// for a caller that never takes `FreshEnable` (Phase-6's TUN-add — an
-/// absent state file is already a hard error there, checked before this
-/// runs). `pfctl -f -` into a DISABLED pf exits 0 while enforcing nothing
-/// (`engage_pf_action`'s own doc: "always load the ruleset into an ENABLED
-/// pf, never an inert one") — this is the SAME reconciliation
-/// [`engage_lockdown`] performs for its own `ReuseToken`/`Reenable` arms,
-/// factored out here so the Phase-6 TUN-add reload cannot load straight
-/// into whatever pf's live state happens to be, with no check.
-///
-/// Whether pf was found already enabled and enforcing going into a
-/// [`reconcile_pf_enabled`] call, or had to be freshly re-enabled.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PfReconciled {
-    /// pf was already enabled: whatever ruleset was loaded under the
-    /// persisted token is genuinely live and has been continuously
-    /// enforcing.
-    AlreadyEnabled,
-    /// pf was DISABLED (e.g. a reboot reset its refcount and cleared its
-    /// in-memory loaded rules) and has just been freshly re-enabled under a
-    /// NEW refcount token. Nothing was being enforced immediately before
-    /// this call, regardless of what the state file claims was loaded --
-    /// `-E` alone does not reload any specific ruleset.
-    JustReenabled,
-}
-
-/// Returns the token to load the ruleset with (reused unchanged, or freshly
-/// re-enabled and re-persisted under the SAME host snapshot if pf had been
-/// disabled since the state file was written) alongside which of those two
-/// happened — callers need this to decide whether a SUBSEQUENT `pfctl -f -`
-/// failure leaves a genuinely-enforcing prior ruleset in place
-/// (`AlreadyEnabled`) or strands the host with nothing actually enforced
-/// (`JustReenabled`, where `-E` re-enabled filtering but loaded no ruleset
-/// of its own).
-fn reconcile_pf_enabled(
-    persisted: &lockdown_state::LockdownPfState,
-    state_dir: &Path,
-    owner: Option<(u32, u32)>,
-) -> Result<(String, PfReconciled), RoutingError> {
-    let info = pfctl(&["-s", "info"], None, PHASE_COVER)?;
-    let pf_enabled = parse_pf_enabled(&String::from_utf8_lossy(&info.stdout));
-    match engage_pf_action(pf_enabled, true) {
-        PfEngageAction::ReuseToken => Ok((persisted.pf_token.clone(), PfReconciled::AlreadyEnabled)),
-        PfEngageAction::Reenable => {
-            let token = enable_pf_capture_token()?;
-            let fresh = lockdown_state::LockdownPfState {
-                version: lockdown_state::SCHEMA_VERSION,
-                pf_token: token.clone(),
-                main_snapshot: persisted.main_snapshot.clone(),
-                nat_snapshot: persisted.nat_snapshot.clone(),
-            };
-            if let Err(e) = lockdown_state::save(state_dir, &fresh, owner) {
-                if let Err(xe) = pfctl(&["-X", &token], None, PHASE_COVER) {
-                    tracing::warn!(error = %xe, "pfctl -X failed unwinding a failed lockdown re-enable");
-                }
-                return Err(RoutingError::RouteSetup(format!(
-                    "failed to re-persist lockdown-pf-state: {e}"
-                )));
-            }
-            Ok((token, PfReconciled::JustReenabled))
-        }
-        // `has_persisted=true` (a `&LockdownPfState` was passed in) forces
-        // `engage_pf_action`'s match into ReuseToken or Reenable -- see its
-        // own `(false, _) => FreshEnable` arm, unreachable with `true` fixed.
-        PfEngageAction::FreshEnable => {
-            unreachable!("reconcile_pf_enabled is only ever called with a persisted state already in hand")
-        }
-    }
-}
-
 /// Engage the standing lockdown cover. Persist-before-mutate, no `-Fa`. Engage
 /// idempotently ENSURES pf is enabled (`engage_pf_action` on the `pfctl -s info`
 /// read) so the ruleset never loads into a disabled, INERT pf. The three cases
@@ -471,71 +327,60 @@ fn reconcile_pf_enabled(
 /// Then load the self-contained main ruleset via `pfctl -f -` (NO `-Fa`), so the
 /// block takes effect while host translation is carried forward.
 ///
-/// On load failure Err is always returned (the bridge's fail-FATAL caller
-/// aborts the start). The host is actively restored (`lockdown_disengage`)
-/// whenever nothing was GENUINELY enforcing immediately before this call:
-/// either a FIRST-ever engage (`persisted` was `None`), or a re-engage where
-/// [`reconcile_pf_enabled`] had to freshly re-enable a DISABLED pf
-/// (`PfReconciled::JustReenabled` — `-E` alone loads no ruleset, so nothing
-/// was actually being enforced despite the state file's claim). Only a
-/// re-engage that found pf ALREADY enabled (`PfReconciled::AlreadyEnabled`)
-/// skips the restore: `pfctl -f -`'s atomicity means a rejected reload there
-/// leaves that previously-loaded ruleset unchanged and still fully
-/// enforced, so disengaging would destroy a cover that is still live and
-/// correct.
+/// On load failure the host is restored (`lockdown_disengage`) and Err returned;
+/// the bridge's fail-FATAL caller aborts the start.
 pub fn engage_lockdown(
     server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    tun_name: Option<&str>,
+    tun_name: &str,
     state_dir: &Path,
     owner: Option<(u32, u32)>,
 ) -> Result<Cover, RoutingError> {
+    // The `pfctl -s info` read is decision-only — `LockdownPfState` records no
+    // `pf_was_enabled` bit (unlike the transient `FailClosedState`).
+    let info = pfctl(&["-s", "info"], None, PHASE_COVER)?;
+    let pf_enabled = parse_pf_enabled(&String::from_utf8_lossy(&info.stdout));
     let persisted = lockdown_state::load(state_dir);
-    // Ownership (see `Ownership`'s own doc and `Drop for Cover`): a
-    // persisted state file means SOME cover already existed when this call
-    // started -- either adopted from a prior bridge process, or (within
-    // this SAME process) a previous attempt's own Adopted cover that a
-    // still-earlier failure already declined to tear down. Either way,
-    // THIS attempt did not create it from nothing, so it must not be the
-    // one to destroy it either.
-    let ownership = if persisted.is_some() {
-        Ownership::Adopted
-    } else {
-        Ownership::Fresh
-    };
 
-    // `resave_after_success` carries the main_snapshot for a `Some(st)`
-    // re-engage ONLY -- see the self-healing re-persist below for why.
-    let (token, main_snapshot_for_resave, nat_snapshot, restore_on_failure) = match &persisted {
-        // Live Adopt re-engage, or a repair/TUN-add on an already-engaged
-        // session: reconcile pf's enabled state against the persisted token
-        // (reused unchanged if pf is still enabled, or freshly re-enabled
-        // and re-persisted if a reboot reset it) — see `reconcile_pf_enabled`.
-        // `restore_on_failure` is false ONLY when pf was found genuinely
-        // already enabled -- a `JustReenabled` re-engage restores on failure
-        // exactly like a first-ever engage, since nothing was actually being
-        // enforced going in.
-        Some(st) => {
-            let (token, reconciled) = reconcile_pf_enabled(st, state_dir, owner)?;
-            (
-                token,
-                Some(st.main_snapshot.clone()),
-                st.nat_snapshot.clone(),
-                reconciled != PfReconciled::AlreadyEnabled,
-            )
+    let (token, nat_snapshot) = match engage_pf_action(pf_enabled, persisted.is_some()) {
+        // Live Adopt re-engage within one boot: pf still enabled and we hold the
+        // token+snapshot. Reuse both so the real host policy is preserved for the
+        // eventual restore. ReuseToken assumes our refcount is still live (the
+        // reboot case is `Reenable`); do not double `-E`.
+        PfEngageAction::ReuseToken => {
+            let st = persisted.expect("ReuseToken implies persisted state");
+            (st.pf_token, st.nat_snapshot)
         }
-        // First engage: enable + snapshot the host. Nothing was live before
-        // this call, so a load failure always restores. `capture_and_persist`
-        // already persists before this function's own `pfctl -f -` mutates
-        // (persist-before-mutate, its own doc), so this branch does not need
-        // the `Some(st)` branch's post-success re-persist below.
-        None => {
+        // Persisted state survived but pf was disabled (reboot reset pf and its
+        // refcount). Enable afresh and re-persist the SAME host snapshot under the
+        // fresh token — never re-snapshot the live lockdown ruleset. The single
+        // `pfctl -X <fresh-token>` on disengage matches this single `-E`.
+        PfEngageAction::Reenable => {
+            let st = persisted.expect("Reenable implies persisted state");
+            let token = enable_pf_capture_token()?;
+            let fresh = lockdown_state::LockdownPfState {
+                version: lockdown_state::SCHEMA_VERSION,
+                pf_token: token.clone(),
+                main_snapshot: st.main_snapshot,
+                nat_snapshot: st.nat_snapshot.clone(),
+            };
+            if let Err(e) = lockdown_state::save(state_dir, &fresh, owner) {
+                if let Err(xe) = pfctl(&["-X", &token], None, PHASE_COVER) {
+                    tracing::warn!(error = %xe, "pfctl -X failed unwinding a failed lockdown re-enable");
+                }
+                return Err(RoutingError::RouteSetup(format!(
+                    "failed to re-persist lockdown-pf-state: {e}"
+                )));
+            }
+            (token, st.nat_snapshot)
+        }
+        // First engage: enable + snapshot the host.
+        PfEngageAction::FreshEnable => {
             let token = enable_pf_capture_token()?;
             // The refcount is now held. Capture + persist may fail, so undo the
             // `-E` on any error before propagating — else the refcount leaks with
             // no state file to recover it from.
             match capture_and_persist(&token, state_dir, owner) {
-                Ok(nat_snapshot) => (token, None, nat_snapshot, true),
+                Ok(nat_snapshot) => (token, nat_snapshot),
                 Err(e) => {
                     if let Err(xe) = pfctl(&["-X", &token], None, PHASE_COVER) {
                         tracing::warn!(error = %xe, "pfctl -X failed unwinding a failed lockdown engage");
@@ -546,147 +391,23 @@ pub fn engage_lockdown(
         }
     };
 
-    let main = build_lockdown_main_ruleset(tun_name, server_ip, resolver_ip, &nat_snapshot);
+    let main = build_lockdown_main_ruleset(tun_name, server_ip, &nat_snapshot);
     let out = pfctl(&["-f", "-"], Some(main.as_bytes()), PHASE_COVER)?;
     if !out.status.success() {
-        if restore_on_failure {
-            // Nothing was genuinely enforcing before this call (first-ever
-            // engage, or a JustReenabled re-engage) -- a partially-loaded
-            // ruleset would strand the host mid-lockdown. Restore the
-            // pre-lockdown host state (snapshot reload + drop refcount)
-            // before failing.
-            lockdown_disengage(state_dir);
-        }
-        // Otherwise this was a re-engage over pf that was ALREADY enabled
-        // and enforcing: `pfctl -f -` is atomic, so this rejected reload
-        // left the PREVIOUSLY loaded ruleset (still fully enforced, still
-        // correct) untouched -- restoring the pre-lockdown snapshot would
-        // destroy a live, correct standing cover instead of merely failing
-        // this one call. Mirrors `engage_lockdown_tun`'s identical
-        // disposition for the same atomicity guarantee.
+        // Restore the host (snapshot reload + drop refcount) before failing, so
+        // a partially-loaded ruleset never strands the host.
+        lockdown_disengage(state_dir);
         return Err(RoutingError::RouteSetup(format!(
             "pfctl lockdown load failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
         )));
     }
 
-    if let Some(main_snapshot) = main_snapshot_for_resave {
-        // Self-healing re-persist, "ask forgiveness" rather than atomic
-        // check-then-act -- see `engage_lockdown_tun`'s identical rationale:
-        // this function's initial `load` above and this successful reload
-        // are not one atomic operation with a concurrent `hole bridge
-        // unlock` (`disengage_lockdown` clears the state file with no "only
-        // when no bridge is alive" enforcement). Without this, a clear
-        // racing in between would leave this just-reloaded ruleset live
-        // with NO state file to disengage it later. Only for the `Some(st)`
-        // (re-engage) case -- a first-ever engage already persisted before
-        // its own mutate, above.
-        let fresh = lockdown_state::LockdownPfState {
-            version: lockdown_state::SCHEMA_VERSION,
-            pf_token: token.clone(),
-            main_snapshot,
-            nat_snapshot: nat_snapshot.clone(),
-        };
-        if let Err(e) = lockdown_state::save(state_dir, &fresh, owner) {
-            return Err(RoutingError::RouteSetup(format!(
-                "engage_lockdown: failed to re-persist lockdown state after a successful reload: {e}"
-            )));
-        }
-    }
-
     Ok(Cover {
         token,
         state_dir: state_dir.to_owned(),
         kind: CoverKind::Lockdown,
-        ownership,
     })
-}
-
-/// Add the TUN pass line to an already-engaged standing lockdown cover
-/// (Phase 6, once `routing.install` has resolved the adapter), by reloading
-/// the FULL ruleset — pf has no incremental update — reusing the SAME
-/// persisted token/nat_snapshot [`engage_lockdown`] (Phase 0) already wrote.
-/// Returns no guard: the [`Cover`] Phase 0 already returned still owns the
-/// whole standing cover.
-///
-/// Unlike [`engage_lockdown`]'s own load-failure branch, a failed reload
-/// here does NOT call [`lockdown_disengage`]: `pfctl -f -` is atomic — a
-/// rejected ruleset leaves the PREVIOUSLY LOADED one (Phase 0's, permitting
-/// loopback/server/resolver/App-ID, minus only the TUN line this call was
-/// trying to add) unchanged and still fully enforced -- true whenever
-/// [`reconcile_pf_enabled`] found pf already enabled. This function never
-/// restores on failure itself either way: within the full bridge flow, the
-/// caller (`start_cancellable`) holds the Phase-0 `Cover` as a plain local
-/// and it drops via ordinary RAII on ANY `start_inner` failure (this one
-/// included) — a `Fresh`-owned guard disengages there; an `Adopted` one
-/// (Phase 0 found a standing cover already live, from a prior bridge
-/// process) does not, by design (see `Ownership` and `Drop for Cover`), so
-/// the aggregate outcome depends on ownership, not solely on what this
-/// function does internally. Restoring here too would double a `Fresh`
-/// disengage and would be wrong outright for an `Adopted` one. A STANDALONE
-/// call (e.g. a test driving this function directly, with no such caller)
-/// has no such backstop; see [`reconcile_pf_enabled`]'s
-/// `PfReconciled::JustReenabled` case for when "still fully enforced" does
-/// NOT hold even for an atomic reload (pf had nothing loaded going in).
-///
-/// Reconciles pf's enabled state via [`reconcile_pf_enabled`] before the
-/// reload — `pfctl -f -` into a DISABLED pf exits 0 while enforcing nothing,
-/// so skipping this would report a connected session as covered while pf
-/// enforces nothing at all.
-///
-/// The initial state-file `load` and the final reload+re-save are NOT one
-/// atomic operation — a concurrent `hole bridge unlock` can clear the state
-/// file in between. On success this function re-persists the state it just
-/// reloaded with ("ask forgiveness" rather than a lock), so that race leaves
-/// a live ruleset WITH a state file to recover it (self-healing on the next
-/// `unlock`/crash-recovery sweep) instead of a live ruleset with none (an
-/// unrecoverable, manually-`pfctl`-only stranding).
-pub fn engage_lockdown_tun(
-    tun_name: &str,
-    server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    state_dir: &Path,
-    owner: Option<(u32, u32)>,
-) -> Result<(), RoutingError> {
-    let persisted = lockdown_state::load(state_dir).ok_or_else(|| {
-        RoutingError::RouteSetup(
-            "engage_lockdown_tun: no lockdown state on disk -- called before the Phase-0 engage".into(),
-        )
-    })?;
-    let (token, _reconciled) = reconcile_pf_enabled(&persisted, state_dir, owner)?;
-    let main = build_lockdown_main_ruleset(Some(tun_name), server_ip, resolver_ip, &persisted.nat_snapshot);
-    let out = pfctl(&["-f", "-"], Some(main.as_bytes()), PHASE_COVER)?;
-    if !out.status.success() {
-        return Err(RoutingError::RouteSetup(format!(
-            "pfctl lockdown TUN-add load failed (the Phase-0 cover is unaffected -- pfctl's reload is atomic): {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        )));
-    }
-    // Self-healing re-persist, "ask forgiveness" rather than atomic
-    // check-then-act: this call's own initial `load` above and this final
-    // `save` are not one indivisible operation with a concurrent
-    // `hole bridge unlock` (`disengage_lockdown` deletes the state file
-    // with no "only when no bridge is alive" enforcement). Without this
-    // save, a clear racing between the load and the reload above would
-    // leave the just-loaded lockdown ruleset live with NO state file to
-    // disengage it later -- a silent no-op for both this attempt's own
-    // `Cover::drop` and any subsequent `unlock`, stranding pf permanently
-    // locked down. Re-saving the SAME already-known snapshots under
-    // `reconcile_pf_enabled`'s current token (idempotent when nothing
-    // raced) makes this successful reload authoritative over a racing
-    // clear instead of the reverse.
-    let fresh = lockdown_state::LockdownPfState {
-        version: lockdown_state::SCHEMA_VERSION,
-        pf_token: token,
-        main_snapshot: persisted.main_snapshot.clone(),
-        nat_snapshot: persisted.nat_snapshot.clone(),
-    };
-    lockdown_state::save(state_dir, &fresh, owner).map_err(|e| {
-        RoutingError::RouteSetup(format!(
-            "engage_lockdown_tun: failed to re-persist lockdown state after a successful reload: {e}"
-        ))
-    })?;
-    Ok(())
 }
 
 /// Fail-loud disengage: restore the pre-lockdown ruleset from the snapshot, drop

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -188,7 +188,7 @@ fn ensure_trailing_nl_keeps_single_newline() {
 const TUN: &str = "hole-tun";
 
 fn lockdown(ip: IpAddr, nat: &str) -> String {
-    build_lockdown_main_ruleset(Some(TUN), ip, None, nat)
+    build_lockdown_main_ruleset(TUN, ip, nat)
 }
 
 #[skuld::test]
@@ -221,54 +221,6 @@ fn lockdown_main_passes_tun_interface() {
     assert!(
         r.contains("pass out quick on hole-tun all"),
         "lockdown main must pass the TUN interface:\n{r}"
-    );
-}
-
-// tun_name: None (Phase-0 permits-only engage) ========================================================================
-
-#[skuld::test]
-fn lockdown_main_omits_tun_pass_when_none() {
-    // The Phase-0 early engage (`install_lockdown_permits`) has no adapter
-    // yet (it doesn't exist before `routing.install`), so the TUN pass line
-    // must be omitted entirely -- not merely named against an absent
-    // interface.
-    let r = build_lockdown_main_ruleset(None, v4(), None, "");
-    assert!(
-        !r.contains("pass out quick on"),
-        "no TUN pass line must exist when tun_name is None:\n{r}"
-    );
-}
-
-#[skuld::test]
-fn lockdown_main_still_passes_server_and_resolver_when_tun_is_none() {
-    // Everything ELSE the Phase-0 early engage needs must still be present:
-    // omitting the TUN pass line must not accidentally omit anything else.
-    let r = build_lockdown_main_ruleset(None, v4(), Some(resolver()), "");
-    assert!(
-        r.contains("pass out quick proto tcp from any to 203.0.113.7"),
-        "lockdown main (tun=None) must still pass the server IP:\n{r}"
-    );
-    assert!(
-        r.contains(&format!(
-            "pass out quick proto tcp from any to {} port {RESOLVER_PERMIT_PORT}",
-            resolver()
-        )),
-        "lockdown main (tun=None) must still pass the resolver IP:\n{r}"
-    );
-    assert!(
-        r.contains("block drop out quick all"),
-        "lockdown main (tun=None) must still carry the fail-closed base:\n{r}"
-    );
-}
-
-#[skuld::test]
-fn lockdown_main_no_blank_line_when_tun_and_resolver_are_both_none() {
-    // Both optional lines omitted at once must not leave a stray blank line
-    // between the server permit and the inet6 block.
-    let r = build_lockdown_main_ruleset(None, v4(), None, "");
-    assert!(
-        !r.contains("\n\n"),
-        "no optional lines must not produce a blank line:\n{r}"
     );
 }
 
@@ -365,64 +317,6 @@ fn lockdown_main_v6_server_permit_precedes_inet6_block() {
     assert!(
         permit_at < block_at,
         "v6 server permit must precede the inet6 block:\n{r}"
-    );
-}
-
-// build_lockdown_main_ruleset resolver permit =========================================================================
-
-#[skuld::test]
-fn lockdown_main_omits_resolver_pass_when_none() {
-    // Negative direction: no resolver_ip means no resolver pass rule at all —
-    // proves the widening is opt-in, never automatic.
-    let r = build_lockdown_main_ruleset(Some(TUN), v4(), None, "");
-    assert!(
-        !r.contains("198.51.100.5"),
-        "lockdown main must not mention a resolver when resolver_ip is None:\n{r}"
-    );
-}
-
-#[skuld::test]
-fn lockdown_main_passes_resolver_scoped_to_tcp_443() {
-    // NOT the server permit's unrestricted shape: doh_url_for_ip
-    // (crates/bridge/src/dns/ech.rs) never constructs a URL with a port other
-    // than RESOLVER_PERMIT_PORT, so this is the one value the fetch can need.
-    let r = build_lockdown_main_ruleset(Some(TUN), v4(), Some(resolver()), "");
-    assert!(
-        r.contains(&format!(
-            "pass out quick proto tcp from any to {} port {RESOLVER_PERMIT_PORT}",
-            resolver()
-        )),
-        "lockdown main must pass the resolver IP scoped to tcp/{RESOLVER_PERMIT_PORT}:\n{r}"
-    );
-}
-
-#[skuld::test]
-fn lockdown_main_resolver_pass_is_quick_and_precedes_block() {
-    let r = build_lockdown_main_ruleset(Some(TUN), v4(), Some(resolver()), "");
-    let resolver_at = r.find(&resolver().to_string()).expect("resolver permit must appear");
-    let block_at = r.find("block drop out quick all").expect("block-all must appear");
-    assert!(
-        resolver_at < block_at,
-        "resolver permit must precede the block-all:\n{r}"
-    );
-    let line = r.lines().find(|l| l.contains(&resolver().to_string())).unwrap();
-    assert!(line.contains("quick"), "resolver pass rule must be quick: {line}");
-}
-
-#[skuld::test]
-fn lockdown_main_v6_resolver_permit_precedes_inet6_block() {
-    // A v6 resolver must be permitted BEFORE the wholesale inet6 block, or the
-    // ECH-config fetch to it is killed.
-    let r = build_lockdown_main_ruleset(Some(TUN), v4(), Some(resolver_v6()), "");
-    let permit_at = r
-        .find(&resolver_v6().to_string())
-        .expect("v6 resolver permit must appear");
-    let block_at = r
-        .find("block drop out quick inet6 all")
-        .expect("inet6 block must appear");
-    assert!(
-        permit_at < block_at,
-        "v6 resolver permit must precede the inet6 block:\n{r}"
     );
 }
 

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -84,23 +84,17 @@ pub const FILTER_GUIDS: [GUID; 12] = [
 const IPPROTO_TCP: u8 = 6;
 
 // Lockdown-cover filter GUIDs — disjoint from FILTER_GUIDS. Recovery sweeps
-// these (Sweep) or deletes the volatile TUN + server + resolver pairs (Adopt)
-// — see `recover_lockdown` / `swept_lockdown_guids`. A crash that leaves the
-// cover engaged is reconciled on the next start.
+// these (Sweep) or deletes the volatile TUN + server pairs (Adopt) — see
+// `recover_lockdown` / `swept_lockdown_guids`. A crash that leaves the cover
+// engaged is reconciled on the next start.
 // Layout: [loopback CONNECT V4, loopback CONNECT V6, TUN V4, TUN V6,
 //          server V4, server V6, block-all V4, block-all V6,
 //          loopback RECV_ACCEPT V4, loopback RECV_ACCEPT V6,
-//          loopback-net CONNECT V4, loopback-net CONNECT V6,
-//          resolver CONNECT V4, resolver CONNECT V6]. New pairs are
+//          loopback-net CONNECT V4, loopback-net CONNECT V6]. New pairs are
 //          appended so the earlier indices referenced by
 //          LOCKDOWN_{TUN,SERVER}_GUID_INDICES stay stable. App-ID
 //          filters get per-binary dynamically-derived GUIDs (see build_lockdown_spec).
-//
-// CROSS-VERSION CONTRACT, same class as `FILTER_GUIDS` (see its own doc for
-// the crash-then-downgrade mechanism): the two resolver-permit GUIDs
-// (indices 12-13) grow this array from twelve entries to fourteen, with the
-// identical un-swept-permit risk and the same bounded, self-healing outcome.
-pub const LOCKDOWN_FILTER_GUIDS: [GUID; 14] = [
+pub const LOCKDOWN_FILTER_GUIDS: [GUID; 12] = [
     GUID::from_u128(0x216a841b_f264_4047_8881_39f24b4d6dce), // loopback CONNECT V4
     GUID::from_u128(0x4d9cd0a2_c48f_40cf_8225_89ce3f8a1376), // loopback CONNECT V6
     GUID::from_u128(0x04216435_0209_4b16_95c4_41f7c26af397), // TUN V4
@@ -113,24 +107,15 @@ pub const LOCKDOWN_FILTER_GUIDS: [GUID; 14] = [
     GUID::from_u128(0xda582b53_9a85_b667_c519_e80db74ab67e), // loopback RECV_ACCEPT V6
     GUID::from_u128(0x2f10387e_8f54_4f82_91ca_44aa862d945e), // loopback-net CONNECT V4 (127.0.0.0/8)
     GUID::from_u128(0xd766a20f_050a_4c40_8de3_33bf259b7e34), // loopback-net CONNECT V6 (::1/128)
-    GUID::from_u128(0x668194ca_a46b_4c76_9b5c_e0f51b980f78), // resolver CONNECT V4
-    GUID::from_u128(0xf50b45a3_9209_4bbc_b5ef_ce2ccdc0b5bf), // resolver CONNECT V6
 ];
 
 /// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the TUN-interface (LUID) permit
-/// pair — one of the three volatile permits Adopt drops (see
+/// pair — one of the two volatile permits Adopt drops (see
 /// [`adopt_delete_guids`]).
 const LOCKDOWN_TUN_GUID_INDICES: [usize; 2] = [2, 3]; // TUN V4, TUN V6
-/// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the server-IP permit pair —
-/// another volatile permit Adopt drops (see [`adopt_delete_guids`]).
+/// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the server-IP permit pair — the
+/// other volatile permit Adopt drops (see [`adopt_delete_guids`]).
 const LOCKDOWN_SERVER_GUID_INDICES: [usize; 2] = [4, 5]; // server V4, server V6
-/// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the resolver-IP permit pair —
-/// the third volatile permit Adopt drops (see [`adopt_delete_guids`]): the
-/// ECH-config resolver a covered start derives is re-computed fresh on every
-/// connect exactly like `server_ip`, so a stale fixed-GUID permit surviving
-/// across an Adopt would (like an unfreshened server permit) silently keep
-/// permitting an address the current config no longer uses.
-const LOCKDOWN_RESOLVER_GUID_INDICES: [usize; 2] = [12, 13]; // resolver V4, resolver V6
 
 /// Derive a deterministic App-ID filter GUID per (binary index, layer) so a
 /// re-engage over an unswept cover is idempotent and recovery can delete by
@@ -154,7 +139,7 @@ fn swept_transient_guids() -> Vec<GUID> {
     FILTER_GUIDS.to_vec()
 }
 
-/// Every lockdown filter GUID a full Sweep must delete: the fourteen fixed
+/// Every lockdown filter GUID a full Sweep must delete: the ten fixed
 /// lockdown GUIDs + the per-binary App-ID GUIDs. (Transient GUIDs are swept
 /// separately by `delete_all`.)
 fn swept_lockdown_guids() -> Vec<GUID> {
@@ -167,17 +152,15 @@ fn swept_lockdown_guids() -> Vec<GUID> {
 }
 
 /// The GUIDs Adopt deletes: the VOLATILE permits — the TUN-LUID pair (dies with
-/// the TUN), the server-IP pair (changes with the server), and the resolver-IP
-/// pair (changes with `dns.servers`/the plugin config, and is absent entirely
-/// on some configs). They carry fixed keys, so engage's `ok_or_exists` would
-/// silently keep a stale one; deleting them lets the next connect re-add all
-/// three fresh with current values. The floor (block-all, loopback, App-ID) is
-/// left in force so the host stays fail-closed across the restart.
+/// the TUN) and the server-IP pair (changes with the server). They carry fixed
+/// keys, so engage's `ok_or_exists` would silently keep a stale one; deleting
+/// them lets the next connect re-add both fresh with current values. The floor
+/// (block-all, loopback, App-ID) is left in force so the host stays fail-closed
+/// across the restart.
 fn adopt_delete_guids() -> Vec<GUID> {
     LOCKDOWN_TUN_GUID_INDICES
         .iter()
         .chain(LOCKDOWN_SERVER_GUID_INDICES.iter())
-        .chain(LOCKDOWN_RESOLVER_GUID_INDICES.iter())
         .map(|&i| LOCKDOWN_FILTER_GUIDS[i])
         .collect()
 }
@@ -341,7 +324,19 @@ pub fn build_cover_spec(server_ip: IpAddr, resolver_ip: Option<IpAddr>) -> Cover
             weight: PERMIT_WEIGHT,
         },
     ];
-    filters.extend(resolver_permit_filter(resolver_ip, FILTER_GUIDS[10], FILTER_GUIDS[11]));
+    if let Some(ip) = resolver_ip {
+        let (guid, layer) = match ip {
+            IpAddr::V4(_) => (FILTER_GUIDS[10], Layer::ConnectV4),
+            IpAddr::V6(_) => (FILTER_GUIDS[11], Layer::ConnectV6),
+        };
+        filters.push(FilterSpec {
+            guid,
+            layer,
+            action: Action::Permit,
+            condition: Condition::RemoteIpPortTcp(ip, RESOLVER_PERMIT_PORT),
+            weight: PERMIT_WEIGHT,
+        });
+    }
     filters.push(block(FILTER_GUIDS[4], Layer::ConnectV4));
     filters.push(block(FILTER_GUIDS[5], Layer::ConnectV6));
     CoverSpec {
@@ -349,29 +344,6 @@ pub fn build_cover_spec(server_ip: IpAddr, resolver_ip: Option<IpAddr>) -> Cover
         sublayer: SUBLAYER_GUID,
         filters,
     }
-}
-
-/// The optional resolver-permit filter for `resolver_ip`, keyed to
-/// `guid_v4`/`guid_v6` per family — shared by `build_cover_spec` (transient)
-/// and `build_lockdown_spec` (standing): both covers permit the identical
-/// resolver address under the identical TCP/[`RESOLVER_PERMIT_PORT`] scope
-/// (see [`crate::routing::Routing::install_failclosed_cover`]'s doc for the
-/// trust condition). `None` in, `None` out — omitted whenever nothing should
-/// be permitted.
-fn resolver_permit_filter(resolver_ip: Option<IpAddr>, guid_v4: GUID, guid_v6: GUID) -> Option<FilterSpec> {
-    resolver_ip.map(|ip| {
-        let (guid, layer) = match ip {
-            IpAddr::V4(_) => (guid_v4, Layer::ConnectV4),
-            IpAddr::V6(_) => (guid_v6, Layer::ConnectV6),
-        };
-        FilterSpec {
-            guid,
-            layer,
-            action: Action::Permit,
-            condition: Condition::RemoteIpPortTcp(ip, RESOLVER_PERMIT_PORT),
-            weight: PERMIT_WEIGHT,
-        }
-    })
 }
 
 /// Build the data description of the standing lockdown cover for `server_ip`,
@@ -385,24 +357,7 @@ fn resolver_permit_filter(resolver_ip: Option<IpAddr>, guid_v4: GUID, guid_v6: G
 /// kill switch, not inbound. Permits at `PERMIT_WEIGHT`, block at `BLOCK_WEIGHT`;
 /// within the single sublayer the higher-weight permit wins (no
 /// `CLEAR_ACTION_RIGHT`). Pure — no FFI.
-///
-/// Optionally also permits ONE more address (`resolver_ip`) on its own
-/// family's CONNECT layer, scoped to `RESOLVER_PERMIT_PORT` — mirrors
-/// `build_cover_spec`'s resolver permit exactly (same trust condition, same
-/// port scope; see [`crate::routing::Routing::install_lockdown_permits`]'s doc for
-/// why an App-ID permit alone does not cover a chained plugin's inner
-/// process). Omitted whenever nothing should be permitted.
-///
-/// `tun_luid` is `None` for the pre-Phase-1 permits-only engage (see
-/// [`crate::routing::Routing::install_lockdown_permits`]'s doc): the TUN
-/// filter pair is omitted entirely, not merely unmatchable, since no LUID is
-/// resolvable before `routing.install` creates the adapter.
-pub fn build_lockdown_spec(
-    server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    tun_luid: Option<u64>,
-    app_ids: &[std::path::PathBuf],
-) -> CoverSpec {
+pub fn build_lockdown_spec(server_ip: IpAddr, tun_luid: u64, app_ids: &[std::path::PathBuf]) -> CoverSpec {
     let server_layer = match server_ip {
         IpAddr::V4(_) => Layer::ConnectV4,
         IpAddr::V6(_) => Layer::ConnectV6,
@@ -441,19 +396,17 @@ pub fn build_lockdown_spec(
             Layer::RecvAcceptV6,
             Condition::LoopbackNet(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)),
         ),
-    ];
-    if let Some(luid) = tun_luid {
-        filters.push(permit(
+        permit(
             LOCKDOWN_FILTER_GUIDS[2],
             Layer::ConnectV4,
-            Condition::LocalInterface(luid),
-        ));
-        filters.push(permit(
+            Condition::LocalInterface(tun_luid),
+        ),
+        permit(
             LOCKDOWN_FILTER_GUIDS[3],
             Layer::ConnectV6,
-            Condition::LocalInterface(luid),
-        ));
-    }
+            Condition::LocalInterface(tun_luid),
+        ),
+    ];
     for (i, path) in app_ids.iter().enumerate() {
         filters.push(permit(
             appid_filter_guid(i, false),
@@ -472,11 +425,6 @@ pub fn build_lockdown_spec(
         LOCKDOWN_FILTER_GUIDS[5]
     };
     filters.push(permit(server_guid, server_layer, Condition::RemoteIp(server_ip)));
-    filters.extend(resolver_permit_filter(
-        resolver_ip,
-        LOCKDOWN_FILTER_GUIDS[12],
-        LOCKDOWN_FILTER_GUIDS[13],
-    ));
     filters.push(block(LOCKDOWN_FILTER_GUIDS[6], Layer::ConnectV4));
     filters.push(block(LOCKDOWN_FILTER_GUIDS[7], Layer::ConnectV6));
     CoverSpec {
@@ -520,38 +468,16 @@ enum CoverKind {
     Lockdown,
 }
 
-/// Whether THIS `engage_lockdown` call created the standing cover from
-/// nothing, or found one already live (adopted from a prior bridge process
-/// that crashed or cutover, `CoverRecovery::Adopt`). Consulted ONLY by
-/// `Drop` — see there for why. Meaningless for `CoverKind::Transient` (the
-/// transient cover has no adoption concept; every engage is fresh), always
-/// `Fresh` in that case.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Ownership {
-    Fresh,
-    Adopted,
-}
-
-/// WFP-backed cover guard. Drop deletes the filters it installed by GUID —
-/// unless `ownership` is `Adopted`, in which case Drop leaves them alone;
-/// see `Drop for Cover`.
+/// WFP-backed cover guard. Drop deletes the filters it installed by GUID.
 pub struct Cover {
     engine: HANDLE,
     kind: CoverKind,
-    ownership: Ownership,
 }
 
 // SAFETY: the FWPM engine handle is owned exclusively by this guard and only
 // touched in `engage` and `Drop`. Sending it between threads is sound; FWPM
 // engine handles are not thread-affine.
 unsafe impl Send for Cover {}
-
-impl Cover {
-    /// See [`crate::routing::CoverGuard::mark_owned`].
-    pub fn mark_owned(&mut self) {
-        self.ownership = Ownership::Fresh;
-    }
-}
 
 fn wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
@@ -626,7 +552,6 @@ pub fn engage(
         Ok(Cover {
             engine,
             kind: CoverKind::Transient,
-            ownership: Ownership::Fresh,
         })
     }
 }
@@ -634,154 +559,11 @@ pub fn engage(
 #[allow(clippy::disallowed_methods)] // THIS is the sanctioned FWPM call site
 pub fn engage_lockdown(
     server_ip: IpAddr,
-    resolver_ip: Option<IpAddr>,
-    tun_luid: Option<u64>,
+    tun_luid: u64,
     app_ids: &[std::path::PathBuf],
     _state_dir: &Path,
 ) -> Result<Cover, RoutingError> {
-    let spec = build_lockdown_spec(server_ip, resolver_ip, tun_luid, app_ids);
-    unsafe {
-        let mut engine = HANDLE::default();
-        wfp_check(
-            FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine),
-            "FwpmEngineOpen0",
-        )?;
-        // Ownership + transaction: the read and the mutation are one
-        // serialized BFE transaction, not check-then-act outside it -- same
-        // rationale as `engage_lockdown_tun`'s identical in-transaction
-        // probe (a concurrent `hole bridge unlock` deletes every lockdown
-        // GUID from any elevated process at any time, with no "only when no
-        // bridge is alive" enforcement, so a probe outside the transaction
-        // could read stale). `Fresh` means this call created the cover from
-        // nothing; `Adopted` means it found one already live (a prior
-        // bridge process's cover, surviving a crash/cutover via
-        // `CoverRecovery::Adopt`). Consulted ONLY by `Drop` — see there for
-        // why this matters. Any error from the probe itself (not just the
-        // adds) now routes through the same abort+close cleanup below,
-        // rather than leaking the just-opened engine handle.
-        let result = (|| -> Result<Ownership, RoutingError> {
-            wfp_check(FwpmTransactionBegin0(engine, 0), "FwpmTransactionBegin0")?;
-            let ownership = if phase_0_engaged(engine)? {
-                Ownership::Adopted
-            } else {
-                Ownership::Fresh
-            };
-            // Delete the volatile permits (TUN + server + resolver) BEFORE
-            // re-adding, unconditionally — idempotent (a "not found" delete
-            // is ignored) for a `Fresh` engage where they don't exist yet,
-            // and load-bearing for `Adopted`: with `Drop for Cover`'s
-            // Adopted arm now leaving these fixed-GUID filters live across a
-            // failed attempt (ordinary RAII ownership -- see `Ownership`'s
-            // doc), a LATER attempt within the SAME process can find them
-            // still present, and `add_filter`'s tolerant `ok_or_exists`
-            // would otherwise silently keep THAT stale value instead of
-            // this attempt's own freshly-derived one. `recover_lockdown`'s
-            // Adopt sweep does the identical delete, but only once at
-            // bridge startup — this repeats it on every engage so "every
-            // attempt derives its own permits from its own config" (see
-            // CONTRIBUTING.md's "Lockdown mode") holds across repeated
-            // Adopted attempts too, not just the first. Same reasoning
-            // covers the TUN pair here even though Phase 0's own `spec`
-            // never adds it (tun_luid is None here) — a stale TUN permit
-            // from a PRIOR attempt's own Phase 6 must not survive into this
-            // attempt's window before its own (possible) Phase 6 runs.
-            for g in adopt_delete_guids() {
-                let _ = FwpmFilterDeleteByKey0(engine, &g);
-            }
-            // Idempotent over an unswept cover: add_provider/add_sublayer use
-            // ok_or_exists, and the filter keys are fixed — a re-engage after
-            // an Adopt re-adds the TUN + server + resolver permits fresh (their
-            // keys were deleted just above, so the new values take effect);
-            // the kept floor (block-all + loopback + App-ID) is a benign re-add.
-            add_provider(engine, spec.provider)?;
-            add_sublayer(engine, spec.sublayer, spec.provider)?;
-            for f in &spec.filters {
-                add_filter(engine, spec.provider, spec.sublayer, f)?;
-            }
-            wfp_check(FwpmTransactionCommit0(engine), "FwpmTransactionCommit0")?;
-            Ok(ownership)
-        })();
-        let ownership = match result {
-            Ok(ownership) => ownership,
-            Err(e) => {
-                let _ = FwpmTransactionAbort0(engine);
-                let _ = FwpmEngineClose0(engine);
-                return Err(e);
-            }
-        };
-        Ok(Cover {
-            engine,
-            kind: CoverKind::Lockdown,
-            ownership,
-        })
-    }
-}
-
-/// `FWP_E_FILTER_NOT_FOUND`, as the Win32 DWORD `FwpmFilterGetByKey0`
-/// returns for an absent filter.
-const FWP_E_FILTER_NOT_FOUND_DWORD: u32 = 0x8032_0003;
-
-/// Whether Phase 0's own loopback-permit filter (`LOCKDOWN_FILTER_GUIDS[0]`,
-/// installed unconditionally by `engage_lockdown` regardless of
-/// resolver/App-ID presence) is currently live in the FWPM engine.
-///
-/// Windows has no persisted marker file for "did Phase 0 run" the way
-/// macOS's `lockdown_pf_state::load(state_dir)` does — Windows Phase 0's
-/// state IS the live filters, keyed by fixed GUID — so this queries the
-/// engine directly instead of reading a file, mirroring the SAME
-/// precondition macOS's `engage_lockdown_tun` enforces before it will add
-/// the TUN permit.
-#[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
-unsafe fn phase_0_engaged(engine: HANDLE) -> Result<bool, RoutingError> {
-    let mut filter: *mut FWPM_FILTER0 = std::ptr::null_mut();
-    let code = unsafe { FwpmFilterGetByKey0(engine, &LOCKDOWN_FILTER_GUIDS[0], &mut filter) };
-    if code == ERROR_SUCCESS.0 {
-        unsafe { FwpmFreeMemory0(std::ptr::addr_of_mut!(filter).cast()) };
-        return Ok(true);
-    }
-    if code == FWP_E_FILTER_NOT_FOUND_DWORD {
-        return Ok(false);
-    }
-    Err(RoutingError::RouteSetup(format!(
-        "FwpmFilterGetByKey0 failed: 0x{code:08x}"
-    )))
-}
-
-/// Add ONLY the TUN-interface permit pair to an already-engaged standing
-/// lockdown cover (from [`engage_lockdown`] with `tun_luid: None`), once
-/// `routing.install` has resolved the adapter. Idempotent, and returns no
-/// guard — see [`crate::routing::Routing::engage_lockdown_tun`]'s doc: the
-/// `Cover` the earlier `engage_lockdown` call already returned owns the
-/// WHOLE standing cover's disengage-on-drop (`swept_lockdown_guids`, TUN
-/// GUIDs included) regardless of whether this function was ever called, so
-/// there is nothing here for a new guard to uniquely own. Checks
-/// [`phase_0_engaged`] first — matching macOS's equivalent precondition
-/// check — so a call before Phase 0 fails loudly with a clear diagnostic
-/// instead of silently adding orphan TUN-permit filters with no floor. Opens
-/// its own engine, deletes then re-adds the two filters in one transaction
-/// (delete-before-add, not a bare tolerant add: `engage_lockdown`'s own
-/// engage already clears the TUN pair unconditionally before this runs, but
-/// this is the function whose OWN correctness this specific GUID pair rests
-/// on, so it does not rely on that as its only line of defense — a stale
-/// pair here, from an `Adopted` attempt's own earlier Phase 6 that a later
-/// phase then failed without disengaging, would silently keep permitting a
-/// dead LUID while this attempt's own adapter's traffic is unpermitted and
-/// blocked), and closes the engine immediately — unlike `engage_lockdown`,
-/// no handle is held past this call.
-#[allow(clippy::disallowed_methods)] // THIS is the sanctioned FWPM call site
-pub fn engage_lockdown_tun(tun_luid: u64) -> Result<(), RoutingError> {
-    let filters = [
-        permit(
-            LOCKDOWN_FILTER_GUIDS[2],
-            Layer::ConnectV4,
-            Condition::LocalInterface(tun_luid),
-        ),
-        permit(
-            LOCKDOWN_FILTER_GUIDS[3],
-            Layer::ConnectV6,
-            Condition::LocalInterface(tun_luid),
-        ),
-    ];
+    let spec = build_lockdown_spec(server_ip, tun_luid, app_ids);
     unsafe {
         let mut engine = HANDLE::default();
         wfp_check(
@@ -789,30 +571,16 @@ pub fn engage_lockdown_tun(tun_luid: u64) -> Result<(), RoutingError> {
             "FwpmEngineOpen0",
         )?;
         let result = (|| -> Result<(), RoutingError> {
-            // The precondition check, the delete, and the adds all share ONE
-            // transaction -- not check-then-act outside it -- so a
-            // concurrent `hole bridge unlock` (which deletes every lockdown
-            // GUID from any elevated process at any time, with no "only
-            // when no bridge is alive" enforcement) cannot land partway
-            // through: BFE serializes transactions against each other, so
-            // that delete's transaction either fully precedes ours (and
-            // this check correctly fails) or fully follows it (a deliberate
-            // post-commit unlock, not a race).
             wfp_check(FwpmTransactionBegin0(engine, 0), "FwpmTransactionBegin0")?;
-            if !phase_0_engaged(engine)? {
-                return Err(RoutingError::RouteSetup(
-                    "engage_lockdown_tun: Phase-0 loopback permit not found -- called before the Phase-0 engage".into(),
-                ));
-            }
-            // Delete-before-add: idempotent (a "not found" delete is
-            // ignored) for the common case where `engage_lockdown` already
-            // cleared this pair, and load-bearing for the case where it
-            // didn't (see this fn's own doc).
-            for i in LOCKDOWN_TUN_GUID_INDICES {
-                let _ = FwpmFilterDeleteByKey0(engine, &LOCKDOWN_FILTER_GUIDS[i]);
-            }
-            for f in &filters {
-                add_filter(engine, PROVIDER_GUID, SUBLAYER_GUID, f)?;
+            // Idempotent over an unswept cover: add_provider/add_sublayer use
+            // ok_or_exists, and the filter keys are fixed — a re-engage after
+            // an Adopt re-adds the TUN + server permits fresh (their keys were
+            // deleted by `recover_lockdown`, so the new server IP takes effect);
+            // the kept floor (block-all + loopback + App-ID) is a benign re-add.
+            add_provider(engine, spec.provider)?;
+            add_sublayer(engine, spec.sublayer, spec.provider)?;
+            for f in &spec.filters {
+                add_filter(engine, spec.provider, spec.sublayer, f)?;
             }
             wfp_check(FwpmTransactionCommit0(engine), "FwpmTransactionCommit0")?;
             Ok(())
@@ -822,8 +590,10 @@ pub fn engage_lockdown_tun(tun_luid: u64) -> Result<(), RoutingError> {
             let _ = FwpmEngineClose0(engine);
             return Err(e);
         }
-        let _ = FwpmEngineClose0(engine);
-        Ok(())
+        Ok(Cover {
+            engine,
+            kind: CoverKind::Lockdown,
+        })
     }
 }
 
@@ -894,8 +664,6 @@ unsafe fn get_app_id_blob(path: &Path) -> Result<AppIdBlob, RoutingError> {
 }
 
 #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
-/// Add one filter, tolerating `FWP_E_ALREADY_EXISTS` — re-engaging over an
-/// unswept cover with a fixed-GUID filter already present is idempotent.
 unsafe fn add_filter(engine: HANDLE, provider: GUID, sublayer: GUID, f: &FilterSpec) -> Result<(), RoutingError> {
     let layer = match f.layer {
         Layer::ConnectV4 => FWPM_LAYER_ALE_AUTH_CONNECT_V4,
@@ -1126,29 +894,15 @@ impl Drop for Cover {
         unsafe {
             match self.kind {
                 // Transient: today's full sweep (filters + sublayer + provider).
-                // No ownership concept here -- every transient engage is Fresh.
                 CoverKind::Transient => delete_all(self.engine),
-                // Lockdown, Fresh: THIS call created the cover from nothing --
-                // delete only the lockdown + App-ID filters it (potentially)
-                // added; the shared sublayer/provider are owned by the
-                // transient sweep.
+                // Lockdown: delete only the lockdown + App-ID filters; the
+                // shared sublayer/provider are owned by the transient sweep.
                 #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
-                CoverKind::Lockdown if self.ownership == Ownership::Fresh => {
+                CoverKind::Lockdown => {
                     for g in swept_lockdown_guids() {
                         let _ = FwpmFilterDeleteByKey0(self.engine, &g);
                     }
                 }
-                // Lockdown, Adopted: ordinary RAII ownership -- Drop must not
-                // destroy a cover this attempt did not create. Leaves every
-                // filter exactly as this attempt's own engage left it: the
-                // floor (loopback/block-all/App-ID) untouched, and the
-                // volatile TUN/server/resolver permits at THIS attempt's own
-                // values (`engage_lockdown`/`engage_lockdown_tun` delete
-                // those fixed GUIDs before re-adding, so they are never
-                // silently left at a stale prior attempt's values). See
-                // CONTRIBUTING.md's "Lockdown mode" for why no
-                // restore-to-before-this-attempt snapshot exists.
-                CoverKind::Lockdown => {}
             }
             #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
             let _ = FwpmEngineClose0(self.engine);
@@ -1158,10 +912,10 @@ impl Drop for Cover {
 
 /// Reconcile a possibly-present standing lockdown cover with the persisted
 /// intent. Opens the engine; `Adopt` deletes the volatile permits — the dead
-/// TUN-LUID pair, the server-IP pair, and the resolver-IP pair — keeping the
-/// fail-closed floor (block-all + loopback + App-ID) so the host stays
-/// blocked across the restart and the next connect re-adds TUN + server +
-/// resolver fresh; `Sweep` deletes all lockdown + App-ID filters,
+/// TUN-LUID pair and the server-IP pair — keeping the fail-closed floor
+/// (block-all + loopback + App-ID) so the host stays blocked across the restart
+/// and the next connect re-adds TUN + server fresh; `Sweep` deletes all
+/// lockdown + App-ID filters,
 /// then the sublayer/provider IFF the transient cover isn't also using them
 /// (they share PROVIDER_GUID/SUBLAYER_GUID, so leave them — the transient
 /// `delete_all` owns their removal, and an orphaned empty sublayer is benign).

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -249,7 +249,7 @@ fn bridge_path() -> std::path::PathBuf {
 
 #[skuld::test]
 fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
-    let s = build_lockdown_spec(v4(), None, Some(luid()), &[plugin_path(), bridge_path()]);
+    let s = build_lockdown_spec(v4(), luid(), &[plugin_path(), bridge_path()]);
     // loopback on all four ALE layers (CONNECT + RECV_ACCEPT) by the deterministic
     // address-range matcher — see spec_permits_loopback_on_all_four_ale_layers for
     // why the accept side matters and why the flag is unreliable.
@@ -305,100 +305,10 @@ fn lockdown_spec_permits_loopback_tun_appids_and_server_then_blocks() {
     );
 }
 
-// tun_luid: None (Phase-0 permits-only engage) ========================================================================
-
-#[skuld::test]
-fn lockdown_spec_omits_tun_permit_when_luid_is_none() {
-    // The Phase-0 early engage (`install_lockdown_permits`) has no LUID to
-    // resolve yet (the adapter doesn't exist before `routing.install`), so
-    // the TUN filter pair must be omitted entirely -- not merely built with a
-    // dummy value.
-    let s = build_lockdown_spec(v4(), None, None, &[plugin_path(), bridge_path()]);
-    assert!(
-        !s.filters
-            .iter()
-            .any(|f| matches!(f.condition, Condition::LocalInterface(_))),
-        "no LocalInterface filter must exist when tun_luid is None"
-    );
-}
-
-#[skuld::test]
-fn lockdown_spec_still_permits_loopback_appids_and_server_when_tun_is_none() {
-    // Everything ELSE the Phase-0 early engage needs must still be present:
-    // omitting the TUN permit must not accidentally omit anything else.
-    let s = build_lockdown_spec(v4(), Some(resolver_v4()), None, &[plugin_path(), bridge_path()]);
-    for layer in [
-        Layer::ConnectV4,
-        Layer::ConnectV6,
-        Layer::RecvAcceptV4,
-        Layer::RecvAcceptV6,
-    ] {
-        assert!(
-            s.filters.iter().any(|f| f.layer == layer
-                && f.action == Action::Permit
-                && matches!(f.condition, Condition::LoopbackNet(_))),
-            "address-range loopback permit missing on {layer:?}"
-        );
-    }
-    let appids = s
-        .filters
-        .iter()
-        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::AppId(_)))
-        .count();
-    assert_eq!(appids, 4, "two binaries x V4+V6");
-    let server: Vec<_> = s
-        .filters
-        .iter()
-        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIp(_)))
-        .collect();
-    assert_eq!(server.len(), 1);
-    let resolver_permits = s
-        .filters
-        .iter()
-        .filter(|f| {
-            f.action == Action::Permit
-                && matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4())
-        })
-        .count();
-    assert_eq!(resolver_permits, 1);
-    assert!(s
-        .filters
-        .iter()
-        .any(|f| f.layer == Layer::ConnectV4 && f.action == Action::Block));
-    assert!(s
-        .filters
-        .iter()
-        .any(|f| f.layer == Layer::ConnectV6 && f.action == Action::Block));
-}
-
-#[skuld::test]
-fn lockdown_spec_tun_none_filters_are_a_subset_of_the_tun_some_filters() {
-    // The Phase-0 (tun=None) filter GUIDs must all reappear in the Phase-6
-    // (tun=Some) spec -- same fixed keys, so a re-engage over the Phase-0
-    // permits is a pure ADD of the two TUN filters, never a replace/rekey
-    // that could orphan a filter recovery doesn't know about.
-    let without_tun = build_lockdown_spec(v4(), Some(resolver_v4()), None, &[plugin_path()]);
-    let with_tun = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()]);
-    let with_tun_guids: std::collections::HashSet<GUID> = with_tun.filters.iter().map(|f| f.guid).collect();
-    for f in &without_tun.filters {
-        assert!(
-            with_tun_guids.contains(&f.guid),
-            "Phase-0 filter {:?} ({:?}) must also appear in the Phase-6 (tun=Some) spec",
-            f.guid,
-            f.layer
-        );
-    }
-    assert_eq!(
-        with_tun.filters.len(),
-        without_tun.filters.len() + 2,
-        "tun=Some must add EXACTLY the two TUN filters over tun=None"
-    );
-}
-
 #[skuld::test]
 fn lockdown_spec_permits_outweigh_block() {
     // Weight-only arbitration in one sublayer (see the const assert above).
-    let s = build_lockdown_spec(v6(), None, Some(luid()), &[plugin_path()]);
+    let s = build_lockdown_spec(v6(), luid(), &[plugin_path()]);
     for f in &s.filters {
         match f.action {
             Action::Permit => assert_eq!(f.weight, PERMIT_WEIGHT),
@@ -409,9 +319,7 @@ fn lockdown_spec_permits_outweigh_block() {
 
 #[skuld::test]
 fn lockdown_spec_uses_distinct_guids_from_transient_cover() {
-    // Exercise both specs WITH a resolver permit engaged, so the new
-    // lockdown resolver GUIDs are covered by this disjointness check too.
-    let lock = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()]);
+    let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
     let cover = build_cover_spec(v4(), Some(resolver_v4()));
     let lock_guids: std::collections::HashSet<_> = lock.filters.iter().map(|f| f.guid).collect();
     let cover_guids: std::collections::HashSet<_> = cover.filters.iter().map(|f| f.guid).collect();
@@ -426,7 +334,7 @@ fn lockdown_spec_uses_distinct_guids_from_transient_cover() {
 
 #[skuld::test]
 fn lockdown_spec_v6_server_lands_on_v6_layer() {
-    let s = build_lockdown_spec(v6(), None, Some(luid()), &[plugin_path()]);
+    let s = build_lockdown_spec(v6(), luid(), &[plugin_path()]);
     let server: Vec<_> = s
         .filters
         .iter()
@@ -434,144 +342,6 @@ fn lockdown_spec_v6_server_lands_on_v6_layer() {
         .collect();
     assert_eq!(server.len(), 1);
     assert_eq!(server[0].layer, Layer::ConnectV6);
-}
-
-// lockdown resolver permit ============================================================================================
-
-#[skuld::test]
-fn lockdown_spec_permits_resolver_ip_on_its_own_family_layer_when_given() {
-    let s = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()]);
-    let resolver_permits: Vec<_> = s
-        .filters
-        .iter()
-        .filter(|f| {
-            f.action == Action::Permit
-                && matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4())
-        })
-        .collect();
-    assert_eq!(resolver_permits.len(), 1, "exactly one resolver permit");
-    assert_eq!(resolver_permits[0].layer, Layer::ConnectV4);
-}
-
-#[skuld::test]
-fn lockdown_spec_permits_v6_resolver_on_v6_layer_only() {
-    let s = build_lockdown_spec(v4(), Some(resolver_v6()), Some(luid()), &[plugin_path()]);
-    let resolver_permits: Vec<_> = s
-        .filters
-        .iter()
-        .filter(|f| {
-            f.action == Action::Permit
-                && matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v6())
-        })
-        .collect();
-    assert_eq!(resolver_permits.len(), 1);
-    assert_eq!(resolver_permits[0].layer, Layer::ConnectV6);
-}
-
-#[skuld::test]
-fn lockdown_spec_omits_resolver_permit_when_none() {
-    // Negative direction: no resolver_ip means no RemoteIpPortTcp permit
-    // exists at all — proves the widening is opt-in, never automatic.
-    let s = build_lockdown_spec(v4(), None, Some(luid()), &[plugin_path()]);
-    let resolver_permits: Vec<_> = s
-        .filters
-        .iter()
-        .filter(|f| f.action == Action::Permit && matches!(f.condition, Condition::RemoteIpPortTcp(..)))
-        .collect();
-    assert_eq!(resolver_permits.len(), 0, "no resolver permit when resolver_ip is None");
-}
-
-#[skuld::test]
-fn lockdown_spec_resolver_permit_is_scoped_to_tcp_443_not_unrestricted() {
-    let s = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()]);
-    let resolver_permit = s
-        .filters
-        .iter()
-        .find(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4()))
-        .expect("resolver permit must exist");
-    assert!(
-        matches!(
-            resolver_permit.condition,
-            Condition::RemoteIpPortTcp(_, RESOLVER_PERMIT_PORT)
-        ),
-        "lockdown resolver permit must be scoped to RESOLVER_PERMIT_PORT, not unrestricted like the server permit: {:?}",
-        resolver_permit.condition
-    );
-}
-
-#[skuld::test]
-fn lockdown_resolver_permit_weight_outweighs_block() {
-    let s = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()]);
-    for f in s
-        .filters
-        .iter()
-        .filter(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4()))
-    {
-        assert_eq!(f.weight, PERMIT_WEIGHT);
-    }
-}
-
-#[skuld::test]
-fn lockdown_resolver_permit_guid_matches_its_own_ip_family() {
-    let v4_filter = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()])
-        .filters
-        .into_iter()
-        .find(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v4()))
-        .expect("a V4 resolver permit filter");
-    assert_eq!(v4_filter.guid, LOCKDOWN_FILTER_GUIDS[12]);
-
-    let v6_filter = build_lockdown_spec(v4(), Some(resolver_v6()), Some(luid()), &[plugin_path()])
-        .filters
-        .into_iter()
-        .find(|f| matches!(f.condition, Condition::RemoteIpPortTcp(ip, _) if ip == resolver_v6()))
-        .expect("a V6 resolver permit filter");
-    assert_eq!(v6_filter.guid, LOCKDOWN_FILTER_GUIDS[13]);
-}
-
-#[skuld::test]
-fn lockdown_resolver_permit_guids_are_swept_and_distinct() {
-    let swept: std::collections::HashSet<GUID> = swept_lockdown_guids().into_iter().collect();
-    for resolver in [resolver_v4(), resolver_v6()] {
-        let s = build_lockdown_spec(v4(), Some(resolver), Some(luid()), &[plugin_path()]);
-        for f in &s.filters {
-            assert!(
-                swept.contains(&f.guid),
-                "{:?} must be in the lockdown sweep set",
-                f.guid
-            );
-        }
-        let unique: std::collections::HashSet<GUID> = s.filters.iter().map(|f| f.guid).collect();
-        assert_eq!(
-            unique.len(),
-            s.filters.len(),
-            "every filter GUID in the lockdown spec must be distinct"
-        );
-    }
-}
-
-#[skuld::test]
-fn adopt_deletes_the_resolver_permit_pair_so_reengage_can_update_it() {
-    // Regression class matching adopt_drops_server_permit_so_reengage_can_update_it:
-    // the resolver, like the server, is re-derived fresh on every connect (a plugin
-    // may be added/removed, or dns.servers may change the fallback address) — a
-    // fixed-key permit kept across Adopt would hit FWP_E_ALREADY_EXISTS on the next
-    // engage and silently keep serving the OLD resolver.
-    let adopt: std::collections::HashSet<GUID> = adopt_delete_guids().into_iter().collect();
-    assert!(
-        adopt.contains(&LOCKDOWN_FILTER_GUIDS[12]),
-        "resolver V4 must be dropped on Adopt"
-    );
-    assert!(
-        adopt.contains(&LOCKDOWN_FILTER_GUIDS[13]),
-        "resolver V6 must be dropped on Adopt"
-    );
-    // Adopt still drops exactly six volatile permits now: TUN V4/V6, server
-    // V4/V6, resolver V4/V6.
-    assert_eq!(
-        adopt.len(),
-        6,
-        "adopt_delete_guids now covers TUN + server + resolver pairs"
-    );
 }
 
 // lockdown sweep / Adopt GUID sets ====================================================================================
@@ -609,13 +379,12 @@ fn all_swept_guids_are_mutually_distinct() {
 #[skuld::test]
 fn adopt_deletes_volatile_permits() {
     // Adopt keeps the host fail-closed but drops the VOLATILE permits — the
-    // TUN-LUID pair (LUID dead after teardown), the server-IP pair (the server
-    // changes between connects), and the resolver-IP pair (the ECH resolver
-    // changes with dns.servers/the plugin config). All three are re-added
-    // fresh by the next connect's engage with current values. The fail-closed
-    // floor (block-all, loopback, App-ID) stays in force.
+    // TUN-LUID pair (LUID dead after teardown) AND the server-IP pair (the
+    // server changes between connects). Both are re-added fresh by the next
+    // connect's engage with current values. The fail-closed floor (block-all,
+    // loopback, App-ID) stays in force.
     let adopt = adopt_delete_guids();
-    assert_eq!(adopt.len(), 6, "TUN V4/V6 + server V4/V6 + resolver V4/V6");
+    assert_eq!(adopt.len(), 4, "TUN V4/V6 + server V4/V6");
     for &i in &LOCKDOWN_TUN_GUID_INDICES {
         assert!(
             adopt.contains(&LOCKDOWN_FILTER_GUIDS[i]),
@@ -626,12 +395,6 @@ fn adopt_deletes_volatile_permits() {
         assert!(
             adopt.contains(&LOCKDOWN_FILTER_GUIDS[i]),
             "Adopt must delete the server permit at index {i}"
-        );
-    }
-    for &i in &LOCKDOWN_RESOLVER_GUID_INDICES {
-        assert!(
-            adopt.contains(&LOCKDOWN_FILTER_GUIDS[i]),
-            "Adopt must delete the resolver permit at index {i}"
         );
     }
     // It must NOT delete the fail-closed floor: block-all or loopback.
@@ -710,7 +473,7 @@ fn both_specs_permit_loopback_recv_accept_by_address_range() {
     // V4 range on RecvAcceptV4, V6 range on RecvAcceptV6.
     for s in [
         build_cover_spec(v4(), None),
-        build_lockdown_spec(v4(), None, Some(luid()), &[plugin_path()]),
+        build_lockdown_spec(v4(), luid(), &[plugin_path()]),
     ] {
         assert!(
             s.filters.iter().any(|f| f.layer == Layer::RecvAcceptV4
@@ -763,8 +526,8 @@ fn every_emitted_filter_guid_is_in_its_sweep_set() {
     // Structural fail-closed invariant: any filter a cover installs must be
     // deletable by recovery, else a crash leaks an unswept block across restarts.
     // Transient -> delete_all iterates swept_transient_guids (the fixed GUIDs);
-    // lockdown -> swept_lockdown_guids. Both sides ALSO carry a resolver permit
-    // here so the new GUIDs' sweep membership is exercised.
+    // lockdown -> swept_lockdown_guids. The transient side ALSO carries a
+    // resolver permit here so the new GUIDs' sweep membership is exercised.
     let transient_swept: std::collections::HashSet<GUID> = swept_transient_guids().into_iter().collect();
     for ip in [v4(), v6()] {
         let cover = build_cover_spec(ip, Some(resolver_v4()));
@@ -777,7 +540,7 @@ fn every_emitted_filter_guid_is_in_its_sweep_set() {
             );
         }
         let swept: std::collections::HashSet<GUID> = swept_lockdown_guids().into_iter().collect();
-        let lock = build_lockdown_spec(ip, Some(resolver_v4()), Some(luid()), &[plugin_path(), bridge_path()]);
+        let lock = build_lockdown_spec(ip, luid(), &[plugin_path(), bridge_path()]);
         for f in &lock.filters {
             assert!(
                 swept.contains(&f.guid),
@@ -799,7 +562,7 @@ fn both_specs_permit_loopback_by_address_range_at_connect() {
     // matches deterministically: 127.0.0.0/8 on CONNECT V4, ::1/128 on CONNECT V6.
     for s in [
         build_cover_spec(v4(), None),
-        build_lockdown_spec(v4(), None, Some(luid()), &[plugin_path()]),
+        build_lockdown_spec(v4(), luid(), &[plugin_path()]),
     ] {
         let v4_net = s.filters.iter().any(|f| {
             f.layer == Layer::ConnectV4
@@ -866,7 +629,7 @@ fn new_loopbacknet_guids_are_in_their_sweep_floors_and_distinct() {
         );
     }
     let swept: std::collections::HashSet<GUID> = swept_lockdown_guids().into_iter().collect();
-    let lock = build_lockdown_spec(v4(), None, Some(luid()), &[plugin_path()]);
+    let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
     for f in lock
         .filters
         .iter()
@@ -883,11 +646,10 @@ fn new_loopbacknet_guids_are_in_their_sweep_floors_and_distinct() {
 #[skuld::test]
 fn adopt_does_not_delete_the_address_range_loopback_floor() {
     // The address-range loopback permits are floor, not volatile: Adopt must keep
-    // them (only the TUN-LUID + server-IP + resolver-IP pairs are dropped).
-    // adopt_delete_guids is keyed on the [2,3] / [4,5] / [12,13] indices, which
-    // the address-range loopback GUIDs do not touch.
+    // them (only the TUN-LUID + server-IP pairs are dropped). adopt_delete_guids
+    // is keyed on the [2,3] / [4,5] indices, which the appended GUIDs do not touch.
     let adopt: std::collections::HashSet<GUID> = adopt_delete_guids().into_iter().collect();
-    let lock = build_lockdown_spec(v4(), Some(resolver_v4()), Some(luid()), &[plugin_path()]);
+    let lock = build_lockdown_spec(v4(), luid(), &[plugin_path()]);
     for f in lock
         .filters
         .iter()
@@ -899,11 +661,6 @@ fn adopt_does_not_delete_the_address_range_loopback_floor() {
             f.guid
         );
     }
-    // Adopt still drops exactly six volatile permits: TUN V4/V6, server V4/V6,
-    // resolver V4/V6.
-    assert_eq!(
-        adopt.len(),
-        6,
-        "adopt_delete_guids: TUN V4/V6 + server V4/V6 + resolver V4/V6"
-    );
+    // Adopt still drops exactly the four volatile permits — unchanged by this fix.
+    assert_eq!(adopt.len(), 4, "adopt_delete_guids unchanged: TUN V4/V6 + server V4/V6");
 }


### PR DESCRIPTION
Reverts 0172d0bed6ea2a6b5970894e1fa4fd4ea316eb67 (merge of #764).

#764 was merged to main in error. It was not supposed to ship: bindreams'
2026-08-09 comment on #764 explicitly says "Not merging as-is" — the redesign
trades the pre-existing #753 bug for a new regression where, on an armed
machine after a restart, neither Disconnect nor the kill switch can bring
down a live-but-untracked standing lockdown cover; only a bridge restart or
elevated `hole bridge unlock` recovers. I merged it anyway without reading
that comment first.

The actual fix for the CI-red test (`macos_failclosed_permits_resolver_blocks_other_egress`)
is unrelated to the #753 redesign — it's a narrow flake fix, tracked separately
in the linked follow-up PR.