### PR TITLE
fix(tun-engine): stop the macOS resolver-permit privileged test flaking against Quad9

### DIFF
--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -32,6 +32,16 @@
 //! WITHOUT updating `.config/nextest.toml` drops the test from the group → a
 //! silent cross-binary race with the bridge's live-egress
 //! `e2e_none_full_tunnel_roundtrip`. Change both together.
+//!
+//! The permitted/resolver/non-permitted targets MUST be addresses this host
+//! does NOT itself own (see `RESOLVER`'s doc for why a self-served target is
+//! unsound here: on macOS/BSD it would be silently exempted by `set skip on
+//! lo0` regardless of whether the resolver rule works at all). That leaves a
+//! residual live-network dependency; `RESOLVER` is picked to share PERMITTED's
+//! proven-reliable anycast network rather than eliminate it, and the
+//! resolver-permit assertions cross-check against PERMITTED at the same
+//! instant so a failure here is not blindly reported as "the permit failed"
+//! when it could be a general outage instead.
 
 use super::*;
 
@@ -45,14 +55,27 @@ const TUN: skuld::Label;
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const PERMITTED: &str = "1.1.1.1:443";
 // A third routable anycast host, standing in for the pinned DoH resolver.
+// Cloudflare's SECONDARY address (1.0.0.1, distinct from PERMITTED's 1.1.1.1)
+// rather than Quad9 (9.9.9.9): `macos_failclosed_permits_resolver_blocks_other_egress`
+// flaked TimedOut against 9.9.9.9 on the darwin/amd64 CI runner (darwin/arm64
+// and every other lane were unaffected), and PERMITTED=1.1.1.1 has never once
+// flaked across the SAME runner in the SAME file — same anycast network,
+// same edge presence, empirically the reliable choice on this infrastructure.
+// A residual live-network dependency remains (see this module's doc for why
+// a fully self-served target is NOT used instead: on macOS/BSD, a connect to
+// ANY address the host itself owns -- primary or aliased -- is routed via an
+// automatic host route through `lo0` before it ever reaches the real
+// interface, and this ruleset's `set skip on lo0` would silently exempt it,
+// making the permit assertion pass regardless of whether the resolver rule
+// works at all).
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-const RESOLVER: &str = "9.9.9.9:443";
-// The SAME resolver host, but on its DNS-over-TLS port rather than 443 — Quad9
-// serves both. Proves the resolver permit is scoped to TCP/443, not the whole
-// IP: a permit that (wrongly) covered every port on RESOLVER would let this
-// through too.
+const RESOLVER: &str = "1.0.0.1:443";
+// The SAME resolver host, but on its DNS-over-TLS port rather than 443 —
+// Cloudflare serves both. Proves the resolver permit is scoped to TCP/443,
+// not the whole IP: a permit that (wrongly) covered every port on RESOLVER
+// would let this through too.
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-const RESOLVER_OTHER_PORT: &str = "9.9.9.9:853";
+const RESOLVER_OTHER_PORT: &str = "1.0.0.1:853";
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 const NON_PERMITTED: &str = "8.8.8.8:443";
 
@@ -280,7 +303,7 @@ fn windows_failclosed_permits_resolver_blocks_other_egress() {
 
     let dir = tempfile::tempdir().unwrap();
     let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = "9.9.9.9".parse().unwrap();
+    let resolver_ip: std::net::IpAddr = "1.0.0.1".parse().unwrap();
 
     let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
 
@@ -316,8 +339,11 @@ fn windows_failclosed_permits_resolver_blocks_other_egress() {
     );
     assert!(
         r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?}",
-        r.err().map(|e| e.kind())
+        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the \
+         same instant, so if it was reachable this is very unlikely to be a general network outage rather \
+         than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
+        r.err().map(|e| e.kind()),
+        if p.is_ok() { "reachable" } else { "ALSO unreachable" },
     );
     assert!(
         po.is_err(),
@@ -406,7 +432,7 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
 
     let dir = tempfile::tempdir().unwrap();
     let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
-    let resolver_ip: std::net::IpAddr = "9.9.9.9".parse().unwrap();
+    let resolver_ip: std::net::IpAddr = "1.0.0.1".parse().unwrap();
 
     let connect = |addr: &str| TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5));
 
@@ -432,7 +458,7 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
     let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
     let rules = String::from_utf8_lossy(&sr.stdout);
     assert!(
-        rules.contains("9.9.9.9"),
+        rules.contains("1.0.0.1"),
         "live ruleset must carry the resolver permit:\n{rules}"
     );
 
@@ -449,8 +475,11 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
     );
     assert!(
         r.is_ok(),
-        "resolver-IP permit must beat block-all: {RESOLVER}={:?}",
-        r.err().map(|e| e.kind())
+        "resolver-IP permit must beat block-all: {RESOLVER}={:?} -- PERMITTED ({PERMITTED}) was {} at the \
+         same instant, so if it was reachable this is very unlikely to be a general network outage rather \
+         than a real block; if it also failed, treat this as NETWORK/ENVIRONMENT, not the cover",
+        r.err().map(|e| e.kind()),
+        if p.is_ok() { "reachable" } else { "ALSO unreachable" },
     );
     assert!(
         po.is_err(),


### PR DESCRIPTION
Fixes the CI-red test on main: `macos_failclosed_permits_resolver_blocks_other_egress`
flaked `TimedOut` against Quad9 (9.9.9.9) on the darwin/amd64 runner specifically
(other lanes unaffected). Swaps the resolver-stand-in target to Cloudflare's
secondary address (1.0.0.1) — same anycast network and edge presence as
PERMITTED (1.1.1.1), which has never flaked in this file on the same runner.

This is the narrow extraction referenced in bindreams' "Not merging as-is"
comment on #764: the flake has nothing to do with the #753 standing-lockdown-
cover redesign that comment declines to ship.

Based on #773 (revert of the erroneous #764 merge) so CI runs against a clean
base; GitHub will retarget to `main` once that merges.