### PR TITLE
fix(garter): surface a plugin's typed start error regardless of chain position

### DIFF
--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -271,11 +271,50 @@ fn unspecified_for(target: SocketAddr) -> SocketAddr {
 pub(crate) fn bind_udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
     // Bind via std so the raw handle is available for the Windows ioctl before
     // the socket is registered with tokio's reactor.
-    let sock = std::net::UdpSocket::bind(addr)?;
+    prepare_udp(std::net::UdpSocket::bind(addr)?)
+}
+
+/// The non-bind half of [`bind_udp`], split out so a caller that classifies bind
+/// failures can route only a real `bind()` error through its classifier — these
+/// steps fail for reasons that have nothing to do with the address.
+pub(crate) fn prepare_udp(sock: std::net::UdpSocket) -> std::io::Result<UdpSocket> {
     sock.set_nonblocking(true)?;
     #[cfg(windows)]
     disable_udp_connreset(&sock)?;
     UdpSocket::from_std(sock)
+}
+
+/// Classify an error from a `bind()` on `addr` for the readiness channel.
+///
+/// A bind race becomes [`garter::StartError::BindConflict`], the only class the
+/// caller retries on a fresh port; everything else is terminal. Feed this only
+/// errors that a `bind()` itself produced — `local_addr()` and socket setup fail
+/// for unrelated reasons and must not be diagnosed as an address conflict.
+/// Report a failed `bind()` on the hop's start-gate channel, and hand the error
+/// back for the lifecycle channel. Both observers see the same failure, by
+/// design: one gates the start, the other drives teardown.
+fn report_bind_failure<A>(
+    bound_addr_tx: Option<oneshot::Sender<std::result::Result<A, garter::StartError>>>,
+    e: std::io::Error,
+    addr: SocketAddr,
+) -> anyhow::Error {
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(Err(bind_start_error(&e, addr)));
+    }
+    anyhow::Error::new(e)
+}
+
+pub(crate) fn bind_start_error(e: &std::io::Error, addr: SocketAddr) -> garter::StartError {
+    if garter::is_bind_race(e) {
+        return garter::StartError::BindConflict {
+            errno: e.raw_os_error().unwrap_or(0),
+            addr,
+        };
+    }
+    garter::StartError::Fatal {
+        detail: format!("could not bind {addr}: {e}"),
+        errno: e.raw_os_error(),
+    }
 }
 
 #[cfg(windows)]
@@ -858,7 +897,7 @@ pub(crate) async fn run_client(
     remote: SocketAddr,
     udp_timeout: Duration,
     shutdown: CancellationToken,
-    bound_addr_tx: Option<oneshot::Sender<ClientBoundAddrs>>,
+    bound_addr_tx: Option<oneshot::Sender<std::result::Result<ClientBoundAddrs, garter::StartError>>>,
     // Test seam (mirrors `bound_addr_tx`): each reconnect decision `(failures,
     // productive)` after a session ends. Production passes `None`.
     reconnect_events: Option<mpsc::UnboundedSender<(u32, bool)>>,
@@ -869,15 +908,38 @@ pub(crate) async fn run_client(
     // churns. Binding per-reconnect would race the previous connection's
     // detached association tasks (which hold `Arc<UdpSocket>` clones) for the
     // port and could fail the rebind, terminating the client.
-    let tcp_listener = TcpListener::bind(local).await.context("bind local TCP")?;
-    let udp_socket = Arc::new(bind_udp(local).context("bind local UDP")?);
+    //
+    // A bind failure is reported on `bound_addr_tx` before returning: it is the
+    // hop's start-gate, and an address conflict there is the one failure the
+    // caller can retry on a fresh port.
+    let tcp_listener = match TcpListener::bind(local).await {
+        Ok(l) => l,
+        Err(e) => return Err(report_bind_failure(bound_addr_tx, e, local).context("bind localTCP")),
+    };
+    let udp_std = match std::net::UdpSocket::bind(local) {
+        Ok(s) => s,
+        Err(e) => return Err(report_bind_failure(bound_addr_tx, e, local).context("bind localUDP")),
+    };
+    let udp_socket = Arc::new(prepare_udp(udp_std).context("prepare local UDP")?);
 
     // Readiness signal: both listeners are up, so the hop is serving.
     if let Some(tx) = bound_addr_tx {
-        let _ = tx.send(ClientBoundAddrs {
-            tcp: tcp_listener.local_addr().context("local tcp addr")?,
-            udp: udp_socket.local_addr().context("local udp addr")?,
-        });
+        let addrs = tcp_listener
+            .local_addr()
+            .and_then(|tcp| udp_socket.local_addr().map(|udp| ClientBoundAddrs { tcp, udp }));
+        match addrs {
+            Ok(addrs) => {
+                let _ = tx.send(Ok(addrs));
+            }
+            // The binds succeeded, so this is not an address conflict.
+            Err(e) => {
+                let _ = tx.send(Err(garter::StartError::Fatal {
+                    detail: format!("could not read the local address of {local}: {e}"),
+                    errno: e.raw_os_error(),
+                }));
+                return Err(anyhow::Error::new(e).context("local addr"));
+            }
+        }
     }
 
     let mut failures: u32 = 0;
@@ -946,7 +1008,7 @@ pub(crate) async fn run_server(
     local: SocketAddr,
     remote: SocketAddr,
     shutdown: CancellationToken,
-    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+    bound_addr_tx: Option<oneshot::Sender<std::result::Result<SocketAddr, garter::StartError>>>,
 ) -> Result<()> {
     run_server_with_connections(config, local, remote, shutdown, bound_addr_tx, serve_underlying).await
 }
@@ -958,22 +1020,39 @@ pub(crate) async fn run_server_with_connections<S, F>(
     local: SocketAddr,
     remote: SocketAddr,
     shutdown: CancellationToken,
-    bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
+    bound_addr_tx: Option<oneshot::Sender<std::result::Result<SocketAddr, garter::StartError>>>,
     serve: S,
 ) -> Result<()>
 where
     S: Fn(TcpStream, SocketAddr, yamux::Config, SocketAddr, CancellationToken) -> F,
     F: std::future::Future<Output = ()> + Send + 'static,
 {
-    let listener = TcpListener::bind(local)
-        .await
-        .with_context(|| format!("bind yamux server on {local}"))?;
+    // A bind failure is reported on `bound_addr_tx` before returning: it is the
+    // hop's start-gate, and an address conflict there is the one failure the
+    // caller can retry on a fresh port.
+    let listener = match TcpListener::bind(local).await {
+        Ok(l) => l,
+        Err(e) => {
+            return Err(report_bind_failure(bound_addr_tx, e, local).context(format!("bind yamux server on {local}")))
+        }
+    };
     tracing::info!(local = %local, "yamux server listening");
 
     // Readiness signal: the listener is up, so the hop is serving.
     if let Some(tx) = bound_addr_tx {
-        let addr = listener.local_addr().context("local tcp addr")?;
-        let _ = tx.send(addr);
+        match listener.local_addr() {
+            Ok(addr) => {
+                let _ = tx.send(Ok(addr));
+            }
+            // The bind succeeded, so this is not an address conflict.
+            Err(e) => {
+                let _ = tx.send(Err(garter::StartError::Fatal {
+                    detail: format!("could not read the local address of {local}: {e}"),
+                    errno: e.raw_os_error(),
+                }));
+                return Err(anyhow::Error::new(e).context("local tcp addr"));
+            }
+        }
     }
 
     // Every connection task is owned here, never detached: joining them is what
@@ -1252,11 +1331,11 @@ impl garter::ChainPlugin for YamuxPlugin {
         ready: tokio::sync::oneshot::Sender<std::result::Result<garter::PluginReady, garter::StartError>>,
     ) -> garter::Result<()> {
         // Readiness comes from the bind point itself, over the same channel the
-        // tests use: `run_server`/`run_client` send their bound address once
-        // their listeners are up, and a YAMUX plugin serves both TCP and UDP
-        // there. A failed bind drops `ready` unsent (RecvError). Startup is not
-        // gated on `shutdown` here — garter's readiness aggregator is `biased` on
-        // it and owns the "shutdown before ready" outcome for the whole chain.
+        // tests use: `run_server`/`run_client` report their bind outcome once
+        // their listeners are up (or have failed), and a YAMUX plugin serves both
+        // TCP and UDP there. Startup is not gated on `shutdown` here — garter's
+        // readiness aggregator is `biased` on it and owns the "shutdown before
+        // ready" outcome for the whole chain.
         //
         // This is galoshes' INTERNAL hop-readiness signal: it feeds galoshes'
         // OWN `ChainRunner` aggregator, which intersects it with the inner
@@ -1268,21 +1347,11 @@ impl garter::ChainPlugin for YamuxPlugin {
         let transports = garter::Transports::TCP | garter::Transports::UDP;
         let result = if self.is_server {
             let (bound_tx, bound_rx) = oneshot::channel();
-            tokio::spawn(async move {
-                let Ok(listen) = bound_rx.await else { return };
-                let _ = ready.send(Ok(garter::PluginReady { listen, transports }));
-            });
-            run_server(self.config, local, remote, shutdown, Some(bound_tx)).await
+            let run = run_server(self.config, local, remote, shutdown, Some(bound_tx));
+            relay_readiness(run, bound_rx, ready, |addr| *addr, transports).await
         } else {
-            let (bound_tx, bound_rx) = oneshot::channel::<ClientBoundAddrs>();
-            tokio::spawn(async move {
-                let Ok(addrs) = bound_rx.await else { return };
-                let _ = ready.send(Ok(garter::PluginReady {
-                    listen: addrs.tcp,
-                    transports,
-                }));
-            });
-            run_client(
+            let (bound_tx, bound_rx) = oneshot::channel();
+            let run = run_client(
                 self.config,
                 local,
                 remote,
@@ -1290,10 +1359,66 @@ impl garter::ChainPlugin for YamuxPlugin {
                 shutdown,
                 Some(bound_tx),
                 None,
-            )
-            .await
+            );
+            relay_readiness(run, bound_rx, ready, |addrs| addrs.tcp, transports).await
         };
 
         result.map_err(|e| garter::Error::Chain(e.to_string()))
+    }
+}
+
+/// Drive `run_fut`, relaying its bind outcome to `ready` on THIS task.
+///
+/// The relay cannot be detached. `run_fut` completing is what lets the chain
+/// observe this plugin's exit, which cancels the shared shutdown token and sends
+/// the aggregator looking for a readiness outcome; a relay that had merely been
+/// scheduled by then would lose that race and the typed error with it. Awaiting
+/// the runner here instead makes the send ordered: if `run_fut` is ready, the
+/// send it performed before returning has already happened, so `try_recv` sees
+/// it.
+async fn relay_readiness<A, F>(
+    run_fut: F,
+    mut bound_rx: oneshot::Receiver<std::result::Result<A, garter::StartError>>,
+    ready: oneshot::Sender<std::result::Result<garter::PluginReady, garter::StartError>>,
+    listen_of: fn(&A) -> SocketAddr,
+    transports: garter::Transports,
+) -> Result<()>
+where
+    F: std::future::Future<Output = Result<()>>,
+{
+    tokio::pin!(run_fut);
+
+    let mut early: Option<Result<()>> = None;
+    let mut bound = tokio::select! {
+        biased;
+        r = &mut bound_rx => r.ok(),
+        outcome = &mut run_fut => {
+            early = Some(outcome);
+            None
+        }
+    };
+    if early.is_some() {
+        bound = bound_rx.try_recv().ok();
+    }
+
+    match bound {
+        Some(Ok(addrs)) => {
+            let _ = ready.send(Ok(garter::PluginReady {
+                listen: listen_of(&addrs),
+                transports,
+            }));
+        }
+        Some(Err(start_err)) => {
+            let _ = ready.send(Err(start_err));
+        }
+        // Never reached the bind (a panic unwinding through `run_fut`). Dropping
+        // `ready` unsent leaves the chain's synthesized process-exit failure as
+        // the backstop.
+        None => {}
+    }
+
+    match early {
+        Some(outcome) => outcome,
+        None => run_fut.await,
     }
 }

--- a/crates/galoshes/src/yamux.rs
+++ b/crates/galoshes/src/yamux.rs
@@ -284,12 +284,6 @@ pub(crate) fn prepare_udp(sock: std::net::UdpSocket) -> std::io::Result<UdpSocke
     UdpSocket::from_std(sock)
 }
 
-/// Classify an error from a `bind()` on `addr` for the readiness channel.
-///
-/// A bind race becomes [`garter::StartError::BindConflict`], the only class the
-/// caller retries on a fresh port; everything else is terminal. Feed this only
-/// errors that a `bind()` itself produced — `local_addr()` and socket setup fail
-/// for unrelated reasons and must not be diagnosed as an address conflict.
 /// Report a failed `bind()` on the hop's start-gate channel, and hand the error
 /// back for the lifecycle channel. Both observers see the same failure, by
 /// design: one gates the start, the other drives teardown.
@@ -304,6 +298,27 @@ fn report_bind_failure<A>(
     anyhow::Error::new(e)
 }
 
+/// As [`report_bind_failure`], for a failure AFTER the address was successfully
+/// bound. Always terminal: no retry can help, so it must not be classified as a
+/// conflict.
+fn report_setup_failure<A>(
+    bound_addr_tx: Option<oneshot::Sender<std::result::Result<A, garter::StartError>>>,
+    e: std::io::Error,
+    addr: SocketAddr,
+) -> anyhow::Error {
+    if let Some(tx) = bound_addr_tx {
+        let _ = tx.send(Err(setup_start_error(&e, addr)));
+    }
+    anyhow::Error::new(e)
+}
+
+/// Classify an error from a `bind()` on `addr` for the readiness channel.
+///
+/// A bind race becomes [`garter::StartError::BindConflict`], the only class the
+/// caller retries on a fresh port; everything else is terminal. Feed this only
+/// errors a `bind()` itself produced — `local_addr()` and socket setup fail for
+/// unrelated reasons and must not be diagnosed as an address conflict. Per
+/// [`garter::is_bind_race`]'s contract, `addr` must be an ephemeral bind.
 pub(crate) fn bind_start_error(e: &std::io::Error, addr: SocketAddr) -> garter::StartError {
     if garter::is_bind_race(e) {
         return garter::StartError::BindConflict {
@@ -311,8 +326,13 @@ pub(crate) fn bind_start_error(e: &std::io::Error, addr: SocketAddr) -> garter::
             addr,
         };
     }
+    setup_start_error(e, addr)
+}
+
+/// A terminal start failure on `addr`, carrying the raw OS errno.
+pub(crate) fn setup_start_error(e: &std::io::Error, addr: SocketAddr) -> garter::StartError {
     garter::StartError::Fatal {
-        detail: format!("could not bind {addr}: {e}"),
+        detail: format!("could not set up a listener on {addr}: {e}"),
         errno: e.raw_os_error(),
     }
 }
@@ -909,18 +929,23 @@ pub(crate) async fn run_client(
     // detached association tasks (which hold `Arc<UdpSocket>` clones) for the
     // port and could fail the rebind, terminating the client.
     //
-    // A bind failure is reported on `bound_addr_tx` before returning: it is the
-    // hop's start-gate, and an address conflict there is the one failure the
+    // Every failure below is reported on `bound_addr_tx` before returning: it is
+    // the hop's start-gate, and an address conflict there is the one failure the
     // caller can retry on a fresh port.
     let tcp_listener = match TcpListener::bind(local).await {
         Ok(l) => l,
-        Err(e) => return Err(report_bind_failure(bound_addr_tx, e, local).context("bind localTCP")),
+        Err(e) => return Err(report_bind_failure(bound_addr_tx, e, local).context("bind local TCP")),
     };
     let udp_std = match std::net::UdpSocket::bind(local) {
         Ok(s) => s,
-        Err(e) => return Err(report_bind_failure(bound_addr_tx, e, local).context("bind localUDP")),
+        Err(e) => return Err(report_bind_failure(bound_addr_tx, e, local).context("bind local UDP")),
     };
-    let udp_socket = Arc::new(prepare_udp(udp_std).context("prepare local UDP")?);
+    // Setting up an already-bound socket fails for reasons that have nothing to
+    // do with the address, so this is terminal rather than a conflict.
+    let udp_socket = match prepare_udp(udp_std) {
+        Ok(s) => Arc::new(s),
+        Err(e) => return Err(report_setup_failure(bound_addr_tx, e, local).context("prepare local UDP")),
+    };
 
     // Readiness signal: both listeners are up, so the hop is serving.
     if let Some(tx) = bound_addr_tx {
@@ -933,10 +958,7 @@ pub(crate) async fn run_client(
             }
             // The binds succeeded, so this is not an address conflict.
             Err(e) => {
-                let _ = tx.send(Err(garter::StartError::Fatal {
-                    detail: format!("could not read the local address of {local}: {e}"),
-                    errno: e.raw_os_error(),
-                }));
+                let _ = tx.send(Err(setup_start_error(&e, local)));
                 return Err(anyhow::Error::new(e).context("local addr"));
             }
         }
@@ -1046,10 +1068,7 @@ where
             }
             // The bind succeeded, so this is not an address conflict.
             Err(e) => {
-                let _ = tx.send(Err(garter::StartError::Fatal {
-                    detail: format!("could not read the local address of {local}: {e}"),
-                    errno: e.raw_os_error(),
-                }));
+                let _ = tx.send(Err(setup_start_error(&e, local)));
                 return Err(anyhow::Error::new(e).context("local tcp addr"));
             }
         }
@@ -1411,9 +1430,10 @@ where
         Some(Err(start_err)) => {
             let _ = ready.send(Err(start_err));
         }
-        // Never reached the bind (a panic unwinding through `run_fut`). Dropping
-        // `ready` unsent leaves the chain's synthesized process-exit failure as
-        // the backstop.
+        // The runner returned without reporting either way. `run_client` and
+        // `run_server` report on every path out of their bind, so this is the
+        // backstop for a future one that does not: dropping `ready` unsent
+        // leaves the chain's synthesized process-exit failure.
         None => {}
     }
 

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -23,9 +23,9 @@ use crate::yamux::{
     bind_start_error, bind_udp, connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram,
     drive_connection, driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout,
     run_client, run_client_session, run_server, run_server_with_connections, saturating_deadline,
-    serve_driven_connection, session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, OpenStreamReply,
-    SessionOutcome, SessionTransport, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN,
-    LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
+    serve_driven_connection, session_reconnect_backoff, setup_start_error, ClientBoundAddrs, FrameAccumulator,
+    OpenStreamReply, SessionOutcome, SessionTransport, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT,
+    KEEPALIVE_NONCE_LEN, LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
 
 #[skuld::test]
@@ -1420,7 +1420,7 @@ async fn a_healthy_session_is_kept_alive_by_its_own_probe() {
     );
 }
 
-// Bind-failure readiness (#795) =======================================================================================
+// Bind-failure readiness ==============================================================================================
 
 /// Run a yamux plugin whose bind is expected to fail, to completion.
 async fn run_yamux_plugin_expecting_failure(
@@ -1496,13 +1496,14 @@ async fn a_yamux_client_reports_bind_conflict_when_its_udp_port_is_taken() {
     }
 }
 
-/// A contract test, not a red: a current-thread runtime plus the success path's
-/// await on `TcpStream::connect` gives a detached relay room to deliver too.
+/// `relay_readiness` sends before `run` can return on the success path too, so
+/// readiness is reported without the caller driving anything else.
+///
+/// Binds `:0` and reads the port back rather than probing one and re-binding it:
+/// the client needs the SAME port on TCP and UDP, which no probe can reserve.
 #[skuld::test]
 async fn a_yamux_client_reports_ready_once_its_listeners_are_up() {
-    let probe = TcpListener::bind("127.0.0.1:0").await.expect("probe a free port");
-    let free = probe.local_addr().expect("probe addr");
-    drop(probe);
+    let free: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
     let (ready_tx, ready_rx) = oneshot::channel();
     let shutdown = CancellationToken::new();
@@ -1518,7 +1519,8 @@ async fn a_yamux_client_reports_ready_once_its_listeners_are_up() {
 
     match ready_rx.await.expect("readiness must be reported, not dropped") {
         Ok(garter::PluginReady { listen, transports }) => {
-            assert_eq!(listen, free, "readiness must report the bound TCP address");
+            assert!(listen.ip().is_loopback(), "readiness must report the bound address");
+            assert_ne!(listen.port(), 0, "readiness must report the port the kernel chose");
             assert_eq!(
                 transports,
                 garter::Transports::TCP | garter::Transports::UDP,
@@ -1530,6 +1532,22 @@ async fn a_yamux_client_reports_ready_once_its_listeners_are_up() {
 
     shutdown.cancel();
     let _ = running.await.expect("plugin task joined");
+}
+
+/// A failure after the address was bound (`set_nonblocking`, the Windows
+/// `SIO_UDP_CONNRESET` ioctl, `from_std`) is terminal, never a conflict: no
+/// retry on a fresh port can resolve it.
+#[skuld::test]
+fn a_post_bind_setup_failure_is_fatal() {
+    let addr: SocketAddr = "127.0.0.1:1080".parse().unwrap();
+    // An excluded-range errno, which `bind_start_error` WOULD call a conflict.
+    let e = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "injected");
+    match setup_start_error(&e, addr) {
+        garter::StartError::Fatal { detail, .. } => {
+            assert!(detail.contains(&addr.to_string()), "the detail must name the address");
+        }
+        other => panic!("expected Fatal, got {other:?}"),
+    }
 }
 
 #[skuld::test]
@@ -1563,8 +1581,7 @@ fn a_windows_excluded_port_bind_error_is_a_conflict() {
 }
 
 /// End to end through a real `ChainRunner`: the aggregator must see the typed
-/// error rather than the synthesized process-exit placeholder. Pre-fix this is
-/// flaky rather than reliably red — that flakiness IS the defect.
+/// error rather than the synthesized process-exit placeholder.
 #[skuld::test]
 async fn a_yamux_bind_conflict_reaches_chain_on_ready() {
     let squatter = TcpListener::bind("127.0.0.1:0").await.expect("squat a port");

--- a/crates/galoshes/src/yamux_tests.rs
+++ b/crates/galoshes/src/yamux_tests.rs
@@ -20,12 +20,12 @@ use garter::tracing_test::set_default_in_current_thread;
 
 use crate::yamux::keepalive::Cadence;
 use crate::yamux::{
-    bind_udp, connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram, drive_connection,
-    driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout, run_client,
-    run_client_session, run_server, run_server_with_connections, saturating_deadline, serve_driven_connection,
-    session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, OpenStreamReply, SessionOutcome, SessionTransport,
-    StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN, LOOPBACK_CONNECT_RETRY,
-    REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
+    bind_start_error, bind_udp, connect_delay, connect_retrying, connection_task_fatal, deframe_udp_datagram,
+    drive_connection, driver_panicked, enable_keepalive, frame_udp_datagram, next_failures, parse_udp_timeout,
+    run_client, run_client_session, run_server, run_server_with_connections, saturating_deadline,
+    serve_driven_connection, session_reconnect_backoff, ClientBoundAddrs, FrameAccumulator, OpenStreamReply,
+    SessionOutcome, SessionTransport, StreamTag, TransportLivenessTap, DEFAULT_UDP_TIMEOUT, KEEPALIVE_NONCE_LEN,
+    LOOPBACK_CONNECT_RETRY, REMOTE_BACKOFF_BASE, REMOTE_BACKOFF_MAX,
 };
 
 #[skuld::test]
@@ -279,7 +279,7 @@ async fn setup_relay_inner(upstream: SocketAddr, udp_timeout: Duration) -> (Clie
         shutdown.clone(),
         Some(srv_tx),
     ));
-    let server_addr = srv_rx.await.expect("server bound");
+    let server_addr = srv_rx.await.expect("server bound").expect("server bind succeeded");
 
     let (cli_tx, cli_rx) = oneshot::channel();
     tokio::spawn(run_client(
@@ -291,7 +291,7 @@ async fn setup_relay_inner(upstream: SocketAddr, udp_timeout: Duration) -> (Clie
         Some(cli_tx),
         None,
     ));
-    let addrs = cli_rx.await.expect("client bound");
+    let addrs = cli_rx.await.expect("client bound").expect("client bind succeeded");
 
     (addrs, shutdown)
 }
@@ -710,7 +710,7 @@ async fn spawn_yamux_server(upstream: SocketAddr, shutdown: CancellationToken) -
         shutdown,
         Some(srv_tx),
     ));
-    srv_rx.await.expect("server bound")
+    srv_rx.await.expect("server bound").expect("server bind succeeded")
 }
 
 /// Spawn a yamux client pointed at `remote`, with a typed reconnect observer.
@@ -731,7 +731,10 @@ async fn spawn_yamux_client(
         Some(cli_tx),
         Some(events_tx),
     ));
-    (cli_rx.await.expect("client bound"), events_rx)
+    (
+        cli_rx.await.expect("client bound").expect("client bind succeeded"),
+        events_rx,
+    )
 }
 
 /// One TCP request/response through the client's local listener.
@@ -956,7 +959,7 @@ async fn shutdown_during_backoff_exits_promptly() {
         Some(cli_tx),
         Some(events_tx),
     ));
-    let _ = cli_rx.await.unwrap();
+    let _ = cli_rx.await.unwrap().expect("client bind succeeded");
 
     // Rendezvous (not the assertion): the observer event means the client has
     // reached the reconnect decision and is entering the backoff sleep.
@@ -984,7 +987,7 @@ async fn server_shutdown_is_prompt_while_client_connected() {
         shutdown.clone(),
         Some(srv_tx),
     ));
-    let server_addr = srv_rx.await.expect("server bound");
+    let server_addr = srv_rx.await.expect("server bound").expect("server bind succeeded");
 
     let _conn = TcpStream::connect(server_addr).await.expect("connect server");
     wait_for_log(&writer, "accepted underlying connection").await;
@@ -1010,7 +1013,7 @@ async fn server_serves_a_client_while_an_idle_connection_is_open() {
         shutdown.clone(),
         Some(srv_tx),
     ));
-    let server_addr = srv_rx.await.expect("server bound");
+    let server_addr = srv_rx.await.expect("server bound").expect("server bind succeeded");
 
     // The idle connection. Held for the whole test; never writes a frame.
     let _idle = TcpStream::connect(server_addr).await.expect("connect idle");
@@ -1026,7 +1029,7 @@ async fn server_serves_a_client_while_an_idle_connection_is_open() {
         Some(cli_tx),
         None,
     ));
-    let addrs = cli_rx.await.expect("client bound");
+    let addrs = cli_rx.await.expect("client bound").expect("client bind succeeded");
 
     let mut app = TcpStream::connect(addrs.tcp).await.expect("connect client TCP");
     app.write_all(b"GET / HTTP/1.0\r\n\r\n").await.expect("write request");
@@ -1096,7 +1099,7 @@ async fn server_exits_on_a_panic_and_winds_down_its_other_connections() {
             }
         },
     ));
-    let server_addr = srv_rx.await.expect("server bound");
+    let server_addr = srv_rx.await.expect("server bound").expect("server bind succeeded");
 
     let _sibling = TcpStream::connect(server_addr).await.expect("connect sibling");
     serving_rx.recv().await.expect("sibling is being served");
@@ -1136,7 +1139,7 @@ async fn server_exits_when_the_yamux_driver_panics() {
             serve_driven_connection(peer, remote, shutdown, driver, inbound_rx)
         },
     ));
-    let server_addr = srv_rx.await.expect("server bound");
+    let server_addr = srv_rx.await.expect("server bound").expect("server bind succeeded");
 
     let _conn = TcpStream::connect(server_addr).await.expect("connect server");
 
@@ -1415,4 +1418,180 @@ async fn a_healthy_session_is_kept_alive_by_its_own_probe() {
         !writer.snapshot().contains("keepalive probe substream ended"),
         "the probe must have been answered by `echo_keepalive`, not rejected"
     );
+}
+
+// Bind-failure readiness (#795) =======================================================================================
+
+/// Run a yamux plugin whose bind is expected to fail, to completion.
+async fn run_yamux_plugin_expecting_failure(
+    is_server: bool,
+    local: SocketAddr,
+) -> (
+    garter::Result<()>,
+    oneshot::Receiver<Result<garter::PluginReady, garter::StartError>>,
+) {
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let plugin = Box::new(crate::yamux::YamuxPlugin::new(is_server, DEFAULT_UDP_TIMEOUT));
+    let remote: SocketAddr = "127.0.0.1:9".parse().unwrap();
+    let result = garter::ChainPlugin::run(plugin, local, remote, CancellationToken::new(), ready_tx).await;
+    (result, ready_rx)
+}
+
+/// `try_recv` with no intervening await: the typed error must already be in the
+/// channel when `run` returns, because the plugin task completing is what fires
+/// `record_exit` -> `shutdown.cancel()` -> the aggregator's sweep. A relay that
+/// had merely been scheduled would lose that race.
+#[skuld::test]
+async fn a_yamux_server_reports_bind_conflict_before_run_returns() {
+    let squatter = TcpListener::bind("127.0.0.1:0").await.expect("squat a port");
+    let taken = squatter.local_addr().expect("squatted addr");
+
+    let (result, mut ready_rx) = run_yamux_plugin_expecting_failure(true, taken).await;
+
+    assert!(result.is_err(), "a failed bind must still fail the plugin's run()");
+    match ready_rx.try_recv() {
+        Ok(Err(garter::StartError::BindConflict { errno, addr })) => {
+            assert_eq!(addr, taken, "the conflict must name the address that failed to bind");
+            assert_ne!(errno, 0, "the host-native errno must be carried");
+        }
+        other => panic!("expected a delivered BindConflict, got {other:?}"),
+    }
+}
+
+/// Client mode, TCP listener contended.
+#[skuld::test]
+async fn a_yamux_client_reports_bind_conflict_before_run_returns() {
+    let squatter = TcpListener::bind("127.0.0.1:0").await.expect("squat a port");
+    let taken = squatter.local_addr().expect("squatted addr");
+
+    let (result, mut ready_rx) = run_yamux_plugin_expecting_failure(false, taken).await;
+
+    assert!(result.is_err(), "a failed bind must still fail the plugin's run()");
+    match ready_rx.try_recv() {
+        Ok(Err(garter::StartError::BindConflict { errno, addr })) => {
+            assert_eq!(addr, taken, "the conflict must name the address that failed to bind");
+            assert_ne!(errno, 0, "the host-native errno must be carried");
+        }
+        other => panic!("expected a delivered BindConflict, got {other:?}"),
+    }
+}
+
+/// NOT discriminating, and does not claim to be: nothing guarantees TCP on this
+/// port is free, and `BindConflict { errno, addr }` has no field naming which of
+/// the client's two binds produced it, so a TCP-side failure satisfies it
+/// identically. What it pins is that the UDP bind path reports AT ALL.
+#[skuld::test]
+async fn a_yamux_client_reports_bind_conflict_when_its_udp_port_is_taken() {
+    let squatter = UdpSocket::bind("127.0.0.1:0").await.expect("squat a udp port");
+    let taken = squatter.local_addr().expect("squatted addr");
+
+    let (result, mut ready_rx) = run_yamux_plugin_expecting_failure(false, taken).await;
+
+    assert!(result.is_err(), "a failed bind must still fail the plugin's run()");
+    match ready_rx.try_recv() {
+        Ok(Err(garter::StartError::BindConflict { addr, .. })) => {
+            assert_eq!(addr, taken, "the conflict must name the address that failed to bind");
+        }
+        other => panic!("expected a delivered BindConflict, got {other:?}"),
+    }
+}
+
+/// A contract test, not a red: a current-thread runtime plus the success path's
+/// await on `TcpStream::connect` gives a detached relay room to deliver too.
+#[skuld::test]
+async fn a_yamux_client_reports_ready_once_its_listeners_are_up() {
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("probe a free port");
+    let free = probe.local_addr().expect("probe addr");
+    drop(probe);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+    let plugin = Box::new(crate::yamux::YamuxPlugin::new(false, DEFAULT_UDP_TIMEOUT));
+    let remote: SocketAddr = "127.0.0.1:9".parse().unwrap();
+    let running = tokio::spawn(garter::ChainPlugin::run(
+        plugin,
+        free,
+        remote,
+        shutdown.clone(),
+        ready_tx,
+    ));
+
+    match ready_rx.await.expect("readiness must be reported, not dropped") {
+        Ok(garter::PluginReady { listen, transports }) => {
+            assert_eq!(listen, free, "readiness must report the bound TCP address");
+            assert_eq!(
+                transports,
+                garter::Transports::TCP | garter::Transports::UDP,
+                "a yamux hop serves both transports"
+            );
+        }
+        other => panic!("expected PluginReady, got {other:?}"),
+    }
+
+    shutdown.cancel();
+    let _ = running.await.expect("plugin task joined");
+}
+
+#[skuld::test]
+fn a_bind_error_that_is_not_a_conflict_is_fatal() {
+    let addr: SocketAddr = "127.0.0.1:1080".parse().unwrap();
+    let e = std::io::Error::from_raw_os_error(22); // EINVAL / WSAEINVAL
+    match bind_start_error(&e, addr) {
+        garter::StartError::Fatal { errno, .. } => {
+            assert_eq!(errno, Some(22), "the raw OS errno must be carried through");
+        }
+        other => panic!("expected Fatal, got {other:?}"),
+    }
+}
+
+/// The Windows excluded-port-range classes are conflicts too, not fatals: the
+/// port yamux binds came from an allocator that already retries exactly these.
+#[skuld::test]
+fn a_windows_excluded_port_bind_error_is_a_conflict() {
+    let addr: SocketAddr = "127.0.0.1:1080".parse().unwrap();
+    for kind in [
+        std::io::ErrorKind::PermissionDenied,
+        std::io::ErrorKind::AddrNotAvailable,
+        std::io::ErrorKind::AddrInUse,
+    ] {
+        let e = std::io::Error::new(kind, "injected");
+        assert!(
+            matches!(bind_start_error(&e, addr), garter::StartError::BindConflict { .. }),
+            "{kind:?} must classify as a retryable bind conflict"
+        );
+    }
+}
+
+/// End to end through a real `ChainRunner`: the aggregator must see the typed
+/// error rather than the synthesized process-exit placeholder. Pre-fix this is
+/// flaky rather than reliably red — that flakiness IS the defect.
+#[skuld::test]
+async fn a_yamux_bind_conflict_reaches_chain_on_ready() {
+    let squatter = TcpListener::bind("127.0.0.1:0").await.expect("squat a port");
+    let taken = squatter.local_addr().expect("squatted addr");
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = garter::ChainRunner::new()
+        .add(Box::new(crate::yamux::YamuxPlugin::new(false, DEFAULT_UDP_TIMEOUT)))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = garter::PluginEnv {
+        local_host: taken.ip(),
+        local_port: taken.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+    let chain = tokio::spawn(async move { runner.run(env).await });
+
+    match ready_rx.await.expect("the aggregator must report, not drop") {
+        Err(garter::StartError::BindConflict { addr, .. }) => {
+            assert_eq!(addr, taken, "the chain must surface the plugin's own conflict");
+        }
+        other => panic!("expected BindConflict at the chain level, got {other:?}"),
+    }
+
+    chain.abort();
+    let _ = chain.await;
 }

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -120,6 +120,11 @@ pub fn allocate_ports(count: usize) -> crate::Result<Vec<SocketAddr>> {
 ///
 /// Retry these on a fresh ephemeral port; report a plugin's as
 /// [`crate::StartError::BindConflict`], the one class the caller retries.
+///
+/// **Contract**: use ONLY on ephemeral bind paths. On Unix `PermissionDenied`
+/// also means "bind to a privileged port without root", which no retry can
+/// resolve — classifying that as a race would burn attempts and bury the real
+/// permission error.
 pub fn is_bind_race(e: &std::io::Error) -> bool {
     matches!(
         e.kind(),
@@ -225,11 +230,17 @@ impl ChainRunner {
     ///
     /// Outcomes are consumed in completion order, not plugin order, so a typed
     /// failure is never held up behind a plugin that has neither reported nor
-    /// exited. A plugin that exits before readying does not immediately produce
-    /// the generic "exited before becoming ready": that is held while any other
-    /// plugin's sender is still alive, so a typed error one poll behind still
-    /// wins, and reported once every receiver has resolved. Among typed errors
-    /// available at once, the lowest plugin index wins.
+    /// exited. Among typed errors available at once, the lowest plugin index
+    /// wins.
+    ///
+    /// A plugin that exits before readying does not immediately produce the
+    /// generic "exited before becoming ready": that placeholder is held while
+    /// other senders are alive, and any typed error found meanwhile outranks it.
+    /// The hold is best-effort, not a guarantee — it ends when every receiver
+    /// resolves OR when shutdown fires, and the exit that started it cancels
+    /// shutdown itself, so a sibling's error that has not reached its channel by
+    /// then is still missed. It strictly improves on reporting the placeholder
+    /// immediately; it does not make the outcome deterministic.
     ///
     /// If shutdown fires before every plugin has readied, `tx` is dropped and the
     /// receiver gets `RecvError` — unless some plugin had already delivered a
@@ -430,8 +441,14 @@ pub(crate) async fn run_readiness_aggregator(
             // an external cancel all fire it — so a delivered `Ok(PluginReady)`
             // is no evidence the chain is still viable and is not rescued. A
             // delivered `StartError` needs no such evidence: that plugin failed
-            // whoever cancelled.
-            if let Some(start_err) = drain_available(&mut pending, &mut plugin_listens, &mut transports) {
+            // whoever cancelled, and it outranks a placeholder held below.
+            //
+            // `record_exit` cancels on the very exit that starts a deferral, so
+            // this is the ordinary end of one, not an edge case. Dropping
+            // `ready_tx` here would report nothing where plugin order reported a
+            // failure.
+            let delivered = drain_available(&mut pending, &mut plugin_listens, &mut transports);
+            if let Some(start_err) = delivered.or(deferred_exit) {
                 let _ = ready_tx.send(Err(start_err));
             }
             return;
@@ -454,12 +471,15 @@ pub(crate) async fn run_readiness_aggregator(
                 // observers of one event (typed cause to on_ready AND lifecycle
                 // error to teardown). Do NOT try to reconcile them into one value.
                 //
-                // A sibling's typed failure outranks this placeholder, and may be
+                // A sibling's typed failure outranks this placeholder and may be
                 // one poll behind rather than already delivered — reporting now
                 // would destroy a `BindConflict`, the only retryable class. So
-                // hold it while any sender is still alive. `record_exit` cancels
-                // `shutdown` on every plugin exit and the arm above stays first,
-                // so the wait is bounded without any timer.
+                // hold it while any sender is alive. The hold is best-effort:
+                // `record_exit` cancels `shutdown` on every plugin exit and the
+                // arm above stays first, which bounds the wait without a timer
+                // but also ends it, so an error that lands after the cancel is
+                // still missed. Waiting for every sender instead would stall a
+                // cancel behind readers that never watch the token.
                 if let Some(start_err) = drain_available(&mut pending, &mut plugin_listens, &mut transports) {
                     let _ = ready_tx.send(Err(start_err));
                     return;

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -108,6 +108,25 @@ pub fn allocate_ports(count: usize) -> crate::Result<Vec<SocketAddr>> {
     Ok(ports)
 }
 
+/// Whether a bind error is a transient port race rather than a real failure.
+///
+/// `AddrInUse` — another socket holds the port. `PermissionDenied` — Windows
+/// `WSAEACCES`: typically a shift in the TCP dynamic excluded-port range
+/// (Hyper-V / WSL2 / Docker Desktop reservations, visible via
+/// `netsh int ipv4 show excludedportrange`), or another socket claiming the
+/// port with `SO_EXCLUSIVEADDRUSE` on a wildcard interface. `AddrNotAvailable`
+/// — the same excluded-range class, distinct from `WSAEACCES` only in whether
+/// the kernel rejects at the address-reservation or the permission layer.
+///
+/// Retry these on a fresh ephemeral port; report a plugin's as
+/// [`crate::StartError::BindConflict`], the one class the caller retries.
+pub fn is_bind_race(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::AddrNotAvailable
+    )
+}
+
 fn allocate_one_port() -> crate::Result<SocketAddr> {
     for attempt in 0..MAX_PORT_RETRIES {
         let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
@@ -122,24 +141,9 @@ fn allocate_one_port() -> crate::Result<SocketAddr> {
                 drop(l);
                 return Ok(addr);
             }
-            // `AddrInUse` — another socket grabbed the port between drop and rebind.
-            // `PermissionDenied` — Windows `WSAEACCES`: typically a shift in the
-            // TCP dynamic excluded-port range (Hyper-V / WSL2 / Docker Desktop
-            // reservations, visible via `netsh int ipv4 show excludedportrange`),
-            // or another socket claiming the port with `SO_EXCLUSIVEADDRUSE` on a
-            // wildcard interface.
-            // `AddrNotAvailable` — same excluded-port-range class; distinct from
-            // `WSAEACCES` only in whether the kernel rejects the bind at the
-            // address-reservation layer or the permission layer.
-            // All three are transient probe-races; retry on a fresh ephemeral port.
-            Err(e)
-                if matches!(
-                    e.kind(),
-                    std::io::ErrorKind::AddrInUse
-                        | std::io::ErrorKind::PermissionDenied
-                        | std::io::ErrorKind::AddrNotAvailable
-                ) =>
-            {
+            // A socket grabbed the port between drop and rebind, or the
+            // excluded-range tables shifted. Retry on a fresh ephemeral port.
+            Err(e) if is_bind_race(&e) => {
                 tracing::debug!(
                     attempt,
                     port = addr.port(),

--- a/crates/garter/src/chain.rs
+++ b/crates/garter/src/chain.rs
@@ -223,11 +223,17 @@ impl ChainRunner {
     /// the `ready` channel passed to [`ChainPlugin::run`]; the aggregator
     /// collects the N per-plugin results into one chain-level outcome.
     ///
-    /// If shutdown fires before every plugin has readied, `tx` is dropped
-    /// and the receiver gets `RecvError` — unless the plugin currently being
-    /// awaited had already delivered a `StartError`, which is reported rather
-    /// than discarded. A `StartError` sitting in a LATER plugin's channel is
-    /// still discarded (bindreams/hole#794).
+    /// Outcomes are consumed in completion order, not plugin order, so a typed
+    /// failure is never held up behind a plugin that has neither reported nor
+    /// exited. A plugin that exits before readying does not immediately produce
+    /// the generic "exited before becoming ready": that is held while any other
+    /// plugin's sender is still alive, so a typed error one poll behind still
+    /// wins, and reported once every receiver has resolved. Among typed errors
+    /// available at once, the lowest plugin index wins.
+    ///
+    /// If shutdown fires before every plugin has readied, `tx` is dropped and the
+    /// receiver gets `RecvError` — unless some plugin had already delivered a
+    /// `StartError`, which is reported rather than discarded.
     pub fn on_ready(mut self, tx: oneshot::Sender<Result<ChainReady, StartError>>) -> Self {
         self.ready_tx = Some(tx);
         self
@@ -372,14 +378,19 @@ impl ChainRunner {
 
 // Helpers =============================================================================================================
 
+/// Readiness receivers still awaiting an outcome, in ASCENDING plugin-index
+/// order. Both the concurrent poll and the sweep scan this order, which is what
+/// makes "the lowest plugin index wins" true without any code saying so.
+type Pending = Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)>;
+
 /// Aggregate the N per-plugin readiness results into a single chain-level
 /// outcome on `ready_tx`.
 ///
-/// Awaits each plugin's `ready` receiver in turn, racing the shared
-/// `shutdown` token so a cancel during startup doesn't hang. The
-/// position-0 plugin's reported `listen` is the chain's public address in
-/// Client mode; in Server mode it is position N-1. The chain's transports
-/// are the intersection across all hops.
+/// Awaits every plugin's `ready` receiver concurrently and consumes them in
+/// completion order, racing the shared `shutdown` token so a cancel during
+/// startup doesn't hang. The position-0 plugin's reported `listen` is the
+/// chain's public address in Client mode; in Server mode it is position N-1.
+/// The chain's transports are the intersection across all hops.
 pub(crate) async fn run_readiness_aggregator(
     ready_rxs: Vec<(usize, oneshot::Receiver<Result<PluginReady, StartError>>)>,
     n: usize,
@@ -387,6 +398,13 @@ pub(crate) async fn run_readiness_aggregator(
     shutdown: CancellationToken,
     ready_tx: oneshot::Sender<Result<ChainReady, StartError>>,
 ) {
+    debug_assert_eq!(ready_rxs.len(), n, "one readiness receiver per plugin");
+    debug_assert!(ready_rxs.iter().all(|(i, _)| *i < n), "plugin index out of range");
+    debug_assert!(
+        ready_rxs.windows(2).all(|w| w[0].0 < w[1].0),
+        "readiness receivers must be in ascending plugin-index order"
+    );
+
     let mut plugin_listens: Vec<Option<SocketAddr>> = vec![None; n];
     // Intersection identity (the full transport set); each plugin's
     // reported transports narrow this. `all()` lives on the
@@ -396,22 +414,27 @@ pub(crate) async fn run_readiness_aggregator(
         Mode::Client => 0,
         Mode::Server => n - 1,
     };
-    for (i, mut rrx) in ready_rxs {
-        let outcome = tokio::select! {
+    let mut pending: Pending = ready_rxs;
+    // A plugin that exited before readying, held rather than reported. See the
+    // `Err(_recv)` arm.
+    let mut deferred_exit: Option<StartError> = None;
+
+    while !pending.is_empty() {
+        let resolved = tokio::select! {
             biased;
-            () = shutdown.cancelled() => match rrx.try_recv() {
-                // A plugin that reports a failure and exits cancels `shutdown`
-                // itself (`record_exit` cancels on every plugin exit), so this
-                // arm can win the race against a typed error already sitting
-                // in the channel. The error stands whoever cancelled.
-                Ok(Err(start_err)) => Ok(Err(start_err)),
-                // Anything else returns as before. A delivered `Ok(PluginReady)`
-                // is NOT rescued: `shutdown` is chain-wide and may have been
-                // cancelled by another plugin's exit or an external cancel, so
-                // nothing here shows the chain is still viable.
-                _ => return,
-            },
-            r = &mut rrx => r,
+            () = shutdown.cancelled() => None,
+            r = next_resolved(&mut pending) => Some(r),
+        };
+        let Some((i, outcome)) = resolved else {
+            // `shutdown` is chain-wide — this plugin's exit, another plugin's, or
+            // an external cancel all fire it — so a delivered `Ok(PluginReady)`
+            // is no evidence the chain is still viable and is not rescued. A
+            // delivered `StartError` needs no such evidence: that plugin failed
+            // whoever cancelled.
+            if let Some(start_err) = drain_available(&mut pending, &mut plugin_listens, &mut transports) {
+                let _ = ready_tx.send(Err(start_err));
+            }
+            return;
         };
         match outcome {
             Ok(Ok(pr)) => {
@@ -423,25 +446,102 @@ pub(crate) async fn run_readiness_aggregator(
                 return;
             }
             Err(_recv) => {
-                // Plugin dropped its sender unsent → it exited before
-                // readying. Synthesize a process-exit Fatal. This is the
-                // START-GATE channel; the SAME exit is independently
+                // Plugin dropped its sender unsent → it exited before readying.
+                // This is the START-GATE channel; the SAME exit is independently
                 // observed by the Phase-1 record_exit loop, which sets
                 // first_error + cancels — that is the LIFECYCLE channel that
                 // becomes run()'s return. The two are intentionally separate
-                // observers of one event (typed cause to on_ready AND
-                // lifecycle error to teardown). Do NOT try to reconcile them
-                // into one value.
-                let _ = ready_tx.send(Err(StartError::Fatal {
+                // observers of one event (typed cause to on_ready AND lifecycle
+                // error to teardown). Do NOT try to reconcile them into one value.
+                //
+                // A sibling's typed failure outranks this placeholder, and may be
+                // one poll behind rather than already delivered — reporting now
+                // would destroy a `BindConflict`, the only retryable class. So
+                // hold it while any sender is still alive. `record_exit` cancels
+                // `shutdown` on every plugin exit and the arm above stays first,
+                // so the wait is bounded without any timer.
+                if let Some(start_err) = drain_available(&mut pending, &mut plugin_listens, &mut transports) {
+                    let _ = ready_tx.send(Err(start_err));
+                    return;
+                }
+                deferred_exit.get_or_insert(StartError::Fatal {
                     detail: "plugin exited before becoming ready".into(),
                     errno: None,
-                }));
-                return;
+                });
             }
         }
     }
+
+    if let Some(start_err) = deferred_exit {
+        let _ = ready_tx.send(Err(start_err));
+        return;
+    }
     let listen = plugin_listens[public_index].expect("public plugin must have reported a listen address");
     let _ = ready_tx.send(Ok(ChainReady { listen, transports }));
+}
+
+/// Await every pending receiver at once; yield the first to resolve and remove
+/// it. Cancel-safe: an entry is removed only once its value is in hand, so
+/// dropping this future in a `select!` loses nothing.
+async fn next_resolved(
+    pending: &mut Pending,
+) -> (
+    usize,
+    Result<Result<PluginReady, StartError>, oneshot::error::RecvError>,
+) {
+    use std::future::Future as _;
+
+    debug_assert!(!pending.is_empty(), "next_resolved needs at least one receiver");
+    // Record the position and break rather than removing mid-scan, which would
+    // borrow `pending` twice.
+    let (pos, value) = std::future::poll_fn(|cx| {
+        for (pos, (_, rrx)) in pending.iter_mut().enumerate() {
+            if let std::task::Poll::Ready(value) = std::pin::Pin::new(rrx).poll(cx) {
+                return std::task::Poll::Ready((pos, value));
+            }
+        }
+        std::task::Poll::Pending
+    })
+    .await;
+    (pending.remove(pos).0, value)
+}
+
+/// Drain every pending receiver that already has an outcome, returning the
+/// lowest-index delivered `StartError` if there is one.
+///
+/// Readiness is RECORDED, not discarded: a plugin that readied before the scan
+/// reached it keeps its contribution to `listens`/`transports`, so this is safe
+/// to call from a caller that goes on looping. Receivers whose sender is merely
+/// still alive are left in `pending` — nothing here distinguishes "not yet" from
+/// "never".
+fn drain_available(
+    pending: &mut Pending,
+    listens: &mut [Option<SocketAddr>],
+    transports: &mut Transports,
+) -> Option<StartError> {
+    let mut resolved: Vec<usize> = Vec::new();
+    let mut delivered: Option<StartError> = None;
+
+    for (pos, (i, rrx)) in pending.iter_mut().enumerate() {
+        match rrx.try_recv() {
+            Ok(Ok(pr)) => {
+                listens[*i] = Some(pr.listen);
+                *transports &= pr.transports;
+                resolved.push(pos);
+            }
+            Ok(Err(start_err)) => {
+                delivered = Some(start_err);
+                break;
+            }
+            Err(oneshot::error::TryRecvError::Empty) => {}
+            // Exited unsent; the caller is already synthesizing that failure.
+            Err(oneshot::error::TryRecvError::Closed) => resolved.push(pos),
+        }
+    }
+    for pos in resolved.into_iter().rev() {
+        pending.remove(pos);
+    }
+    delivered
 }
 
 /// Shared handler for a single plugin-task exit result. Updates

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -1056,3 +1056,322 @@ async fn aggregator_drops_ready_tx_when_shutdown_preempts_a_closed_receiver() {
         "a sender dropped unsent must not become a synthesized Fatal in this arm"
     );
 }
+
+/// #794 itself: a typed error in a LATER plugin's channel must not wait on an
+/// earlier plugin that has neither reported nor dropped its sender. Pre-fix the
+/// aggregator parks on index 0 forever and this HANGS.
+#[skuld::test]
+async fn aggregator_reports_a_later_plugins_error_while_an_earlier_one_is_still_starting() {
+    let (_tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx1, rx1) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx1.send(Err(StartError::BindConflict {
+        errno: 98,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    match ready_rx.await.expect("a later plugin's error must be reported") {
+        Err(StartError::BindConflict { errno, .. }) => assert_eq!(errno, 98),
+        other => panic!("expected the later plugin's BindConflict, got {other:?}"),
+    }
+}
+
+/// A plugin exiting unsent must not bury a sibling's real failure under the
+/// generic placeholder. Both receivers are resolvable at the first poll, so the
+/// assertion holds under either completion order.
+#[skuld::test]
+async fn aggregator_prefers_a_delivered_error_over_a_siblings_exit() {
+    let (tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx1, rx1) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx1.send(Err(StartError::BindConflict {
+        errno: 98,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+    drop(tx0);
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    match ready_rx.await.expect("a delivered error outranks a bare exit") {
+        Err(StartError::BindConflict { errno, .. }) => assert_eq!(errno, 98),
+        other => panic!("expected the sibling's BindConflict, got {other:?}"),
+    }
+}
+
+/// Shutdown preempting the scan must still find an error further down the
+/// chain, not just in the receiver that happened to be next.
+#[skuld::test]
+async fn aggregator_rescues_a_later_plugins_error_when_shutdown_won_the_race() {
+    let (tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx1, rx1) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx1.send(Err(StartError::BindConflict {
+        errno: 98,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+    drop(tx0);
+    shutdown.cancel();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    match ready_rx.await.expect("the scan must reach index 1") {
+        Err(StartError::BindConflict { errno, .. }) => assert_eq!(errno, 98),
+        other => panic!("expected the later plugin's BindConflict, got {other:?}"),
+    }
+}
+
+/// Two typed errors at once resolve to the lowest plugin index. Passes pre-fix
+/// too — it locks the rule against the rewrite rather than driving it.
+#[skuld::test]
+async fn aggregator_reports_the_lowest_index_error_when_two_plugins_both_fail() {
+    let (tx0, rx0) = oneshot::channel();
+    let (tx1, rx1) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx0.send(Err(StartError::Fatal {
+        detail: "first".into(),
+        errno: None,
+    }))
+    .unwrap();
+    tx1.send(Err(StartError::BindConflict {
+        errno: 98,
+        addr: "127.0.0.1:1080".parse().unwrap(),
+    }))
+    .unwrap();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    match ready_rx.await.expect("aggregator should send") {
+        Err(StartError::Fatal { detail, .. }) => assert_eq!(detail, "first"),
+        other => panic!("expected the lowest-index error, got {other:?}"),
+    }
+}
+
+/// The regression guard for deferral. A higher-index plugin's bare exit must not
+/// be reported while a lower-index plugin's sender is still alive — its typed
+/// error may be one poll behind, and reporting early destroys the only retryable
+/// class. `main` passes this by parking on index 0; a point-in-time sweep fails it.
+#[skuld::test]
+async fn aggregator_defers_an_exit_until_a_live_sibling_answers() {
+    let (tx0, rx0) = oneshot::channel();
+    let (tx1, rx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    // Index 1 exits unsent; index 0 answers only afterwards.
+    drop(tx1);
+    let sender = tokio::spawn(async move {
+        tx0.send(Err(StartError::BindConflict {
+            errno: 98,
+            addr: "127.0.0.1:1080".parse().unwrap(),
+        }))
+    });
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+    sender.await.expect("sender task joined").expect("index 0 sent");
+
+    match ready_rx.await.expect("aggregator should send") {
+        Err(StartError::BindConflict { errno, .. }) => assert_eq!(errno, 98),
+        other => panic!("a live sibling's typed error must outrank a bare exit, got {other:?}"),
+    }
+}
+
+/// Deferral must not swallow the failure: once every sibling has resolved with
+/// nothing typed, the synthesized exit is reported.
+#[skuld::test]
+async fn aggregator_reports_the_exit_once_every_sibling_has_resolved() {
+    let (tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx1, rx1) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    drop(tx0);
+    tx1.send(Ok(PluginReady {
+        listen: "127.0.0.1:1081".parse().unwrap(),
+        transports: Transports::TCP,
+    }))
+    .unwrap();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    match ready_rx.await.expect("a deferred exit must still be reported") {
+        Err(StartError::Fatal { detail, .. }) => {
+            assert_eq!(detail, "plugin exited before becoming ready");
+        }
+        other => panic!("expected the synthesized exit failure, got {other:?}"),
+    }
+}
+
+/// The one case where the sweep must walk past — and consume — a delivered
+/// readiness to reach an error further down.
+#[skuld::test]
+async fn aggregator_finds_an_error_behind_an_already_ready_plugin_on_shutdown() {
+    let (tx0, rx0) = oneshot::channel();
+    let (_tx1, rx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx2, rx2) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx0.send(Ok(PluginReady {
+        listen: "127.0.0.1:1080".parse().unwrap(),
+        transports: Transports::TCP,
+    }))
+    .unwrap();
+    tx2.send(Err(StartError::BindConflict {
+        errno: 98,
+        addr: "127.0.0.1:1082".parse().unwrap(),
+    }))
+    .unwrap();
+    shutdown.cancel();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1), (2, rx2)],
+        3,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    match ready_rx.await.expect("the scan must walk past a ready plugin") {
+        Err(StartError::BindConflict { errno, .. }) => assert_eq!(errno, 98),
+        other => panic!("expected the deeper BindConflict, got {other:?}"),
+    }
+}
+
+/// Deliberately NOT an ordering test: both assertions are order-independent and
+/// this passes pre- and post-fix alike. It exists to catch a rewrite that keys
+/// `plugin_listens` by position in the pending set instead of by plugin index.
+#[skuld::test]
+async fn aggregator_keys_listens_and_transports_by_plugin_index() {
+    let (tx0, rx0) = oneshot::channel();
+    let (tx1, rx1) = oneshot::channel();
+    let (tx2, rx2) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx2.send(Ok(PluginReady {
+        listen: "127.0.0.1:1082".parse().unwrap(),
+        transports: Transports::TCP | Transports::UDP,
+    }))
+    .unwrap();
+    tx0.send(Ok(PluginReady {
+        listen: "127.0.0.1:1080".parse().unwrap(),
+        transports: Transports::TCP | Transports::UDP,
+    }))
+    .unwrap();
+    tx1.send(Ok(PluginReady {
+        listen: "127.0.0.1:1081".parse().unwrap(),
+        transports: Transports::TCP,
+    }))
+    .unwrap();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1), (2, rx2)],
+        3,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    let ready = ready_rx
+        .await
+        .expect("aggregator should send")
+        .expect("every plugin readied");
+    assert_eq!(
+        ready.listen,
+        "127.0.0.1:1080".parse::<std::net::SocketAddr>().unwrap(),
+        "Client mode reports position 0's listen address"
+    );
+    assert_eq!(
+        ready.transports,
+        Transports::TCP,
+        "the chain carries only what every hop serves"
+    );
+}
+
+/// #797's no-rescue rule, extended to the multi-plugin sweep: a LATER plugin's
+/// delivered readiness is no evidence the chain survived the cancel either.
+#[skuld::test]
+async fn aggregator_never_reports_ready_when_a_later_plugin_readied_before_shutdown() {
+    let (_tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx1, rx1) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    tx1.send(Ok(PluginReady {
+        listen: "127.0.0.1:1081".parse().unwrap(),
+        transports: Transports::TCP,
+    }))
+    .unwrap();
+    shutdown.cancel();
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+
+    assert!(
+        ready_rx.await.is_err(),
+        "a chain cancelled mid-start must never be reported ready"
+    );
+}

--- a/crates/garter/src/chain_tests.rs
+++ b/crates/garter/src/chain_tests.rs
@@ -1057,9 +1057,8 @@ async fn aggregator_drops_ready_tx_when_shutdown_preempts_a_closed_receiver() {
     );
 }
 
-/// #794 itself: a typed error in a LATER plugin's channel must not wait on an
-/// earlier plugin that has neither reported nor dropped its sender. Pre-fix the
-/// aggregator parks on index 0 forever and this HANGS.
+/// A typed error in a LATER plugin's channel must not wait on an earlier plugin
+/// that has neither reported nor dropped its sender.
 #[skuld::test]
 async fn aggregator_reports_a_later_plugins_error_while_an_earlier_one_is_still_starting() {
     let (_tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
@@ -1152,8 +1151,7 @@ async fn aggregator_rescues_a_later_plugins_error_when_shutdown_won_the_race() {
     }
 }
 
-/// Two typed errors at once resolve to the lowest plugin index. Passes pre-fix
-/// too — it locks the rule against the rewrite rather than driving it.
+/// Two typed errors at once resolve to the lowest plugin index.
 #[skuld::test]
 async fn aggregator_reports_the_lowest_index_error_when_two_plugins_both_fail() {
     let (tx0, rx0) = oneshot::channel();
@@ -1190,7 +1188,7 @@ async fn aggregator_reports_the_lowest_index_error_when_two_plugins_both_fail() 
 /// The regression guard for deferral. A higher-index plugin's bare exit must not
 /// be reported while a lower-index plugin's sender is still alive — its typed
 /// error may be one poll behind, and reporting early destroys the only retryable
-/// class. `main` passes this by parking on index 0; a point-in-time sweep fails it.
+/// class.
 #[skuld::test]
 async fn aggregator_defers_an_exit_until_a_live_sibling_answers() {
     let (tx0, rx0) = oneshot::channel();
@@ -1293,9 +1291,9 @@ async fn aggregator_finds_an_error_behind_an_already_ready_plugin_on_shutdown() 
     }
 }
 
-/// Deliberately NOT an ordering test: both assertions are order-independent and
-/// this passes pre- and post-fix alike. It exists to catch a rewrite that keys
-/// `plugin_listens` by position in the pending set instead of by plugin index.
+/// Deliberately NOT an ordering test: both assertions are order-independent. It
+/// exists to catch a rewrite that keys `plugin_listens` by position in the
+/// pending set instead of by plugin index.
 #[skuld::test]
 async fn aggregator_keys_listens_and_transports_by_plugin_index() {
     let (tx0, rx0) = oneshot::channel();
@@ -1345,7 +1343,7 @@ async fn aggregator_keys_listens_and_transports_by_plugin_index() {
     );
 }
 
-/// #797's no-rescue rule, extended to the multi-plugin sweep: a LATER plugin's
+/// The no-rescue rule, extended to the multi-plugin sweep: a LATER plugin's
 /// delivered readiness is no evidence the chain survived the cancel either.
 #[skuld::test]
 async fn aggregator_never_reports_ready_when_a_later_plugin_readied_before_shutdown() {
@@ -1374,4 +1372,41 @@ async fn aggregator_never_reports_ready_when_a_later_plugin_readied_before_shutd
         ready_rx.await.is_err(),
         "a chain cancelled mid-start must never be reported ready"
     );
+}
+
+/// A deferred exit must survive the cancel that the very same exit triggers.
+/// `record_exit` fires `shutdown` on every plugin exit, so the shutdown arm is
+/// the normal way out of a deferral, not an edge case — returning empty-handed
+/// there would report a dropped channel where plugin order reported a `Fatal`.
+#[skuld::test]
+async fn aggregator_reports_a_deferred_exit_when_shutdown_ends_the_wait() {
+    let (_tx0, rx0) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (tx1, rx1) = oneshot::channel::<Result<PluginReady, StartError>>();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = CancellationToken::new();
+
+    // Index 1 exits unsent; index 0 never answers, so the aggregator defers and
+    // parks — which is what lets the canceller below run.
+    drop(tx1);
+    let canceller = {
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { shutdown.cancel() })
+    };
+
+    run_readiness_aggregator(
+        vec![(0, rx0), (1, rx1)],
+        2,
+        crate::chain::Mode::Client,
+        shutdown,
+        ready_tx,
+    )
+    .await;
+    canceller.await.expect("canceller joined");
+
+    match ready_rx.await.expect("a deferred exit must not be lost to the cancel") {
+        Err(StartError::Fatal { detail, .. }) => {
+            assert_eq!(detail, "plugin exited before becoming ready");
+        }
+        other => panic!("expected the synthesized exit failure, got {other:?}"),
+    }
 }

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -14,7 +14,7 @@ pub mod test_utils;
 pub mod tracing_test;
 
 pub use binary::{BinaryPlugin, LogSink, PidSink, ReadinessMode};
-pub use chain::{ChainReady, ChainRunner, Mode};
+pub use chain::{is_bind_race, ChainReady, ChainRunner, Mode};
 pub use counting::{ByteCounters, CountingStream, StreamCounters};
 pub use error::{Error, Result};
 pub use plugin::ChainPlugin;

--- a/crates/garter/src/tap.rs
+++ b/crates/garter/src/tap.rs
@@ -270,21 +270,18 @@ async fn drain_inner(plugin_name: &str, inner_handle: tokio::task::JoinHandle<cr
     }
 }
 
-/// Probe-and-drop a free TCP port on `(ip, 0)`. Retries on
-/// `AddrInUse` / `PermissionDenied` / `AddrNotAvailable` (the Windows
-/// excluded-port-range flake) up to [`INNER_PORT_ALLOC_ATTEMPTS`] times.
+/// Probe-and-drop a free TCP port on `(ip, 0)`. Retries a
+/// [`crate::chain::is_bind_race`] error up to [`INNER_PORT_ALLOC_ATTEMPTS`] times.
 fn allocate_inner_port(ip: IpAddr) -> io::Result<SocketAddr> {
     let mut last_err: Option<io::Error> = None;
     for _ in 0..INNER_PORT_ALLOC_ATTEMPTS {
         match std::net::TcpListener::bind(SocketAddr::new(ip, 0)).and_then(|l| l.local_addr()) {
             Ok(addr) => return Ok(addr),
-            Err(e) => match e.kind() {
-                io::ErrorKind::AddrInUse | io::ErrorKind::PermissionDenied | io::ErrorKind::AddrNotAvailable => {
-                    last_err = Some(e);
-                    continue;
-                }
-                _ => return Err(e),
-            },
+            Err(e) if crate::chain::is_bind_race(&e) => {
+                last_err = Some(e);
+                continue;
+            }
+            Err(e) => return Err(e),
         }
     }
     // Reaching here means the loop ran its full `INNER_PORT_ALLOC_ATTEMPTS`

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -1138,9 +1138,9 @@ async fn log_sink_receives_lines_drained_after_version_skew_fallback() {
     chain_task.abort();
 }
 
-/// #794 through the production sitrep reader rather than hand-built channels: a
-/// stub can pass while the reader ex-ray and galoshes actually use still loses
-/// the error.
+/// Through the production sitrep reader rather than hand-built channels: a stub
+/// can pass while the reader ex-ray and galoshes actually use still loses the
+/// error.
 ///
 /// Index 0 sleeps forever without ever printing, so the reader holds its
 /// readiness sender open indefinitely — what a yamux hop does while its own bind

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -1138,6 +1138,61 @@ async fn log_sink_receives_lines_drained_after_version_skew_fallback() {
     chain_task.abort();
 }
 
+/// #794 through the production sitrep reader rather than hand-built channels: a
+/// stub can pass while the reader ex-ray and galoshes actually use still loses
+/// the error.
+///
+/// Index 0 sleeps forever without ever printing, so the reader holds its
+/// readiness sender open indefinitely — what a yamux hop does while its own bind
+/// is pending. Index 1 emits `bind_conflict` and exits, which cancels the shared
+/// token. Awaiting in plugin order never looks at index 1 and reports the exit
+/// placeholder instead of the one retryable class.
+#[skuld::test]
+async fn a_later_plugins_bind_conflict_surfaces_while_an_earlier_plugin_hangs() {
+    let mock_path = mock_plugin_path();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_SLEEP", "1"),
+        ))
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_FAIL", "bind_conflict"),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    match outcome {
+        Err(garter::StartError::BindConflict { errno, .. }) => {
+            assert_ne!(errno, 0, "bind_conflict errno should be the host-native value");
+        }
+        other => panic!("expected StartError::BindConflict, got {other:?}"),
+    }
+
+    chain_task.abort();
+    let _ = chain_task.await;
+}
+
 fn main() {
     skuld::run_all();
 }


### PR DESCRIPTION
Closes #795, closes #794.

Two coupled losses of the same signal. `StartError::BindConflict` is the only retryable start class — `spawn_plugin_runner_at` maps it to `ProxyError::BindRace` so `bind_ephemeral` retries on a fresh port — and both bugs turn it into a hard start failure.

## #795: yamux never sent `Err(StartError)`

`YamuxPlugin::run` handed its readiness sender to a detached relay gated on a bound-address oneshot that only ever carried a success address. A failed bind dropped the sender, and the chain synthesized a generic `Fatal`.

The bound-address channel now carries `Result<_, StartError>`, and `run_client`/`run_server` classify their bind errors before returning.

**The relay could not stay detached.** `bound_tx.send(Err(..))` only *schedules* a detached relay; `run_*` then returns, the plugin task completes, `record_exit` cancels the shared token, and the aggregator sweeps the readiness channel. On the multi-thread runtime galoshes uses, nothing orders the relay against any of that, so the fix would have depended on winning a scheduler race. `relay_readiness` drives the relay on the plugin's own task instead: if the run future is ready, the send it performed before returning has already happened. Three tests assert with `try_recv` and no intervening await; all three fail with `Err(Empty)` against the detached shape.

Every failure path out of the bind now reports. `local_addr()` and the post-bind socket setup map to `Fatal`, never `BindConflict` — the bind succeeded, so diagnosing either as a conflict would hand `bind_ephemeral`'s unbounded retry an uncontended port. `bind_udp` is split so `set_nonblocking` / `SIO_UDP_CONNRESET` / `from_std` route through `report_setup_failure` rather than a bare `?` that dropped the sender; review caught that one still reproducing #795's exact bug class one step past the bind.

## #794: a later plugin's failure stayed invisible

`run_readiness_aggregator` awaited receivers in strict index order, so a typed error at index *k* waited on every earlier plugin. yamux sits at index 0 and can sit unresolved indefinitely, which is what made this bite. Outcomes are now consumed in completion order.

**Completion order alone would have regressed it.** A plugin exiting unsent resolves immediately, so a bare exit at a higher index could beat a lower-index plugin's typed error that was one poll behind — reporting `Fatal` → `ProxyError::Plugin` → no retry, where plugin order gave `BindConflict` → `BindRace` → retry. So the synthesized "exited before becoming ready" is **deferred** while other senders are alive, and any typed error found meanwhile outranks it.

The hold is **best-effort, and documented as such** — not a guarantee. It ends when every receiver resolves *or* when shutdown fires, and the exit that starts it cancels shutdown itself via `record_exit`, so a sibling error that has not reached its channel by then is still missed. Closing that window would mean waiting for every sender, which stalls a cancel behind readers that never watch the token — the regression the biased shutdown arm exists to prevent. The deferral strictly improves on reporting the placeholder immediately; it never reports less than plugin order did.

The shutdown arm therefore reports the deferred placeholder when it finds nothing delivered. Missing that fallback was a real regression caught in review: `record_exit` cancels on the very exit that starts a deferral, so the shutdown arm is the *ordinary* end of one, and returning empty-handed there gave `RecvError` where plugin order gave a typed `Fatal` — for galoshes that degrades to bare stdout EOF, since its emitter emits nothing on `RecvError`. Pinned by `aggregator_reports_a_deferred_exit_when_shutdown_ends_the_wait`.

The shutdown arm otherwise keeps #797's shape and generalizes its single-receiver `try_recv` rescue to every pending receiver. Its sweep records readiness rather than discarding it, so it is safe to call from a caller that goes on looping.

## Scope

- The **biased shutdown arm stays**, unchanged in position. `poll_ready` returns `None` only on cancellation but governs only `ReadinessMode::Probe`; the `ExpectSitrep`/`Auto` reader ex-ray and galoshes actually use never watches the token and ends only on child-stdout EOF behind a 5s graceful stop. Cancel-during-startup latency is unchanged.
- #797's settled behaviours are preserved and its four tests are untouched: a delivered `Ok(PluginReady)` is never rescued after shutdown, and shutdown with nothing delivered still drops `ready_tx`.
- `StartError`, `PluginReady`, the readiness channel type, `ChainPlugin::run` and `run_readiness_aggregator`'s signature are all unchanged. The bound-address channel is `pub(crate)` inside galoshes.
- `garter::is_bind_race` is lifted from `allocate_one_port`; `tap::allocate_inner_port` and galoshes now share it instead of each hardcoding the same three `ErrorKind`s. A plugin's bind race is the Windows excluded-port-range class too (`PermissionDenied`, `AddrNotAvailable`), matching the allocator the port came from. `util::retry::is_bind_race`'s ephemeral-only contract travels with it: on Unix `PermissionDenied` also means "privileged port without root", which no retry resolves. Every in-repo caller binds an allocator-derived port, so the contract holds; enforcing it in the type would need a `ChainPlugin` API change, so it is documented rather than gated.
- No new dependency: the concurrent await is a `std::future::poll_fn` over the owned receivers, so they stay inspectable by `try_recv` — which the sweep needs, and which a forwarding channel would have made racy.

## Tests

- garter, 10 new aggregator tests driving `run_readiness_aggregator` directly with hand-built channels — no plugin process, no port, no timing. Pre-fix: the head-of-line test **hangs** (that hang is #794); three more fail on the exit placeholder or a dropped `ready_tx`.
- garter, one integration test through the **production** `ExpectSitrep` reader and real subprocesses: index 0 sleeps forever without printing, index 1 emits `bind_conflict` and exits. Pre-fix it fails with `RecvError`. A stub-vs-production gap in exactly this area sank an earlier attempt, so the unit tests alone were not enough.
- galoshes, 8 new tests: the three happens-before assertions above, the UDP-side bind, readiness on the success path, the `ErrorKind` classification either side of the conflict/fatal line, the post-bind setup failure, and one end-to-end through a real `ChainRunner`.

`cargo test -p garter -p galoshes` and `cargo test -p hole-bridge --test plugin_chain` (the `BindConflict` → `bind_ephemeral` retry consumer) all pass.

## Left open, tracked

- **#756** stays open, deliberately untouched: a *benign* shutdown is still reported as `Fatal{"plugin exited before becoming ready"}`. The synthesis is reached only when shutdown has not fired, and it still has no access to the lifecycle reason — that remains a design change, not a patch.
- `BinaryPlugin::run` joins its stdout reader under a 100 ms budget after child exit, so the integration test's timing is bounded rather than ordered, and it is also what leaves the deferral's hold best-effort rather than exact. This is pre-existing — the merged `bind_conflict_start_error_surfaces_typed` rests on the same property — and `binary.rs` belongs to #802. The ordered fix is to join `stdout_task` unbounded on the child-exit path: the child is already dead, so its stdout pipe must EOF and there is no external event to bound.
