### PR TITLE
fix(tun-engine): detect the upstream gateway from the Windows routing table

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,9 @@ nextest-version = "0.9.130"
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #   - `failclosed_permits_` (transient block-until-connected cover real engage):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+#   - `gateway_global_net_state_` prefix:
+#     crates/tun-engine/src/gateway/windows_privileged_tests.rs (creates a real
+#       wintun adapter to prove the route lookup can see an IfType 53 adapter)
 #   - `cutover_global_net_state_` prefix:
 #     crates/bridge/tests/cutover_privileged.rs (real cutover swap + SCM restart)
 #     crates/bridge/tests/cutover_leak_privileged.rs (fail-open + both-covers)
@@ -36,5 +39,5 @@ nextest-version = "0.9.130"
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/cutover_global_net_state_/)'
+filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/cutover_global_net_state_/) + test(/gateway_global_net_state_/)'
 test-group = 'global-net-state'

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use tun_engine::gateway::GatewayInfo;
+use tun_engine::gateway::{GatewayError, GatewayInfo, HopDetail};
 use tun_engine::routing::{state as route_state, Routing};
 use tun_engine::RoutingError;
 
@@ -189,7 +189,13 @@ impl Routing for MockRouting {
 
     fn default_gateway(&self) -> Result<GatewayInfo, RoutingError> {
         if self.fail_gateway.load(Ordering::SeqCst) {
-            return Err(RoutingError::Gateway("mock gateway failure".into()));
+            return Err(RoutingError::Gateway(GatewayError::NoUsableGateway {
+                detail: HopDetail {
+                    interface_alias: "MockVpnTun".into(),
+                    interface_index: 99,
+                    next_hop: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                },
+            }));
         }
         Ok(GatewayInfo {
             gateway_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -28,8 +28,13 @@ pub enum ProxyError {
     InvalidPluginName(String),
     #[error("proxy runtime error: {0}")]
     Runtime(#[from] std::io::Error),
-    #[error("gateway detection failed: {0}")]
-    Gateway(String),
+    /// Upstream-route detection failed. Transparent: the wrapped
+    /// [`tun_engine::GatewayError`] already Displays as the finished, PII-free
+    /// user sentence and carries the adapter in `Debug` for `bridge.log`. Typed
+    /// rather than stringly so that guarantee is compiler-checked — a `String`
+    /// payload would let any future producer put arbitrary text in a toast.
+    #[error(transparent)]
+    Gateway(tun_engine::GatewayError),
     /// Private DoH bootstrap could not resolve the proxy server's hostname and
     /// `dns.allow_insecure_bootstrap` is off. PII-free `Display` (the wrapped
     /// error names neither host nor path) so it is safe to surface verbatim to

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -1143,7 +1143,15 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         tun_engine::device::wintun::ensure_loaded()?;
 
         // Query the OS default gateway via the routing provider.
-        let gw_info = routing.default_gateway()?;
+        //
+        // `error = ?e` (Debug, not Display) is load-bearing: the user-facing
+        // sentence tells them to look the adapter up in bridge.log, and the
+        // adapter lives in `GatewayError`'s Debug precisely so it can never
+        // reach the toast. Display here would log the sentence and drop the
+        // one fact the sentence promises.
+        let gw_info = routing.default_gateway().inspect_err(|e| {
+            warn!(error = ?e, "gateway detection failed");
+        })?;
 
         // Compile filter rules.
         let ruleset = crate::filter::rules::RuleSet::from_user_rules(&config.filters);

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tun_engine::gateway::GatewayInfo;
+use tun_engine::gateway::{GatewayError, GatewayInfo, HopDetail};
 use tun_engine::routing::failclosed::lockdown_state;
 use tun_engine::routing::{self, state as route_state, Routing};
 use tun_engine::RoutingError;
@@ -248,7 +248,22 @@ impl MockRouting {
         m.state.fail_gateway.store(true, Ordering::SeqCst);
         m
     }
+}
 
+/// The gateway failure the mock raises: a REAL `GatewayError`, not a stand-in
+/// string, so the tests below assert against production copy and production
+/// `Debug` rather than against a fixture that could drift from either.
+fn mock_gateway_error() -> GatewayError {
+    GatewayError::NoUsableGateway {
+        detail: HopDetail {
+            interface_alias: "MockVpnTun".into(),
+            interface_index: 99,
+            next_hop: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+        },
+    }
+}
+
+impl MockRouting {
     fn failing_lockdown(state_dir: PathBuf) -> Self {
         let m = Self::new(state_dir);
         m.state.fail_lockdown.store(true, Ordering::SeqCst);
@@ -301,7 +316,7 @@ impl Routing for MockRouting {
 
     fn default_gateway(&self) -> Result<GatewayInfo, RoutingError> {
         if self.state.fail_gateway.load(Ordering::SeqCst) {
-            return Err(RoutingError::Gateway("mock gateway failure".into()));
+            return Err(RoutingError::Gateway(mock_gateway_error()));
         }
         Ok(GatewayInfo {
             gateway_ip: self.gateway,
@@ -1266,7 +1281,57 @@ fn gateway_failure_sets_last_error() {
         assert!(matches!(err, ProxyError::Gateway(_)));
         assert_eq!(pm.state(), ProxyState::Stopped);
         assert!(pm.last_error().is_some(), "default_gateway failure must set last_error");
-        assert!(pm.last_error().unwrap().contains("mock gateway failure"));
+        assert_eq!(pm.last_error().unwrap(), mock_gateway_error().to_string());
+    });
+}
+
+/// The refusal a user reads. `MockRouting::failing_gateway` returns the real
+/// `GatewayError`, so this pins the whole chain — `RoutingError::Gateway` ->
+/// `ProxyError::Gateway` -> `StartError::Failed` — against re-acquiring a
+/// library-shaped prefix. `tray.rs` still wraps this as `Bridge error: {message}`;
+/// what must not come back is a SECOND prefix inside it.
+#[skuld::test]
+fn gateway_failure_message_reaches_start_error_verbatim() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::failing_gateway(dir.path().to_path_buf());
+        let (mut pm, _dir) = new_manager_with_routing(proxy, routing, dir);
+
+        let err = pm.start(&test_config()).await.unwrap_err();
+        let start_error = hole_common::protocol::StartError::from(&err);
+        let hole_common::protocol::StartError::Failed { message } = start_error else {
+            panic!("gateway failure must classify as StartError::Failed, got {start_error:?}");
+        };
+        assert_eq!(message, mock_gateway_error().to_string());
+        assert!(
+            !message.contains("gateway detection failed"),
+            "the sentence re-acquired a library prefix: {message}"
+        );
+    });
+}
+
+/// The copy tells the user to look the adapter up in `bridge.log`. That is only
+/// true if the detail survives the `tun-engine` -> `bridge` boundary, which a
+/// `String` payload would destroy at `SystemRouting::default_gateway`.
+#[skuld::test]
+fn gateway_failure_detail_survives_to_the_bridge() {
+    rt().block_on(async {
+        let proxy = MockProxy::new();
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::failing_gateway(dir.path().to_path_buf());
+        let (mut pm, _dir) = new_manager_with_routing(proxy, routing, dir);
+
+        let err = pm.start(&test_config()).await.unwrap_err();
+        let logged = format!("{err:?}");
+        assert!(
+            logged.contains("MockVpnTun"),
+            "the adapter must reach the bridge for `warn!(error = ?e)` to log it: {logged}"
+        );
+        assert!(
+            !err.to_string().contains("MockVpnTun"),
+            "...and must NOT reach the toast: {err}"
+        );
     });
 }
 

--- a/crates/tun-engine/Cargo.toml
+++ b/crates/tun-engine/Cargo.toml
@@ -67,3 +67,19 @@ wintun-bindings = "0.7"
 [dev-dependencies]
 skuld = { workspace = true }
 hole-test-observability = { path = "../test-observability" }
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
+] }
+
+# Own binary, not a module in the lib test binary: skuld validates that a label
+# is declared once per binary, and the lib already declares `TUN` in
+# `routing/failclosed/lockdown_privileged_tests.rs`.
+[[test]]
+name = "gateway_privileged"
+path = "tests/gateway_privileged.rs"
+harness = false

--- a/crates/tun-engine/src/error.rs
+++ b/crates/tun-engine/src/error.rs
@@ -4,12 +4,18 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::gateway::GatewayError;
+
 /// Errors surfaced by the `routing` module: gateway discovery and route
 /// table manipulation.
 #[derive(Debug, Error)]
 pub enum RoutingError {
-    #[error("gateway detection failed: {0}")]
-    Gateway(String),
+    /// Transparent: [`GatewayError`]'s `Display` is already the finished,
+    /// PII-free user sentence, and its `Debug` carries the adapter detail. A
+    /// prefix here would be a second one inside `tray.rs`'s `Bridge error: {..}`,
+    /// and re-stringifying would destroy the detail at this boundary.
+    #[error(transparent)]
+    Gateway(#[from] GatewayError),
     #[error("route setup failed: {0}")]
     RouteSetup(String),
 }

--- a/crates/tun-engine/src/gateway.rs
+++ b/crates/tun-engine/src/gateway.rs
@@ -1,25 +1,35 @@
 //! Default gateway detection.
 //!
 //! On Windows the upstream route comes from the OS routing table
-//! ([`windows::best_route`]). On macOS it still comes from the `default-net`
-//! crate — see bindreams/hole#798 for why the Windows path could not.
+//! (`platform::best_route` -> `GetBestRoute2`). On macOS it still comes from the
+//! `default-net` crate; see bindreams/hole#798 for why the Windows path could
+//! not, and `gateway/error.rs` for the failure vocabulary both share.
 
 pub mod error;
+
+// Named `platform`, not `windows`, so the module does not shadow the `windows`
+// crate in this file. Matches `routing/failclosed.rs`.
+#[cfg(target_os = "windows")]
+#[path = "gateway/windows.rs"]
+mod platform;
 
 pub use error::{GatewayError, HopDetail};
 
 use std::net::IpAddr;
 
+use tracing::warn;
+
 use crate::net::bind_to_interface_v6;
 
 /// Gateway detection result, bundling the gateway IP with the original
 /// interface name.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatewayInfo {
-    /// Default gateway IP address (typically IPv4 — `default-net` does not
-    /// expose IPv6 gateways on Windows).
+    /// Default gateway IP address (IPv4 in practice — the default-route lookup
+    /// is issued for the IPv4 unspecified address).
     pub gateway_ip: IpAddr,
     /// Platform-appropriate interface name for route commands.
-    /// On Windows: friendly name (e.g., "Wi-Fi"). On macOS: BSD name (e.g., "en0").
+    /// On Windows: connection alias (e.g., "Wi-Fi"). On macOS: BSD name (e.g., "en0").
     pub interface_name: String,
     /// OS interface index (used by bypass socket helpers to bind to the
     /// upstream NIC).
@@ -28,92 +38,116 @@ pub struct GatewayInfo {
     pub ipv6_available: bool,
 }
 
+/// One upstream route, as the OS resolved it.
+///
+/// Lives here rather than in the platform module so [`classify_hop`] has one
+/// body for every platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteHop {
+    /// Next hop the route names. Unspecified (`0.0.0.0` / `::`) means the route
+    /// is **on-link** — there is no gateway address to point a bypass route at.
+    pub next_hop: IpAddr,
+    pub interface_index: u32,
+    /// OS interface alias.
+    pub interface_alias: String,
+}
+
 /// Detect the system's default gateway IP and original interface name.
+#[cfg(target_os = "windows")]
+pub fn get_default_gateway_info() -> Result<GatewayInfo, GatewayError> {
+    // The IPv4 unspecified address: a lookup for `::` returns ERROR_NOT_FOUND on
+    // a working IPv4-only host, which would render as "no default route".
+    let dest = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
+    let hop = platform::best_route(dest)?;
+    let ipv6_available = hop.as_ref().map(|h| probe_ipv6(h.interface_index)).unwrap_or(false);
+    classify_hop(hop, ipv6_available)
+}
+
+/// Detect the system's default gateway IP and original interface name.
+#[cfg(target_os = "macos")]
 pub fn get_default_gateway_info() -> Result<GatewayInfo, GatewayError> {
     let iface = default_net::get_default_interface().map_err(|e| GatewayError::RouteQueryFailed {
         code: 0,
         source: std::io::Error::other(e),
     })?;
 
-    let interface_name = platform_interface_name(&iface)?;
-    let interface_index = platform_interface_index(&iface)?;
-
-    let gateway_ip = iface
+    let interface_alias = iface.name.clone();
+    let interface_index = macos_interface_index(&iface)?;
+    let next_hop = iface
         .gateway
         .as_ref()
         .map(|gw| gw.ip_addr)
-        .ok_or_else(|| GatewayError::NoUsableGateway {
-            detail: HopDetail {
-                interface_alias: interface_name.clone(),
-                interface_index,
-                next_hop: IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
-            },
-        })?;
+        .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
 
     let ipv6_available = probe_ipv6(interface_index);
+    classify_hop(
+        Some(RouteHop {
+            next_hop,
+            interface_index,
+            interface_alias,
+        }),
+        ipv6_available,
+    )
+}
+
+/// Turn a resolved route into a [`GatewayInfo`], or into the reason Hole cannot
+/// use it.
+///
+/// Every branch keys on a **structural** property of what the OS returned — the
+/// absence of a route, an unspecified next hop, an unnamed interface. None of
+/// them inspects the adapter's type or name: separating "another VPN's tunnel"
+/// from "a point-to-point physical link" would take an `IfType` allowlist, which
+/// is the heuristic class this codebase does not allow, and `NoUsableGateway`'s
+/// copy names both causes instead of guessing.
+///
+/// The refusal branches carry the hop into the error rather than dropping it —
+/// see `gateway/error.rs` for why that is the guarantee and the `warn!` is only
+/// a convenience.
+pub(crate) fn classify_hop(hop: Option<RouteHop>, ipv6_available: bool) -> Result<GatewayInfo, GatewayError> {
+    let Some(hop) = hop else {
+        warn!("no default route: nothing routes off this host");
+        return Err(GatewayError::NoDefaultRoute);
+    };
+
+    if hop.interface_alias.is_empty() {
+        warn!(
+            interface_index = hop.interface_index,
+            %hop.next_hop,
+            "upstream route names an interface with no alias"
+        );
+        return Err(GatewayError::InterfaceNameUnavailable {
+            interface_index: hop.interface_index,
+            source: std::io::Error::other("interface alias is empty"),
+        });
+    }
+
+    if hop.next_hop.is_unspecified() {
+        warn!(
+            interface_alias = %hop.interface_alias,
+            interface_index = hop.interface_index,
+            "default route is on-link — no next-hop gateway to build the server bypass through"
+        );
+        return Err(GatewayError::NoUsableGateway {
+            detail: HopDetail {
+                interface_alias: hop.interface_alias,
+                interface_index: hop.interface_index,
+                next_hop: hop.next_hop,
+            },
+        });
+    }
 
     Ok(GatewayInfo {
-        gateway_ip,
-        interface_name,
-        interface_index,
+        gateway_ip: hop.next_hop,
+        interface_name: hop.interface_alias,
+        interface_index: hop.interface_index,
         ipv6_available,
     })
 }
 
-#[cfg(target_os = "windows")]
-fn platform_interface_name(iface: &default_net::Interface) -> Result<String, GatewayError> {
-    iface
-        .friendly_name
-        .clone()
-        .ok_or_else(|| GatewayError::InterfaceNameUnavailable {
-            interface_index: iface.index,
-            source: std::io::Error::other("default interface has no friendly name"),
-        })
-}
-
-#[cfg(target_os = "macos")]
-fn platform_interface_name(iface: &default_net::Interface) -> Result<String, GatewayError> {
-    Ok(iface.name.clone())
-}
-
 // Interface index detection ===========================================================================================
 
-#[cfg(target_os = "windows")]
-fn platform_interface_index(iface: &default_net::Interface) -> Result<u32, GatewayError> {
-    use windows::core::HSTRING;
-    use windows::Win32::Foundation::NO_ERROR;
-    use windows::Win32::NetworkManagement::IpHelper::{ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToIndex};
-    use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
-
-    let friendly_name = iface
-        .friendly_name
-        .as_deref()
-        .ok_or_else(|| GatewayError::InterfaceNameUnavailable {
-            interface_index: iface.index,
-            source: std::io::Error::other("default interface has no friendly name"),
-        })?;
-    let alias = HSTRING::from(friendly_name);
-    let mut luid = NET_LUID_LH::default();
-    let err = unsafe { ConvertInterfaceAliasToLuid(&alias, &mut luid) };
-    if err != NO_ERROR {
-        return Err(GatewayError::InterfaceNameUnavailable {
-            interface_index: iface.index,
-            source: std::io::Error::other(format!("ConvertInterfaceAliasToLuid: error {err:?}")),
-        });
-    }
-    let mut index = 0u32;
-    let err = unsafe { ConvertInterfaceLuidToIndex(&luid, &mut index) };
-    if err != NO_ERROR {
-        return Err(GatewayError::InterfaceNameUnavailable {
-            interface_index: iface.index,
-            source: std::io::Error::other(format!("ConvertInterfaceLuidToIndex: error {err:?}")),
-        });
-    }
-    Ok(index)
-}
-
 #[cfg(target_os = "macos")]
-fn platform_interface_index(iface: &default_net::Interface) -> Result<u32, GatewayError> {
+fn macos_interface_index(iface: &default_net::Interface) -> Result<u32, GatewayError> {
     let c_name = std::ffi::CString::new(iface.name.as_str()).map_err(|e| GatewayError::InterfaceNameUnavailable {
         interface_index: iface.index,
         source: std::io::Error::other(format!("invalid interface name: {e}")),
@@ -130,6 +164,16 @@ fn platform_interface_index(iface: &default_net::Interface) -> Result<u32, Gatew
 
 // IPv6 availability probe =============================================================================================
 
+/// Deliberately still a socket probe, on both platforms.
+///
+/// `connect()` on a UDP socket sends nothing — it is a route lookup **plus
+/// source-address selection** — and `GetBestRoute2` reports the second half
+/// separately, so a route-table replacement is not equivalent on a host that has
+/// a route but no usable source address. It is also interface-scoped here, and
+/// that scoping is a contract: `InterfaceEndpoint` `debug_assert!`s that the
+/// cascade never hands it an IPv6 destination when this returned `false`.
+/// Whether the fail-closed WFP cover blocks this probe — and therefore whether
+/// IPv6 bypass has been silently off in the field — is bindreams/hole#835.
 fn probe_ipv6(interface_index: u32) -> bool {
     let socket = match socket2::Socket::new(
         socket2::Domain::IPV6,

--- a/crates/tun-engine/src/gateway.rs
+++ b/crates/tun-engine/src/gateway.rs
@@ -15,6 +15,12 @@ mod platform;
 
 pub use error::{GatewayError, HopDetail};
 
+/// The raw upstream-route lookup. Public so the privileged integration test can
+/// drive it against a real wintun adapter, which is the only proof that this
+/// path does not have `default-net`'s interface-type blind spot.
+#[cfg(target_os = "windows")]
+pub use platform::best_route;
+
 use std::net::IpAddr;
 
 use tracing::warn;
@@ -43,7 +49,7 @@ pub struct GatewayInfo {
 /// Lives here rather than in the platform module so [`classify_hop`] has one
 /// body for every platform.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RouteHop {
+pub struct RouteHop {
     /// Next hop the route names. Unspecified (`0.0.0.0` / `::`) means the route
     /// is **on-link** — there is no gateway address to point a bypass route at.
     pub next_hop: IpAddr,

--- a/crates/tun-engine/src/gateway.rs
+++ b/crates/tun-engine/src/gateway.rs
@@ -1,4 +1,12 @@
-//! Default gateway detection — wraps the `default-net` crate.
+//! Default gateway detection.
+//!
+//! On Windows the upstream route comes from the OS routing table
+//! ([`windows::best_route`]). On macOS it still comes from the `default-net`
+//! crate — see bindreams/hole#798 for why the Windows path could not.
+
+pub mod error;
+
+pub use error::{GatewayError, HopDetail};
 
 use std::net::IpAddr;
 
@@ -21,17 +29,27 @@ pub struct GatewayInfo {
 }
 
 /// Detect the system's default gateway IP and original interface name.
-pub fn get_default_gateway_info() -> std::io::Result<GatewayInfo> {
-    let iface = default_net::get_default_interface().map_err(|e| std::io::Error::other(e.to_string()))?;
+pub fn get_default_gateway_info() -> Result<GatewayInfo, GatewayError> {
+    let iface = default_net::get_default_interface().map_err(|e| GatewayError::RouteQueryFailed {
+        code: 0,
+        source: std::io::Error::other(e),
+    })?;
+
+    let interface_name = platform_interface_name(&iface)?;
+    let interface_index = platform_interface_index(&iface)?;
 
     let gateway_ip = iface
         .gateway
         .as_ref()
         .map(|gw| gw.ip_addr)
-        .ok_or_else(|| std::io::Error::other("default interface has no gateway"))?;
+        .ok_or_else(|| GatewayError::NoUsableGateway {
+            detail: HopDetail {
+                interface_alias: interface_name.clone(),
+                interface_index,
+                next_hop: IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            },
+        })?;
 
-    let interface_name = platform_interface_name(&iface)?;
-    let interface_index = platform_interface_index(&iface)?;
     let ipv6_available = probe_ipv6(interface_index);
 
     Ok(GatewayInfo {
@@ -43,22 +61,25 @@ pub fn get_default_gateway_info() -> std::io::Result<GatewayInfo> {
 }
 
 #[cfg(target_os = "windows")]
-fn platform_interface_name(iface: &default_net::Interface) -> std::io::Result<String> {
+fn platform_interface_name(iface: &default_net::Interface) -> Result<String, GatewayError> {
     iface
         .friendly_name
         .clone()
-        .ok_or_else(|| std::io::Error::other("default interface has no friendly name"))
+        .ok_or_else(|| GatewayError::InterfaceNameUnavailable {
+            interface_index: iface.index,
+            source: std::io::Error::other("default interface has no friendly name"),
+        })
 }
 
 #[cfg(target_os = "macos")]
-fn platform_interface_name(iface: &default_net::Interface) -> std::io::Result<String> {
+fn platform_interface_name(iface: &default_net::Interface) -> Result<String, GatewayError> {
     Ok(iface.name.clone())
 }
 
 // Interface index detection ===========================================================================================
 
 #[cfg(target_os = "windows")]
-fn platform_interface_index(iface: &default_net::Interface) -> std::io::Result<u32> {
+fn platform_interface_index(iface: &default_net::Interface) -> Result<u32, GatewayError> {
     use windows::core::HSTRING;
     use windows::Win32::Foundation::NO_ERROR;
     use windows::Win32::NetworkManagement::IpHelper::{ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToIndex};
@@ -67,35 +88,42 @@ fn platform_interface_index(iface: &default_net::Interface) -> std::io::Result<u
     let friendly_name = iface
         .friendly_name
         .as_deref()
-        .ok_or_else(|| std::io::Error::other("default interface has no friendly name"))?;
+        .ok_or_else(|| GatewayError::InterfaceNameUnavailable {
+            interface_index: iface.index,
+            source: std::io::Error::other("default interface has no friendly name"),
+        })?;
     let alias = HSTRING::from(friendly_name);
     let mut luid = NET_LUID_LH::default();
     let err = unsafe { ConvertInterfaceAliasToLuid(&alias, &mut luid) };
     if err != NO_ERROR {
-        return Err(std::io::Error::other(format!(
-            "ConvertInterfaceAliasToLuid: error {err:?}"
-        )));
+        return Err(GatewayError::InterfaceNameUnavailable {
+            interface_index: iface.index,
+            source: std::io::Error::other(format!("ConvertInterfaceAliasToLuid: error {err:?}")),
+        });
     }
     let mut index = 0u32;
     let err = unsafe { ConvertInterfaceLuidToIndex(&luid, &mut index) };
     if err != NO_ERROR {
-        return Err(std::io::Error::other(format!(
-            "ConvertInterfaceLuidToIndex: error {err:?}"
-        )));
+        return Err(GatewayError::InterfaceNameUnavailable {
+            interface_index: iface.index,
+            source: std::io::Error::other(format!("ConvertInterfaceLuidToIndex: error {err:?}")),
+        });
     }
     Ok(index)
 }
 
 #[cfg(target_os = "macos")]
-fn platform_interface_index(iface: &default_net::Interface) -> std::io::Result<u32> {
-    let c_name = std::ffi::CString::new(iface.name.as_str())
-        .map_err(|e| std::io::Error::other(format!("invalid interface name: {e}")))?;
+fn platform_interface_index(iface: &default_net::Interface) -> Result<u32, GatewayError> {
+    let c_name = std::ffi::CString::new(iface.name.as_str()).map_err(|e| GatewayError::InterfaceNameUnavailable {
+        interface_index: iface.index,
+        source: std::io::Error::other(format!("invalid interface name: {e}")),
+    })?;
     let idx = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
     if idx == 0 {
-        return Err(std::io::Error::other(format!(
-            "if_nametoindex failed for '{}'",
-            iface.name
-        )));
+        return Err(GatewayError::InterfaceNameUnavailable {
+            interface_index: iface.index,
+            source: std::io::Error::other(format!("if_nametoindex failed for '{}'", iface.name)),
+        });
     }
     Ok(idx)
 }

--- a/crates/tun-engine/src/gateway/error.rs
+++ b/crates/tun-engine/src/gateway/error.rs
@@ -1,0 +1,79 @@
+//! Gateway-detection failures.
+//!
+//! # The `Display` / `Debug` split
+//!
+//! `Display` is the **final user-facing sentence** and nothing else — it is
+//! rendered straight into a toast, so it must never carry an adapter alias, an
+//! interface index, an address, a path, or an OS error string. Every
+//! `#[error(...)]` below is a bare literal with no payload interpolation, which
+//! makes that structural rather than a habit.
+//!
+//! `Debug` carries the diagnostic detail, and the failure call sites log it with
+//! `?err`. Three of the four sentences tell the user to read `bridge.log`; if the
+//! detail lived only in a `warn!` that someone must remember to write, deleting
+//! that line would turn the toast into a promise the log does not keep — leaving
+//! support with strictly less than the `"Default Interface not found"` string
+//! this type replaces. Carrying it in the error means it travels to every call
+//! site on its own.
+
+use std::net::IpAddr;
+
+use thiserror::Error;
+
+/// The upstream route a failure is about. `Debug`-only by design: this is
+/// exactly the material that must not reach a toast. Never given a `Display`
+/// impl — that would make leaking it a one-character mistake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HopDetail {
+    /// OS interface alias (Windows connection name, e.g. `Wi-Fi`).
+    pub interface_alias: String,
+    /// OS interface index.
+    pub interface_index: u32,
+    /// Next hop the route named. Unspecified means the route is on-link.
+    pub next_hop: IpAddr,
+}
+
+#[derive(Debug, Error)]
+pub enum GatewayError {
+    /// The routing table answered, and the answer is that nothing routes off
+    /// this host.
+    #[error(
+        "No default network route was found. Hole needs an active Internet connection before it \
+         can build the tunnel."
+    )]
+    NoDefaultRoute,
+
+    /// A default route exists but is **on-link** — it names no next-hop gateway,
+    /// so there is nothing for the server-bypass route to point at.
+    ///
+    /// The copy names two causes and picks neither. On-link is equally the
+    /// signature of another VPN's tunnel adapter and of a point-to-point
+    /// physical link (cellular/WWAN, PPPoE), and separating them would take an
+    /// `IfType` allowlist — the heuristic class this codebase does not allow.
+    /// Asserting "a VPN" would be confidently wrong for a mobile user.
+    #[error(
+        "Your default network route has no gateway Hole can route around, so the tunnel cannot \
+         be built. This happens when another VPN is handling your traffic, and on point-to-point \
+         links such as some mobile and PPP connections. See bridge.log for the adapter involved."
+    )]
+    NoUsableGateway { detail: HopDetail },
+
+    /// The route lookup itself failed — distinct from it answering "no route".
+    /// `code` is the raw OS status, kept for `bridge.log` so a status this
+    /// crate's mapping table does not anticipate is still identifiable.
+    #[error("Could not read the system routing table. See bridge.log for details.")]
+    RouteQueryFailed { code: u32, source: std::io::Error },
+
+    /// A route was found but its interface could not be named. The alias is not
+    /// cosmetic — it is what `netsh interface ip add route`, the system-DNS
+    /// capture, and crash-recovery replay all key on.
+    #[error("The upstream network adapter could not be identified. See bridge.log for details.")]
+    InterfaceNameUnavailable {
+        interface_index: u32,
+        source: std::io::Error,
+    },
+}
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/crates/tun-engine/src/gateway/error_tests.rs
+++ b/crates/tun-engine/src/gateway/error_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use std::net::{IpAddr, Ipv4Addr};
+
+fn sample_detail() -> HopDetail {
+    HopDetail {
+        interface_alias: "ProtonVPN TUN".into(),
+        interface_index: 42,
+        next_hop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+    }
+}
+
+#[skuld::test]
+fn display_strings_are_the_user_facing_copy() {
+    assert_eq!(
+        GatewayError::NoDefaultRoute.to_string(),
+        "No default network route was found. Hole needs an active Internet connection before it \
+         can build the tunnel."
+    );
+    assert_eq!(
+        GatewayError::NoUsableGateway {
+            detail: sample_detail()
+        }
+        .to_string(),
+        "Your default network route has no gateway Hole can route around, so the tunnel cannot \
+         be built. This happens when another VPN is handling your traffic, and on point-to-point \
+         links such as some mobile and PPP connections. See bridge.log for the adapter involved."
+    );
+    assert_eq!(
+        GatewayError::RouteQueryFailed {
+            code: 1232,
+            source: std::io::Error::other("boom"),
+        }
+        .to_string(),
+        "Could not read the system routing table. See bridge.log for details."
+    );
+    assert_eq!(
+        GatewayError::InterfaceNameUnavailable {
+            interface_index: 7,
+            source: std::io::Error::other("boom"),
+        }
+        .to_string(),
+        "The upstream network adapter could not be identified. See bridge.log for details."
+    );
+}
+
+/// The load-bearing split: the toast gets the sentence, `bridge.log` gets the
+/// adapter. Asserted in BOTH directions — a `Display` that leaks is a PII bug,
+/// and a `Debug` that drops the detail makes "see bridge.log" a promise nothing
+/// keeps (which is what #798 already did to support).
+#[skuld::test]
+fn no_usable_gateway_hides_the_adapter_in_display_and_keeps_it_in_debug() {
+    let err = GatewayError::NoUsableGateway {
+        detail: sample_detail(),
+    };
+
+    let shown = err.to_string();
+    assert!(
+        !shown.contains("ProtonVPN"),
+        "adapter alias leaked into Display: {shown}"
+    );
+    assert!(!shown.contains("42"), "interface index leaked into Display: {shown}");
+    assert!(!shown.contains("0.0.0.0"), "next hop leaked into Display: {shown}");
+
+    let logged = format!("{err:?}");
+    assert!(
+        logged.contains("ProtonVPN TUN"),
+        "adapter alias missing from Debug: {logged}"
+    );
+    assert!(logged.contains("42"), "interface index missing from Debug: {logged}");
+    assert!(logged.contains("0.0.0.0"), "next hop missing from Debug: {logged}");
+}
+
+#[skuld::test]
+fn route_query_failed_hides_the_os_error_in_display_and_keeps_it_in_debug() {
+    let err = GatewayError::RouteQueryFailed {
+        code: 1214,
+        source: std::io::Error::other(r"C:\Users\alice\AppData\Hole adapter 'Wi-Fi 2'"),
+    };
+
+    let shown = err.to_string();
+    assert!(!shown.contains("alice"), "username leaked into Display: {shown}");
+    assert!(!shown.contains("Wi-Fi"), "adapter name leaked into Display: {shown}");
+    assert!(!shown.contains("1214"), "os code leaked into Display: {shown}");
+
+    let logged = format!("{err:?}");
+    assert!(logged.contains("alice"), "path missing from Debug: {logged}");
+    assert!(logged.contains("1214"), "os code missing from Debug: {logged}");
+
+    // The OS error also stays reachable through the error chain.
+    let source = std::error::Error::source(&err).expect("RouteQueryFailed carries a source");
+    assert!(source.to_string().contains(r"C:\Users\alice"));
+}
+
+#[skuld::test]
+fn interface_name_unavailable_hides_the_index_in_display_and_keeps_it_in_debug() {
+    let err = GatewayError::InterfaceNameUnavailable {
+        interface_index: 31337,
+        source: std::io::Error::other("ConvertInterfaceLuidToAlias failed"),
+    };
+
+    assert!(!err.to_string().contains("31337"));
+    assert!(format!("{err:?}").contains("31337"));
+    assert!(std::error::Error::source(&err).is_some());
+}

--- a/crates/tun-engine/src/gateway/nextest_group_tests.rs
+++ b/crates/tun-engine/src/gateway/nextest_group_tests.rs
@@ -1,0 +1,106 @@
+//! Workspace-wide guard for `.config/nextest.toml`'s `global-net-state`
+//! group. Lives in the lib test binary (not the privileged one) so it runs in
+//! the ordinary unprivileged pass on every push — which is where a forgotten
+//! filter term must be caught, not in the elevated lane that would already be
+//! racing.
+
+/// Guard for the COUPLED NAME above, expressed generically so it also catches a
+/// human adding the next global-net-state test rather than only this one.
+///
+/// `.config/nextest.toml`'s `global-net-state` group matches tests by NAME
+/// SUBSTRING. A test that mutates global OS network state but whose name no
+/// pattern matches silently leaves the group and races the other binaries' tests
+/// — a cross-binary data race that shows up as an unrelated flake. This scans
+/// the workspace for test functions whose names say they belong to the group and
+/// fails if the filter would not pick one up.
+///
+/// Deliberately unlabelled: it needs no elevation, so it runs in the ordinary
+/// `SKULD_LABELS="!tun"` pass on every push — which is where a forgotten filter
+/// term needs to be caught, not in the elevated lane that would already be
+/// racing.
+///
+/// The matcher understands the two pattern shapes the filter actually uses:
+/// a bare substring, and a `$`-anchored suffix.
+///
+/// Its own name deliberately avoids the `global_net_state` marker it scans for —
+/// otherwise it reports itself, which is a false positive AND masks a real one.
+#[skuld::test]
+fn nextest_group_filter_covers_every_serialized_net_test() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root is two levels above the crate manifest")
+        .to_path_buf();
+
+    let config = std::fs::read_to_string(root.join(".config/nextest.toml")).expect("nextest config must exist");
+    let filter_line = config
+        .lines()
+        .find(|l| l.trim_start().starts_with("filter ="))
+        .expect("the global-net-state override must have a filter");
+
+    // Pull the inner regex out of each `test(/.../)` term.
+    let patterns: Vec<&str> = filter_line
+        .match_indices("test(/")
+        .filter_map(|(i, _)| {
+            let rest = &filter_line[i + "test(/".len()..];
+            rest.find("/)").map(|end| &rest[..end])
+        })
+        .collect();
+    assert!(
+        !patterns.is_empty(),
+        "could not parse any pattern out of: {filter_line}"
+    );
+
+    let matches_filter = |name: &str| {
+        patterns.iter().any(|p| match p.strip_suffix('$') {
+            Some(suffix) => name.ends_with(suffix),
+            None => name.contains(p),
+        })
+    };
+
+    let mut checked = 0usize;
+    for path in rust_sources(&root.join("crates")) {
+        let src = std::fs::read_to_string(&path).unwrap_or_default();
+        for line in src.lines() {
+            let Some(rest) = line.trim_start().strip_prefix("fn ") else {
+                continue;
+            };
+            let name = rest.split(['(', '<']).next().unwrap_or("").trim();
+            if !name.contains("global_net_state") {
+                continue;
+            }
+            checked += 1;
+            assert!(
+                matches_filter(name),
+                "test `{name}` ({}) names itself part of the global-net-state group, but no \
+                 pattern in .config/nextest.toml's filter matches it — it would run \
+                 unserialized against the other binaries' global-network-state tests. \
+                 Add a matching `test(/.../)` term.",
+                path.display()
+            );
+        }
+    }
+    assert!(
+        checked > 0,
+        "found no global-net-state tests to check — the scan is broken, not the config"
+    );
+}
+
+fn rust_sources(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "target" || n == ".tmp") {
+                continue;
+            }
+            out.extend(rust_sources(&path));
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+    out
+}

--- a/crates/tun-engine/src/gateway/windows.rs
+++ b/crates/tun-engine/src/gateway/windows.rs
@@ -1,0 +1,160 @@
+//! Windows upstream-route lookup.
+//!
+//! Asks the OS routing table via [`GetBestRoute2`], which performs the full
+//! next-hop selection itself. The `default-net` crate this replaced did not read
+//! the routing table at all: it UDP-`connect()`ed to a public address to learn
+//! the OS-chosen source address, then scanned `GetAdaptersAddresses` for an
+//! adapter carrying it — **skipping every adapter whose `IfType` was not in its
+//! own hard-coded allowlist**. Wintun reports `IF_TYPE_PROP_VIRTUAL` (53), which
+//! is absent from that list, so a WireGuard/wintun adapter holding the default
+//! route (and Hole's own `hole-tun`) was invisible and the scan returned
+//! `"Default Interface not found"`. See bindreams/hole#798.
+//!
+//! Two properties follow from asking the routing table instead of a socket: no
+//! adapter class can be filtered out, and no socket is opened — so the lookup is
+//! unaffected by the fail-closed WFP cover that is already engaged by the time
+//! the bridge asks (`proxy_manager::start` engages it before `start_inner`).
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use ::windows::Win32::Foundation::{
+    ERROR_HOST_UNREACHABLE, ERROR_NETWORK_UNREACHABLE, ERROR_NOT_FOUND, NO_ERROR, WIN32_ERROR,
+};
+use ::windows::Win32::NetworkManagement::IpHelper::{ConvertInterfaceLuidToAlias, GetBestRoute2, MIB_IPFORWARD_ROW2};
+use ::windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+use ::windows::Win32::Networking::WinSock::{AF_INET, AF_INET6, SOCKADDR_INET};
+use tracing::{debug, warn};
+
+use super::{GatewayError, RouteHop};
+
+/// Windows caps an interface alias at `NDIS_IF_MAX_STRING_SIZE` (255) WCHARs,
+/// plus the NUL `ConvertInterfaceLuidToAlias` writes.
+const IF_ALIAS_BUF: usize = 256;
+
+/// Classify a `GetBestRoute2` status.
+///
+/// `None` means "not a failure — the caller returns `Ok(None)`". Keeping the
+/// reachability family out of the error type is what stops a "there is no route"
+/// answer from rendering as "Could not read the system routing table": the
+/// routing table was read fine, and it said no.
+///
+/// Pure over the status code so the mapping is testable without provoking a real
+/// OS failure. Anything unanticipated falls through to a query failure carrying
+/// its raw code — a real diagnostic beats a wrong reassurance, and the code keeps
+/// it identifiable in `bridge.log`.
+pub(crate) fn map_query_error(code: u32) -> Option<GatewayError> {
+    let reachability = [ERROR_NETWORK_UNREACHABLE.0, ERROR_HOST_UNREACHABLE.0, ERROR_NOT_FOUND.0];
+    if reachability.contains(&code) {
+        return None;
+    }
+    Some(GatewayError::RouteQueryFailed {
+        code,
+        source: std::io::Error::from_raw_os_error(code as i32),
+    })
+}
+
+/// Ask the OS which route it would use to reach `dest`.
+///
+/// Three outcomes, deliberately distinct: `Ok(Some)` is a route, `Ok(None)` is a
+/// definitive "no route", `Err` is "the query itself failed".
+///
+/// Does **not** judge the next hop — an on-link answer is legitimate for a caller
+/// asking about a specific destination. Classification is
+/// [`super::classify_hop`]'s job.
+pub(crate) fn best_route(dest: IpAddr) -> Result<Option<RouteHop>, GatewayError> {
+    let dest_sa = to_sockaddr_inet(dest);
+    let mut row = MIB_IPFORWARD_ROW2::default();
+    let mut best_source = SOCKADDR_INET::default();
+
+    // SAFETY: `GetBestRoute2` reads `dest_sa` and writes `row` / `best_source`,
+    // all three owned locals of the exact FFI types. The optional LUID and
+    // source-address parameters are `None` (unscoped lookup, OS-chosen source).
+    let status = unsafe {
+        GetBestRoute2(
+            None,
+            0,
+            None,
+            &dest_sa,
+            0,
+            &mut row as *mut MIB_IPFORWARD_ROW2,
+            &mut best_source as *mut SOCKADDR_INET,
+        )
+    };
+
+    if status != NO_ERROR {
+        return match map_query_error(status.0) {
+            None => {
+                debug!(%dest, status = status.0, "no route to destination");
+                Ok(None)
+            }
+            Some(err) => {
+                warn!(%dest, status = status.0, "GetBestRoute2 failed");
+                Err(err)
+            }
+        };
+    }
+
+    let interface_index = row.InterfaceIndex;
+    let interface_alias = interface_alias(&row.InterfaceLuid, interface_index)?;
+    let next_hop = from_sockaddr_inet(&row.NextHop);
+
+    debug!(%dest, %next_hop, interface_index, interface_alias, "resolved upstream route");
+    Ok(Some(RouteHop {
+        next_hop,
+        interface_index,
+        interface_alias,
+    }))
+}
+
+fn interface_alias(luid: &NET_LUID_LH, interface_index: u32) -> Result<String, GatewayError> {
+    let mut buf = [0u16; IF_ALIAS_BUF];
+    // SAFETY: `luid` is a live reference and `buf` is a fixed-size owned array;
+    // the binding passes its length, so the callee cannot overrun it.
+    let status: WIN32_ERROR = unsafe { ConvertInterfaceLuidToAlias(luid, &mut buf) };
+    if status != NO_ERROR {
+        return Err(GatewayError::InterfaceNameUnavailable {
+            interface_index,
+            source: std::io::Error::from_raw_os_error(status.0 as i32),
+        });
+    }
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    Ok(String::from_utf16_lossy(&buf[..len]))
+}
+
+// SOCKADDR_INET conversion ============================================================================================
+
+fn to_sockaddr_inet(addr: IpAddr) -> SOCKADDR_INET {
+    let mut sa = SOCKADDR_INET::default();
+    match addr {
+        IpAddr::V4(v4) => {
+            sa.Ipv4.sin_family = AF_INET;
+            sa.Ipv4.sin_addr.S_un.S_addr = u32::from_ne_bytes(v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            sa.Ipv6.sin6_family = AF_INET6;
+            sa.Ipv6.sin6_addr.u.Byte = v6.octets();
+        }
+    }
+    sa
+}
+
+fn from_sockaddr_inet(sa: &SOCKADDR_INET) -> IpAddr {
+    // SAFETY: `SOCKADDR_INET` is a union whose `si_family` discriminant is
+    // readable from every variant (all begin with the family field), and the
+    // matching variant is read only for its own family.
+    let family = unsafe { sa.si_family };
+    if family == AF_INET6 {
+        let bytes = unsafe { sa.Ipv6.sin6_addr.u.Byte };
+        return IpAddr::V6(Ipv6Addr::from(bytes));
+    }
+    // AF_INET, and AF_UNSPEC — which `GetBestRoute2` reports for an on-link
+    // route with no next hop. Both read as the IPv4 address field, and
+    // AF_UNSPEC's zeroed field is the unspecified address, which is exactly the
+    // on-link marker `classify_hop` keys on.
+    let raw = unsafe { sa.Ipv4.sin_addr.S_un.S_addr };
+    IpAddr::V4(Ipv4Addr::from(raw.to_ne_bytes()))
+}
+
+#[cfg(test)]
+#[path = "windows_tests.rs"]
+mod windows_tests;

--- a/crates/tun-engine/src/gateway/windows.rs
+++ b/crates/tun-engine/src/gateway/windows.rs
@@ -61,7 +61,7 @@ pub(crate) fn map_query_error(code: u32) -> Option<GatewayError> {
 /// Does **not** judge the next hop — an on-link answer is legitimate for a caller
 /// asking about a specific destination. Classification is
 /// [`super::classify_hop`]'s job.
-pub(crate) fn best_route(dest: IpAddr) -> Result<Option<RouteHop>, GatewayError> {
+pub fn best_route(dest: IpAddr) -> Result<Option<RouteHop>, GatewayError> {
     let dest_sa = to_sockaddr_inet(dest);
     let mut row = MIB_IPFORWARD_ROW2::default();
     let mut best_source = SOCKADDR_INET::default();
@@ -158,3 +158,7 @@ fn from_sockaddr_inet(sa: &SOCKADDR_INET) -> IpAddr {
 #[cfg(test)]
 #[path = "windows_tests.rs"]
 mod windows_tests;
+
+#[cfg(test)]
+#[path = "nextest_group_tests.rs"]
+mod nextest_group_tests;

--- a/crates/tun-engine/src/gateway/windows_tests.rs
+++ b/crates/tun-engine/src/gateway/windows_tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+use std::net::{IpAddr, Ipv4Addr};
+use windows::Win32::Foundation::{
+    ERROR_ACCESS_DENIED, ERROR_HOST_UNREACHABLE, ERROR_INVALID_NETNAME, ERROR_INVALID_PARAMETER,
+    ERROR_NETWORK_UNREACHABLE, ERROR_NOT_FOUND,
+};
+
+// Oracle ==============================================================================================================
+
+/// The route object `Find-NetRoute` reports for a destination.
+struct OracleRoute {
+    if_index: u32,
+    next_hop: String,
+}
+
+/// Ask Windows itself where a destination routes.
+///
+/// `Find-NetRoute` is the cmdlet wrapper over the OS's own best-route lookup, so
+/// it is an independent *implementation* of the selection rather than a
+/// reimplementation of the *policy* — sorting `Get-NetRoute` by metric in
+/// PowerShell would be the latter, and reimplementing route selection outside
+/// the OS is the mistake bindreams/hole#798 is made of. It proves we read the
+/// right fields off the right row; it cannot prove the selection itself.
+///
+/// It emits TWO objects: the source `NetIPAddress` (no `DestinationPrefix`) and
+/// the `NetRoute`. Taking `[0]` would silently take the wrong one, so the route
+/// is identified by having a `DestinationPrefix`.
+fn find_net_route(dest: &str) -> Option<OracleRoute> {
+    let script = format!(
+        "$ErrorActionPreference='Stop'; \
+         try {{ Find-NetRoute -RemoteIPAddress {dest} | \
+         Select-Object ifIndex,NextHop,DestinationPrefix | ConvertTo-Json -Depth 4 }} \
+         catch {{ '[]' }}"
+    );
+    let out = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .expect("powershell must be runnable");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or(serde_json::Value::Null);
+
+    // A single result comes back as an object, several as an array.
+    let rows: Vec<&serde_json::Value> = match &parsed {
+        serde_json::Value::Array(a) => a.iter().collect(),
+        serde_json::Value::Object(_) => vec![&parsed],
+        _ => vec![],
+    };
+    rows.into_iter()
+        .find(|r| !r["DestinationPrefix"].is_null())
+        .map(|r| OracleRoute {
+            if_index: r["ifIndex"].as_u64().expect("ifIndex is a number") as u32,
+            next_hop: r["NextHop"].as_str().unwrap_or("0.0.0.0").to_string(),
+        })
+}
+
+fn get_netadapter_name(if_index: u32) -> Option<String> {
+    let script = format!(
+        "$ErrorActionPreference='Stop'; \
+         try {{ (Get-NetAdapter -IncludeHidden -InterfaceIndex {if_index}).Name }} catch {{ '' }}"
+    );
+    let out = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .expect("powershell must be runnable");
+    let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!name.is_empty()).then_some(name)
+}
+
+// Error mapping =======================================================================================================
+
+/// The three-way split is the whole point: a reachability answer must not
+/// render as "Could not read the system routing table". `GetBestRoute2` really
+/// does return all of these — `ERROR_HOST_UNREACHABLE` for a destination with no
+/// path, `ERROR_NOT_FOUND` for a family with no routes at all.
+#[skuld::test]
+fn map_query_error_separates_reachability_from_query_failure() {
+    for code in [ERROR_NETWORK_UNREACHABLE, ERROR_HOST_UNREACHABLE, ERROR_NOT_FOUND] {
+        assert!(
+            map_query_error(code.0).is_none(),
+            "{code:?} is a reachability answer, not a query failure"
+        );
+    }
+
+    for code in [ERROR_INVALID_PARAMETER, ERROR_INVALID_NETNAME, ERROR_ACCESS_DENIED] {
+        let mapped = map_query_error(code.0).unwrap_or_else(|| panic!("{code:?} must map to an error"));
+        assert!(
+            matches!(mapped, GatewayError::RouteQueryFailed { code: c, .. } if c == code.0),
+            "{code:?} must carry its raw code for bridge.log, got {mapped:?}"
+        );
+    }
+
+    // An unlisted code falls through to the query-failure bucket: a real
+    // diagnostic beats a wrong reassurance, and `code` keeps it identifiable.
+    let mapped = map_query_error(0xDEAD).expect("an unanticipated code is a query failure");
+    assert!(matches!(mapped, GatewayError::RouteQueryFailed { code: 0xDEAD, .. }));
+}
+
+// Real-OS agreement ===================================================================================================
+
+/// Asserted for BOTH a routable address and `0.0.0.0` — the latter is the value
+/// production actually queries (`get_default_gateway_info`), so the load-bearing
+/// assumption is exercised rather than assumed.
+#[skuld::test]
+fn best_route_agrees_with_find_netroute() {
+    for dest_str in ["1.1.1.1", "0.0.0.0"] {
+        let dest: IpAddr = dest_str.parse().unwrap();
+        let ours = best_route(dest).expect("route lookup must not fail on a healthy host");
+
+        match find_net_route(dest_str) {
+            None => assert!(
+                ours.is_none(),
+                "oracle found no route to {dest_str} but best_route returned {ours:?}"
+            ),
+            Some(oracle) => {
+                let hop = ours.unwrap_or_else(|| panic!("oracle found a route to {dest_str}, best_route did not"));
+                assert_eq!(
+                    hop.interface_index, oracle.if_index,
+                    "interface index disagrees for {dest_str}"
+                );
+                assert_eq!(
+                    hop.next_hop.to_string(),
+                    oracle.next_hop,
+                    "next hop disagrees for {dest_str}"
+                );
+            }
+        }
+    }
+}
+
+/// The alias changes provenance in this commit (GAA `FriendlyName` ->
+/// `ConvertInterfaceLuidToAlias`), and it is not cosmetic: it is the adapter
+/// token in `netsh interface ip add route`, the alias the system-DNS capture
+/// keys on, and the value crash recovery replays out of `bridge-routes.json`.
+/// A silent change there breaks three subsystems at once.
+#[skuld::test]
+fn interface_alias_matches_get_netadapter_name() {
+    let Some(hop) = best_route(IpAddr::V4(Ipv4Addr::UNSPECIFIED)).expect("lookup must not fail") else {
+        // No default route on this host; the agreement test above covers that branch.
+        return;
+    };
+    let Some(expected) = get_netadapter_name(hop.interface_index) else {
+        // The upstream is not a Get-NetAdapter object (e.g. a loopback/tunnel
+        // pseudo-interface). Nothing independent to compare against.
+        return;
+    };
+    assert_eq!(hop.interface_alias, expected);
+}

--- a/crates/tun-engine/src/gateway_tests.rs
+++ b/crates/tun-engine/src/gateway_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[skuld::test]
 #[ignore] // Requires network — run manually with `cargo test -- --ignored`
@@ -13,4 +14,76 @@ fn get_default_gateway_info_returns_valid_result() {
     assert!(info.interface_index > 0, "interface index should be non-zero");
     // ipv6_available is informational — just ensure it doesn't panic.
     let _ = info.ipv6_available;
+}
+
+// classify_hop ========================================================================================================
+//
+// These drive the refusal branches over FABRICATED hops. They are honest
+// classification tests and prove nothing about detection — that the lookup can
+// see a wintun adapter at all is `gateway/windows_privileged_tests.rs`.
+
+fn hop(next_hop: IpAddr) -> RouteHop {
+    RouteHop {
+        next_hop,
+        interface_index: 42,
+        interface_alias: "ProtonVPN TUN".into(),
+    }
+}
+
+#[skuld::test]
+fn classify_hop_maps_no_route_to_no_default_route() {
+    let err = classify_hop(None, false).expect_err("no route must be an error");
+    assert!(matches!(err, GatewayError::NoDefaultRoute), "got {err:?}");
+}
+
+/// Run for both families: reading the on-link marker with the wrong address
+/// family would silently turn "no gateway" into a working start pointed at
+/// `0.0.0.0`.
+#[skuld::test]
+fn classify_hop_maps_unspecified_next_hop_to_no_usable_gateway() {
+    for unspecified in [IpAddr::V4(Ipv4Addr::UNSPECIFIED), IpAddr::V6(Ipv6Addr::UNSPECIFIED)] {
+        let err = classify_hop(Some(hop(unspecified)), false).expect_err("on-link must be refused");
+        assert!(
+            matches!(err, GatewayError::NoUsableGateway { .. }),
+            "{unspecified} should be on-link, got {err:?}"
+        );
+    }
+}
+
+/// The refusal branch must not destroy the adapter its own copy tells the user
+/// to look up. Without this the toast says "see bridge.log for the adapter
+/// involved" and `bridge.log` names nothing.
+#[skuld::test]
+fn classify_hop_preserves_the_adapter_in_the_error() {
+    let err = classify_hop(Some(hop(IpAddr::V4(Ipv4Addr::UNSPECIFIED))), false).expect_err("on-link is refused");
+    let GatewayError::NoUsableGateway { detail } = &err else {
+        panic!("expected NoUsableGateway, got {err:?}");
+    };
+    assert_eq!(detail.interface_alias, "ProtonVPN TUN");
+    assert_eq!(detail.interface_index, 42);
+    assert_eq!(detail.next_hop, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+}
+
+#[skuld::test]
+fn classify_hop_maps_empty_alias_to_interface_name_unavailable() {
+    let nameless = RouteHop {
+        next_hop: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+        interface_index: 7,
+        interface_alias: String::new(),
+    };
+    let err = classify_hop(Some(nameless), false).expect_err("an unnamed adapter must be refused");
+    assert!(
+        matches!(err, GatewayError::InterfaceNameUnavailable { interface_index: 7, .. }),
+        "got {err:?}"
+    );
+}
+
+#[skuld::test]
+fn classify_hop_accepts_a_real_next_hop() {
+    let gateway = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
+    let info = classify_hop(Some(hop(gateway)), true).expect("a real next hop is usable");
+    assert_eq!(info.gateway_ip, gateway);
+    assert_eq!(info.interface_name, "ProtonVPN TUN");
+    assert_eq!(info.interface_index, 42);
+    assert!(info.ipv6_available);
 }

--- a/crates/tun-engine/src/lib.rs
+++ b/crates/tun-engine/src/lib.rs
@@ -49,5 +49,5 @@ pub use engine::{
     DnsInterceptor, Engine, EngineConfig, MutEngineConfig, Router, TcpFlow, TcpMeta, UdpFlow, UdpMeta, UdpSender,
 };
 pub use error::{DeviceError, EngineError, RoutingError};
-pub use gateway::{get_default_gateway_info, GatewayInfo};
+pub use gateway::{get_default_gateway_info, GatewayError, GatewayInfo, HopDetail};
 pub use routing::{Routing, SystemRoutes, SystemRouting};

--- a/crates/tun-engine/src/lib.rs
+++ b/crates/tun-engine/src/lib.rs
@@ -49,5 +49,5 @@ pub use engine::{
     DnsInterceptor, Engine, EngineConfig, MutEngineConfig, Router, TcpFlow, TcpMeta, UdpFlow, UdpMeta, UdpSender,
 };
 pub use error::{DeviceError, EngineError, RoutingError};
-pub use gateway::{get_default_gateway_info, GatewayError, GatewayInfo, HopDetail};
+pub use gateway::{get_default_gateway_info, GatewayError, GatewayInfo, HopDetail, RouteHop};
 pub use routing::{Routing, SystemRoutes, SystemRouting};

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -517,7 +517,7 @@ impl Routing for SystemRouting {
     }
 
     fn default_gateway(&self) -> Result<GatewayInfo, RoutingError> {
-        get_default_gateway_info().map_err(|e| RoutingError::Gateway(e.to_string()))
+        get_default_gateway_info().map_err(RoutingError::Gateway)
     }
 
     fn install_failclosed_cover(

--- a/crates/tun-engine/tests/gateway_privileged.rs
+++ b/crates/tun-engine/tests/gateway_privileged.rs
@@ -1,0 +1,201 @@
+//! Privileged-lane proof that the upstream-route lookup can see a **wintun**
+//! adapter.
+//!
+//! This is the one test that covers bindreams/hole#798's actual defect. The
+//! `default-net` crate this replaced enumerated adapters through
+//! `GetAdaptersAddresses` and silently skipped every one whose `IfType` was
+//! absent from its own hard-coded allowlist. Wintun reports
+//! `IF_TYPE_PROP_VIRTUAL` (53), which is not in that list, so an adapter of
+//! exactly this kind was invisible to it, and a user whose default route ran
+//! through one got `"Default Interface not found"`. A lookup that asks the OS
+//! cannot have that blind spot — and here is the adapter that proves it.
+//!
+//! **It never touches the default route.** The property under test is "can this
+//! lookup name an `IfType 53` adapter", not "what happens when one owns the
+//! default route" — and hijacking a runner's (or a dev box's) default route to
+//! ask the second question would sever the machine. Creating the adapter with an
+//! address is enough: Windows installs the on-link subnet route itself, so a
+//! lookup into that subnet must land on the adapter. No `route add`, and
+//! therefore no route to leak.
+//!
+//! Its own binary rather than a module in the lib test binary: skuld validates
+//! that a label is declared once per binary, and the lib already declares `TUN`
+//! in `routing/failclosed/lockdown_privileged_tests.rs`. Keeping this separate
+//! also leaves that file — contended by bindreams/hole#832 — untouched.
+//!
+//! Runs on the elevated `tun` lane only: creating a wintun adapter needs the
+//! elevated token. Not `#[ignore]`d, and it does not skip on missing privilege —
+//! a default run on an unelevated box runs it and fails loud; opting out is the
+//! explicit `SKULD_LABELS="!tun"` filter, and CI provisions the elevation.
+//!
+//! COUPLED NAME: `.config/nextest.toml`'s `global-net-state` filter matches this
+//! test by the `gateway_global_net_state_` prefix, serializing it against the
+//! other tests that mutate global OS network state across binaries. Renaming it
+//! without updating that filter would silently drop it from the group — which
+//! `nextest_group_filter_covers_every_serialized_net_test` (tun-engine lib,
+//! unprivileged) fails on.
+
+hole_test_observability::register!();
+
+fn main() {
+    skuld::run_all();
+}
+
+#[skuld::label]
+const TUN: skuld::Label;
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use super::TUN;
+    use std::sync::mpsc::{channel, Sender};
+
+    use windows::Win32::Foundation::{HANDLE, NO_ERROR};
+    use windows::Win32::NetworkManagement::IpHelper::{
+        CancelMibChangeNotify2, ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToIndex, NotifyUnicastIpAddressChange,
+        MIB_NOTIFICATION_TYPE, MIB_UNICASTIPADDRESS_ROW,
+    };
+    use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+    use windows::Win32::Networking::WinSock::{
+        IpDadStateDeprecated, IpDadStateDuplicate, IpDadStateInvalid, IpDadStatePreferred, AF_INET,
+    };
+
+    /// Distinct from `TUN_DEVICE_NAME` (`hole-tun`) so a concurrent bridge e2e,
+    /// the adapter-cleanup sweep, and this test can never target each other's
+    /// adapter.
+    const TEST_ADAPTER: &str = "hole-test-gw";
+    /// Distinct from `TUN_SUBNET` (`10.255.0.1/24`), same reason.
+    const TEST_CIDR: &str = "10.254.0.1/24";
+    /// Inside `TEST_CIDR`, so the on-link route Windows creates for the adapter
+    /// is the route this lookup must find.
+    const TEST_DEST: &str = "10.254.0.7";
+
+    /// Removes the adapter on the way out, including on panic — a leaked wintun
+    /// adapter is exactly the residue `diagnostics::ndis` reports as a teardown
+    /// leak, so a failing test must not manufacture one.
+    struct AdapterGuard;
+
+    impl Drop for AdapterGuard {
+        fn drop(&mut self) {
+            tun_engine::adapter_cleanup::remove_adapter(TEST_ADAPTER);
+        }
+    }
+
+    enum DadOutcome {
+        Usable,
+        Rejected(i32),
+    }
+
+    unsafe extern "system" fn on_address_change(
+        context: *const core::ffi::c_void,
+        row: *const MIB_UNICASTIPADDRESS_ROW,
+        _kind: MIB_NOTIFICATION_TYPE,
+    ) {
+        if context.is_null() || row.is_null() {
+            return;
+        }
+        // SAFETY: `context` is the boxed `Sender` passed to
+        // `NotifyUnicastIpAddressChange`, kept alive until after
+        // `CancelMibChangeNotify2`. `row` is kernel-owned and valid for the
+        // duration of the callback.
+        let tx = unsafe { &*(context as *const Sender<DadOutcome>) };
+        let row = unsafe { &*row };
+
+        if Some(row.InterfaceIndex) != adapter_index() {
+            return;
+        }
+        // Every TERMINAL DAD state is reported, not just success. Waiting only
+        // for `Preferred` would never return if the address were rejected, and
+        // an unbounded wait is precisely the shape this codebase forbids.
+        let outcome = match row.DadState {
+            s if s == IpDadStatePreferred || s == IpDadStateDeprecated => DadOutcome::Usable,
+            s if s == IpDadStateDuplicate || s == IpDadStateInvalid => DadOutcome::Rejected(s.0),
+            _ => return, // Tentative — not yet terminal.
+        };
+        let _ = tx.send(outcome);
+    }
+
+    /// The test adapter's interface index, or `None` while it does not exist.
+    fn adapter_index() -> Option<u32> {
+        let alias = windows::core::HSTRING::from(TEST_ADAPTER);
+        let mut luid = NET_LUID_LH::default();
+        // SAFETY: both calls take a live reference in and write an owned local.
+        if unsafe { ConvertInterfaceAliasToLuid(&alias, &mut luid) } != NO_ERROR {
+            return None;
+        }
+        let mut index = 0u32;
+        if unsafe { ConvertInterfaceLuidToIndex(&luid, &mut index) } != NO_ERROR {
+            return None;
+        }
+        Some(index)
+    }
+
+    #[skuld::test(labels = [TUN], serial = TUN)]
+    fn gateway_global_net_state_best_route_sees_a_wintun_adapter() {
+        // A previously crashed run could have left the adapter behind; removing
+        // it first makes this idempotent rather than order-dependent.
+        tun_engine::adapter_cleanup::remove_adapter(TEST_ADAPTER);
+
+        // `Device::build` does NOT pre-load wintun.dll — production calls this
+        // separately, and the `tun` crate's bare `LoadLibraryExW("wintun.dll")`
+        // would fail from the test binary's directory. `resolve_wintun_path`
+        // falls back to the repo's `.cache/wintun/wintun.dll`, which covers it.
+        tun_engine::device::wintun::ensure_loaded().expect("wintun.dll must load (run `cargo xtask deps`)");
+
+        // Registered BEFORE the adapter exists, so the address's DAD transition
+        // cannot be missed in the gap between creation and subscription.
+        let (tx, rx) = channel::<DadOutcome>();
+        let tx = Box::new(tx);
+        let mut notify = HANDLE::default();
+        // SAFETY: `tx` is boxed and outlives the registration (cancelled below),
+        // so the callback's context pointer stays valid throughout.
+        let status = unsafe {
+            NotifyUnicastIpAddressChange(
+                AF_INET,
+                Some(on_address_change),
+                Some(&*tx as *const Sender<DadOutcome> as *const core::ffi::c_void),
+                false,
+                &mut notify,
+            )
+        };
+        assert_eq!(status, NO_ERROR, "NotifyUnicastIpAddressChange failed: {status:?}");
+
+        let _guard = AdapterGuard;
+        let _device = tun_engine::Device::build(|c| {
+            c.tun_name = TEST_ADAPTER.into();
+            c.mtu = 1400;
+            c.ipv4 = Some(TEST_CIDR.parse().unwrap());
+        })
+        .expect("creating a wintun adapter requires elevation");
+
+        // Rendezvous on the OS publishing a terminal DAD state, not on a sleep
+        // or a poll: `GetBestRoute2` needs a valid unicast source on the
+        // interface, so asserting while the address is still `Tentative` would
+        // be a race.
+        match rx.recv().expect("the channel outlives the registration") {
+            DadOutcome::Usable => {}
+            DadOutcome::Rejected(state) => panic!(
+                "the test adapter's address was rejected by DAD (state {state}) — \
+                 is {TEST_CIDR} already in use on this host?"
+            ),
+        }
+
+        // SAFETY: `notify` is the live handle from the registration above.
+        let cancelled = unsafe { CancelMibChangeNotify2(notify) };
+        assert_eq!(cancelled, NO_ERROR, "CancelMibChangeNotify2 failed: {cancelled:?}");
+        drop(tx);
+
+        let expected = adapter_index().expect("the test adapter must resolve after creation");
+
+        let hop = tun_engine::gateway::best_route(TEST_DEST.parse().unwrap())
+            .expect("route lookup must not fail")
+            .expect("Windows installs an on-link route for the adapter's own subnet");
+
+        assert_eq!(
+            hop.interface_index, expected,
+            "the lookup named interface {} instead of the wintun adapter {expected} — that is \
+             the #798 blind spot: an IfType 53 adapter the enumeration cannot see",
+            hop.interface_index
+        );
+        assert_eq!(hop.interface_alias, TEST_ADAPTER);
+    }
+}

--- a/crates/tun-engine/tests/gateway_privileged.rs
+++ b/crates/tun-engine/tests/gateway_privileged.rs
@@ -49,14 +49,14 @@ mod windows_impl {
     use super::TUN;
     use std::sync::mpsc::{channel, Sender};
 
-    use windows::Win32::Foundation::{HANDLE, NO_ERROR};
+    use windows::Win32::Foundation::{ERROR_NOT_FOUND, HANDLE, NO_ERROR};
     use windows::Win32::NetworkManagement::IpHelper::{
-        CancelMibChangeNotify2, ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToIndex, NotifyUnicastIpAddressChange,
-        MIB_NOTIFICATION_TYPE, MIB_UNICASTIPADDRESS_ROW,
+        CancelMibChangeNotify2, ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToIndex, GetUnicastIpAddressEntry,
+        NotifyUnicastIpAddressChange, MIB_NOTIFICATION_TYPE, MIB_UNICASTIPADDRESS_ROW,
     };
     use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
     use windows::Win32::Networking::WinSock::{
-        IpDadStateDeprecated, IpDadStateDuplicate, IpDadStateInvalid, IpDadStatePreferred, AF_INET,
+        IpDadStateDeprecated, IpDadStateDuplicate, IpDadStateInvalid, IpDadStatePreferred, AF_INET, SOCKADDR_INET,
     };
 
     /// Distinct from `TUN_DEVICE_NAME` (`hole-tun`) so a concurrent bridge e2e,
@@ -65,6 +65,8 @@ mod windows_impl {
     const TEST_ADAPTER: &str = "hole-test-gw";
     /// Distinct from `TUN_SUBNET` (`10.255.0.1/24`), same reason.
     const TEST_CIDR: &str = "10.254.0.1/24";
+    /// The address inside `TEST_CIDR`, as `GetUnicastIpAddressEntry` needs it.
+    const TEST_ADDR: std::net::Ipv4Addr = std::net::Ipv4Addr::new(10, 254, 0, 1);
     /// Inside `TEST_CIDR`, so the on-link route Windows creates for the adapter
     /// is the route this lookup must find.
     const TEST_DEST: &str = "10.254.0.7";
@@ -80,11 +82,39 @@ mod windows_impl {
         }
     }
 
-    enum DadOutcome {
+    /// What the address's DAD state means for this test, read from the
+    /// authoritative entry rather than from the notification.
+    enum DadVerdict {
+        /// Usable as a source address, so `GetBestRoute2` can resolve through
+        /// this interface.
         Usable,
-        Rejected(i32),
+        /// DAD found another host holding the address.
+        Duplicate,
+        /// The stack rejected the address outright.
+        Invalid,
+        /// `GetUnicastIpAddressEntry` itself failed.
+        QueryFailed(u32),
+        /// DAD is still running, or the address is not registered yet. The only
+        /// state worth waiting through — wait for the next notification.
+        Pending,
     }
 
+    /// The notification callback.
+    ///
+    /// **It must not read `DadState`.** `NotifyUnicastIpAddressChange`'s contract
+    /// is that the row handed to the callback "contains incomplete data ... only
+    /// enough information that an application can call
+    /// `GetUnicastIpAddressEntry`": exactly `Address`, `InterfaceLuid` and
+    /// `InterfaceIndex`. Every other member — `DadState` included — is left at
+    /// its zero value, and `IpDadStateInvalid` IS zero, so reading it here
+    /// reports a rejection on every single notification. That is what made the
+    /// first version of this test fail deterministically while claiming the
+    /// subnet was already in use.
+    ///
+    /// So the callback forwards only the interface index and the main thread
+    /// does the authoritative query. Keeping it to a channel send also respects
+    /// the documented rule that `CancelMibChangeNotify2` must never be reached
+    /// from the callback thread.
     unsafe extern "system" fn on_address_change(
         context: *const core::ffi::c_void,
         row: *const MIB_UNICASTIPADDRESS_ROW,
@@ -96,26 +126,44 @@ mod windows_impl {
         // SAFETY: `context` is the boxed `Sender` passed to
         // `NotifyUnicastIpAddressChange`, kept alive until after
         // `CancelMibChangeNotify2`. `row` is kernel-owned and valid for the
-        // duration of the callback.
-        let tx = unsafe { &*(context as *const Sender<DadOutcome>) };
-        let row = unsafe { &*row };
-
-        if Some(row.InterfaceIndex) != adapter_index() {
-            return;
-        }
-        // Every TERMINAL DAD state is reported, not just success. Waiting only
-        // for `Preferred` would never return if the address were rejected, and
-        // an unbounded wait is precisely the shape this codebase forbids.
-        let outcome = match row.DadState {
-            s if s == IpDadStatePreferred || s == IpDadStateDeprecated => DadOutcome::Usable,
-            s if s == IpDadStateDuplicate || s == IpDadStateInvalid => DadOutcome::Rejected(s.0),
-            _ => return, // Tentative — not yet terminal.
-        };
-        let _ = tx.send(outcome);
+        // duration of the callback; `InterfaceIndex` is one of the three members
+        // the API documents as populated.
+        let tx = unsafe { &*(context as *const Sender<u32>) };
+        let index = unsafe { (*row).InterfaceIndex };
+        let _ = tx.send(index);
     }
 
-    /// The test adapter's interface index, or `None` while it does not exist.
-    fn adapter_index() -> Option<u32> {
+    /// Ask for the COMPLETE entry, which is the only place `DadState` is real.
+    fn dad_verdict(luid: NET_LUID_LH, index: u32) -> DadVerdict {
+        let mut row = MIB_UNICASTIPADDRESS_ROW {
+            Address: ipv4_sockaddr(TEST_ADDR),
+            InterfaceLuid: luid,
+            InterfaceIndex: index,
+            ..Default::default()
+        };
+        // SAFETY: `row` is an owned local seeded with the three members
+        // `GetUnicastIpAddressEntry` requires as input.
+        let status = unsafe { GetUnicastIpAddressEntry(&mut row) };
+        if status == ERROR_NOT_FOUND {
+            // The address has not been registered yet — the adapter's creation
+            // notification can arrive first.
+            return DadVerdict::Pending;
+        }
+        if status != NO_ERROR {
+            return DadVerdict::QueryFailed(status.0);
+        }
+        match row.DadState {
+            s if s == IpDadStatePreferred || s == IpDadStateDeprecated => DadVerdict::Usable,
+            s if s == IpDadStateDuplicate => DadVerdict::Duplicate,
+            s if s == IpDadStateInvalid => DadVerdict::Invalid,
+            // Tentative — the documented transient.
+            _ => DadVerdict::Pending,
+        }
+    }
+
+    /// The test adapter's LUID and interface index, or `None` while it does not
+    /// exist yet.
+    fn adapter_identity() -> Option<(NET_LUID_LH, u32)> {
         let alias = windows::core::HSTRING::from(TEST_ADAPTER);
         let mut luid = NET_LUID_LH::default();
         // SAFETY: both calls take a live reference in and write an owned local.
@@ -126,7 +174,14 @@ mod windows_impl {
         if unsafe { ConvertInterfaceLuidToIndex(&luid, &mut index) } != NO_ERROR {
             return None;
         }
-        Some(index)
+        Some((luid, index))
+    }
+
+    fn ipv4_sockaddr(addr: std::net::Ipv4Addr) -> SOCKADDR_INET {
+        let mut sa = SOCKADDR_INET::default();
+        sa.Ipv4.sin_family = AF_INET;
+        sa.Ipv4.sin_addr.S_un.S_addr = u32::from_ne_bytes(addr.octets());
+        sa
     }
 
     #[skuld::test(labels = [TUN], serial = TUN)]
@@ -143,7 +198,7 @@ mod windows_impl {
 
         // Registered BEFORE the adapter exists, so the address's DAD transition
         // cannot be missed in the gap between creation and subscription.
-        let (tx, rx) = channel::<DadOutcome>();
+        let (tx, rx) = channel::<u32>();
         let tx = Box::new(tx);
         let mut notify = HANDLE::default();
         // SAFETY: `tx` is boxed and outlives the registration (cancelled below),
@@ -152,7 +207,7 @@ mod windows_impl {
             NotifyUnicastIpAddressChange(
                 AF_INET,
                 Some(on_address_change),
-                Some(&*tx as *const Sender<DadOutcome> as *const core::ffi::c_void),
+                Some(&*tx as *const Sender<u32> as *const core::ffi::c_void),
                 false,
                 &mut notify,
             )
@@ -167,24 +222,47 @@ mod windows_impl {
         })
         .expect("creating a wintun adapter requires elevation");
 
-        // Rendezvous on the OS publishing a terminal DAD state, not on a sleep
-        // or a poll: `GetBestRoute2` needs a valid unicast source on the
-        // interface, so asserting while the address is still `Tentative` would
-        // be a race.
-        match rx.recv().expect("the channel outlives the registration") {
-            DadOutcome::Usable => {}
-            DadOutcome::Rejected(state) => panic!(
-                "the test adapter's address was rejected by DAD (state {state}) — \
-                 is {TEST_CIDR} already in use on this host?"
-            ),
-        }
+        // Rendezvous on the OS publishing a TERMINAL DAD state — never a sleep
+        // and never a poll. `GetBestRoute2` requires a valid unicast source on
+        // the interface, so asserting while the address is still `Tentative`
+        // would be a race.
+        //
+        // The notification only reports THAT something changed; `dad_verdict`
+        // does the authoritative `GetUnicastIpAddressEntry` query, because the
+        // row handed to the callback leaves `DadState` zeroed and zero is
+        // `IpDadStateInvalid` (see `on_address_change`).
+        //
+        // Checks BEFORE blocking, so an address that is already usable by the
+        // time `Device::build` returns needs no notification at all. Registering
+        // the callback before creating the adapter means any change after the
+        // check is already queued, so nothing can be missed in between. Every
+        // terminal verdict panics, so this cannot wait forever on an address the
+        // stack rejected.
+        let expected = loop {
+            if let Some((luid, index)) = adapter_identity() {
+                match dad_verdict(luid, index) {
+                    DadVerdict::Usable => break index,
+                    DadVerdict::Duplicate => panic!(
+                        "{TEST_ADDR} is already in use on this host (DAD reported a duplicate); pick a different subnet than {TEST_CIDR}"
+                    ),
+                    DadVerdict::Invalid => panic!(
+                        "the stack rejected {TEST_ADDR} as invalid — this is NOT an address collision; check the adapter's IP configuration"
+                    ),
+                    DadVerdict::QueryFailed(code) => {
+                        panic!("GetUnicastIpAddressEntry failed for {TEST_ADDR} with status {code}")
+                    }
+                    DadVerdict::Pending => {}
+                }
+            }
+            // Not usable yet: block until the OS reports another change, then
+            // re-read the authoritative state.
+            rx.recv().expect("the channel outlives the registration");
+        };
 
         // SAFETY: `notify` is the live handle from the registration above.
         let cancelled = unsafe { CancelMibChangeNotify2(notify) };
         assert_eq!(cancelled, NO_ERROR, "CancelMibChangeNotify2 failed: {cancelled:?}");
         drop(tx);
-
-        let expected = adapter_index().expect("the test adapter must resolve after creation");
 
         let hop = tun_engine::gateway::best_route(TEST_DEST.parse().unwrap())
             .expect("route lookup must not fail")


### PR DESCRIPTION
Closes #798.

## ⚠️ OPEN QUESTION — must be answered before merge

**This change widens who Hole will try to connect for, and rule #0 bears on it.**

Today, a wintun VPN holding the default route **always** fails detection, so Hole
**always refuses** and leaves the machine exactly as it found it. After this change
detection succeeds whenever that VPN's route has a real next hop, and Hole
**proceeds** — installing a bypass route *through* the other tunnel and, at
`proxy_manager.rs:1393-1394`, capturing and rewriting resolvers on **the other VPN's
adapter**, later restoring a stale copy of them.

Rule #0 is comparative — *do not make it worse than if the user hadn't installed the
VPN at all*. This fails that test in a specific way: the DNS damage lands on another
product's configuration, **persists outside Hole, and survives uninstalling Hole**.

Live options:

- **(a) Ship the widening** — what this PR currently does. No extra work. Some users
  get a working nested tunnel; others get a broken one plus a mangled third-party DNS
  config. Untested — nobody has a two-VPN box.
- **(c) Proceed with routes, skip the third-party DNS capture**, disclose degraded DNS.
  About half a task. Ships a partially-configured tunnel, but the damage stays inside Hole.
- **Refuse** — keep today's behaviour for this cohort, with the new message.

**(b) "classify the upstream as a VPN" is not on the table** — it needs the
`IfType`/adapter-name heuristic this codebase forbids, and it would refuse users whose
only Internet path is a corporate always-on VPN.

Full coexistence (VPN-over-VPN) is an epic, not a variant of this PR: interface-scoped
bypass routes (`routing.rs`, contended by #832), route metrics, a `NotifyRouteChange2`
watcher, permitting a third party's adapter and daemon **inside the lockdown kill
switch**, the DNS problem above, and crash-recovery replay.

## What was wrong

`default_net::get_default_interface()` never read the routing table. It UDP-`connect()`ed
to `1.1.1.1:80` for the OS-chosen source address, then scanned `GetAdaptersAddresses` for
an adapter carrying it — **silently skipping every adapter whose `IfType` was absent from
its own hard-coded allowlist** (`default-net-0.22.0/src/interface/windows.rs:86-92`,
`types.rs:73-100`). Wintun sets `IfType = IF_TYPE_PROP_VIRTUAL` (53)
(`WireGuard/wintun` `driver/wintun.c:1122`), so any WireGuard/wintun/Tailscale adapter —
and Hole's own `hole-tun` — was invisible, and the scan returned the bare string
`"Default Interface not found"`, which rode all the way to a toast unaltered.

## What changed

- **Windows detection asks the OS.** `GetBestRoute2` performs the selection; no adapter
  class can be filtered out, and no socket is opened — so it is also unaffected by the
  fail-closed WFP cover that is already engaged by the time the bridge asks.
- **Typed, PII-free failures.** `GatewayError`'s `Display` is the finished user sentence
  and nothing else; its `Debug` carries the adapter, and the bridge logs `?err`. Three of
  the four sentences tell the user to read `bridge.log` — carrying the detail in the error
  rather than in a `warn!` someone must remember means that promise cannot be silently
  emptied.
- **Threaded through the error types.** `RoutingError::Gateway(GatewayError)` and
  `ProxyError::Gateway(GatewayError)`, both `#[error(transparent)]`. **The IPC wire is
  unchanged** — `StartError::Failed { message }` is still built from `e.to_string()`.
  This removes the *middle* prefix only; the toast still reads `Bridge error: …` because
  `tray.rs:85` wraps every `StartError::Failed`. A raw-render path is a follow-up.
- **Classification is structural** — no route, unspecified next hop, unnamed interface.
  Nothing inspects adapter type or name.

### Copy

```
No default network route was found. Hole needs an active Internet connection before it can build the tunnel.

Your default network route has no gateway Hole can route around, so the tunnel cannot be built. This happens when another VPN is handling your traffic, and on point-to-point links such as some mobile and PPP connections. See bridge.log for the adapter involved.

Could not read the system routing table. See bridge.log for details.

The upstream network adapter could not be identified. See bridge.log for details.
```

The second names two causes and picks neither: an on-link default route is equally the
signature of a point-to-point physical link (cellular/WWAN, PPPoE), and asserting "a VPN"
would be confidently wrong for a mobile user. Same discipline as `ProxyError::TunnelSilent`.

**Not a regression for that cohort:** an on-link default route fails today too, via
`"default interface has no gateway"`.

## Tests

- `gateway_global_net_state_best_route_sees_a_wintun_adapter` (privileged `tun` lane) —
  creates a **real wintun adapter** and asserts the lookup names it. This is the capability
  `default-net` lacked. It never touches the default route; the on-link subnet route Windows
  creates is enough. Bring-up rendezvous is `NotifyUnicastIpAddressChange` on a terminal DAD
  state — no sleep, no poll, no timeout — and every terminal state is handled so the wait
  cannot hang. RAII guard removes the adapter on panic.
- `nextest_group_filter_covers_every_serialized_net_test` (unprivileged, every push) — scans
  the workspace for `*global_net_state*` tests and fails if `.config/nextest.toml`'s filter
  would not pick one up. The group matches by name substring, so a forgotten term silently
  drops a test from its serial group; this makes that impossible to miss, generically enough
  to catch the next one too.
- `best_route_agrees_with_find_netroute` — real-OS agreement at both a routable address and
  `0.0.0.0` (the value production queries), oracle parsed as JSON.
- `interface_alias_matches_get_netadapter_name` — the alias changes provenance here and
  drives route install, DNS capture, and crash-recovery replay.
- `classify_hop_*` — every refusal branch, both address families, plus that the refusal
  preserves the adapter its own copy promises.
- `map_query_error_*` — reachability vs query-failure, so "no route" never renders as
  "could not read the routing table".
- `gateway_failure_message_reaches_start_error_verbatim` / `..._detail_survives_to_the_bridge`.

## Not verified

- **The field scenario end to end** — needs a second VPN *product* holding the default route.
- **The privileged test has not run locally** (this box is unelevated and `wintun.dll` is not
  staged). Its group membership and `tun`-lane gating were verified via
  `cargo nextest show-config test-groups`; CI's `tun` lane is the authority for the test itself.
- **A real on-link default route** — proven by unit tests over fabricated hops, never on a
  cellular/PPPoE host.
- **`Find-NetRoute`'s independence** — it wraps the same OS lookup, so it proves the plumbing,
  not the selection policy.

## Scope deliberately excluded

macOS keeps `default-net` (its latent interface/gateway mismatch is unreported and separate);
`probe_ipv6` is untouched (#835); destination-scoped `upstream_route(dest)` and
`handle_diagnostics` are #834; `test_support/net_discovery.rs` is #833.
No file contended by #832 was modified — the privileged test lives in its own binary
specifically to avoid touching `routing/failclosed/lockdown_privileged_tests.rs`.
