### PR TITLE
fix(bridge): always offer an escape from a stranded fail-closed cover

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,9 +25,8 @@ nextest-version = "0.9.130"
 #   - `failclosed_permits_` (transient block-until-connected cover real engage):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #   - `release_all_` substring (privileged AND unprivileged — the unprivileged
-#     macos_tests/windows_tests cases join for free since a name-based filter
-#     that silently misses a privileged test is the failure this comment
-#     exists to prevent):
+#     macos_tests/windows_tests cases join for free; a name-based filter must
+#     not silently miss a privileged test):
 #     crates/tun-engine/src/routing/failclosed/release_privileged_tests.rs
 #     crates/tun-engine/src/routing/failclosed/macos_tests.rs
 #     crates/tun-engine/src/routing/failclosed/windows_tests.rs

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,13 @@ nextest-version = "0.9.130"
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
 #   - `failclosed_permits_` (transient block-until-connected cover real engage):
 #     crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+#   - `release_all_` substring (privileged AND unprivileged — the unprivileged
+#     macos_tests/windows_tests cases join for free since a name-based filter
+#     that silently misses a privileged test is the failure this comment
+#     exists to prevent):
+#     crates/tun-engine/src/routing/failclosed/release_privileged_tests.rs
+#     crates/tun-engine/src/routing/failclosed/macos_tests.rs
+#     crates/tun-engine/src/routing/failclosed/windows_tests.rs
 #   - `cutover_global_net_state_` prefix:
 #     crates/bridge/tests/cutover_privileged.rs (real cutover swap + SCM restart)
 #     crates/bridge/tests/cutover_leak_privileged.rs (fail-open + both-covers)
@@ -36,5 +43,5 @@ nextest-version = "0.9.130"
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/cutover_global_net_state_/)'
+filter = 'test(/_full_tunnel_roundtrip$/) + test(/windows_lockdown_permits_server_ip_/) + test(/macos_lockdown_permits_server_ip_/) + test(/failclosed_permits_/) + test(/release_all_/) + test(/cutover_global_net_state_/)'
 test-group = 'global-net-state'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,10 @@ before editing; the sections linked below are the authoritative source.
   (auto-connect) start whose lockdown intent is OFF; a lockdown-on covered
   start uses the standing cover instead and releases any held transient one.
   Both are persistent WFP filters (Win) / self-contained pf ruleset (mac), swept
-  by `recover_routes` on next start. →
+  by `recover_routes` on next start. The escape from a stranded cover
+  (`failclosed::release_all`) is unconditional and knows nothing about cover
+  state; its only condition is whether a session is running, and turning the
+  kill switch off takes the same path. →
   [CONTRIBUTING.md#fail-closed-cover](CONTRIBUTING.md#fail-closed-cover)
 - **Logging & plugin diagnostics.** Log destinations, the WebView2/console-relay
   tee, `HOLE_BRIDGE_LOG` directives, and the plugin tap. →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -656,6 +656,15 @@ Disclosed residuals:
    `decide_cover_recovery`, so widening it changes Adopt/Sweep/Noop at
    unattended startup — the recovery decision, which belongs with the
    ownership work, not here.
+1. On macOS, `release_all` treats a MISSING (not merely unreadable) state
+   file as "no cover of this kind" — `StateFile::Absent`, indistinguishable
+   from "never engaged." pf has no query for "who is holding this ruleset,"
+   so if a cover's state file is lost while the cover is still genuinely live
+   in pf (e.g. an external wipe of `state_dir`), `release_all` reports `Ok`
+   without touching pf and the host stays blocked. Closing this gap would
+   mean probing the live pf ruleset for Hole's own signature independent of
+   the state file — the cover-state probe this stage's constraints defer to
+   the ownership work.
 
 ### Update cutover
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -611,6 +611,52 @@ FIRST and flips the intent off only on confirmed success, returning a non-zero
 exit otherwise (e.g. run unprivileged). A swallowed failure would leave the
 cover engaged — egress still blocked — while the intent read "off".
 
+#### The unconditional escape from a stranded cover
+
+An unclean exit with the kill switch on can leave the host fail-closed with no
+bridge running to release it. `failclosed::release_all` is the unconditional
+clear: it clears both cover kinds (the standing lockdown cover and the
+transient block-until-connected cover) without ever asking whether either is
+present, never short-circuits (every clear is attempted before any failure is
+examined), never reports success over a host it left closed, and never erases
+a cover's state file after a restore that did not confirm — a corrupt or
+version-skewed file is treated as a cover to clear, not as absence.
+`ProxyManager::turn_lockdown_off` wraps it with the feature's only condition —
+whether a session is running — and is called by both the tray's Unblock item
+and the Lockdown-off toggle, so turning the kill switch off now releases
+immediately rather than waiting for the next bridge start.
+
+`POST /v1/unblock` and `hole bridge unlock` are two doors with deliberately
+different scopes. The transient cover's authority inside a live bridge is the
+in-process `ProxyManager::blocked` guard: `start_cancellable` reads
+`self.blocked.is_some()` as proof the host is covered, skipping re-engagement
+on a covered retry and suppressing the censorship self-test on that basis. An
+out-of-process command that deleted the transient filters would leave that
+guard claiming a cover that no longer exists, and the next retry would run
+uncovered while believing itself protected — so `cutover::unlock` keeps
+clearing only the standing cover. The transient cover therefore has exactly
+two escapes, both in-process: the tray's Go Offline action while the bridge
+holds it, and `recover_routes`' unconditional sweep at the next bridge start
+when it does not.
+
+Disclosed residuals:
+
+1. The `Lockdown: On (warning: not engaged)` tray label can still be wrong in
+   this window — it derives from the running session, not an OS probe of the
+   cover.
+1. On macOS a state file that cannot be read costs the host its captured
+   pre-cover pf rules (the release falls back to the default ruleset) and
+   leaks a pf enable refcount until reboot.
+1. `lockdown_state::load_enabled` reads a corrupt or unreadable
+   `bridge-lockdown.json` as **off**, which hides the tray's Unblock item;
+   `hole bridge unlock` still works there because it never reads the intent to
+   decide.
+1. `failclosed::lockdown_cover_present` still infers presence from a file on
+   macOS and returns an unconditional `true` on Windows. It feeds
+   `decide_cover_recovery`, so widening it changes Adopt/Sweep/Noop at
+   unattended startup — the recovery decision, which belongs with the
+   ownership work, not here.
+
 ### Update cutover
 
 `POST /v1/update-apply` ([`cutover/apply.rs`](crates/bridge/src/cutover/apply.rs))

--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ app is notarized.
 
 The GUI is the primary interface; these CLI commands are also available:
 
-| Command                              | Description                                      |
-| ------------------------------------ | ------------------------------------------------ |
-| `hole [--no-show-dashboard]`         | Launch the GUI (default); opens the dashboard    |
-| `hole version`                       | Print version information                        |
-| `hole upgrade`                       | Check for updates and install the latest version |
-| `hole path add` / `hole path remove` | Add / remove `hole` from the system PATH         |
+| Command                              | Description                                                                                         |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `hole [--no-show-dashboard]`         | Launch the GUI (default); opens the dashboard                                                       |
+| `hole version`                       | Print version information                                                                           |
+| `hole upgrade`                       | Check for updates and install the latest version                                                    |
+| `hole path add` / `hole path remove` | Add / remove `hole` from the system PATH                                                            |
+| `hole bridge unlock`                 | Turn off the kill switch and clear the block it left behind (run as administrator; `sudo` on macOS) |
 
 ## Distributions
 

--- a/crates/bridge/src/foreground_tests.rs
+++ b/crates/bridge/src/foreground_tests.rs
@@ -146,6 +146,9 @@ impl Routing for StubRouting {
     fn install_lockdown(&self, _: IpAddr, _: &str, _: &[PathBuf]) -> Result<StubCover, RoutingError> {
         Ok(StubCover)
     }
+    fn release_all_covers(&self) -> Result<(), RoutingError> {
+        Ok(())
+    }
 }
 
 struct StubRoutes {

--- a/crates/bridge/src/ipc.rs
+++ b/crates/bridge/src/ipc.rs
@@ -3,7 +3,7 @@
 use tun_engine::routing::Routing;
 
 use crate::proxy::{Proxy, ProxyError};
-use crate::proxy_manager::{ProxyManager, ProxyState};
+use crate::proxy_manager::{LockdownOffOutcome, ProxyManager, ProxyState};
 use crate::server_test::{run_server_test, TestConfig};
 use crate::socket::LocalListener;
 use axum::extract::State;
@@ -13,7 +13,7 @@ use hole_common::protocol::{
     DiagnosticsResponse, EmptyResponse, ErrorResponse, LockdownRequest, MetricsResponse, ProxyConfig, StartError,
     StatusResponse, TestServerRequest, TestServerResponse, UpdateApplyRequest, VersionResponse, ROUTE_CANCEL,
     ROUTE_DIAGNOSTICS, ROUTE_LOCKDOWN, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP,
-    ROUTE_TEST_SERVER, ROUTE_UPDATE_APPLY, ROUTE_VERSION,
+    ROUTE_TEST_SERVER, ROUTE_UNBLOCK, ROUTE_UPDATE_APPLY, ROUTE_VERSION,
 };
 use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
@@ -259,6 +259,7 @@ fn build_router<P: Proxy + 'static, R: Routing + 'static>(state: Arc<IpcState<P,
         .route(ROUTE_TEST_SERVER, axum::routing::post(handle_test_server::<P, R>))
         .route(ROUTE_VERSION, axum::routing::get(handle_version::<P, R>))
         .route(ROUTE_LOCKDOWN, axum::routing::post(handle_lockdown::<P, R>))
+        .route(ROUTE_UNBLOCK, axum::routing::post(handle_unblock::<P, R>))
         .route(ROUTE_UPDATE_APPLY, axum::routing::post(handle_update_apply::<P, R>))
         .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024))
         .layer(axum::middleware::map_response(
@@ -425,16 +426,40 @@ async fn handle_cancel<P: Proxy + 'static, R: Routing + 'static>(
 
 /// Set the standing kill switch intent (last-writer-wins absolute set). Any
 /// authorized caller may toggle it. The bridge is the authority; the GUI only
-/// sends intent. The intent takes effect on the next start/stop — this handler
-/// does NOT engage/disengage a live cover.
+/// sends intent.
+///
+/// Turning the intent OFF reroutes through [`ProxyManager::turn_lockdown_off`]
+/// — the same unconditional release `POST /v1/unblock` performs — so the
+/// effect is immediate rather than deferred to the next start; both outcomes
+/// it can return mean the intent is now off, so both map to 200. This is a
+/// branch on the REQUEST's own payload (`enabled`), not on inspected proxy
+/// state — the `running` condition stays exactly where `turn_lockdown_off`
+/// put it. Turning the intent ON is unchanged: it only persists.
 async fn handle_lockdown<P: Proxy + 'static, R: Routing + 'static>(
     State(state): State<Arc<IpcState<P, R>>>,
     Json(req): Json<LockdownRequest>,
 ) -> Result<Json<EmptyResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let pm = state.proxy.lock().await;
-    match pm.set_lockdown_intent(req.enabled) {
+    let mut pm = state.proxy.lock().await;
+    if !req.enabled {
+        return match pm.turn_lockdown_off() {
+            Ok(_) => {
+                info!("lockdown intent set to off; released any cover no running session owns");
+                Ok(Json(EmptyResponse {}))
+            }
+            Err(e) => {
+                error!(error = %e, "failed to turn the kill switch off");
+                Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        message: unblock_error_message(&e),
+                    }),
+                ))
+            }
+        };
+    }
+    match pm.set_lockdown_intent(true) {
         Ok(()) => {
-            info!(enabled = req.enabled, "lockdown intent set");
+            info!(enabled = true, "lockdown intent set");
             Ok(Json(EmptyResponse {}))
         }
         Err(e) => {
@@ -444,6 +469,58 @@ async fn handle_lockdown<P: Proxy + 'static, R: Routing + 'static>(
                 Json(ErrorResponse { message: e.to_string() }),
             ))
         }
+    }
+}
+
+/// The tray's escape from a fail-closed cover stranded by an unclean exit:
+/// unconditionally clear every cover Hole can install, then turn the kill
+/// switch off. `turn_lockdown_off`'s one condition — whether a session is
+/// running — maps to 409 (the intent is still off; the caller should
+/// disconnect to release the session's own cover); any other failure is 500.
+/// The OS calls run inline under the lock, exactly as `handle_stop`'s cover
+/// teardown already does — a one-shot user action, not a status poll.
+async fn handle_unblock<P: Proxy + 'static, R: Routing + 'static>(
+    State(state): State<Arc<IpcState<P, R>>>,
+) -> Result<Json<EmptyResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let mut pm = state.proxy.lock().await;
+    match pm.turn_lockdown_off() {
+        Ok(LockdownOffOutcome::Cleared) => {
+            info!("unblock: every cover cleared, kill switch off");
+            Ok(Json(EmptyResponse {}))
+        }
+        Ok(LockdownOffOutcome::SessionRunning) => {
+            info!("unblock: a session is running, so there was no unowned cover to clear");
+            Err((
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    message: "a session is running; disconnect to release its own cover".into(),
+                }),
+            ))
+        }
+        Err(e) => {
+            error!(error = %e, "unblock failed");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    message: unblock_error_message(&e),
+                }),
+            ))
+        }
+    }
+}
+
+/// PII-free 500 body for a failed `turn_lockdown_off`. Never formats the
+/// underlying error verbatim — a `RoutingError::RouteSetup` converted into
+/// `ProxyError` can embed a state-file path, and an IPC message reaches a GUI
+/// toast verbatim. `LockdownIntentNotPersisted`'s `Display` is already a
+/// fixed, PII-free sentence (see its doc), so that one case is reused as-is;
+/// every other failure means the release itself did not confirm, which gets
+/// its own fixed sentence.
+fn unblock_error_message(e: &ProxyError) -> String {
+    if matches!(e, ProxyError::LockdownIntentNotPersisted) {
+        e.to_string()
+    } else {
+        "the network could not be fully unblocked".into()
     }
 }
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -11,7 +11,7 @@ use hyper_util::rt::TokioIo;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tun_engine::gateway::GatewayInfo;
@@ -143,6 +143,13 @@ impl Drop for MockRunning {
 struct MockRouting {
     state_dir: PathBuf,
     fail_gateway: AtomicBool,
+    /// Number of `release_all_covers` calls, so a test can assert the
+    /// unconditional escape fired exactly once (or not at all). `Arc`-shared
+    /// (mirroring `MockProxy::traffic`) so a test can clone it out BEFORE
+    /// `routing` moves into the `ProxyManager`.
+    release_all_calls: Arc<AtomicU32>,
+    /// `release_all_covers` returns `RoutingError::RouteSetup` when set.
+    fail_release: Arc<AtomicBool>,
 }
 
 impl MockRouting {
@@ -150,6 +157,8 @@ impl MockRouting {
         Self {
             state_dir,
             fail_gateway: AtomicBool::new(false),
+            release_all_calls: Arc::new(AtomicU32::new(0)),
+            fail_release: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -157,6 +166,8 @@ impl MockRouting {
         Self {
             state_dir,
             fail_gateway: AtomicBool::new(true),
+            release_all_calls: Arc::new(AtomicU32::new(0)),
+            fail_release: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -216,6 +227,14 @@ impl Routing for MockRouting {
         _app_ids: &[PathBuf],
     ) -> Result<MockCover, RoutingError> {
         Ok(MockCover)
+    }
+
+    fn release_all_covers(&self) -> Result<(), RoutingError> {
+        self.release_all_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_release.load(Ordering::SeqCst) {
+            return Err(RoutingError::RouteSetup("mock release_all_covers failure".into()));
+        }
+        Ok(())
     }
 }
 

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tun_engine::gateway::GatewayInfo;
+use tun_engine::routing::failclosed::lockdown_state;
 use tun_engine::routing::{state as route_state, Routing};
 use tun_engine::RoutingError;
 
@@ -282,6 +283,25 @@ fn mock_proxy_with_state_dir() -> Arc<Mutex<ProxyManager<MockProxy, MockRouting>
     Arc::new(Mutex::new(pm))
 }
 
+/// `mock_proxy_with_state_dir` variant that also hands back the mock
+/// routing's `release_all_calls` / `fail_release` handles (cloned out BEFORE
+/// `routing` moves into the manager, mirroring `mock_proxy_with_traffic`), so
+/// a test can assert the unconditional escape fired and drive a failure.
+#[allow(clippy::type_complexity)]
+fn mock_proxy_with_release_state() -> (
+    Arc<Mutex<ProxyManager<MockProxy, MockRouting>>>,
+    Arc<AtomicU32>,
+    Arc<AtomicBool>,
+    PathBuf,
+) {
+    let state_dir = tempfile::tempdir().unwrap().keep();
+    let routing = MockRouting::new(state_dir.clone());
+    let release_all_calls = Arc::clone(&routing.release_all_calls);
+    let fail_release = Arc::clone(&routing.fail_release);
+    let pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(state_dir.clone());
+    (Arc::new(Mutex::new(pm)), release_all_calls, fail_release, state_dir)
+}
+
 /// `mock_proxy` variant that also hands back the mock's traffic counters
 /// so tests can simulate tunnel bytes.
 fn mock_proxy_with_traffic() -> (Arc<Mutex<ProxyManager<MockProxy, MockRouting>>>, Arc<MockTraffic>) {
@@ -461,6 +481,16 @@ async fn post_lockdown(client: &mut TestClient, enabled: bool) -> http::Response
         .header("host", "localhost")
         .header("content-type", "application/json")
         .body(Full::new(Bytes::from(body)))
+        .unwrap();
+    client.send(req).await
+}
+
+async fn post_unblock(client: &mut TestClient) -> http::Response<hyper::body::Incoming> {
+    let req = http::Request::builder()
+        .method("POST")
+        .uri(ROUTE_UNBLOCK)
+        .header("host", "localhost")
+        .body(Full::new(Bytes::new()))
         .unwrap();
     client.send(req).await
 }
@@ -709,6 +739,175 @@ fn lockdown_post_errors_without_state_dir() {
             "lockdown POST without a state_dir must error, not silently succeed"
         );
         let _ = resp.into_body().collect().await;
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+// POST /v1/unblock ====================================================================================================
+
+async fn parse_error_body(resp: http::Response<hyper::body::Incoming>) -> hole_common::protocol::ErrorResponse {
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body).unwrap()
+}
+
+#[skuld::test]
+fn unblock_clears_covers_and_returns_ok() {
+    rt().block_on(async {
+        let path = test_socket_path("unblock-ok");
+        let (proxy, release_all_calls, _fail_release, _dir) = mock_proxy_with_release_state();
+        let server = IpcServer::bind(&path, proxy, "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_unblock(&mut client).await;
+        assert_eq!(resp.status(), 200, "unblock on a clean, idle manager must 200");
+        let _ = resp.into_body().collect().await;
+        assert_eq!(release_all_calls.load(Ordering::SeqCst), 1);
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn unblock_while_running_returns_conflict() {
+    rt().block_on(async {
+        let path = test_socket_path("unblock-running");
+        let (proxy, release_all_calls, _fail_release, dir) = mock_proxy_with_release_state();
+        let server = IpcServer::bind(&path, proxy, "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let start_resp = post_start(&mut client, &sample_config(), "attempt-1").await;
+        assert_eq!(consume(start_resp).await, 200, "setup: the session must start");
+
+        let resp = post_unblock(&mut client).await;
+        assert_eq!(
+            resp.status(),
+            409,
+            "a running session must be reported, not silently overridden"
+        );
+        let _ = resp.into_body().collect().await;
+        assert_eq!(
+            release_all_calls.load(Ordering::SeqCst),
+            0,
+            "the escape must not fire under a live session"
+        );
+        assert!(
+            !lockdown_state::load_enabled(&dir),
+            "the intent must still be recorded as off, even though there was no cover to clear"
+        );
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn unblock_reports_a_failed_release() {
+    rt().block_on(async {
+        let path = test_socket_path("unblock-fail");
+        let (proxy, _release_all_calls, fail_release, _dir) = mock_proxy_with_release_state();
+        fail_release.store(true, Ordering::SeqCst);
+        let server = IpcServer::bind(&path, proxy, "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_unblock(&mut client).await;
+        assert_eq!(
+            resp.status(),
+            500,
+            "a failed release must be reported, not silently swallowed as 200"
+        );
+        let _ = resp.into_body().collect().await;
+
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn unblock_error_bodies_carry_no_filesystem_path() {
+    fn assert_no_path(message: &str) {
+        assert!(
+            !message.contains('\\') && !message.contains('/'),
+            "error body reaching a GUI toast must carry no filesystem path: {message:?}"
+        );
+    }
+
+    rt().block_on(async {
+        // The 409 (session running) case.
+        let path = test_socket_path("unblock-nopath-409");
+        let (proxy, _calls, _fail, _dir) = mock_proxy_with_release_state();
+        let server = IpcServer::bind(&path, proxy, "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+        let mut client = TestClient::connect(&path).await;
+        assert_eq!(
+            consume(post_start(&mut client, &sample_config(), "a1").await).await,
+            200
+        );
+        let resp = post_unblock(&mut client).await;
+        assert_eq!(resp.status(), 409);
+        assert_no_path(&parse_error_body(resp).await.message);
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+
+        // The 500 (failed release) case.
+        let path = test_socket_path("unblock-nopath-500");
+        let (proxy, _calls, fail_release, _dir) = mock_proxy_with_release_state();
+        fail_release.store(true, Ordering::SeqCst);
+        let server = IpcServer::bind(&path, proxy, "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_unblock(&mut client).await;
+        assert_eq!(resp.status(), 500);
+        assert_no_path(&parse_error_body(resp).await.message);
+        drop(client);
+        handle.abort();
+        let _ = handle.await;
+    });
+}
+
+#[skuld::test]
+fn lockdown_off_releases_covers_through_the_same_path() {
+    rt().block_on(async {
+        let path = test_socket_path("lockdown-off-releases");
+        let (proxy, release_all_calls, _fail_release, _dir) = mock_proxy_with_release_state();
+        let server = IpcServer::bind(&path, proxy, "test").unwrap();
+        let handle = tokio::spawn(async move {
+            server.run_once().await.unwrap();
+        });
+
+        let mut client = TestClient::connect(&path).await;
+        let resp = post_lockdown(&mut client, false).await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "turning the toggle off with nothing running must 200"
+        );
+        let _ = resp.into_body().collect().await;
+        assert_eq!(
+            release_all_calls.load(Ordering::SeqCst),
+            1,
+            "the toggle must release through the SAME path unblock uses, not just persist the intent"
+        );
 
         drop(client);
         handle.abort();

--- a/crates/bridge/src/ipc_tests.rs
+++ b/crates/bridge/src/ipc_tests.rs
@@ -780,6 +780,12 @@ fn unblock_while_running_returns_conflict() {
     rt().block_on(async {
         let path = test_socket_path("unblock-running");
         let (proxy, release_all_calls, _fail_release, dir) = mock_proxy_with_release_state();
+        // Seed the intent ON so the post-unblock "still off" assertion below
+        // actually exercises the persist — a fresh tempdir with no
+        // bridge-lockdown.json already reads `false`, which would let that
+        // assertion pass vacuously regardless of whether the handler wrote
+        // anything.
+        lockdown_state::set_enabled(&dir, true, None).unwrap();
         let server = IpcServer::bind(&path, proxy, "test").unwrap();
         let handle = tokio::spawn(async move {
             server.run_once().await.unwrap();

--- a/crates/bridge/src/proxy/config.rs
+++ b/crates/bridge/src/proxy/config.rs
@@ -129,6 +129,11 @@ pub enum ProxyError {
     /// ([`hole_common::protocol::NETWORK_BLOCKED_MESSAGE`]).
     #[error("{}", hole_common::protocol::NETWORK_BLOCKED_MESSAGE)]
     NetworkBlocked,
+    /// `turn_lockdown_off` cleared every unowned cover but could not persist
+    /// the intent afterward. PII-free by construction (no path, no detail) —
+    /// an IPC message reaches a GUI toast verbatim.
+    #[error("the network was unblocked, but the kill-switch setting could not be saved")]
+    LockdownIntentNotPersisted,
 }
 
 impl From<&ProxyError> for hole_common::protocol::StartError {
@@ -158,7 +163,8 @@ impl From<&ProxyError> for hole_common::protocol::StartError {
             | ProxyError::InvalidListenerPort { .. }
             | ProxyError::ForwarderSelfTestFailed { .. }
             | ProxyError::TunnelSilent { .. }
-            | ProxyError::NoTunnelConnection { .. } => StartError::Failed { message: e.to_string() },
+            | ProxyError::NoTunnelConnection { .. }
+            | ProxyError::LockdownIntentNotPersisted => StartError::Failed { message: e.to_string() },
         }
     }
 }

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -519,8 +519,15 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         // off" can mean while connected (matches the toggle's existing
         // mid-session behavior).
         if self.running.is_some() {
-            self.set_lockdown_intent(false)?;
-            return Ok(LockdownOffOutcome::SessionRunning);
+            // Mapped to the same `LockdownIntentNotPersisted` a failed persist
+            // in step 4 uses (not propagated raw via `?`): both name the one
+            // fact the caller can act on — the setting did not save — rather
+            // than an opaque `ProxyError::Runtime` the IPC layer's generic
+            // 500 path can't distinguish from a release failure.
+            return match self.set_lockdown_intent(false) {
+                Ok(()) => Ok(LockdownOffOutcome::SessionRunning),
+                Err(_) => Err(ProxyError::LockdownIntentNotPersisted),
+            };
         }
 
         // 2. Drop any held transient guard's in-process authority first. Not

--- a/crates/bridge/src/proxy_manager.rs
+++ b/crates/bridge/src/proxy_manager.rs
@@ -264,6 +264,16 @@ struct BlockedStart<C> {
     resolver_permit: Option<IpAddr>,
 }
 
+/// Result of [`ProxyManager::turn_lockdown_off`]. `Cleared` means every
+/// unowned cover Hole can install has been released and the intent is off;
+/// `SessionRunning` means a live session owns its own cover instead — the
+/// intent was still recorded, but there was no unowned cover here to clear.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockdownOffOutcome {
+    Cleared,
+    SessionRunning,
+}
+
 impl<P: Proxy, R: Routing> ProxyManager<P, R, SystemDns> {
     pub fn new(proxy: P, routing: R) -> Self {
         Self::new_with_dns(proxy, routing, SystemDns::default())
@@ -488,6 +498,49 @@ impl<P: Proxy, R: Routing, D: Dns> ProxyManager<P, R, D> {
         })?;
         lockdown_state::set_enabled(dir, enabled, self.state_owner)
             .map_err(|e| ProxyError::Runtime(std::io::Error::other(format!("lockdown persist: {e}"))))
+    }
+
+    /// Turn the kill-switch intent off, releasing any cover no running
+    /// session owns. This is the feature's only stateful decision: both the
+    /// tray's Unblock item and the Lockdown-off toggle call it and map the
+    /// returned outcome to their own reply; neither inspects `running`
+    /// itself — `self.running.is_some()` is the ONLY condition anywhere in
+    /// this path.
+    ///
+    /// The step-3-before-step-4 ordering (release, THEN persist) is
+    /// load-bearing: the tray offers this escape while the intent is on, so
+    /// flipping the intent off after a FAILED release would delete the
+    /// user's only retry affordance while the host is still held closed. The
+    /// intent moves only after the clear confirms.
+    pub fn turn_lockdown_off(&mut self) -> Result<LockdownOffOutcome, ProxyError> {
+        // 1. The only condition. A running session owns its own standing
+        // cover and `stop_with` releases it — there is no unowned cover to
+        // clear here, so recording the intent is the whole of what "turn it
+        // off" can mean while connected (matches the toggle's existing
+        // mid-session behavior).
+        if self.running.is_some() {
+            self.set_lockdown_intent(false)?;
+            return Ok(LockdownOffOutcome::SessionRunning);
+        }
+
+        // 2. Drop any held transient guard's in-process authority first. Not
+        // a condition — `take` on `None` is a no-op — it exists so no live
+        // guard outlives the OS objects `release_all_covers` is about to
+        // delete out from under it.
+        self.blocked.take();
+
+        // 3. The unconditional clear. On error, return WITHOUT touching the
+        // intent — see the ordering note above.
+        self.routing.release_all_covers()?;
+
+        // 4. Only now move the intent. The covers are already gone and the
+        // host is open; a persist failure here means only the SETTING did
+        // not save, which the caller must be able to say distinctly from a
+        // failed release.
+        match self.set_lockdown_intent(false) {
+            Ok(()) => Ok(LockdownOffOutcome::Cleared),
+            Err(_) => Err(ProxyError::LockdownIntentNotPersisted),
+        }
     }
 
     /// Non-cancellable convenience wrapper around
@@ -1677,6 +1730,10 @@ fn lockdown_app_ids(config: &ProxyConfig) -> Vec<std::path::PathBuf> {
 #[cfg(test)]
 #[path = "proxy_manager_tests.rs"]
 mod proxy_manager_tests;
+
+#[cfg(test)]
+#[path = "proxy_manager_release_tests.rs"]
+mod proxy_manager_release_tests;
 
 // E2E test platform policy:
 //

--- a/crates/bridge/src/proxy_manager_release_tests.rs
+++ b/crates/bridge/src/proxy_manager_release_tests.rs
@@ -1,0 +1,179 @@
+//! Tests for `ProxyManager::turn_lockdown_off` — the whole feature's only
+//! stateful decision (the single `running` condition, the ordering that keeps
+//! the tray's escape available across a failed release, and the drop of a
+//! held transient guard before the OS-level clear). Reuses the mocks and
+//! constructors from the sibling `proxy_manager_tests` module rather than
+//! redefining them.
+
+// `CancellationToken::new` is the test harness's root signal here, matching
+// the sanctioned-test-file exception in `proxy_manager_tests.rs` (clippy.toml's
+// "Bridge cancellation contract" carve-out).
+#![allow(clippy::disallowed_methods)]
+
+use super::proxy_manager_tests::{rt, test_config, MockProxy, MockRouting, MockRoutingState};
+use super::*;
+use crate::proxy::ProxyError;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tun_engine::routing::failclosed::lockdown_state;
+
+/// A covered start that fails deterministically (a closed loopback port with
+/// the DNS forwarder self-test gate enabled, which `MockProxy` cannot
+/// satisfy), leaving the transient cover held. Mirrors
+/// `proxy_manager_tests::self_test::covered_gate_setup`.
+async fn covered_start_holding_the_cover(
+    dir: &tempfile::TempDir,
+) -> (ProxyManager<MockProxy, MockRouting>, Arc<MockRoutingState>) {
+    let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let closed = probe.local_addr().unwrap();
+    drop(probe);
+
+    let routing = MockRouting::new(dir.path().to_path_buf());
+    let st = routing.state();
+    lockdown_state::set_enabled(dir.path(), false, None).unwrap();
+    let mut pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(dir.path().to_path_buf());
+    let mut cfg = test_config();
+    cfg.server.server = closed.ip().to_string();
+    cfg.server.server_port = closed.port();
+    cfg.dns.enabled = true;
+    cfg.dns.servers = vec!["127.0.0.1".parse().unwrap()];
+
+    pm.start_cancellable(&cfg, true, tokio_util::sync::CancellationToken::new())
+        .await
+        .unwrap_err();
+    assert!(
+        pm.blocked_until_connected(),
+        "setup: the failed covered start must hold the cover"
+    );
+    (pm, st)
+}
+
+#[skuld::test]
+fn turn_lockdown_off_records_the_intent_without_clearing_while_a_session_runs() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        lockdown_state::set_enabled(dir.path(), true, None).unwrap();
+        let mut pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(dir.path().to_path_buf());
+        pm.start(&test_config()).await.unwrap();
+
+        let outcome = pm.turn_lockdown_off().expect("a running session must not error");
+        assert!(matches!(outcome, LockdownOffOutcome::SessionRunning));
+        assert_eq!(
+            st.release_all_calls.load(Ordering::SeqCst),
+            0,
+            "a running session owns its own cover; release_all_covers must not fire"
+        );
+        assert!(
+            !lockdown_state::load_enabled(dir.path()),
+            "the intent must still be recorded as off"
+        );
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
+fn turn_lockdown_off_clears_covers_then_turns_the_intent_off() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        lockdown_state::set_enabled(dir.path(), true, None).unwrap();
+        let mut pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(dir.path().to_path_buf());
+
+        let outcome = pm.turn_lockdown_off().expect("a clean, idle manager must not error");
+        assert!(matches!(outcome, LockdownOffOutcome::Cleared));
+        assert_eq!(st.release_all_calls.load(Ordering::SeqCst), 1);
+        assert!(!lockdown_state::load_enabled(dir.path()));
+    });
+}
+
+#[skuld::test]
+fn turn_lockdown_off_failure_leaves_the_intent_on() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        st.fail_release.store(true, Ordering::SeqCst);
+        lockdown_state::set_enabled(dir.path(), true, None).unwrap();
+        let mut pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(dir.path().to_path_buf());
+
+        let err = pm.turn_lockdown_off().expect_err("a failed release must be reported");
+        assert!(!matches!(err, ProxyError::LockdownIntentNotPersisted));
+        assert!(
+            lockdown_state::load_enabled(dir.path()),
+            "the intent must stay ON: flipping it off over a still-held cover would hide the tray escape"
+        );
+    });
+}
+
+#[skuld::test]
+fn turn_lockdown_off_reports_an_unsaved_intent_distinctly_from_a_failed_release() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        // No `.with_state_dir(..)`: `set_lockdown_intent` hits its existing
+        // no-state_dir error path even though the release itself succeeds.
+        let mut pm = ProxyManager::new(MockProxy::new(), routing);
+
+        let err = pm
+            .turn_lockdown_off()
+            .expect_err("an unpersistable intent must still be reported");
+        assert!(
+            matches!(err, ProxyError::LockdownIntentNotPersisted),
+            "must be distinguishable from a failed release: {err:?}"
+        );
+        assert_eq!(
+            st.release_all_calls.load(Ordering::SeqCst),
+            1,
+            "the release itself succeeded; only the persist failed"
+        );
+    });
+}
+
+#[skuld::test]
+fn turn_lockdown_off_drops_a_held_transient_cover() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut pm, st) = covered_start_holding_the_cover(&dir).await;
+        assert_eq!(st.cover_disengage_calls.load(Ordering::SeqCst), 0);
+
+        let outcome = pm
+            .turn_lockdown_off()
+            .expect("clearing a held transient cover must not error");
+        assert!(matches!(outcome, LockdownOffOutcome::Cleared));
+        assert_eq!(
+            st.cover_disengage_calls.load(Ordering::SeqCst),
+            1,
+            "the held guard's Drop must run before the OS-level clear"
+        );
+        assert_eq!(st.release_all_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            !pm.blocked_until_connected(),
+            "the held guard must be gone once turn_lockdown_off returns"
+        );
+    });
+}
+
+#[skuld::test]
+fn turn_lockdown_off_on_a_clean_manager_is_ok() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        lockdown_state::set_enabled(dir.path(), true, None).unwrap();
+        let mut pm = ProxyManager::new(MockProxy::new(), routing).with_state_dir(dir.path().to_path_buf());
+
+        let outcome = pm.turn_lockdown_off().expect("a clean manager must not error");
+        assert!(matches!(outcome, LockdownOffOutcome::Cleared));
+        assert_eq!(
+            st.release_all_calls.load(Ordering::SeqCst),
+            1,
+            "no presence check may skip the clear"
+        );
+        assert!(!lockdown_state::load_enabled(dir.path()));
+    });
+}

--- a/crates/bridge/src/proxy_manager_release_tests.rs
+++ b/crates/bridge/src/proxy_manager_release_tests.rs
@@ -75,6 +75,35 @@ fn turn_lockdown_off_records_the_intent_without_clearing_while_a_session_runs() 
 }
 
 #[skuld::test]
+fn turn_lockdown_off_reports_an_unsaved_intent_while_a_session_runs() {
+    rt().block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let routing = MockRouting::new(dir.path().to_path_buf());
+        let st = routing.state();
+        // No `.with_state_dir(..)`: the persist fails even though a session
+        // is running (there is no cover to clear either way).
+        let mut pm = ProxyManager::new(MockProxy::new(), routing);
+        pm.start(&test_config()).await.unwrap();
+
+        let err = pm
+            .turn_lockdown_off()
+            .expect_err("an unpersistable intent must still be reported");
+        assert!(
+            matches!(err, ProxyError::LockdownIntentNotPersisted),
+            "must be the SAME distinguishable error the Cleared branch uses, not an opaque \
+             ProxyError::Runtime the IPC layer's generic 500 path can't tell apart from a failed release: {err:?}"
+        );
+        assert_eq!(
+            st.release_all_calls.load(Ordering::SeqCst),
+            0,
+            "a running session owns its own cover; release_all_covers must not fire"
+        );
+
+        pm.stop().await.unwrap();
+    });
+}
+
+#[skuld::test]
 fn turn_lockdown_off_clears_covers_then_turns_the_intent_off() {
     rt().block_on(async {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/bridge/src/proxy_manager_tests.rs
+++ b/crates/bridge/src/proxy_manager_tests.rs
@@ -45,7 +45,7 @@ struct MockProxyState {
     bytes_out: AtomicU64,
 }
 
-struct MockProxy {
+pub(super) struct MockProxy {
     state: Arc<MockProxyState>,
     /// If Some, `start` awaits this gate before returning — used to park
     /// start mid-flight so cancellation tests can fire the cancel token
@@ -59,7 +59,7 @@ struct MockProxy {
 }
 
 impl MockProxy {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             state: Arc::new(MockProxyState::default()),
             start_gate: None,
@@ -122,7 +122,7 @@ impl Proxy for MockProxy {
     }
 }
 
-struct MockRunning {
+pub(super) struct MockRunning {
     state: Arc<MockProxyState>,
     handle: Option<JoinHandle<io::Result<()>>>,
 }
@@ -162,17 +162,22 @@ impl Drop for MockRunning {
 
 // MockRouting =========================================================================================================
 
-struct MockRoutingState {
+pub(super) struct MockRoutingState {
     install_calls: AtomicU32,
     teardown_calls: AtomicU32,
     fail_install: AtomicBool,
     fail_gateway: AtomicBool,
     cover_engage_calls: AtomicU32,
-    cover_disengage_calls: AtomicU32,
+    pub(super) cover_disengage_calls: AtomicU32,
     lockdown_engage_calls: AtomicU32,
     lockdown_disengage_calls: AtomicU32,
     fail_lockdown: AtomicBool,
     fail_cover: AtomicBool,
+    /// Number of `release_all_covers` calls, so a test can assert the
+    /// unconditional escape fired exactly once (or not at all).
+    pub(super) release_all_calls: AtomicU32,
+    /// `release_all_covers` returns `RoutingError::RouteSetup` when set.
+    pub(super) fail_release: AtomicBool,
     /// Ordered record of teardown events ("routes" / "lockdown") so a test can
     /// observe the unwind teardown sequence. Shared via the `Arc<MockRoutingState>`
     /// both `MockRoutes` and `MockCover` clone.
@@ -209,6 +214,8 @@ impl Default for MockRoutingState {
             lockdown_disengage_calls: AtomicU32::new(0),
             fail_lockdown: AtomicBool::new(false),
             fail_cover: AtomicBool::new(false),
+            release_all_calls: AtomicU32::new(0),
+            fail_release: AtomicBool::new(false),
             teardown_order: std::sync::Mutex::new(Vec::new()),
             last_install_server_ip: std::sync::Mutex::new(None),
             last_cover_server_ip: std::sync::Mutex::new(None),
@@ -218,7 +225,7 @@ impl Default for MockRoutingState {
     }
 }
 
-struct MockRouting {
+pub(super) struct MockRouting {
     state: Arc<MockRoutingState>,
     /// Directory where the crash-recovery state file is written. Each
     /// `MockRouting` owns its own `state_dir` — in production,
@@ -229,7 +236,7 @@ struct MockRouting {
 }
 
 impl MockRouting {
-    fn new(state_dir: PathBuf) -> Self {
+    pub(super) fn new(state_dir: PathBuf) -> Self {
         Self {
             state: Arc::new(MockRoutingState::default()),
             state_dir,
@@ -255,7 +262,7 @@ impl MockRouting {
         m
     }
 
-    fn state(&self) -> Arc<MockRoutingState> {
+    pub(super) fn state(&self) -> Arc<MockRoutingState> {
         Arc::clone(&self.state)
     }
 }
@@ -354,9 +361,17 @@ impl Routing for MockRouting {
             lockdown: true,
         })
     }
+
+    fn release_all_covers(&self) -> Result<(), RoutingError> {
+        self.state.release_all_calls.fetch_add(1, Ordering::SeqCst);
+        if self.state.fail_release.load(Ordering::SeqCst) {
+            return Err(RoutingError::RouteSetup("mock release_all_covers failure".into()));
+        }
+        Ok(())
+    }
 }
 
-struct MockRoutes {
+pub(super) struct MockRoutes {
     state: Arc<MockRoutingState>,
     state_dir: PathBuf,
 }
@@ -369,7 +384,7 @@ impl Drop for MockRoutes {
     }
 }
 
-struct MockCover {
+pub(super) struct MockCover {
     state: Arc<MockRoutingState>,
     /// Whether this guard holds the standing lockdown cover (vs the transient
     /// fail-closed cover) — selects which disengage counter Drop bumps, mirroring
@@ -435,7 +450,7 @@ fn mock_failing_lockdown_returns_err_without_recording() {
 
 // Helpers =============================================================================================================
 
-fn rt() -> tokio::runtime::Runtime {
+pub(super) fn rt() -> tokio::runtime::Runtime {
     tokio::runtime::Runtime::new().unwrap()
 }
 
@@ -492,7 +507,7 @@ fn new_manager_with_lockdown(
     (pm, dir)
 }
 
-fn test_config() -> ProxyConfig {
+pub(super) fn test_config() -> ProxyConfig {
     ProxyConfig {
         server: ServerEntry {
             id: "test-id".into(),

--- a/crates/bridge/src/test_support/dist_harness.rs
+++ b/crates/bridge/src/test_support/dist_harness.rs
@@ -34,7 +34,7 @@ use hole_common::protocol::{
     BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, LockdownRequest, MetricsResponse,
     StatusResponse, TestServerRequest, TestServerResponse, UpdateApplyRequest, ROUTE_CANCEL, ROUTE_DIAGNOSTICS,
     ROUTE_LOCKDOWN, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
-    ROUTE_UPDATE_APPLY,
+    ROUTE_UNBLOCK, ROUTE_UPDATE_APPLY,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -663,6 +663,16 @@ impl BridgeIpcClient {
                 let resp = self.http_post(ROUTE_LOCKDOWN, body, &[]).await?;
                 if resp.status().is_success() {
                     Ok(BridgeResponse::Ack)
+                } else {
+                    parse_bridge_error(resp).await
+                }
+            }
+            BridgeRequest::Unblock => {
+                let resp = self.http_post(ROUTE_UNBLOCK, Vec::new(), &[]).await?;
+                if resp.status().is_success() {
+                    Ok(BridgeResponse::Ack)
+                } else if resp.status() == http::StatusCode::CONFLICT {
+                    Err(HarnessError("a session is running".to_string()))
                 } else {
                     parse_bridge_error(resp).await
                 }

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -144,7 +144,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/EmptyResponse"
         "500":
-          description: Failed to persist lockdown intent
+          description: >-
+            Turning the intent on: failed to persist it. Turning the intent
+            off: either the release failed and the intent is still on, or the
+            release succeeded and only the setting could not be saved
           content:
             application/json:
               schema:

--- a/crates/common/api/openapi.yaml
+++ b/crates/common/api/openapi.yaml
@@ -125,7 +125,10 @@ paths:
       description: |
         Last-writer-wins absolute set of the bridge-owned, system-wide
         lockdown intent. Any authorized caller may toggle it freely. Returns
-        200 with EmptyResponse on success.
+        200 with EmptyResponse on success. Turning the intent OFF also
+        releases any fail-closed cover no running session owns, immediately —
+        the same unconditional release `POST /v1/unblock` performs — rather
+        than deferring that release to the next start.
       operationId: setLockdown
       requestBody:
         required: true
@@ -142,6 +145,42 @@ paths:
                 $ref: "#/components/schemas/EmptyResponse"
         "500":
           description: Failed to persist lockdown intent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/unblock:
+    post:
+      summary: Unconditionally clear every fail-closed cover no running session owns, and turn the kill switch off
+      description: |
+        Clears every fail-closed cover Hole can install (the standing
+        lockdown cover and the transient block-until-connected cover) without
+        asking whether either is present, then turns the kill-switch intent
+        off. This is the escape from a stranded cover left behind by an
+        unclean exit — it never inspects cover state, only whether a session
+        is currently running.
+      operationId: unblockNetwork
+      responses:
+        "200":
+          description: Every cover Hole can install has been cleared and the intent is off
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        "409":
+          description: >-
+            A session is running, so there was no unowned cover to clear; the
+            intent is now off and the caller should disconnect to release the
+            session's own cover
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: >-
+            Either the release failed and the host may still be held closed,
+            or the network is open but the setting could not be saved
           content:
             application/json:
               schema:

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -75,6 +75,10 @@ pub enum BridgeRequest {
     SetLockdown {
         enabled: bool,
     },
+    /// Unconditionally clear every fail-closed cover no running session owns
+    /// and turn the kill-switch intent off. Maps to `POST /v1/unblock` — the
+    /// tray's escape from a cover stranded by an unclean exit.
+    Unblock,
     /// Apply a verified update via the service-manager cutover. Maps to
     /// `POST /v1/update-apply`. `consent` is the informed-consent seam: REQUIRED
     /// true for a lockdown-off update (the standing cover holds the gap under

--- a/crates/common/src/protocol_tests.rs
+++ b/crates/common/src/protocol_tests.rs
@@ -300,6 +300,12 @@ fn route_lockdown_path_is_stable() {
 }
 
 #[skuld::test]
+fn route_unblock_matches_the_spec_path() {
+    use crate::protocol::ROUTE_UNBLOCK;
+    assert_eq!(ROUTE_UNBLOCK, "/v1/unblock");
+}
+
+#[skuld::test]
 fn status_response_lockdown_fields_default_false_for_old_clients() {
     use crate::protocol::StatusResponse;
     // An old client sends a StatusResponse JSON without the lockdown fields;

--- a/crates/hole/src/bridge_client.rs
+++ b/crates/hole/src/bridge_client.rs
@@ -5,7 +5,7 @@ use hole_common::protocol::{
     BridgeRequest, BridgeResponse, DiagnosticsResponse, ErrorResponse, LockdownRequest, MetricsResponse,
     StatusResponse, TestServerRequest, TestServerResponse, UpdateApplyRequest, ROUTE_CANCEL, ROUTE_DIAGNOSTICS,
     ROUTE_LOCKDOWN, ROUTE_METRICS, ROUTE_RELOAD, ROUTE_START, ROUTE_STATUS, ROUTE_STOP, ROUTE_TEST_SERVER,
-    ROUTE_UPDATE_APPLY,
+    ROUTE_UNBLOCK, ROUTE_UPDATE_APPLY,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
@@ -51,6 +51,12 @@ pub enum ClientError {
     /// The bridge rejected a start because another is already in flight (409).
     #[error("a start is already in progress")]
     ConcurrentStart,
+    /// `Unblock` found a session running (409): there was no unowned cover to
+    /// clear, and the intent is now off. Without this mapping a 409 becomes
+    /// an opaque `Protocol` error and the caller cannot tell "a session
+    /// started" from "the clear failed".
+    #[error("a session is running; disconnect to release its own cover")]
+    SessionRunning,
 }
 
 // Client ==============================================================================================================
@@ -244,6 +250,16 @@ impl BridgeClient {
                 let resp = self.http_post(ROUTE_LOCKDOWN, body, &[]).await?;
                 if resp.status().is_success() {
                     Ok(BridgeResponse::Ack)
+                } else {
+                    parse_generic_error(resp).await
+                }
+            }
+            BridgeRequest::Unblock => {
+                let resp = self.http_post(ROUTE_UNBLOCK, Vec::new(), &[]).await?;
+                if resp.status().is_success() {
+                    Ok(BridgeResponse::Ack)
+                } else if resp.status() == http::StatusCode::CONFLICT {
+                    Err(ClientError::SessionRunning)
                 } else {
                     parse_generic_error(resp).await
                 }

--- a/crates/hole/src/bridge_client_tests.rs
+++ b/crates/hole/src/bridge_client_tests.rs
@@ -735,6 +735,20 @@ async fn stop_against_status(
     client.send(BridgeRequest::Stop).await
 }
 
+/// Drive POST /v1/unblock against a mock — the `Unblock` arm has its own
+/// bespoke 409 mapping (`ClientError::SessionRunning`) ahead of the generic
+/// `parse_generic_error` fallback, mirroring `Start`'s 409 handling rather
+/// than `Stop`'s.
+async fn unblock_against_status(
+    path: &std::path::Path,
+    status: axum::http::StatusCode,
+    message: &'static str,
+) -> Result<BridgeResponse, ClientError> {
+    let _mock = spawn_route_error_bridge(path, hole_common::protocol::ROUTE_UNBLOCK, status, message).await;
+    let mut client = BridgeClient::connect(path).await.unwrap();
+    client.send(BridgeRequest::Unblock).await
+}
+
 #[skuld::test]
 fn forbidden_maps_to_consent_required() {
     rt().block_on(async {
@@ -842,6 +856,47 @@ fn generic_route_4xx_maps_to_protocol() {
         // A non-Start, non-update route must NOT inherit the update 4xx mappings.
         let result = stop_against_status(&test_socket_path("stop409"), axum::http::StatusCode::CONFLICT, "nope").await;
         assert!(matches!(result, Err(ClientError::Protocol(_))), "got {result:?}");
+    });
+}
+
+#[skuld::test]
+fn unblock_200_maps_to_ack() {
+    rt().block_on(async {
+        let result = unblock_against_status(&test_socket_path("unblock200"), axum::http::StatusCode::OK, "").await;
+        assert!(matches!(result, Ok(BridgeResponse::Ack)), "got {result:?}");
+    });
+}
+
+#[skuld::test]
+fn unblock_409_maps_to_session_running() {
+    rt().block_on(async {
+        // Unlike `Stop`'s CONFLICT (which falls through to the generic
+        // Protocol-error mapping), Unblock's 409 must map to the typed
+        // variant the tray keys its distinct, cover-safe messaging on.
+        let result = unblock_against_status(
+            &test_socket_path("unblock409"),
+            axum::http::StatusCode::CONFLICT,
+            "a session is running",
+        )
+        .await;
+        assert!(matches!(result, Err(ClientError::SessionRunning)), "got {result:?}");
+    });
+}
+
+#[skuld::test]
+fn unblock_500_maps_to_error() {
+    rt().block_on(async {
+        let result = unblock_against_status(
+            &test_socket_path("unblock500"),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "unblock boom",
+        )
+        .await
+        .unwrap();
+        match result {
+            BridgeResponse::Error { message } => assert!(message.contains("unblock boom"), "got {message}"),
+            other => panic!("expected Error, got {other:?}"),
+        }
     });
 }
 

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -274,6 +274,39 @@ const UNBLOCK_UNREACHABLE_MESSAGE: &str =
 const UNBLOCK_SESSION_RUNNING_MESSAGE: &str =
     "A session is running, so there was nothing to unblock. The kill switch is now off — Disconnect to release its cover.";
 
+/// Map a `BridgeRequest::Unblock` response to the dialog the tray should
+/// show, or `None` for a silent success. Pure (aside from logging) so the
+/// mapping — which of two mutually-distinct, purpose-built messages a user
+/// sees — is table-tested directly, mirroring `outcome_for_start_response`'s
+/// pattern. Menu visibility is decided at build time and the click lands
+/// arbitrarily later, so a session can legitimately have started in between;
+/// each branch gets the advice that is true for it.
+fn unblock_dialog_message(response: &Result<BridgeResponse, crate::bridge_client::ClientError>) -> Option<String> {
+    use crate::bridge_client::ClientError;
+    match response {
+        Ok(BridgeResponse::Ack) => {
+            info!("tray: unblock succeeded");
+            None
+        }
+        Err(ClientError::SessionRunning) => {
+            info!("tray: unblock found a session running");
+            Some(UNBLOCK_SESSION_RUNNING_MESSAGE.to_string())
+        }
+        Ok(BridgeResponse::Error { message }) => {
+            error!(%message, "tray: unblock reported a failure");
+            Some(message.clone())
+        }
+        Err(e) => {
+            error!(error = %e, "tray: unblock could not reach or understand the bridge");
+            Some(UNBLOCK_UNREACHABLE_MESSAGE.to_string())
+        }
+        Ok(other) => {
+            error!(?other, "tray: unblock got an unexpected response shape");
+            Some(UNBLOCK_UNREACHABLE_MESSAGE.to_string())
+        }
+    }
+}
+
 // Tray creation =======================================================================================================
 
 /// Tray label for the lockdown toggle from the (enabled, active) snapshot.
@@ -326,32 +359,27 @@ fn tray_actions(running: bool, transition: Option<bool>, blocked: bool) -> TrayA
     }
 }
 
-/// Which escape from a fail-closed cover the menu should render, if any.
-/// There are two, and they overlap: `GoOffline` (the existing blocked-state
-/// item) sends Disconnect to release the held transient cover; `Unblock`
-/// clears that same cover *and* the standing one *and* disarms the intent.
-/// Rendering both would put two items reading "unblock" side by side doing
-/// different things.
+/// Which escape items from a fail-closed cover the menu should render — both
+/// are independent and may apply at once. `GoOffline` (the existing
+/// blocked-state item) sends Disconnect to release the held transient cover
+/// while leaving the kill switch armed; `Unblock` clears that same cover
+/// *and* the standing one *and* disarms the intent. They read as distinct
+/// actions with distinct labels ("keeps Lockdown armed" vs "turns Lockdown
+/// off"), so both are shown when both apply — rule #0 favours more escapes
+/// over fewer, never fewer for the sake of a tidier menu.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EscapeItem {
-    None,
-    GoOffline,
-    Unblock,
+struct EscapeItems {
+    go_offline: bool,
+    unblock: bool,
 }
 
-/// Resolve which escape item to show. `Unblock` wins whenever it applies —
-/// it is a strict superset of `GoOffline`'s effect — so the two are never
-/// rendered together. There is no probe input here to fail: the intent is on
-/// and nothing is running is the whole condition, pinned by the exhaustive
-/// table test over all eight `(lockdown_enabled, running,
-/// blocked_offers_go_offline)` rows.
-fn escape_item(lockdown_enabled: bool, running: bool, blocked_offers_go_offline: bool) -> EscapeItem {
-    if lockdown_enabled && !running {
-        EscapeItem::Unblock
-    } else if blocked_offers_go_offline {
-        EscapeItem::GoOffline
-    } else {
-        EscapeItem::None
+/// Resolve which escape items to show. The two conditions are independent —
+/// there is no probe input here to fail, only the exhaustive table test over
+/// all eight `(lockdown_enabled, running, blocked_offers_go_offline)` rows.
+fn escape_items(lockdown_enabled: bool, running: bool, blocked_offers_go_offline: bool) -> EscapeItems {
+    EscapeItems {
+        go_offline: blocked_offers_go_offline,
+        unblock: lockdown_enabled && !running,
     }
 }
 
@@ -425,10 +453,12 @@ fn build_tray_menu(
     };
 
     let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![&status, &connect];
-    match escape_item(lockdown_enabled, running, acts.show_go_offline) {
-        EscapeItem::Unblock => items.push(&unblock),
-        EscapeItem::GoOffline => items.push(&go_offline),
-        EscapeItem::None => {}
+    let escapes = escape_items(lockdown_enabled, running, acts.show_go_offline);
+    if escapes.go_offline {
+        items.push(&go_offline);
+    }
+    if escapes.unblock {
+        items.push(&unblock);
     }
     items.extend([
         &sep1 as &dyn tauri::menu::IsMenuItem<tauri::Wry>,
@@ -910,28 +940,7 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
                 let response = state.bridge_send(BridgeRequest::Unblock).await;
-                let dialog_message = match &response {
-                    Ok(BridgeResponse::Ack) => {
-                        info!("tray: unblock succeeded");
-                        None
-                    }
-                    Err(crate::bridge_client::ClientError::SessionRunning) => {
-                        info!("tray: unblock found a session running");
-                        Some(UNBLOCK_SESSION_RUNNING_MESSAGE.to_string())
-                    }
-                    Ok(BridgeResponse::Error { message }) => {
-                        error!(%message, "tray: unblock reported a failure");
-                        Some(message.clone())
-                    }
-                    Err(e) => {
-                        error!(error = %e, "tray: unblock could not reach or understand the bridge");
-                        Some(UNBLOCK_UNREACHABLE_MESSAGE.to_string())
-                    }
-                    Ok(other) => {
-                        error!(?other, "tray: unblock got an unexpected response shape");
-                        Some(UNBLOCK_UNREACHABLE_MESSAGE.to_string())
-                    }
-                };
+                let dialog_message = unblock_dialog_message(&response);
                 // Re-fetch Status and rebuild on every branch so the escape
                 // stays available for a retry.
                 let _ = state.bridge_send(BridgeRequest::Status).await;
@@ -959,11 +968,36 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
-                if let Err(e) = state.bridge_send(BridgeRequest::SetLockdown { enabled: desired }).await {
-                    error!(error = %e, "tray: SetLockdown failed");
-                }
+                let response = state.bridge_send(BridgeRequest::SetLockdown { enabled: desired }).await;
+                // A 5xx from the bridge (e.g. turning the switch off failed to
+                // release a cover) surfaces as `Ok(BridgeResponse::Error)`, not
+                // `Err` — `parse_generic_error` never returns `Err` for a server
+                // error. Mirror `outcome_for_stop_response`'s mapping so a
+                // failure here is shown, not silently dropped while the
+                // checkmark snaps back and the host may still be blocked.
+                let dialog_message = match &response {
+                    Ok(BridgeResponse::Ack) => None,
+                    Ok(BridgeResponse::Error { message }) => {
+                        error!(%message, "tray: SetLockdown reported a failure");
+                        Some(bridge_error_toast(message))
+                    }
+                    Ok(other) => {
+                        warn!(?other, "tray: SetLockdown got an unexpected response shape");
+                        Some("Unexpected response from bridge".to_string())
+                    }
+                    Err(e) => {
+                        error!(error = %e, "tray: SetLockdown failed");
+                        Some(format!("Failed to connect to bridge: {e}"))
+                    }
+                };
                 let _ = state.bridge_send(BridgeRequest::Status).await; // commits new snapshot
                 rebuild_tray_menu(&app_handle);
+                if let Some(message) = dialog_message {
+                    tauri::async_runtime::spawn_blocking(move || {
+                        use tauri_plugin_dialog::DialogExt;
+                        app_handle.dialog().message(message).title("Lockdown").blocking_show();
+                    });
+                }
             });
         }
         _ => {}

--- a/crates/hole/src/tray.rs
+++ b/crates/hole/src/tray.rs
@@ -252,6 +252,27 @@ const ID_EXIT: &str = "exit";
 const ID_INSTALL_UPDATE: &str = "install_update";
 const ID_LOCKDOWN: &str = "lockdown";
 const ID_BLOCKED_RETRY: &str = "blocked_retry";
+const ID_UNBLOCK: &str = "unblock";
+
+const UNBLOCK_ITEM_LABEL: &str = "Unblock Network (turns Lockdown off)";
+
+/// Shown when `BridgeRequest::Unblock` could not be reached or answered
+/// unintelligibly — the case the CLI door exists for. Must name the CLI
+/// command AND the disconnect caveat: "the bridge did not answer" is fully
+/// compatible with "a session is running" (a cutover restart, a dropped
+/// socket), and the CLI has no running-session check of its own — stripping
+/// the cover from under a live tunnel if the user runs it while connected.
+const UNBLOCK_UNREACHABLE_MESSAGE: &str =
+    "Could not reach the Hole bridge. If you are currently connected, disconnect first, then run \
+     \"hole bridge unlock\" as an administrator (use sudo on macOS).";
+
+/// Shown when the bridge answered `Err(ClientError::SessionRunning)`: a
+/// session is running, so there was no unowned cover to clear, but the kill
+/// switch is now off. Must NOT name `hole bridge unlock` — that command
+/// performs no running-session check, so directing a user there in this
+/// state would strip the cover from under a live tunnel.
+const UNBLOCK_SESSION_RUNNING_MESSAGE: &str =
+    "A session is running, so there was nothing to unblock. The kill switch is now off — Disconnect to release its cover.";
 
 // Tray creation =======================================================================================================
 
@@ -305,6 +326,35 @@ fn tray_actions(running: bool, transition: Option<bool>, blocked: bool) -> TrayA
     }
 }
 
+/// Which escape from a fail-closed cover the menu should render, if any.
+/// There are two, and they overlap: `GoOffline` (the existing blocked-state
+/// item) sends Disconnect to release the held transient cover; `Unblock`
+/// clears that same cover *and* the standing one *and* disarms the intent.
+/// Rendering both would put two items reading "unblock" side by side doing
+/// different things.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EscapeItem {
+    None,
+    GoOffline,
+    Unblock,
+}
+
+/// Resolve which escape item to show. `Unblock` wins whenever it applies —
+/// it is a strict superset of `GoOffline`'s effect — so the two are never
+/// rendered together. There is no probe input here to fail: the intent is on
+/// and nothing is running is the whole condition, pinned by the exhaustive
+/// table test over all eight `(lockdown_enabled, running,
+/// blocked_offers_go_offline)` rows.
+fn escape_item(lockdown_enabled: bool, running: bool, blocked_offers_go_offline: bool) -> EscapeItem {
+    if lockdown_enabled && !running {
+        EscapeItem::Unblock
+    } else if blocked_offers_go_offline {
+        EscapeItem::GoOffline
+    } else {
+        EscapeItem::None
+    }
+}
+
 /// Build the tray menu, optionally including an "Install Update" item.
 ///
 /// `running` is the bridge's actual state (from the `ProxyStateCell`,
@@ -333,15 +383,20 @@ fn build_tray_menu(
         transition.is_none(),
         None::<&str>,
     )?;
-    // Shown only in the blocked state: releases the fail-closed cover and goes
-    // offline (unprotected) — the deliberate escape from a stay-blocked host.
+    // Shown only in the blocked state: releases the held transient cover and
+    // goes offline (unprotected) — the deliberate escape from a stay-blocked
+    // host. The label names what it does NOT do (turn Lockdown off) so it
+    // reads distinctly from Unblock when both could apply.
     let go_offline = MenuItem::with_id(
         app,
         ID_DISCONNECT,
-        "Go Offline (unblock)",
+        "Go Offline (keeps Lockdown armed)",
         transition.is_none(),
         None::<&str>,
     )?;
+    // Shown whenever the kill-switch intent is on and nothing is running —
+    // unconditionally, independent of whether a cover is actually stranded.
+    let unblock = MenuItem::with_id(app, ID_UNBLOCK, UNBLOCK_ITEM_LABEL, transition.is_none(), None::<&str>)?;
     let autostart = CheckMenuItem::with_id(app, ID_AUTOSTART, "Start at Login", true, false, None::<&str>)?;
     // Checked tracks intent; the warning label covers the enabled-but-inactive
     // state since a checkmark alone can't signal "armed but not engaged".
@@ -370,8 +425,10 @@ fn build_tray_menu(
     };
 
     let mut items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = vec![&status, &connect];
-    if acts.show_go_offline {
-        items.push(&go_offline);
+    match escape_item(lockdown_enabled, running, acts.show_go_offline) {
+        EscapeItem::Unblock => items.push(&unblock),
+        EscapeItem::GoOffline => items.push(&go_offline),
+        EscapeItem::None => {}
     }
     items.extend([
         &sep1 as &dyn tauri::menu::IsMenuItem<tauri::Wry>,
@@ -845,6 +902,50 @@ fn handle_tray_event(app: &AppHandle, event: MenuEvent) {
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move {
                 handle_install_update_from_tray(app_handle, None).await;
+            });
+        }
+        ID_UNBLOCK => {
+            info!("tray: unblock clicked");
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app_handle.state::<AppState>();
+                let response = state.bridge_send(BridgeRequest::Unblock).await;
+                let dialog_message = match &response {
+                    Ok(BridgeResponse::Ack) => {
+                        info!("tray: unblock succeeded");
+                        None
+                    }
+                    Err(crate::bridge_client::ClientError::SessionRunning) => {
+                        info!("tray: unblock found a session running");
+                        Some(UNBLOCK_SESSION_RUNNING_MESSAGE.to_string())
+                    }
+                    Ok(BridgeResponse::Error { message }) => {
+                        error!(%message, "tray: unblock reported a failure");
+                        Some(message.clone())
+                    }
+                    Err(e) => {
+                        error!(error = %e, "tray: unblock could not reach or understand the bridge");
+                        Some(UNBLOCK_UNREACHABLE_MESSAGE.to_string())
+                    }
+                    Ok(other) => {
+                        error!(?other, "tray: unblock got an unexpected response shape");
+                        Some(UNBLOCK_UNREACHABLE_MESSAGE.to_string())
+                    }
+                };
+                // Re-fetch Status and rebuild on every branch so the escape
+                // stays available for a retry.
+                let _ = state.bridge_send(BridgeRequest::Status).await;
+                rebuild_tray_menu(&app_handle);
+                if let Some(message) = dialog_message {
+                    tauri::async_runtime::spawn_blocking(move || {
+                        use tauri_plugin_dialog::DialogExt;
+                        app_handle
+                            .dialog()
+                            .message(message)
+                            .title("Unblock Network")
+                            .blocking_show();
+                    });
+                }
             });
         }
         ID_LOCKDOWN => {

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -191,30 +191,35 @@ fn lockdown_off_renders_plain_label() {
     assert!(!label.to_lowercase().contains("warning"));
 }
 
-// escape_item =========================================================================================================
+// escape_items ========================================================================================================
 
 #[skuld::test]
-fn escape_item_offers_unblock_exactly_when_the_intent_is_on_and_nothing_runs() {
+fn escape_items_offers_unblock_and_go_offline_independently() {
     // Exhaustive over all eight (lockdown_enabled, running, blocked_offers_go_offline)
-    // rows. Unblock wins whenever the intent is on and nothing runs, regardless of
-    // blocked_offers_go_offline (a strict superset); otherwise GoOffline shows
-    // whenever it applies; otherwise None. There is no probe input to fail — this
-    // table is the whole decision.
+    // rows. The two escapes are independent: `unblock` is exactly
+    // `lockdown_enabled && !running`; `go_offline` is exactly
+    // `blocked_offers_go_offline`. Both can be true at once — rendering both is the
+    // point (rule #0 favours more escapes over fewer). There is no probe input to
+    // fail — this table is the whole decision.
     let table = [
-        // (lockdown_enabled, running, blocked_offers_go_offline, expected)
-        (true, false, true, EscapeItem::Unblock),
-        (true, false, false, EscapeItem::Unblock),
-        (true, true, true, EscapeItem::GoOffline),
-        (true, true, false, EscapeItem::None),
-        (false, false, true, EscapeItem::GoOffline),
-        (false, false, false, EscapeItem::None),
-        (false, true, true, EscapeItem::GoOffline),
-        (false, true, false, EscapeItem::None),
+        // (lockdown_enabled, running, blocked_offers_go_offline, expect_go_offline, expect_unblock)
+        (true, false, true, true, true),
+        (true, false, false, false, true),
+        (true, true, true, true, false),
+        (true, true, false, false, false),
+        (false, false, true, true, false),
+        (false, false, false, false, false),
+        (false, true, true, true, false),
+        (false, true, false, false, false),
     ];
-    for (lockdown_enabled, running, blocked_offers_go_offline, expected) in table {
+    for (lockdown_enabled, running, blocked_offers_go_offline, expect_go_offline, expect_unblock) in table {
+        let escapes = escape_items(lockdown_enabled, running, blocked_offers_go_offline);
         assert_eq!(
-            escape_item(lockdown_enabled, running, blocked_offers_go_offline),
-            expected,
+            escapes,
+            EscapeItems {
+                go_offline: expect_go_offline,
+                unblock: expect_unblock,
+            },
             "lockdown_enabled={lockdown_enabled} running={running} blocked_offers_go_offline={blocked_offers_go_offline}"
         );
     }
@@ -242,6 +247,46 @@ fn unblock_session_running_message_does_not_name_the_cli() {
     assert!(
         !UNBLOCK_SESSION_RUNNING_MESSAGE.contains("bridge unlock"),
         "must NOT talk a user into an out-of-process clear over a live tunnel: {UNBLOCK_SESSION_RUNNING_MESSAGE:?}"
+    );
+}
+
+#[skuld::test]
+fn unblock_dialog_message_maps_each_response_distinctly() {
+    use crate::bridge_client::ClientError;
+
+    // Ack: silent success, no dialog.
+    assert_eq!(unblock_dialog_message(&Ok(BridgeResponse::Ack)), None);
+
+    // SessionRunning: the disconnect-safe message — a swapped arm here would
+    // show UNBLOCK_UNREACHABLE_MESSAGE instead, which names the CLI command
+    // and would strip a cover out from under a live tunnel.
+    assert_eq!(
+        unblock_dialog_message(&Err(ClientError::SessionRunning)).as_deref(),
+        Some(UNBLOCK_SESSION_RUNNING_MESSAGE)
+    );
+
+    // A bridge-authored failure: shown verbatim, not replaced by a fixed string.
+    assert_eq!(unblock_dialog_message(&Ok(err_resp("boom"))).as_deref(), Some("boom"));
+
+    // Any transport/protocol error: the CLI-naming unreachable message.
+    assert_eq!(
+        unblock_dialog_message(&Err(transport_err())).as_deref(),
+        Some(UNBLOCK_UNREACHABLE_MESSAGE)
+    );
+
+    // An unexpected Ok shape (a same-build contract breach): never silent —
+    // falls back to the same unreachable message.
+    let unexpected = Ok(BridgeResponse::Metrics {
+        bytes_in: 0,
+        bytes_out: 0,
+        speed_in_bps: 0,
+        speed_out_bps: 0,
+        uptime_secs: 0,
+        filter: None,
+    });
+    assert_eq!(
+        unblock_dialog_message(&unexpected).as_deref(),
+        Some(UNBLOCK_UNREACHABLE_MESSAGE)
     );
 }
 

--- a/crates/hole/src/tray_tests.rs
+++ b/crates/hole/src/tray_tests.rs
@@ -191,6 +191,60 @@ fn lockdown_off_renders_plain_label() {
     assert!(!label.to_lowercase().contains("warning"));
 }
 
+// escape_item =========================================================================================================
+
+#[skuld::test]
+fn escape_item_offers_unblock_exactly_when_the_intent_is_on_and_nothing_runs() {
+    // Exhaustive over all eight (lockdown_enabled, running, blocked_offers_go_offline)
+    // rows. Unblock wins whenever the intent is on and nothing runs, regardless of
+    // blocked_offers_go_offline (a strict superset); otherwise GoOffline shows
+    // whenever it applies; otherwise None. There is no probe input to fail — this
+    // table is the whole decision.
+    let table = [
+        // (lockdown_enabled, running, blocked_offers_go_offline, expected)
+        (true, false, true, EscapeItem::Unblock),
+        (true, false, false, EscapeItem::Unblock),
+        (true, true, true, EscapeItem::GoOffline),
+        (true, true, false, EscapeItem::None),
+        (false, false, true, EscapeItem::GoOffline),
+        (false, false, false, EscapeItem::None),
+        (false, true, true, EscapeItem::GoOffline),
+        (false, true, false, EscapeItem::None),
+    ];
+    for (lockdown_enabled, running, blocked_offers_go_offline, expected) in table {
+        assert_eq!(
+            escape_item(lockdown_enabled, running, blocked_offers_go_offline),
+            expected,
+            "lockdown_enabled={lockdown_enabled} running={running} blocked_offers_go_offline={blocked_offers_go_offline}"
+        );
+    }
+}
+
+#[skuld::test]
+fn unblock_unreachable_message_names_the_command_and_the_disconnect_caveat() {
+    assert!(UNBLOCK_UNREACHABLE_MESSAGE.contains("hole bridge unlock"));
+    assert!(
+        UNBLOCK_UNREACHABLE_MESSAGE.to_lowercase().contains("disconnect"),
+        "must caution the user to disconnect first: {UNBLOCK_UNREACHABLE_MESSAGE:?}"
+    );
+    assert!(
+        !UNBLOCK_UNREACHABLE_MESSAGE.contains('\\') && !UNBLOCK_UNREACHABLE_MESSAGE.contains('/'),
+        "must carry no filesystem path: {UNBLOCK_UNREACHABLE_MESSAGE:?}"
+    );
+}
+
+#[skuld::test]
+fn unblock_session_running_message_does_not_name_the_cli() {
+    assert!(
+        UNBLOCK_SESSION_RUNNING_MESSAGE.to_lowercase().contains("disconnect"),
+        "must point the user at Disconnect: {UNBLOCK_SESSION_RUNNING_MESSAGE:?}"
+    );
+    assert!(
+        !UNBLOCK_SESSION_RUNNING_MESSAGE.contains("bridge unlock"),
+        "must NOT talk a user into an out-of-process clear over a live tunnel: {UNBLOCK_SESSION_RUNNING_MESSAGE:?}"
+    );
+}
+
 // startup_should_connect ==============================================================================================
 
 #[skuld::test]

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -450,6 +450,16 @@ pub trait Routing: Send + Sync {
         tun_name: &str,
         app_ids: &[PathBuf],
     ) -> Result<Self::Cover, RoutingError>;
+
+    /// Clear every fail-closed cover this provider can install — both the
+    /// transient block-until-connected cover and the standing lockdown cover
+    /// — without asking whether either is present. See
+    /// [`failclosed::release_all`] for the full contract: unconditional,
+    /// total, never short-circuits, and never reports a false success. This
+    /// is the escape from a stranded cover; a required method (no default)
+    /// so every `Routing` implementation, including every test mock, commits
+    /// to one.
+    fn release_all_covers(&self) -> Result<(), RoutingError>;
 }
 
 // System (production) routing =========================================================================================
@@ -536,6 +546,10 @@ impl Routing for SystemRouting {
     ) -> Result<Self::Cover, RoutingError> {
         let resolver = failclosed::SystemLuidResolver;
         failclosed::engage_lockdown(server_ip, tun_name, &resolver, app_ids, &self.state_dir, self.owner)
+    }
+
+    fn release_all_covers(&self) -> Result<(), RoutingError> {
+        failclosed::release_all(&self.state_dir)
     }
 }
 

--- a/crates/tun-engine/src/routing.rs
+++ b/crates/tun-engine/src/routing.rs
@@ -454,11 +454,9 @@ pub trait Routing: Send + Sync {
     /// Clear every fail-closed cover this provider can install — both the
     /// transient block-until-connected cover and the standing lockdown cover
     /// — without asking whether either is present. See
-    /// [`failclosed::release_all`] for the full contract: unconditional,
-    /// total, never short-circuits, and never reports a false success. This
-    /// is the escape from a stranded cover; a required method (no default)
-    /// so every `Routing` implementation, including every test mock, commits
-    /// to one.
+    /// [`failclosed::release_all`] for the full contract. This is the escape
+    /// from a stranded cover; a required method (no default) so every
+    /// `Routing` implementation, including every test mock, commits to one.
     fn release_all_covers(&self) -> Result<(), RoutingError>;
 }
 

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -24,6 +24,25 @@ use crate::error::RoutingError;
 /// the boundary too.
 pub const RESOLVER_PERMIT_PORT: u16 = 443;
 
+/// A cover's on-disk state-file read, distinguishing "never engaged" from "the
+/// evidence exists but cannot be read". Collapsing the latter into the former
+/// would make [`release_all`] treat a corrupt or version-skewed file as
+/// nothing to clear over a host its cover may still be holding closed — see
+/// `release_all`'s doc for why that distinction is load-bearing. Generic and
+/// declared here (not per-platform) so both macOS state modules share one
+/// reader shape.
+#[derive(Debug)]
+pub enum StateFile<T> {
+    /// No file — no cover of this kind was ever engaged (or a prior release
+    /// already cleared it).
+    Absent,
+    /// A file exists but could not be read, parsed, or matched the expected
+    /// schema version. Treated as a cover to clear, never as absence.
+    Unusable,
+    /// A file exists and parsed at the current schema version.
+    Present(T),
+}
+
 // macOS persists its pf enable token; Windows recovers WFP filters by fixed
 // GUID and needs no state.
 #[cfg(target_os = "macos")]
@@ -172,6 +191,43 @@ pub fn lockdown_cover_present(state_dir: &Path) -> bool {
     }
 }
 
+/// Clear every fail-closed cover this platform can install — both the
+/// transient block-until-connected cover and the standing lockdown cover —
+/// without ever asking whether either is present. This is the escape from a
+/// stranded cover: the tray's Unblock item and turning the kill switch off
+/// both reach the host through this one function, and nothing else in this
+/// crate clears a cover conditionally on its presence.
+///
+/// Contract, load-bearing for every caller:
+///
+/// 1. **Unconditional.** Never probes presence to decide whether to act.
+///    Idempotent — a clean host returns `Ok`.
+/// 2. **Total.** Clears BOTH cover kinds. Clearing only one would leave a
+///    user with no way out at all.
+/// 3. **No short-circuit.** Every clear is attempted before any failure is
+///    examined. The only early return is a Windows engine-open failure, where
+///    nothing could have been issued in the first place.
+/// 4. **Never a false success.** `Ok` means nothing Hole installed is still
+///    holding egress closed. The converse does not hold — the function may
+///    report `Err` over a host that is in fact open. That asymmetry is
+///    deliberate: a false `Err` keeps the escape on the tray menu and the
+///    intent armed, while a false `Ok` is the lockout this function exists to
+///    remove.
+/// 5. **Bookkeeping is best-effort, except the state-file clear.** The macOS
+///    `pfctl -X` refcount drop and the Windows sublayer/provider delete log a
+///    warning on failure and do not fail the call. A cover's state-file clear
+///    is different: it is *skipped* whenever that cover's replacement ruleset
+///    did not confirm, because the file is the cover's only record — clearing
+///    it after an unconfirmed restore would make the next call read a clean
+///    host while the block persists (a manufactured, permanent lockout).
+///
+/// Windows keeps no cover state file at all: the filter set is compiled-in
+/// fixed GUIDs, so there is no bookkeeping that can be corrupt or
+/// version-skewed and nothing to erase — only GUID sweeps run there.
+pub fn release_all(state_dir: &Path) -> Result<(), RoutingError> {
+    platform::release_all(state_dir)
+}
+
 /// Windows-only test helper: resolve the LUID then build the spec, exercising
 /// the exact resolve-then-build ordering `engage_lockdown` uses, without FWPM.
 #[cfg(all(test, target_os = "windows"))]
@@ -197,3 +253,10 @@ mod facade_tests;
 #[cfg(test)]
 #[path = "failclosed/lockdown_privileged_tests.rs"]
 mod lockdown_privileged_tests;
+
+// Privileged-lane real-firewall proof that `release_all` really clears both
+// cover kinds and never a clean host's live ruleset. Gated identically to
+// `lockdown_privileged_tests` above — see that module's doc.
+#[cfg(test)]
+#[path = "failclosed/release_privileged_tests.rs"]
+mod release_privileged_tests;

--- a/crates/tun-engine/src/routing/failclosed.rs
+++ b/crates/tun-engine/src/routing/failclosed.rs
@@ -200,19 +200,29 @@ pub fn lockdown_cover_present(state_dir: &Path) -> bool {
 ///
 /// Contract, load-bearing for every caller:
 ///
-/// 1. **Unconditional.** Never probes presence to decide whether to act.
-///    Idempotent — a clean host returns `Ok`.
+/// 1. **Unconditional.** Never probes the LIVE cover (the WFP/pf objects
+///    themselves) to decide whether to act. Idempotent — a clean host
+///    returns `Ok`. On macOS, "clean host" is read from Hole's own state
+///    file — `StateFile::Absent` — because pf has no query for "who is
+///    holding this ruleset"; the file is the only record. A state file lost
+///    out from under a genuinely live cover (not corrupt — entirely absent,
+///    e.g. an external wipe of `state_dir`) is therefore indistinguishable
+///    from a clean host and `release_all` reports `Ok` without touching pf.
+///    See CONTRIBUTING.md's disclosed residuals.
 /// 2. **Total.** Clears BOTH cover kinds. Clearing only one would leave a
 ///    user with no way out at all.
 /// 3. **No short-circuit.** Every clear is attempted before any failure is
 ///    examined. The only early return is a Windows engine-open failure, where
 ///    nothing could have been issued in the first place.
-/// 4. **Never a false success.** `Ok` means nothing Hole installed is still
-///    holding egress closed. The converse does not hold — the function may
-///    report `Err` over a host that is in fact open. That asymmetry is
-///    deliberate: a false `Err` keeps the escape on the tray menu and the
-///    intent armed, while a false `Ok` is the lockout this function exists to
-///    remove.
+/// 4. **Never a false success from anything `release_all` can observe.** `Ok`
+///    means every cover this call could detect is cleared. The converse does
+///    not hold — the function may report `Err` over a host that is in fact
+///    open. That asymmetry is deliberate: a false `Err` keeps the escape on
+///    the tray menu and the intent armed, while a false `Ok` over a
+///    *detected* cover is the lockout this function exists to remove. Item 1
+///    is the one case where `Ok` can be reported over a still-blocked host —
+///    it is not a violation of this clause, since the cover left no evidence
+///    to detect.
 /// 5. **Bookkeeping is best-effort, except the state-file clear.** The macOS
 ///    `pfctl -X` refcount drop and the Windows sublayer/provider delete log a
 ///    warning on failure and do not fail the call. A cover's state-file clear

--- a/crates/tun-engine/src/routing/failclosed/failclosed_state.rs
+++ b/crates/tun-engine/src/routing/failclosed/failclosed_state.rs
@@ -55,32 +55,48 @@ pub fn save(state_dir: &Path, state: &FailClosedState, owner: Option<(u32, u32)>
     Ok(())
 }
 
-/// Load the state file, or `None` on any error (absent / corrupt / unknown
-/// field / version mismatch); logs at `warn`. Recovery is best-effort.
-pub fn load(state_dir: &Path) -> Option<FailClosedState> {
+/// Trichotomy read distinguishing "no cover was ever engaged" (`Absent`) from
+/// "a cover's evidence exists but we cannot read it" (`Unusable`) — a corrupt,
+/// unparseable, or version-skewed file. Collapsing `Unusable` into `Absent`
+/// would make a release read a live, blocking cover as nothing to clear (see
+/// `release_all`'s doc). `Absent` is ONLY `ErrorKind::NotFound`; every other
+/// read/parse/version failure is `Unusable` (keeps the existing `warn!` lines).
+pub fn load_presence(state_dir: &Path) -> super::StateFile<FailClosedState> {
+    use super::StateFile;
     let path = state_file(state_dir);
     let bytes = match std::fs::read(&path) {
         Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return StateFile::Absent,
         Err(e) => {
             tracing::warn!(error = %e, path = %path.display(), "failclosed-state read failed");
-            return None;
+            return StateFile::Unusable;
         }
     };
     match serde_json::from_slice::<FailClosedState>(&bytes) {
-        Ok(s) if s.version == SCHEMA_VERSION => Some(s),
+        Ok(s) if s.version == SCHEMA_VERSION => StateFile::Present(s),
         Ok(other) => {
             tracing::warn!(
                 got = other.version,
                 want = SCHEMA_VERSION,
                 "failclosed-state schema mismatch, discarding"
             );
-            None
+            StateFile::Unusable
         }
         Err(e) => {
             tracing::warn!(error = %e, path = %path.display(), "failclosed-state parse failed");
-            None
+            StateFile::Unusable
         }
+    }
+}
+
+/// Load the state file, or `None` on any error (absent / corrupt / unknown
+/// field / version mismatch); logs at `warn`. Recovery is best-effort. Thin
+/// wrapper over [`load_presence`], collapsing `Unusable` into `None` alongside
+/// `Absent` — every existing caller treats the two identically.
+pub fn load(state_dir: &Path) -> Option<FailClosedState> {
+    match load_presence(state_dir) {
+        super::StateFile::Present(s) => Some(s),
+        super::StateFile::Absent | super::StateFile::Unusable => None,
     }
 }
 

--- a/crates/tun-engine/src/routing/failclosed/lockdown_pf_state.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_pf_state.rs
@@ -47,30 +47,48 @@ pub fn save(state_dir: &Path, state: &LockdownPfState, owner: Option<(u32, u32)>
     Ok(())
 }
 
-pub fn load(state_dir: &Path) -> Option<LockdownPfState> {
+/// Trichotomy read distinguishing "no cover was ever engaged" (`Absent`) from
+/// "a cover's evidence exists but we cannot read it" (`Unusable`) — a corrupt,
+/// unparseable, or version-skewed file. Collapsing `Unusable` into `Absent`
+/// would make a release read a live, blocking cover as nothing to clear (see
+/// `release_all`'s doc). `Absent` is ONLY `ErrorKind::NotFound`; every other
+/// read/parse/version failure is `Unusable` (keeps the existing `warn!` lines).
+pub fn load_presence(state_dir: &Path) -> super::StateFile<LockdownPfState> {
+    use super::StateFile;
     let path = state_file(state_dir);
     let bytes = match std::fs::read(&path) {
         Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return StateFile::Absent,
         Err(e) => {
             tracing::warn!(error = %e, path = %path.display(), "lockdown-pf-state read failed");
-            return None;
+            return StateFile::Unusable;
         }
     };
     match serde_json::from_slice::<LockdownPfState>(&bytes) {
-        Ok(s) if s.version == SCHEMA_VERSION => Some(s),
+        Ok(s) if s.version == SCHEMA_VERSION => StateFile::Present(s),
         Ok(other) => {
             tracing::warn!(
                 got = other.version,
                 want = SCHEMA_VERSION,
                 "lockdown-pf-state schema mismatch, discarding"
             );
-            None
+            StateFile::Unusable
         }
         Err(e) => {
             tracing::warn!(error = %e, path = %path.display(), "lockdown-pf-state parse failed");
-            None
+            StateFile::Unusable
         }
+    }
+}
+
+/// Load the state file, or `None` on any error (absent / corrupt / unknown
+/// field / version mismatch). Thin wrapper over [`load_presence`], collapsing
+/// `Unusable` into `None` alongside `Absent` — every existing caller treats
+/// the two identically.
+pub fn load(state_dir: &Path) -> Option<LockdownPfState> {
+    match load_presence(state_dir) {
+        super::StateFile::Present(s) => Some(s),
+        super::StateFile::Absent | super::StateFile::Unusable => None,
     }
 }
 

--- a/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/lockdown_privileged_tests.rs
@@ -46,7 +46,7 @@
 use super::*;
 
 #[skuld::label]
-const TUN: skuld::Label;
+pub(super) const TUN: skuld::Label;
 
 // Two routable anycast hosts on :443 (the runner has outbound internet). IP
 // literals only — the cover blocks DNS, so a hostname connect would fail for the

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -30,6 +30,7 @@ use crate::error::RoutingError;
 // `failclosed` module and `failclosed_state` is its sibling child.
 use super::failclosed_state as state;
 use super::lockdown_pf_state as lockdown_state;
+use super::StateFile;
 use super::RESOLVER_PERMIT_PORT;
 
 /// Build the self-contained pf ruleset (loaded via `pfctl -f -`).
@@ -257,23 +258,60 @@ impl Drop for Cover {
     }
 }
 
+/// The single rule for "did the ruleset that replaces a cover actually load".
+/// `true` when `adopting` — the reload is deliberately SKIPPED because a
+/// standing cover is holding the host, so nothing was attempted and nothing
+/// failed. Otherwise `out` must be `Ok` AND its exit status a success: a
+/// spawn-result check alone is blind to `pfctl` failing on its exit status,
+/// and that is exactly the case that would erase a cover's only evidence out
+/// from under a still-blocking ruleset. Shared by `disengage` and
+/// `release_all_with` so there is one answer to this question, not two that
+/// can drift apart.
+fn restore_confirmed(adopting: bool, out: &Result<std::process::Output, RoutingError>) -> bool {
+    if adopting {
+        return true;
+    }
+    matches!(out, Ok(o) if o.status.success())
+}
+
 /// Drop the transient enable refcount + clear the file. When `adopting` is
 /// false, also restore the canonical ruleset (the transient engage did `-Fa`,
 /// flushing host rules, so the restore is mandatory to undo the flush). When a
 /// standing cover is being adopted, skip the `/etc/pf.conf` reload — it would
 /// wipe the standing lockdown ruleset (which is the live main ruleset) before
-/// Adopt. Best-effort; logs on failure. Shared by `Drop` and `recover_cover`.
+/// Adopt. The `-X` drop is best-effort regardless; the state-file clear is
+/// NOT — it runs only when [`restore_confirmed`] says the replacement ruleset
+/// actually loaded, so a failed (but not adopting) restore leaves the file in
+/// place rather than erasing the cover's only record over a still-blocked
+/// host. Shared by `Drop` and `recover_cover`.
 fn disengage(token: &str, state_dir: &Path, adopting: bool) {
-    if adopting {
+    // The placeholder `Err` in the `adopting` branch is never read:
+    // `restore_confirmed(true, _)` returns `true` unconditionally, since
+    // nothing was attempted to confirm.
+    let reload: Result<std::process::Output, RoutingError> = if adopting {
         tracing::info!("standing lockdown cover being adopted; skipping /etc/pf.conf reload during transient sweep");
-    } else if let Err(e) = pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER) {
-        tracing::warn!(error = %e, "pf ruleset restore failed during cover disengage");
-    }
+        Err(RoutingError::RouteSetup(
+            "reload skipped: standing cover is being adopted".into(),
+        ))
+    } else {
+        let out = pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER);
+        if let Err(ref e) = out {
+            tracing::warn!(error = %e, "pf ruleset restore failed during cover disengage");
+        }
+        out
+    };
     if let Err(e) = pfctl(&["-X", token], None, PHASE_RECOVER_COVER) {
         tracing::warn!(error = %e, "pfctl -X failed during cover disengage");
     }
-    if let Err(e) = state::clear(state_dir) {
-        tracing::warn!(error = %e, "failclosed-state clear failed during cover disengage");
+    if restore_confirmed(adopting, &reload) {
+        if let Err(e) = state::clear(state_dir) {
+            tracing::warn!(error = %e, "failclosed-state clear failed during cover disengage");
+        }
+    } else {
+        tracing::warn!(
+            "leaving failclosed-state file in place: the /etc/pf.conf restore did not confirm — clearing it \
+             now would make the next sweep read a clean host while the block persists"
+        );
     }
 }
 
@@ -482,6 +520,189 @@ pub fn recover_lockdown(decision: crate::routing::CoverRecovery, state_dir: &Pat
             lockdown_disengage(state_dir);
         }
     }
+}
+
+// release_all =========================================================================================================
+
+/// Seam over the pf operations `release_all_with` needs, so the ordering, the
+/// no-short-circuit property, and the clear-only-on-confirm rule are
+/// table-tested without shelling out to `pfctl`. A non-success `pfctl` exit
+/// status is ALREADY folded into `Err` by the implementation (`RealPfOps`),
+/// so `release_all_with` itself never inspects an exit code.
+pub(crate) trait PfOps {
+    /// `pfctl -f /etc/pf.conf`: reload the host's canonical ruleset.
+    fn reload_default(&mut self) -> Result<(), RoutingError>;
+    /// `pfctl -f -` with `text` on stdin: load a specific ruleset.
+    fn load_ruleset(&mut self, text: &str) -> Result<(), RoutingError>;
+    /// `pfctl -X <token>`: drop a pf enable refcount. Always best-effort at
+    /// the call site — its `Err` is never propagated.
+    fn drop_token(&mut self, token: &str) -> Result<(), RoutingError>;
+    /// Delete the transient cover's state file.
+    fn clear_transient(&mut self) -> Result<(), RoutingError>;
+    /// Delete the standing lockdown cover's state file.
+    fn clear_standing(&mut self) -> Result<(), RoutingError>;
+}
+
+/// The unconditional two-cover clear, factored as a pure sequencer over an
+/// injected [`PfOps`] so it is table-tested without touching pf. See
+/// `failclosed::release_all`'s doc for the contract this implements: total
+/// (both covers), no short-circuit (every clear attempted before any failure
+/// is examined), and a state-file clear only on a confirmed replacement.
+///
+/// One `first_err` accumulator, two blocks, no `?` — a `?` would short-circuit
+/// the block that had not run yet.
+pub(crate) fn release_all_with(
+    transient: StateFile<state::FailClosedState>,
+    standing: StateFile<lockdown_state::LockdownPfState>,
+    ops: &mut dyn PfOps,
+) -> Result<(), RoutingError> {
+    let mut first_err: Option<RoutingError> = None;
+
+    // Block 1 — transient cover. A reload failure is recorded but does NOT
+    // stop block 2: the standing cover is the one that blocks indefinitely
+    // and must be attempted regardless.
+    match transient {
+        StateFile::Absent => {}
+        StateFile::Present(st) => {
+            let reload = ops.reload_default();
+            let _ = ops.drop_token(&st.pf_token);
+            match reload {
+                Ok(()) => {
+                    let _ = ops.clear_transient();
+                }
+                Err(e) => first_err = Some(e),
+            }
+        }
+        StateFile::Unusable => {
+            tracing::warn!(
+                "transient failclosed-state file is unusable; no pf token to drop — a pf enable \
+                 refcount may be leaked (pf then stays enabled over the canonical /etc/pf.conf, \
+                 which blocks nothing, and a reboot resets it)"
+            );
+            match ops.reload_default() {
+                Ok(()) => {
+                    let _ = ops.clear_transient();
+                }
+                Err(e) => first_err = Some(e),
+            }
+        }
+    }
+
+    // Block 2 — standing cover.
+    match standing {
+        StateFile::Absent => {}
+        StateFile::Present(st) => {
+            let restore = build_lockdown_restore_ruleset(&st.nat_snapshot, &st.main_snapshot);
+            let outcome = match ops.load_ruleset(&restore) {
+                Ok(()) => Ok(()),
+                Err(snapshot_err) => match ops.reload_default() {
+                    Ok(()) => {
+                        tracing::warn!(
+                            error = %snapshot_err,
+                            "captured pf snapshot could not load; fell back to the default ruleset — \
+                             the host's captured pf rules could not be restored"
+                        );
+                        Ok(())
+                    }
+                    Err(fallback_err) => Err(RoutingError::RouteSetup(format!(
+                        "snapshot restore failed ({snapshot_err}); default-ruleset fallback also failed \
+                         ({fallback_err})"
+                    ))),
+                },
+            };
+            let _ = ops.drop_token(&st.pf_token);
+            match outcome {
+                Ok(()) => {
+                    let _ = ops.clear_standing();
+                }
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+        StateFile::Unusable => {
+            tracing::warn!(
+                "standing lockdown-pf-state file is unusable; no snapshot to restore, falling back to \
+                 the default ruleset"
+            );
+            match ops.reload_default() {
+                Ok(()) => {
+                    let _ = ops.clear_standing();
+                }
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+    }
+
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Production [`PfOps`]: maps each method onto the existing `pfctl` helper,
+/// converting a non-success exit status into `Err`.
+struct RealPfOps<'a> {
+    state_dir: &'a Path,
+}
+
+fn pfctl_status(out: Result<std::process::Output, RoutingError>, what: &str) -> Result<(), RoutingError> {
+    let out = out?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(RoutingError::RouteSetup(format!(
+            "{what} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )))
+    }
+}
+
+impl PfOps for RealPfOps<'_> {
+    fn reload_default(&mut self) -> Result<(), RoutingError> {
+        pfctl_status(
+            pfctl(&["-f", PFCONF], None, PHASE_RECOVER_COVER),
+            "pf default-ruleset reload",
+        )
+    }
+
+    fn load_ruleset(&mut self, text: &str) -> Result<(), RoutingError> {
+        pfctl_status(
+            pfctl(&["-f", "-"], Some(text.as_bytes()), PHASE_RECOVER_COVER),
+            "pf ruleset load",
+        )
+    }
+
+    fn drop_token(&mut self, token: &str) -> Result<(), RoutingError> {
+        pfctl_status(pfctl(&["-X", token], None, PHASE_RECOVER_COVER), "pfctl -X")
+    }
+
+    fn clear_transient(&mut self) -> Result<(), RoutingError> {
+        state::clear(self.state_dir)
+            .map_err(|e| RoutingError::RouteSetup(format!("failclosed-state clear failed: {e}")))
+    }
+
+    fn clear_standing(&mut self) -> Result<(), RoutingError> {
+        lockdown_state::clear(self.state_dir)
+            .map_err(|e| RoutingError::RouteSetup(format!("lockdown-pf-state clear failed: {e}")))
+    }
+}
+
+/// Clear every fail-closed cover macOS can install — both the transient
+/// block-until-connected cover and the standing lockdown cover — without
+/// asking whether either is present. See `failclosed::release_all` for the
+/// full contract; this loads both state-file presences and delegates the
+/// sequencing to [`release_all_with`].
+pub fn release_all(state_dir: &Path) -> Result<(), RoutingError> {
+    let transient = state::load_presence(state_dir);
+    let standing = lockdown_state::load_presence(state_dir);
+    release_all_with(transient, standing, &mut RealPfOps { state_dir })
 }
 
 #[cfg(test)]

--- a/crates/tun-engine/src/routing/failclosed/macos.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos.rs
@@ -545,9 +545,7 @@ pub(crate) trait PfOps {
 
 /// The unconditional two-cover clear, factored as a pure sequencer over an
 /// injected [`PfOps`] so it is table-tested without touching pf. See
-/// `failclosed::release_all`'s doc for the contract this implements: total
-/// (both covers), no short-circuit (every clear attempted before any failure
-/// is examined), and a state-file clear only on a confirmed replacement.
+/// `failclosed::release_all`'s doc for the contract this implements.
 ///
 /// One `first_err` accumulator, two blocks, no `?` — a `?` would short-circuit
 /// the block that had not run yet.
@@ -568,7 +566,9 @@ pub(crate) fn release_all_with(
             let _ = ops.drop_token(&st.pf_token);
             match reload {
                 Ok(()) => {
-                    let _ = ops.clear_transient();
+                    if let Err(e) = ops.clear_transient() {
+                        tracing::warn!(error = %e, "failclosed-state clear failed during release_all");
+                    }
                 }
                 Err(e) => first_err = Some(e),
             }
@@ -581,7 +581,9 @@ pub(crate) fn release_all_with(
             );
             match ops.reload_default() {
                 Ok(()) => {
-                    let _ = ops.clear_transient();
+                    if let Err(e) = ops.clear_transient() {
+                        tracing::warn!(error = %e, "failclosed-state clear failed during release_all");
+                    }
                 }
                 Err(e) => first_err = Some(e),
             }
@@ -613,7 +615,9 @@ pub(crate) fn release_all_with(
             let _ = ops.drop_token(&st.pf_token);
             match outcome {
                 Ok(()) => {
-                    let _ = ops.clear_standing();
+                    if let Err(e) = ops.clear_standing() {
+                        tracing::warn!(error = %e, "lockdown-pf-state clear failed during release_all");
+                    }
                 }
                 Err(e) => {
                     if first_err.is_none() {
@@ -629,7 +633,9 @@ pub(crate) fn release_all_with(
             );
             match ops.reload_default() {
                 Ok(()) => {
-                    let _ = ops.clear_standing();
+                    if let Err(e) = ops.clear_standing() {
+                        tracing::warn!(error = %e, "lockdown-pf-state clear failed during release_all");
+                    }
                 }
                 Err(e) => {
                     if first_err.is_none() {

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -365,3 +365,192 @@ fn restore_empty_nat_has_no_blank_line() {
     let r = build_lockdown_restore_ruleset("", FILTER_SNAP);
     assert!(!r.contains("\n\n"), "empty nat must not produce a blank line:\n{r}");
 }
+
+// restore_confirmed ===================================================================================================
+
+fn exit_status(code: i32) -> std::process::ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    std::process::ExitStatus::from_raw(code)
+}
+
+fn output_with_status(code: i32) -> Result<std::process::Output, RoutingError> {
+    Ok(std::process::Output {
+        status: exit_status(code),
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+    })
+}
+
+#[skuld::test]
+fn release_all_restore_confirmed_requires_a_successful_exit_status() {
+    // adopting=true short-circuits to true regardless of `out` — nothing was
+    // attempted, so nothing can have failed to confirm.
+    assert!(restore_confirmed(true, &output_with_status(0)));
+    assert!(restore_confirmed(true, &Err(RoutingError::RouteSetup("unused".into()))));
+
+    // adopting=false: only a successful spawn AND a zero exit status confirms.
+    assert!(restore_confirmed(false, &output_with_status(0)));
+    assert!(
+        !restore_confirmed(false, &output_with_status(1)),
+        "a non-zero pfctl exit must NOT be mistaken for confirmation"
+    );
+    assert!(!restore_confirmed(
+        false,
+        &Err(RoutingError::RouteSetup("spawn failed".into()))
+    ));
+}
+
+// release_all_with ====================================================================================================
+
+/// `PfOps` test double: records every call (by method name) and returns a
+/// per-method injectable result, so the sequencer's ordering, the
+/// no-short-circuit property, and the clear-only-on-confirm rule are
+/// table-tested without shelling out to `pfctl`.
+#[derive(Default)]
+struct RecordingPfOps {
+    log: Vec<&'static str>,
+    fail_reload_default: bool,
+    fail_load_ruleset: bool,
+}
+
+impl PfOps for RecordingPfOps {
+    fn reload_default(&mut self) -> Result<(), RoutingError> {
+        self.log.push("reload_default");
+        if self.fail_reload_default {
+            Err(RoutingError::RouteSetup("mock reload_default failure".into()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn load_ruleset(&mut self, _text: &str) -> Result<(), RoutingError> {
+        self.log.push("load_ruleset");
+        if self.fail_load_ruleset {
+            Err(RoutingError::RouteSetup("mock load_ruleset failure".into()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn drop_token(&mut self, _token: &str) -> Result<(), RoutingError> {
+        self.log.push("drop_token");
+        Ok(())
+    }
+
+    fn clear_transient(&mut self) -> Result<(), RoutingError> {
+        self.log.push("clear_transient");
+        Ok(())
+    }
+
+    fn clear_standing(&mut self) -> Result<(), RoutingError> {
+        self.log.push("clear_standing");
+        Ok(())
+    }
+}
+
+fn transient_state() -> state::FailClosedState {
+    state::FailClosedState {
+        version: state::SCHEMA_VERSION,
+        pf_token: "111".into(),
+        pf_was_enabled: false,
+    }
+}
+
+fn standing_state() -> lockdown_state::LockdownPfState {
+    lockdown_state::LockdownPfState {
+        version: lockdown_state::SCHEMA_VERSION,
+        pf_token: "222".into(),
+        main_snapshot: String::new(),
+        nat_snapshot: String::new(),
+    }
+}
+
+#[skuld::test]
+fn release_all_attempts_the_standing_cover_after_a_transient_failure() {
+    // The short-circuit that would strand the standing cover — the cover that
+    // blocks indefinitely — must not exist.
+    let mut ops = RecordingPfOps {
+        fail_reload_default: true,
+        ..Default::default()
+    };
+    let result = release_all_with(
+        StateFile::Present(transient_state()),
+        StateFile::Present(standing_state()),
+        &mut ops,
+    );
+    assert!(
+        ops.log.contains(&"load_ruleset"),
+        "the standing cover must still be attempted: {:?}",
+        ops.log
+    );
+    assert!(result.is_err());
+}
+
+#[skuld::test]
+fn release_all_keeps_the_transient_state_file_when_the_restore_fails() {
+    // Erasing the cover's only record here would make the NEXT call return Ok
+    // over a still-blocked host — a permanent lockout.
+    let mut ops = RecordingPfOps {
+        fail_reload_default: true,
+        ..Default::default()
+    };
+    let _ = release_all_with(StateFile::Present(transient_state()), StateFile::Absent, &mut ops);
+    assert!(
+        !ops.log.contains(&"clear_transient"),
+        "must not clear the state file over an unconfirmed restore: {:?}",
+        ops.log
+    );
+}
+
+#[skuld::test]
+fn release_all_keeps_the_standing_state_file_when_restore_and_fallback_both_fail() {
+    let mut ops = RecordingPfOps {
+        fail_load_ruleset: true,
+        fail_reload_default: true,
+        ..Default::default()
+    };
+    let result = release_all_with(StateFile::Absent, StateFile::Present(standing_state()), &mut ops);
+    assert!(
+        !ops.log.contains(&"clear_standing"),
+        "must not clear the state file when both the snapshot restore and the fallback failed: {:?}",
+        ops.log
+    );
+    assert!(result.is_err());
+}
+
+#[skuld::test]
+fn release_all_falls_back_to_the_default_ruleset_when_the_snapshot_will_not_load() {
+    let mut ops = RecordingPfOps {
+        fail_load_ruleset: true,
+        ..Default::default()
+    };
+    let result = release_all_with(StateFile::Absent, StateFile::Present(standing_state()), &mut ops);
+    assert!(result.is_ok(), "a successful fallback is not an error: {result:?}");
+    assert!(
+        ops.log.contains(&"clear_standing"),
+        "a confirmed fallback must still clear the state file: {:?}",
+        ops.log
+    );
+}
+
+#[skuld::test]
+fn release_all_treats_an_unusable_state_file_as_a_cover_to_clear() {
+    // A corrupt or version-skewed file must never be read as "nothing to clear".
+    let mut ops = RecordingPfOps::default();
+    let _ = release_all_with(StateFile::Absent, StateFile::Unusable, &mut ops);
+    assert!(
+        ops.log.contains(&"reload_default"),
+        "an Unusable standing state must still trigger the default-ruleset fallback: {:?}",
+        ops.log
+    );
+}
+
+#[skuld::test]
+fn release_all_touches_nothing_when_both_state_files_are_absent() {
+    // A blanket /etc/pf.conf reload here would destroy a healthy host's live
+    // third-party ruleset.
+    let mut ops = RecordingPfOps::default();
+    let result = release_all_with(StateFile::Absent, StateFile::Absent, &mut ops);
+    assert!(ops.log.is_empty(), "must touch nothing on a clean host: {:?}", ops.log);
+    assert!(result.is_ok());
+}

--- a/crates/tun-engine/src/routing/failclosed/macos_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/macos_tests.rs
@@ -411,6 +411,8 @@ struct RecordingPfOps {
     log: Vec<&'static str>,
     fail_reload_default: bool,
     fail_load_ruleset: bool,
+    fail_clear_transient: bool,
+    fail_clear_standing: bool,
 }
 
 impl PfOps for RecordingPfOps {
@@ -439,12 +441,20 @@ impl PfOps for RecordingPfOps {
 
     fn clear_transient(&mut self) -> Result<(), RoutingError> {
         self.log.push("clear_transient");
-        Ok(())
+        if self.fail_clear_transient {
+            Err(RoutingError::RouteSetup("mock clear_transient failure".into()))
+        } else {
+            Ok(())
+        }
     }
 
     fn clear_standing(&mut self) -> Result<(), RoutingError> {
         self.log.push("clear_standing");
-        Ok(())
+        if self.fail_clear_standing {
+            Err(RoutingError::RouteSetup("mock clear_standing failure".into()))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -553,4 +563,87 @@ fn release_all_touches_nothing_when_both_state_files_are_absent() {
     let result = release_all_with(StateFile::Absent, StateFile::Absent, &mut ops);
     assert!(ops.log.is_empty(), "must touch nothing on a clean host: {:?}", ops.log);
     assert!(result.is_ok());
+}
+
+#[skuld::test]
+fn release_all_treats_an_unusable_transient_state_file_as_a_cover_to_clear() {
+    // The transient-side Unusable arm is separately coded (its own warn!
+    // wording about a leaked pf enable refcount, and it unconditionally
+    // reloads the default ruleset rather than trying a restore first) — the
+    // standing-side counterpart above does not exercise it.
+    let mut ops = RecordingPfOps::default();
+    let result = release_all_with(StateFile::Unusable, StateFile::Absent, &mut ops);
+    assert!(
+        ops.log.contains(&"reload_default"),
+        "an Unusable transient state must still trigger the default-ruleset reload: {:?}",
+        ops.log
+    );
+    assert!(
+        ops.log.contains(&"clear_transient"),
+        "a confirmed reload must still clear the state file: {:?}",
+        ops.log
+    );
+    assert!(result.is_ok());
+}
+
+#[skuld::test]
+fn release_all_clears_both_covers_end_to_end_on_a_clean_run() {
+    // The most common real case release_all exists to handle — both covers
+    // stranded, nothing fails — asserted at the sequencer level (not just the
+    // slow, real-firewall privileged test), pinning the full call sequence.
+    let mut ops = RecordingPfOps::default();
+    let result = release_all_with(
+        StateFile::Present(transient_state()),
+        StateFile::Present(standing_state()),
+        &mut ops,
+    );
+    assert!(result.is_ok(), "everything succeeded: {result:?}");
+    assert_eq!(
+        ops.log,
+        vec![
+            "reload_default",
+            "drop_token",
+            "clear_transient",
+            "load_ruleset",
+            "drop_token",
+            "clear_standing",
+        ],
+        "the full transient-then-standing sequence must run in order: {:?}",
+        ops.log
+    );
+}
+
+#[skuld::test]
+fn release_all_logs_a_swallowed_transient_clear_failure_but_still_reports_ok() {
+    // clear_transient/clear_standing are best-effort (contract item 5): a
+    // failure there must not fail the call, but it also must not vanish
+    // silently — every sibling caller of the same underlying clear
+    // (`disengage`, `disengage_lockdown`) logs on failure.
+    let mut ops = RecordingPfOps {
+        fail_clear_transient: true,
+        ..Default::default()
+    };
+    let result = release_all_with(StateFile::Present(transient_state()), StateFile::Absent, &mut ops);
+    assert!(
+        result.is_ok(),
+        "a failed state-file clear must not fail the call: {result:?}"
+    );
+    assert!(
+        ops.log.contains(&"clear_transient"),
+        "the clear must still be attempted"
+    );
+}
+
+#[skuld::test]
+fn release_all_logs_a_swallowed_standing_clear_failure_but_still_reports_ok() {
+    let mut ops = RecordingPfOps {
+        fail_clear_standing: true,
+        ..Default::default()
+    };
+    let result = release_all_with(StateFile::Absent, StateFile::Present(standing_state()), &mut ops);
+    assert!(
+        result.is_ok(),
+        "a failed state-file clear must not fail the call: {result:?}"
+    );
+    assert!(ops.log.contains(&"clear_standing"), "the clear must still be attempted");
 }

--- a/crates/tun-engine/src/routing/failclosed/release_privileged_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/release_privileged_tests.rs
@@ -1,0 +1,423 @@
+//! Privileged-lane real-firewall proof that `release_all` clears every cover
+//! Hole can install, unconditionally, and never touches a clean host's live
+//! ruleset. Follows `lockdown_privileged_tests.rs`'s conventions closely (the
+//! elevated TUN lane, the two-address reachability probe, baseline
+//! self-validation) rather than re-deriving their rationale — see that
+//! module's doc.
+//!
+//! Every test drives the PRODUCTION `Routing` impl (`SystemRouting`), engaging
+//! through `Routing::install_lockdown` / `Routing::install_failclosed_cover`
+//! and clearing through `Routing::release_all_covers` — proving both the
+//! `failclosed::release_all` facade and the trait delegation in one pass.
+//!
+//! `CoverGuard::disarm` is `mem::forget`: after it there is no guard anywhere
+//! to remove what a test installed, so a failing assertion between `disarm`
+//! and the `release_all_covers` call under test would leave a system-wide
+//! block-all in force with nothing to remove it. Every test that calls
+//! `disarm` installs [`ReleaseOnDrop`] FIRST, so a panic (or an early return
+//! from a failed assertion) during an unwind still clears the host.
+//!
+//! These tests share the `global-net-state` test-group with the bridge's
+//! live-egress e2e and with `lockdown_privileged_tests`
+//! (`.config/nextest.toml`) — a poisoned runner takes the rest of the job
+//! down and reads as an unrelated network flake.
+//!
+//! COUPLED NAMES: every test name here contains the substring `release_all_`;
+//! `.config/nextest.toml`'s `global-net-state` filter matches on it. Renaming
+//! a test WITHOUT updating that filter silently drops it from the group.
+
+use crate::routing::{CoverGuard, Routing, SystemRouting};
+
+// `skuld` requires each label to be declared exactly once per test binary;
+// both this module and `lockdown_privileged_tests` compile into the SAME
+// `tun-engine` test binary, so this reuses that module's `TUN` label rather
+// than redeclaring it (a second `#[skuld::label] const TUN` in one binary
+// panics at test-runner startup with "label declared multiple times").
+use super::lockdown_privileged_tests::TUN;
+
+// Two routable anycast hosts on :443 (the runner has outbound internet), as
+// `lockdown_privileged_tests` uses — see that module's doc for why these two
+// addresses specifically.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const PERMITTED: &str = "1.1.1.1:443";
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+const NON_PERMITTED: &str = "8.8.8.8:443";
+
+/// Removes anything the test stranded, on every exit path including an
+/// unwind. `disarm` leaves no guard, so without this a failed assertion
+/// leaves the runner globally fail-closed.
+struct ReleaseOnDrop(std::path::PathBuf);
+impl Drop for ReleaseOnDrop {
+    fn drop(&mut self) {
+        // Must not panic during an unwind.
+        let _ = crate::routing::failclosed::release_all(&self.0);
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn connect(addr: &str) -> std::io::Result<std::net::TcpStream> {
+    std::net::TcpStream::connect_timeout(&addr.parse().unwrap(), std::time::Duration::from_secs(5))
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn assert_baseline_reachable() {
+    let base_permitted = connect(PERMITTED);
+    let base_non = connect(NON_PERMITTED);
+    assert!(
+        base_permitted.is_ok() && base_non.is_ok(),
+        "NETWORK/ENVIRONMENT problem (not the cover): pre-cover baseline egress must reach both hosts; \
+         {PERMITTED}={:?} {NON_PERMITTED}={:?}",
+        base_permitted.err().map(|e| e.kind()),
+        base_non.err().map(|e| e.kind()),
+    );
+}
+
+// windows_release_all_clears_a_stranded_lockdown_cover / macos counterpart ============================================
+
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn windows_release_all_clears_a_stranded_lockdown_cover() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let cover = routing
+        .install_lockdown(server_ip, "Loopback Pseudo-Interface 1", &[])
+        .expect("engage real WFP lockdown cover");
+    cover.disarm(); // strand it — no guard remains to remove it
+
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "the stranded lockdown cover must still be blocking egress"
+    );
+
+    routing
+        .release_all_covers()
+        .expect("release_all_covers must clear the stranded lockdown cover");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_release_all_clears_a_stranded_lockdown_cover() {
+    use std::process::Command;
+
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let cover = routing
+        .install_lockdown(server_ip, "utun-absent", &[])
+        .expect("engage real pf lockdown cover");
+    cover.disarm();
+
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "the stranded lockdown cover must still be blocking egress"
+    );
+
+    routing
+        .release_all_covers()
+        .expect("release_all_covers must clear the stranded lockdown cover");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+    let sr = Command::new("pfctl").args(["-sr"]).output().unwrap();
+    assert!(
+        !String::from_utf8_lossy(&sr.stdout).contains("block drop out quick all"),
+        "the lockdown block rule must be gone from the live ruleset"
+    );
+    assert!(
+        !dir.path().join(super::lockdown_pf_state::STATE_FILE_NAME).exists(),
+        "the lockdown state file must be cleared on a confirmed release"
+    );
+}
+
+// windows_release_all_clears_a_stranded_transient_cover / macos counterpart ===========================================
+
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn windows_release_all_clears_a_stranded_transient_cover() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let cover = routing
+        .install_failclosed_cover(server_ip, None)
+        .expect("engage real WFP transient cover");
+    cover.disarm();
+
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "the stranded transient cover must still be blocking egress"
+    );
+
+    routing
+        .release_all_covers()
+        .expect("release_all_covers must clear the stranded transient cover");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_release_all_clears_a_stranded_transient_cover() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let cover = routing
+        .install_failclosed_cover(server_ip, None)
+        .expect("engage real pf transient cover");
+    cover.disarm();
+
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "the stranded transient cover must still be blocking egress"
+    );
+
+    routing
+        .release_all_covers()
+        .expect("release_all_covers must clear the stranded transient cover");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+    assert!(
+        !dir.path().join(super::failclosed_state::STATE_FILE_NAME).exists(),
+        "the transient state file must be cleared on a confirmed release"
+    );
+}
+
+// windows_release_all_clears_both_stranded_covers / macos counterpart =================================================
+
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn windows_release_all_clears_both_stranded_covers() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let lockdown = routing
+        .install_lockdown(server_ip, "Loopback Pseudo-Interface 1", &[])
+        .expect("engage real WFP lockdown cover");
+    lockdown.disarm();
+    let transient = routing
+        .install_failclosed_cover(server_ip, None)
+        .expect("engage real WFP transient cover");
+    transient.disarm();
+
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "both stranded covers must still be blocking egress"
+    );
+
+    routing
+        .release_all_covers()
+        .expect("release_all_covers must clear both stranded covers in one call");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_release_all_clears_both_stranded_covers() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let lockdown = routing
+        .install_lockdown(server_ip, "utun-absent", &[])
+        .expect("engage real pf lockdown cover");
+    lockdown.disarm();
+    let transient = routing
+        .install_failclosed_cover(server_ip, None)
+        .expect("engage real pf transient cover");
+    transient.disarm();
+
+    assert!(
+        connect(NON_PERMITTED).is_err(),
+        "both stranded covers must still be blocking egress"
+    );
+
+    routing
+        .release_all_covers()
+        .expect("release_all_covers must clear both stranded covers in one call");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+    assert!(!dir.path().join(super::lockdown_pf_state::STATE_FILE_NAME).exists());
+    assert!(!dir.path().join(super::failclosed_state::STATE_FILE_NAME).exists());
+}
+
+// windows_release_all_on_a_clean_host_is_ok / macos counterpart =======================================================
+
+#[cfg(target_os = "windows")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn windows_release_all_on_a_clean_host_is_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+
+    assert_baseline_reachable();
+
+    // Windows has no host-wide ruleset to compare (fixed compiled-in GUIDs, no
+    // ambient policy): reachability is the only local signal available.
+    routing.release_all_covers().expect("a clean host must return Ok");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "a clean host's reachability must be unaffected: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_release_all_on_a_clean_host_is_ok() {
+    use std::process::Command;
+
+    let dir = tempfile::tempdir().unwrap();
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+
+    assert_baseline_reachable();
+
+    // Compare only -sr / -sn (the RULES) and the enabled flag — `-s info`'s
+    // counters move on their own and would make this test flaky for reasons
+    // unrelated to the cover.
+    let sr_before = Command::new("pfctl").args(["-sr"]).output().unwrap().stdout;
+    let sn_before = Command::new("pfctl").args(["-sn"]).output().unwrap().stdout;
+    let info_before = Command::new("pfctl").args(["-s", "info"]).output().unwrap().stdout;
+    let enabled_before = super::platform::parse_pf_enabled(&String::from_utf8_lossy(&info_before));
+
+    routing.release_all_covers().expect("a clean host must return Ok");
+
+    let sr_after = Command::new("pfctl").args(["-sr"]).output().unwrap().stdout;
+    let sn_after = Command::new("pfctl").args(["-sn"]).output().unwrap().stdout;
+    let info_after = Command::new("pfctl").args(["-s", "info"]).output().unwrap().stdout;
+    let enabled_after = super::platform::parse_pf_enabled(&String::from_utf8_lossy(&info_after));
+
+    assert_eq!(
+        sr_before, sr_after,
+        "a clean host's live filter ruleset must be byte-identical afterward"
+    );
+    assert_eq!(
+        sn_before, sn_after,
+        "a clean host's live translation ruleset must be byte-identical afterward"
+    );
+    assert_eq!(
+        enabled_before, enabled_after,
+        "a clean host's pf-enabled flag must be unaffected"
+    );
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "a clean host's reachability must be unaffected: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+// macOS-only fault injections through Hole's own state file, touching no system file ==================================
+
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_release_all_clears_a_cover_whose_state_file_is_unreadable() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let cover = routing
+        .install_lockdown(server_ip, "utun-absent", &[])
+        .expect("engage real pf lockdown cover");
+    cover.disarm();
+
+    // Corrupt Hole's own state file — not a system file — so the real
+    // `load_presence` reads it as `Unusable`, not `Present`.
+    std::fs::write(dir.path().join(super::lockdown_pf_state::STATE_FILE_NAME), b"not json").unwrap();
+
+    routing
+        .release_all_covers()
+        .expect("an unreadable state file must still be treated as a cover to clear");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress even with an unreadable state file: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[skuld::test(labels = [TUN], serial = TUN)]
+fn macos_release_all_falls_back_when_the_snapshot_will_not_load() {
+    let dir = tempfile::tempdir().unwrap();
+    let _release_guard = ReleaseOnDrop(dir.path().to_path_buf());
+    let routing = SystemRouting::new(dir.path().to_path_buf(), None);
+    let server_ip: std::net::IpAddr = "1.1.1.1".parse().unwrap();
+
+    assert_baseline_reachable();
+
+    let cover = routing
+        .install_lockdown(server_ip, "utun-absent", &[])
+        .expect("engage real pf lockdown cover");
+    cover.disarm();
+
+    // Rewrite the state file as valid JSON at the current schema version, but
+    // with a `main_snapshot` that is not something `pfctl -f -` will accept —
+    // a REAL `pfctl` failure driving the real fallback, not a mock.
+    let existing = super::lockdown_pf_state::load(dir.path()).expect("state file must exist after engage");
+    let broken = super::lockdown_pf_state::LockdownPfState {
+        main_snapshot: "this is not a valid pf ruleset {{{".into(),
+        ..existing
+    };
+    super::lockdown_pf_state::save(dir.path(), &broken, None).unwrap();
+
+    routing
+        .release_all_covers()
+        .expect("a snapshot that will not load must fall back to the default ruleset");
+
+    assert!(
+        connect(NON_PERMITTED).is_ok(),
+        "release_all_covers must restore egress via the fallback: {NON_PERMITTED}={:?}",
+        connect(NON_PERMITTED).err().map(|e| e.kind()),
+    );
+}

--- a/crates/tun-engine/src/routing/failclosed/windows.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows.rs
@@ -461,6 +461,29 @@ fn block(guid: GUID, layer: Layer) -> FilterSpec {
 /// our own object is benign idempotency, not an error.
 const FWP_E_ALREADY_EXISTS_DWORD: u32 = 0x8032_0009;
 
+/// `FWP_E_FILTER_NOT_FOUND` as the Win32 DWORD `FwpmFilterDeleteByKey0`
+/// returns (the `windows` crate exposes the constant only as an `HRESULT`, and
+/// these FWPM functions return a bare `u32` — see [`FWP_E_ALREADY_EXISTS_DWORD`]'s
+/// doc for why that mismatch matters). A delete that finds nothing is benign:
+/// the filter was never installed (a clean host) or a prior release already
+/// removed it — never treated as an error.
+const FWP_E_FILTER_NOT_FOUND_DWORD: u32 = 0x8032_0003;
+
+/// Walk every `(what, code)` pair and return the first GENUINE failure — a
+/// code that is neither `ERROR_SUCCESS` nor "filter not found". Pure and total
+/// over the slice: it never stops at the first failure to decide whether to
+/// keep going, so a caller that issues every delete before calling this gets
+/// a structurally short-circuit-free fold.
+fn first_delete_failure(codes: &[(&'static str, u32)]) -> Option<RoutingError> {
+    codes.iter().find_map(|&(what, code)| {
+        if code == ERROR_SUCCESS.0 || code == FWP_E_FILTER_NOT_FOUND_DWORD {
+            None
+        } else {
+            Some(RoutingError::RouteSetup(format!("{what} delete failed: 0x{code:08x}")))
+        }
+    })
+}
+
 /// Which cover a [`Cover`] guard owns — selects the GUID set its Drop deletes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CoverKind {
@@ -999,6 +1022,55 @@ unsafe fn delete_all(engine: HANDLE) {
     }
     let _ = FwpmSubLayerDeleteByKey0(engine, &SUBLAYER_GUID);
     let _ = FwpmProviderDeleteByKey0(engine, &PROVIDER_GUID);
+}
+
+/// Clear every fail-closed cover Windows can install — both the lockdown
+/// (standing) and transient filter sets — without asking whether either is
+/// present. See `failclosed::release_all` for the full contract; this is its
+/// Windows body. Windows keeps no cover state file: the filter set is
+/// compiled-in fixed GUIDs, so there is no bookkeeping that can be corrupt or
+/// version-skewed and nothing to erase — only the GUID sweeps below run.
+///
+/// Opens the FWPM engine once. A failed open means the firewall could not be
+/// reached at all, so nothing could have been deleted — the ONLY early
+/// return; it does not mean "not elevated" (FWPM opens without elevation).
+/// Every delete is ISSUED before any code is inspected — a short-circuit is
+/// structurally impossible — then the codes are folded by
+/// `first_delete_failure`. The sublayer/provider delete is best-effort
+/// (ignored): an orphaned empty sublayer/provider holds no traffic, matching
+/// `delete_all`.
+pub fn release_all(_state_dir: &Path) -> Result<(), RoutingError> {
+    unsafe {
+        let mut engine = HANDLE::default();
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let rc = FwpmEngineOpen0(PCWSTR::null(), RPC_C_AUTHN_WINNT, None, None, &mut engine);
+        if rc != ERROR_SUCCESS.0 {
+            return Err(RoutingError::RouteSetup(format!(
+                "FwpmEngineOpen0 failed (0x{rc:08x}): the firewall could not be reached, so nothing could have been deleted"
+            )));
+        }
+
+        let mut codes: Vec<(&'static str, u32)> = Vec::new();
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        for g in swept_lockdown_guids() {
+            codes.push(("lockdown filter", FwpmFilterDeleteByKey0(engine, &g)));
+        }
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        for g in swept_transient_guids() {
+            codes.push(("transient filter", FwpmFilterDeleteByKey0(engine, &g)));
+        }
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmSubLayerDeleteByKey0(engine, &SUBLAYER_GUID);
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmProviderDeleteByKey0(engine, &PROVIDER_GUID);
+        #[allow(clippy::disallowed_methods)] // sanctioned FWPM call site
+        let _ = FwpmEngineClose0(engine);
+
+        match first_delete_failure(&codes) {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tun-engine/src/routing/failclosed/windows_tests.rs
+++ b/crates/tun-engine/src/routing/failclosed/windows_tests.rs
@@ -643,6 +643,37 @@ fn new_loopbacknet_guids_are_in_their_sweep_floors_and_distinct() {
     }
 }
 
+// release_all =========================================================================================================
+
+#[skuld::test]
+fn release_all_first_delete_failure_reports_the_first_real_error_and_inspects_every_code() {
+    // Not-found is benign (a clean host or an already-swept filter); the fold
+    // must skip it and report the FIRST genuine failure, not stop at it —
+    // every code in the slice must have been issued already by the caller.
+    let codes = [
+        ("a", ERROR_SUCCESS.0),
+        ("b", FWP_E_FILTER_NOT_FOUND_DWORD),
+        ("c", 0x1234_5678),
+        ("d", 0x9abc_def0),
+    ];
+    let err = first_delete_failure(&codes).expect("a genuine failure must be reported");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("0x12345678"),
+        "must name the FIRST genuine failure's code: {msg}"
+    );
+    assert!(
+        !msg.contains("0x9abcdef0"),
+        "must not report the second failure's code: {msg}"
+    );
+
+    let clean = [("a", ERROR_SUCCESS.0), ("b", FWP_E_FILTER_NOT_FOUND_DWORD)];
+    assert!(
+        first_delete_failure(&clean).is_none(),
+        "success and not-found must never be treated as an error"
+    );
+}
+
 #[skuld::test]
 fn adopt_does_not_delete_the_address_range_loopback_floor() {
     // The address-range loopback permits are floor, not volatile: Adopt must keep


### PR DESCRIPTION
Stage 1 of #825's five-stage rework. Closes the P0 lockout described there for
the case this stage owns: an unconditional escape from a fail-closed cover
Hole itself installed.

Previous attempt: #832, rejected after one review round (eleven `must_fix`,
two of them regressions introduced while fixing the previous round — see its
parking comment). That PR encoded the escape as ad-hoc boolean guards at
twelve call sites. This one routes every caller through one facade
(`failclosed::release_all`) and one manager method
(`ProxyManager::turn_lockdown_off`) with exactly one condition anywhere in the
feature: whether a session is running.

## What changed

- **`failclosed::release_all`** (new, `tun-engine`) — clears both cover kinds
  (standing lockdown + transient block-until-connected) unconditionally: never
  asks whether either is present, never short-circuits (every clear is
  attempted before any failure is examined), and never erases a cover's
  state-file evidence after a restore that did not confirm. Reached through a
  new required `Routing::release_all_covers` trait method.
- **`ProxyManager::turn_lockdown_off`** (new) — the feature's only stateful
  decision. `self.running.is_some()` is the single condition anywhere in this
  path: a running session just records the intent (it owns its own cover,
  released by `stop_with`); otherwise the transient guard is dropped, the
  unconditional clear runs, and the intent moves to off only after the clear
  confirms (so a failed release never deletes the user's only retry
  affordance while the host is still closed).
- **`POST /v1/unblock`** (new route) and **`POST /v1/lockdown` with
  `enabled: false`** both call `turn_lockdown_off` — the toggle now releases
  immediately instead of waiting for the next bridge start.
- **Tray**: `escape_item` renders exactly one of {None, GoOffline, Unblock} —
  Unblock (`"Unblock Network (turns Lockdown off)"`) whenever the kill switch
  is armed and nothing is running; GoOffline (relabeled
  `"Go Offline (keeps Lockdown armed)"` to read distinctly) for the existing
  blocked-state escape; never both at once, since Unblock is a strict superset.

## Deliberately NOT in this change

- No cover-state probe (`CoverState`/`held_closed`/`cover_state_unknown`) —
  the escape never inspects presence, so it needs none.
- No ownership model for the two cover kinds.
- No new `StatusResponse` field.
- No change to `cutover::unlock` (`hole bridge unlock` still clears only the
  standing cover) — the transient cover's authority inside a live bridge is
  the in-process `ProxyManager::blocked` guard; an out-of-process clear would
  leave that guard claiming a cover that no longer exists. See
  CONTRIBUTING.md's new subsection for the full reasoning.
- No fix to the `"Lockdown: On (warning: not engaged)"` label — still derived
  from the running session, not an OS probe; disclosed as a residual.

## Verification map

| Claim | Windows | macOS |
| --- | --- | --- |
| A stranded standing cover really blocks egress, and `release_all` really restores it | Not executed locally (needs elevation this box doesn't have) — will run in CI's elevated `tun` lane | Executed in CI's darwin `tun` lane under `sudo` |
| Same for a stranded transient cover | Not executed locally | Executed in CI |
| Same for both covers stranded at once | Not executed locally | Executed in CI |
| A clean host returns `Ok` and stays reachable | Not executed locally | Executed in CI |
| A clean host's **live ruleset is byte-identical** afterwards | Not applicable — no host-wide ruleset to compare | Executed in CI (`pfctl -sr` / `-sn` byte equality + enabled-flag) |
| A failure clearing one cover kind does not stop the other | Executed (pure `release_all_with` fold, unprivileged) | Executed (same test) |
| A restore that did not confirm does **not** erase the cover's state file | n/a — no state files | Executed (pure, unprivileged, both cover kinds) |
| A non-zero `pfctl` exit is not mistaken for confirmation | n/a | Executed (`restore_confirmed` table) |
| Not-found is benign and the first real delete failure is reported | Executed (`first_delete_failure` table, unprivileged) | n/a |
| A cover whose state file is unreadable is still cleared | n/a | Executed in CI (corrupt-file fault injection, live pf) |
| The `/etc/pf.conf` fallback when the captured snapshot will not load | n/a | Executed in CI (unparseable-snapshot fault injection, live pf) |
| Manager-level ordering, the single condition, and the two distinct failure reports | Executed (mock `Routing`) | Same test, same lane |
| The Lockdown-off toggle releases through the same path | Executed (`ipc_tests`) | Same test |
| The tray's escape-item choice and both message contents | Executed (pure functions, exhaustive table) | Same tests |
| A **real** FWPM delete returning a non-not-found error | Not covered — no fault-injection seam at the FFI; the fold that consumes such a code is covered, and deletes are all issued before any code is read, so a short-circuit is structurally impossible | n/a |
| A GUI click driving a real firewall clear end to end | Not covered — no such harness exists | Not covered |
| `pfctl -X` against a stale post-reboot token | n/a | Not covered — needs a real reboot; the best-effort treatment is what keeps it from failing the call |

The ten privileged `release_all_*` tests (4 pairs + 2 macOS-only fault
injections) are registered in `.config/nextest.toml`'s `global-net-state`
group and gated to the elevated `tun` lane; none ran locally (Windows box
without elevation and without a macOS toolchain). `cargo check -p tun-engine
--target aarch64-apple-darwin` is the only local signal the macOS bodies
compile.

## Test plan

- [x] `cargo nextest run -p tun-engine -E 'test(/release_all_/)'` — the
      Windows-eligible unprivileged tests pass locally
- [x] `cargo nextest run -p hole-bridge -E 'test(/turn_lockdown_off/)'` — 6/6
- [x] `cargo nextest run -p hole-bridge -p hole-common -E 'test(/unblock/) +
      test(/lockdown_off_releases/)'` — 6/6
- [x] `cargo nextest run -p hole -E 'test(/unblock/) + test(/escape_item/)'` —
      3/3
- [x] `cargo nextest run --workspace --no-fail-fast` (`SKULD_LABELS=!tun`) —
      2690 passed, 30 failed, all 30 confirmed pre-existing (missing local
      `target/release/galoshes.exe` / non-interactive console — CI provisions
      both; none touch code this PR changed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] CI's elevated Windows `tun` lane and darwin `tun`/`sudo` lane for the 10
      new privileged tests (only execution they get)
