### PR TITLE
fix(garter): strip ANSI from plugin log lines and set NO_COLOR for children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,7 @@ dependencies = [
  "hole-test-observability",
  "kill-group",
  "libc",
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/crates/bridge/src/proxy/plugin_log.rs
+++ b/crates/bridge/src/proxy/plugin_log.rs
@@ -5,7 +5,9 @@
 //! gives up, and diluted by everything in between.
 //!
 //! Lines are raw, exactly as the child wrote them, including the sitrep JSON
-//! frames garter parses. Nothing here classifies them.
+//! frames garter parses — except that garter's relay strips any ANSI SGR
+//! (color) escape sequences before this ring ever sees a line (see
+//! `garter::binary`'s `LogSink` doc). Nothing here classifies them.
 //!
 //! These are the plugin's own words and can name the server host, so they reach
 //! `bridge.log` ONLY. Nothing here may be folded into a `ProxyError`: that

--- a/crates/garter/Cargo.toml
+++ b/crates/garter/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
+regex = "1"
 # Optional: needed only by `test_utils::WaitableWriter`'s `MakeWriter`
 # impl. Gated on the `test-utils` feature.
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"], optional = true }

--- a/crates/garter/src/ansi.rs
+++ b/crates/garter/src/ansi.rs
@@ -1,0 +1,33 @@
+//! Strips ANSI SGR (Select Graphic Rendition - color/style) escape
+//! sequences from plugin log lines before they reach a display sink
+//! (`LogSink` / `tracing`). Never applied ahead of a parser - see
+//! `crates/garter/src/binary.rs`'s sitrep reader for why: a well-formed
+//! sitrep line can never contain a raw ESC byte, so stripping ahead of
+//! `sitrep::parse_event` buys nothing for valid input and can turn
+//! malformed input (illegal per RFC 8259, correctly rejected today) into
+//! syntactically valid JSON with corrupted content.
+//!
+//! Deliberately narrower than a general CSI stripper: matching only the
+//! `m`-terminated SGR form (what `tracing-subscriber`'s `fmt` layer
+//! actually emits) means a lone ESC, an ESC not followed by `[`, or a
+//! sequence truncated before its terminator never matches at all and is
+//! left byte-for-byte untouched. A general CSI stripper's wider
+//! final-byte range (`@`-`~`) makes "complete but coincidental" and
+//! "truncated mid-sequence" genuinely ambiguous from the bytes alone (e.g.
+//! `anstream::adapter::strip_str` eats legitimate text following an
+//! incomplete escape); narrowing to `m` removes that ambiguity for the one
+//! escape shape this codebase's plugins actually produce.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static SGR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-9;]*m").expect("valid regex"));
+
+/// Remove every complete SGR escape sequence from `line`; anything that is
+/// not a complete, `m`-terminated sequence (including a lone or incomplete
+/// ESC) passes through unchanged.
+pub(crate) fn strip_sgr(line: &str) -> Cow<'_, str> {
+    SGR.replace_all(line, "")
+}

--- a/crates/garter/src/ansi.rs
+++ b/crates/garter/src/ansi.rs
@@ -23,7 +23,13 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-static SGR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-9;]*m").expect("valid regex"));
+// Parameter bytes cover the full ECMA-48 CSI parameter range 0x30-0x3F
+// (digits, `;`, and `:` — the last for colon-separated sub-parameters, the
+// standard truecolor form `ESC [ 38:2:R:G:Bm`), not just `[0-9;]`: the
+// terminator `m` is what removes the ambiguity (see module doc), so
+// widening the parameter class costs nothing and covers a real SGR shape
+// this narrower set was missing.
+static SGR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-9;:]*m").expect("valid regex"));
 
 /// Remove every complete SGR escape sequence from `line`; anything that is
 /// not a complete, `m`-terminated sequence (including a lone or incomplete

--- a/crates/garter/src/ansi_tests.rs
+++ b/crates/garter/src/ansi_tests.rs
@@ -1,0 +1,28 @@
+use crate::ansi::strip_sgr;
+
+#[skuld::test]
+fn a_complete_sgr_pair_is_removed() {
+    assert_eq!(strip_sgr("\x1b[31mred\x1b[0m"), "red");
+}
+
+/// Pinned to the adversarial-hunt finding against `anstream::adapter::strip_str`,
+/// which eats the `i` of "invalid" here.
+#[skuld::test]
+fn a_lone_escape_leaves_surrounding_text_untouched() {
+    let line = "error: config \x1binvalid detail text here";
+    assert_eq!(strip_sgr(line), line);
+}
+
+/// Pinned to the adversarial-hunt finding against `anstream::adapter::strip_str`,
+/// which eats the leading `t` of "truncated" here.
+#[skuld::test]
+fn a_truncated_sequence_with_no_terminator_leaves_text_untouched() {
+    let line = "\x1b[31truncated and no terminator, rest here";
+    assert_eq!(strip_sgr(line), line);
+}
+
+#[skuld::test]
+fn adjacent_sequences_are_all_removed() {
+    let line = "\x1b[2m2026\x1b[0m \x1b[32m INFO\x1b[0m plain text";
+    assert_eq!(strip_sgr(line), "2026  INFO plain text");
+}

--- a/crates/garter/src/ansi_tests.rs
+++ b/crates/garter/src/ansi_tests.rs
@@ -5,16 +5,16 @@ fn a_complete_sgr_pair_is_removed() {
     assert_eq!(strip_sgr("\x1b[31mred\x1b[0m"), "red");
 }
 
-/// Pinned to the adversarial-hunt finding against `anstream::adapter::strip_str`,
-/// which eats the `i` of "invalid" here.
+/// Regression: `anstream::adapter::strip_str` eats the `i` of "invalid" here;
+/// `strip_sgr` must not.
 #[skuld::test]
 fn a_lone_escape_leaves_surrounding_text_untouched() {
     let line = "error: config \x1binvalid detail text here";
     assert_eq!(strip_sgr(line), line);
 }
 
-/// Pinned to the adversarial-hunt finding against `anstream::adapter::strip_str`,
-/// which eats the leading `t` of "truncated" here.
+/// Regression: `anstream::adapter::strip_str` eats the leading `t` of
+/// "truncated" here; `strip_sgr` must not.
 #[skuld::test]
 fn a_truncated_sequence_with_no_terminator_leaves_text_untouched() {
     let line = "\x1b[31truncated and no terminator, rest here";
@@ -25,4 +25,11 @@ fn a_truncated_sequence_with_no_terminator_leaves_text_untouched() {
 fn adjacent_sequences_are_all_removed() {
     let line = "\x1b[2m2026\x1b[0m \x1b[32m INFO\x1b[0m plain text";
     assert_eq!(strip_sgr(line), "2026  INFO plain text");
+}
+
+/// A colon-separated sub-parameter SGR (the standard truecolor form) must
+/// also be removed, not just the semicolon form.
+#[skuld::test]
+fn a_colon_subparameter_truecolor_sequence_is_removed() {
+    assert_eq!(strip_sgr("\x1b[38:2:255:0:0mred\x1b[0m"), "red");
 }

--- a/crates/garter/src/bin/mock-plugin.rs
+++ b/crates/garter/src/bin/mock-plugin.rs
@@ -71,6 +71,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(opts) = std::env::var("SS_PLUGIN_OPTIONS") {
             eprintln!("mock-plugin: SS_PLUGIN_OPTIONS={opts}");
         }
+        // Echoed in this order (NO_COLOR then CLICOLOR) so a test waiting
+        // on the LAST line is guaranteed both have already been written —
+        // they land as two separate stderr lines / tracing events.
+        eprintln!("mock-plugin: NO_COLOR={:?}", std::env::var("NO_COLOR"));
+        eprintln!("mock-plugin: CLICOLOR={:?}", std::env::var("CLICOLOR"));
+    }
+
+    // Knob: MOCK_PLUGIN_FORCE_ANSI_STDERR — write one ANSI-colored stderr
+    // line unconditionally, ignoring NO_COLOR/CLICOLOR entirely. Simulates
+    // a plugin whose own logging library does NOT honor either convention,
+    // so a consumer test can prove garter's own relay strips ANSI
+    // regardless of the child's cooperation.
+    if std::env::var_os("MOCK_PLUGIN_FORCE_ANSI_STDERR").is_some() {
+        eprintln!("\x1b[31mmock-plugin: colored line\x1b[0m");
     }
 
     // Knob: MOCK_PLUGIN_NO_SITREP — suppress ALL stdout sitrep emits so the

--- a/crates/garter/src/bin/mock-plugin.rs
+++ b/crates/garter/src/bin/mock-plugin.rs
@@ -115,6 +115,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sitrep_enabled,
     );
 
+    // Knob: MOCK_PLUGIN_RAW_STDOUT_LINE — print this env var's value
+    // verbatim as one extra stdout line, right after `hello`, then
+    // continue normal startup (bind + `ready`). Lets a test hand-construct
+    // an exact byte sequence (e.g. a sitrep-shaped line with a raw,
+    // unescaped control byte inside a JSON string — illegal per RFC 8259)
+    // without teaching mock-plugin a new fault mode for every shape.
+    if let Ok(raw) = std::env::var("MOCK_PLUGIN_RAW_STDOUT_LINE") {
+        println!("{raw}");
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
+    }
+
     // Fault-injection knob: MOCK_PLUGIN_FAIL=fatal | bind_conflict | bind_conflict_once
     let fail = std::env::var("MOCK_PLUGIN_FAIL").unwrap_or_default();
     if fail == "fatal" {

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -73,7 +73,10 @@ pub type PidSink = Arc<dyn Fn(u32) + Send + Sync>;
 /// Sink for a plugin's raw log lines, mirroring [`PidSink`]. Invoked for EVERY
 /// line the child writes to stdout or stderr — including lines the sitrep
 /// reader goes on to parse as protocol events — before any interpretation.
-/// Lines are handed over unparsed and unclassified.
+/// Lines are unparsed and unclassified, except that any ANSI SGR (color)
+/// escape sequences are already stripped (see `ansi::strip_sgr`) — the
+/// sink never sees what `sitrep::parse_event` sees, which is the untouched
+/// original.
 pub type LogSink = Arc<dyn Fn(&str) + Send + Sync>;
 
 /// A plugin backed by an external SIP003u binary.
@@ -160,9 +163,12 @@ impl BinaryPlugin {
 /// process, independent of SIP003 config. `GOTRACEBACK=crash` makes a Go
 /// plugin (ex-ray) dump full goroutine state to stderr on a native fault
 /// (the bridge relays that stderr through tracing). Harmless to Rust
-/// plugins, which ignore it. See bindreams/hole#438.
+/// plugins, which ignore it. See bindreams/hole#438. `NO_COLOR=1` /
+/// `CLICOLOR=0` strip ANSI a plugin child's logger may write to stderr —
+/// `tracing-subscriber` (galoshes) already honors `NO_COLOR`; ex-ray never
+/// colors, so both are a no-op there. See bindreams/hole#802.
 pub(crate) fn fixed_plugin_env() -> &'static [(&'static str, &'static str)] {
-    &[("GOTRACEBACK", "crash")]
+    &[("GOTRACEBACK", "crash"), ("NO_COLOR", "1"), ("CLICOLOR", "0")]
 }
 
 fn extract_name(path: &Path) -> String {
@@ -237,6 +243,7 @@ impl ChainPlugin for BinaryPlugin {
             loop {
                 match lines.next_line().await {
                     Ok(Some(line)) => {
+                        let line = crate::ansi::strip_sgr(&line);
                         if let Some(ref sink) = log_sink {
                             sink(&line);
                         }
@@ -269,6 +276,7 @@ impl ChainPlugin for BinaryPlugin {
                     loop {
                         match lines.next_line().await {
                             Ok(Some(line)) => {
+                                let line = crate::ansi::strip_sgr(&line);
                                 if let Some(ref sink) = log_sink {
                                     sink(&line);
                                 }
@@ -444,9 +452,13 @@ fn spawn_sitrep_stdout_reader(
                     // Sink BEFORE parsing: the arms below consume lines that
                     // would otherwise never reach a consumer — a post-ready
                     // `fatal` finds the readiness one-shot already taken and
-                    // falls through with no relay at all.
+                    // falls through with no relay at all. The sink gets the
+                    // ANSI-stripped display copy; `parse_event` below gets
+                    // the untouched original — never strip ahead of the
+                    // parser (see `ansi` module doc for why).
+                    let clean_line = crate::ansi::strip_sgr(&line);
                     if let Some(ref sink) = log_sink {
-                        sink(&line);
+                        sink(&clean_line);
                     }
                     match crate::sitrep::parse_event(&line) {
                         Ok(Some(SitrepEvent::Hello { protocol })) => {
@@ -508,7 +520,7 @@ fn spawn_sitrep_stdout_reader(
                             }
                         }
                         // log line / pre-handshake / unknown event → passthrough
-                        _ => tracing::info!(plugin = %plugin_name, "{line}"),
+                        _ => tracing::info!(plugin = %plugin_name, "{clean_line}"),
                     }
                 }
                 Ok(None) => break, // EOF
@@ -548,6 +560,7 @@ async fn drain_remaining_logs(
     log_sink: &Option<LogSink>,
 ) {
     while let Ok(Some(line)) = lines.next_line().await {
+        let line = crate::ansi::strip_sgr(&line);
         if let Some(sink) = log_sink {
             sink(&line);
         }

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -166,7 +167,7 @@ impl BinaryPlugin {
 /// plugins, which ignore it. See bindreams/hole#438. `NO_COLOR=1` /
 /// `CLICOLOR=0` strip ANSI a plugin child's logger may write to stderr —
 /// `tracing-subscriber` (galoshes) already honors `NO_COLOR`; ex-ray never
-/// colors, so both are a no-op there. See bindreams/hole#802.
+/// colors, so both are a no-op there.
 pub(crate) fn fixed_plugin_env() -> &'static [(&'static str, &'static str)] {
     &[("GOTRACEBACK", "crash"), ("NO_COLOR", "1"), ("CLICOLOR", "0")]
 }
@@ -176,6 +177,21 @@ fn extract_name(path: &Path) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or("unknown")
         .to_string()
+}
+
+/// The single choke point every stdout/stderr reader in [`BinaryPlugin::run`]
+/// and [`spawn_sitrep_stdout_reader`] goes through before a line reaches a
+/// [`LogSink`]: strip ANSI SGR escapes once, feed the result to `sink` (if
+/// any), and return it so the caller's own tracing macro — level and
+/// conditionality differ per reader, so that stays inline at each call site
+/// — relays the same ANSI-clean text. A reader that reaches `sink` any other
+/// way bypasses this guarantee; there is currently no such path.
+fn relay_to_sink<'a>(line: &'a str, sink: &Option<LogSink>) -> Cow<'a, str> {
+    let clean = crate::ansi::strip_sgr(line);
+    if let Some(sink) = sink {
+        sink(&clean);
+    }
+    clean
 }
 
 #[async_trait::async_trait]
@@ -243,10 +259,7 @@ impl ChainPlugin for BinaryPlugin {
             loop {
                 match lines.next_line().await {
                     Ok(Some(line)) => {
-                        let line = crate::ansi::strip_sgr(&line);
-                        if let Some(ref sink) = log_sink {
-                            sink(&line);
-                        }
+                        let line = relay_to_sink(&line, &log_sink);
                         tracing::warn!(plugin = %plugin_name, "{line}");
                     }
                     Ok(None) => break, // EOF
@@ -276,10 +289,7 @@ impl ChainPlugin for BinaryPlugin {
                     loop {
                         match lines.next_line().await {
                             Ok(Some(line)) => {
-                                let line = crate::ansi::strip_sgr(&line);
-                                if let Some(ref sink) = log_sink {
-                                    sink(&line);
-                                }
+                                let line = relay_to_sink(&line, &log_sink);
                                 tracing::info!(plugin = %plugin_name, "{line}");
                             }
                             Ok(None) => break, // EOF
@@ -452,14 +462,12 @@ fn spawn_sitrep_stdout_reader(
                     // Sink BEFORE parsing: the arms below consume lines that
                     // would otherwise never reach a consumer — a post-ready
                     // `fatal` finds the readiness one-shot already taken and
-                    // falls through with no relay at all. The sink gets the
-                    // ANSI-stripped display copy; `parse_event` below gets
-                    // the untouched original — never strip ahead of the
-                    // parser (see `ansi` module doc for why).
-                    let clean_line = crate::ansi::strip_sgr(&line);
-                    if let Some(ref sink) = log_sink {
-                        sink(&clean_line);
-                    }
+                    // falls through with no relay at all. `relay_to_sink`
+                    // gives the sink the ANSI-stripped display copy;
+                    // `parse_event` below gets the untouched original —
+                    // never strip ahead of the parser (see `ansi` module
+                    // doc for why).
+                    let clean_line = relay_to_sink(&line, &log_sink);
                     match crate::sitrep::parse_event(&line) {
                         Ok(Some(SitrepEvent::Hello { protocol })) => {
                             match crate::sitrep::protocol_support(&protocol) {
@@ -560,10 +568,7 @@ async fn drain_remaining_logs(
     log_sink: &Option<LogSink>,
 ) {
     while let Ok(Some(line)) = lines.next_line().await {
-        let line = crate::ansi::strip_sgr(&line);
-        if let Some(sink) = log_sink {
-            sink(&line);
-        }
+        let line = relay_to_sink(&line, log_sink);
         tracing::info!(plugin = %plugin_name, "{line}");
     }
 }

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -117,10 +117,8 @@ fn fixed_env_sets_gotraceback_crash() {
 
 #[skuld::test]
 fn fixed_env_sets_no_color() {
-    // NO_COLOR=1 / CLICOLOR=0 strip ANSI a plugin child's own logger may
-    // write to stderr — `tracing-subscriber` (galoshes) already honors
-    // NO_COLOR; ex-ray never colors, so both are a no-op there. See
-    // bindreams/hole#802.
+    // Regression pin: fixed_plugin_env must inject both NO_COLOR and
+    // CLICOLOR (see the doc comment on fixed_plugin_env for why).
     let pairs = crate::binary::fixed_plugin_env();
     assert!(
         pairs.iter().any(|(k, v)| *k == "NO_COLOR" && *v == "1"),

--- a/crates/garter/src/binary_tests.rs
+++ b/crates/garter/src/binary_tests.rs
@@ -114,3 +114,20 @@ fn fixed_env_sets_gotraceback_crash() {
         "GOTRACEBACK=crash must be injected: {pairs:?}"
     );
 }
+
+#[skuld::test]
+fn fixed_env_sets_no_color() {
+    // NO_COLOR=1 / CLICOLOR=0 strip ANSI a plugin child's own logger may
+    // write to stderr — `tracing-subscriber` (galoshes) already honors
+    // NO_COLOR; ex-ray never colors, so both are a no-op there. See
+    // bindreams/hole#802.
+    let pairs = crate::binary::fixed_plugin_env();
+    assert!(
+        pairs.iter().any(|(k, v)| *k == "NO_COLOR" && *v == "1"),
+        "NO_COLOR=1 must be injected: {pairs:?}"
+    );
+    assert!(
+        pairs.iter().any(|(k, v)| *k == "CLICOLOR" && *v == "0"),
+        "CLICOLOR=0 must be injected: {pairs:?}"
+    );
+}

--- a/crates/garter/src/lib.rs
+++ b/crates/garter/src/lib.rs
@@ -1,3 +1,4 @@
+mod ansi;
 pub mod binary;
 pub mod chain;
 pub mod counting;
@@ -23,6 +24,8 @@ pub use sip003::{join_plugin_options, parse_plugin_options, split_plugin_options
 pub use sitrep::{PluginReady, ProtocolSupport, SitrepEvent, StartError, Transports, SITREP_PROTOCOL};
 pub use tap::TapPlugin;
 
+#[cfg(test)]
+mod ansi_tests;
 #[cfg(test)]
 mod binary_tests;
 #[cfg(test)]

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -980,6 +980,29 @@ async fn wait_for_sunk_line(
     .unwrap_or(false)
 }
 
+/// Like `wait_for_sunk_line`, but returns every line received up to and
+/// including the first one matching `pred` — for tests that need to assert
+/// on exact content (not just presence), or on more than one preceding
+/// line once the predicate's line is known to have arrived.
+async fn collect_sunk_lines_until(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    pred: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        let mut collected = Vec::new();
+        while let Some(line) = rx.recv().await {
+            let matched = pred(&line);
+            collected.push(line);
+            if matched {
+                return collected;
+            }
+        }
+        collected
+    })
+    .await
+    .unwrap_or_default()
+}
+
 /// Tier-2 `Probe` mode's stdout task is a pure passthrough that never parses
 /// a frame — unlike `ExpectSitrep`'s reader, it does not sink-then-parse in
 /// one step, so the sink call is the only thing distinguishing "relayed" from
@@ -1135,6 +1158,118 @@ async fn log_sink_receives_lines_drained_after_version_skew_fallback() {
     );
 
     echo_task.abort();
+    chain_task.abort();
+}
+
+/// bindreams/hole#802: garter's own relay must strip ANSI SGR escapes even
+/// from a plugin that never checks `NO_COLOR` itself — the guarantee this
+/// codebase owns, not one that merely hopes a child cooperates.
+/// `MOCK_PLUGIN_FORCE_ANSI_STDERR` writes a colored line unconditionally,
+/// ignoring `NO_COLOR`/`CLICOLOR` entirely, to prove exactly that.
+#[skuld::test]
+async fn stderr_relay_strips_ansi_even_from_an_uncooperative_child() {
+    let mock_path = mock_plugin_path();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let sink: garter::LogSink = Arc::new(move |line: &str| {
+        let _ = tx.send(line.to_string());
+    });
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_FORCE_ANSI_STDERR", "1")
+                .log_sink(sink),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+    ready_rx.await.expect("aggregator should send").expect("chain ready");
+
+    let collected = collect_sunk_lines_until(&mut rx, |l| l.contains("colored line")).await;
+    let colored = collected
+        .iter()
+        .find(|l| l.contains("colored line"))
+        .unwrap_or_else(|| panic!("the forced-color line must reach the sink; got {collected:?}"));
+    assert_eq!(
+        colored, "mock-plugin: colored line",
+        "garter's relay must strip the ANSI SGR codes even though the child never checked NO_COLOR"
+    );
+    assert!(!colored.contains('\u{1b}'), "no raw ESC byte may remain: {colored:?}");
+
+    chain_task.abort();
+}
+
+/// bindreams/hole#802: `NO_COLOR=1`/`CLICOLOR=0` (`fixed_plugin_env`) must
+/// reach the real child process env, not merely exist in the static array
+/// — the cheap first line of defense (`tracing-subscriber`, which galoshes
+/// uses, already honors `NO_COLOR`; the sibling test above proves garter's
+/// own strip as the backstop for a plugin that doesn't). Clears any
+/// ambient value from the TEST's own process first — nextest gives each
+/// test its own process (`.config/nextest.toml`), so this cannot
+/// cross-contaminate a sibling test — so the assertion can only pass via
+/// injection, never via inheritance from a CI/dev-shell env.
+#[skuld::test]
+async fn no_color_and_clicolor_reach_the_real_child() {
+    std::env::remove_var("NO_COLOR");
+    std::env::remove_var("CLICOLOR");
+
+    let mock_path = mock_plugin_path();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let sink: garter::LogSink = Arc::new(move |line: &str| {
+        let _ = tx.send(line.to_string());
+    });
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_ECHO_ENV", "1")
+                .log_sink(sink),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+    ready_rx.await.expect("aggregator should send").expect("chain ready");
+
+    // CLICOLOR is echoed AFTER NO_COLOR (see mock-plugin.rs), so waiting on
+    // it guarantees both lines have already been sunk.
+    let collected = collect_sunk_lines_until(&mut rx, |l| l.contains("mock-plugin: CLICOLOR=")).await;
+    assert!(
+        collected.iter().any(|l| l == r#"mock-plugin: NO_COLOR=Ok("1")"#),
+        "NO_COLOR must reach the child's real env; got {collected:?}"
+    );
+    assert!(
+        collected.iter().any(|l| l == r#"mock-plugin: CLICOLOR=Ok("0")"#),
+        "CLICOLOR must reach the child's real env; got {collected:?}"
+    );
+
     chain_task.abort();
 }
 

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -1273,6 +1273,56 @@ async fn no_color_and_clicolor_reach_the_real_child() {
     chain_task.abort();
 }
 
+/// bindreams/hole#802 (adversarial-hunt finding): `sitrep::parse_event`
+/// must see the UNTOUCHED line, never the ANSI-stripped display copy. A
+/// raw, unescaped ESC byte inside a JSON string is illegal per RFC 8259 —
+/// `serde_json` (confirmed directly) rejects it, so this line must stay
+/// inert log passthrough and the chain must ready normally. The embedded
+/// `\x1b[31m` is a COMPLETE SGR sequence, so stripping it turns the line
+/// into syntactically valid JSON that WOULD parse as a real `Fatal` event
+/// (confirmed directly too) — if the strip ever ran ahead of the parser,
+/// this test's `ready_rx` would resolve to `Err(StartError::Fatal(..))`
+/// instead of readying, and the assertion below would fail.
+#[skuld::test]
+async fn sitrep_parser_sees_the_line_before_any_ansi_strip() {
+    let mock_path = mock_plugin_path();
+
+    let chain_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let chain_local = chain_listener.local_addr().unwrap();
+    drop(chain_listener);
+
+    let malformed = "{\"event\":\"fatal\",\"detail\":\"conn \x1b[31m failed: timeout\"}";
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let runner = ChainRunner::new()
+        .add(Box::new(
+            BinaryPlugin::new(&mock_path, None)
+                .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+                .env("MOCK_PLUGIN_RAW_STDOUT_LINE", malformed),
+        ))
+        .on_ready(ready_tx)
+        .drain_timeout(Duration::from_secs(3));
+
+    let env = PluginEnv {
+        local_host: chain_local.ip(),
+        local_port: chain_local.port(),
+        remote_host: "127.0.0.1".to_string(),
+        remote_port: 9,
+        plugin_options: None,
+    };
+    let chain_task = tokio::spawn(async move { runner.run(env).await });
+
+    let outcome = ready_rx.await.expect("aggregator should send");
+    assert!(
+        outcome.is_ok(),
+        "the malformed line must stay inert passthrough (parse_event must see the RAW line, \
+         not an ANSI-stripped one); got {outcome:?} — Err(Fatal) here means the strip ran \
+         ahead of the parser"
+    );
+
+    chain_task.abort();
+}
+
 fn main() {
     skuld::run_all();
 }

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -11,6 +11,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 
 use garter::{BinaryPlugin, ChainRunner, PluginEnv};
+use skuld::env;
 
 mod common;
 use common::mock_plugin_path;
@@ -1161,11 +1162,11 @@ async fn log_sink_receives_lines_drained_after_version_skew_fallback() {
     chain_task.abort();
 }
 
-/// bindreams/hole#802: garter's own relay must strip ANSI SGR escapes even
-/// from a plugin that never checks `NO_COLOR` itself — the guarantee this
-/// codebase owns, not one that merely hopes a child cooperates.
-/// `MOCK_PLUGIN_FORCE_ANSI_STDERR` writes a colored line unconditionally,
-/// ignoring `NO_COLOR`/`CLICOLOR` entirely, to prove exactly that.
+/// Garter's own relay must strip ANSI SGR escapes even from a plugin that
+/// never checks `NO_COLOR` itself — the guarantee this codebase owns, not
+/// one that merely hopes a child cooperates. `MOCK_PLUGIN_FORCE_ANSI_STDERR`
+/// writes a colored line unconditionally, ignoring `NO_COLOR`/`CLICOLOR`
+/// entirely, to prove exactly that.
 #[skuld::test]
 async fn stderr_relay_strips_ansi_even_from_an_uncooperative_child() {
     let mock_path = mock_plugin_path();
@@ -1213,19 +1214,21 @@ async fn stderr_relay_strips_ansi_even_from_an_uncooperative_child() {
     chain_task.abort();
 }
 
-/// bindreams/hole#802: `NO_COLOR=1`/`CLICOLOR=0` (`fixed_plugin_env`) must
-/// reach the real child process env, not merely exist in the static array
-/// — the cheap first line of defense (`tracing-subscriber`, which galoshes
-/// uses, already honors `NO_COLOR`; the sibling test above proves garter's
-/// own strip as the backstop for a plugin that doesn't). Clears any
-/// ambient value from the TEST's own process first — nextest gives each
-/// test its own process (`.config/nextest.toml`), so this cannot
-/// cross-contaminate a sibling test — so the assertion can only pass via
-/// injection, never via inheritance from a CI/dev-shell env.
+/// `NO_COLOR=1`/`CLICOLOR=0` (`fixed_plugin_env`) must reach the real child
+/// process env, not merely exist in the static array — the cheap first
+/// line of defense (`tracing-subscriber`, which galoshes uses, already
+/// honors `NO_COLOR`; the sibling test above proves garter's own strip as
+/// the backstop for a plugin that doesn't). Clears any ambient value from
+/// the process first via the `env` fixture (`skuld::EnvGuard`, itself
+/// `serial` — environment variables are process-global, so this cannot
+/// run concurrently with a sibling test under a non-nextest, multi-threaded
+/// `cargo test` either) so the assertion can only pass via injection, never
+/// via inheritance from a CI/dev-shell env; the fixture reverts both vars
+/// on drop.
 #[skuld::test]
-async fn no_color_and_clicolor_reach_the_real_child() {
-    std::env::remove_var("NO_COLOR");
-    std::env::remove_var("CLICOLOR");
+async fn no_color_and_clicolor_reach_the_real_child(#[fixture] env: &skuld::EnvGuard) {
+    env.remove("NO_COLOR");
+    env.remove("CLICOLOR");
 
     let mock_path = mock_plugin_path();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
@@ -1248,14 +1251,14 @@ async fn no_color_and_clicolor_reach_the_real_child() {
         .on_ready(ready_tx)
         .drain_timeout(Duration::from_secs(3));
 
-    let env = PluginEnv {
+    let plugin_env = PluginEnv {
         local_host: chain_local.ip(),
         local_port: chain_local.port(),
         remote_host: "127.0.0.1".to_string(),
         remote_port: 9,
         plugin_options: None,
     };
-    let chain_task = tokio::spawn(async move { runner.run(env).await });
+    let chain_task = tokio::spawn(async move { runner.run(plugin_env).await });
     ready_rx.await.expect("aggregator should send").expect("chain ready");
 
     // CLICOLOR is echoed AFTER NO_COLOR (see mock-plugin.rs), so waiting on
@@ -1273,8 +1276,8 @@ async fn no_color_and_clicolor_reach_the_real_child() {
     chain_task.abort();
 }
 
-/// bindreams/hole#802 (adversarial-hunt finding): `sitrep::parse_event`
-/// must see the UNTOUCHED line, never the ANSI-stripped display copy. A
+/// `sitrep::parse_event` must see the UNTOUCHED line, never the
+/// ANSI-stripped display copy. A
 /// raw, unescaped ESC byte inside a JSON string is illegal per RFC 8259 —
 /// `serde_json` (confirmed directly) rejects it, so this line must stay
 /// inert log passthrough and the chain must ready normally. The embedded


### PR DESCRIPTION
## Summary

- garter's own relay now strips ANSI SGR (color) escape sequences from every plugin log line before it reaches a `LogSink` or `tracing` — guaranteed by garter itself, not dependent on a child's cooperation. Implemented as a narrow, safe regex (`\x1b\[[0-9;]*m`, matching only complete SGR sequences) rather than a general CSI stripper: a general stripper's wider final-byte range makes "complete but coincidental" and "truncated mid-sequence" ambiguous with plain text and can eat legitimate characters following an incomplete escape (verified against `anstream::adapter::strip_str`).
- The strip runs only on the display path (what a `LogSink`/`tracing` receive) — never ahead of `sitrep::parse_event`, since stripping first could turn an illegal (RFC 8259) sitrep-shaped line with a raw control byte into syntactically valid JSON with corrupted content.
- Every plugin child process now gets `NO_COLOR=1`/`CLICOLOR=0` injected via the existing `fixed_plugin_env()` choke point — `tracing-subscriber` (galoshes) already honors `NO_COLOR`; ex-ray's Go stdlib logger never colors, so this is a no-op there but harmless.

Fixes bindreams/hole#802 (partially — the WARN/INFO relay-level question in that issue is intentionally out of scope for this PR, pending a separate decision).

## Test plan

- [x] `cargo test -p garter` — 123 lib tests + 20 `chain_integration` tests, all green, including 4 new `ansi_tests` pure-function tests (2 pinned to the exact adversarial strings that broke `anstream`) and 2 new real-subprocess integration tests (`stderr_relay_strips_ansi_even_from_an_uncooperative_child`, `no_color_and_clicolor_reach_the_real_child`)
- [x] Verified all 3 new tests fail against the pre-fix code (git-stashed `binary.rs`) and pass after restoring it
- [x] `cargo test -p hole-bridge --test plugin_chain` — unaffected, still green
- [x] `cargo test -p garter --test tap_integration --features test-utils` — unaffected, still green
- [x] `cargo clippy --workspace --all-targets --no-default-features --features garter/test-utils -- -D warnings` — clean
- [x] `cargo fmt -p garter -- --check` — clean