### PR TITLE
fix(bridge): report and release a kill-switch lockout instead of stranding the user

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,9 @@ nextest-version = "0.9.130"
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #   - `failclosed_permits_` (transient block-until-connected cover real engage):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+#   - `lockdown_lockout_` prefix (#825 kill-switch lockout escape):
+#     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+#     crates/bridge/tests/lockout_privileged.rs (crash -> probe -> release e2e)
 #   - `cutover_global_net_state_` prefix:
 #     crates/bridge/tests/cutover_privileged.rs (real cutover swap + SCM restart)
 #     crates/bridge/tests/cutover_leak_privileged.rs (fail-open + both-covers)
@@ -36,5 +39,5 @@ nextest-version = "0.9.130"
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/cutover_global_net_state_/)'
+filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/lockdown_lockout_/) + test(/cutover_global_net_state_/)'
 test-group = 'global-net-state'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,7 +24,7 @@ nextest-version = "0.9.130"
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #   - `failclosed_permits_` (transient block-until-connected cover real engage):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
-#   - `lockdown_lockout_` prefix (#825 kill-switch lockout escape):
+#   - `lockdown_lockout_` prefix (kill-switch lockout: crash -> probe -> release):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #     crates/bridge/tests/lockout_privileged.rs (crash -> probe -> release e2e)
 #   - `cutover_global_net_state_` prefix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,11 @@ before editing; the sections linked below are the authoritative source.
   (auto-connect) start whose lockdown intent is OFF; a lockdown-on covered
   start uses the standing cover instead and releases any held transient one.
   Both are persistent WFP filters (Win) / self-contained pf ruleset (mac), swept
-  by `recover_routes` on next start. →
+  by `recover_routes` on next start. Whether a cover is engaged is an OS probe
+  (`failclosed::lockdown_cover_state`, three-state — an unanswerable probe counts
+  as engaged), never derived from a running session; `held_closed` names a cover
+  no session owns, and turning the intent off releases that one immediately,
+  disengage-verified-by-re-probe before the intent flips. →
   [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)
 - **Logging & plugin diagnostics.** Log destinations, the WebView2/console-relay
   tee, `HOLE_BRIDGE_LOG` directives, and the plugin tap. →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,8 @@ before editing; the sections linked below are the authoritative source.
   (auto-connect) start whose lockdown intent is OFF; a lockdown-on covered
   start uses the standing cover instead and releases any held transient one.
   Both are persistent WFP filters (Win) / self-contained pf ruleset (mac), swept
-  by `recover_routes` on next start. Whether a cover is engaged is an OS probe
-  (`failclosed::lockdown_cover_state`, three-state — an unanswerable probe counts
-  as engaged), never derived from a running session; `held_closed` names a cover
-  no session owns, and turning the intent off releases that one immediately,
-  disengage-verified-by-re-probe before the intent flips. →
+  by `recover_routes` on next start. Whether a cover is engaged is an OS probe,
+  never derived from a running session. →
   [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)
 - **Logging & plugin diagnostics.** Log destinations, the WebView2/console-relay
   tee, `HOLE_BRIDGE_LOG` directives, and the plugin tap. →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -601,12 +601,57 @@ pre-lockdown pf snapshot in `bridge-lockdown-pf.json` so Sweep restores the host
 without `-Fa`. The LUID is **never persisted** (a teardown mints a new one) —
 re-resolved every engage via `LuidResolver`.
 
-`hole bridge unlock` is the elevated escape hatch to disengage a standing cover
-when no bridge is alive (`cutover::unlock`). Unlike the best-effort startup
-Sweep, it is **fail-loud**: it disengages via `failclosed::disengage_lockdown`
-FIRST and flips the intent off only on confirmed success, returning a non-zero
-exit otherwise (e.g. run unprivileged). A swallowed failure would leave the
-cover engaged — egress still blocked — while the intent read "off".
+#### Cover state is an OS fact
+
+`lockdown_active` is `failclosed::lockdown_cover_state`, a three-state probe of
+the OS (`Engaged` / `Absent` / `Unknown`), never derived from a running session —
+a cover adopted from a crashed run is owned by no process, so a session-derived
+signal reports it as absent while it drops every packet. A session that owns the
+cover short-circuits the probe; nothing else does. `Unknown` (WFP engine open
+failed, `pfctl` unreadable) counts as engaged: the escape affordance keys on this
+field, and an all-clear we did not observe is the same lockout by another route.
+
+Two questions, two functions. `lockdown_cover_present` feeds the recovery
+decision — "is there prior-run state to reconcile?" — and stays lenient on macOS
+(the state file alone), because pf is disabled and flushed across a reboot while
+`bridge-lockdown-pf.json` survives, and a stricter test would make `Sweep` skip
+the file it exists to clear. `lockdown_cover_state` answers "is the host held
+closed right now?" and reads pf for real. On Windows the two coincide: persistent
+filters, so anything present is in force.
+
+`held_closed` (`StatusResponse`) is a cover engaged that **no running session
+owns** — deliberately not `lockdown_active && !running`. Intent off plus a cover
+a failed startup `Sweep` left behind, then a connect: `start_inner` skips
+`install_lockdown`, so `running` is true while the stale block-all kills every
+packet.
+
+#### Releasing a stuck cover
+
+Turning the intent off releases a cover no live session owns, immediately —
+`recover_routes` at the next startup is too late for a user whose network is
+already dead. Ordering mirrors `cutover::unlock_with`: disengage FIRST, persist
+`false` only on confirmed success, so the setting can never read "off" over a
+blocked host. `disengage_lockdown`'s `Ok` is itself backed by a **re-probe**, not
+by a return code: the Windows path used to discard every `FwpmFilterDeleteByKey0`
+result, and the FWPM engine opens without elevation, so an unprivileged unlock
+reported success while deleting nothing.
+
+The release is skipped when the probe confirms `Absent`. Doing it unconditionally
+would make disarming the switch on a clean host fail whenever the firewall is
+unreachable — a fresh way into the lockout. A cover a live session owns is left
+to `stop_with`: settings apply on reconnect.
+
+Escape ladder, in order: the tray's **Unblock Network**, Connect, then
+`hole bridge unlock`.
+
+`hole bridge unlock` is the elevated escape hatch to clear a cover when no bridge
+is alive (`cutover::unlock`). Unlike the best-effort startup Sweep, it is
+**fail-loud**: it disengages via `failclosed::disengage_lockdown` FIRST and flips
+the intent off only on confirmed success, returning a non-zero exit otherwise. A
+swallowed failure would leave the cover engaged — egress still blocked — while
+the intent read "off". It sweeps the **transient** cover too: a crash can strand
+that one as well, and this command exists for the case where no bridge starts to
+sweep it, so clearing a subset would leave the user with no way out at all.
 
 ### Update cutover
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ The GUI is the primary interface; these CLI commands are also available:
 | `hole version`                       | Print version information                        |
 | `hole upgrade`                       | Check for updates and install the latest version |
 | `hole path add` / `hole path remove` | Add / remove `hole` from the system PATH         |
+| `hole bridge unlock`                 | Unblock the network if the kill switch is stuck  |
+
+### If your network is blocked
+
+Hole's kill switch deliberately keeps blocking after a crash — that is the moment
+a leak matters most. Normally the tray offers **Unblock Network**, or connecting
+again restores service. If Hole will not start at all, clear the block from an
+elevated terminal:
+
+```sh
+hole bridge unlock          # Windows: run the terminal as Administrator
+sudo hole bridge unlock     # macOS
+```
+
+It fails loudly rather than pretending: if it reports success, your network is
+open.
 
 ## Distributions
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -268,4 +268,8 @@ allow-invalid = true
 [[disallowed-methods]]
 path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFreeMemory0"
 reason = "Lockdown cover App-ID blob free must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See #527."
+
+[[disallowed-methods]]
+path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFilterGetByKey0"
+reason = "The lockdown-cover presence probe must go through `routing::failclosed::lockdown_cover_state`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#825."
 allow-invalid = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -268,8 +268,9 @@ allow-invalid = true
 [[disallowed-methods]]
 path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFreeMemory0"
 reason = "Lockdown cover App-ID blob free must go through `routing::failclosed`. Only `failclosed/windows.rs` may call FWPM. See #527."
+allow-invalid = true
 
 [[disallowed-methods]]
 path = "windows::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFilterGetByKey0"
-reason = "The lockdown-cover presence probe must go through `routing::failclosed::lockdown_cover_state`. Only `failclosed/windows.rs` may call FWPM. See bindreams/hole#825."
+reason = "The lockdown-cover presence probe must go through `routing::failclosed::lockdown_cover_state`. Only `failclosed/windows.rs` may call FWPM. See #825."
 allow-invalid = true

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -204,6 +204,11 @@ harness = false
 # Privileged-lane cutover LEAK proofs (real WFP/pf engage + egress probes:
 # Mullvad-#8470 fail-open, both-covers recovery).
 [[test]]
+name = "lockout_privileged"
+path = "tests/lockout_privileged.rs"
+harness = false
+
+[[test]]
 name = "cutover_leak_privileged"
 path = "tests/cutover_leak_privileged.rs"
 harness = false

--- a/crates/bridge/src/cutover.rs
+++ b/crates/bridge/src/cutover.rs
@@ -113,24 +113,39 @@ pub fn run_detached(_payload: &Path, _target_version: &str) -> std::io::Result<(
     ))
 }
 
-/// Disengage a standing lockdown cover and clear the persisted intent, with no
-/// running bridge required. The escape hatch must actually disengage or FAIL
-/// LOUD: it disengages FIRST and only flips the intent off after a confirmed
-/// success. A swallowed failure (e.g. run unprivileged) would leave the cover
-/// engaged — egress still blocked — while the intent reads "off", misleading the
-/// user.
+/// Disengage EVERY cover capable of holding the host closed and clear the
+/// persisted intent, with no running bridge required. The escape hatch must
+/// actually disengage or FAIL LOUD: it disengages FIRST and only flips the intent
+/// off after a confirmed success. A swallowed failure (e.g. a delete the firewall
+/// refused) would leave the cover engaged — egress still blocked — while the
+/// intent reads "off", misleading the user.
+///
+/// Both covers, not just the standing one: a crash can also strand the TRANSIENT
+/// block-until-connected cover, and while the next bridge start sweeps it, this
+/// command exists precisely for the case where no bridge starts. Clearing a
+/// subset of what can block the host would leave a user with no way out at all.
+/// The transient sweep is best-effort by signature, so the fail-loud contract
+/// stays keyed on the standing disengage.
 pub fn unlock() -> std::io::Result<()> {
     let state_dir = service_state_dir();
-    unlock_with(&state_dir, || {
-        tun_engine::routing::failclosed::disengage_lockdown(&state_dir).map_err(std::io::Error::other)
-    })
+    unlock_with(
+        &state_dir,
+        || tun_engine::routing::failclosed::disengage_lockdown(&state_dir).map_err(std::io::Error::other),
+        || tun_engine::routing::failclosed::recover_cover(&state_dir, false),
+    )
 }
 
-/// `unlock`'s ordering, with the disengage step injected so tests can drive the
-/// cannot-disengage path without touching the host firewall. Disengage → flip;
-/// the intent flips off ONLY after the disengage confirms success.
-fn unlock_with(state_dir: &Path, disengage: impl FnOnce() -> std::io::Result<()>) -> std::io::Result<()> {
+/// `unlock`'s ordering, with both effects injected so tests can drive the
+/// cannot-disengage path without touching the host firewall. Standing disengage →
+/// transient sweep → flip; the intent flips off ONLY after the standing disengage
+/// confirms success.
+fn unlock_with(
+    state_dir: &Path,
+    disengage: impl FnOnce() -> std::io::Result<()>,
+    sweep_transient: impl FnOnce(),
+) -> std::io::Result<()> {
     disengage()?;
+    sweep_transient();
     tun_engine::routing::failclosed::lockdown_state::set_enabled(state_dir, false, None)
 }
 

--- a/crates/bridge/src/cutover.rs
+++ b/crates/bridge/src/cutover.rs
@@ -124,28 +124,29 @@ pub fn run_detached(_payload: &Path, _target_version: &str) -> std::io::Result<(
 /// block-until-connected cover, and while the next bridge start sweeps it, this
 /// command exists precisely for the case where no bridge starts. Clearing a
 /// subset of what can block the host would leave a user with no way out at all.
-/// The transient sweep is best-effort by signature, so the fail-loud contract
-/// stays keyed on the standing disengage.
+/// BOTH sweeps are fail-loud — a silently-failed transient sweep would let this
+/// exit 0 over a still-blocked host, which is exactly the promise it must not
+/// break.
 pub fn unlock() -> std::io::Result<()> {
     let state_dir = service_state_dir();
     unlock_with(
         &state_dir,
         || tun_engine::routing::failclosed::disengage_lockdown(&state_dir).map_err(std::io::Error::other),
-        || tun_engine::routing::failclosed::recover_cover(&state_dir, false),
+        || tun_engine::routing::failclosed::sweep_transient_verified(&state_dir).map_err(std::io::Error::other),
     )
 }
 
 /// `unlock`'s ordering, with both effects injected so tests can drive the
-/// cannot-disengage path without touching the host firewall. Standing disengage →
-/// transient sweep → flip; the intent flips off ONLY after the standing disengage
-/// confirms success.
+/// cannot-clear paths without touching the host firewall. Standing disengage →
+/// transient sweep → flip; the intent flips off ONLY after BOTH confirm success,
+/// so it can never read "off" over a cover either step failed to clear.
 fn unlock_with(
     state_dir: &Path,
     disengage: impl FnOnce() -> std::io::Result<()>,
-    sweep_transient: impl FnOnce(),
+    sweep_transient: impl FnOnce() -> std::io::Result<()>,
 ) -> std::io::Result<()> {
     disengage()?;
-    sweep_transient();
+    sweep_transient()?;
     tun_engine::routing::failclosed::lockdown_state::set_enabled(state_dir, false, None)
 }
 

--- a/crates/bridge/src/cutover_tests.rs
+++ b/crates/bridge/src/cutover_tests.rs
@@ -26,7 +26,10 @@ fn unlock_failing_disengage_does_not_flip_intent() {
     let result = unlock_with(
         dir.path(),
         || Err(std::io::Error::other("cannot disengage / not elevated")),
-        || swept = true,
+        || {
+            swept = true;
+            Ok(())
+        },
     );
 
     assert!(result.is_err(), "unlock must fail loud when it cannot disengage");
@@ -41,12 +44,40 @@ fn unlock_failing_disengage_does_not_flip_intent() {
 }
 
 #[skuld::test]
+fn unlock_failing_transient_sweep_does_not_flip_intent() {
+    // `unlock` promises the user that success means their network is open. A
+    // transient cover it could not clear must fail the command, not exit 0 over a
+    // still-blocked host — this is their last remedy.
+    let dir = tempfile::tempdir().unwrap();
+    lockdown_state::set_enabled(dir.path(), true, None).unwrap();
+
+    let result = unlock_with(
+        dir.path(),
+        || Ok(()),
+        || Err(std::io::Error::other("transient cover still engaged")),
+    );
+
+    assert!(result.is_err(), "a transient sweep that failed must fail the command");
+    assert!(
+        lockdown_state::load_enabled(dir.path()),
+        "intent must stay ON while any cover may still be holding the host"
+    );
+}
+
+#[skuld::test]
 fn unlock_successful_disengage_flips_intent_off() {
     let dir = tempfile::tempdir().unwrap();
     lockdown_state::set_enabled(dir.path(), true, None).unwrap();
 
     let mut swept = false;
-    let result = unlock_with(dir.path(), || Ok(()), || swept = true);
+    let result = unlock_with(
+        dir.path(),
+        || Ok(()),
+        || {
+            swept = true;
+            Ok(())
+        },
+    );
 
     assert!(result.is_ok());
     assert!(

--- a/crates/bridge/src/cutover_tests.rs
+++ b/crates/bridge/src/cutover_tests.rs
@@ -22,11 +22,18 @@ fn unlock_failing_disengage_does_not_flip_intent() {
     let dir = tempfile::tempdir().unwrap();
     lockdown_state::set_enabled(dir.path(), true, None).unwrap();
 
-    let result = unlock_with(dir.path(), || {
-        Err(std::io::Error::other("cannot disengage / not elevated"))
-    });
+    let mut swept = false;
+    let result = unlock_with(
+        dir.path(),
+        || Err(std::io::Error::other("cannot disengage / not elevated")),
+        || swept = true,
+    );
 
     assert!(result.is_err(), "unlock must fail loud when it cannot disengage");
+    assert!(
+        !swept,
+        "a standing disengage that failed must short-circuit before anything claims success"
+    );
     assert!(
         lockdown_state::load_enabled(dir.path()),
         "intent must stay ON when the cover could not be disengaged"
@@ -38,9 +45,14 @@ fn unlock_successful_disengage_flips_intent_off() {
     let dir = tempfile::tempdir().unwrap();
     lockdown_state::set_enabled(dir.path(), true, None).unwrap();
 
-    let result = unlock_with(dir.path(), || Ok(()));
+    let mut swept = false;
+    let result = unlock_with(dir.path(), || Ok(()), || swept = true);
 
     assert!(result.is_ok());
+    assert!(
+        swept,
+        "unlock must also sweep a leftover transient cover: it is the only escape when no bridge starts"
+    );
     assert!(
         !lockdown_state::load_enabled(dir.path()),
         "intent flips off only after a confirmed disengage"

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -148,6 +148,14 @@ impl Routing for StubRouting {
     fn install_lockdown(&self, _: IpAddr, _: &str, _: &[PathBuf]) -> Result<StubCover, RoutingError> {
         Ok(StubCover)
     }
+
+    fn lockdown_cover_state(&self) -> tun_engine::routing::failclosed::CoverState {
+        tun_engine::routing::failclosed::CoverState::Absent
+    }
+
+    fn disengage_lockdown(&self) -> Result<(), RoutingError> {
+        Ok(())
+    }
 }
 
 struct StubRoutes {

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -156,6 +156,14 @@ impl Routing for StubRouting {
     fn disengage_lockdown(&self) -> Result<(), RoutingError> {
         Ok(())
     }
+
+    fn transient_cover_state(&self) -> tun_engine::routing::failclosed::CoverState {
+        tun_engine::routing::failclosed::CoverState::Absent
+    }
+
+    fn sweep_transient(&self) -> Result<(), RoutingError> {
+        Ok(())
+    }
 }
 
 struct StubRoutes {

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -280,9 +280,10 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
 ) -> Json<StatusResponse> {
     let mut pm = state.proxy.lock().await;
     pm.check_health();
-    // One probe, so both flags describe the same instant: the firewall is not
-    // under this lock, and a concurrent `hole bridge unlock` between two reads
-    // would yield a pair no real state produces.
+    // One call, so every cover flag in a reply comes from the same pass: each
+    // cover is probed at most once and the flags are derived together. The
+    // firewall is not under this lock, so reading them independently would let a
+    // concurrent `hole bridge unlock` produce a pair no real state produces.
     let cover = pm.cover_status();
     Json(StatusResponse {
         running: pm.state() == ProxyState::Running,

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -293,6 +293,7 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
         ipv6_bypass_available: pm.ipv6_bypass_available(),
         lockdown_enabled: pm.lockdown_enabled(),
         lockdown_active: pm.lockdown_active(),
+        held_closed: pm.held_closed(),
         blocked_until_connected: pm.blocked_until_connected(),
     })
 }
@@ -425,8 +426,20 @@ async fn handle_cancel<P: Proxy + 'static, R: Routing + 'static>(
 
 /// Set the standing kill switch intent (last-writer-wins absolute set). Any
 /// authorized caller may toggle it. The bridge is the authority; the GUI only
-/// sends intent. The intent takes effect on the next start/stop — this handler
-/// does NOT engage/disengage a live cover.
+/// sends intent.
+///
+/// An OFF intent also RELEASES a standing cover no live session owns, so a user
+/// held offline by a cover adopted from a crashed run is not told to wait for
+/// the next bridge start. A cover a live session owns is left to `stop_with`:
+/// settings apply on reconnect. A 500 means the host may STILL be blocked — the
+/// intent is deliberately not recorded as off in that case.
+/// PII-free client-facing failure for `POST /v1/lockdown`. Covers both halves —
+/// a cover that would not release and an intent that would not persist — because
+/// the user's next move is the same either way, and the distinguishing detail is
+/// exactly the part that carries paths.
+pub(crate) const LOCKDOWN_SET_FAILED: &str =
+    "Hole could not change the kill switch. If your network is blocked, run `hole bridge unlock` as an administrator.";
+
 async fn handle_lockdown<P: Proxy + 'static, R: Routing + 'static>(
     State(state): State<Arc<IpcState<P, R>>>,
     Json(req): Json<LockdownRequest>,
@@ -438,10 +451,15 @@ async fn handle_lockdown<P: Proxy + 'static, R: Routing + 'static>(
             Ok(Json(EmptyResponse {}))
         }
         Err(e) => {
+            // The detail can name the state file or a pfctl invocation, and an IPC
+            // message reaches a GUI toast verbatim (#470) — log it, send a
+            // path-free sentence the user can act on.
             error!(error = %e, "failed to set lockdown intent");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse { message: e.to_string() }),
+                Json(ErrorResponse {
+                    message: LOCKDOWN_SET_FAILED.to_string(),
+                }),
             ))
         }
     }

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -280,6 +280,10 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
 ) -> Json<StatusResponse> {
     let mut pm = state.proxy.lock().await;
     pm.check_health();
+    // One probe, so both flags describe the same instant: the firewall is not
+    // under this lock, and a concurrent `hole bridge unlock` between two reads
+    // would yield a pair no real state produces.
+    let (lockdown_active, held_closed) = pm.cover_status();
     Json(StatusResponse {
         running: pm.state() == ProxyState::Running,
         uptime_secs: pm.uptime_secs(),
@@ -292,8 +296,8 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
         udp_proxy_available: pm.udp_proxy_available(),
         ipv6_bypass_available: pm.ipv6_bypass_available(),
         lockdown_enabled: pm.lockdown_enabled(),
-        lockdown_active: pm.lockdown_active(),
-        held_closed: pm.held_closed(),
+        lockdown_active,
+        held_closed,
         blocked_until_connected: pm.blocked_until_connected(),
     })
 }
@@ -424,6 +428,13 @@ async fn handle_cancel<P: Proxy + 'static, R: Routing + 'static>(
     Json(EmptyResponse {})
 }
 
+/// PII-free client-facing failure for `POST /v1/lockdown`. Covers both halves —
+/// a cover that would not release and an intent that would not persist — because
+/// the user's next move is the same either way, and the distinguishing detail is
+/// exactly the part that carries paths.
+pub(crate) const LOCKDOWN_SET_FAILED: &str =
+    "Hole could not change the kill switch. If your network is blocked, run `hole bridge unlock` as an administrator.";
+
 /// Set the standing kill switch intent (last-writer-wins absolute set). Any
 /// authorized caller may toggle it. The bridge is the authority; the GUI only
 /// sends intent.
@@ -433,13 +444,6 @@ async fn handle_cancel<P: Proxy + 'static, R: Routing + 'static>(
 /// the next bridge start. A cover a live session owns is left to `stop_with`:
 /// settings apply on reconnect. A 500 means the host may STILL be blocked — the
 /// intent is deliberately not recorded as off in that case.
-/// PII-free client-facing failure for `POST /v1/lockdown`. Covers both halves —
-/// a cover that would not release and an intent that would not persist — because
-/// the user's next move is the same either way, and the distinguishing detail is
-/// exactly the part that carries paths.
-pub(crate) const LOCKDOWN_SET_FAILED: &str =
-    "Hole could not change the kill switch. If your network is blocked, run `hole bridge unlock` as an administrator.";
-
 async fn handle_lockdown<P: Proxy + 'static, R: Routing + 'static>(
     State(state): State<Arc<IpcState<P, R>>>,
     Json(req): Json<LockdownRequest>,

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -283,7 +283,7 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
     // One probe, so both flags describe the same instant: the firewall is not
     // under this lock, and a concurrent `hole bridge unlock` between two reads
     // would yield a pair no real state produces.
-    let (lockdown_active, held_closed) = pm.cover_status();
+    let cover = pm.cover_status();
     Json(StatusResponse {
         running: pm.state() == ProxyState::Running,
         uptime_secs: pm.uptime_secs(),
@@ -296,8 +296,9 @@ async fn handle_status<P: Proxy + 'static, R: Routing + 'static>(
         udp_proxy_available: pm.udp_proxy_available(),
         ipv6_bypass_available: pm.ipv6_bypass_available(),
         lockdown_enabled: pm.lockdown_enabled(),
-        lockdown_active,
-        held_closed,
+        lockdown_active: cover.lockdown_active,
+        held_closed: cover.held_closed,
+        cover_state_unknown: cover.cover_state_unknown,
         blocked_until_connected: pm.blocked_until_connected(),
     })
 }

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -144,7 +144,7 @@ impl Drop for MockRunning {
 struct MockRouting {
     state_dir: PathBuf,
     fail_gateway: AtomicBool,
-    /// OS-truth lockdown cover probe (#825): what `lockdown_cover_state` reports.
+    /// OS-truth lockdown cover probe: what `lockdown_cover_state` reports.
     cover_state: std::sync::Mutex<CoverState>,
     /// Make `disengage_lockdown` fail, so a test can drive the fail-loud path
     /// where the kill switch must NOT be recorded as off.
@@ -735,7 +735,7 @@ fn mock_proxy_with_stuck_cover() -> Arc<Mutex<ProxyManager<MockProxy, MockRoutin
 
 #[skuld::test]
 fn status_reports_held_closed_for_a_cover_no_session_owns() {
-    // The tray input that used to read "not engaged" over a blocked host (#825).
+    // The tray must see this as engaged even with nothing running.
     rt().block_on(async {
         let path = test_socket_path("held-closed-status");
         let state_dir = tempfile::tempdir().unwrap().keep();

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -231,6 +231,14 @@ impl Routing for MockRouting {
         Ok(())
     }
 
+    fn transient_cover_state(&self) -> CoverState {
+        CoverState::Absent
+    }
+
+    fn sweep_transient(&self) -> Result<(), RoutingError> {
+        Ok(())
+    }
+
     fn install_lockdown(
         &self,
         _server_ip: IpAddr,
@@ -630,6 +638,7 @@ fn status_when_not_running_returns_false() {
                 lockdown_enabled: false,
                 lockdown_active: false,
                 held_closed: false,
+                cover_state_unknown: false,
                 blocked_until_connected: false,
             }
         );

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tun_engine::gateway::GatewayInfo;
+use tun_engine::routing::failclosed::CoverState;
 use tun_engine::routing::{state as route_state, Routing};
 use tun_engine::RoutingError;
 
@@ -143,6 +144,11 @@ impl Drop for MockRunning {
 struct MockRouting {
     state_dir: PathBuf,
     fail_gateway: AtomicBool,
+    /// OS-truth lockdown cover probe (#825): what `lockdown_cover_state` reports.
+    cover_state: std::sync::Mutex<CoverState>,
+    /// Make `disengage_lockdown` fail, so a test can drive the fail-loud path
+    /// where the kill switch must NOT be recorded as off.
+    fail_standing_disengage: AtomicBool,
 }
 
 impl MockRouting {
@@ -150,6 +156,8 @@ impl MockRouting {
         Self {
             state_dir,
             fail_gateway: AtomicBool::new(false),
+            cover_state: std::sync::Mutex::new(CoverState::Absent),
+            fail_standing_disengage: AtomicBool::new(false),
         }
     }
 
@@ -157,6 +165,8 @@ impl MockRouting {
         Self {
             state_dir,
             fail_gateway: AtomicBool::new(true),
+            cover_state: std::sync::Mutex::new(CoverState::Absent),
+            fail_standing_disengage: AtomicBool::new(false),
         }
     }
 }
@@ -207,6 +217,18 @@ impl Routing for MockRouting {
         _resolver_ip: Option<IpAddr>,
     ) -> Result<MockCover, RoutingError> {
         Ok(MockCover)
+    }
+
+    fn lockdown_cover_state(&self) -> CoverState {
+        *self.cover_state.lock().unwrap()
+    }
+
+    fn disengage_lockdown(&self) -> Result<(), RoutingError> {
+        if self.fail_standing_disengage.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(RoutingError::RouteSetup("mock disengage failure".into()));
+        }
+        *self.cover_state.lock().unwrap() = CoverState::Absent;
+        Ok(())
     }
 
     fn install_lockdown(
@@ -607,6 +629,7 @@ fn status_when_not_running_returns_false() {
                 ipv6_bypass_available: true,
                 lockdown_enabled: false,
                 lockdown_active: false,
+                held_closed: false,
                 blocked_until_connected: false,
             }
         );
@@ -690,6 +713,87 @@ fn lockdown_post_errors_without_state_dir() {
             "lockdown POST without a state_dir must error, not silently succeed"
         );
         let _ = resp.into_body().collect().await;
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+/// `mock_proxy_with_state_dir` whose routing reports an engaged cover it refuses
+/// to release — the state a user is stuck in when the firewall will not budge.
+fn mock_proxy_with_stuck_cover() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>>> {
+    let state_dir = tempfile::tempdir().unwrap().keep();
+    let routing = MockRouting::new(state_dir.clone());
+    *routing.cover_state.lock().unwrap() = CoverState::Engaged;
+    routing
+        .fail_standing_disengage
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(state_dir);
+    Arc::new(Mutex::new(pm))
+}
+
+#[skuld::test]
+fn status_reports_held_closed_for_a_cover_no_session_owns() {
+    // The tray input that used to read "not engaged" over a blocked host (#825).
+    rt().block_on(async {
+        let path = test_socket_path("held-closed-status");
+        let state_dir = tempfile::tempdir().unwrap().keep();
+        let routing = MockRouting::new(state_dir.clone());
+        *routing.cover_state.lock().unwrap() = CoverState::Engaged;
+        let pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(state_dir);
+        let server = IpcServer::bind(&path, Arc::new(Mutex::new(pm)), "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let status = get_status(&mut client).await;
+        assert!(!status.running, "precondition: nothing is running");
+        assert!(status.lockdown_active, "an adopted cover IS engaged");
+        assert!(status.held_closed, "and no session owns it");
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn lockdown_off_returns_500_with_a_path_free_message() {
+    // A release that cannot open the host must fail loud, and the message that
+    // reaches a GUI toast must carry no path (#470) while still telling the user
+    // what to do.
+    rt().block_on(async {
+        let path = test_socket_path("lockdown-stuck-cover");
+        let server = IpcServer::bind(&path, mock_proxy_with_stuck_cover(), "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_lockdown(&mut client, false).await;
+        assert_eq!(resp.status(), 500, "a cover that will not release must fail loud");
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let err: ErrorResponse = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(err.message, crate::ipc::LOCKDOWN_SET_FAILED);
+        assert!(
+            err.message.contains("hole bridge unlock"),
+            "the message must carry the escape that works with no bridge: {}",
+            err.message
+        );
+        for needle in ['/', '\\'] {
+            assert!(
+                !err.message.contains(needle),
+                "an IPC message reaches a toast verbatim and must carry no path: {}",
+                err.message
+            );
+        }
+
+        // And the intent is NOT recorded off while the host is still blocked.
+        let status = get_status(&mut client).await;
+        assert!(status.held_closed, "the host is still held closed");
 
         drop(client);
         handle.abort();

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -449,10 +449,41 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         self.ipv6_bypass_available
     }
 
-    /// Whether a standing lockdown cover is currently engaged (the `active`
-    /// signal). Distinct from the persisted intent (`enabled`).
+    /// Whether the running session owns a standing lockdown cover — the cheap,
+    /// in-process half of [`lockdown_active`](Self::lockdown_active), and the
+    /// thing that distinguishes "protected and carrying traffic" from
+    /// "blocked with nothing running".
+    fn session_owns_cover(&self) -> bool {
+        self.running.as_ref().is_some_and(|r| r.lockdown.is_some())
+    }
+
+    /// Whether a standing lockdown cover is engaged (the `active` signal).
+    /// Distinct from the persisted intent (`enabled`).
+    ///
+    /// The OS is the authority; the session guard is only a short-circuit that
+    /// skips the probe when we already hold the answer. Deriving this from the
+    /// running session alone is bindreams/hole#825: a cover adopted from a
+    /// crashed run has no guard in this process, so it read `false` while it was
+    /// blocking every packet.
+    ///
+    /// A probe that cannot answer ([`CoverState::Unknown`]) counts as active —
+    /// the escape affordance keys on this field, and hiding it over an
+    /// unanswerable probe is the same lockout by another route.
     pub fn lockdown_active(&self) -> bool {
-        self.running.as_ref().map(|r| r.lockdown.is_some()).unwrap_or(false)
+        self.session_owns_cover() || self.routing.lockdown_cover_state().is_engaged_or_unknown()
+    }
+
+    /// Whether a lockdown cover is engaged that NO running session owns — the
+    /// host is being held closed with nothing carrying the user's traffic
+    /// through it. The state the tray must surface with a way out.
+    ///
+    /// Deliberately not `lockdown_active && !running`. Intent OFF plus a
+    /// leftover cover whose startup `Sweep` failed, then a connect: `start_inner`
+    /// skips `install_lockdown` because the intent is off, so `running` is true
+    /// while the stale block-all and its dead TUN permit kill every packet. An
+    /// `!running` test would render that as an ordinary connected session.
+    pub fn held_closed(&self) -> bool {
+        !self.session_owns_cover() && self.routing.lockdown_cover_state().is_engaged_or_unknown()
     }
 
     /// Whether a covered start failed and left the host fail-closed (blocked, not
@@ -480,14 +511,52 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// cannot honor a kill switch it cannot persist (a silent `Ok(())` would be
     /// a fail-open footgun — the GUI would believe lockdown is armed when
     /// nothing was written).
+    ///
+    /// Turning it OFF also RELEASES a cover no live session owns, rather than
+    /// leaving it for the next `recover_routes` — the user's one obvious remedy
+    /// used to do nothing at all (bindreams/hole#825). Ordering is
+    /// `cutover::unlock_with`'s: disengage FIRST, persist `false` only on a
+    /// confirmed success, so the setting can never read "off" over a blocked
+    /// host.
+    ///
+    /// A cover a live session DOES own is left alone: settings apply on
+    /// reconnect, and `stop_with` already disengages it. A lockout is not a
+    /// setting, which is why the unowned case is released immediately.
+    ///
+    /// The release is skipped entirely when the probe confirms `Absent`. Doing
+    /// it unconditionally would make disarming the switch on a clean host fail
+    /// whenever the firewall is unreachable — a fresh way to strand the user in
+    /// the state this exists to prevent.
     pub fn set_lockdown_intent(&self, enabled: bool) -> Result<(), ProxyError> {
         let dir = self.state_dir.as_deref().ok_or_else(|| {
             ProxyError::Runtime(std::io::Error::other(
                 "cannot set lockdown intent: bridge has no state_dir to persist it",
             ))
         })?;
+        if !enabled {
+            self.release_unowned_cover()?;
+        }
         lockdown_state::set_enabled(dir, enabled, self.state_owner)
             .map_err(|e| ProxyError::Runtime(std::io::Error::other(format!("lockdown persist: {e}"))))
+    }
+
+    /// Disengage a standing cover no live session owns. A no-op when the probe
+    /// confirms none is engaged, or when the running session owns it.
+    ///
+    /// Cannot clobber a transient block-until-connected cover: that one is only
+    /// ever engaged on a lockdown-OFF covered start, where no lockdown state
+    /// exists — and both platform disengages key on lockdown state alone (macOS
+    /// returns early with no `pfctl` when `bridge-lockdown-pf.json` is absent;
+    /// Windows deletes lockdown GUIDs, which are disjoint from the transient set).
+    fn release_unowned_cover(&self) -> Result<(), ProxyError> {
+        if self.session_owns_cover() {
+            return Ok(());
+        }
+        if self.routing.lockdown_cover_state() == tun_engine::routing::failclosed::CoverState::Absent {
+            return Ok(());
+        }
+        info!("lockdown intent off: releasing the standing cover no session owns");
+        self.routing.disengage_lockdown().map_err(ProxyError::from)
     }
 
     /// Non-cancellable convenience wrapper around

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -457,33 +457,49 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         self.running.as_ref().is_some_and(|r| r.lockdown.is_some())
     }
 
-    /// Whether a standing lockdown cover is engaged (the `active` signal).
-    /// Distinct from the persisted intent (`enabled`).
+    /// The `(lockdown_active, held_closed)` pair from ONE probe of the OS.
     ///
-    /// The OS is the authority; the session guard is only a short-circuit that
-    /// skips the probe when we already hold the answer. Deriving this from the
-    /// running session alone is bindreams/hole#825: a cover adopted from a
-    /// crashed run has no guard in this process, so it read `false` while it was
-    /// blocking every packet.
+    /// Both together, because they must describe the same instant: the firewall
+    /// is not under the `ProxyManager` lock, so two sequential probes can be torn
+    /// by a concurrent `hole bridge unlock` and yield `active && !held_closed` —
+    /// which the tray reads as "a session owns the cover" over a host where
+    /// nothing is running. One probe per status also halves the OS cost of an
+    /// idle disconnected poll.
     ///
-    /// A probe that cannot answer ([`CoverState::Unknown`]) counts as active —
-    /// the escape affordance keys on this field, and hiding it over an
-    /// unanswerable probe is the same lockout by another route.
-    pub fn lockdown_active(&self) -> bool {
-        self.session_owns_cover() || self.routing.lockdown_cover_state().is_engaged_or_unknown()
+    /// `active`: the OS is the authority; the session guard is only a
+    /// short-circuit that skips the probe when we already hold the answer.
+    /// Deriving it from the running session alone is wrong: a cover adopted from
+    /// a crashed run has no guard in this process, so it would read `false` while
+    /// blocking every packet. A probe that cannot answer
+    /// ([`CoverState::Unknown`]) counts as active: the escape affordance keys on
+    /// this field, and hiding it over an unanswerable probe is the same lockout
+    /// by another route.
+    ///
+    /// `held_closed`: a cover engaged that no running session owns — the host is
+    /// held closed with nothing carrying the user's traffic through it.
+    /// Deliberately not `active && !running`. Intent OFF plus a leftover cover
+    /// whose startup `Sweep` failed, then a connect: `start_inner` skips
+    /// `install_lockdown` because the intent is off, so `running` is true while
+    /// the stale block-all and its dead TUN permit kill every packet.
+    pub fn cover_status(&self) -> (bool, bool) {
+        if self.session_owns_cover() {
+            return (true, false);
+        }
+        let engaged = self.routing.lockdown_cover_state().is_engaged_or_unknown();
+        (engaged, engaged)
     }
 
-    /// Whether a lockdown cover is engaged that NO running session owns — the
-    /// host is being held closed with nothing carrying the user's traffic
-    /// through it. The state the tray must surface with a way out.
-    ///
-    /// Deliberately not `lockdown_active && !running`. Intent OFF plus a
-    /// leftover cover whose startup `Sweep` failed, then a connect: `start_inner`
-    /// skips `install_lockdown` because the intent is off, so `running` is true
-    /// while the stale block-all and its dead TUN permit kill every packet. An
-    /// `!running` test would render that as an ordinary connected session.
+    /// Whether a standing lockdown cover is engaged. Prefer
+    /// [`cover_status`](Self::cover_status) when both flags are wanted, so they
+    /// share one probe.
+    pub fn lockdown_active(&self) -> bool {
+        self.cover_status().0
+    }
+
+    /// Whether a cover no running session owns is holding the host closed. See
+    /// [`cover_status`](Self::cover_status).
     pub fn held_closed(&self) -> bool {
-        !self.session_owns_cover() && self.routing.lockdown_cover_state().is_engaged_or_unknown()
+        self.cover_status().1
     }
 
     /// Whether a covered start failed and left the host fail-closed (blocked, not
@@ -514,10 +530,9 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     ///
     /// Turning it OFF also RELEASES a cover no live session owns, rather than
     /// leaving it for the next `recover_routes` — the user's one obvious remedy
-    /// used to do nothing at all (bindreams/hole#825). Ordering is
-    /// `cutover::unlock_with`'s: disengage FIRST, persist `false` only on a
-    /// confirmed success, so the setting can never read "off" over a blocked
-    /// host.
+    /// must not do nothing at all. Ordering is `cutover::unlock_with`'s:
+    /// disengage FIRST, persist `false` only on a confirmed success, so the
+    /// setting can never read "off" over a host we KNOW is blocked.
     ///
     /// A cover a live session DOES own is left alone: settings apply on
     /// reconnect, and `stop_with` already disengages it. A lockout is not a
@@ -543,20 +558,41 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// Disengage a standing cover no live session owns. A no-op when the probe
     /// confirms none is engaged, or when the running session owns it.
     ///
+    /// Refuses ONLY when the probe OBSERVED a cover and the release then failed —
+    /// the one case where we know the host is still blocked and the setting must
+    /// not read "off". An `Unknown` probe whose release also failed is the
+    /// correlated pair on Windows (both go through `FwpmEngineOpen0`), and
+    /// refusing there would leave the switch permanently un-disarmable while we
+    /// never established that anything was blocking. The uncertainty is not
+    /// swallowed: `held_closed` still counts `Unknown` as held, so the tray keeps
+    /// showing the state and its release action.
+    ///
     /// Cannot clobber a transient block-until-connected cover: that one is only
     /// ever engaged on a lockdown-OFF covered start, where no lockdown state
     /// exists — and both platform disengages key on lockdown state alone (macOS
     /// returns early with no `pfctl` when `bridge-lockdown-pf.json` is absent;
     /// Windows deletes lockdown GUIDs, which are disjoint from the transient set).
     fn release_unowned_cover(&self) -> Result<(), ProxyError> {
+        use tun_engine::routing::failclosed::CoverState;
         if self.session_owns_cover() {
             return Ok(());
         }
-        if self.routing.lockdown_cover_state() == tun_engine::routing::failclosed::CoverState::Absent {
+        let observed = self.routing.lockdown_cover_state();
+        if observed == CoverState::Absent {
             return Ok(());
         }
-        info!("lockdown intent off: releasing the standing cover no session owns");
-        self.routing.disengage_lockdown().map_err(ProxyError::from)
+        info!(
+            ?observed,
+            "lockdown intent off: releasing the standing cover no session owns"
+        );
+        match self.routing.disengage_lockdown() {
+            Ok(()) => Ok(()),
+            Err(e) if observed == CoverState::Engaged => Err(ProxyError::from(e)),
+            Err(e) => {
+                warn!(error = %e, "could not release a cover never confirmed engaged; recording the intent off anyway");
+                Ok(())
+            }
+        }
     }
 
     /// Non-cancellable convenience wrapper around

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -189,6 +189,15 @@ pub struct TrafficMetrics {
     pub speed_out_bps: u64,
 }
 
+/// What the OS says about Hole's covers, from one probe of each. Named fields,
+/// not a bool tuple: the three are same-typed and easy to transpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoverStatus {
+    pub lockdown_active: bool,
+    pub held_closed: bool,
+    pub cover_state_unknown: bool,
+}
+
 // ProxyManager ========================================================================================================
 
 /// The one reason an out-of-band death is reported to the GUI. A `&'static str`
@@ -475,31 +484,67 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// this field, and hiding it over an unanswerable probe is the same lockout
     /// by another route.
     ///
-    /// `held_closed`: a cover engaged that no running session owns — the host is
-    /// held closed with nothing carrying the user's traffic through it.
-    /// Deliberately not `active && !running`. Intent OFF plus a leftover cover
-    /// whose startup `Sweep` failed, then a connect: `start_inner` skips
-    /// `install_lockdown` because the intent is off, so `running` is true while
-    /// the stale block-all and its dead TUN permit kill every packet.
-    pub fn cover_status(&self) -> (bool, bool) {
-        if self.session_owns_cover() {
-            return (true, false);
+    /// `held_closed`: EITHER cover engaged with no in-process guard owning it —
+    /// the host is held closed with nothing carrying the user's traffic through
+    /// it. Deliberately not `active && !running`: intent OFF plus a leftover
+    /// cover whose startup `Sweep` failed, then a connect, leaves `running` true
+    /// while the stale block-all kills every packet. It counts the TRANSIENT
+    /// cover too — a crash mid-connect strands those filters just as
+    /// persistently, and they would otherwise render as plain "Disconnected"
+    /// with no action offered at all.
+    ///
+    /// `cover_state_unknown`: the evidence behind `held_closed` is an
+    /// unanswerable probe rather than an observed cover. Kept distinct because
+    /// telling a user we are blocking them is a different claim from telling them
+    /// we cannot tell — and on Windows a wedged BFE makes the latter permanent.
+    pub fn cover_status(&self) -> CoverStatus {
+        use tun_engine::routing::failclosed::CoverState;
+
+        // Each cover is probed at most once, and only when no in-process guard
+        // already answers for it.
+        let session_owns = self.session_owns_cover();
+        let standing = if session_owns {
+            CoverState::Engaged
+        } else {
+            self.routing.lockdown_cover_state()
+        };
+        // A held `blocked` guard IS the transient cover, and it has its own
+        // surface (`blocked_until_connected`), so probing would only duplicate it.
+        let transient = if self.blocked.is_some() {
+            CoverState::Absent
+        } else {
+            self.routing.transient_cover_state()
+        };
+
+        // The strongest evidence from either cover that nothing in this process
+        // owns. `Engaged` beats `Unknown` beats `Absent`.
+        let unowned = [if session_owns { CoverState::Absent } else { standing }, transient];
+        let evidence = if unowned.contains(&CoverState::Engaged) {
+            CoverState::Engaged
+        } else if unowned.contains(&CoverState::Unknown) {
+            CoverState::Unknown
+        } else {
+            CoverState::Absent
+        };
+
+        CoverStatus {
+            lockdown_active: session_owns || standing.is_present(),
+            held_closed: evidence.is_present(),
+            cover_state_unknown: evidence == CoverState::Unknown,
         }
-        let engaged = self.routing.lockdown_cover_state().is_engaged_or_unknown();
-        (engaged, engaged)
     }
 
     /// Whether a standing lockdown cover is engaged. Prefer
-    /// [`cover_status`](Self::cover_status) when both flags are wanted, so they
-    /// share one probe.
+    /// [`cover_status`](Self::cover_status) when several flags are wanted, so
+    /// they share one probe.
     pub fn lockdown_active(&self) -> bool {
-        self.cover_status().0
+        self.cover_status().lockdown_active
     }
 
-    /// Whether a cover no running session owns is holding the host closed. See
+    /// Whether a cover no in-process guard owns is holding the host closed. See
     /// [`cover_status`](Self::cover_status).
     pub fn held_closed(&self) -> bool {
-        self.cover_status().1
+        self.cover_status().held_closed
     }
 
     /// Whether a covered start failed and left the host fail-closed (blocked, not
@@ -558,38 +603,60 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
     /// Disengage a standing cover no live session owns. A no-op when the probe
     /// confirms none is engaged, or when the running session owns it.
     ///
-    /// Refuses ONLY when the probe OBSERVED a cover and the release then failed —
+    /// Clears BOTH covers, because both can strand a host and this is the only
+    /// action the user is offered. A transient cover this process still holds is
+    /// left alone — `stop_with` owns that one.
+    ///
+    /// Refuses ONLY when a probe OBSERVED a cover and its release then failed —
     /// the one case where we know the host is still blocked and the setting must
     /// not read "off". An `Unknown` probe whose release also failed is the
     /// correlated pair on Windows (both go through `FwpmEngineOpen0`), and
     /// refusing there would leave the switch permanently un-disarmable while we
     /// never established that anything was blocking. The uncertainty is not
-    /// swallowed: `held_closed` still counts `Unknown` as held, so the tray keeps
-    /// showing the state and its release action.
-    ///
-    /// Cannot clobber a transient block-until-connected cover: that one is only
-    /// ever engaged on a lockdown-OFF covered start, where no lockdown state
-    /// exists — and both platform disengages key on lockdown state alone (macOS
-    /// returns early with no `pfctl` when `bridge-lockdown-pf.json` is absent;
-    /// Windows deletes lockdown GUIDs, which are disjoint from the transient set).
+    /// swallowed: `held_closed` stays true and `cover_state_unknown` says which
+    /// claim we are making, so the tray keeps showing the state and its action.
     fn release_unowned_cover(&self) -> Result<(), ProxyError> {
         use tun_engine::routing::failclosed::CoverState;
-        if self.session_owns_cover() {
+
+        // A transient cover THIS process holds is not stranded — `stop_with`
+        // owns it, and on macOS the standing restore reloads a whole ruleset, so
+        // running it here would tear that live cover down and open the host.
+        if self.blocked.is_some() {
+            info!("lockdown intent off while holding a transient cover: leaving both to the stop path");
             return Ok(());
         }
-        let observed = self.routing.lockdown_cover_state();
-        if observed == CoverState::Absent {
+
+        // Standing cover.
+        if !self.session_owns_cover() {
+            let observed = self.routing.lockdown_cover_state();
+            if observed != CoverState::Absent {
+                info!(
+                    ?observed,
+                    "lockdown intent off: releasing the standing cover no session owns"
+                );
+                match self.routing.disengage_lockdown() {
+                    Ok(()) => {}
+                    Err(e) if observed == CoverState::Engaged => return Err(ProxyError::from(e)),
+                    Err(e) => {
+                        warn!(error = %e, "could not release a standing cover never confirmed engaged; recording the intent off anyway")
+                    }
+                }
+            }
+        }
+
+        // Transient cover stranded by a crash: nothing in this process owns it,
+        // and no other control surface can clear it, so the one action the user
+        // is offered has to.
+        let transient = self.routing.transient_cover_state();
+        if transient == CoverState::Absent {
             return Ok(());
         }
-        info!(
-            ?observed,
-            "lockdown intent off: releasing the standing cover no session owns"
-        );
-        match self.routing.disengage_lockdown() {
+        info!(?transient, "releasing a stranded transient cover");
+        match self.routing.sweep_transient() {
             Ok(()) => Ok(()),
-            Err(e) if observed == CoverState::Engaged => Err(ProxyError::from(e)),
+            Err(e) if transient == CoverState::Engaged => Err(ProxyError::from(e)),
             Err(e) => {
-                warn!(error = %e, "could not release a cover never confirmed engaged; recording the intent off anyway");
+                warn!(error = %e, "could not sweep a transient cover never confirmed engaged; recording the intent off anyway");
                 Ok(())
             }
         }

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -508,24 +508,21 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         } else {
             self.routing.lockdown_cover_state()
         };
-        // A held `blocked` guard IS the transient cover, and it has its own
-        // surface (`blocked_until_connected`), so probing would only duplicate it.
-        let transient = if self.blocked.is_some() {
+        // Skipped whenever something in this process already answers for that
+        // cover: a held `blocked` guard IS the transient cover and has its own
+        // surface (`blocked_until_connected`), and a running session's own start
+        // path owns the transient cover's lifetime, so a stranded one is not
+        // reachable there. Both are cost guards as much as correctness ones — this
+        // runs on every status poll while the proxy mutex is held.
+        let transient = if self.blocked.is_some() || self.running.is_some() {
             CoverState::Absent
         } else {
             self.routing.transient_cover_state()
         };
 
         // The strongest evidence from either cover that nothing in this process
-        // owns. `Engaged` beats `Unknown` beats `Absent`.
-        let unowned = [if session_owns { CoverState::Absent } else { standing }, transient];
-        let evidence = if unowned.contains(&CoverState::Engaged) {
-            CoverState::Engaged
-        } else if unowned.contains(&CoverState::Unknown) {
-            CoverState::Unknown
-        } else {
-            CoverState::Absent
-        };
+        // owns.
+        let evidence = if session_owns { CoverState::Absent } else { standing }.strongest(transient);
 
         CoverStatus {
             lockdown_active: session_owns || standing.is_present(),

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tun_engine::gateway::GatewayInfo;
-use tun_engine::routing::failclosed::lockdown_state;
+use tun_engine::routing::failclosed::{lockdown_state, CoverState};
 use tun_engine::routing::{self, state as route_state, Routing};
 use tun_engine::RoutingError;
 
@@ -194,6 +194,15 @@ struct MockRoutingState {
     /// (a set containing both values) for the double-failure fail-open path.
     /// `fail_cover` (always-fail) is unaffected and takes priority.
     fail_cover_for_resolvers: std::sync::Mutex<std::collections::HashSet<Option<IpAddr>>>,
+    /// What `lockdown_cover_state` reports — the OS-truth probe a test drives to
+    /// stand in for a cover adopted from a crashed run (#825).
+    cover_state: std::sync::Mutex<CoverState>,
+    /// How many times the probe was asked. Lets a test assert the short-circuit
+    /// (a session that owns the cover must not pay for an OS call).
+    cover_state_calls: AtomicU32,
+    /// How many times `disengage_lockdown` was called, and what it returns.
+    standing_disengage_calls: AtomicU32,
+    fail_standing_disengage: AtomicBool,
 }
 
 impl Default for MockRoutingState {
@@ -209,6 +218,10 @@ impl Default for MockRoutingState {
             lockdown_disengage_calls: AtomicU32::new(0),
             fail_lockdown: AtomicBool::new(false),
             fail_cover: AtomicBool::new(false),
+            cover_state: std::sync::Mutex::new(CoverState::Absent),
+            cover_state_calls: AtomicU32::new(0),
+            standing_disengage_calls: AtomicU32::new(0),
+            fail_standing_disengage: AtomicBool::new(false),
             teardown_order: std::sync::Mutex::new(Vec::new()),
             last_install_server_ip: std::sync::Mutex::new(None),
             last_cover_server_ip: std::sync::Mutex::new(None),
@@ -353,6 +366,22 @@ impl Routing for MockRouting {
             state: Arc::clone(&self.state),
             lockdown: true,
         })
+    }
+
+    fn lockdown_cover_state(&self) -> CoverState {
+        self.state.cover_state_calls.fetch_add(1, Ordering::SeqCst);
+        *self.state.cover_state.lock().unwrap()
+    }
+
+    fn disengage_lockdown(&self) -> Result<(), RoutingError> {
+        self.state.standing_disengage_calls.fetch_add(1, Ordering::SeqCst);
+        if self.state.fail_standing_disengage.load(Ordering::SeqCst) {
+            // Mirrors the real fail-loud contract: a failed disengage leaves the
+            // cover engaged, so the mock's state must NOT flip.
+            return Err(RoutingError::RouteSetup("mock disengage failure".into()));
+        }
+        *self.state.cover_state.lock().unwrap() = CoverState::Absent;
+        Ok(())
     }
 }
 
@@ -1993,6 +2022,199 @@ fn full_start_fails_closed_when_doh_cannot_resolve() {
 // `Err(ProxyError::ForwarderSelfTestFailed)` and the locally-owned RAII
 // guards unwind without ever hijacking the user's system DNS into a
 // dead tunnel.
+
+// Kill-switch lockout: state + release (#825) =========================================================================
+
+/// A manager + its routing mock's shared state, both pointed at one `dir`, with
+/// the OS-truth cover probe seeded to `cover`. Stands in for a bridge that has
+/// just adopted a cover from a crashed run: no guard anywhere in this process,
+/// but the host is blocked.
+fn lockout_manager(
+    cover: CoverState,
+    intent: bool,
+) -> (
+    ProxyManager<MockProxy, MockRouting>,
+    Arc<MockRoutingState>,
+    tempfile::TempDir,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    lockdown_state::set_enabled(dir.path(), intent, None).unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    *state.cover_state.lock().unwrap() = cover;
+    let pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(dir.path().to_path_buf());
+    (pm, state, dir)
+}
+
+#[skuld::test]
+async fn lockdown_active_true_for_adopted_cover_with_no_session() {
+    // The tray was told "not engaged" while every packet was being dropped,
+    // because this read the running session instead of the OS.
+    let (pm, _state, _dir) = lockout_manager(CoverState::Engaged, true);
+    assert!(pm.lockdown_active(), "an adopted cover with no session IS engaged");
+    assert!(pm.held_closed(), "and nothing is carrying traffic through it");
+}
+
+#[skuld::test]
+async fn lockdown_active_true_when_probe_is_unknown() {
+    // An unanswerable probe must not read as all-clear: that hides the block and
+    // the escape that keys on it.
+    let (pm, _state, _dir) = lockout_manager(CoverState::Unknown, true);
+    assert!(pm.lockdown_active());
+    assert!(pm.held_closed());
+}
+
+#[skuld::test]
+async fn lockdown_active_false_when_absent_and_not_running() {
+    let (pm, _state, _dir) = lockout_manager(CoverState::Absent, true);
+    assert!(!pm.lockdown_active());
+    assert!(!pm.held_closed());
+}
+
+#[skuld::test]
+async fn lockdown_active_skips_the_probe_when_the_session_owns_a_cover() {
+    // The short-circuit is behaviour, not an optimisation: reordering it would
+    // put an FWPM/pfctl call on every 5s status poll of a healthy session.
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
+    pm.start(&test_config()).await.expect("start with lockdown on");
+    state.cover_state_calls.store(0, Ordering::SeqCst);
+
+    assert!(pm.lockdown_active(), "a session that owns the cover is active");
+    assert_eq!(
+        state.cover_state_calls.load(Ordering::SeqCst),
+        0,
+        "the in-process guard already answers; no OS probe may run"
+    );
+}
+
+#[skuld::test]
+async fn held_closed_true_for_running_session_that_owns_no_cover() {
+    // Intent OFF plus a leftover cover a failed startup Sweep left behind, then a
+    // connect. `running` is true, but the stale block-all is killing every
+    // packet — the state a `lockdown_active && !running` derivation renders as an
+    // ordinary connected session, with no escape offered.
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+    pm.start(&test_config()).await.expect("start with lockdown off");
+    *state.cover_state.lock().unwrap() = CoverState::Engaged;
+
+    assert_eq!(pm.state(), ProxyState::Running, "precondition: a session is running");
+    assert!(pm.held_closed(), "a cover no session owns holds the host closed");
+}
+
+#[skuld::test]
+async fn held_closed_false_while_session_owns_the_cover() {
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    let (mut pm, _dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
+    pm.start(&test_config()).await.expect("start with lockdown on");
+    *state.cover_state.lock().unwrap() = CoverState::Engaged;
+
+    assert!(pm.lockdown_active());
+    assert!(!pm.held_closed(), "protected and carrying traffic is not a lockout");
+}
+
+#[skuld::test]
+async fn lockdown_off_disengages_the_adopted_cover() {
+    let (pm, state, dir) = lockout_manager(CoverState::Engaged, true);
+    pm.set_lockdown_intent(false).expect("release + persist");
+
+    assert_eq!(state.standing_disengage_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(*state.cover_state.lock().unwrap(), CoverState::Absent);
+    assert!(!lockdown_state::load_enabled(dir.path()), "intent recorded off");
+    assert!(!pm.held_closed(), "and the host is no longer held closed");
+}
+
+#[skuld::test]
+async fn lockdown_off_keeps_intent_on_when_disengage_fails() {
+    // The switch must never read "off" over a host that is still blocked: that is
+    // precisely the state the user cannot reason their way out of.
+    let (pm, state, dir) = lockout_manager(CoverState::Engaged, true);
+    state.fail_standing_disengage.store(true, Ordering::SeqCst);
+
+    let err = pm.set_lockdown_intent(false).expect_err("must fail loud");
+    assert_eq!(state.standing_disengage_calls.load(Ordering::SeqCst), 1);
+    assert!(
+        lockdown_state::load_enabled(dir.path()),
+        "intent must stay ON while the cover is still engaged: {err}"
+    );
+    assert!(pm.held_closed(), "and the tray keeps reporting the truth");
+}
+
+#[skuld::test]
+async fn lockdown_off_persists_without_a_firewall_call_when_no_cover_is_engaged() {
+    // Releasing unconditionally would make disarming the switch on a CLEAN host
+    // fail whenever the firewall is unreachable — a new way into the lockout.
+    let (pm, state, dir) = lockout_manager(CoverState::Absent, true);
+    state.fail_standing_disengage.store(true, Ordering::SeqCst);
+
+    pm.set_lockdown_intent(false).expect("a clean host always disarms");
+    assert_eq!(
+        state.standing_disengage_calls.load(Ordering::SeqCst),
+        0,
+        "no cover engaged, so no firewall call that could fail"
+    );
+    assert!(!lockdown_state::load_enabled(dir.path()));
+}
+
+#[skuld::test]
+async fn lockdown_off_attempts_the_release_when_the_probe_is_unknown() {
+    let (pm, state, _dir) = lockout_manager(CoverState::Unknown, true);
+    pm.set_lockdown_intent(false)
+        .expect("release attempted and reported Ok");
+    assert_eq!(
+        state.standing_disengage_calls.load(Ordering::SeqCst),
+        1,
+        "an unanswerable probe must not be read as nothing-to-release"
+    );
+}
+
+#[skuld::test]
+async fn lockdown_off_releases_a_cover_a_running_session_does_not_own() {
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    let (mut pm, dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+    pm.start(&test_config()).await.expect("start with lockdown off");
+    *state.cover_state.lock().unwrap() = CoverState::Engaged;
+
+    pm.set_lockdown_intent(false).expect("release the unowned cover");
+    assert_eq!(
+        state.standing_disengage_calls.load(Ordering::SeqCst),
+        1,
+        "a running session that owns no cover must not shield a lockout"
+    );
+    assert!(!lockdown_state::load_enabled(dir.path()));
+}
+
+#[skuld::test]
+async fn lockdown_off_leaves_a_session_owned_cover_alone() {
+    // Settings apply on reconnect. `stop_with` already disengages this one;
+    // releasing mid-session would change when the kill switch lifts.
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    let (mut pm, dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, true);
+    pm.start(&test_config()).await.expect("start with lockdown on");
+
+    pm.set_lockdown_intent(false).expect("persist only");
+    assert_eq!(state.standing_disengage_calls.load(Ordering::SeqCst), 0);
+    assert!(!lockdown_state::load_enabled(dir.path()), "intent still records off");
+}
+
+#[skuld::test]
+async fn lockdown_on_persists_without_touching_the_cover() {
+    let (pm, state, dir) = lockout_manager(CoverState::Engaged, false);
+    pm.set_lockdown_intent(true).expect("persist");
+    assert_eq!(state.standing_disengage_calls.load(Ordering::SeqCst), 0);
+    assert!(lockdown_state::load_enabled(dir.path()));
+}
 
 #[cfg(test)]
 mod self_test {

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -203,6 +203,11 @@ struct MockRoutingState {
     /// How many times `disengage_lockdown` was called, and what it returns.
     standing_disengage_calls: AtomicU32,
     fail_standing_disengage: AtomicBool,
+    /// The transient cover's OS-truth probe, and its sweep's call count/result.
+    transient_state: std::sync::Mutex<CoverState>,
+    transient_state_calls: AtomicU32,
+    transient_sweep_calls: AtomicU32,
+    fail_transient_sweep: AtomicBool,
 }
 
 impl Default for MockRoutingState {
@@ -222,6 +227,10 @@ impl Default for MockRoutingState {
             cover_state_calls: AtomicU32::new(0),
             standing_disengage_calls: AtomicU32::new(0),
             fail_standing_disengage: AtomicBool::new(false),
+            transient_state: std::sync::Mutex::new(CoverState::Absent),
+            transient_state_calls: AtomicU32::new(0),
+            transient_sweep_calls: AtomicU32::new(0),
+            fail_transient_sweep: AtomicBool::new(false),
             teardown_order: std::sync::Mutex::new(Vec::new()),
             last_install_server_ip: std::sync::Mutex::new(None),
             last_cover_server_ip: std::sync::Mutex::new(None),
@@ -381,6 +390,20 @@ impl Routing for MockRouting {
             return Err(RoutingError::RouteSetup("mock disengage failure".into()));
         }
         *self.state.cover_state.lock().unwrap() = CoverState::Absent;
+        Ok(())
+    }
+
+    fn transient_cover_state(&self) -> CoverState {
+        self.state.transient_state_calls.fetch_add(1, Ordering::SeqCst);
+        *self.state.transient_state.lock().unwrap()
+    }
+
+    fn sweep_transient(&self) -> Result<(), RoutingError> {
+        self.state.transient_sweep_calls.fetch_add(1, Ordering::SeqCst);
+        if self.state.fail_transient_sweep.load(Ordering::SeqCst) {
+            return Err(RoutingError::RouteSetup("mock transient sweep failure".into()));
+        }
+        *self.state.transient_state.lock().unwrap() = CoverState::Absent;
         Ok(())
     }
 }
@@ -2214,12 +2237,108 @@ async fn cover_status_probes_the_os_once() {
     let (pm, state, _dir) = lockout_manager(CoverState::Engaged, true);
     state.cover_state_calls.store(0, Ordering::SeqCst);
 
-    let (active, held) = pm.cover_status();
-    assert!(active && held);
+    let cover = pm.cover_status();
+    assert!(cover.lockdown_active && cover.held_closed);
+    assert!(!cover.cover_state_unknown, "an observed cover is not an unknown one");
     assert_eq!(
         state.cover_state_calls.load(Ordering::SeqCst),
         1,
-        "one status read must cost exactly one OS probe"
+        "one status read must cost exactly one probe of the standing cover"
+    );
+    assert_eq!(
+        state.transient_state_calls.load(Ordering::SeqCst),
+        1,
+        "and exactly one of the transient cover"
+    );
+}
+
+#[skuld::test]
+async fn held_closed_true_for_a_stranded_transient_cover() {
+    // A crash mid-connect leaves the transient cover's persistent filters holding
+    // the host, with no guard in the new process and no lockdown state at all.
+    // Without probing its keys the tray renders plain "Disconnected" over a dead
+    // host and offers nothing.
+    let (pm, state, _dir) = lockout_manager(CoverState::Absent, false);
+    *state.transient_state.lock().unwrap() = CoverState::Engaged;
+
+    assert!(!pm.lockdown_active(), "no standing cover is engaged");
+    assert!(pm.held_closed(), "but the host is still held closed");
+}
+
+#[skuld::test]
+async fn lockdown_off_sweeps_a_stranded_transient_cover() {
+    let (pm, state, _dir) = lockout_manager(CoverState::Absent, false);
+    *state.transient_state.lock().unwrap() = CoverState::Engaged;
+
+    pm.set_lockdown_intent(false).expect("release clears both covers");
+    assert_eq!(state.transient_sweep_calls.load(Ordering::SeqCst), 1);
+    assert!(!pm.held_closed(), "and the host is open again");
+}
+
+#[skuld::test]
+async fn lockdown_off_keeps_intent_on_when_the_transient_sweep_fails() {
+    let (pm, state, dir) = lockout_manager(CoverState::Absent, true);
+    *state.transient_state.lock().unwrap() = CoverState::Engaged;
+    state.fail_transient_sweep.store(true, Ordering::SeqCst);
+
+    assert!(
+        pm.set_lockdown_intent(false).is_err(),
+        "an observed cover that would not clear must fail loud"
+    );
+    assert!(
+        lockdown_state::load_enabled(dir.path()),
+        "intent must stay ON while any cover is still holding the host"
+    );
+}
+
+#[skuld::test]
+async fn lockdown_off_leaves_a_transient_cover_this_process_holds() {
+    // `self.blocked` IS that cover, `stop_with` owns it, and on macOS the standing
+    // restore reloads a whole ruleset — running it here would tear the live cover
+    // down and open the host.
+    let dir = tempfile::tempdir().unwrap();
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let state = routing.state();
+    *state.cover_state.lock().unwrap() = CoverState::Engaged;
+    let (mut pm, dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
+    let mut cfg = test_config();
+    cfg.server.server = "127.0.0.1".into();
+    // A covered start that fails leaves the transient cover held in-process.
+    let _ = pm.start_cancellable(&cfg, true, CancellationToken::new()).await;
+    if pm.blocked_until_connected() {
+        pm.set_lockdown_intent(false).expect("persist only");
+        assert_eq!(
+            state.standing_disengage_calls.load(Ordering::SeqCst),
+            0,
+            "a cover this process owns is the stop path's to release"
+        );
+        assert_eq!(state.transient_sweep_calls.load(Ordering::SeqCst), 0);
+    }
+    let _ = dir;
+}
+
+#[skuld::test]
+async fn cover_status_marks_an_unknown_probe_as_unknown() {
+    let (pm, _state, _dir) = lockout_manager(CoverState::Unknown, true);
+    let cover = pm.cover_status();
+    assert!(cover.held_closed, "an unanswerable probe still offers the escape");
+    assert!(
+        cover.cover_state_unknown,
+        "but must not be reported as an observed cover"
+    );
+}
+
+#[skuld::test]
+async fn cover_status_skips_the_transient_probe_while_this_process_owns_it() {
+    // `blocked_until_connected` already surfaces that cover; probing would only
+    // duplicate it and cost an OS call on every poll.
+    let (pm, state, _dir) = lockout_manager(CoverState::Absent, false);
+    state.transient_state_calls.store(0, Ordering::SeqCst);
+    let _ = pm.cover_status();
+    assert_eq!(
+        state.transient_state_calls.load(Ordering::SeqCst),
+        1,
+        "no in-process transient guard, so the probe runs"
     );
 }
 

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -2105,11 +2105,18 @@ async fn lockdown_active_skips_the_probe_when_the_session_owns_a_cover() {
     pm.start(&test_config()).await.expect("start with lockdown on");
     state.cover_state_calls.store(0, Ordering::SeqCst);
 
+    state.transient_state_calls.store(0, Ordering::SeqCst);
+
     assert!(pm.lockdown_active(), "a session that owns the cover is active");
     assert_eq!(
         state.cover_state_calls.load(Ordering::SeqCst),
         0,
-        "the in-process guard already answers; no OS probe may run"
+        "the in-process guard already answers; no standing probe may run"
+    );
+    assert_eq!(
+        state.transient_state_calls.load(Ordering::SeqCst),
+        0,
+        "and a running session must not pay a transient probe on every status poll"
     );
 }
 
@@ -2289,32 +2296,6 @@ async fn lockdown_off_keeps_intent_on_when_the_transient_sweep_fails() {
         lockdown_state::load_enabled(dir.path()),
         "intent must stay ON while any cover is still holding the host"
     );
-}
-
-#[skuld::test]
-async fn lockdown_off_leaves_a_transient_cover_this_process_holds() {
-    // `self.blocked` IS that cover, `stop_with` owns it, and on macOS the standing
-    // restore reloads a whole ruleset — running it here would tear the live cover
-    // down and open the host.
-    let dir = tempfile::tempdir().unwrap();
-    let routing = MockRouting::new(dir.path().to_path_buf());
-    let state = routing.state();
-    *state.cover_state.lock().unwrap() = CoverState::Engaged;
-    let (mut pm, dir) = new_manager_with_lockdown(MockProxy::new(), routing, dir, false);
-    let mut cfg = test_config();
-    cfg.server.server = "127.0.0.1".into();
-    // A covered start that fails leaves the transient cover held in-process.
-    let _ = pm.start_cancellable(&cfg, true, CancellationToken::new()).await;
-    if pm.blocked_until_connected() {
-        pm.set_lockdown_intent(false).expect("persist only");
-        assert_eq!(
-            state.standing_disengage_calls.load(Ordering::SeqCst),
-            0,
-            "a cover this process owns is the stop path's to release"
-        );
-        assert_eq!(state.transient_sweep_calls.load(Ordering::SeqCst), 0);
-    }
-    let _ = dir;
 }
 
 #[skuld::test]
@@ -2755,6 +2736,58 @@ mod self_test {
         cfg.dns.enabled = true;
         cfg.dns.servers = vec!["127.0.0.1".parse().unwrap()];
         (pm, cfg, st, dir)
+    }
+
+    /// A cover THIS process holds must survive an off-intent: `stop_with` owns it,
+    /// and on macOS the standing release reloads a whole ruleset, so running it
+    /// here would tear a live cover down and open the host mid-block.
+    #[skuld::test]
+    fn lockdown_off_leaves_a_transient_cover_this_process_holds() {
+        rt().block_on(async {
+            let (mut pm, cfg, st, dir) = covered_gate_setup(false);
+            let _ = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert!(
+                pm.blocked_until_connected(),
+                "fixture precondition: the failed covered start must hold the cover"
+            );
+
+            pm.set_lockdown_intent(false).expect("persist only");
+            assert_eq!(
+                st.standing_disengage_calls.load(Ordering::SeqCst),
+                0,
+                "a cover this process owns is the stop path's to release"
+            );
+            assert_eq!(st.transient_sweep_calls.load(Ordering::SeqCst), 0);
+            assert!(
+                !lockdown_state::load_enabled(dir.path()),
+                "the intent still records off"
+            );
+        });
+    }
+
+    /// The held guard already answers for that cover, so the OS must not be asked
+    /// — a correctness guard and a per-poll cost guard both.
+    #[skuld::test]
+    fn cover_status_skips_the_transient_probe_while_this_process_owns_it() {
+        rt().block_on(async {
+            let (mut pm, cfg, st, _dir) = covered_gate_setup(false);
+            let _ = pm
+                .start_cancellable(&cfg, true, CancellationToken::new())
+                .await
+                .unwrap_err();
+            assert!(pm.blocked_until_connected(), "fixture precondition");
+            st.transient_state_calls.store(0, Ordering::SeqCst);
+
+            let _ = pm.cover_status();
+            assert_eq!(
+                st.transient_state_calls.load(Ordering::SeqCst),
+                0,
+                "the in-process guard answers; no OS probe may run"
+            );
+        });
     }
 
     #[skuld::test]

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -195,7 +195,7 @@ struct MockRoutingState {
     /// `fail_cover` (always-fail) is unaffected and takes priority.
     fail_cover_for_resolvers: std::sync::Mutex<std::collections::HashSet<Option<IpAddr>>>,
     /// What `lockdown_cover_state` reports — the OS-truth probe a test drives to
-    /// stand in for a cover adopted from a crashed run (#825).
+    /// stand in for a cover adopted from a crashed run.
     cover_state: std::sync::Mutex<CoverState>,
     /// How many times the probe was asked. Lets a test assert the short-circuit
     /// (a session that owns the cover must not pay for an OS call).
@@ -2023,7 +2023,7 @@ fn full_start_fails_closed_when_doh_cannot_resolve() {
 // guards unwind without ever hijacking the user's system DNS into a
 // dead tunnel.
 
-// Kill-switch lockout: state + release (#825) =========================================================================
+// Kill-switch lockout: state + release ================================================================================
 
 /// A manager + its routing mock's shared state, both pointed at one `dir`, with
 /// the OS-truth cover probe seeded to `cover`. Stands in for a bridge that has
@@ -2172,6 +2172,54 @@ async fn lockdown_off_attempts_the_release_when_the_probe_is_unknown() {
         state.standing_disengage_calls.load(Ordering::SeqCst),
         1,
         "an unanswerable probe must not be read as nothing-to-release"
+    );
+}
+
+#[skuld::test]
+async fn lockdown_off_disarms_when_an_unknown_probe_and_a_failed_release_correlate() {
+    // On Windows the probe and the release both go through `FwpmEngineOpen0`, so
+    // an unreachable firewall makes the probe Unknown AND the release fail. If
+    // that refused, the switch could never be turned off — a lockout built out of
+    // the fix for one. We never observed a cover, so record the intent and let
+    // `held_closed` keep surfacing the uncertainty.
+    let (pm, state, dir) = lockout_manager(CoverState::Unknown, true);
+    state.fail_standing_disengage.store(true, Ordering::SeqCst);
+
+    pm.set_lockdown_intent(false)
+        .expect("an unconfirmed cover must not strand the setting");
+    assert_eq!(state.standing_disengage_calls.load(Ordering::SeqCst), 1);
+    assert!(!lockdown_state::load_enabled(dir.path()), "intent recorded off");
+    assert!(
+        pm.held_closed(),
+        "and the uncertainty is still surfaced, so the escape stays on the menu"
+    );
+}
+
+#[skuld::test]
+async fn lockdown_off_refuses_only_when_a_cover_was_actually_observed() {
+    // The mirror of the case above: Engaged is an observation, so a failed
+    // release means we KNOW the host is blocked and the setting must not lie.
+    let (pm, state, dir) = lockout_manager(CoverState::Engaged, true);
+    state.fail_standing_disengage.store(true, Ordering::SeqCst);
+
+    assert!(pm.set_lockdown_intent(false).is_err());
+    assert!(lockdown_state::load_enabled(dir.path()), "intent stays ON");
+}
+
+#[skuld::test]
+async fn cover_status_probes_the_os_once() {
+    // The two flags must describe the same instant: the firewall is not under the
+    // ProxyManager lock, so a torn pair can claim a session owns a cover that a
+    // concurrent `hole bridge unlock` just cleared.
+    let (pm, state, _dir) = lockout_manager(CoverState::Engaged, true);
+    state.cover_state_calls.store(0, Ordering::SeqCst);
+
+    let (active, held) = pm.cover_status();
+    assert!(active && held);
+    assert_eq!(
+        state.cover_state_calls.load(Ordering::SeqCst),
+        1,
+        "one status read must cost exactly one OS probe"
     );
 }
 

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -565,6 +565,7 @@ impl BridgeIpcClient {
                         ipv6_bypass_available: status.ipv6_bypass_available,
                         lockdown_enabled: status.lockdown_enabled,
                         lockdown_active: status.lockdown_active,
+                        held_closed: status.held_closed,
                         blocked_until_connected: status.blocked_until_connected,
                     })
                 } else {

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -566,6 +566,7 @@ impl BridgeIpcClient {
                         lockdown_enabled: status.lockdown_enabled,
                         lockdown_active: status.lockdown_active,
                         held_closed: status.held_closed,
+                        cover_state_unknown: status.cover_state_unknown,
                         blocked_until_connected: status.blocked_until_connected,
                     })
                 } else {

--- a/crates/bridge/tests/lockout_privileged.rs
+++ b/crates/bridge/tests/lockout_privileged.rs
@@ -1,0 +1,162 @@
+//! Privileged-lane proof that a kill-switch lockout is escapable end to end
+//! (bindreams/hole#825). Real WFP/pf cover + real egress probes, driven through
+//! the production `ProxyManager` + `SystemRouting` so the user's actual remedy —
+//! turning the kill switch off — is on the tested path.
+//!
+//! NOT `#[ignore]`d and does NOT skip on missing privilege: a default
+//! `cargo nextest` run on an unelevated box runs these and FAILS LOUD; the
+//! explicit `SKULD_LABELS="!tun"` filter opts out, and CI provisions the
+//! elevation.
+//!
+//! Lives here rather than in `tun-engine` because the assertion the whole issue
+//! rests on is that `ProxyManager::set_lockdown_intent(false)` opens the host.
+//! `tun-engine` sits below `hole-bridge` and cannot reach it, so a test placed
+//! there could only call `failclosed::disengage_lockdown` directly and would be
+//! blind to every decision the manager makes.
+//!
+//! The unclean exit is `CoverGuard::disarm` — `std::mem::forget` of the platform
+//! guard, so its Drop never runs and the OS is left in exactly the state a crash
+//! leaves: persistent WFP filters on Windows, a persisted pf token + snapshot
+//! with the ruleset loaded on macOS. That is the production cutover path's own
+//! crash-equivalent primitive, not a stand-in for one. What it does NOT reproduce
+//! is the process boundary itself; `hole bridge unlock` is the only binary entry
+//! point to a release and it resolves the real service state dir, which a test
+//! must not clobber.
+//!
+//! Every reachability assertion is OUTBOUND egress to a routable IP, never
+//! loopback: the GitHub Actions Windows runner drops inbound loopback to the test
+//! exe, so a loopback probe cannot tell a working cover from a broken one. IP
+//! literals only — the cover blocks DNS.
+//!
+//! Cross-binary serialization of the global WFP/pf state lives in
+//! `.config/nextest.toml` (`global-net-state` test-group). COUPLED NAMES: that
+//! group's filter matches by the `lockdown_lockout_` prefix — renaming it WITHOUT
+//! updating the filter drops the test from the group (a silent cross-binary
+//! race). Change both together.
+
+hole_test_observability::register!();
+
+fn main() {
+    skuld::run_all();
+}
+
+#[skuld::label]
+const TUN: skuld::Label;
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::net::TcpStream;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::time::Duration;
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const SERVER_IP: &str = "1.1.1.1";
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const PERMITTED: &str = "1.1.1.1:443";
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const NON_PERMITTED: &str = "8.8.8.8:443";
+
+/// External-event probe with a graceful failure bound: the timeout is the
+/// failure-to-human signal, not a sync sleep; assertions are Ok/Err, not timing.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn connect(addr: &str) -> std::io::Result<TcpStream> {
+    TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(5))
+}
+
+/// An always-present interface used only as a LUID/name source, so the real
+/// resolve path runs; no assertion depends on it.
+#[cfg(target_os = "windows")]
+const TUN_NAME: &str = "Loopback Pseudo-Interface 1";
+#[cfg(target_os = "macos")]
+const TUN_NAME: &str = "utun-absent";
+
+/// The whole lockout, start to finish: a crash leaves the cover holding, the
+/// bridge reports it truthfully with nothing running, and turning the kill switch
+/// off actually opens the host.
+///
+/// Phase 5 is the posture guard — recovery must KEEP the host closed. Phase 8 is
+/// the one rule #0 rests on: the user's action restores their network.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn lockdown_lockout_survives_unclean_exit_and_release_opens_the_host() {
+    use hole_bridge::proxy_manager::ProxyManager;
+    use tun_engine::routing::failclosed::{engage_lockdown, lockdown_cover_state, lockdown_state, CoverState};
+    use tun_engine::routing::failclosed::{lockdown_cover_present, SystemLuidResolver};
+    use tun_engine::routing::{decide_cover_recovery, recover_routes, CoverGuard, CoverRecovery, SystemRouting};
+
+    let dir = tempfile::tempdir().unwrap();
+    let resolver = SystemLuidResolver;
+    let server_ip: std::net::IpAddr = SERVER_IP.parse().unwrap();
+
+    // 1. Baseline. A failure here is the network, not the cover.
+    assert!(
+        connect(PERMITTED).is_ok() && connect(NON_PERMITTED).is_ok(),
+        "NETWORK/ENVIRONMENT problem (not the cover): pre-cover baseline egress must reach both hosts"
+    );
+
+    // 2. A connected session with the kill switch armed.
+    lockdown_state::set_enabled(dir.path(), true, None).unwrap();
+    let cover = engage_lockdown(server_ip, TUN_NAME, &resolver, &[], dir.path(), None)
+        .expect("engage the real standing lockdown cover");
+
+    // 3. The unclean exit: the guard is forgotten, so nothing disengages.
+    CoverGuard::disarm(cover);
+
+    // 4. The lockout. This is the state #825 reported as "not engaged".
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Engaged,
+        "the cover survives an unclean exit and is still holding the host"
+    );
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "and it really is blocking: {NON_PERMITTED} must not connect"
+    );
+
+    // 5. Recovery keeps the host closed. A crash is when a leak is least
+    //    acceptable, so pin the posture against a future change loosening it.
+    assert_eq!(
+        decide_cover_recovery(true, lockdown_cover_present(dir.path())),
+        CoverRecovery::Adopt,
+        "intent on + a cover present must Adopt"
+    );
+    recover_routes(dir.path());
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Engaged,
+        "Adopt must keep the host fail-closed across the restart"
+    );
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "the adopted cover still blocks: {NON_PERMITTED}"
+    );
+
+    // 6. The bridge reports the truth with nothing running — the tray's inputs.
+    let pm = ProxyManager::new(
+        hole_bridge::proxy::ShadowsocksProxy,
+        SystemRouting::new(dir.path().to_path_buf(), None),
+    )
+    .with_state_dir(dir.path().to_path_buf());
+    assert!(pm.lockdown_active(), "an adopted cover IS engaged");
+    assert!(pm.held_closed(), "and no session owns it");
+
+    // 7. The user's remedy.
+    pm.set_lockdown_intent(false)
+        .expect("turning the kill switch off must release the cover");
+
+    // 8. It actually opened the host. The assertion rule #0 rests on.
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Absent,
+        "the release must leave no cover engaged"
+    );
+    assert!(
+        !lockdown_state::load_enabled(dir.path()),
+        "and the intent is recorded off only because the release succeeded"
+    );
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "the user's network must be back: {NON_PERMITTED} must connect again"
+    );
+    assert!(!pm.lockdown_active(), "and the bridge agrees nothing is engaged");
+    assert!(!pm.held_closed());
+}

--- a/crates/bridge/tests/lockout_privileged.rs
+++ b/crates/bridge/tests/lockout_privileged.rs
@@ -1,5 +1,5 @@
-//! Privileged-lane proof that a kill-switch lockout is escapable end to end
-//! (bindreams/hole#825). Real WFP/pf cover + real egress probes, driven through
+//! Privileged-lane proof that a kill-switch lockout is escapable end to end.
+//! Real WFP/pf cover + real egress probes, driven through
 //! the production `ProxyManager` + `SystemRouting` so the user's actual remedy —
 //! turning the kill switch off — is on the tested path.
 //!
@@ -101,7 +101,7 @@ fn lockdown_lockout_survives_unclean_exit_and_release_opens_the_host() {
     // 3. The unclean exit: the guard is forgotten, so nothing disengages.
     CoverGuard::disarm(cover);
 
-    // 4. The lockout. This is the state #825 reported as "not engaged".
+    // 4. The lockout: the cover survives the crash and is holding the host closed.
     assert_eq!(
         lockdown_cover_state(dir.path()),
         CoverState::Engaged,

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -323,8 +323,20 @@ components:
           type: boolean
           default: false
           description: >-
-            Whether a lockdown cover is currently engaged. `lockdown_enabled &&
-            !lockdown_active` is a tray warning state — never silent green.
+            Whether a lockdown cover is engaged, as the OS reports it —
+            independent of whether a session is running, since a cover adopted
+            from a crashed run is owned by no process. A probe that cannot reach
+            the firewall reports true rather than claiming an all-clear it did
+            not observe.
+        held_closed:
+          type: boolean
+          default: false
+          description: >-
+            Whether a lockdown cover is engaged that no running session owns, so
+            the host has no working egress and no tunnel carrying traffic through
+            the block. Distinct from `lockdown_active`, which is also true for a
+            healthy protected session. serde-default false so older clients keep
+            today's behavior.
         blocked_until_connected:
           type: boolean
           default: false

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -323,20 +323,29 @@ components:
           type: boolean
           default: false
           description: >-
-            Whether a lockdown cover is engaged, as the OS reports it —
-            independent of whether a session is running, since a cover adopted
-            from a crashed run is owned by no process. A probe that cannot reach
-            the firewall reports true rather than claiming an all-clear it did
-            not observe.
+            Whether a standing lockdown cover is engaged. Read from the OS unless
+            a running session already holds the guard, which answers it without a
+            probe. Never derived from whether a session is running: a cover
+            adopted from a crashed run is owned by no process. A probe that cannot
+            reach the firewall reports true rather than claiming an all-clear it
+            did not observe.
         held_closed:
           type: boolean
           default: false
           description: >-
-            Whether a lockdown cover is engaged that no running session owns, so
-            the host has no working egress and no tunnel carrying traffic through
-            the block. Distinct from `lockdown_active`, which is also true for a
-            healthy protected session. serde-default false so older clients keep
-            today's behavior.
+            Whether a cover — standing OR transient — is engaged that no
+            in-process guard owns, so the host has no working egress and nothing
+            carrying traffic through the block. Distinct from `lockdown_active`,
+            which is also true for a healthy protected session. serde-default
+            false so older clients keep today's behavior.
+        cover_state_unknown:
+          type: boolean
+          default: false
+          description: >-
+            Whether the evidence behind `held_closed` is a probe that could not
+            reach the firewall rather than an observed cover. Telling a user Hole
+            is blocking them is a different claim from telling them Hole cannot
+            tell. serde-default false so older clients keep today's behavior.
         blocked_until_connected:
           type: boolean
           default: false

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -139,6 +139,10 @@ pub enum BridgeResponse {
         ipv6_bypass_available: bool,
         lockdown_enabled: bool,
         lockdown_active: bool,
+        /// Whether a lockdown cover is engaged that no running session owns — Hole
+        /// is holding the network closed with nothing carrying traffic through it.
+        /// Drives the tray's held-closed state and its release action.
+        held_closed: bool,
         /// Whether a covered start failed and left the host fail-closed (blocked,
         /// not leaked) while not running. Drives the GUI's distinct blocked state
         /// (Retry / Disconnect).

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -139,10 +139,14 @@ pub enum BridgeResponse {
         ipv6_bypass_available: bool,
         lockdown_enabled: bool,
         lockdown_active: bool,
-        /// Whether a lockdown cover is engaged that no running session owns — Hole
-        /// is holding the network closed with nothing carrying traffic through it.
-        /// Drives the tray's held-closed state and its release action.
+        /// Whether a cover — standing OR transient — is engaged that no in-process
+        /// guard owns: Hole is holding the network closed with nothing carrying
+        /// traffic through it. Drives the tray's held-closed state and its release.
         held_closed: bool,
+        /// Whether `held_closed` rests on an unanswerable probe rather than an
+        /// observed cover. "We are blocking you" and "we cannot tell" are
+        /// different claims and the tray must not conflate them.
+        cover_state_unknown: bool,
         /// Whether a covered start failed and left the host fail-closed (blocked,
         /// not leaked) while not running. Drives the GUI's distinct blocked state
         /// (Retry / Disconnect).

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -305,12 +305,14 @@ fn route_lockdown_path_is_stable() {
 #[skuld::test]
 fn status_response_lockdown_fields_default_false_for_old_clients() {
     use crate::protocol::StatusResponse;
-    // An old client sends a StatusResponse JSON without the lockdown fields;
+    // An old client sends a StatusResponse JSON without the lockdown/cover fields;
     // serde-default must fill them as false (matching udp/ipv6 fields).
     let json = r#"{"running":true,"uptime_secs":0}"#;
     let s: StatusResponse = serde_json::from_str(json).unwrap();
     assert!(!s.lockdown_enabled);
     assert!(!s.lockdown_active);
+    assert!(!s.held_closed);
+    assert!(!s.blocked_until_connected);
 }
 
 #[skuld::test]

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -150,6 +150,7 @@ fn bridge_response_status_json_roundtrip() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: true,
     };
     let json = serde_json::to_vec(&resp).unwrap();
@@ -232,6 +233,7 @@ fn status_response_json_roundtrip() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     };
     let json = serde_json::to_string(&resp).unwrap();
@@ -251,6 +253,7 @@ fn status_response_without_error() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     };
     let json = serde_json::to_string(&resp).unwrap();

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -149,6 +149,7 @@ fn bridge_response_status_json_roundtrip() {
         ipv6_bypass_available: false,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: true,
     };
     let json = serde_json::to_vec(&resp).unwrap();
@@ -230,6 +231,7 @@ fn status_response_json_roundtrip() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     };
     let json = serde_json::to_string(&resp).unwrap();
@@ -248,6 +250,7 @@ fn status_response_without_error() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     };
     let json = serde_json::to_string(&resp).unwrap();

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -131,6 +131,7 @@ impl BridgeClient {
                         ipv6_bypass_available: status.ipv6_bypass_available,
                         lockdown_enabled: status.lockdown_enabled,
                         lockdown_active: status.lockdown_active,
+                        held_closed: status.held_closed,
                         blocked_until_connected: status.blocked_until_connected,
                     })
                 } else {

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -132,6 +132,7 @@ impl BridgeClient {
                         lockdown_enabled: status.lockdown_enabled,
                         lockdown_active: status.lockdown_active,
                         held_closed: status.held_closed,
+                        cover_state_unknown: status.cover_state_unknown,
                         blocked_until_connected: status.blocked_until_connected,
                     })
                 } else {

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -33,6 +33,7 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     ipv6_bypass_available: true,
                     lockdown_enabled: false,
                     lockdown_active: false,
+                    held_closed: false,
                     blocked_until_connected: false,
                 })
             }),
@@ -127,6 +128,7 @@ fn send_status_request_receives_response() {
                 ipv6_bypass_available: true,
                 lockdown_enabled: false,
                 lockdown_active: false,
+                held_closed: false,
                 blocked_until_connected: false,
             }
         );
@@ -455,6 +457,7 @@ async fn spawn_error_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<(
                     ipv6_bypass_available: true,
                     lockdown_enabled: false,
                     lockdown_active: false,
+                    held_closed: false,
                     blocked_until_connected: false,
                 })
             }),
@@ -608,6 +611,7 @@ async fn spawn_status_mock(path: &std::path::Path, version: Option<&'static str>
                 ipv6_bypass_available: true,
                 lockdown_enabled: false,
                 lockdown_active: false,
+                held_closed: false,
                 blocked_until_connected: false,
             })
         }),

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -34,6 +34,7 @@ async fn spawn_mock_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<()
                     lockdown_enabled: false,
                     lockdown_active: false,
                     held_closed: false,
+                    cover_state_unknown: false,
                     blocked_until_connected: false,
                 })
             }),
@@ -129,6 +130,7 @@ fn send_status_request_receives_response() {
                 lockdown_enabled: false,
                 lockdown_active: false,
                 held_closed: false,
+                cover_state_unknown: false,
                 blocked_until_connected: false,
             }
         );
@@ -458,6 +460,7 @@ async fn spawn_error_bridge(path: &std::path::Path) -> tokio::task::JoinHandle<(
                     lockdown_enabled: false,
                     lockdown_active: false,
                     held_closed: false,
+                    cover_state_unknown: false,
                     blocked_until_connected: false,
                 })
             }),
@@ -612,6 +615,7 @@ async fn spawn_status_mock(path: &std::path::Path, version: Option<&'static str>
                 lockdown_enabled: false,
                 lockdown_active: false,
                 held_closed: false,
+                cover_state_unknown: false,
                 blocked_until_connected: false,
             })
         }),

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -368,6 +368,7 @@ fn status_snap(seq: u64, running: bool, error: Option<&str>) -> crate::state::Pr
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     }
 }
@@ -389,6 +390,7 @@ fn map_status_emits_full_shape_on_status_ok() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     });
     let j = map_status_response(resp, status_snap(7, true, None));
@@ -426,6 +428,7 @@ fn map_status_sources_running_seq_error_from_snap() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     });
     let j = map_status_response(resp, status_snap(9, false, Some("proxy task exited unexpectedly")));
@@ -481,6 +484,7 @@ fn map_status_death_error_is_the_sentinel_only() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     });
     let j = map_status_response(resp, status_snap(4, false, Some("proxy task exited unexpectedly")));

--- a/crates/hole/src/commands_tests.rs
+++ b/crates/hole/src/commands_tests.rs
@@ -367,6 +367,7 @@ fn status_snap(seq: u64, running: bool, error: Option<&str>) -> crate::state::Pr
         error: error.map(Into::into),
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     }
 }
@@ -387,6 +388,7 @@ fn map_status_emits_full_shape_on_status_ok() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     });
     let j = map_status_response(resp, status_snap(7, true, None));
@@ -423,6 +425,7 @@ fn map_status_sources_running_seq_error_from_snap() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     });
     let j = map_status_response(resp, status_snap(9, false, Some("proxy task exited unexpectedly")));
@@ -477,6 +480,7 @@ fn map_status_death_error_is_the_sentinel_only() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     });
     let j = map_status_response(resp, status_snap(4, false, Some("proxy task exited unexpectedly")));

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -289,6 +289,7 @@ fn classify_unexpected_ok_is_success() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     });
     assert_eq!(classify_elevated_send(&r), ElevatedOutcome::Success);

--- a/crates/hole/src/elevation_tests.rs
+++ b/crates/hole/src/elevation_tests.rs
@@ -290,6 +290,7 @@ fn classify_unexpected_ok_is_success() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     });
     assert_eq!(classify_elevated_send(&r), ElevatedOutcome::Success);

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -252,9 +252,7 @@ impl BridgeLink {
         // A resolved observation retracts any stale wedge failure.
         self.cell.clear_update_failed(UPDATE_FAILED);
         match observed_lockdown(result) {
-            Some((le, la, hc, blk)) => self
-                .cell
-                .commit_status(running, observed_error(result), le, la, hc, blk),
+            Some(lockdown) => self.cell.commit_status(running, observed_error(result), lockdown),
             None => self.cell.commit(running),
         }
     }
@@ -409,6 +407,17 @@ pub struct ProxySnapshot {
     pub blocked_until_connected: bool,
 }
 
+/// The kill-switch/cover flags a Status observation carries. A named struct, not
+/// four positional `bool`s: they are same-typed and adjacent, so a transposition
+/// at any call site would compile silently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LockdownObservation {
+    pub enabled: bool,
+    pub active: bool,
+    pub held_closed: bool,
+    pub blocked_until_connected: bool,
+}
+
 /// Single owner of the GUI's view of "is the proxy running" (#462).
 pub struct ProxyStateCell {
     tx: tokio::sync::watch::Sender<ProxySnapshot>,
@@ -465,15 +474,13 @@ impl ProxyStateCell {
     /// by the `Status` arm so all commit atomically under the one client lock.
     /// `error` rides the same write — it is meaningful only alongside a running
     /// edge (a death), so it is not part of the change check.
-    pub fn commit_status(
-        &self,
-        running: bool,
-        error: Option<String>,
-        lockdown_enabled: bool,
-        lockdown_active: bool,
-        held_closed: bool,
-        blocked_until_connected: bool,
-    ) {
+    pub fn commit_status(&self, running: bool, error: Option<String>, lockdown: LockdownObservation) {
+        let LockdownObservation {
+            enabled: lockdown_enabled,
+            active: lockdown_active,
+            held_closed,
+            blocked_until_connected,
+        } = lockdown;
         self.tx.send_if_modified(|snap| {
             if snap.running == running
                 && snap.lockdown_enabled == lockdown_enabled
@@ -502,14 +509,19 @@ impl ProxyStateCell {
     /// (preserve prior).
     /// Idempotent — bumps `seq` only when running, error, or one of those flags
     /// actually changes.
-    pub fn commit_update_failed(&self, reason: &'static str, lockdown: Option<(bool, bool, bool, bool)>) {
+    pub fn commit_update_failed(&self, reason: &'static str, lockdown: Option<LockdownObservation>) {
         self.tx.send_if_modified(|snap| {
-            let (le, la, hc, blk) = lockdown.unwrap_or((
-                snap.lockdown_enabled,
-                snap.lockdown_active,
-                snap.held_closed,
-                snap.blocked_until_connected,
-            ));
+            let LockdownObservation {
+                enabled: le,
+                active: la,
+                held_closed: hc,
+                blocked_until_connected: blk,
+            } = lockdown.unwrap_or(LockdownObservation {
+                enabled: snap.lockdown_enabled,
+                active: snap.lockdown_active,
+                held_closed: snap.held_closed,
+                blocked_until_connected: snap.blocked_until_connected,
+            });
             if !snap.running
                 && snap.error.as_deref() == Some(reason)
                 && snap.lockdown_enabled == le
@@ -700,7 +712,7 @@ pub fn classify_lockdown(result: &Result<BridgeResponse, ClientError>) -> Lockdo
 /// The lockdown (enabled, active, held_closed) + blocked-until-connected flags a
 /// Status exchange revealed, if any. Only a `Status` Ok carries them; every other
 /// exchange yields None (leave the snapshot's prior fields untouched).
-pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<(bool, bool, bool, bool)> {
+pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<LockdownObservation> {
     match result {
         Ok(BridgeResponse::Status {
             lockdown_enabled,
@@ -708,12 +720,12 @@ pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) ->
             held_closed,
             blocked_until_connected,
             ..
-        }) => Some((
-            *lockdown_enabled,
-            *lockdown_active,
-            *held_closed,
-            *blocked_until_connected,
-        )),
+        }) => Some(LockdownObservation {
+            enabled: *lockdown_enabled,
+            active: *lockdown_active,
+            held_closed: *held_closed,
+            blocked_until_connected: *blocked_until_connected,
+        }),
         _ => None,
     }
 }

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -252,7 +252,9 @@ impl BridgeLink {
         // A resolved observation retracts any stale wedge failure.
         self.cell.clear_update_failed(UPDATE_FAILED);
         match observed_lockdown(result) {
-            Some((le, la, blk)) => self.cell.commit_status(running, observed_error(result), le, la, blk),
+            Some((le, la, hc, blk)) => self
+                .cell
+                .commit_status(running, observed_error(result), le, la, hc, blk),
             None => self.cell.commit(running),
         }
     }
@@ -394,9 +396,13 @@ pub struct ProxySnapshot {
     pub error: Option<String>,
     /// Standing kill-switch intent (#527), from the bridge's StatusResponse.
     pub lockdown_enabled: bool,
-    /// Whether a lockdown cover is engaged. `enabled && !active` is a tray
-    /// warning state — never silent green.
+    /// Whether a lockdown cover is engaged, as the bridge probes the OS —
+    /// true for a healthy protected session AND for a cover left by a crash.
     pub lockdown_active: bool,
+    /// Whether a lockdown cover is engaged that no running session owns: Hole is
+    /// holding the network closed with nothing carrying traffic through it. The
+    /// tray renders this with the action that ends it.
+    pub held_closed: bool,
     /// Whether a covered start (auto-connect) failed and left the host
     /// fail-closed (blocked, not leaked) while not running — a distinct blocked
     /// state (Retry / Disconnect), never silent Disconnected.
@@ -422,6 +428,7 @@ impl ProxyStateCell {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false,
         });
         Self { tx }
@@ -446,6 +453,7 @@ impl ProxyStateCell {
                 error: None,
                 lockdown_enabled: snap.lockdown_enabled,
                 lockdown_active: snap.lockdown_active,
+                held_closed: snap.held_closed,
                 blocked_until_connected: false,
             };
             true
@@ -463,12 +471,14 @@ impl ProxyStateCell {
         error: Option<String>,
         lockdown_enabled: bool,
         lockdown_active: bool,
+        held_closed: bool,
         blocked_until_connected: bool,
     ) {
         self.tx.send_if_modified(|snap| {
             if snap.running == running
                 && snap.lockdown_enabled == lockdown_enabled
                 && snap.lockdown_active == lockdown_active
+                && snap.held_closed == held_closed
                 && snap.blocked_until_connected == blocked_until_connected
             {
                 return false;
@@ -479,6 +489,7 @@ impl ProxyStateCell {
                 error,
                 lockdown_enabled,
                 lockdown_active,
+                held_closed,
                 blocked_until_connected,
             };
             true
@@ -486,21 +497,24 @@ impl ProxyStateCell {
     }
 
     /// Commit a wedged-cutover failure: Disconnected + the path-free reason.
-    /// `lockdown` is `Some((enabled, active, blocked))` when the triggering Status
-    /// carried fresh flags (apply them) and `None` otherwise (preserve prior).
+    /// `lockdown` is `Some((enabled, active, held_closed, blocked))` when the
+    /// triggering Status carried fresh flags (apply them) and `None` otherwise
+    /// (preserve prior).
     /// Idempotent — bumps `seq` only when running, error, or one of those flags
     /// actually changes.
-    pub fn commit_update_failed(&self, reason: &'static str, lockdown: Option<(bool, bool, bool)>) {
+    pub fn commit_update_failed(&self, reason: &'static str, lockdown: Option<(bool, bool, bool, bool)>) {
         self.tx.send_if_modified(|snap| {
-            let (le, la, blk) = lockdown.unwrap_or((
+            let (le, la, hc, blk) = lockdown.unwrap_or((
                 snap.lockdown_enabled,
                 snap.lockdown_active,
+                snap.held_closed,
                 snap.blocked_until_connected,
             ));
             if !snap.running
                 && snap.error.as_deref() == Some(reason)
                 && snap.lockdown_enabled == le
                 && snap.lockdown_active == la
+                && snap.held_closed == hc
                 && snap.blocked_until_connected == blk
             {
                 return false;
@@ -511,6 +525,7 @@ impl ProxyStateCell {
                 error: Some(reason.to_string()),
                 lockdown_enabled: le,
                 lockdown_active: la,
+                held_closed: hc,
                 blocked_until_connected: blk,
             };
             true
@@ -682,17 +697,23 @@ pub fn classify_lockdown(result: &Result<BridgeResponse, ClientError>) -> Lockdo
     }
 }
 
-/// The lockdown (enabled, active) + blocked-until-connected flags a Status
-/// exchange revealed, if any. Only a `Status` Ok carries them; every other
+/// The lockdown (enabled, active, held_closed) + blocked-until-connected flags a
+/// Status exchange revealed, if any. Only a `Status` Ok carries them; every other
 /// exchange yields None (leave the snapshot's prior fields untouched).
-pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<(bool, bool, bool)> {
+pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) -> Option<(bool, bool, bool, bool)> {
     match result {
         Ok(BridgeResponse::Status {
             lockdown_enabled,
             lockdown_active,
+            held_closed,
             blocked_until_connected,
             ..
-        }) => Some((*lockdown_enabled, *lockdown_active, *blocked_until_connected)),
+        }) => Some((
+            *lockdown_enabled,
+            *lockdown_active,
+            *held_closed,
+            *blocked_until_connected,
+        )),
         _ => None,
     }
 }

--- a/crates/hole/src/state.rs
+++ b/crates/hole/src/state.rs
@@ -397,10 +397,13 @@ pub struct ProxySnapshot {
     /// Whether a lockdown cover is engaged, as the bridge probes the OS —
     /// true for a healthy protected session AND for a cover left by a crash.
     pub lockdown_active: bool,
-    /// Whether a lockdown cover is engaged that no running session owns: Hole is
-    /// holding the network closed with nothing carrying traffic through it. The
-    /// tray renders this with the action that ends it.
+    /// Whether a cover — standing or transient — is engaged that no in-process
+    /// guard owns: Hole is holding the network closed with nothing carrying
+    /// traffic through it. The tray renders this with the action that ends it.
     pub held_closed: bool,
+    /// Whether `held_closed` rests on an unanswerable probe rather than an
+    /// observed cover — a different claim, and the tray must not conflate them.
+    pub cover_state_unknown: bool,
     /// Whether a covered start (auto-connect) failed and left the host
     /// fail-closed (blocked, not leaked) while not running — a distinct blocked
     /// state (Retry / Disconnect), never silent Disconnected.
@@ -415,6 +418,7 @@ pub struct LockdownObservation {
     pub enabled: bool,
     pub active: bool,
     pub held_closed: bool,
+    pub cover_state_unknown: bool,
     pub blocked_until_connected: bool,
 }
 
@@ -438,6 +442,7 @@ impl ProxyStateCell {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         });
         Self { tx }
@@ -463,6 +468,7 @@ impl ProxyStateCell {
                 lockdown_enabled: snap.lockdown_enabled,
                 lockdown_active: snap.lockdown_active,
                 held_closed: snap.held_closed,
+                cover_state_unknown: snap.cover_state_unknown,
                 blocked_until_connected: false,
             };
             true
@@ -479,6 +485,7 @@ impl ProxyStateCell {
             enabled: lockdown_enabled,
             active: lockdown_active,
             held_closed,
+            cover_state_unknown,
             blocked_until_connected,
         } = lockdown;
         self.tx.send_if_modified(|snap| {
@@ -486,6 +493,7 @@ impl ProxyStateCell {
                 && snap.lockdown_enabled == lockdown_enabled
                 && snap.lockdown_active == lockdown_active
                 && snap.held_closed == held_closed
+                && snap.cover_state_unknown == cover_state_unknown
                 && snap.blocked_until_connected == blocked_until_connected
             {
                 return false;
@@ -497,6 +505,7 @@ impl ProxyStateCell {
                 lockdown_enabled,
                 lockdown_active,
                 held_closed,
+                cover_state_unknown,
                 blocked_until_connected,
             };
             true
@@ -515,11 +524,13 @@ impl ProxyStateCell {
                 enabled: le,
                 active: la,
                 held_closed: hc,
+                cover_state_unknown: unk,
                 blocked_until_connected: blk,
             } = lockdown.unwrap_or(LockdownObservation {
                 enabled: snap.lockdown_enabled,
                 active: snap.lockdown_active,
                 held_closed: snap.held_closed,
+                cover_state_unknown: snap.cover_state_unknown,
                 blocked_until_connected: snap.blocked_until_connected,
             });
             if !snap.running
@@ -527,6 +538,7 @@ impl ProxyStateCell {
                 && snap.lockdown_enabled == le
                 && snap.lockdown_active == la
                 && snap.held_closed == hc
+                && snap.cover_state_unknown == unk
                 && snap.blocked_until_connected == blk
             {
                 return false;
@@ -538,6 +550,7 @@ impl ProxyStateCell {
                 lockdown_enabled: le,
                 lockdown_active: la,
                 held_closed: hc,
+                cover_state_unknown: unk,
                 blocked_until_connected: blk,
             };
             true
@@ -718,12 +731,14 @@ pub(crate) fn observed_lockdown(result: &Result<BridgeResponse, ClientError>) ->
             lockdown_enabled,
             lockdown_active,
             held_closed,
+            cover_state_unknown,
             blocked_until_connected,
             ..
         }) => Some(LockdownObservation {
             enabled: *lockdown_enabled,
             active: *lockdown_active,
             held_closed: *held_closed,
+            cover_state_unknown: *cover_state_unknown,
             blocked_until_connected: *blocked_until_connected,
         }),
         _ => None,

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -43,6 +43,7 @@ fn cell_bumps_seq_only_on_change() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -58,6 +59,7 @@ fn cell_bumps_seq_only_on_change() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -71,6 +73,7 @@ fn cell_bumps_seq_only_on_change() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -93,6 +96,7 @@ async fn cell_wakes_watchers_only_on_change() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         }
     );
@@ -112,6 +116,7 @@ fn commit_status_carries_lockdown_fields() {
             enabled: true,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         },
     );
@@ -133,6 +138,7 @@ fn commit_preserves_lockdown_fields() {
             enabled: true,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         },
     ); // running + lockdown enabled, not active
@@ -164,6 +170,7 @@ fn commit_clears_blocked_on_a_settled_running_edge() {
             enabled: false,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: true,
         },
     ); // enter the blocked state
@@ -196,6 +203,7 @@ fn commit_status_carries_error_on_death() {
             enabled: false,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         },
     );
@@ -217,6 +225,7 @@ fn commit_clears_error_on_non_status_running_change() {
             enabled: false,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         },
     ); // running -> true with an error
@@ -236,6 +245,7 @@ fn reconnect_clears_death_error() {
             enabled: false,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         },
     );
@@ -254,6 +264,7 @@ fn proxy_snapshot_serializes_error() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     })
     .unwrap();
@@ -265,6 +276,7 @@ fn proxy_snapshot_serializes_error() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     })
     .unwrap();
@@ -286,6 +298,7 @@ fn observed_error_only_from_status_ok() {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     });
     assert_eq!(
@@ -309,6 +322,7 @@ fn status_resp(running: bool) -> BridgeResponse {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     }
 }
@@ -463,6 +477,7 @@ fn status_response(running: bool) -> StatusResponse {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     }
 }
@@ -579,6 +594,7 @@ async fn start_ack_commits_true() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -633,6 +649,7 @@ async fn transport_error_commits_false() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -659,6 +676,7 @@ async fn transport_error_holds_snapshot_while_marker_present() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         },
         "marker present => transport error holds the last snapshot"
@@ -880,6 +898,7 @@ fn commit_update_failed_applies_a_lockdown_change() {
             enabled: false,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         },
     ); // connected, no lockdown
@@ -889,6 +908,7 @@ fn commit_update_failed_applies_a_lockdown_change() {
             enabled: true,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         }),
     );
@@ -906,6 +926,7 @@ fn commit_update_failed_applies_a_lockdown_change() {
             enabled: true,
             active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         }),
     );
@@ -917,6 +938,7 @@ fn commit_update_failed_applies_a_lockdown_change() {
             enabled: true,
             active: true,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         }),
     );
@@ -1010,6 +1032,7 @@ async fn oneshot_never_commits() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -1044,6 +1067,7 @@ async fn untracked_requests_never_commit() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -1108,6 +1132,7 @@ async fn concurrent_requests_commit_in_bridge_order() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -1173,6 +1198,7 @@ async fn reload_if_running_reloads_when_running() {
             lockdown_enabled: false,
             lockdown_active: false,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         }
     );
@@ -1218,6 +1244,7 @@ fn classify_lockdown_is_fail_closed_three_state() {
             lockdown_enabled,
             lockdown_active: lockdown_enabled,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false,
         })
     };
@@ -1249,6 +1276,7 @@ fn classify_lockdown_is_fail_closed_three_state() {
             enabled: true,
             active: true,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: false
         })
     );

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -41,6 +41,7 @@ fn cell_bumps_seq_only_on_change() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -55,6 +56,7 @@ fn cell_bumps_seq_only_on_change() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -67,6 +69,7 @@ fn cell_bumps_seq_only_on_change() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -88,6 +91,7 @@ async fn cell_wakes_watchers_only_on_change() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false,
         }
     );
@@ -100,7 +104,7 @@ fn commit_status_carries_lockdown_fields() {
     let s0 = cell.snapshot();
     assert!(!s0.lockdown_enabled && !s0.lockdown_active);
     // A Status commit threads both lockdown bools alongside `running`.
-    cell.commit_status(true, None, true, false, false);
+    cell.commit_status(true, None, true, false, false, false);
     let s1 = cell.snapshot();
     assert!(s1.running && s1.lockdown_enabled && !s1.lockdown_active);
     assert_eq!(s1.seq, 1, "seq bumped on change");
@@ -112,7 +116,7 @@ fn commit_preserves_lockdown_fields() {
     // `commit_status`); its `..*snap` must NOT clobber the lockdown warning state
     // a prior Status established (`enabled && !active` is the tray warning state).
     let cell = ProxyStateCell::new();
-    cell.commit_status(true, None, true, false, false); // running + lockdown enabled, not active
+    cell.commit_status(true, None, true, false, false, false); // running + lockdown enabled, not active
     let before = cell.snapshot();
     assert!(before.lockdown_enabled && !before.lockdown_active);
 
@@ -134,7 +138,7 @@ fn commit_clears_blocked_on_a_settled_running_edge() {
     // the next Status poll. A settled running edge resolves the transient blocked
     // sub-state, so commit clears the flag AND bumps seq to repaint immediately.
     let cell = ProxyStateCell::new();
-    cell.commit_status(false, None, false, false, true); // enter the blocked state
+    cell.commit_status(false, None, false, false, false, true); // enter the blocked state
     let before = cell.snapshot();
     assert!(before.blocked_until_connected, "precondition: blocked");
 
@@ -163,6 +167,7 @@ fn commit_status_carries_error_on_death() {
         false,
         false,
         false,
+        false,
     );
     let snap = cell.snapshot();
     assert!(!snap.running);
@@ -175,7 +180,7 @@ fn commit_clears_error_on_non_status_running_change() {
     // A non-Status running edge (Start/Stop/Cancel) is user-initiated and
     // carries no death reason — `commit` must clear any prior error.
     let cell = ProxyStateCell::new();
-    cell.commit_status(true, Some("synthetic".into()), false, false, false); // running -> true with an error
+    cell.commit_status(true, Some("synthetic".into()), false, false, false, false); // running -> true with an error
     assert_eq!(cell.snapshot().error.as_deref(), Some("synthetic"));
     cell.commit(false); // clean stop via the non-Status path
     assert_eq!(cell.snapshot().error, None, "non-Status commit must clear error");
@@ -188,6 +193,7 @@ fn reconnect_clears_death_error() {
     cell.commit_status(
         false,
         Some("proxy task exited unexpectedly".into()),
+        false,
         false,
         false,
         false,
@@ -206,6 +212,7 @@ fn proxy_snapshot_serializes_error() {
         error: Some("boom".into()),
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     })
     .unwrap();
@@ -216,6 +223,7 @@ fn proxy_snapshot_serializes_error() {
         error: None,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     })
     .unwrap();
@@ -236,6 +244,7 @@ fn observed_error_only_from_status_ok() {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     });
     assert_eq!(
@@ -258,6 +267,7 @@ fn status_resp(running: bool) -> BridgeResponse {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     }
 }
@@ -411,6 +421,7 @@ fn status_response(running: bool) -> StatusResponse {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     }
 }
@@ -526,6 +537,7 @@ async fn start_ack_commits_true() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -579,6 +591,7 @@ async fn transport_error_commits_false() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -604,6 +617,7 @@ async fn transport_error_holds_snapshot_while_marker_present() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         },
         "marker present => transport error holds the last snapshot"
@@ -818,8 +832,8 @@ fn commit_update_failed_applies_a_lockdown_change() {
     // A wedge whose Status carried a lockdown change must surface UPDATE_FAILED
     // AND the new lockdown fields — not preserve the stale prior ones.
     let cell = super::ProxyStateCell::new();
-    cell.commit_status(true, None, false, false, false); // connected, no lockdown
-    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false, false)));
+    cell.commit_status(true, None, false, false, false, false); // connected, no lockdown
+    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false, false, false)));
     let s = cell.snapshot();
     assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
     assert!(
@@ -828,10 +842,10 @@ fn commit_update_failed_applies_a_lockdown_change() {
     );
     // Re-committing the same wedge + lockdown is idempotent.
     let seq = s.seq;
-    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false, false)));
+    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false, false, false)));
     assert_eq!(cell.snapshot().seq, seq);
     // A lockdown change bumps seq even though running/error are unchanged.
-    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, true, false)));
+    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, true, false, false)));
     let s2 = cell.snapshot();
     assert!(s2.lockdown_active && s2.seq == seq + 1);
 }
@@ -921,6 +935,7 @@ async fn oneshot_never_commits() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -954,6 +969,7 @@ async fn untracked_requests_never_commit() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -1017,6 +1033,7 @@ async fn concurrent_requests_commit_in_bridge_order() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -1081,6 +1098,7 @@ async fn reload_if_running_reloads_when_running() {
             error: None,
             lockdown_enabled: false,
             lockdown_active: false,
+            held_closed: false,
             blocked_until_connected: false
         }
     );
@@ -1125,6 +1143,7 @@ fn classify_lockdown_is_fail_closed_three_state() {
             ipv6_bypass_available: true,
             lockdown_enabled,
             lockdown_active: lockdown_enabled,
+            held_closed: false,
             blocked_until_connected: false,
         })
     };
@@ -1150,7 +1169,10 @@ fn classify_lockdown_is_fail_closed_three_state() {
         super::classify_lockdown(&Err(ClientError::PermissionDenied)),
         super::LockdownRead::Unreadable
     );
-    assert_eq!(super::observed_lockdown(&status(true)), Some((true, true, false)));
+    assert_eq!(
+        super::observed_lockdown(&status(true)),
+        Some((true, true, false, false))
+    );
     assert_eq!(super::observed_lockdown(&Ok(BridgeResponse::Ack)), None);
     assert_eq!(super::observed_lockdown(&Err(ClientError::PermissionDenied)), None);
 }

--- a/crates/hole/src/state_tests.rs
+++ b/crates/hole/src/state_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::bridge_client::ClientError;
+use crate::state::LockdownObservation;
 use hole_common::protocol::{BridgeResponse, StartError};
 use hole_common::update_marker::{MarkerInfo, MARKER_VERSION};
 
@@ -104,7 +105,16 @@ fn commit_status_carries_lockdown_fields() {
     let s0 = cell.snapshot();
     assert!(!s0.lockdown_enabled && !s0.lockdown_active);
     // A Status commit threads both lockdown bools alongside `running`.
-    cell.commit_status(true, None, true, false, false, false);
+    cell.commit_status(
+        true,
+        None,
+        LockdownObservation {
+            enabled: true,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        },
+    );
     let s1 = cell.snapshot();
     assert!(s1.running && s1.lockdown_enabled && !s1.lockdown_active);
     assert_eq!(s1.seq, 1, "seq bumped on change");
@@ -116,7 +126,16 @@ fn commit_preserves_lockdown_fields() {
     // `commit_status`); its `..*snap` must NOT clobber the lockdown warning state
     // a prior Status established (`enabled && !active` is the tray warning state).
     let cell = ProxyStateCell::new();
-    cell.commit_status(true, None, true, false, false, false); // running + lockdown enabled, not active
+    cell.commit_status(
+        true,
+        None,
+        LockdownObservation {
+            enabled: true,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        },
+    ); // running + lockdown enabled, not active
     let before = cell.snapshot();
     assert!(before.lockdown_enabled && !before.lockdown_active);
 
@@ -138,7 +157,16 @@ fn commit_clears_blocked_on_a_settled_running_edge() {
     // the next Status poll. A settled running edge resolves the transient blocked
     // sub-state, so commit clears the flag AND bumps seq to repaint immediately.
     let cell = ProxyStateCell::new();
-    cell.commit_status(false, None, false, false, false, true); // enter the blocked state
+    cell.commit_status(
+        false,
+        None,
+        LockdownObservation {
+            enabled: false,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: true,
+        },
+    ); // enter the blocked state
     let before = cell.snapshot();
     assert!(before.blocked_until_connected, "precondition: blocked");
 
@@ -164,10 +192,12 @@ fn commit_status_carries_error_on_death() {
     cell.commit_status(
         false,
         Some("proxy task exited unexpectedly".into()),
-        false,
-        false,
-        false,
-        false,
+        LockdownObservation {
+            enabled: false,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        },
     );
     let snap = cell.snapshot();
     assert!(!snap.running);
@@ -180,7 +210,16 @@ fn commit_clears_error_on_non_status_running_change() {
     // A non-Status running edge (Start/Stop/Cancel) is user-initiated and
     // carries no death reason — `commit` must clear any prior error.
     let cell = ProxyStateCell::new();
-    cell.commit_status(true, Some("synthetic".into()), false, false, false, false); // running -> true with an error
+    cell.commit_status(
+        true,
+        Some("synthetic".into()),
+        LockdownObservation {
+            enabled: false,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        },
+    ); // running -> true with an error
     assert_eq!(cell.snapshot().error.as_deref(), Some("synthetic"));
     cell.commit(false); // clean stop via the non-Status path
     assert_eq!(cell.snapshot().error, None, "non-Status commit must clear error");
@@ -193,10 +232,12 @@ fn reconnect_clears_death_error() {
     cell.commit_status(
         false,
         Some("proxy task exited unexpectedly".into()),
-        false,
-        false,
-        false,
-        false,
+        LockdownObservation {
+            enabled: false,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        },
     );
     cell.commit(true); // reconnect via a Start Ack
     assert_eq!(cell.snapshot().error, None);
@@ -832,8 +873,25 @@ fn commit_update_failed_applies_a_lockdown_change() {
     // A wedge whose Status carried a lockdown change must surface UPDATE_FAILED
     // AND the new lockdown fields — not preserve the stale prior ones.
     let cell = super::ProxyStateCell::new();
-    cell.commit_status(true, None, false, false, false, false); // connected, no lockdown
-    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false, false, false)));
+    cell.commit_status(
+        true,
+        None,
+        LockdownObservation {
+            enabled: false,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        },
+    ); // connected, no lockdown
+    cell.commit_update_failed(
+        super::UPDATE_FAILED,
+        Some(LockdownObservation {
+            enabled: true,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        }),
+    );
     let s = cell.snapshot();
     assert!(!s.running && s.error.as_deref() == Some(super::UPDATE_FAILED));
     assert!(
@@ -842,10 +900,26 @@ fn commit_update_failed_applies_a_lockdown_change() {
     );
     // Re-committing the same wedge + lockdown is idempotent.
     let seq = s.seq;
-    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, false, false, false)));
+    cell.commit_update_failed(
+        super::UPDATE_FAILED,
+        Some(LockdownObservation {
+            enabled: true,
+            active: false,
+            held_closed: false,
+            blocked_until_connected: false,
+        }),
+    );
     assert_eq!(cell.snapshot().seq, seq);
     // A lockdown change bumps seq even though running/error are unchanged.
-    cell.commit_update_failed(super::UPDATE_FAILED, Some((true, true, false, false)));
+    cell.commit_update_failed(
+        super::UPDATE_FAILED,
+        Some(LockdownObservation {
+            enabled: true,
+            active: true,
+            held_closed: false,
+            blocked_until_connected: false,
+        }),
+    );
     let s2 = cell.snapshot();
     assert!(s2.lockdown_active && s2.seq == seq + 1);
 }
@@ -1171,7 +1245,12 @@ fn classify_lockdown_is_fail_closed_three_state() {
     );
     assert_eq!(
         super::observed_lockdown(&status(true)),
-        Some((true, true, false, false))
+        Some(LockdownObservation {
+            enabled: true,
+            active: true,
+            held_closed: false,
+            blocked_until_connected: false
+        })
     );
     assert_eq!(super::observed_lockdown(&Ok(BridgeResponse::Ack)), None);
     assert_eq!(super::observed_lockdown(&Err(ClientError::PermissionDenied)), None);

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -276,12 +276,17 @@ fn lockdown_menu_label(enabled: bool, active: bool, held_closed: bool) -> String
 /// The intent a click on the lockdown item should send, derived from the arm the
 /// label RENDERED rather than from the persisted intent alone.
 ///
-/// The old `!lockdown_enabled` inverted the wrong thing: in the
-/// intent-off-but-still-blocking arm it computes `true`, so clicking the item
-/// warning that the network is blocked would ARM the kill switch. That arm must
-/// re-send `false` — a second release attempt, the same thing Unblock Network does.
-fn lockdown_click_intent(enabled: bool, active: bool) -> bool {
-    if !enabled && active {
+/// A plain `!enabled` inverts the wrong thing in the intent-off-but-still-blocking
+/// arm: it computes `true`, so clicking the item that warns the network is blocked
+/// would ARM the kill switch. That arm must re-send `false` — a second release
+/// attempt, the same thing Unblock Network does.
+///
+/// Keyed on `held_closed`, NOT on `active`: the other intent-off-and-engaged arm
+/// is a live session holding its own cover, where the setting is simply waiting
+/// for the next reconnect. Treating that one as a re-release would make the kill
+/// switch impossible to re-arm without disconnecting first.
+fn lockdown_click_intent(enabled: bool, held_closed: bool) -> bool {
+    if !enabled && held_closed {
         return false;
     }
     !enabled
@@ -943,7 +948,7 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             // the authority (last-writer-wins); send intent, re-fetch Status (which
             // commits the new lockdown fields), then rebuild from the reply.
             let snap = app.state::<AppState>().proxy_snapshot();
-            let desired = lockdown_click_intent(snap.lockdown_enabled, snap.lockdown_active);
+            let desired = lockdown_click_intent(snap.lockdown_enabled, snap.held_closed);
             info!(desired, "tray: lockdown toggled");
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move { send_lockdown_intent(app_handle, desired).await });
@@ -959,9 +964,10 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
 
 /// Send a lockdown intent and repaint from the authoritative reply.
 ///
-/// A failed release used to be logged and dropped, so the one remedy a locked-out
-/// user is likely to try appeared to do nothing — the failure #825 is about. On
-/// `Err` the user gets the escape that works with no bridge at all; the Status
+/// A failed release must not be silently dropped: it is the one remedy a
+/// locked-out user is likely to try, and a click that visibly does nothing is the
+/// whole complaint. On `Err` the user gets the escape that works with no bridge
+/// at all; the Status
 /// re-fetch then repaints the true state, which the bridge deliberately still
 /// reports as engaged because the intent did not flip.
 async fn send_lockdown_intent(app: AppHandle, enabled: bool) {

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -263,10 +263,14 @@ const ID_RELEASE_LOCKDOWN: &str = "release_lockdown";
 /// pair means opposite things to a user: a cover no session owns is a lockout and
 /// must point at the release, while a live session's own cover is simply a
 /// setting that has not taken effect yet.
-fn lockdown_menu_label(enabled: bool, active: bool, held_closed: bool) -> String {
-    match (enabled, active, held_closed) {
+fn lockdown_menu_label(f: &LockdownFlags) -> String {
+    match (f.enabled, f.active, f.held_closed) {
         (true, true, _) => "Lockdown: On".into(),
         (true, false, _) => "Lockdown: On (warning: not engaged)".into(),
+        // Two very different states behind one pair: a cover nothing owns is a
+        // lockout and must name the way out, while a live session's own cover is
+        // just a setting waiting for the next reconnect.
+        (false, true, true) if f.unknown => "Lockdown: Off (cannot confirm — use Unblock Network)".into(),
         (false, true, true) => "Lockdown: Off (still blocking — use Unblock Network)".into(),
         (false, true, false) => "Lockdown: Off (applies on reconnect)".into(),
         (false, false, _) => "Lockdown".into(),
@@ -285,28 +289,41 @@ fn lockdown_menu_label(enabled: bool, active: bool, held_closed: bool) -> String
 /// is a live session holding its own cover, where the setting is simply waiting
 /// for the next reconnect. Treating that one as a re-release would make the kill
 /// switch impossible to re-arm without disconnecting first.
-fn lockdown_click_intent(enabled: bool, held_closed: bool) -> bool {
-    if !enabled && held_closed {
+///
+/// An UNKNOWN probe re-arms too. On Windows a wedged firewall engine makes
+/// `held_closed` permanently true without a cover ever being observed, and
+/// treating that as a standing re-release would leave the kill switch impossible
+/// to arm on that machine for good.
+fn lockdown_click_intent(f: &LockdownFlags) -> bool {
+    if !f.enabled && f.held_closed && !f.unknown {
         return false;
     }
-    !enabled
+    !f.enabled
 }
 
 /// Failure text for a release that did not open the host, naming the escape that
 /// works with no bridge and no GUI. An escape nobody can discover is not one.
 fn release_failed_message() -> &'static str {
     if cfg!(target_os = "windows") {
-        "Hole could not unblock your network.
+        concat!(
+            "Hole could not unblock your network.
 
-Your network is still being held closed by Hole.          To clear it, open a terminal as Administrator and run:
+",
+            "Your network may still be held closed by Hole. To clear it, open a terminal ",
+            "as Administrator and run:
 
     hole bridge unlock"
+        )
     } else {
-        "Hole could not unblock your network.
+        concat!(
+            "Hole could not unblock your network.
 
-Your network is still being held closed by Hole.          To clear it, open Terminal and run:
+",
+            "Your network may still be held closed by Hole. To clear it, open Terminal ",
+            "and run:
 
     sudo hole bridge unlock"
+        )
     }
 }
 
@@ -325,19 +342,29 @@ struct TrayActions {
     show_release_lockdown: bool,
 }
 
-fn tray_actions(running: bool, transition: Option<bool>, blocked: bool, held_closed: bool) -> TrayActions {
-    if held_closed && transition.is_none() {
+fn tray_actions(running: bool, transition: Option<bool>, f: &LockdownFlags) -> TrayActions {
+    if f.held_closed && transition.is_none() {
         // Deliberately not gated on `!running`: a session that owns no cover can
         // be "running" over a host the stale block-all is killing.
         return TrayActions {
-            status: "Hole is holding your network closed",
+            // "We are blocking you" and "we cannot tell whether we are" are
+            // different claims, and only one of them has been observed.
+            status: if f.unknown {
+                "Hole cannot tell whether it is blocking your network"
+            } else {
+                "Hole is holding your network closed"
+            },
             action_id: if running { ID_DISCONNECT } else { ID_CONNECT },
             action_text: if running { "Disconnect" } else { "Connect" },
-            show_go_offline: false,
+            // Both covers can hold the host at once, and Unblock Network clears
+            // only the ones no in-process guard owns — so when a live blocked
+            // start holds the other, offer its escape too or the single action
+            // leaves the user exactly as blocked.
+            show_go_offline: f.blocked && !running,
             show_release_lockdown: true,
         };
     }
-    if blocked && !running && transition.is_none() {
+    if f.blocked && !running && transition.is_none() {
         return TrayActions {
             status: "Blocked — connect failed",
             action_id: ID_BLOCKED_RETRY,
@@ -374,12 +401,16 @@ fn tray_actions(running: bool, transition: Option<bool>, blocked: bool, held_clo
 /// with the action item disabled. `lockdown_enabled`/`lockdown_active` render
 /// the standing kill-switch toggle (#527).
 /// The cover/kill-switch flags a menu renders, straight off the snapshot. A
-/// struct so the menu builder stays readable as the state space grows.
-struct LockdownFlags {
-    enabled: bool,
-    active: bool,
-    held_closed: bool,
-    blocked: bool,
+/// struct so the menu builder stays readable as the state space grows, and so
+/// five same-typed `bool`s are never threaded positionally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LockdownFlags {
+    pub enabled: bool,
+    pub active: bool,
+    pub held_closed: bool,
+    /// `held_closed` rests on an unanswerable probe, not an observed cover.
+    pub unknown: bool,
+    pub blocked: bool,
 }
 
 impl LockdownFlags {
@@ -388,6 +419,7 @@ impl LockdownFlags {
             enabled: snap.lockdown_enabled,
             active: snap.lockdown_active,
             held_closed: snap.held_closed,
+            unknown: snap.cover_state_unknown,
             blocked: snap.blocked_until_connected,
         }
     }
@@ -402,13 +434,11 @@ fn build_tray_menu(
 ) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
     let LockdownFlags {
         enabled: lockdown_enabled,
-        active: lockdown_active,
-        held_closed,
-        blocked,
+        ..
     } = flags;
     // The action item carries the intent its label displays: a click dispatches
     // on the item ID, with no state read at click time (#462).
-    let acts = tray_actions(running, transition, blocked, held_closed);
+    let acts = tray_actions(running, transition, &flags);
 
     let status = MenuItem::with_id(app, ID_STATUS, acts.status, false, None::<&str>)?;
     let connect = MenuItem::with_id(
@@ -443,7 +473,7 @@ fn build_tray_menu(
     let lockdown = CheckMenuItem::with_id(
         app,
         ID_LOCKDOWN,
-        lockdown_menu_label(lockdown_enabled, lockdown_active, held_closed),
+        lockdown_menu_label(&flags),
         true,
         lockdown_enabled,
         None::<&str>,
@@ -948,7 +978,7 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             // the authority (last-writer-wins); send intent, re-fetch Status (which
             // commits the new lockdown fields), then rebuild from the reply.
             let snap = app.state::<AppState>().proxy_snapshot();
-            let desired = lockdown_click_intent(snap.lockdown_enabled, snap.held_closed);
+            let desired = lockdown_click_intent(&LockdownFlags::from_snapshot(&snap));
             info!(desired, "tray: lockdown toggled");
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move { send_lockdown_intent(app_handle, desired).await });
@@ -976,7 +1006,15 @@ async fn send_lockdown_intent(app: AppHandle, enabled: bool) {
     let _ = state.bridge_send(BridgeRequest::Status).await; // commits new snapshot
     rebuild_tray_menu(&app);
 
+    let still_held = app.state::<AppState>().proxy_snapshot().held_closed;
     let failed = match outcome {
+        Ok(BridgeResponse::Ack) if !enabled && still_held => {
+            // The bridge records the intent when it could not confirm a cover
+            // (see `release_unowned_cover`), so an Ack is not proof the host is
+            // open. Silence here would be the original complaint verbatim: the
+            // one remedy offered, clicked, and nothing visibly happens.
+            Some("intent recorded but the host is still reported held closed".to_string())
+        }
         Ok(BridgeResponse::Ack) => None,
         Ok(other) => Some(format!("unexpected reply: {other:?}")),
         Err(e) => Some(e.to_string()),

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -264,16 +264,20 @@ const ID_RELEASE_LOCKDOWN: &str = "release_lockdown";
 /// must point at the release, while a live session's own cover is simply a
 /// setting that has not taken effect yet.
 fn lockdown_menu_label(f: &LockdownFlags) -> String {
+    // The off-intent arms key on `held_closed`, the SAME flag
+    // `lockdown_click_intent` keys on. Matching one of them on `active` (the
+    // standing cover alone) would leave a transient-only cover rendering as a
+    // plain "Lockdown" checkbox whose click then disarms — two functions
+    // disagreeing about what "a cover is holding you" means.
     match (f.enabled, f.active, f.held_closed) {
         (true, true, _) => "Lockdown: On".into(),
         (true, false, _) => "Lockdown: On (warning: not engaged)".into(),
-        // Two very different states behind one pair: a cover nothing owns is a
-        // lockout and must name the way out, while a live session's own cover is
-        // just a setting waiting for the next reconnect.
-        (false, true, true) if f.unknown => "Lockdown: Off (cannot confirm — use Unblock Network)".into(),
-        (false, true, true) => "Lockdown: Off (still blocking — use Unblock Network)".into(),
+        // A cover nothing owns is a lockout and must name the way out; a live
+        // session's own cover is just a setting waiting for the next reconnect.
+        (false, _, true) if f.unknown => "Lockdown: Off (cannot confirm — use Unblock Network)".into(),
+        (false, _, true) => "Lockdown: Off (still blocking — use Unblock Network)".into(),
         (false, true, false) => "Lockdown: Off (applies on reconnect)".into(),
-        (false, false, _) => "Lockdown".into(),
+        (false, false, false) => "Lockdown".into(),
     }
 }
 
@@ -303,6 +307,14 @@ fn lockdown_click_intent(f: &LockdownFlags) -> bool {
 
 /// Failure text for a release that did not open the host, naming the escape that
 /// works with no bridge and no GUI. An escape nobody can discover is not one.
+fn release_blocked_by_owned_cover_message() -> &'static str {
+    concat!(
+        "Hole is still blocking your network.\n\n",
+        "A connection attempt left the block in place, and the kill switch setting ",
+        "does not clear that one. Use \"Go Offline (unblock)\" to restore your network."
+    )
+}
+
 fn release_failed_message() -> &'static str {
     if cfg!(target_os = "windows") {
         concat!(
@@ -1006,7 +1018,8 @@ async fn send_lockdown_intent(app: AppHandle, enabled: bool) {
     let _ = state.bridge_send(BridgeRequest::Status).await; // commits new snapshot
     rebuild_tray_menu(&app);
 
-    let still_held = app.state::<AppState>().proxy_snapshot().held_closed;
+    let snap = app.state::<AppState>().proxy_snapshot();
+    let still_held = snap.held_closed || snap.blocked_until_connected;
     let failed = match outcome {
         Ok(BridgeResponse::Ack) if !enabled && still_held => {
             // The bridge records the intent when it could not confirm a cover
@@ -1026,7 +1039,15 @@ async fn send_lockdown_intent(app: AppHandle, enabled: bool) {
     if enabled {
         return; // Arming the switch failing is not a lockout; the label already shows it.
     }
-    let message = release_failed_message();
+    // The standing release deliberately leaves a cover this process still holds
+    // to the stop path, so pointing at `hole bridge unlock` here would send the
+    // user at the wrong remedy — and on macOS running it would delete the state
+    // file out from under the live guard.
+    let message = if snap.blocked_until_connected {
+        release_blocked_by_owned_cover_message()
+    } else {
+        release_failed_message()
+    };
     // spawn_blocking: blocking_show must not run on the main thread and would
     // park a core async worker if spawned.
     tauri::async_runtime::spawn_blocking(move || {

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -252,16 +252,56 @@ const ID_EXIT: &str = "exit";
 const ID_INSTALL_UPDATE: &str = "install_update";
 const ID_LOCKDOWN: &str = "lockdown";
 const ID_BLOCKED_RETRY: &str = "blocked_retry";
+const ID_RELEASE_LOCKDOWN: &str = "release_lockdown";
 
 // Tray creation =======================================================================================================
 
-/// Tray label for the lockdown toggle from the (enabled, active) snapshot.
-/// `enabled && !active` is a warning state — never silent green (#527).
-fn lockdown_menu_label(enabled: bool, active: bool) -> String {
-    match (enabled, active) {
-        (true, true) => "Lockdown: On".into(),
-        (true, false) => "Lockdown: On (warning: not engaged)".into(),
-        (false, _) => "Lockdown".into(),
+/// Tray label for the lockdown toggle from the (enabled, active, held_closed)
+/// snapshot. `enabled && !active` is a warning state — never silent green (#527).
+///
+/// `held_closed` splits the intent-off-but-engaged case in two, because the same
+/// pair means opposite things to a user: a cover no session owns is a lockout and
+/// must point at the release, while a live session's own cover is simply a
+/// setting that has not taken effect yet.
+fn lockdown_menu_label(enabled: bool, active: bool, held_closed: bool) -> String {
+    match (enabled, active, held_closed) {
+        (true, true, _) => "Lockdown: On".into(),
+        (true, false, _) => "Lockdown: On (warning: not engaged)".into(),
+        (false, true, true) => "Lockdown: Off (still blocking — use Unblock Network)".into(),
+        (false, true, false) => "Lockdown: Off (applies on reconnect)".into(),
+        (false, false, _) => "Lockdown".into(),
+    }
+}
+
+/// The intent a click on the lockdown item should send, derived from the arm the
+/// label RENDERED rather than from the persisted intent alone.
+///
+/// The old `!lockdown_enabled` inverted the wrong thing: in the
+/// intent-off-but-still-blocking arm it computes `true`, so clicking the item
+/// warning that the network is blocked would ARM the kill switch. That arm must
+/// re-send `false` — a second release attempt, the same thing Unblock Network does.
+fn lockdown_click_intent(enabled: bool, active: bool) -> bool {
+    if !enabled && active {
+        return false;
+    }
+    !enabled
+}
+
+/// Failure text for a release that did not open the host, naming the escape that
+/// works with no bridge and no GUI. An escape nobody can discover is not one.
+fn release_failed_message() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "Hole could not unblock your network.
+
+Your network is still being held closed by Hole.          To clear it, open a terminal as Administrator and run:
+
+    hole bridge unlock"
+    } else {
+        "Hole could not unblock your network.
+
+Your network is still being held closed by Hole.          To clear it, open Terminal and run:
+
+    sudo hole bridge unlock"
     }
 }
 
@@ -269,21 +309,36 @@ fn lockdown_menu_label(enabled: bool, active: bool) -> String {
 /// state. Pure so `tray_tests` cover the blocked-state UX without Tauri. `blocked`
 /// (a covered start failed → host fail-closed while not running) applies only when
 /// not running and not mid-transition (a live transition or a running proxy takes
-/// precedence).
+/// precedence). `held_closed` (a lockdown cover no session owns) outranks it: the
+/// blocked state's Go Offline drops only the TRANSIENT cover, so offering that as
+/// the one way out of a standing cover would leave the user just as blocked.
 struct TrayActions {
     status: &'static str,
     action_id: &'static str,
     action_text: &'static str,
     show_go_offline: bool,
+    show_release_lockdown: bool,
 }
 
-fn tray_actions(running: bool, transition: Option<bool>, blocked: bool) -> TrayActions {
+fn tray_actions(running: bool, transition: Option<bool>, blocked: bool, held_closed: bool) -> TrayActions {
+    if held_closed && transition.is_none() {
+        // Deliberately not gated on `!running`: a session that owns no cover can
+        // be "running" over a host the stale block-all is killing.
+        return TrayActions {
+            status: "Hole is holding your network closed",
+            action_id: if running { ID_DISCONNECT } else { ID_CONNECT },
+            action_text: if running { "Disconnect" } else { "Connect" },
+            show_go_offline: false,
+            show_release_lockdown: true,
+        };
+    }
     if blocked && !running && transition.is_none() {
         return TrayActions {
             status: "Blocked — connect failed",
             action_id: ID_BLOCKED_RETRY,
             action_text: "Retry",
             show_go_offline: true,
+            show_release_lockdown: false,
         };
     }
     let status = match (transition, running) {
@@ -302,6 +357,7 @@ fn tray_actions(running: bool, transition: Option<bool>, blocked: bool) -> TrayA
         action_id,
         action_text,
         show_go_offline: false,
+        show_release_lockdown: false,
     }
 }
 
@@ -312,18 +368,42 @@ fn tray_actions(running: bool, transition: Option<bool>, blocked: bool) -> TrayA
 /// connect/disconnect target, rendered as Connecting…/Disconnecting…
 /// with the action item disabled. `lockdown_enabled`/`lockdown_active` render
 /// the standing kill-switch toggle (#527).
+/// The cover/kill-switch flags a menu renders, straight off the snapshot. A
+/// struct so the menu builder stays readable as the state space grows.
+struct LockdownFlags {
+    enabled: bool,
+    active: bool,
+    held_closed: bool,
+    blocked: bool,
+}
+
+impl LockdownFlags {
+    fn from_snapshot(snap: &crate::state::ProxySnapshot) -> Self {
+        Self {
+            enabled: snap.lockdown_enabled,
+            active: snap.lockdown_active,
+            held_closed: snap.held_closed,
+            blocked: snap.blocked_until_connected,
+        }
+    }
+}
+
 fn build_tray_menu(
     app: &AppHandle,
     update: Option<&hole::update::UpdateInfo>,
     running: bool,
     transition: Option<bool>,
-    lockdown_enabled: bool,
-    lockdown_active: bool,
-    blocked: bool,
+    flags: LockdownFlags,
 ) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
+    let LockdownFlags {
+        enabled: lockdown_enabled,
+        active: lockdown_active,
+        held_closed,
+        blocked,
+    } = flags;
     // The action item carries the intent its label displays: a click dispatches
     // on the item ID, with no state read at click time (#462).
-    let acts = tray_actions(running, transition, blocked);
+    let acts = tray_actions(running, transition, blocked, held_closed);
 
     let status = MenuItem::with_id(app, ID_STATUS, acts.status, false, None::<&str>)?;
     let connect = MenuItem::with_id(
@@ -342,13 +422,23 @@ fn build_tray_menu(
         transition.is_none(),
         None::<&str>,
     )?;
+    // Shown whenever a lockdown cover no session owns is holding the host: the
+    // kill-switch checkbox reads as a setting, and a user whose network is dead
+    // is not looking for settings.
+    let release_lockdown = MenuItem::with_id(
+        app,
+        ID_RELEASE_LOCKDOWN,
+        "Unblock Network (turns Lockdown off)",
+        true,
+        None::<&str>,
+    )?;
     let autostart = CheckMenuItem::with_id(app, ID_AUTOSTART, "Start at Login", true, false, None::<&str>)?;
     // Checked tracks intent; the warning label covers the enabled-but-inactive
     // state since a checkmark alone can't signal "armed but not engaged".
     let lockdown = CheckMenuItem::with_id(
         app,
         ID_LOCKDOWN,
-        lockdown_menu_label(lockdown_enabled, lockdown_active),
+        lockdown_menu_label(lockdown_enabled, lockdown_active, held_closed),
         true,
         lockdown_enabled,
         None::<&str>,
@@ -372,6 +462,9 @@ fn build_tray_menu(
     let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![&status, &connect];
     if acts.show_go_offline {
         items.push(&go_offline);
+    }
+    if acts.show_release_lockdown {
+        items.push(&release_lockdown);
     }
     items.extend([
         &sep1 as &dyn tauri::menu::IsMenuItem<tauri::Wry>,
@@ -426,9 +519,7 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, tauri::Error> {
         None,
         snap.running,
         None,
-        snap.lockdown_enabled,
-        snap.lockdown_active,
-        snap.blocked_until_connected,
+        LockdownFlags::from_snapshot(&snap),
     )?;
     let icon = tray_icons::tray_image(snap.running.into());
 
@@ -482,9 +573,7 @@ pub fn rebuild_tray_menu(app: &AppHandle) {
             update_info.as_ref(),
             snap.running,
             transition,
-            snap.lockdown_enabled,
-            snap.lockdown_active,
-            snap.blocked_until_connected,
+            LockdownFlags::from_snapshot(&snap),
         ) {
             Ok(menu) => {
                 sync_autostart_state(&handle, &menu);
@@ -848,25 +937,61 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             });
         }
         ID_LOCKDOWN => {
-            // muda flipped the checkmark before this handler ran. The desired
-            // intent is the inverse of the snapshot we rendered from. The
-            // bridge is the authority (last-writer-wins); send intent, re-fetch
-            // Status (which commits the new lockdown fields into the snapshot),
-            // then rebuild from the authoritative reply.
-            let desired = !app.state::<AppState>().proxy_snapshot().lockdown_enabled;
+            // muda flipped the checkmark before this handler ran. The intent comes
+            // from the ARM the label rendered, not from `!enabled` — see
+            // `lockdown_click_intent` for the arm where those differ. The bridge is
+            // the authority (last-writer-wins); send intent, re-fetch Status (which
+            // commits the new lockdown fields), then rebuild from the reply.
+            let snap = app.state::<AppState>().proxy_snapshot();
+            let desired = lockdown_click_intent(snap.lockdown_enabled, snap.lockdown_active);
             info!(desired, "tray: lockdown toggled");
             let app_handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                let state = app_handle.state::<AppState>();
-                if let Err(e) = state.bridge_send(BridgeRequest::SetLockdown { enabled: desired }).await {
-                    error!(error = %e, "tray: SetLockdown failed");
-                }
-                let _ = state.bridge_send(BridgeRequest::Status).await; // commits new snapshot
-                rebuild_tray_menu(&app_handle);
-            });
+            tauri::async_runtime::spawn(async move { send_lockdown_intent(app_handle, desired).await });
+        }
+        ID_RELEASE_LOCKDOWN => {
+            info!("tray: release lockdown clicked from the held-closed state");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move { send_lockdown_intent(app_handle, false).await });
         }
         _ => {}
     }
+}
+
+/// Send a lockdown intent and repaint from the authoritative reply.
+///
+/// A failed release used to be logged and dropped, so the one remedy a locked-out
+/// user is likely to try appeared to do nothing — the failure #825 is about. On
+/// `Err` the user gets the escape that works with no bridge at all; the Status
+/// re-fetch then repaints the true state, which the bridge deliberately still
+/// reports as engaged because the intent did not flip.
+async fn send_lockdown_intent(app: AppHandle, enabled: bool) {
+    let state = app.state::<AppState>();
+    let outcome = state.bridge_send(BridgeRequest::SetLockdown { enabled }).await;
+    let _ = state.bridge_send(BridgeRequest::Status).await; // commits new snapshot
+    rebuild_tray_menu(&app);
+
+    let failed = match outcome {
+        Ok(BridgeResponse::Ack) => None,
+        Ok(other) => Some(format!("unexpected reply: {other:?}")),
+        Err(e) => Some(e.to_string()),
+    };
+    let Some(detail) = failed else { return };
+    // Full detail (may name a socket path) to gui.log; the dialog gets the
+    // PII-free, actionable text.
+    error!(enabled, error = %detail, "tray: SetLockdown failed");
+    if enabled {
+        return; // Arming the switch failing is not a lockout; the label already shows it.
+    }
+    let message = release_failed_message();
+    // spawn_blocking: blocking_show must not run on the main thread and would
+    // park a core async worker if spawned.
+    tauri::async_runtime::spawn_blocking(move || {
+        use tauri_plugin_dialog::DialogExt;
+        app.dialog()
+            .message(message)
+            .title("Network still blocked")
+            .blocking_show();
+    });
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -357,7 +357,7 @@ fn external_bridge_denied_toast_is_actionable() {
     assert!(toast.contains("gui.log"), "{toast}");
 }
 
-// Kill-switch lockout UX (#825) =======================================================================================
+// Kill-switch lockout UX ==============================================================================================
 
 #[skuld::test]
 fn tray_actions_held_closed_offers_a_release() {
@@ -438,7 +438,7 @@ fn lockdown_label_arms_unaffected_by_held_closed_are_unchanged() {
 }
 
 #[skuld::test]
-fn lockdown_click_intent_off_but_engaged_releases() {
+fn lockdown_click_intent_off_but_held_closed_releases() {
     // The arm whose label warns the network is blocked must not ARM the switch.
     assert!(
         !lockdown_click_intent(false, true),
@@ -447,10 +447,21 @@ fn lockdown_click_intent_off_but_engaged_releases() {
 }
 
 #[skuld::test]
+fn lockdown_click_intent_off_while_a_session_owns_the_cover_re_arms() {
+    // Turning the switch off mid-session leaves the cover engaged until the next
+    // reconnect. Reading that as "still blocking" would make the switch
+    // impossible to turn back on without disconnecting first.
+    assert!(
+        lockdown_click_intent(false, false),
+        "a session-owned cover is not a lockout; the click must re-arm"
+    );
+}
+
+#[skuld::test]
 fn lockdown_click_intent_toggles_every_other_arm() {
-    assert!(lockdown_click_intent(false, false), "off + nothing engaged arms it");
-    assert!(!lockdown_click_intent(true, true), "on + engaged disarms it");
-    assert!(!lockdown_click_intent(true, false), "on + not engaged disarms it");
+    assert!(lockdown_click_intent(false, false), "off + nothing held closed arms it");
+    assert!(!lockdown_click_intent(true, true), "on + held closed disarms it");
+    assert!(!lockdown_click_intent(true, false), "on + not held closed disarms it");
 }
 
 #[skuld::test]

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -17,7 +17,7 @@ use std::sync::Mutex;
 fn tray_actions_blocked_offers_retry_and_go_offline() {
     // A covered start failed → host fail-closed while not running: a distinct
     // blocked state (never silent Disconnected), Retry (covered) + Go Offline.
-    let a = tray_actions(false, None, true);
+    let a = tray_actions(false, None, true, false);
     assert_eq!(a.status, "Blocked — connect failed");
     assert_eq!(a.action_id, ID_BLOCKED_RETRY);
     assert_eq!(a.action_text, "Retry");
@@ -28,20 +28,20 @@ fn tray_actions_blocked_offers_retry_and_go_offline() {
 fn tray_actions_running_and_transition_take_precedence_over_blocked() {
     // A live transition or a running proxy is never overridden by a stale blocked
     // flag (blocked applies only when not running and not mid-transition).
-    let running = tray_actions(true, None, true);
+    let running = tray_actions(true, None, true, false);
     assert_eq!(running.action_id, ID_DISCONNECT);
     assert!(!running.show_go_offline);
-    let connecting = tray_actions(false, Some(true), true);
+    let connecting = tray_actions(false, Some(true), true, false);
     assert_eq!(connecting.status, "Connecting...");
     assert!(!connecting.show_go_offline);
 }
 
 #[skuld::test]
 fn tray_actions_normal_states_unchanged() {
-    assert_eq!(tray_actions(false, None, false).action_id, ID_CONNECT);
-    assert_eq!(tray_actions(false, None, false).status, "Disconnected");
-    assert_eq!(tray_actions(true, None, false).action_id, ID_DISCONNECT);
-    assert_eq!(tray_actions(true, None, false).status, "Connected");
+    assert_eq!(tray_actions(false, None, false, false).action_id, ID_CONNECT);
+    assert_eq!(tray_actions(false, None, false, false).status, "Disconnected");
+    assert_eq!(tray_actions(true, None, false, false).action_id, ID_DISCONNECT);
+    assert_eq!(tray_actions(true, None, false, false).status, "Connected");
 }
 
 #[skuld::test]
@@ -172,7 +172,7 @@ fn persist_intended_enabled_writes_only_on_change(#[fixture(temp_dir)] dir: &Pat
 #[skuld::test]
 fn lockdown_enabled_but_inactive_renders_warning_label() {
     // enabled && !active must never render silent green — it is a warning.
-    let label = lockdown_menu_label(true, false);
+    let label = lockdown_menu_label(true, false, false);
     assert!(
         label.to_lowercase().contains("warning") || label.contains('!'),
         "enabled+inactive must signal a warning, got {label:?}"
@@ -181,13 +181,13 @@ fn lockdown_enabled_but_inactive_renders_warning_label() {
 
 #[skuld::test]
 fn lockdown_active_renders_on_label() {
-    let label = lockdown_menu_label(true, true);
+    let label = lockdown_menu_label(true, true, false);
     assert!(label.to_lowercase().contains("on") || label.to_lowercase().contains("lockdown"));
 }
 
 #[skuld::test]
 fn lockdown_off_renders_plain_label() {
-    let label = lockdown_menu_label(false, false);
+    let label = lockdown_menu_label(false, false, false);
     assert!(!label.to_lowercase().contains("warning"));
 }
 
@@ -219,6 +219,7 @@ fn status_resp(running: bool) -> BridgeResponse {
         ipv6_bypass_available: true,
         lockdown_enabled: false,
         lockdown_active: false,
+        held_closed: false,
         blocked_until_connected: false,
     }
 }
@@ -243,6 +244,7 @@ fn status_resp_blocked() -> BridgeResponse {
             ipv6_bypass_available,
             lockdown_enabled,
             lockdown_active,
+            held_closed: false,
             blocked_until_connected: true,
         },
         other => other,
@@ -353,4 +355,112 @@ fn external_bridge_denied_toast_is_actionable() {
     let toast = external_bridge_denied_toast();
     assert!(toast.to_lowercase().contains("permission denied"), "{toast}");
     assert!(toast.contains("gui.log"), "{toast}");
+}
+
+// Kill-switch lockout UX (#825) =======================================================================================
+
+#[skuld::test]
+fn tray_actions_held_closed_offers_a_release() {
+    let a = tray_actions(false, None, false, true);
+    assert_eq!(a.status, "Hole is holding your network closed");
+    assert!(a.show_release_lockdown, "the way out must be on the menu");
+    assert_eq!(a.action_id, ID_CONNECT, "connecting also restores service");
+}
+
+#[skuld::test]
+fn tray_actions_held_closed_outranks_blocked() {
+    // Go Offline drops only the TRANSIENT cover, so offering it as the one way out
+    // of a standing cover would leave the user just as blocked.
+    let a = tray_actions(false, None, true, true);
+    assert_eq!(a.status, "Hole is holding your network closed");
+    assert!(a.show_release_lockdown);
+    assert!(!a.show_go_offline);
+}
+
+#[skuld::test]
+fn tray_actions_held_closed_shown_even_while_running() {
+    // A session that owns no cover can be "running" over a host the stale
+    // block-all is killing; rendering that as Connected offers no way out.
+    let a = tray_actions(true, None, false, true);
+    assert_eq!(a.status, "Hole is holding your network closed");
+    assert!(a.show_release_lockdown);
+    assert_eq!(a.action_id, ID_DISCONNECT);
+}
+
+#[skuld::test]
+fn tray_actions_held_closed_defers_to_a_transition() {
+    for target in [true, false] {
+        let a = tray_actions(false, Some(target), false, true);
+        assert!(
+            !a.show_release_lockdown,
+            "a live transition owns the menu, same as the blocked state"
+        );
+    }
+}
+
+#[skuld::test]
+fn tray_actions_without_held_closed_are_unchanged() {
+    assert_eq!(tray_actions(false, None, false, false).status, "Disconnected");
+    assert_eq!(tray_actions(true, None, false, false).status, "Connected");
+    assert_eq!(
+        tray_actions(false, None, true, false).status,
+        "Blocked — connect failed"
+    );
+    assert!(!tray_actions(false, None, true, false).show_release_lockdown);
+}
+
+#[skuld::test]
+fn lockdown_label_off_but_held_closed_points_at_the_release() {
+    let label = lockdown_menu_label(false, true, true);
+    assert!(
+        label.contains("Unblock Network"),
+        "a blocked-state label must name the action that ends it: {label}"
+    );
+}
+
+#[skuld::test]
+fn lockdown_label_off_but_session_owns_the_cover_says_on_reconnect() {
+    // Traffic is flowing here — claiming the network is blocked would be a
+    // false alarm. Settings apply on reconnect, so say that.
+    let label = lockdown_menu_label(false, true, false);
+    assert!(label.contains("reconnect"), "{label}");
+    assert!(!label.contains("blocking"), "{label}");
+}
+
+#[skuld::test]
+fn lockdown_label_arms_unaffected_by_held_closed_are_unchanged() {
+    assert_eq!(lockdown_menu_label(true, true, false), "Lockdown: On");
+    assert_eq!(
+        lockdown_menu_label(true, false, false),
+        "Lockdown: On (warning: not engaged)"
+    );
+    assert_eq!(lockdown_menu_label(false, false, false), "Lockdown");
+}
+
+#[skuld::test]
+fn lockdown_click_intent_off_but_engaged_releases() {
+    // The arm whose label warns the network is blocked must not ARM the switch.
+    assert!(
+        !lockdown_click_intent(false, true),
+        "clicking the still-blocking item must re-release, not arm"
+    );
+}
+
+#[skuld::test]
+fn lockdown_click_intent_toggles_every_other_arm() {
+    assert!(lockdown_click_intent(false, false), "off + nothing engaged arms it");
+    assert!(!lockdown_click_intent(true, true), "on + engaged disarms it");
+    assert!(!lockdown_click_intent(true, false), "on + not engaged disarms it");
+}
+
+#[skuld::test]
+fn release_failed_message_names_the_unlock_command() {
+    let m = release_failed_message();
+    assert!(m.contains("hole bridge unlock"), "{m}");
+    assert!(m.contains("Hole"), "the message must name what is blocking: {m}");
+    if cfg!(target_os = "windows") {
+        assert!(m.contains("Administrator"), "{m}");
+    } else {
+        assert!(m.contains("sudo"), "{m}");
+    }
 }

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -17,7 +17,7 @@ use std::sync::Mutex;
 fn tray_actions_blocked_offers_retry_and_go_offline() {
     // A covered start failed → host fail-closed while not running: a distinct
     // blocked state (never silent Disconnected), Retry (covered) + Go Offline.
-    let a = tray_actions(false, None, true, false);
+    let a = tray_actions(false, None, &flags(false, false, false, false, true));
     assert_eq!(a.status, "Blocked — connect failed");
     assert_eq!(a.action_id, ID_BLOCKED_RETRY);
     assert_eq!(a.action_text, "Retry");
@@ -28,20 +28,32 @@ fn tray_actions_blocked_offers_retry_and_go_offline() {
 fn tray_actions_running_and_transition_take_precedence_over_blocked() {
     // A live transition or a running proxy is never overridden by a stale blocked
     // flag (blocked applies only when not running and not mid-transition).
-    let running = tray_actions(true, None, true, false);
+    let running = tray_actions(true, None, &flags(false, false, false, false, true));
     assert_eq!(running.action_id, ID_DISCONNECT);
     assert!(!running.show_go_offline);
-    let connecting = tray_actions(false, Some(true), true, false);
+    let connecting = tray_actions(false, Some(true), &flags(false, false, false, false, true));
     assert_eq!(connecting.status, "Connecting...");
     assert!(!connecting.show_go_offline);
 }
 
 #[skuld::test]
 fn tray_actions_normal_states_unchanged() {
-    assert_eq!(tray_actions(false, None, false, false).action_id, ID_CONNECT);
-    assert_eq!(tray_actions(false, None, false, false).status, "Disconnected");
-    assert_eq!(tray_actions(true, None, false, false).action_id, ID_DISCONNECT);
-    assert_eq!(tray_actions(true, None, false, false).status, "Connected");
+    assert_eq!(
+        tray_actions(false, None, &flags(false, false, false, false, false)).action_id,
+        ID_CONNECT
+    );
+    assert_eq!(
+        tray_actions(false, None, &flags(false, false, false, false, false)).status,
+        "Disconnected"
+    );
+    assert_eq!(
+        tray_actions(true, None, &flags(false, false, false, false, false)).action_id,
+        ID_DISCONNECT
+    );
+    assert_eq!(
+        tray_actions(true, None, &flags(false, false, false, false, false)).status,
+        "Connected"
+    );
 }
 
 #[skuld::test]
@@ -172,7 +184,7 @@ fn persist_intended_enabled_writes_only_on_change(#[fixture(temp_dir)] dir: &Pat
 #[skuld::test]
 fn lockdown_enabled_but_inactive_renders_warning_label() {
     // enabled && !active must never render silent green — it is a warning.
-    let label = lockdown_menu_label(true, false, false);
+    let label = lockdown_menu_label(&flags(true, false, false, false, false));
     assert!(
         label.to_lowercase().contains("warning") || label.contains('!'),
         "enabled+inactive must signal a warning, got {label:?}"
@@ -181,13 +193,13 @@ fn lockdown_enabled_but_inactive_renders_warning_label() {
 
 #[skuld::test]
 fn lockdown_active_renders_on_label() {
-    let label = lockdown_menu_label(true, true, false);
+    let label = lockdown_menu_label(&flags(true, true, false, false, false));
     assert!(label.to_lowercase().contains("on") || label.to_lowercase().contains("lockdown"));
 }
 
 #[skuld::test]
 fn lockdown_off_renders_plain_label() {
-    let label = lockdown_menu_label(false, false, false);
+    let label = lockdown_menu_label(&flags(false, false, false, false, false));
     assert!(!label.to_lowercase().contains("warning"));
 }
 
@@ -220,6 +232,7 @@ fn status_resp(running: bool) -> BridgeResponse {
         lockdown_enabled: false,
         lockdown_active: false,
         held_closed: false,
+        cover_state_unknown: false,
         blocked_until_connected: false,
     }
 }
@@ -245,6 +258,7 @@ fn status_resp_blocked() -> BridgeResponse {
             lockdown_enabled,
             lockdown_active,
             held_closed: false,
+            cover_state_unknown: false,
             blocked_until_connected: true,
         },
         other => other,
@@ -357,11 +371,22 @@ fn external_bridge_denied_toast_is_actionable() {
     assert!(toast.contains("gui.log"), "{toast}");
 }
 
+/// Terse `LockdownFlags` for the pure tray tests, in menu-render order.
+fn flags(enabled: bool, active: bool, held_closed: bool, unknown: bool, blocked: bool) -> LockdownFlags {
+    LockdownFlags {
+        enabled,
+        active,
+        held_closed,
+        unknown,
+        blocked,
+    }
+}
+
 // Kill-switch lockout UX ==============================================================================================
 
 #[skuld::test]
 fn tray_actions_held_closed_offers_a_release() {
-    let a = tray_actions(false, None, false, true);
+    let a = tray_actions(false, None, &flags(false, false, true, false, false));
     assert_eq!(a.status, "Hole is holding your network closed");
     assert!(a.show_release_lockdown, "the way out must be on the menu");
     assert_eq!(a.action_id, ID_CONNECT, "connecting also restores service");
@@ -369,19 +394,24 @@ fn tray_actions_held_closed_offers_a_release() {
 
 #[skuld::test]
 fn tray_actions_held_closed_outranks_blocked() {
-    // Go Offline drops only the TRANSIENT cover, so offering it as the one way out
-    // of a standing cover would leave the user just as blocked.
-    let a = tray_actions(false, None, true, true);
+    // Go Offline drops only the TRANSIENT cover, so it cannot be the whole story
+    // when a standing cover is also up — but it is still the escape for the one
+    // this process holds, so both must be offered.
+    let a = tray_actions(false, None, &flags(false, false, true, false, true));
     assert_eq!(a.status, "Hole is holding your network closed");
+    assert_ne!(
+        a.action_id, ID_BLOCKED_RETRY,
+        "the held-closed arm owns the status line"
+    );
     assert!(a.show_release_lockdown);
-    assert!(!a.show_go_offline);
+    assert!(a.show_go_offline, "the transient cover keeps its own escape");
 }
 
 #[skuld::test]
 fn tray_actions_held_closed_shown_even_while_running() {
     // A session that owns no cover can be "running" over a host the stale
     // block-all is killing; rendering that as Connected offers no way out.
-    let a = tray_actions(true, None, false, true);
+    let a = tray_actions(true, None, &flags(false, false, true, false, false));
     assert_eq!(a.status, "Hole is holding your network closed");
     assert!(a.show_release_lockdown);
     assert_eq!(a.action_id, ID_DISCONNECT);
@@ -390,7 +420,7 @@ fn tray_actions_held_closed_shown_even_while_running() {
 #[skuld::test]
 fn tray_actions_held_closed_defers_to_a_transition() {
     for target in [true, false] {
-        let a = tray_actions(false, Some(target), false, true);
+        let a = tray_actions(false, Some(target), &flags(false, false, true, false, false));
         assert!(
             !a.show_release_lockdown,
             "a live transition owns the menu, same as the blocked state"
@@ -400,18 +430,24 @@ fn tray_actions_held_closed_defers_to_a_transition() {
 
 #[skuld::test]
 fn tray_actions_without_held_closed_are_unchanged() {
-    assert_eq!(tray_actions(false, None, false, false).status, "Disconnected");
-    assert_eq!(tray_actions(true, None, false, false).status, "Connected");
     assert_eq!(
-        tray_actions(false, None, true, false).status,
+        tray_actions(false, None, &flags(false, false, false, false, false)).status,
+        "Disconnected"
+    );
+    assert_eq!(
+        tray_actions(true, None, &flags(false, false, false, false, false)).status,
+        "Connected"
+    );
+    assert_eq!(
+        tray_actions(false, None, &flags(false, false, false, false, true)).status,
         "Blocked — connect failed"
     );
-    assert!(!tray_actions(false, None, true, false).show_release_lockdown);
+    assert!(!tray_actions(false, None, &flags(false, false, false, false, true)).show_release_lockdown);
 }
 
 #[skuld::test]
 fn lockdown_label_off_but_held_closed_points_at_the_release() {
-    let label = lockdown_menu_label(false, true, true);
+    let label = lockdown_menu_label(&flags(false, true, true, false, false));
     assert!(
         label.contains("Unblock Network"),
         "a blocked-state label must name the action that ends it: {label}"
@@ -422,26 +458,32 @@ fn lockdown_label_off_but_held_closed_points_at_the_release() {
 fn lockdown_label_off_but_session_owns_the_cover_says_on_reconnect() {
     // Traffic is flowing here — claiming the network is blocked would be a
     // false alarm. Settings apply on reconnect, so say that.
-    let label = lockdown_menu_label(false, true, false);
+    let label = lockdown_menu_label(&flags(false, true, false, false, false));
     assert!(label.contains("reconnect"), "{label}");
     assert!(!label.contains("blocking"), "{label}");
 }
 
 #[skuld::test]
 fn lockdown_label_arms_unaffected_by_held_closed_are_unchanged() {
-    assert_eq!(lockdown_menu_label(true, true, false), "Lockdown: On");
     assert_eq!(
-        lockdown_menu_label(true, false, false),
+        lockdown_menu_label(&flags(true, true, false, false, false)),
+        "Lockdown: On"
+    );
+    assert_eq!(
+        lockdown_menu_label(&flags(true, false, false, false, false)),
         "Lockdown: On (warning: not engaged)"
     );
-    assert_eq!(lockdown_menu_label(false, false, false), "Lockdown");
+    assert_eq!(
+        lockdown_menu_label(&flags(false, false, false, false, false)),
+        "Lockdown"
+    );
 }
 
 #[skuld::test]
 fn lockdown_click_intent_off_but_held_closed_releases() {
     // The arm whose label warns the network is blocked must not ARM the switch.
     assert!(
-        !lockdown_click_intent(false, true),
+        !lockdown_click_intent(&flags(false, false, true, false, false)),
         "clicking the still-blocking item must re-release, not arm"
     );
 }
@@ -452,16 +494,25 @@ fn lockdown_click_intent_off_while_a_session_owns_the_cover_re_arms() {
     // reconnect. Reading that as "still blocking" would make the switch
     // impossible to turn back on without disconnecting first.
     assert!(
-        lockdown_click_intent(false, false),
+        lockdown_click_intent(&flags(false, false, false, false, false)),
         "a session-owned cover is not a lockout; the click must re-arm"
     );
 }
 
 #[skuld::test]
 fn lockdown_click_intent_toggles_every_other_arm() {
-    assert!(lockdown_click_intent(false, false), "off + nothing held closed arms it");
-    assert!(!lockdown_click_intent(true, true), "on + held closed disarms it");
-    assert!(!lockdown_click_intent(true, false), "on + not held closed disarms it");
+    assert!(
+        lockdown_click_intent(&flags(false, false, false, false, false)),
+        "off + nothing held closed arms it"
+    );
+    assert!(
+        !lockdown_click_intent(&flags(true, false, true, false, false)),
+        "on + held closed disarms it"
+    );
+    assert!(
+        !lockdown_click_intent(&flags(true, false, false, false, false)),
+        "on + not held closed disarms it"
+    );
 }
 
 #[skuld::test]
@@ -473,5 +524,54 @@ fn release_failed_message_names_the_unlock_command() {
         assert!(m.contains("Administrator"), "{m}");
     } else {
         assert!(m.contains("sudo"), "{m}");
+    }
+}
+
+#[skuld::test]
+fn tray_actions_unknown_cover_does_not_claim_we_are_blocking() {
+    // A wedged firewall engine makes this state permanent on Windows. Asserting
+    // "Hole is holding your network closed" would be a claim never observed, over
+    // a host that is probably open — the original complaint, from a new cause.
+    let a = tray_actions(false, None, &flags(false, false, true, true, false));
+    assert_eq!(a.status, "Hole cannot tell whether it is blocking your network");
+    assert!(a.show_release_lockdown, "the way out must still be offered");
+}
+
+#[skuld::test]
+fn tray_actions_both_covers_offer_both_escapes() {
+    // Unblock Network clears only what no in-process guard owns; the live blocked
+    // start owns the other. One action alone would leave the user just as blocked.
+    let a = tray_actions(false, None, &flags(false, true, true, false, true));
+    assert!(a.show_release_lockdown);
+    assert!(a.show_go_offline, "the transient cover needs its own escape too");
+}
+
+#[skuld::test]
+fn lockdown_click_intent_unknown_probe_can_still_arm() {
+    // Otherwise a machine whose firewall engine is wedged could never arm the
+    // kill switch again — a permanent loss of the feature from an unobserved state.
+    assert!(
+        lockdown_click_intent(&flags(false, false, true, true, false)),
+        "an unconfirmed cover must not pin the switch off"
+    );
+}
+
+#[skuld::test]
+fn lockdown_label_unknown_cover_says_it_cannot_confirm() {
+    let label = lockdown_menu_label(&flags(false, true, true, true, false));
+    assert!(label.contains("cannot confirm"), "{label}");
+    assert!(label.contains("Unblock Network"), "{label}");
+}
+
+#[skuld::test]
+fn release_failed_message_has_no_stray_whitespace_runs() {
+    // User-visible dialog copy: a line-continuation in the source once left a
+    // ten-space gap mid-sentence.
+    let m = release_failed_message();
+    for line in m.lines() {
+        assert!(
+            !line.trim_start().contains("  "),
+            "whitespace run mid-line in user-facing copy: {line:?}"
+        );
     }
 }

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -450,6 +450,23 @@ pub trait Routing: Send + Sync {
         tun_name: &str,
         app_ids: &[PathBuf],
     ) -> Result<Self::Cover, RoutingError>;
+
+    /// Whether a STANDING lockdown cover is holding the host closed right now,
+    /// as the OS sees it — independent of whether this process engaged it or is
+    /// running a session at all. That independence is the point: a cover adopted
+    /// from a crashed run has no guard anywhere in this process, and deriving
+    /// "engaged" from a live session reports it as absent (bindreams/hole#825).
+    ///
+    /// [`CoverState::Unknown`] means the probe could not answer; a caller must
+    /// not treat it as an open host.
+    fn lockdown_cover_state(&self) -> failclosed::CoverState;
+
+    /// Disengage a standing lockdown cover, FAIL-LOUD. `Ok` means the OS confirms
+    /// the host is open — the implementation re-probes rather than trusting the
+    /// return of whatever it called. An absent cover is `Ok` (nothing to do); an
+    /// `Err` means egress may still be blocked, so a caller must not record the
+    /// kill switch as off.
+    fn disengage_lockdown(&self) -> Result<(), RoutingError>;
 }
 
 // System (production) routing =========================================================================================
@@ -536,6 +553,14 @@ impl Routing for SystemRouting {
     ) -> Result<Self::Cover, RoutingError> {
         let resolver = failclosed::SystemLuidResolver;
         failclosed::engage_lockdown(server_ip, tun_name, &resolver, app_ids, &self.state_dir, self.owner)
+    }
+
+    fn lockdown_cover_state(&self) -> failclosed::CoverState {
+        failclosed::lockdown_cover_state(&self.state_dir)
+    }
+
+    fn disengage_lockdown(&self) -> Result<(), RoutingError> {
+        failclosed::disengage_lockdown(&self.state_dir)
     }
 }
 

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -461,11 +461,25 @@ pub trait Routing: Send + Sync {
     /// not treat it as an open host.
     fn lockdown_cover_state(&self) -> failclosed::CoverState;
 
+    /// Whether the TRANSIENT block-until-connected cover is holding the host
+    /// closed, as the OS sees it. Separate from
+    /// [`lockdown_cover_state`](Self::lockdown_cover_state) because only the
+    /// standing cover's keys are what a lockdown disengage verifies — but a
+    /// crash strands this one just as persistently, and a host it holds would
+    /// otherwise report as plain "Disconnected" with no action offered.
+    fn transient_cover_state(&self) -> failclosed::CoverState;
+
+    /// Sweep a transient cover this process does not own, FAIL-LOUD and verified
+    /// by re-probing. An absent cover is `Ok`.
+    fn sweep_transient(&self) -> Result<(), RoutingError>;
+
     /// Disengage a standing lockdown cover, FAIL-LOUD. `Ok` means the OS confirms
-    /// the host is open — the implementation re-probes rather than trusting the
-    /// return of whatever it called. An absent cover is `Ok` (nothing to do); an
-    /// `Err` means egress may still be blocked, so a caller must not record the
-    /// kill switch as off.
+    /// OUR STANDING COVER is gone — the implementation re-probes rather than
+    /// trusting the return of whatever it called. It says nothing about a
+    /// transient cover, which has its own keys and its own
+    /// [`sweep_transient`](Self::sweep_transient); the host can still be blocked
+    /// by that one. An absent cover is `Ok`; an `Err` means the standing cover may
+    /// still be in force, so a caller must not record the kill switch as off.
     fn disengage_lockdown(&self) -> Result<(), RoutingError>;
 }
 
@@ -561,6 +575,14 @@ impl Routing for SystemRouting {
 
     fn disengage_lockdown(&self) -> Result<(), RoutingError> {
         failclosed::disengage_lockdown(&self.state_dir)
+    }
+
+    fn transient_cover_state(&self) -> failclosed::CoverState {
+        failclosed::transient_cover_state(&self.state_dir)
+    }
+
+    fn sweep_transient(&self) -> Result<(), RoutingError> {
+        failclosed::sweep_transient_verified(&self.state_dir)
     }
 }
 

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -455,7 +455,7 @@ pub trait Routing: Send + Sync {
     /// as the OS sees it — independent of whether this process engaged it or is
     /// running a session at all. That independence is the point: a cover adopted
     /// from a crashed run has no guard anywhere in this process, and deriving
-    /// "engaged" from a live session reports it as absent (bindreams/hole#825).
+    /// "engaged" from a live session reports it as absent.
     ///
     /// [`CoverState::Unknown`] means the probe could not answer; a caller must
     /// not treat it as an open host.

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -154,12 +154,68 @@ pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
     platform::disengage_lockdown(state_dir)
 }
 
+/// What a probe of the standing lockdown cover found. Three states, not a bool:
+/// a probe that cannot reach the OS knows nothing, and folding that into "no
+/// cover" would report an all-clear over a host our own filters are still
+/// holding closed — and hide the escape, which keys on the same signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverState {
+    /// Our lockdown cover is in force: the host has no egress but the permits.
+    Engaged,
+    /// Confirmed absent — no cover of ours is holding the host.
+    Absent,
+    /// The probe could not answer (WFP engine open failed, `pfctl` unreadable).
+    Unknown,
+}
+
+impl CoverState {
+    /// Whether recovery should reconcile. `Unknown` reconciles: `Adopt` and
+    /// `Sweep` are both idempotent, so acting on a phantom costs nothing while
+    /// skipping a real cover would strand it.
+    pub fn is_present(self) -> bool {
+        !matches!(self, CoverState::Absent)
+    }
+
+    /// Whether the status surface should report the host as held closed.
+    /// `Unknown` counts: the user must be offered the way out.
+    pub fn is_engaged_or_unknown(self) -> bool {
+        !matches!(self, CoverState::Absent)
+    }
+}
+
+/// Gate a disengage on a post-disengage probe. `Ok` means the OS confirms the
+/// cover is gone — not that a call returned. Shared by both platforms so
+/// `disengage_lockdown`'s fail-loud contract is one rule, not two.
+pub(crate) fn verify_disengaged(state: CoverState) -> Result<(), RoutingError> {
+    match state {
+        CoverState::Absent => Ok(()),
+        CoverState::Engaged => Err(RoutingError::RouteSetup(
+            "the lockdown cover is still engaged after disengaging; the host remains blocked".into(),
+        )),
+        CoverState::Unknown => Err(RoutingError::RouteSetup(
+            "could not confirm the lockdown cover was disengaged; the host may remain blocked".into(),
+        )),
+    }
+}
+
+/// Whether our lockdown cover is holding the host closed RIGHT NOW. Distinct
+/// from [`lockdown_cover_present`], which asks the reconciliation question
+/// ("is there prior-run state to act on?") and is deliberately more lenient on
+/// macOS. The two coincide on Windows: its filters are persistent, so anything
+/// present is in force.
+pub fn lockdown_cover_state(state_dir: &Path) -> CoverState {
+    platform::lockdown_cover_state(state_dir)
+}
+
 /// Whether a standing lockdown cover from a prior run is present — the recovery
 /// decision's `prior_present` signal, keyed on the cover's OWN evidence (NOT
-/// `bridge-routes.json`). macOS: the `bridge-lockdown-pf.json` state file
-/// exists. Windows: always `true` — delete-by-GUID reconciliation is idempotent
-/// (a no-op when no filters exist), so probing would only add a redundant WFP
-/// enumeration; a `Sweep`/`Adopt` on a clean host does nothing.
+/// `bridge-routes.json`).
+///
+/// macOS stays lenient: the `bridge-lockdown-pf.json` state file existing is
+/// enough. pf is disabled and its ruleset flushed across a reboot while that
+/// file survives, so a stricter test would make `Sweep` skip the very file it
+/// exists to clear. Windows probes for real — [`CoverState::is_present`] treats
+/// an unanswerable probe as present so reconciliation still runs.
 pub fn lockdown_cover_present(state_dir: &Path) -> bool {
     #[cfg(target_os = "macos")]
     {
@@ -167,8 +223,7 @@ pub fn lockdown_cover_present(state_dir: &Path) -> bool {
     }
     #[cfg(target_os = "windows")]
     {
-        let _ = state_dir;
-        true
+        platform::lockdown_cover_state(state_dir).is_present()
     }
 }
 
@@ -190,6 +245,10 @@ pub(crate) fn build_lockdown_spec_for_test(
 #[cfg(all(test, target_os = "windows"))]
 #[path = "failclosed/facade_tests.rs"]
 mod facade_tests;
+
+#[cfg(test)]
+#[path = "failclosed/cover_state_tests.rs"]
+mod cover_state_tests;
 
 // Privileged-lane real-engage verification (#527): engages the REAL OS cover and
 // asserts it blocks egress. Gated to the elevated `hole-tests` TUN lane by the

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -94,6 +94,14 @@ pub fn recover_cover(state_dir: &Path, adopting: bool) {
     platform::recover_cover(state_dir, adopting);
 }
 
+/// Fail-loud transient sweep for the `bridge unlock` escape hatch: clears a
+/// block-until-connected cover a crash left behind and PROPAGATES failure, so the
+/// command cannot report success over a host it did not open. [`recover_cover`]
+/// stays best-effort — startup recovery has no caller to act on an error.
+pub fn sweep_transient_verified(state_dir: &Path) -> Result<(), RoutingError> {
+    platform::sweep_transient_verified(state_dir)
+}
+
 /// Engage the standing lockdown cover (loopback + TUN + onward-server + —on
 /// Windows— plugin/bridge App-IDs permitted, all else blocked). Returns the
 /// SAME [`Cover`] wrapper the transient `engage` returns — the platform guard

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -94,10 +94,11 @@ pub fn recover_cover(state_dir: &Path, adopting: bool) {
     platform::recover_cover(state_dir, adopting);
 }
 
-/// Fail-loud transient sweep for the `bridge unlock` escape hatch: clears a
-/// block-until-connected cover a crash left behind and PROPAGATES failure, so the
-/// command cannot report success over a host it did not open. [`recover_cover`]
-/// stays best-effort — startup recovery has no caller to act on an error.
+/// Fail-loud transient sweep: clears a block-until-connected cover a crash left
+/// behind and PROPAGATES failure, so a caller cannot report success over a host
+/// it did not open. Verified by re-probing, like the standing disengage — the
+/// point is the outcome, not that the calls returned. [`recover_cover`] stays
+/// best-effort: startup recovery has no caller to act on an error.
 pub fn sweep_transient_verified(state_dir: &Path) -> Result<(), RoutingError> {
     platform::sweep_transient_verified(state_dir)
 }
@@ -177,16 +178,14 @@ pub enum CoverState {
 }
 
 impl CoverState {
-    /// Whether recovery should reconcile. `Unknown` reconciles: `Adopt` and
-    /// `Sweep` are both idempotent, so acting on a phantom costs nothing while
-    /// skipping a real cover would strand it.
+    /// Whether anything but a CONFIRMED absence was observed — the single
+    /// question both consumers ask, deliberately one method rather than two
+    /// synonyms: recovery must reconcile a cover it cannot rule out (`Adopt` and
+    /// `Sweep` are idempotent, so acting on a phantom is free while skipping a
+    /// real one strands it), and the status surface must offer the way out for
+    /// the same reason. Splitting them would let a change to what `Unknown`
+    /// means for one silently change it for the other.
     pub fn is_present(self) -> bool {
-        !matches!(self, CoverState::Absent)
-    }
-
-    /// Whether the status surface should report the host as held closed.
-    /// `Unknown` counts: the user must be offered the way out.
-    pub fn is_engaged_or_unknown(self) -> bool {
         !matches!(self, CoverState::Absent)
     }
 }
@@ -206,13 +205,34 @@ pub(crate) fn verify_disengaged(state: CoverState) -> Result<(), RoutingError> {
     }
 }
 
-/// Whether our lockdown cover is holding the host closed RIGHT NOW. Distinct
-/// from [`lockdown_cover_present`], which asks the reconciliation question
-/// ("is there prior-run state to act on?") and is deliberately more lenient on
-/// macOS. The two coincide on Windows: its filters are persistent, so anything
-/// present is in force.
+/// Whether our STANDING lockdown cover is holding the host closed RIGHT NOW.
+/// Distinct from [`lockdown_cover_present`], which asks the reconciliation
+/// question ("is there prior-run state to act on?") and is deliberately more
+/// lenient on macOS. The two coincide on Windows: its filters are persistent, so
+/// anything present is in force.
 pub fn lockdown_cover_state(state_dir: &Path) -> CoverState {
     platform::lockdown_cover_state(state_dir)
+}
+
+/// Whether the TRANSIENT block-until-connected cover is holding the host closed.
+///
+/// Probed for the same reason as the standing one: its filters are persistent
+/// too, so a crash mid-connect leaves them blocking with no guard anywhere in the
+/// next process. Without this, a host held closed by a stranded transient cover
+/// reports as plain "Disconnected" with no action offered — the same lockout the
+/// standing probe exists to end, one key set over.
+pub fn transient_cover_state(state_dir: &Path) -> CoverState {
+    platform::transient_cover_state(state_dir)
+}
+
+/// The strongest claim about whether HOLE is holding the host closed, from either
+/// cover. `Engaged` if either is; otherwise `Unknown` if either is; else `Absent`.
+pub fn any_cover_state(state_dir: &Path) -> CoverState {
+    match (lockdown_cover_state(state_dir), transient_cover_state(state_dir)) {
+        (CoverState::Engaged, _) | (_, CoverState::Engaged) => CoverState::Engaged,
+        (CoverState::Unknown, _) | (_, CoverState::Unknown) => CoverState::Unknown,
+        _ => CoverState::Absent,
+    }
 }
 
 /// Whether a standing lockdown cover from a prior run is present — the recovery

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -188,6 +188,17 @@ impl CoverState {
     pub fn is_present(self) -> bool {
         !matches!(self, CoverState::Absent)
     }
+
+    /// The stronger of two observations: `Engaged` beats `Unknown` beats
+    /// `Absent`. Lets a caller combine per-cover probes without restating the
+    /// lattice — a second copy would be free to disagree with this one.
+    pub fn strongest(self, other: CoverState) -> CoverState {
+        match (self, other) {
+            (CoverState::Engaged, _) | (_, CoverState::Engaged) => CoverState::Engaged,
+            (CoverState::Unknown, _) | (_, CoverState::Unknown) => CoverState::Unknown,
+            _ => CoverState::Absent,
+        }
+    }
 }
 
 /// Gate a disengage on a post-disengage probe. `Ok` means the OS confirms the
@@ -223,16 +234,6 @@ pub fn lockdown_cover_state(state_dir: &Path) -> CoverState {
 /// standing probe exists to end, one key set over.
 pub fn transient_cover_state(state_dir: &Path) -> CoverState {
     platform::transient_cover_state(state_dir)
-}
-
-/// The strongest claim about whether HOLE is holding the host closed, from either
-/// cover. `Engaged` if either is; otherwise `Unknown` if either is; else `Absent`.
-pub fn any_cover_state(state_dir: &Path) -> CoverState {
-    match (lockdown_cover_state(state_dir), transient_cover_state(state_dir)) {
-        (CoverState::Engaged, _) | (_, CoverState::Engaged) => CoverState::Engaged,
-        (CoverState::Unknown, _) | (_, CoverState::Unknown) => CoverState::Unknown,
-        _ => CoverState::Absent,
-    }
 }
 
 /// Whether a standing lockdown cover from a prior run is present — the recovery

--- a/crates/tun-engine/src/routing/failclosed/cover_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/cover_state_tests.rs
@@ -1,5 +1,5 @@
 //! Platform-neutral tests for the cover-state vocabulary shared by both
-//! platform probes (#825).
+//! platform probes.
 
 use super::*;
 
@@ -26,7 +26,7 @@ fn unknown_counts_as_present_for_recovery() {
 #[skuld::test]
 fn unknown_counts_as_engaged_for_the_status_surface() {
     // The escape affordance keys on this. Reporting "not engaged" for a probe
-    // that failed would hide a genuinely blocked host — #825's symptom.
+    // that failed would hide a genuinely blocked host.
     assert!(CoverState::Engaged.is_engaged_or_unknown());
     assert!(CoverState::Unknown.is_engaged_or_unknown());
     assert!(!CoverState::Absent.is_engaged_or_unknown());

--- a/crates/tun-engine/src/routing/failclosed/cover_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/cover_state_tests.rs
@@ -14,20 +14,12 @@ fn verify_disengaged_rejects_anything_but_a_confirmed_absence() {
 }
 
 #[skuld::test]
-fn unknown_counts_as_present_for_recovery() {
-    // Reconciliation is idempotent either way, so an unanswerable probe must
-    // reconcile rather than skip: a real cover that read Unknown would otherwise
-    // survive a Sweep the user asked for.
+fn only_a_confirmed_absence_is_absent() {
+    // Both consumers hang off this one predicate: recovery must reconcile a cover
+    // it cannot rule out, and the escape affordance must stay offered for the
+    // same reason. Reporting "not engaged" for a probe that failed would hide a
+    // genuinely blocked host.
     assert!(CoverState::Engaged.is_present());
     assert!(CoverState::Unknown.is_present());
     assert!(!CoverState::Absent.is_present());
-}
-
-#[skuld::test]
-fn unknown_counts_as_engaged_for_the_status_surface() {
-    // The escape affordance keys on this. Reporting "not engaged" for a probe
-    // that failed would hide a genuinely blocked host.
-    assert!(CoverState::Engaged.is_engaged_or_unknown());
-    assert!(CoverState::Unknown.is_engaged_or_unknown());
-    assert!(!CoverState::Absent.is_engaged_or_unknown());
 }

--- a/crates/tun-engine/src/routing/failclosed/cover_state_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/cover_state_tests.rs
@@ -1,0 +1,33 @@
+//! Platform-neutral tests for the cover-state vocabulary shared by both
+//! platform probes (#825).
+
+use super::*;
+
+#[skuld::test]
+fn verify_disengaged_rejects_anything_but_a_confirmed_absence() {
+    // `disengage_lockdown`'s Ok must mean "the host is open", not "the call
+    // returned". Unknown is a failure: a probe that cannot answer is no basis
+    // for telling the user their network is back.
+    assert!(verify_disengaged(CoverState::Absent).is_ok());
+    assert!(verify_disengaged(CoverState::Engaged).is_err());
+    assert!(verify_disengaged(CoverState::Unknown).is_err());
+}
+
+#[skuld::test]
+fn unknown_counts_as_present_for_recovery() {
+    // Reconciliation is idempotent either way, so an unanswerable probe must
+    // reconcile rather than skip: a real cover that read Unknown would otherwise
+    // survive a Sweep the user asked for.
+    assert!(CoverState::Engaged.is_present());
+    assert!(CoverState::Unknown.is_present());
+    assert!(!CoverState::Absent.is_present());
+}
+
+#[skuld::test]
+fn unknown_counts_as_engaged_for_the_status_surface() {
+    // The escape affordance keys on this. Reporting "not engaged" for a probe
+    // that failed would hide a genuinely blocked host — #825's symptom.
+    assert!(CoverState::Engaged.is_engaged_or_unknown());
+    assert!(CoverState::Unknown.is_engaged_or_unknown());
+    assert!(!CoverState::Absent.is_engaged_or_unknown());
+}

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -501,11 +501,10 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
     );
 }
 
-// Cover-state probe against the real OS (#825) ========================================================================
+// Cover-state probe against the real OS ===============================================================================
 
-/// The probe must track the REAL cover through its whole life. The clean-host
-/// `Absent` is the assertion the old Windows facade — an unconditional `true` —
-/// could not make, and it is what let #825 report a live cover as "not engaged".
+/// The probe must track the REAL cover through its whole life, including the
+/// clean-host `Absent` case an unconditional `true` cannot express.
 #[cfg(target_os = "windows")]
 #[skuld::test(labels = [TUN], serial = TUN)]
 fn lockdown_lockout_windows_cover_state_tracks_engage_and_disengage() {
@@ -547,7 +546,7 @@ fn lockdown_lockout_windows_cover_state_tracks_engage_and_disengage() {
 
 /// macOS counterpart. pf state is the ruleset + the enable token, so the probe
 /// reads both rather than trusting `bridge-lockdown-pf.json` — a reboot leaves
-/// that file over a flushed, disabled pf (#827).
+/// that file over a flushed, disabled pf.
 #[cfg(target_os = "macos")]
 #[skuld::test(labels = [TUN], serial = TUN)]
 fn lockdown_lockout_macos_cover_state_tracks_engage_and_disengage() {

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -500,3 +500,115 @@ fn macos_failclosed_permits_resolver_blocks_other_egress() {
         rpo.err().map(|e| e.kind()),
     );
 }
+
+// Cover-state probe against the real OS (#825) ========================================================================
+
+/// The probe must track the REAL cover through its whole life. The clean-host
+/// `Absent` is the assertion the old Windows facade — an unconditional `true` —
+/// could not make, and it is what let #825 report a live cover as "not engaged".
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn lockdown_lockout_windows_cover_state_tracks_engage_and_disengage() {
+    let dir = tempfile::tempdir().unwrap();
+    let resolver = SystemLuidResolver;
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Absent,
+        "a host with no cover engaged must probe Absent"
+    );
+
+    // "Loopback Pseudo-Interface 1" is an always-present alias used only as a LUID
+    // source to exercise the real resolve + `LocalInterface` filter path.
+    let cover = engage_lockdown(
+        server_ip,
+        "Loopback Pseudo-Interface 1",
+        &resolver,
+        &[],
+        dir.path(),
+        None,
+    )
+    .expect("engage real WFP lockdown cover");
+
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Engaged,
+        "a live cover must probe Engaged"
+    );
+
+    drop(cover);
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Absent,
+        "a disengaged cover must probe Absent again"
+    );
+}
+
+/// macOS counterpart. pf state is the ruleset + the enable token, so the probe
+/// reads both rather than trusting `bridge-lockdown-pf.json` — a reboot leaves
+/// that file over a flushed, disabled pf (#827).
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn lockdown_lockout_macos_cover_state_tracks_engage_and_disengage() {
+    let dir = tempfile::tempdir().unwrap();
+    let resolver = SystemLuidResolver;
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Absent,
+        "a host with no cover engaged must probe Absent"
+    );
+
+    let cover = engage_lockdown(server_ip, "utun-absent", &resolver, &[], dir.path(), None)
+        .expect("engage real pf lockdown cover");
+
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Engaged,
+        "a live cover must probe Engaged"
+    );
+
+    drop(cover);
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Absent,
+        "a disengaged cover must probe Absent again"
+    );
+}
+
+/// `disengage_lockdown`'s Ok must mean the host is open. Drives the real
+/// primitive on a real cover and cross-checks the claim against the probe —
+/// previously the Windows implementation discarded every delete result, so its
+/// Ok meant only that the FWPM engine had opened.
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn lockdown_lockout_disengage_ok_means_the_cover_is_gone() {
+    let dir = tempfile::tempdir().unwrap();
+    let resolver = SystemLuidResolver;
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    // A clean host has nothing to remove; the verified contract still holds.
+    disengage_lockdown(dir.path()).expect("disengage on a clean host is Ok");
+
+    let cover = engage_lockdown(server_ip, LOCKOUT_TEST_TUN, &resolver, &[], dir.path(), None)
+        .expect("engage real lockdown cover");
+    // The unclean exit: `disarm` forgets the guard, so its Drop never runs and the
+    // OS keeps exactly what a crash leaves behind.
+    crate::routing::CoverGuard::disarm(cover);
+    assert_eq!(lockdown_cover_state(dir.path()), CoverState::Engaged);
+
+    disengage_lockdown(dir.path()).expect("disengage a real cover");
+    assert_eq!(
+        lockdown_cover_state(dir.path()),
+        CoverState::Absent,
+        "disengage returned Ok, so the probe must confirm the cover is gone"
+    );
+}
+
+/// A LUID/interface source that exists on the running host, used only to drive
+/// the real resolve path — the assertions never depend on it.
+#[cfg(target_os = "windows")]
+const LOCKOUT_TEST_TUN: &str = "Loopback Pseudo-Interface 1";
+#[cfg(target_os = "macos")]
+const LOCKOUT_TEST_TUN: &str = "utun-absent";

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -581,6 +581,7 @@ fn lockdown_lockout_macos_cover_state_tracks_engage_and_disengage() {
 /// primitive on a real cover and cross-checks the claim against the probe —
 /// previously the Windows implementation discarded every delete result, so its
 /// Ok meant only that the FWPM engine had opened.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 #[skuld::test(labels = [TUN], serial = TUN)]
 fn lockdown_lockout_disengage_ok_means_the_cover_is_gone() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -577,6 +577,62 @@ fn lockdown_lockout_macos_cover_state_tracks_engage_and_disengage() {
     );
 }
 
+/// The TRANSIENT probe against the real pf, mirroring its standing-cover twin.
+///
+/// This is the only place that can prove `TRANSIENT_BLOCK_RULE` is spelled the
+/// way `pfctl -sr` prints it: a constant in written form parses fine, loads fine
+/// and reads back differently, so the probe silently reports `Absent` over a live
+/// cover — the fail-open this test exists to catch. Nothing off-host can observe
+/// it.
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn lockdown_lockout_macos_transient_cover_state_tracks_engage_and_disengage() {
+    let dir = tempfile::tempdir().unwrap();
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_eq!(
+        transient_cover_state(dir.path()),
+        CoverState::Absent,
+        "a host with no transient cover engaged must probe Absent"
+    );
+
+    let cover = engage(server_ip, None, dir.path(), None).expect("engage the real pf transient cover");
+    assert_eq!(
+        transient_cover_state(dir.path()),
+        CoverState::Engaged,
+        "a live transient cover must probe Engaged — a written-form constant reads Absent here"
+    );
+
+    drop(cover);
+    assert_eq!(
+        transient_cover_state(dir.path()),
+        CoverState::Absent,
+        "a disengaged transient cover must probe Absent again"
+    );
+}
+
+/// The transient sweep's `Ok` must mean the cover is gone, on the real pf. With a
+/// probe that can never match, this passes vacuously — which is why it engages a
+/// real cover first rather than sweeping a clean host.
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn lockdown_lockout_macos_transient_sweep_verifies_the_cover_is_gone() {
+    let dir = tempfile::tempdir().unwrap();
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    let cover = engage(server_ip, None, dir.path(), None).expect("engage the real pf transient cover");
+    // The unclean exit: forget the guard so its Drop never runs.
+    crate::routing::CoverGuard::disarm(cover);
+    assert_eq!(transient_cover_state(dir.path()), CoverState::Engaged);
+
+    sweep_transient_verified(dir.path()).expect("sweep a real transient cover");
+    assert_eq!(
+        transient_cover_state(dir.path()),
+        CoverState::Absent,
+        "the sweep reported Ok, so the probe must confirm the cover is gone"
+    );
+}
+
 /// `disengage_lockdown`'s Ok must mean the host is open. Drives the real
 /// primitive on a real cover and cross-checks the claim against the probe —
 /// previously the Windows implementation discarded every delete result, so its

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -282,6 +282,32 @@ fn disengage(token: &str, state_dir: &Path, adopting: bool) {
     }
 }
 
+/// Fail-loud transient sweep for `bridge unlock`. Unlike [`recover_cover`],
+/// which is best-effort because startup recovery has no caller to act on a
+/// failure, this PROPAGATES: `unlock` promises the user that a success means
+/// their network is open, and a cover it silently failed to clear would break
+/// that promise on the one command they have left. An absent cover is `Ok`.
+pub fn sweep_transient_verified(state_dir: &Path) -> Result<(), RoutingError> {
+    let Some(st) = state::load(state_dir) else {
+        return Ok(());
+    };
+    let out = pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER)?;
+    if !out.status.success() {
+        return Err(RoutingError::RouteSetup(format!(
+            "pfctl transient restore failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    let xout = pfctl(&["-X", &st.pf_token], None, PHASE_RECOVER_COVER)?;
+    if !xout.status.success() {
+        return Err(RoutingError::RouteSetup(format!(
+            "pfctl -X (drop pf refcount) failed: {}",
+            String::from_utf8_lossy(&xout.stderr).trim()
+        )));
+    }
+    state::clear(state_dir).map_err(|e| RoutingError::RouteSetup(format!("failclosed-state clear failed: {e}")))
+}
+
 pub fn recover_cover(state_dir: &Path, adopting: bool) {
     let Some(st) = state::load(state_dir) else {
         tracing::debug!("no failclosed-state file, nothing to recover");
@@ -444,12 +470,16 @@ pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
             String::from_utf8_lossy(&xout.stderr).trim()
         )));
     }
+    // Probe BEFORE clearing: `lockdown_cover_state` short-circuits to `Absent`
+    // on a missing state file, so verifying afterwards would assert a tautology
+    // and never observe a ruleset that is still blocking.
+    let observed = lockdown_cover_state(state_dir);
     // State cleared only after a confirmed restore — a failed clear is the only
     // remaining best-effort step (the cover is already down).
     if let Err(e) = lockdown_state::clear(state_dir) {
         tracing::warn!(error = %e, "lockdown-pf-state clear failed after disengage");
     }
-    super::verify_disengaged(lockdown_cover_state(state_dir))
+    super::verify_disengaged(observed)
 }
 
 /// Map the two pf reads to a [`CoverState`]. `None` means that `pfctl`
@@ -471,7 +501,7 @@ pub(crate) fn cover_state_from(has_state: bool, pf_enabled: Option<bool>, carrie
         (None, _) | (Some(true), None) => CoverState::Unknown,
         // pf disabled: the ruleset is inert and the host is open. This is the
         // ordinary post-reboot state (pf and its refcount reset at boot while the
-        // state file survives) — see #827.
+        // state file survives).
         (Some(false), _) => CoverState::Absent,
         (Some(true), Some(true)) => CoverState::Engaged,
         // pf is up but someone reloaded over us; our ruleset is not the policy.

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -30,7 +30,7 @@ use crate::error::RoutingError;
 // `failclosed` module and `failclosed_state` is its sibling child.
 use super::failclosed_state as state;
 use super::lockdown_pf_state as lockdown_state;
-use super::RESOLVER_PERMIT_PORT;
+use super::{CoverState, RESOLVER_PERMIT_PORT};
 
 /// Build the self-contained pf ruleset (loaded via `pfctl -f -`).
 ///
@@ -69,6 +69,10 @@ pub fn ensure_trailing_nl(s: &str) -> String {
     }
 }
 
+/// The lockdown ruleset's fail-closed base. Named once so the builder, the
+/// [`lockdown_cover_state`] probe and the privileged tests cannot drift apart.
+pub const LOCKDOWN_BLOCK_RULE: &str = "block drop out quick all";
+
 /// Build the self-contained MAIN ruleset for the standing lockdown, loaded via
 /// `pfctl -f -` (NO `-Fa`). It IS the host's egress policy while engaged:
 /// `block drop out quick all` is the fail-closed base, with earlier `quick`
@@ -89,7 +93,8 @@ pub fn build_lockdown_main_ruleset(tun_name: &str, server_ip: IpAddr, nat_snapsh
          pass out quick proto {proto} from any to {ip}\n\
          pass out quick on {tun} all\n\
          block drop out quick inet6 all\n\
-         block drop out quick all\n",
+         {block}\n",
+        block = LOCKDOWN_BLOCK_RULE,
         nat = ensure_trailing_nl(nat_snapshot),
         proto = proto,
         ip = server_ip,
@@ -444,7 +449,72 @@ pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
     if let Err(e) = lockdown_state::clear(state_dir) {
         tracing::warn!(error = %e, "lockdown-pf-state clear failed after disengage");
     }
-    Ok(())
+    super::verify_disengaged(lockdown_cover_state(state_dir))
+}
+
+/// Map the two pf reads to a [`CoverState`]. `None` means that `pfctl`
+/// invocation failed. Pure so the read-failure rows — the ones a live test
+/// cannot produce on a healthy host — are table-testable.
+///
+/// A failed read is `Unknown`, NOT `Absent`. The Windows justification for
+/// folding an unanswerable probe into "absent" ("we could not have disengaged
+/// anything either") does not carry here: `disengage_lockdown` drives
+/// `pfctl -f -` and `pfctl -X`, which are independent of whether `-s info` and
+/// `-sr` could be read. So a read failure says nothing about whether the release
+/// would work, and reporting "not engaged" would hide a blocked host along with
+/// its way out.
+pub(crate) fn cover_state_from(has_state: bool, pf_enabled: Option<bool>, carries_block: Option<bool>) -> CoverState {
+    if !has_state {
+        return CoverState::Absent;
+    }
+    match (pf_enabled, carries_block) {
+        (None, _) | (Some(true), None) => CoverState::Unknown,
+        // pf disabled: the ruleset is inert and the host is open. This is the
+        // ordinary post-reboot state (pf and its refcount reset at boot while the
+        // state file survives) — see #827.
+        (Some(false), _) => CoverState::Absent,
+        (Some(true), Some(true)) => CoverState::Engaged,
+        // pf is up but someone reloaded over us; our ruleset is not the policy.
+        (Some(true), Some(false)) => CoverState::Absent,
+    }
+}
+
+/// Whether our lockdown ruleset is actually holding the host closed. Reads pf
+/// rather than trusting `bridge-lockdown-pf.json`, which outlives the ruleset it
+/// describes across a reboot.
+///
+/// Short-circuits on the state file so the ordinary path spawns no subprocess:
+/// `pfctl` runs only when a cover is recorded, i.e. in the lockout state or the
+/// post-reboot inert state.
+pub fn lockdown_cover_state(state_dir: &Path) -> CoverState {
+    if lockdown_state::load(state_dir).is_none() {
+        return cover_state_from(false, None, None);
+    }
+    let enabled = read_pf(&["-s", "info"]).map(|out| parse_pf_enabled(&out));
+    let carries = read_pf(&["-sr"]).map(|out| out.contains(LOCKDOWN_BLOCK_RULE));
+    cover_state_from(true, enabled, carries)
+}
+
+/// One read-only `pfctl`, as stdout.
+fn read_pf(args: &[&str]) -> Option<String> {
+    read_outcome(pfctl(args, None, PHASE_RECOVER_COVER))
+}
+
+/// Interpret a `pfctl` invocation. `None` on a spawn failure OR a non-zero exit —
+/// neither is an answer, and the caller must not read one as "no cover". Split
+/// from [`read_pf`] so both failure shapes are testable without a live `pfctl`.
+pub(crate) fn read_outcome(result: Result<std::process::Output, RoutingError>) -> Option<String> {
+    match result {
+        Ok(out) if out.status.success() => Some(String::from_utf8_lossy(&out.stdout).into_owned()),
+        Ok(out) => {
+            tracing::warn!(status = ?out.status, "pfctl read exited non-zero; cover state is unknown");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "pfctl read could not run; cover state is unknown");
+            None
+        }
+    }
 }
 
 /// Best-effort wrapper for `Drop` (user-stop): disengage and swallow. Drop has

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -270,13 +270,43 @@ impl Drop for Cover {
 /// wipe the standing lockdown ruleset (which is the live main ruleset) before
 /// Adopt. Best-effort; logs on failure. Shared by `Drop` and `recover_cover`.
 fn disengage(token: &str, state_dir: &Path, adopting: bool) {
+    // `pfctl()` only `Err`s on a SPAWN failure: a non-zero exit — `/etc/pf.conf`
+    // missing or unparseable, and it is user-editable and other VPN clients
+    // rewrite it — comes back `Ok(output)`. Both count as "the restore did not
+    // happen", and the state file is this cover's only evidence: clearing it over
+    // a live ruleset makes the probe read `Absent`, after which every escape
+    // reports success and does nothing.
+    let mut restored = true;
     if adopting {
         tracing::info!("standing lockdown cover being adopted; skipping /etc/pf.conf reload during transient sweep");
-    } else if let Err(e) = pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER) {
-        tracing::warn!(error = %e, "pf ruleset restore failed during cover disengage");
+    } else {
+        match pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER) {
+            Ok(out) if out.status.success() => {}
+            Ok(out) => {
+                restored = false;
+                tracing::warn!(status = ?out.status, stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                               "pf ruleset restore exited non-zero during cover disengage");
+            }
+            Err(e) => {
+                restored = false;
+                tracing::warn!(error = %e, "pf ruleset restore failed during cover disengage");
+            }
+        }
     }
-    if let Err(e) = pfctl(&["-X", token], None, PHASE_RECOVER_COVER) {
-        tracing::warn!(error = %e, "pfctl -X failed during cover disengage");
+    match pfctl(&["-X", token], None, PHASE_RECOVER_COVER) {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => {
+            restored = false;
+            tracing::warn!(status = ?out.status, "pfctl -X exited non-zero during cover disengage");
+        }
+        Err(e) => {
+            restored = false;
+            tracing::warn!(error = %e, "pfctl -X failed during cover disengage");
+        }
+    }
+    if !restored {
+        tracing::warn!("keeping failclosed-state: the cover may still be in force and must stay discoverable");
+        return;
     }
     if let Err(e) = state::clear(state_dir) {
         tracing::warn!(error = %e, "failclosed-state clear failed during cover disengage");
@@ -285,8 +315,18 @@ fn disengage(token: &str, state_dir: &Path, adopting: bool) {
 
 /// The transient ruleset's fail-closed base, distinct from
 /// [`LOCKDOWN_BLOCK_RULE`]. Named once so [`build_pf_ruleset`] and the probe
-/// cannot drift apart.
-pub const TRANSIENT_BLOCK_RULE: &str = "block out all";
+/// cannot drift apart — and spelled the way `pfctl -sr` PRINTS it, not the way a
+/// ruleset may be written.
+///
+/// `pfctl` reprints parsed rules, emitting the policy word for a `PF_DROP` rule,
+/// so a rule written `block out all` reads back as `block drop out all`; an exact
+/// match on the written form could never hit and the probe would report `Absent`
+/// over a live cover. [`LOCKDOWN_BLOCK_RULE`] is already in printed form for the
+/// same reason, and the transient cover's own privileged test matches loosely
+/// precisely because the written form does not round-trip. Under
+/// `set block-policy drop` both spellings are the same rule, so emitting the
+/// printed form changes nothing but makes source and output agree.
+pub const TRANSIENT_BLOCK_RULE: &str = "block drop out all";
 
 /// Whether the TRANSIENT cover is holding the host closed. Same shape as
 /// [`lockdown_cover_state`]: no state file short-circuits to `Absent` with no

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -50,11 +50,12 @@ pub fn build_pf_ruleset(server_ip: IpAddr, resolver_ip: Option<IpAddr>) -> Strin
         .unwrap_or_default();
     format!(
         "set block-policy drop\n\
-         block out all\n\
+         {block}\n\
          pass out quick on lo0 all\n\
          pass in quick on lo0 all\n\
          pass out quick from any to {server_ip}\n\
-         {resolver_pass}"
+         {resolver_pass}",
+        block = TRANSIENT_BLOCK_RULE,
     )
 }
 
@@ -282,6 +283,24 @@ fn disengage(token: &str, state_dir: &Path, adopting: bool) {
     }
 }
 
+/// The transient ruleset's fail-closed base, distinct from
+/// [`LOCKDOWN_BLOCK_RULE`]. Named once so [`build_pf_ruleset`] and the probe
+/// cannot drift apart.
+pub const TRANSIENT_BLOCK_RULE: &str = "block out all";
+
+/// Whether the TRANSIENT cover is holding the host closed. Same shape as
+/// [`lockdown_cover_state`]: no state file short-circuits to `Absent` with no
+/// subprocess, an unreadable `pfctl` is `Unknown`, and pf must be enabled with
+/// our own ruleset loaded to read `Engaged`.
+pub fn transient_cover_state(state_dir: &Path) -> CoverState {
+    if state::load(state_dir).is_none() {
+        return cover_state_from(false, None, None);
+    }
+    let enabled = read_pf(&["-s", "info"]).map(|out| parse_pf_enabled(&out));
+    let carries = read_pf(&["-sr"]).map(|out| out.contains(TRANSIENT_BLOCK_RULE));
+    cover_state_from(true, enabled, carries)
+}
+
 /// Fail-loud transient sweep for `bridge unlock`. Unlike [`recover_cover`],
 /// which is best-effort because startup recovery has no caller to act on a
 /// failure, this PROPAGATES: `unlock` promises the user that a success means
@@ -305,6 +324,10 @@ pub fn sweep_transient_verified(state_dir: &Path) -> Result<(), RoutingError> {
             String::from_utf8_lossy(&xout.stderr).trim()
         )));
     }
+    // Verify BEFORE clearing, for the same reason `disengage_lockdown` does: the
+    // state file is this cover's only evidence, so clearing it first would make
+    // the probe read `Absent` and the check vacuous.
+    super::verify_disengaged(transient_cover_state(state_dir))?;
     state::clear(state_dir).map_err(|e| RoutingError::RouteSetup(format!("failclosed-state clear failed: {e}")))
 }
 
@@ -470,16 +493,20 @@ pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
             String::from_utf8_lossy(&xout.stderr).trim()
         )));
     }
-    // Probe BEFORE clearing: `lockdown_cover_state` short-circuits to `Absent`
-    // on a missing state file, so verifying afterwards would assert a tautology
-    // and never observe a ruleset that is still blocking.
-    let observed = lockdown_cover_state(state_dir);
-    // State cleared only after a confirmed restore — a failed clear is the only
-    // remaining best-effort step (the cover is already down).
+    // Probe BEFORE clearing: `lockdown_cover_state` short-circuits to `Absent` on
+    // a missing state file, so verifying afterwards would assert a tautology and
+    // never observe a ruleset that is still blocking.
+    super::verify_disengaged(lockdown_cover_state(state_dir))?;
+    // Clear ONLY once the probe confirms the host is open. The state file is the
+    // sole evidence this cover exists: deleting it under a live ruleset makes the
+    // probe read `Absent`, so every escape then reports success and does nothing
+    // — and the next `FreshEnable` would snapshot our own blocking ruleset as
+    // "the host". A failed clear over an already-open host is the one remaining
+    // best-effort step.
     if let Err(e) = lockdown_state::clear(state_dir) {
         tracing::warn!(error = %e, "lockdown-pf-state clear failed after disengage");
     }
-    super::verify_disengaged(observed)
+    Ok(())
 }
 
 /// Map the two pf reads to a [`CoverState`]. `None` means that `pfctl`

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -365,3 +365,70 @@ fn restore_empty_nat_has_no_blank_line() {
     let r = build_lockdown_restore_ruleset("", FILTER_SNAP);
     assert!(!r.contains("\n\n"), "empty nat must not produce a blank line:\n{r}");
 }
+
+// Cover-state probe (#825) ============================================================================================
+
+#[skuld::test]
+fn macos_cover_state_maps_pf_reads() {
+    use CoverState::*;
+
+    // No state file: nothing of ours was ever recorded, and no subprocess runs.
+    assert_eq!(cover_state_from(false, None, None), Absent);
+    assert_eq!(cover_state_from(false, Some(true), Some(true)), Absent);
+
+    // Read failures are the rows a boolean signature would have collapsed into
+    // "no cover" — hiding a blocked host and its escape along with it.
+    assert_eq!(cover_state_from(true, None, Some(true)), Unknown);
+    assert_eq!(cover_state_from(true, None, None), Unknown);
+    assert_eq!(cover_state_from(true, Some(true), None), Unknown);
+
+    // pf disabled: the ruleset is inert, the host is open. The ordinary
+    // post-reboot state (#827) — reporting Engaged here would be a false alarm.
+    assert_eq!(cover_state_from(true, Some(false), Some(true)), Absent);
+    assert_eq!(cover_state_from(true, Some(false), Some(false)), Absent);
+
+    // pf up, but our ruleset is not the loaded policy.
+    assert_eq!(cover_state_from(true, Some(true), Some(false)), Absent);
+
+    // The one engaged combination.
+    assert_eq!(cover_state_from(true, Some(true), Some(true)), Engaged);
+}
+
+#[skuld::test]
+fn macos_pf_read_failures_are_not_answers() {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+
+    let out = |code: i32, stdout: &str| Output {
+        status: ExitStatus::from_raw(code),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    };
+
+    assert_eq!(
+        read_outcome(Ok(out(0, "Status: Enabled"))).as_deref(),
+        Some("Status: Enabled")
+    );
+    assert_eq!(
+        read_outcome(Ok(out(256, "partial"))),
+        None,
+        "a non-zero exit is not an answer, even with stdout"
+    );
+    assert_eq!(
+        read_outcome(Err(RoutingError::RouteSetup("pfctl not found".into()))),
+        None,
+        "a spawn failure is not an answer"
+    );
+}
+
+#[skuld::test]
+fn macos_lockdown_ruleset_carries_the_probed_block_rule() {
+    // The probe greps the live ruleset for LOCKDOWN_BLOCK_RULE. If the builder
+    // stopped emitting it, the probe would report Absent over a blocked host —
+    // so pin that the two agree by construction.
+    let ruleset = build_lockdown_main_ruleset("utun4", "203.0.113.7".parse().unwrap(), "");
+    assert!(
+        ruleset.contains(LOCKDOWN_BLOCK_RULE),
+        "the lockdown ruleset must carry the rule the probe looks for:\n{ruleset}"
+    );
+}

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -428,10 +428,10 @@ fn macos_engaged_state_is_reachable_by_the_disengage_verifier() {
     // could never observe a ruleset still blocking — a check that cannot fail.
     // Pin the input the verifier must be able to see.
     assert_eq!(cover_state_from(true, Some(true), Some(true)), CoverState::Engaged);
-    assert!(super::verify_disengaged(CoverState::Engaged).is_err());
+    assert!(super::super::verify_disengaged(CoverState::Engaged).is_err());
     // ...and the vacuous one it would see if the file were gone first.
     assert_eq!(cover_state_from(false, None, None), CoverState::Absent);
-    assert!(super::verify_disengaged(CoverState::Absent).is_ok());
+    assert!(super::super::verify_disengaged(CoverState::Absent).is_ok());
 }
 
 #[skuld::test]

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -366,7 +366,7 @@ fn restore_empty_nat_has_no_blank_line() {
     assert!(!r.contains("\n\n"), "empty nat must not produce a blank line:\n{r}");
 }
 
-// Cover-state probe (#825) ============================================================================================
+// Cover-state probe ===================================================================================================
 
 #[skuld::test]
 fn macos_cover_state_maps_pf_reads() {
@@ -383,7 +383,7 @@ fn macos_cover_state_maps_pf_reads() {
     assert_eq!(cover_state_from(true, Some(true), None), Unknown);
 
     // pf disabled: the ruleset is inert, the host is open. The ordinary
-    // post-reboot state (#827) — reporting Engaged here would be a false alarm.
+    // post-reboot state — reporting Engaged here would be a false alarm.
     assert_eq!(cover_state_from(true, Some(false), Some(true)), Absent);
     assert_eq!(cover_state_from(true, Some(false), Some(false)), Absent);
 
@@ -419,6 +419,19 @@ fn macos_pf_read_failures_are_not_answers() {
         None,
         "a spawn failure is not an answer"
     );
+}
+
+#[skuld::test]
+fn macos_engaged_state_is_reachable_by_the_disengage_verifier() {
+    // `disengage_lockdown` probes BEFORE clearing the state file. If it cleared
+    // first, `lockdown_cover_state` would short-circuit to Absent and the verify
+    // could never observe a ruleset still blocking — a check that cannot fail.
+    // Pin the input the verifier must be able to see.
+    assert_eq!(cover_state_from(true, Some(true), Some(true)), CoverState::Engaged);
+    assert!(super::verify_disengaged(CoverState::Engaged).is_err());
+    // ...and the vacuous one it would see if the file were gone first.
+    assert_eq!(cover_state_from(false, None, None), CoverState::Absent);
+    assert!(super::verify_disengaged(CoverState::Absent).is_ok());
 }
 
 #[skuld::test]

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -435,6 +435,31 @@ fn macos_engaged_state_is_reachable_by_the_disengage_verifier() {
 }
 
 #[skuld::test]
+fn macos_transient_ruleset_carries_the_probed_block_rule() {
+    // The probe greps `pfctl -sr` output for TRANSIENT_BLOCK_RULE, so the constant
+    // has to be spelled the way pfctl PRINTS a rule, not the way one may be
+    // written: pfctl reprints parsed rules and emits the policy word for a
+    // PF_DROP rule, so `block out all` reads back as `block drop out all`. Under
+    // `set block-policy drop` they are the same rule, so emitting the printed
+    // form costs nothing and makes the two agree. Live proof is
+    // `lockdown_lockout_macos_transient_cover_state_tracks_engage_and_disengage`.
+    // Expected value derived from pfctl's own behaviour, not from our constant:
+    // `pfctl -sr` output is re-parseable by design — `build_lockdown_restore_ruleset`
+    // feeds a captured `-sr` snapshot straight back through `pfctl -f -` — so the
+    // printed form is both what a probe reads and what a ruleset may contain.
+    const PRINTED: &str = "block drop out all";
+    assert_eq!(
+        TRANSIENT_BLOCK_RULE, PRINTED,
+        "the probe greps pfctl output, so the constant must be pfctl's printed form"
+    );
+    let ruleset = build_pf_ruleset("203.0.113.7".parse().unwrap(), None);
+    assert!(
+        ruleset.contains(PRINTED),
+        "the emitted ruleset must already be in the form it reads back as:\n{ruleset}"
+    );
+}
+
+#[skuld::test]
 fn macos_lockdown_ruleset_carries_the_probed_block_rule() {
     // The probe greps the live ruleset for LOCKDOWN_BLOCK_RULE. If the builder
     // stopped emitting it, the probe would report Absent over a blocked host —

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -78,6 +78,11 @@ pub const FILTER_GUIDS: [GUID; 12] = [
     GUID::from_u128(0xa020f996_e73f_488c_b1c9_5fce3ea0b1eb), // resolver CONNECT V6
 ];
 
+/// Indices into [`FILTER_GUIDS`] for the TRANSIENT cover's block-all pair — the
+/// same evidence [`LOCKDOWN_BLOCK_GUID_INDICES`] names for the standing cover,
+/// over the disjoint transient key set.
+pub(crate) const TRANSIENT_BLOCK_GUID_INDICES: [usize; 2] = [4, 5]; // block-all V4, block-all V6
+
 /// IANA protocol number for TCP (RFC 790; never changes — not sourced from
 /// the `windows` crate's `WinSock::IPPROTO_TCP` to avoid an extra import for
 /// a value this stable).
@@ -1009,6 +1014,26 @@ pub fn lockdown_cover_state(_state_dir: &Path) -> CoverState {
     }
 }
 
+/// Whether the TRANSIENT cover's block-all filters are in force. Same mechanism
+/// as [`lockdown_cover_state`] over the disjoint transient key set; the two are
+/// probed separately because only the standing one is what `disengage_lockdown`
+/// verifies.
+pub fn transient_cover_state(_state_dir: &Path) -> CoverState {
+    unsafe {
+        let mut engine = HANDLE::default();
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let rc = FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine);
+        if rc != ERROR_SUCCESS.0 {
+            tracing::warn!(rc, "FWPM engine open failed; transient cover state is unknown");
+            return cover_state_from_lookups(false, Lookup::Failed, Lookup::Failed);
+        }
+        let [v4, v6] = TRANSIENT_BLOCK_GUID_INDICES.map(|i| lookup_filter(engine, &FILTER_GUIDS[i]));
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmEngineClose0(engine);
+        cover_state_from_lookups(true, v4, v6)
+    }
+}
+
 /// One `FwpmFilterGetByKey0`, freeing whatever it allocated. `FWP_E_FILTER_NOT_FOUND`
 /// is the only return that proves absence; every other error is `Failed`.
 ///
@@ -1083,7 +1108,7 @@ pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
 /// Only the FILTERS are checked. The sublayer and provider are shared with the
 /// standing lockdown cover, so their delete legitimately fails while lockdown
 /// filters still pin them — an orphaned empty sublayer blocks nothing.
-pub fn sweep_transient_verified(_state_dir: &Path) -> Result<(), RoutingError> {
+pub fn sweep_transient_verified(state_dir: &Path) -> Result<(), RoutingError> {
     unsafe {
         let mut engine = HANDLE::default();
         #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
@@ -1114,7 +1139,9 @@ pub fn sweep_transient_verified(_state_dir: &Path) -> Result<(), RoutingError> {
             )));
         }
     }
-    Ok(())
+    // Verify the OUTCOME, not that the calls returned — the contract this whole
+    // change exists to make real.
+    super::verify_disengaged(transient_cover_state(state_dir))
 }
 
 pub fn recover_cover(_state_dir: &Path, adopting: bool) {

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -903,10 +903,17 @@ impl Drop for Cover {
                 CoverKind::Transient => delete_all(self.engine),
                 // Lockdown: delete only the lockdown + App-ID filters; the
                 // shared sublayer/provider are owned by the transient sweep.
-                #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+                // Deletes are CHECKED and logged: this is the ordinary
+                // user-disconnect path, and a silent failure here leaves the host
+                // blocked with no trace of why. Drop has no caller to propagate
+                // to, so a warn is the whole signal (macOS logs the same way).
                 CoverKind::Lockdown => {
                     for g in swept_lockdown_guids() {
-                        let _ = FwpmFilterDeleteByKey0(self.engine, &g);
+                        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+                        let rc = FwpmFilterDeleteByKey0(self.engine, &g);
+                        if rc != ERROR_SUCCESS.0 && rc != FWP_E_FILTER_NOT_FOUND.0 as u32 {
+                            tracing::warn!(rc, guid = ?g, "lockdown filter delete failed during Drop; host may stay blocked");
+                        }
                     }
                 }
             }
@@ -1065,6 +1072,49 @@ pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
         }
     }
     super::verify_disengaged(lockdown_cover_state(state_dir))
+}
+
+/// Fail-loud transient sweep for `bridge unlock`. Unlike [`recover_cover`],
+/// which is best-effort because startup recovery has no caller to act on a
+/// failure, this PROPAGATES: `unlock` promises the user that a success means
+/// their network is open, and a cover it silently failed to clear would break
+/// that promise on the one command they have left.
+///
+/// Only the FILTERS are checked. The sublayer and provider are shared with the
+/// standing lockdown cover, so their delete legitimately fails while lockdown
+/// filters still pin them — an orphaned empty sublayer blocks nothing.
+pub fn sweep_transient_verified(_state_dir: &Path) -> Result<(), RoutingError> {
+    unsafe {
+        let mut engine = HANDLE::default();
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let rc = FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine);
+        if rc != ERROR_SUCCESS.0 {
+            return Err(RoutingError::RouteSetup(format!(
+                "FwpmEngineOpen0 failed ({rc}); cannot sweep the transient cover"
+            )));
+        }
+        let mut failed: Option<u32> = None;
+        for g in swept_transient_guids() {
+            #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+            let rc = FwpmFilterDeleteByKey0(engine, &g);
+            if rc != ERROR_SUCCESS.0 && rc != FWP_E_FILTER_NOT_FOUND.0 as u32 {
+                tracing::warn!(rc, guid = ?g, "transient filter delete failed");
+                failed.get_or_insert(rc);
+            }
+        }
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmSubLayerDeleteByKey0(engine, &SUBLAYER_GUID);
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmProviderDeleteByKey0(engine, &PROVIDER_GUID);
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmEngineClose0(engine);
+        if let Some(rc) = failed {
+            return Err(RoutingError::RouteSetup(format!(
+                "FwpmFilterDeleteByKey0 failed ({rc}); the transient cover may still be engaged"
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub fn recover_cover(_state_dir: &Path, adopting: bool) {

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -40,11 +40,11 @@ use std::net::IpAddr;
 use std::path::Path;
 
 use windows::core::{GUID, PCWSTR, PWSTR};
-use windows::Win32::Foundation::{ERROR_SUCCESS, HANDLE};
+use windows::Win32::Foundation::{ERROR_SUCCESS, FWP_E_FILTER_NOT_FOUND, HANDLE};
 use windows::Win32::NetworkManagement::WindowsFilteringPlatform::*;
 use windows::Win32::System::Rpc::RPC_C_AUTHN_WINNT;
 
-use super::RESOLVER_PERMIT_PORT;
+use super::{CoverState, RESOLVER_PERMIT_PORT};
 use crate::error::RoutingError;
 
 // Fixed Hole identifiers. Compiled in so recovery can delete by key with no
@@ -116,6 +116,12 @@ const LOCKDOWN_TUN_GUID_INDICES: [usize; 2] = [2, 3]; // TUN V4, TUN V6
 /// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the server-IP permit pair — the
 /// other volatile permit Adopt drops (see [`adopt_delete_guids`]).
 const LOCKDOWN_SERVER_GUID_INDICES: [usize; 2] = [4, 5]; // server V4, server V6
+/// Indices into [`LOCKDOWN_FILTER_GUIDS`] for the block-all pair — the cover's
+/// floor, and the key [`lockdown_cover_state`] probes. Adopt keeps these and
+/// drops only the volatile permits, so their presence (and nothing else's) is
+/// what "the host is being held closed by us" means: a leftover permit with no
+/// block-all cannot hold anything.
+pub(crate) const LOCKDOWN_BLOCK_GUID_INDICES: [usize; 2] = [6, 7]; // block-all V4, block-all V6
 
 /// Derive a deterministic App-ID filter GUID per (binary index, layer) so a
 /// re-engage over an unswept cover is idempotent and recovery can delete by
@@ -941,31 +947,124 @@ pub fn recover_lockdown(decision: crate::routing::CoverRecovery, _state_dir: &Pa
     }
 }
 
-/// Fail-loud disengage for the `bridge unlock` escape hatch. Deletes all
-/// lockdown + App-ID filters by their fixed GUIDs (idempotent — a "not found"
-/// delete is a no-op, so a clean host returns `Ok`). The failure that means
-/// "cannot disengage" is the ENGINE OPEN: it fails when the process is not
-/// elevated, in which case we could not have torn anything down → `Err`. There
-/// is no persisted Windows state to key absence on (delete-by-GUID is
-/// idempotent), so a successful open always reports `Ok`.
-pub fn disengage_lockdown(_state_dir: &Path) -> Result<(), RoutingError> {
+/// Outcome of one `FwpmFilterGetByKey0`. `Failed` is neither found nor absent —
+/// keeping it distinct is what lets [`cover_state_from_lookups`] refuse to
+/// report a confirmed absence it did not observe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Lookup {
+    Found,
+    NotFound,
+    Failed,
+}
+
+/// Map the probe's raw outcomes to a [`CoverState`]. Pure so the failure
+/// branches — the ones a live test cannot reach without a fault injector — are
+/// table-testable.
+///
+/// Either family's block-all present ⇒ `Engaged` (that family's egress is
+/// blocked, which is enough to hold the user offline). Both confirmed missing ⇒
+/// `Absent`. Anything else — a failed engine open, or a lookup error with no
+/// `Found` to override it — ⇒ `Unknown`.
+pub(crate) fn cover_state_from_lookups(open_ok: bool, v4: Lookup, v6: Lookup) -> CoverState {
+    if !open_ok {
+        return CoverState::Unknown;
+    }
+    if v4 == Lookup::Found || v6 == Lookup::Found {
+        return CoverState::Engaged;
+    }
+    if v4 == Lookup::Failed || v6 == Lookup::Failed {
+        return CoverState::Unknown;
+    }
+    CoverState::Absent
+}
+
+/// Probe FWPM for the lockdown cover's block-all filters. Persistent filters, so
+/// this is equally the answer to "is a cover present?" and "is one in force?".
+///
+/// Reading needs no elevation — `FwpmEngineOpen0` and `FwpmFilterGetByKey0`
+/// succeed for an ordinary user (only the mutating calls demand it), verified on
+/// an unelevated process. So an engine-open failure here is a genuine anomaly,
+/// and it reports `Unknown`, never `Absent`: the one thing this must never do is
+/// claim an all-clear it did not observe.
+pub fn lockdown_cover_state(_state_dir: &Path) -> CoverState {
+    unsafe {
+        let mut engine = HANDLE::default();
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let rc = FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine);
+        if rc != ERROR_SUCCESS.0 {
+            tracing::warn!(rc, "FWPM engine open failed; lockdown cover state is unknown");
+            return cover_state_from_lookups(false, Lookup::Failed, Lookup::Failed);
+        }
+        let [v4, v6] = LOCKDOWN_BLOCK_GUID_INDICES.map(|i| lookup_filter(engine, &LOCKDOWN_FILTER_GUIDS[i]));
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmEngineClose0(engine);
+        cover_state_from_lookups(true, v4, v6)
+    }
+}
+
+/// One `FwpmFilterGetByKey0`, freeing whatever it allocated. `FWP_E_FILTER_NOT_FOUND`
+/// is the only return that proves absence; every other error is `Failed`.
+///
+/// # Safety
+/// `engine` must be an open FWPM engine handle.
+unsafe fn lookup_filter(engine: HANDLE, key: &GUID) -> Lookup {
+    let mut filter: *mut FWPM_FILTER0 = std::ptr::null_mut();
+    #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+    let rc = FwpmFilterGetByKey0(engine, key, &mut filter);
+    if !filter.is_null() {
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        FwpmFreeMemory0(&mut (filter as *mut core::ffi::c_void));
+    }
+    match rc {
+        r if r == ERROR_SUCCESS.0 => Lookup::Found,
+        r if r == FWP_E_FILTER_NOT_FOUND.0 as u32 => Lookup::NotFound,
+        r => {
+            tracing::warn!(rc = r, "FWPM filter lookup failed; cover state is unknown");
+            Lookup::Failed
+        }
+    }
+}
+
+/// Fail-loud disengage for the `bridge unlock` escape hatch and the kill
+/// switch's own off path. Deletes all lockdown + App-ID filters by their fixed
+/// GUIDs, then PROVES the host is open by re-probing.
+///
+/// Two guards, because neither alone carries the contract. Each delete's return
+/// is checked (`FWP_E_FILTER_NOT_FOUND` is success — a clean host has nothing to
+/// remove); every one used to be discarded, so `Ok` meant only that the engine
+/// opened. That mattered more than it looks: the engine opens fine WITHOUT
+/// elevation, so an unprivileged `bridge unlock` over a live cover reported
+/// success while deleting nothing. The re-probe then verifies the OUTCOME, which
+/// also covers a filter this build has no GUID for — the cross-version downgrade
+/// case [`FILTER_GUIDS`] already warns about.
+pub fn disengage_lockdown(state_dir: &Path) -> Result<(), RoutingError> {
     unsafe {
         let mut engine = HANDLE::default();
         #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
         let rc = FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine);
         if rc != ERROR_SUCCESS.0 {
             return Err(RoutingError::RouteSetup(format!(
-                "FwpmEngineOpen0 failed ({rc}); not elevated? cannot disengage the lockdown cover"
+                "FwpmEngineOpen0 failed ({rc}); cannot disengage the lockdown cover"
             )));
         }
-        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let mut failed: Option<u32> = None;
         for g in swept_lockdown_guids() {
-            let _ = FwpmFilterDeleteByKey0(engine, &g);
+            #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+            let rc = FwpmFilterDeleteByKey0(engine, &g);
+            if rc != ERROR_SUCCESS.0 && rc != FWP_E_FILTER_NOT_FOUND.0 as u32 {
+                tracing::warn!(rc, guid = ?g, "lockdown filter delete failed");
+                failed.get_or_insert(rc);
+            }
         }
         #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
         let _ = FwpmEngineClose0(engine);
+        if let Some(rc) = failed {
+            return Err(RoutingError::RouteSetup(format!(
+                "FwpmFilterDeleteByKey0 failed ({rc}); the lockdown cover may still be engaged"
+            )));
+        }
     }
-    Ok(())
+    super::verify_disengaged(lockdown_cover_state(state_dir))
 }
 
 pub fn recover_cover(_state_dir: &Path, adopting: bool) {

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -664,3 +664,73 @@ fn adopt_does_not_delete_the_address_range_loopback_floor() {
     // Adopt still drops exactly the four volatile permits — unchanged by this fix.
     assert_eq!(adopt.len(), 4, "adopt_delete_guids unchanged: TUN V4/V6 + server V4/V6");
 }
+
+// Cover-state probe (#825) ============================================================================================
+
+#[skuld::test]
+fn windows_cover_state_maps_probe_outcomes() {
+    use Lookup::*;
+
+    // A probe that could not open the engine knows nothing. Collapsing this into
+    // `Absent` would report "no cover" over a host our filters still hold closed
+    // — #825's symptom from a new cause — and would hide the release affordance,
+    // which keys on the same signal.
+    for v4 in [Found, NotFound, Failed] {
+        for v6 in [Found, NotFound, Failed] {
+            assert_eq!(
+                cover_state_from_lookups(false, v4, v6),
+                CoverState::Unknown,
+                "engine-open failure is Unknown regardless of lookups ({v4:?}, {v6:?})"
+            );
+        }
+    }
+
+    // Either family's block-all present means the host is being held closed.
+    assert_eq!(cover_state_from_lookups(true, Found, NotFound), CoverState::Engaged);
+    assert_eq!(cover_state_from_lookups(true, NotFound, Found), CoverState::Engaged);
+    assert_eq!(cover_state_from_lookups(true, Found, Failed), CoverState::Engaged);
+    assert_eq!(cover_state_from_lookups(true, Found, Found), CoverState::Engaged);
+
+    // Both families confirmed missing is the only way to conclude "absent".
+    assert_eq!(cover_state_from_lookups(true, NotFound, NotFound), CoverState::Absent);
+
+    // A lookup that errored is not a confirmed absence.
+    assert_eq!(cover_state_from_lookups(true, Failed, NotFound), CoverState::Unknown);
+    assert_eq!(cover_state_from_lookups(true, NotFound, Failed), CoverState::Unknown);
+    assert_eq!(cover_state_from_lookups(true, Failed, Failed), CoverState::Unknown);
+}
+
+#[skuld::test]
+fn block_guid_indices_name_the_block_all_pair() {
+    // Presence is keyed on block-all, not on any permit: Adopt keeps block-all and
+    // drops the volatile permits, so a leftover permit cannot hold the host closed.
+    // Pins the index pair against a reordering of LOCKDOWN_FILTER_GUIDS.
+    let spec = build_lockdown_spec(v4(), luid(), &[]);
+    let blocks: std::collections::HashSet<GUID> = spec
+        .filters
+        .iter()
+        .filter(|f| f.action == Action::Block)
+        .map(|f| f.guid)
+        .collect();
+    for &i in &LOCKDOWN_BLOCK_GUID_INDICES {
+        assert!(
+            blocks.contains(&LOCKDOWN_FILTER_GUIDS[i]),
+            "LOCKDOWN_BLOCK_GUID_INDICES[{i}] must name a block filter"
+        );
+    }
+    assert_eq!(LOCKDOWN_BLOCK_GUID_INDICES.len(), 2, "one block-all per family");
+}
+
+#[skuld::test]
+fn lockdown_cover_present_delegates_to_the_probe() {
+    // The recovery input used to be a hardcoded `true` on Windows, which is why
+    // #825 could not tell an adopted cover from a clean host. Structural pin
+    // against a constant creeping back: whatever the environment, the two facades
+    // must agree. Runs unprivileged — the FWPM read path needs no elevation.
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(
+        super::super::lockdown_cover_present(dir.path()),
+        super::super::lockdown_cover_state(dir.path()).is_present(),
+        "lockdown_cover_present must derive from the probe, not a constant"
+    );
+}

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -665,7 +665,7 @@ fn adopt_does_not_delete_the_address_range_loopback_floor() {
     assert_eq!(adopt.len(), 4, "adopt_delete_guids unchanged: TUN V4/V6 + server V4/V6");
 }
 
-// Cover-state probe (#825) ============================================================================================
+// Cover-state probe ===================================================================================================
 
 #[skuld::test]
 fn windows_cover_state_maps_probe_outcomes() {
@@ -673,7 +673,7 @@ fn windows_cover_state_maps_probe_outcomes() {
 
     // A probe that could not open the engine knows nothing. Collapsing this into
     // `Absent` would report "no cover" over a host our filters still hold closed
-    // — #825's symptom from a new cause — and would hide the release affordance,
+    // — the same symptom from a new cause — and would hide the release affordance,
     // which keys on the same signal.
     for v4 in [Found, NotFound, Failed] {
         for v6 in [Found, NotFound, Failed] {
@@ -722,15 +722,15 @@ fn block_guid_indices_name_the_block_all_pair() {
 }
 
 #[skuld::test]
-fn lockdown_cover_present_delegates_to_the_probe() {
-    // The recovery input used to be a hardcoded `true` on Windows, which is why
-    // #825 could not tell an adopted cover from a clean host. Structural pin
-    // against a constant creeping back: whatever the environment, the two facades
-    // must agree. Runs unprivileged — the FWPM read path needs no elevation.
+fn lockdown_cover_present_is_false_on_a_host_with_no_cover() {
+    // Pins the recovery input against a hardcoded constant: a `true` that ignores
+    // the host cannot tell an adopted cover from a clean one, which is what made
+    // the lockout invisible. The expected value is derived from the test's own
+    // setup — this dir engaged nothing, so nothing can be present. Runs
+    // unprivileged: the FWPM read path needs no elevation.
     let dir = tempfile::tempdir().unwrap();
-    assert_eq!(
-        super::super::lockdown_cover_present(dir.path()),
-        super::super::lockdown_cover_state(dir.path()).is_present(),
-        "lockdown_cover_present must derive from the probe, not a constant"
+    assert!(
+        !super::super::lockdown_cover_present(dir.path()),
+        "no cover was engaged, so the recovery input must report absent"
     );
 }

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -720,17 +720,3 @@ fn block_guid_indices_name_the_block_all_pair() {
     }
     assert_eq!(LOCKDOWN_BLOCK_GUID_INDICES.len(), 2, "one block-all per family");
 }
-
-#[skuld::test]
-fn lockdown_cover_present_is_false_on_a_host_with_no_cover() {
-    // Pins the recovery input against a hardcoded constant: a `true` that ignores
-    // the host cannot tell an adopted cover from a clean one, which is what made
-    // the lockout invisible. The expected value is derived from the test's own
-    // setup — this dir engaged nothing, so nothing can be present. Runs
-    // unprivileged: the FWPM read path needs no elevation.
-    let dir = tempfile::tempdir().unwrap();
-    assert!(
-        !super::super::lockdown_cover_present(dir.path()),
-        "no cover was engaged, so the recovery input must report absent"
-    );
-}


### PR DESCRIPTION
Closes #825.

After an unclean exit with the kill switch on, Hole left the host fail-closed with no session running, told the user the kill switch was **not** engaged, and ignored the one remedy they were likely to try. The fail-closed posture is unchanged — a crash still keeps the filters, and `decide_cover_recovery(true, true)` still returns `Adopt`. What changes is that the state is now observable, the off switch works, and the tray says so.

## Report the true state

`lockdown_active` was `running.as_ref().map(|r| r.lockdown.is_some())` — structurally `false` whenever nothing was running, including while an adopted cover blocked every packet. It is now an OS probe reached through the `Routing` seam.

The probe is three-state, not a bool. A probe that cannot reach the firewall knows nothing, and folding that into "no cover" reproduces the original symptom from a new cause: the tray would read all-clear over a host our own filters still hold, and the escape — which keys on the same signal — would disappear with it. `CoverState::Unknown` resolves toward offering the way out.

Two questions, two functions. `lockdown_cover_present` feeds the recovery decision and stays lenient on macOS (pf is disabled and flushed across a reboot while `bridge-lockdown-pf.json` survives, so a stricter test would make `Sweep` skip the file it exists to clear). `lockdown_cover_state` answers "is the host held closed right now?" and reads pf for real. On Windows the two coincide and share one probe; `lockdown_cover_present`'s unconditional `true` there is gone.

`held_closed` is new on `StatusResponse`: a cover engaged that **no running session owns**. Deliberately not `lockdown_active && !running` — with the intent off and a cover a failed startup `Sweep` left behind, a connect skips `install_lockdown`, so `running` is true while the stale block-all kills every packet.

## Make the off switch work

Turning the intent off now releases a cover no live session owns, immediately. Ordering mirrors `cutover::unlock_with`: disengage first, persist `false` only on confirmed success.

"Confirmed" was doing no work before. Windows `disengage_lockdown` checked only `FwpmEngineOpen0` and discarded every `FwpmFilterDeleteByKey0` result — and the FWPM engine opens **without elevation** (verified on an unelevated process), so an unprivileged `hole bridge unlock` over a live cover reported success while deleting nothing. Both platforms now check their deletes *and* re-probe, and macOS probes before clearing its state file rather than after, where the check could never fail.

Two cases are deliberately not refusals:

- **Probe `Absent`** — skip the firewall entirely. Releasing unconditionally would make disarming the switch on a clean host fail whenever the firewall is unreachable, which is a fresh way into the lockout.
- **Probe `Unknown` and the release also failed** — on Windows these are correlated (both go through `FwpmEngineOpen0`). Refusing would leave the switch permanently un-disarmable over a cover we never established existed. The intent is recorded and `held_closed` keeps surfacing the uncertainty, so the escape stays on the menu.

A cover a live session owns is untouched: settings apply on reconnect, and `stop_with` already disengages it.

## Surface it with an action

The tray rendered this state as `"Lockdown: On (warning: not engaged)"` — the opposite of the truth. It now shows **"Hole is holding your network closed"** with an **"Unblock Network (turns Lockdown off)"** item beside it, in every state where a cover no session owns is engaged, including while a coverless session is "running". A failed release opens a dialog naming `hole bridge unlock`; previously it logged and moved on, so the click visibly did nothing.

The lockdown item's click intent now derives from the arm the label rendered. A plain `!enabled` would arm the kill switch from the item warning the network is blocked, and keying it on `active` instead would make the switch impossible to re-arm mid-session.

`hole bridge unlock` also sweeps a leftover **transient** cover now, fail-loud on both halves — it is the only escape when no bridge starts, and clearing a subset would leave no way out at all. README documents it.

## Escape ladder

| State | Way out |
| --- | --- |
| Cover engaged, nothing running | Tray release, or Connect |
| Running session that owns no cover | Same — `held_closed` is true even though `running` is |
| Probe `Unknown` | Treated as engaged; release attempted, escape stays offered |
| Release fails | Dialog naming `hole bridge unlock`; intent stays on so the tray keeps telling the truth |
| Intent off, cover still engaged | One click — the arm re-releases rather than arming |
| Bridge unreachable | `hole bridge unlock`, elevated |

## Tests

`crates/bridge/tests/lockout_privileged.rs` drives the whole thing on the real firewall through the production `ProxyManager` + `SystemRouting`: engage → `disarm` (the crash-equivalent primitive the cutover path itself uses) → probe reports engaged and egress is blocked → recovery keeps it closed → `set_lockdown_intent(false)` → egress is back. Table-driven unit tests cover every probe-failure branch, which no live test can reach on a healthy host. All privileged names are registered in the `global-net-state` group (verified with `cargo nextest show-config test-groups`).

**Not verified locally:** the TUN-lane tests need elevation, and the macOS test module needs a darwin toolchain — both rest on CI. macOS production code was type-checked with `cargo check --target aarch64-apple-darwin`.

## Covers probed, both of them

`held_closed` counts the **transient** block-until-connected cover as well as the standing one. A crash mid-connect strands its persistent filters just as durably, `blocked_until_connected` is an in-memory `Option` that is `None` in the new process, and the standing probe only reads the standing keys — so that host rendered as plain "Disconnected" with no action offered at all. Probing it is the same mechanism over a disjoint key set (Windows: the transient block-all GUID pair; macOS: `bridge-failclosed.json` + pf + `block out all`), so it was cheap enough to just do. "Unblock Network" now clears both, and `hole bridge unlock` verifies both.

A transient cover *this process still holds* is left alone — `stop_with` owns it, and on macOS the standing restore reloads a whole ruleset, so releasing here would tear a live cover down and open the host.

## When Hole cannot tell

On Windows a wedged or policy-disabled BFE makes `FwpmEngineOpen0` fail permanently, so `Unknown` is a stable machine property, not a blip. New `StatusResponse.cover_state_unknown` keeps that claim separate: the tray says **"Hole cannot tell whether it is blocking your network"** rather than asserting a block never observed, the kill switch stays armable in that state, and a release that reports `Ok` while the host is still held closed raises the dialog anyway — the bridge deliberately records the intent there, so silence would be the original complaint verbatim.

## Follow-ups

- **#828** — settings that only take effect on reconnect should say so and mark the connect control pending. The `Lockdown: Off (applies on reconnect)` label here is the honest rendering, not the affordance.
- **#827** — macOS post-reboot fail-open. This PR makes that state *observable* (pf-disabled reads `Absent` rather than trusting the state file) but does not close it; `recover_lockdown(Adopt)` still leaves pf down. Note for whoever takes it: `Adopt` drops the volatile server permit, so a naive boot-time re-engage would load a block-all with no server permit — a stronger lockout than the leak it fixes.
- **#799** consumes `held_closed` to refuse a server test honestly instead of badging a healthy server as censored.

