### PR TITLE
fix(garter): make a plugin's readiness outcome final before run returns

### DIFF
--- a/crates/garter/src/bin/mock-plugin.rs
+++ b/crates/garter/src/bin/mock-plugin.rs
@@ -44,6 +44,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // reaped. That is reuse-immune (a recycled PID cannot resurrect this specific
     // TCP connection) and needs no sleep. We never write to the socket — closing
     // it is purely an exit signal.
+    //
+    // MOCK_PLUGIN_GRANDCHILD_RENDEZVOUS is dialed LAST, and is what unblocks the
+    // parent: once it accepts, both this dial and the callback above have already
+    // happened, so the parent may exit without racing our startup.
     if std::env::var_os("MOCK_PLUGIN_SLEEP").is_some() {
         let _callback = match std::env::var_os("MOCK_PLUGIN_GRANDCHILD_CALLBACK") {
             Some(addr) => {
@@ -52,6 +56,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     TcpStream::connect(addr)
                         .await
                         .expect("grandchild dials the test callback"),
+                )
+            }
+            None => None,
+        };
+        let _rendezvous = match std::env::var_os("MOCK_PLUGIN_GRANDCHILD_RENDEZVOUS") {
+            Some(addr) => {
+                let addr = addr.to_str().expect("MOCK_PLUGIN_GRANDCHILD_RENDEZVOUS is valid utf-8");
+                Some(
+                    TcpStream::connect(addr)
+                        .await
+                        .expect("grandchild dials the parent rendezvous"),
                 )
             }
             None => None,
@@ -115,6 +130,53 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sitrep_enabled,
     );
 
+    // Knob: MOCK_PLUGIN_SPAWN_GRANDCHILD=<callback_addr> — spawn a long-lived
+    // grandchild that INHERITS our stdio (default `Command` stdio), mimicking an
+    // inner plugin (galoshes→ex-ray) that, if orphaned, holds the host's
+    // stdout/stderr pipe. The grandchild dials <callback_addr> on startup and
+    // holds the connection, so a test can verify a force-kill of the chain reaps
+    // the whole process tree via the connection's liveness/EOF (reuse-immune, no
+    // PID poll). The grandchild gets MOCK_PLUGIN_SLEEP (so it short-circuits) plus
+    // the callback addr, and NOT this knob (so it does not recurse). std `Child`
+    // is not kill-on-drop, so letting it drop leaves the process running for the
+    // test.
+    //
+    // Placed BEFORE fault injection so a plugin that exits without ever binding
+    // still leaves the grandchild holding the pipes. `spawn` returns before the
+    // grandchild has run an instruction, so we block on its rendezvous dial: it
+    // makes "the grandchild is alive and holding our stdio" a fact before we can
+    // exit, with no timer.
+    if let Some(callback_addr) = std::env::var_os("MOCK_PLUGIN_SPAWN_GRANDCHILD") {
+        let rendezvous = TcpListener::bind("127.0.0.1:0").await?;
+        let exe = std::env::current_exe()?;
+        let mut cmd = std::process::Command::new(exe);
+        cmd.env("MOCK_PLUGIN_SLEEP", "1")
+            .env("MOCK_PLUGIN_GRANDCHILD_CALLBACK", &callback_addr)
+            .env(
+                "MOCK_PLUGIN_GRANDCHILD_RENDEZVOUS",
+                rendezvous.local_addr()?.to_string(),
+            )
+            .env_remove("MOCK_PLUGIN_SPAWN_GRANDCHILD");
+        // Mimic how garter spawns a NESTED plugin (galoshes→ex-ray) so this
+        // grandchild is reaped only by the root's process-tree kill, never by the
+        // parent's graceful stop:
+        //  - Windows: give it its OWN console group (CREATE_NEW_PROCESS_GROUP,
+        //    exactly as garter spawns every plugin) so graceful_stop's CTRL_BREAK
+        //    to the parent's group can't reach it; it still joins the root's job
+        //    object by handle inheritance and is reaped that way.
+        //  - Unix: do NOT setpgid — inherit the parent's process group like a
+        //    nested ex-ray, so the root's kill(-pgid) reaps it. graceful_stop's
+        //    SIGTERM is PID-targeted, so it can't reach the grandchild anyway.
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+        }
+        let _grandchild = cmd.spawn()?;
+        let _ = rendezvous.accept().await?;
+    }
+
     // Knob: MOCK_PLUGIN_RAW_STDOUT_LINE — print this env var's value
     // verbatim as one extra stdout line, right after `hello`, then
     // continue normal startup (bind + `ready`). Lets a test hand-construct
@@ -127,8 +189,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = std::io::stdout().flush();
     }
 
-    // Fault-injection knob: MOCK_PLUGIN_FAIL=fatal | bind_conflict | bind_conflict_once
+    // Fault-injection knob:
+    // MOCK_PLUGIN_FAIL=fatal | bind_conflict | bind_conflict_once | exit_silently
     let fail = std::env::var("MOCK_PLUGIN_FAIL").unwrap_or_default();
+    // The only mode that exits with NO readiness-bearing sitrep event, so a
+    // consumer's sole route to resolving readiness is stdout EOF.
+    if fail == "exit_silently" {
+        std::process::exit(1);
+    }
     if fail == "fatal" {
         emit(
             &SitrepEvent::Fatal {
@@ -192,41 +260,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         sitrep_enabled,
     );
-
-    // Knob: MOCK_PLUGIN_SPAWN_GRANDCHILD=<callback_addr> — spawn a long-lived
-    // grandchild that INHERITS our stdio (default `Command` stdio), mimicking an
-    // inner plugin (galoshes→ex-ray) that, if orphaned, holds the host's
-    // stdout/stderr pipe. The grandchild dials <callback_addr> on startup and
-    // holds the connection, so a test can verify a force-kill of the chain reaps
-    // the whole process tree via the connection's liveness/EOF (reuse-immune, no
-    // PID poll). The grandchild gets MOCK_PLUGIN_SLEEP (so it short-circuits) plus
-    // the callback addr, and NOT this knob (so it does not recurse). std `Child`
-    // is not kill-on-drop, so letting it drop leaves the process running for the
-    // test.
-    if let Some(callback_addr) = std::env::var_os("MOCK_PLUGIN_SPAWN_GRANDCHILD") {
-        let exe = std::env::current_exe()?;
-        let mut cmd = std::process::Command::new(exe);
-        cmd.env("MOCK_PLUGIN_SLEEP", "1")
-            .env("MOCK_PLUGIN_GRANDCHILD_CALLBACK", &callback_addr)
-            .env_remove("MOCK_PLUGIN_SPAWN_GRANDCHILD");
-        // Mimic how garter spawns a NESTED plugin (galoshes→ex-ray) so this
-        // grandchild is reaped only by the root's process-tree kill, never by the
-        // parent's graceful stop:
-        //  - Windows: give it its OWN console group (CREATE_NEW_PROCESS_GROUP,
-        //    exactly as garter spawns every plugin) so graceful_stop's CTRL_BREAK
-        //    to the parent's group can't reach it; it still joins the root's job
-        //    object by handle inheritance and is reaped that way.
-        //  - Unix: do NOT setpgid — inherit the parent's process group like a
-        //    nested ex-ray, so the root's kill(-pgid) reaps it. graceful_stop's
-        //    SIGTERM is PID-targeted, so it can't reach the grandchild anyway.
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
-        }
-        let _grandchild = cmd.spawn()?;
-    }
 
     loop {
         let (inbound, peer) = listener.accept().await?;

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -242,12 +242,11 @@ impl ChainPlugin for BinaryPlugin {
         }
 
         // Capture stderr FIRST: the sitrep stdout reader's readiness-FAILURE
-        // path (child exited before ever readying) joins `stderr_done` —
-        // bounded, not indefinite — before reporting that failure, so a
-        // plugin whose crash lands on stderr (the common shape for a Go
-        // panic under `GOTRACEBACK=crash`) isn't reported as if it said
-        // nothing. `Notify` (not the `JoinHandle` itself) so this task's
-        // handle stays free for the unconditional drain below too.
+        // path (child exited before ever readying) joins `stderr_done` before
+        // reporting that failure, so a plugin whose crash lands on stderr (the
+        // common shape for a Go panic under `GOTRACEBACK=crash`) isn't reported
+        // as if it said nothing. `Notify` (not the `JoinHandle` itself) so this
+        // task's handle stays free for the unconditional drain below too.
         let stderr = gc.child.stderr.take().expect("stderr was piped");
         let plugin_name = self.name.clone();
         let log_sink = self.log_sink.clone();
@@ -271,6 +270,14 @@ impl ChainPlugin for BinaryPlugin {
             }
             stderr_done_signal.notify_one();
         });
+
+        // Every task that can still resolve readiness is owned HERE, not by the
+        // reader: in `Probe` the sender lives in a self-probe task outright, and
+        // in `Auto` / the tier-2 fallback a probe CO-owns it through
+        // `SharedReady`. `run` therefore holds their standdown token and their
+        // handles, so `reap_and_drain` can end them and wait for them.
+        let probe_standdown = shutdown.child_token();
+        let (probe_tx, mut probe_rx) = tokio::sync::mpsc::unbounded_channel::<tokio::task::JoinHandle<()>>();
 
         // Stdout consumer: in Probe mode it forwards lines to tracing and
         // readiness comes from a separate self-probe task; in ExpectSitrep
@@ -302,18 +309,18 @@ impl ChainPlugin for BinaryPlugin {
                 });
 
                 // Self-probe readiness. On a successful connect, report TCP
-                // readiness; on shutdown-first, drop `ready` unsent (the
+                // readiness; on standdown-first, drop `ready` unsent (the
                 // receiver gets RecvError: shutdown happened before readiness).
                 let probe_local = local;
-                let probe_shutdown = shutdown.clone();
-                tokio::spawn(async move {
-                    if let Some(addr) = crate::chain::poll_ready(probe_local, probe_shutdown).await {
+                let probe_standdown = probe_standdown.clone();
+                let _ = probe_tx.send(tokio::spawn(async move {
+                    if let Some(addr) = crate::chain::poll_ready(probe_local, probe_standdown).await {
                         let _ = ready.send(Ok(PluginReady {
                             listen: addr,
                             transports: crate::sitrep::Transports::TCP,
                         }));
                     }
-                });
+                }));
 
                 log_task
             }
@@ -321,23 +328,28 @@ impl ChainPlugin for BinaryPlugin {
                 stdout,
                 self.name.clone(),
                 local,
-                shutdown.clone(),
+                probe_standdown.clone(),
                 ready,
                 false,
                 self.log_sink.clone(),
                 stderr_done,
+                probe_tx.clone(),
             ),
             ReadinessMode::Auto => spawn_sitrep_stdout_reader(
                 stdout,
                 self.name.clone(),
                 local,
-                shutdown.clone(),
+                probe_standdown.clone(),
                 ready,
                 true,
                 self.log_sink.clone(),
                 stderr_done,
+                probe_tx.clone(),
             ),
         };
+        // Drop `run`'s own sender: the reader is then the last holder, so the
+        // drain terminates once it has ended.
+        drop(probe_tx);
 
         // Wait for child exit or shutdown signal.
         //
@@ -353,11 +365,7 @@ impl ChainPlugin for BinaryPlugin {
         tokio::select! {
             status = gc.child.wait() => {
                 let status = status?;
-                // Drain remaining log lines (tasks will EOF when child's pipes close)
-                let _ = tokio::time::timeout(
-                    std::time::Duration::from_millis(100),
-                    async { let _ = tokio::join!(stdout_task, stderr_task); }
-                ).await;
+                reap_and_drain(&mut gc, &probe_standdown, stdout_task, stderr_task, &mut probe_rx).await;
                 if status.success() {
                     Ok(())
                 } else {
@@ -377,14 +385,47 @@ impl ChainPlugin for BinaryPlugin {
                 // Force path force-kills the direct child; `gc` dropping at the
                 // end of `run` (or on task abort) reaps the whole tree.
                 shutdown::graceful_stop(&mut gc.child, drain_timeout).await?;
-                // Drain remaining log lines (tasks will EOF when child's pipes close)
-                let _ = tokio::time::timeout(
-                    std::time::Duration::from_millis(100),
-                    async { let _ = tokio::join!(stdout_task, stderr_task); }
-                ).await;
+                reap_and_drain(&mut gc, &probe_standdown, stdout_task, stderr_task, &mut probe_rx).await;
                 Ok(())
             }
         }
+    }
+}
+
+/// Reap the plugin's process tree, then wait for every task that can still
+/// resolve this plugin's readiness. Both `run` arms end here, so the guarantee
+/// — when `run` returns, the readiness outcome is FINAL — does not depend on
+/// which arm an already-dead child happened to be handled by (`select!` is
+/// unbiased).
+///
+/// **The reap is what makes the wait terminate.** A dead direct child does NOT
+/// close its stdout/stderr: any descendant that inherited its stdio holds a
+/// duplicate of the write end, so the readers reach EOF only once the whole tree
+/// is gone (bindreams/hole#197). `GroupedChild::Drop` reaps that tree either way
+/// when `run` returns; this only orders the reap ahead of the drain instead of
+/// after it. Standing the probes down is the same argument for the other
+/// readiness owner: the child is gone, so no probe can still report a real
+/// listener.
+///
+/// RESIDUAL: the reap covers only processes inside THIS spawn's kill-group. A
+/// nested spawn (no group of its own), a Windows job kill-group already logged
+/// as degraded, or a descendant that `setsid()`s out of the process group can
+/// still hold a write end, and this wait would then block. Closing that needs a
+/// "what containment did I actually achieve" answer from the spawn itself, which
+/// bindreams/hole#816 tracks.
+async fn reap_and_drain(
+    gc: &mut kill_group::GroupedChild,
+    probe_standdown: &CancellationToken,
+    stdout_task: tokio::task::JoinHandle<()>,
+    stderr_task: tokio::task::JoinHandle<()>,
+    probes: &mut tokio::sync::mpsc::UnboundedReceiver<tokio::task::JoinHandle<()>>,
+) {
+    gc.kill_tree().await;
+    probe_standdown.cancel();
+    let _ = tokio::join!(stdout_task, stderr_task);
+    // Reachable only after the reader ended: it held the last sender.
+    while let Some(probe) = probes.recv().await {
+        let _ = probe.await;
     }
 }
 
@@ -402,8 +443,17 @@ type SharedReady = Arc<tokio::sync::Mutex<Option<oneshot::Sender<Result<PluginRe
 /// reports `PluginReady` (TCP-only) through the shared send-once sender.
 /// Shared by `ExpectSitrep`'s unknown-major fallback and `Auto`'s concurrent
 /// probe. `standdown` ends the probe early (without sending) when cancelled.
-fn spawn_shared_probe(local: SocketAddr, standdown: CancellationToken, shared: SharedReady) {
-    tokio::spawn(async move {
+///
+/// The handle goes to `probes` because this task CO-OWNS the readiness sender:
+/// `run` must be able to wait for it, not just for the reader (see
+/// [`reap_and_drain`]).
+fn spawn_shared_probe(
+    local: SocketAddr,
+    standdown: CancellationToken,
+    shared: SharedReady,
+    probes: &tokio::sync::mpsc::UnboundedSender<tokio::task::JoinHandle<()>>,
+) {
+    let _ = probes.send(tokio::spawn(async move {
         if let Some(addr) = crate::chain::poll_ready(local, standdown).await {
             if let Some(tx) = shared.lock().await.take() {
                 let _ = tx.send(Ok(PluginReady {
@@ -412,7 +462,7 @@ fn spawn_shared_probe(local: SocketAddr, standdown: CancellationToken, shared: S
                 }));
             }
         }
-    });
+    }));
 }
 
 /// Spawn the sitrep stdout reader.
@@ -428,16 +478,17 @@ fn spawn_shared_probe(local: SocketAddr, standdown: CancellationToken, shared: S
 /// process-exit failure (the intended backstop) — bounded on `stderr_done` first
 /// (see its call site), so a crash whose last words land on stderr is not
 /// reported as if the plugin said nothing.
-#[allow(clippy::too_many_arguments)] // 8 args — bundling into a struct adds more noise than the warning.
+#[allow(clippy::too_many_arguments)] // 9 args — bundling into a struct adds more noise than the warning.
 fn spawn_sitrep_stdout_reader(
     stdout: tokio::process::ChildStdout,
     plugin_name: String,
     local: SocketAddr,
-    shutdown: CancellationToken,
+    probe_standdown: CancellationToken,
     ready: oneshot::Sender<Result<PluginReady, StartError>>,
     auto: bool,
     log_sink: Option<LogSink>,
     stderr_done: Arc<tokio::sync::Notify>,
+    probes: tokio::sync::mpsc::UnboundedSender<tokio::task::JoinHandle<()>>,
 ) -> tokio::task::JoinHandle<()> {
     use crate::sitrep::{ProtocolSupport, SitrepEvent};
 
@@ -448,10 +499,10 @@ fn spawn_sitrep_stdout_reader(
         // `hello` cancels `probe_standdown` so the probe defers to sitrep;
         // otherwise the probe readies the plugin (handles a non-sitrep plugin
         // that is silent on stdout — there is no first line to classify on).
-        // `probe_standdown` is a child of `shutdown`, so chain shutdown stops it.
-        let probe_standdown = shutdown.child_token();
+        // `probe_standdown` is a child of the plugin's `shutdown` token and is
+        // owned by `run`, so both chain shutdown and child exit stop the probe.
         if auto {
-            spawn_shared_probe(local, probe_standdown.clone(), shared.clone());
+            spawn_shared_probe(local, probe_standdown.clone(), shared.clone(), &probes);
         }
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
@@ -492,7 +543,7 @@ fn spawn_sitrep_stdout_reader(
                                     // start it now. The reader continues only as a log
                                     // passthrough (it never sends readiness again).
                                     if !auto {
-                                        spawn_shared_probe(local, shutdown.clone(), shared.clone());
+                                        spawn_shared_probe(local, probe_standdown.clone(), shared.clone(), &probes);
                                     }
                                     // Drain the rest of stdout as logs so the
                                     // child's pipe never blocks; the probe task
@@ -538,16 +589,16 @@ fn spawn_sitrep_stdout_reader(
                 }
             }
         }
-        // If the child closed stdout without ever sending readiness, give the
-        // stderr reader a bounded chance to catch up before dropping the
-        // shared sender below signals process-exit to the aggregator — a
-        // crash lands on stderr more often than stdout (e.g. a Go panic
-        // under `GOTRACEBACK=crash`), and the two pipes are read by
-        // independent tasks with no ordering between them otherwise. Bounded
-        // on the child's own exit (stdout just EOF'd, so stderr is expected
-        // to follow shortly), not an arbitrary wait: this mirrors the
-        // existing drain timeout in `run`'s own shutdown paths.
-        let _ = tokio::time::timeout(std::time::Duration::from_millis(100), stderr_done.notified()).await;
+        // If the child closed stdout without ever sending readiness, wait for the
+        // stderr reader before dropping the shared sender signals process-exit to
+        // the aggregator — a crash lands on stderr more often than stdout (e.g. a
+        // Go panic under `GOTRACEBACK=crash`), and the two pipes are read by
+        // independent tasks with no ordering between them otherwise. Unbounded on
+        // the same guarantor as this reader's own EOF (the tree is reaped, so both
+        // pipes close), rather than a budget a large panic dump can overrun. A
+        // plugin that closes stdout while still ALIVE parks here instead of
+        // reporting an exit it has not made.
+        stderr_done.notified().await;
     })
 }
 

--- a/crates/garter/src/binary.rs
+++ b/crates/garter/src/binary.rs
@@ -194,6 +194,16 @@ fn relay_to_sink<'a>(line: &'a str, sink: &Option<LogSink>) -> Cow<'a, str> {
     clean
 }
 
+/// Fires a [`tokio::sync::Notify`] when dropped, so a task's completion signal
+/// survives the task unwinding or being aborted — not only returning normally.
+struct SignalOnDrop(Arc<tokio::sync::Notify>);
+
+impl Drop for SignalOnDrop {
+    fn drop(&mut self) {
+        self.0.notify_one();
+    }
+}
+
 #[async_trait::async_trait]
 impl ChainPlugin for BinaryPlugin {
     fn name(&self) -> &str {
@@ -251,8 +261,12 @@ impl ChainPlugin for BinaryPlugin {
         let plugin_name = self.name.clone();
         let log_sink = self.log_sink.clone();
         let stderr_done = Arc::new(tokio::sync::Notify::new());
-        let stderr_done_signal = Arc::clone(&stderr_done);
+        let stderr_done_signal = SignalOnDrop(Arc::clone(&stderr_done));
         let stderr_task = tokio::spawn(async move {
+            // Signalled on unwind and on abort too: the stdout reader waits on
+            // this with no bound, and `relay_to_sink` runs a consumer-supplied
+            // `LogSink` that garter cannot assume is panic-free.
+            let _stderr_done = stderr_done_signal;
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
             loop {
@@ -268,7 +282,6 @@ impl ChainPlugin for BinaryPlugin {
                     }
                 }
             }
-            stderr_done_signal.notify_one();
         });
 
         // Every task that can still resolve readiness is owned HERE, not by the
@@ -347,9 +360,6 @@ impl ChainPlugin for BinaryPlugin {
                 probe_tx.clone(),
             ),
         };
-        // Drop `run`'s own sender: the reader is then the last holder, so the
-        // drain terminates once it has ended.
-        drop(probe_tx);
 
         // Wait for child exit or shutdown signal.
         //
@@ -364,8 +374,10 @@ impl ChainPlugin for BinaryPlugin {
         let drain_timeout = std::time::Duration::from_secs(5);
         tokio::select! {
             status = gc.child.wait() => {
-                let status = status?;
+                // Drain BEFORE inspecting `status`: readiness must be final on
+                // every exit from `run`, including a `wait()` that itself failed.
                 reap_and_drain(&mut gc, &probe_standdown, stdout_task, stderr_task, &mut probe_rx).await;
+                let status = status?;
                 if status.success() {
                     Ok(())
                 } else {
@@ -382,21 +394,25 @@ impl ChainPlugin for BinaryPlugin {
             }
             _ = shutdown.cancelled() => {
                 tracing::info!(plugin = %self.name, "shutting down");
-                // Force path force-kills the direct child; `gc` dropping at the
-                // end of `run` (or on task abort) reaps the whole tree.
-                shutdown::graceful_stop(&mut gc.child, drain_timeout).await?;
+                // Force path force-kills the direct child; `reap_and_drain` below
+                // takes the rest of the tree. Its result is held, not `?`-ed:
+                // readiness must be final on every exit from `run`, and
+                // `graceful_stop` is fallible (a Windows console-event error, an
+                // io error from wait/kill).
+                let stopped = shutdown::graceful_stop(&mut gc.child, drain_timeout).await;
                 reap_and_drain(&mut gc, &probe_standdown, stdout_task, stderr_task, &mut probe_rx).await;
-                Ok(())
+                stopped
             }
         }
     }
 }
 
 /// Reap the plugin's process tree, then wait for every task that can still
-/// resolve this plugin's readiness. Both `run` arms end here, so the guarantee
-/// — when `run` returns, the readiness outcome is FINAL — does not depend on
-/// which arm an already-dead child happened to be handled by (`select!` is
-/// unbiased).
+/// resolve this plugin's readiness. EVERY exit from `run` ends here — both
+/// `select!` arms and both their error paths — so the guarantee (when `run`
+/// returns, the readiness outcome is FINAL) depends neither on which arm an
+/// already-dead child was handled by (`select!` is unbiased) nor on the arm
+/// succeeding.
 ///
 /// **The reap is what makes the wait terminate.** A dead direct child does NOT
 /// close its stdout/stderr: any descendant that inherited its stdio holds a
@@ -423,7 +439,10 @@ async fn reap_and_drain(
     gc.kill_tree().await;
     probe_standdown.cancel();
     let _ = tokio::join!(stdout_task, stderr_task);
-    // Reachable only after the reader ended: it held the last sender.
+    // Close rather than rely on every sender having been dropped: the reader (the
+    // only task that spawns a probe mid-stream) has ended, so no send can still be
+    // coming, and `recv` then drains what is buffered and stops.
+    probes.close();
     while let Some(probe) = probes.recv().await {
         let _ = probe.await;
     }
@@ -475,8 +494,9 @@ fn spawn_shared_probe(
 /// a non-sitrep plugin (including one silent on stdout) is still readied by the
 /// probe. Non-event lines pass through to tracing as logs. On stdout EOF without
 /// ever sending, the sender drops unsent → the chain aggregator synthesizes a
-/// process-exit failure (the intended backstop) — bounded on `stderr_done` first
-/// (see its call site), so a crash whose last words land on stderr is not
+/// process-exit failure (the intended backstop) — waiting on `stderr_done` first
+/// (unbounded, on the same guarantor as this reader's own EOF: see
+/// [`reap_and_drain`]), so a crash whose last words land on stderr is not
 /// reported as if the plugin said nothing.
 #[allow(clippy::too_many_arguments)] // 9 args — bundling into a struct adds more noise than the warning.
 fn spawn_sitrep_stdout_reader(

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -873,6 +873,15 @@ fn spawn_run(
     (handle, ready_rx)
 }
 
+/// A listener the plugin's grandchild dials on startup. mock-plugin blocks on its
+/// own rendezvous before continuing, so accepting proves the pipe holder is alive
+/// and the test that uses it is not vacuous.
+async fn grandchild_control() -> (TcpListener, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    (listener, addr)
+}
+
 /// `run` must not return while a task that can still resolve readiness is alive.
 /// If it does, `record_exit` cancels the chain first and the outcome that task
 /// was about to produce — a typed `StartError` in the case this exists for — is
@@ -890,24 +899,19 @@ fn spawn_run(
 #[skuld::test]
 async fn run_drains_stdout_before_returning_with_a_pipe_holding_grandchild() {
     let mock_path = mock_plugin_path();
-
-    // The grandchild dials here on startup, and mock-plugin blocks on its own
-    // rendezvous before exiting — so accepting proves the pipe holder is alive
-    // and the setup is not vacuous.
-    let control_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let control_addr = control_listener.local_addr().unwrap();
+    let (control, control_addr) = grandchild_control().await;
 
     let local = free_loopback_addr().await;
     let (handle, mut ready_rx) = spawn_run(
         BinaryPlugin::new(&mock_path, None)
             .readiness(garter::binary::ReadinessMode::ExpectSitrep)
-            .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr.to_string())
+            .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr)
             .env("MOCK_PLUGIN_FAIL", "exit_silently"),
         local,
         "127.0.0.1:9".parse().unwrap(), // discard; never dialed
     );
 
-    let _held = control_listener
+    let _held = control
         .accept()
         .await
         .expect("grandchild should dial the control channel");
@@ -920,6 +924,122 @@ async fn run_drains_stdout_before_returning_with_a_pipe_holding_grandchild() {
     assert!(
         matches!(ready_rx.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
         "run returned while the stdout reader still owned the readiness sender"
+    );
+}
+
+/// `Auto` runs a self-probe that CO-OWNS the readiness sender from the start, so
+/// draining the reader alone leaves the outcome unresolved: with the child gone
+/// the probe would poll a listener that will never exist, holding its half of the
+/// sender forever. `run` must stand it down and wait for it too.
+///
+/// `MOCK_PLUGIN_NO_SITREP` keeps the probe in play — a supported `hello` would
+/// have stood it down early and the co-ownership would go untested.
+#[skuld::test]
+async fn auto_readiness_is_final_when_run_returns() {
+    let mock_path = mock_plugin_path();
+    let (control, control_addr) = grandchild_control().await;
+
+    let local = free_loopback_addr().await;
+    let (handle, mut ready_rx) = spawn_run(
+        BinaryPlugin::new(&mock_path, None)
+            .readiness(garter::binary::ReadinessMode::Auto)
+            .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr)
+            .env("MOCK_PLUGIN_NO_SITREP", "1")
+            .env("MOCK_PLUGIN_FAIL", "exit_silently"),
+        local,
+        "127.0.0.1:9".parse().unwrap(),
+    );
+
+    let _held = control
+        .accept()
+        .await
+        .expect("grandchild should dial the control channel");
+
+    let _ = handle.await.expect("plugin task panicked");
+    assert!(
+        matches!(ready_rx.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
+        "run returned while the Auto self-probe still co-owned the readiness sender"
+    );
+}
+
+/// The other place a probe takes co-ownership: an unknown sitrep MAJOR hands
+/// readiness to a tier-2 probe mid-stream, and the reader continues as a pure log
+/// drain. Same requirement as `Auto`, reached by a different route.
+#[skuld::test]
+async fn tier2_fallback_readiness_is_final_when_run_returns() {
+    let mock_path = mock_plugin_path();
+    let (control, control_addr) = grandchild_control().await;
+
+    let local = free_loopback_addr().await;
+    let (handle, mut ready_rx) = spawn_run(
+        BinaryPlugin::new(&mock_path, None)
+            .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+            .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr)
+            .env("MOCK_PLUGIN_BAD_PROTOCOL", "1")
+            .env("MOCK_PLUGIN_FAIL", "exit_silently"),
+        local,
+        "127.0.0.1:9".parse().unwrap(),
+    );
+
+    let _held = control
+        .accept()
+        .await
+        .expect("grandchild should dial the control channel");
+
+    let _ = handle.await.expect("plugin task panicked");
+    assert!(
+        matches!(ready_rx.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
+        "run returned while the tier-2 probe still co-owned the readiness sender"
+    );
+}
+
+/// The property #794/#795 rebuild on: the typed error a plugin emitted before
+/// dying is in its channel, and every line it wrote is in the sink, by the time
+/// `run` returns.
+///
+/// A guarantee pin, not a regression test — with no descendant holding the pipe
+/// the child's stdout EOFs immediately either way, so this passes against the
+/// bounded drain too. Coverage for the drain itself is the grandchild tests above.
+#[skuld::test]
+async fn typed_start_error_and_every_log_line_land_before_run_returns() {
+    let mock_path = mock_plugin_path();
+    let sunk: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_lines = sunk.clone();
+    let sink: garter::LogSink = Arc::new(move |line: &str| sink_lines.lock().unwrap().push(line.to_string()));
+
+    let local = free_loopback_addr().await;
+    let (handle, mut ready_rx) = spawn_run(
+        BinaryPlugin::new(&mock_path, None)
+            .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+            .env("MOCK_PLUGIN_FAIL", "bind_conflict")
+            .log_sink(sink),
+        local,
+        "127.0.0.1:9".parse().unwrap(),
+    );
+
+    let _ = handle.await.expect("plugin task panicked");
+    match ready_rx.try_recv() {
+        Ok(Err(garter::StartError::BindConflict { errno, addr })) => {
+            // Host-native errno (10048 / 98 / 48) — assert nonzero rather than a
+            // specific foreign constant.
+            assert_ne!(errno, 0, "bind_conflict errno should be the host-native value");
+            // mock-plugin reports the address the chain told it to bind, which in
+            // Client mode is what `run` was handed as `local`.
+            assert_eq!(
+                addr, local,
+                "bind_conflict should carry the plugin's own listen address"
+            );
+        }
+        other => panic!("expected a delivered BindConflict, got {other:?}"),
+    }
+    let sunk = sunk.lock().unwrap();
+    assert!(
+        sunk.iter().any(|l| l.contains(r#""event":"hello""#)),
+        "the sink must hold every line the child wrote; got {sunk:?}"
+    );
+    assert!(
+        sunk.iter().any(|l| l.contains(r#""event":"bind_conflict""#)),
+        "including the frame the sitrep parser consumed; got {sunk:?}"
     );
 }
 

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -3,6 +3,7 @@
 // sanctioned-test-file exception.
 #![allow(clippy::disallowed_methods)]
 
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -10,7 +11,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 
-use garter::{BinaryPlugin, ChainRunner, PluginEnv};
+use garter::{BinaryPlugin, ChainPlugin, ChainRunner, PluginEnv};
 use skuld::env;
 
 mod common;
@@ -841,6 +842,85 @@ async fn force_kill_reaps_descendant_tree() {
     }
 
     drop(echo_listener);
+}
+
+// Readiness finality ==================================================================================================
+
+/// Bind an ephemeral loopback port and release it: an address a plugin can be
+/// told to listen on.
+async fn free_loopback_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    addr
+}
+
+/// Drive ONE plugin through `ChainPlugin::run` directly rather than through
+/// `ChainRunner`, so the test owns the readiness receiver and can inspect it the
+/// instant `run` returns. The shutdown token is never cancelled, so every test
+/// built on this exercises the child-exit arm.
+fn spawn_run(
+    plugin: BinaryPlugin,
+    local: SocketAddr,
+    remote: SocketAddr,
+) -> (
+    tokio::task::JoinHandle<garter::Result<()>>,
+    oneshot::Receiver<Result<garter::PluginReady, garter::StartError>>,
+) {
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let handle = tokio::spawn(async move { Box::new(plugin).run(local, remote, shutdown, ready_tx).await });
+    (handle, ready_rx)
+}
+
+/// `run` must not return while a task that can still resolve readiness is alive.
+/// If it does, `record_exit` cancels the chain first and the outcome that task
+/// was about to produce — a typed `StartError` in the case this exists for — is
+/// lost.
+///
+/// The plugin spawns a grandchild that inherits its stdio and then exits after
+/// `hello` alone, so its stdout cannot EOF on the child's death: the reader
+/// resolves readiness only by dropping its sender at task end, which makes
+/// `Closed` (drained) and `Empty` (cut off mid-stream) distinguishable. This is
+/// also the hang proof — a drain waiting on an EOF the grandchild is withholding
+/// never returns.
+///
+/// `try_recv` needs no await guard: on skuld's current-thread runtime nothing can
+/// poll the reader task between the plugin task completing and this assertion.
+#[skuld::test]
+async fn run_drains_stdout_before_returning_with_a_pipe_holding_grandchild() {
+    let mock_path = mock_plugin_path();
+
+    // The grandchild dials here on startup, and mock-plugin blocks on its own
+    // rendezvous before exiting — so accepting proves the pipe holder is alive
+    // and the setup is not vacuous.
+    let control_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let control_addr = control_listener.local_addr().unwrap();
+
+    let local = free_loopback_addr().await;
+    let (handle, mut ready_rx) = spawn_run(
+        BinaryPlugin::new(&mock_path, None)
+            .readiness(garter::binary::ReadinessMode::ExpectSitrep)
+            .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr.to_string())
+            .env("MOCK_PLUGIN_FAIL", "exit_silently"),
+        local,
+        "127.0.0.1:9".parse().unwrap(), // discard; never dialed
+    );
+
+    let _held = control_listener
+        .accept()
+        .await
+        .expect("grandchild should dial the control channel");
+
+    let run_result = handle.await.expect("plugin task panicked");
+    assert!(
+        matches!(run_result, Err(garter::Error::PluginExit { code: 1, .. })),
+        "the plugin exits 1 after hello; got {run_result:?}"
+    );
+    assert!(
+        matches!(ready_rx.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
+        "run returned while the stdout reader still owned the readiness sender"
+    );
 }
 
 // Install the workspace test subscriber + panic hook. See

--- a/crates/garter/tests/chain_integration.rs
+++ b/crates/garter/tests/chain_integration.rs
@@ -927,6 +927,38 @@ async fn run_drains_stdout_before_returning_with_a_pipe_holding_grandchild() {
     );
 }
 
+/// `Probe` is the default mode and the bridge's mode for unknown plugins, and it
+/// is the one shape where the reader touches readiness not at all: the sender
+/// lives in the self-probe task outright. Draining the reader therefore proves
+/// nothing here — only waiting for the probe does.
+#[skuld::test]
+async fn probe_readiness_is_final_when_run_returns() {
+    let mock_path = mock_plugin_path();
+    let (control, control_addr) = grandchild_control().await;
+
+    let local = free_loopback_addr().await;
+    let (handle, mut ready_rx) = spawn_run(
+        // No `.readiness(..)`: `Probe` is the default, and asserting it here
+        // would hide a default change rather than exercise it.
+        BinaryPlugin::new(&mock_path, None)
+            .env("MOCK_PLUGIN_SPAWN_GRANDCHILD", control_addr)
+            .env("MOCK_PLUGIN_FAIL", "exit_silently"),
+        local,
+        "127.0.0.1:9".parse().unwrap(),
+    );
+
+    let _held = control
+        .accept()
+        .await
+        .expect("grandchild should dial the control channel");
+
+    let _ = handle.await.expect("plugin task panicked");
+    assert!(
+        matches!(ready_rx.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
+        "run returned while the Probe-mode self-probe still owned the readiness sender"
+    );
+}
+
 /// `Auto` runs a self-probe that CO-OWNS the readiness sender from the start, so
 /// draining the reader alone leaves the outcome unresolved: with the child gone
 /// the probe would poll a listener that will never exist, holding its half of the
@@ -993,7 +1025,7 @@ async fn tier2_fallback_readiness_is_final_when_run_returns() {
     );
 }
 
-/// The property #794/#795 rebuild on: the typed error a plugin emitted before
+/// The property bindreams/hole#794 and #795 rebuild on: the typed error a plugin emitted before
 /// dying is in its channel, and every line it wrote is in the sink, by the time
 /// `run` returns.
 ///

--- a/crates/kill-group/src/grouped_child.rs
+++ b/crates/kill-group/src/grouped_child.rs
@@ -390,15 +390,17 @@ mod imp {
     fn assign_to_kill_on_close_job(child: &Child) -> Option<HANDLE> {
         // Every failure here degrades tree-reaping to just the direct child
         // (`kill_on_drop`), which would re-orphan grandchildren — so log loudly.
+        // An orphan holding an inherited stdio pipe also blocks any caller that
+        // waits for that pipe to EOF, so the warning names that consequence too.
         let Some(raw) = child.raw_handle() else {
-            tracing::warn!("kill-group: child has no raw handle; process-tree reaping disabled");
+            tracing::warn!("kill-group: child has no raw handle; process-tree reaping disabled (a descendant can keep a pipe open, blocking a caller that waits for EOF)");
             return None;
         };
         unsafe {
             let job = match CreateJobObjectW(None, windows::core::PCWSTR::null()) {
                 Ok(j) => j,
                 Err(e) => {
-                    tracing::warn!(error = %e, "kill-group: CreateJobObjectW failed; process-tree reaping disabled");
+                    tracing::warn!(error = %e, "kill-group: CreateJobObjectW failed; process-tree reaping disabled (a descendant can keep a pipe open, blocking a caller that waits for EOF)");
                     return None;
                 }
             };
@@ -410,12 +412,12 @@ mod imp {
                 std::ptr::addr_of!(info).cast(),
                 std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
             ) {
-                tracing::warn!(error = %e, "kill-group: SetInformationJobObject failed; process-tree reaping disabled");
+                tracing::warn!(error = %e, "kill-group: SetInformationJobObject failed; process-tree reaping disabled (a descendant can keep a pipe open, blocking a caller that waits for EOF)");
                 let _ = CloseHandle(job);
                 return None;
             }
             if let Err(e) = AssignProcessToJobObject(job, HANDLE(raw)) {
-                tracing::warn!(error = %e, "kill-group: AssignProcessToJobObject failed; process-tree reaping disabled");
+                tracing::warn!(error = %e, "kill-group: AssignProcessToJobObject failed; process-tree reaping disabled (a descendant can keep a pipe open, blocking a caller that waits for EOF)");
                 let _ = CloseHandle(job);
                 return None;
             }

--- a/crates/kill-group/src/grouped_child.rs
+++ b/crates/kill-group/src/grouped_child.rs
@@ -136,8 +136,13 @@ impl GroupedChild {
         imp::signal_group_term(self)
     }
 
-    /// Hard-kill the whole tree and reap the direct child. Safe to call after
-    /// the child already exited.
+    /// Hard-kill the whole tree and reap the direct child. Callable after the
+    /// child already exited — with one Unix caveat it shares with
+    /// [`term_group`]: the group id IS the leader's pid, so once the leader has
+    /// been reaped AND no descendant is left in the group, the id is free for
+    /// reuse and `kill(-pgid)` could reach an unrelated group. While any
+    /// descendant remains — the only case where the group kill has anything to
+    /// do — the group is still alive and its id is still pinned.
     pub async fn kill_tree(&mut self) {
         // Errors ignored: the child may already be gone, which is the goal state.
         self.group.kill();


### PR DESCRIPTION
Closes #810.

`BinaryPlugin::run` joined its stdout reader under a 100 ms budget after the child exited, so a
plugin's typed `StartError` could be cut off before it reached the readiness channel. That is what
left PR #807's readiness deferral best-effort rather than exact.

## The issue's stated precondition is false

The proposed fix was to join `stdout_task` unbounded, on the grounds that "the child has already
exited, so its stdout pipe is closed and the reader must observe EOF." The child *is* always dead
at that point — on all four paths into the join — but the pipe is not closed: any descendant that
inherited the plugin's stdio holds a duplicate of the write end. That is the #197 shape, and
`kill-group`'s own module doc already says it (*"the orphan also inherits the host's stdout/stderr
pipe handles, so the host's pipe-reader never EOFs"*), as does `drain_remaining_logs`, which states
the real rule: EOF is guaranteed *"when the child (and its tree) is reaped."*

Joined unbounded on that assumption, the child-exit arm would wedge the whole chain: nothing has
cancelled `shutdown` yet, so `ChainRunner::run`'s Phase 1 blocks on `set.join_next()` with no cancel
arm and never reaches Phase 2's drain budget.

So the fix *establishes* the precondition instead of assuming it: `GroupedChild::kill_tree()` first,
then wait. The reap is not new behaviour — `run` returning drops `gc`, which reaps the tree
unconditionally; this only orders the reap ahead of the drain instead of after it.

## `stdout_task` was also the wrong terminator

Joining the reader does not resolve readiness in three of the four shapes. In `Probe` (the
`BinaryPlugin::new` default) the sender is owned by a separate self-probe task outright; in `Auto`
and in `ExpectSitrep` after a `FallBackToTier2` handoff, a probe *co-owns* it through `SharedReady`.
Joining the reader drops one `Arc` and the sender survives in a task that, on the child-exit arm,
keeps looping in `poll_ready` forever.

`run` therefore owns the probe standdown token and every probe handle, and the invariant is stated
as what it actually is: **when `run` returns, this plugin's readiness outcome is final.**

## Scope

- **Every exit from `run`** gets the reap-then-drain — both `select!` arms *and* both their error
  paths (`child.wait()` failing, `graceful_stop` failing, which on Windows it genuinely can). One arm
  would not have been enough: `select!` is unbiased, so a sibling's exit can route an already-dead
  plugin to the `shutdown.cancelled()` arm. Adding `biased;` toward `child.wait()` is not an
  alternative — it would turn a clean cancel's `Ok(())` into `Err(PluginKilled)`.
- **The reader's release signal is panic-safe.** `stderr_done` now fires from a drop guard, so a
  `LogSink` or subscriber that panics (the bridge's own sink takes a mutex it `expect`s on) releases
  the reader instead of parking it against a signal that can no longer come.
- **The reader's internal 100 ms `stderr_done` wait is dropped too.** It is reached only after stdout
  EOF, which is itself downstream of the reap, so under this change it has the same guarantor — and
  a Go panic dump under `GOTRACEBACK=crash`, the case it exists for, can overrun a 100 ms budget. A
  plugin that closes stdout while still alive now parks there instead of reporting an exit it has not
  made. `a_crash_on_stderr_reaches_the_ring_before_the_chain_reports_failure` covers the ordering.
- **Cancel latency** stops being capped at 100 ms and becomes "as long as the buffered output takes
  to drain" — bounded by volume once the write ends are closed.

## Residual

`kill_tree` closes write ends only inside *this* spawn's kill-group. A nested spawn (no group of its
own), a Windows job already logged as degraded, or a descendant that `setsid()`s away can still hold
one, and the drain would block. Only the first is production-reachable — galoshes runs a nested
garter — and it is inert unless ex-ray grows a subprocess, which would be a deliberate change. The
disposition is written at the join site rather than only here, and the four kill-group warnings that
log the degraded case now name the new consequence. Removing the residual properly needs a "what
containment did I actually achieve" answer from the spawn itself, which is #816.

## Tests

- `run_drains_stdout_before_returning_with_a_pipe_holding_grandchild` — the structural red. A plugin
  spawns a stdio-inheriting grandchild and exits after `hello` alone, so its stdout cannot EOF on the
  child's death and `Closed` (drained) is distinguishable from `Empty` (cut off). Fails pre-fix on
  exactly that assertion. It is also the hang proof: a drain waiting on the withheld EOF never
  returns.
- `auto_readiness_is_final_when_run_returns` and `tier2_fallback_readiness_is_final_when_run_returns`
  — the probe co-ownership, reached by its two routes. Both fail pre-fix; both would hang if `run`
  joined the probe without standing it down.
- `typed_start_error_and_every_log_line_land_before_run_returns` — a guarantee pin, documented as
  such: with no descendant holding the pipe it passes either way.
- mock-plugin gains a parent↔grandchild rendezvous. `spawn` returns before the grandchild has run an
  instruction, so without it a plugin that exits immediately afterwards races its own grandchild's
  startup — process-startup timing as a sync point.

Every assertion is a `try_recv` with no intervening await, on skuld's current-thread runtime. No
timer, no poll, no sleep anywhere in the change.

`cargo nextest run -p garter -p galoshes -p kill-group` (251 tests) and
`cargo nextest run -p hole-bridge --test plugin_chain` all pass, including the full
`chain_integration` suite the item flagged as resting on the 100 ms property.
