### PR TITLE
chore(deps): update v2ray-core to v5.53.0

### DIFF
--- a/crates/ex-ray/third_party/v2ray-core/.gitrepo
+++ b/crates/ex-ray/third_party/v2ray-core/.gitrepo
@@ -5,7 +5,7 @@
 ;
 [subrepo]
 	remote = https://github.com/v2fly/v2ray-core
-	branch = v5.52.0
+	branch = v5.53.0
 	commit = 9db9c4bb0cd92d18064f8c430cca641b5c49ea43
 	parent = be0b5488b5e2bb9cda09522d4110944e984c0934
 	method = merge


### PR DESCRIPTION
Task 12 Step 5b: throwaway PR to observe Lint settle red on a bare .gitrepo-only bump, without racing vendor-bump.yaml's own push (this branch deliberately doesn't match renovate/**). Will be closed and superseded by a real renovate/test-... PR.