### PR TITLE
fix(garter): report a readiness outcome the plugin already delivered instead of discarding it

### DIFF
--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -220,7 +220,10 @@ impl ChainRunner {
     /// collects the N per-plugin results into one chain-level outcome.
     ///
     /// If shutdown fires before every plugin has readied, `tx` is dropped
-    /// and the receiver gets `RecvError`.
+    /// and the receiver gets `RecvError` — unless the plugin currently being
+    /// awaited had already delivered a `StartError`, which is reported rather
+    /// than discarded. A `StartError` sitting in a LATER plugin's channel is
+    /// still discarded (bindreams/hole#794).
     pub fn on_ready(mut self, tx: oneshot::Sender<Result<ChainReady, StartError>>) -> Self {
         self.ready_tx = Some(tx);
         self
@@ -373,7 +376,7 @@ impl ChainRunner {
 /// position-0 plugin's reported `listen` is the chain's public address in
 /// Client mode; in Server mode it is position N-1. The chain's transports
 /// are the intersection across all hops.
-async fn run_readiness_aggregator(
+pub(crate) async fn run_readiness_aggregator(
     ready_rxs: Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)>,
     n: usize,
     mode: Mode,
@@ -389,15 +392,22 @@ async fn run_readiness_aggregator(
         Mode::Client => 0,
         Mode::Server => n - 1,
     };
-    for (i, rrx) in ready_rxs {
+    for (i, mut rrx) in ready_rxs {
         let outcome = tokio::select! {
             biased;
-            () = shutdown.cancelled() => {
-                // Shutdown before all plugins readied → drop ready_tx; the
-                // receiver gets RecvError.
-                return;
-            }
-            r = rrx => r,
+            () = shutdown.cancelled() => match rrx.try_recv() {
+                // A plugin that reports a failure and exits cancels `shutdown`
+                // itself (`record_exit` cancels on every plugin exit), so this
+                // arm can win the race against a typed error already sitting
+                // in the channel. The error stands whoever cancelled.
+                Ok(Err(start_err)) => Ok(Err(start_err)),
+                // Anything else returns as before. A delivered `Ok(PluginReady)`
+                // is NOT rescued: `shutdown` is chain-wide and may have been
+                // cancelled by another plugin's exit or an external cancel, so
+                // nothing here shows the chain is still viable.
+                _ => return,
+            },
+            r = &mut rrx => r,
         };
         match outcome {
             Ok(Ok(pr)) => {

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -968,3 +968,91 @@ async fn plugin_panic_surfaces_as_chain_error() {
         other => panic!("expected Chain(\"...panicked...\") error, got {other:?}"),
     }
 }
+
+use crate::chain::run_readiness_aggregator;
+
+/// `BindConflict` is the only retryable class, so discarding one that the
+/// plugin already delivered turns a transient port collision into a hard
+/// start failure.
+#[skuld::test]
+async fn aggregator_reports_a_start_error_delivered_before_shutdown_won_the_race() {
+    let (tx0, rx0) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx0.send(Err(StartError::BindConflict {
+        errno: 98,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+    shutdown.cancel();
+
+    run_readiness_aggregator(vec![(0, rx0)], 1, crate::chain::Mode::Client, shutdown, ready_tx).await;
+
+    match ready_rx
+        .await
+        .expect("a delivered StartError must be reported, not discarded")
+    {
+        Err(StartError::BindConflict { errno, .. }) => assert_eq!(errno, 98),
+        other => panic!("expected the delivered BindConflict, got {other:?}"),
+    }
+}
+
+/// A delivered `Ok(PluginReady)` must NOT be rescued (see the shutdown
+/// arm's comment for why).
+#[skuld::test]
+async fn aggregator_never_reports_ready_once_shutdown_won_the_race() {
+    let (tx0, rx0) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx0.send(Ok(PluginReady {
+        listen: "127.0.0.1:1080".parse().unwrap(),
+        transports: Transports::TCP,
+    }))
+    .unwrap();
+    shutdown.cancel();
+
+    run_readiness_aggregator(vec![(0, rx0)], 1, crate::chain::Mode::Client, shutdown, ready_tx).await;
+
+    assert!(
+        ready_rx.await.is_err(),
+        "a chain whose plugin already exited must never be reported ready"
+    );
+}
+
+/// Shutdown preempting a plugin that delivered nothing: `ready_tx` is still
+/// dropped. Covers `TryRecvError::Empty` — the sender is alive but unused.
+#[skuld::test]
+async fn aggregator_drops_ready_tx_when_shutdown_preempts_an_empty_receiver() {
+    let (tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    shutdown.cancel();
+
+    run_readiness_aggregator(vec![(0, rx0)], 1, crate::chain::Mode::Client, shutdown, ready_tx).await;
+
+    assert!(ready_rx.await.is_err(), "nothing delivered must still drop ready_tx");
+    drop(tx0);
+}
+
+/// Covers `TryRecvError::Closed` — the sender was dropped unsent BEFORE the
+/// arm runs. Distinct from the empty case above, and pinned so a later PR
+/// that gives `Closed` its own meaning has to do so deliberately.
+#[skuld::test]
+async fn aggregator_drops_ready_tx_when_shutdown_preempts_a_closed_receiver() {
+    let (tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    drop(tx0);
+    shutdown.cancel();
+
+    run_readiness_aggregator(vec![(0, rx0)], 1, crate::chain::Mode::Client, shutdown, ready_tx).await;
+
+    assert!(
+        ready_rx.await.is_err(),
+        "a sender dropped unsent must not become a synthesized Fatal in this arm"
+    );
+}


### PR DESCRIPTION
Refs #756.

`run_readiness_aggregator` awaits each plugin's readiness receiver in a `tokio::select!` that is `biased;` with the shutdown arm first. `record_exit` cancels `shutdown` on **every** plugin exit, so a plugin that reports `bind_conflict` and then exits races its own cancel. When the shutdown arm wins that race it returns without ever reading the value already sitting in the channel, and the `BindConflict` is gone.

That matters because `BindConflict` is the only retryable start class: losing it turns a transient local-port collision into a hard start failure. `plugin-e2e`'s server fixture retries on exactly this error, so the loss also shows up as CI flakiness rather than a clean failure.

The shutdown arm now calls `try_recv()` before returning and reports a delivered `StartError`. Everything else returns exactly as before.

## Why only `Err(StartError)` is rescued

The arm cannot tell *why* `shutdown` fired — it is one token shared by the whole chain, cancelled by this plugin's own exit, by any other plugin's exit, or by an external cancel token. A delivered `Ok(PluginReady)` therefore carries no local evidence that the chain is still viable, so it is not rescued. A delivered `Err(StartError)` needs no such evidence: the plugin failed regardless of who cancelled.

This is not a claim that the aggregator never reports an already-exited chain as ready — a plugin that readies and then exits normally has its readiness consumed by the value arm before the cancel lands. That behaviour is untouched here.

## Scope

Four tests, one per branch of the arm: the rescued `StartError`, the deliberately-unrescued `Ok(PluginReady)`, `TryRecvError::Empty`, and `TryRecvError::Closed`. They drive `run_readiness_aggregator` directly with hand-built channels, so the race is reproduced deterministically with no plugin process, no port, and no timing. `run_readiness_aggregator` becomes `pub(crate)` for that; its signature is unchanged.

Iteration order, the shutdown race itself, liveness, and the success/`RecvError` arms are all untouched — each was measured or proven unsafe to change in this PR:

- The loss is **intermittent, not deterministic**: the value arm wins essentially always on a current-thread runtime; the shutdown arm won ~2 in 500 runs on a multi-thread one.
- Deleting the shutdown arm is **not** safe. `poll_ready` returns `None` only on cancellation, but it governs only `ReadinessMode::Probe`; the `ExpectSitrep`/`Auto` reader that ex-ray and galoshes actually use never watches shutdown and ends only on child-stdout EOF behind a 5s graceful stop.

## Left open, tracked

- #756 stays open: a *benign* shutdown is still reported as `Fatal{"plugin exited before becoming ready"}`. A dropped sender carries no reason; that fact lives on the lifecycle channel (`run()`'s `Result`, already captured by `record_exit`), and wiring the two together is a design change, not a patch.
- #794 — head-of-line blocking: a `StartError` in a *later* plugin's channel is still discarded. The `on_ready` doc now says so explicitly.
- #795 — `YamuxPlugin` never sends `Err(StartError)`.
- #796 — a sitrep `fatal` with no preceding `hello` is discarded.

This supersedes the readiness half of #750, which is being abandoned.